### PR TITLE
Use the tempfile api rather than manual seeding.

### DIFF
--- a/zef-service/Cargo.toml
+++ b/zef-service/Cargo.toml
@@ -17,7 +17,6 @@ futures = "0.3.17"
 hex = "0.4.3"
 log = "0.4.14"
 net2 = "0.2.37"
-rand = { version = "0.7.3", features = ["small_rng"] }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 serde-name = "0.2.0"


### PR DESCRIPTION
Turns out the `tempfile` crate was already in the dependencies of `zef-service` so it's quite simple to use it instead of creating manually the random file.
The `NamedTempFile` ensures that the file can be retrieved, `new_in` is helpful so that it's on the same device as the final file and the documentation for [persist](https://docs.rs/tempfile/latest/tempfile/struct.NamedTempFile.html#method.persist) mentions that the move is atomic.