### PR TITLE
[ci] active test_readme in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,9 +20,11 @@ jobs:
         rustup component add rustfmt --toolchain 1.58.1-x86_64-unknown-linux-gnu
         rustup component add clippy --toolchain 1.58.1-x86_64-unknown-linux-gnu
     - name: Build
-      run: cargo build --verbose
+      run: cargo build
+    - name: Release build
+      run: cargo build --release
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test
     - name: Clippy
       run: cargo clippy --all-targets
     - name: Rustfmt

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ kill "$LAST_PID"
 ./client --wallet wallet.json --genesis genesis.json query_balance "$ACCOUNT2"
 
 # Launch local benchmark using all user accounts
-./client --wallet wallet.json --genesis genesis.json benchmark
+./client --wallet wallet.json --genesis genesis.json benchmark --max-in-flight 50
 
 # Create derived account
 ACCOUNT3="`./client --wallet wallet.json --genesis genesis.json open_account --from "$ACCOUNT1"`"

--- a/zef-service/tests/test_readme.rs
+++ b/zef-service/tests/test_readme.rs
@@ -6,7 +6,6 @@ use std::{io::Write, process::Command};
 use tempfile::tempdir;
 
 #[test]
-#[ignore]
 fn test_examples_in_readme() -> std::io::Result<()> {
     let dir = tempdir().unwrap();
     let file = std::io::BufReader::new(std::fs::File::open("../README.md")?);


### PR DESCRIPTION
Tentatively run the integration test in CI.

The option `client .. benchmark --max-in-flight 50` seems to be required under Linux.