### PR TITLE
[CI] switch README tests to DEBUG compilation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,8 +21,6 @@ jobs:
         rustup component add clippy --toolchain 1.58.1-x86_64-unknown-linux-gnu
     - name: Build
       run: cargo build
-    - name: Release build
-      run: cargo build --release
     - name: Run tests
       run: cargo test
     - name: Clippy

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ the client and CLI code is missing).
 The following script can be run with `cargo test -- --ignored`.
 
 ```bash
-cargo build --release
-cd target/release
+# For debug builds:
+cargo build && cd target/debug
+# For release builds:
+# cargo build --release && cd target/release
+
+# Clean up data files
 rm -f *.json *.txt
 
 # Make sure to clean up child processes on exit.


### PR DESCRIPTION
Since we don't use expensive cryptography, debug builds should be good enough for testing.