### PR TITLE
Support shards on multiple hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ trap 'kill $(jobs -p)' EXIT
 # * Private server states are stored in `server*.json`.
 # * `committee.json` is the public description of the FastPay committee.
 ./server generate-all --validators \
-   server_1.json:udp:127.0.0.1:9100:4 \
-   server_2.json:udp:127.0.0.1:9200:4 \
-   server_3.json:udp:127.0.0.1:9300:4 \
-   server_4.json:udp:127.0.0.1:9400:4 \
+   server_1.json:udp:127.0.0.1:9100:127.0.0.1:9101:127.0.0.1:9102:127.0.0.1:9103 \
+   server_2.json:udp:127.0.0.1:9200:127.0.0.1:9201:127.0.0.1:9202:127.0.0.1:9203 \
+   server_3.json:udp:127.0.0.1:9300:127.0.0.1:9301:127.0.0.1:9302:127.0.0.1:9303 \
+   server_4.json:udp:127.0.0.1:9400:127.0.0.1:9401:127.0.0.1:9402:127.0.0.1:9403 \
 --committee committee.json
 
 # Create configuration files for 1000 user chains.

--- a/zef-service/src/config.rs
+++ b/zef-service/src/config.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transport::NetworkProtocol;
+use crate::network::ValidatorNetworkConfig;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -38,22 +38,16 @@ pub trait Export: Serialize {
     }
 }
 
+/// The (public) configuration of a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidatorConfig {
-    pub network_protocol: NetworkProtocol,
+    /// The public key of the validator.
     pub name: ValidatorName,
-    pub host: String,
-    pub base_port: u32,
-    pub num_shards: u32,
+    /// The network configuration for the validator.
+    pub network: ValidatorNetworkConfig,
 }
 
-impl ValidatorConfig {
-    pub fn print(&self) {
-        let data = serde_json::to_string(self).unwrap();
-        println!("{}", data);
-    }
-}
-
+/// The private configuration of a validator service.
 #[derive(Serialize, Deserialize)]
 pub struct ValidatorServerConfig {
     pub validator: ValidatorConfig,
@@ -63,6 +57,7 @@ pub struct ValidatorServerConfig {
 impl Import for ValidatorServerConfig {}
 impl Export for ValidatorServerConfig {}
 
+/// The (public) configuration for all validators.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CommitteeConfig {
     pub validators: Vec<ValidatorConfig>,


### PR DESCRIPTION
Shard assignment is still static and copied in multiple places but at least we don't assume that all shards are on the same hosts.

Note: I haven't actually tested on multiple hosts yet