### PR TITLE
Run integration test using LocalStack S3 storage

### DIFF
--- a/linera-service/tests/test_readme.rs
+++ b/linera-service/tests/test_readme.rs
@@ -2,6 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use linera_storage::LocalStackTestContext;
 use std::{io::Write, process::Command};
 use tempfile::tempdir;
 
@@ -12,13 +13,13 @@ fn test_examples_in_readme() -> std::io::Result<()> {
     let mut quotes = get_bash_quotes(file)?;
     // Check that we have the expected number of examples starting with "```bash".
     assert_eq!(quotes.len(), 1);
+    let quote = quotes.pop().unwrap();
 
     let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
-    write!(&mut test_script, "{}", quotes.pop().unwrap())?;
+    write!(&mut test_script, "{}", quote)?;
 
     let status = Command::new("bash")
         .current_dir("..") // root of the repo
-        .env("DEST", dir.path())
         .arg("-e")
         .arg("-x")
         .arg(dir.path().join("test.sh"))
@@ -52,4 +53,33 @@ where
     }
 
     Ok(result)
+}
+
+const ROCKSDB_STORAGE: &str = "--storage rocksdb:server_\"$I\"_\"$J\".db";
+const S3_STORAGE: &str = "--storage s3:localstack:server-\"$I\"";
+
+#[test]
+#[ignore]
+fn test_examples_in_readme_s3() -> std::io::Result<()> {
+    let _localstack_guard = LocalStackTestContext::new();
+    let dir = tempdir().unwrap();
+    let file = std::io::BufReader::new(std::fs::File::open("../README.md")?);
+    let mut quotes = get_bash_quotes(file)?;
+    // Check that we have the expected number of examples starting with "```bash".
+    assert_eq!(quotes.len(), 1);
+    let quote = quotes.pop().unwrap();
+    assert_eq!(quote.matches(ROCKSDB_STORAGE).count(), 3);
+    let quote = quote.replace(ROCKSDB_STORAGE, S3_STORAGE);
+
+    let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
+    write!(&mut test_script, "{}", quote)?;
+
+    let status = Command::new("bash")
+        .current_dir("..") // root of the repo
+        .arg("-e")
+        .arg("-x")
+        .arg(dir.path().join("test.sh"))
+        .status()?;
+    assert!(status.success());
+    Ok(())
 }


### PR DESCRIPTION
# Motivation

Using AWS S3 for storage in the server shards allows an increase of crash tolerance in deployments, because new stateless containers can be spawned for a crashed worker and continue the operations of a crashed worker.

It also prepares for dynamic shard assignments, because workers can change shards without having to communicate among them.

# Solution

@ma2bd created a test that runs the integration test in the README, but with the servers using S3 storage instead of RocksDB. A couple of other issues prevented the test from working (#82 and #83), and two tweaks had to made:

1. Assign a different bucket name per server
2. Acquire a `LocalStackTestContext` guard to prevent other tests from running while the integration test was running

# Related issues

Closes #76 