### PR TITLE
Fix possible loss of messages in channels

### DIFF
--- a/linera-base/tests/staged/formats.yaml
+++ b/linera-base/tests/staged/formats.yaml
@@ -186,7 +186,13 @@ ChannelState:
         MAP:
           KEY:
             TYPENAME: ChainId
-          VALUE: BOOL
+          VALUE: UNIT
+    - outboxes:
+        MAP:
+          KEY:
+            TYPENAME: ChainId
+          VALUE:
+            TYPENAME: OutboxState
     - block_height:
         OPTION:
           TYPENAME: BlockHeight


### PR DESCRIPTION
This PR makes channels contain proper "outbox" data-structures. The previous data-structure was only tracking if the recipient was "up to date". This doesn't work if messages are lost while the channels is producing new ones. Previously, I thought losing channel messages was ok but I was wrong.

Unfortunately, it's a bit difficult to show the bug. In any case, the code is better after the fix because we actually share the more logic between direct messages and channels.