### PR TITLE
nit: simplify trait bound storage2::Error

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -19,7 +19,6 @@ use linera_base::{
     system::{Address, Amount, Balance, SystemExecutionState, SystemOperation, UserData},
 };
 use linera_storage2::Store;
-use linera_views::views;
 use std::{
     collections::{BTreeMap, HashMap},
     time::Duration,
@@ -214,7 +213,7 @@ where
     P: ValidatorNodeProvider,
     P::Node: ValidatorNode + Send + Sync + 'static + Clone,
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     async fn chain_info(&mut self) -> Result<ChainInfo, Error> {
         let query = ChainInfoQuery::new(self.chain_id);
@@ -353,7 +352,7 @@ where
     P: ValidatorNodeProvider + Send + 'static,
     P::Node: ValidatorNode + Send + Sync + 'static + Clone,
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     /// Prepare the chain for the next operation.
     async fn prepare_chain(&mut self) -> Result<(), Error> {
@@ -827,7 +826,7 @@ where
     P: ValidatorNodeProvider + Send + 'static,
     P::Node: ValidatorNode + Send + Sync + 'static + Clone,
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     async fn local_balance(&mut self) -> Result<Balance> {
         ensure!(

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use futures::lock::Mutex;
 use linera_base::{error::Error, manager::ChainManager, messages::*};
 use linera_storage2::Store;
-use linera_views::views;
 use rand::prelude::SliceRandom;
 use std::sync::Arc;
 
@@ -45,7 +44,7 @@ pub struct LocalNodeClient<S>(Arc<Mutex<LocalNode<S>>>);
 impl<S> ValidatorNode for LocalNodeClient<S>
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     async fn handle_block_proposal(
         &mut self,
@@ -100,7 +99,7 @@ where
 impl<S> LocalNodeClient<S>
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     pub(crate) async fn stage_block_execution(
         &self,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -16,7 +16,6 @@ use linera_base::{
     system::{Amount, Balance, SystemOperation, UserData},
 };
 use linera_storage2::{MemoryStoreClient, RocksdbStoreClient, Store};
-use linera_views::views;
 use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -39,7 +38,7 @@ struct LocalValidatorClient<S>(Arc<Mutex<LocalValidator<S>>>);
 impl<S> ValidatorNode for LocalValidatorClient<S>
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     async fn handle_block_proposal(
         &mut self,
@@ -89,7 +88,7 @@ struct NodeProvider<S>(BTreeMap<ValidatorName, LocalValidatorClient<S>>);
 impl<S> ValidatorNodeProvider for NodeProvider<S>
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     type Node = LocalValidatorClient<S>;
 
@@ -150,7 +149,7 @@ impl GenesisStoreBuilder {
     ) -> S
     where
         S: Store + Clone + Send + Sync + 'static,
-        Error: From<<S::Context as views::Context>::Error>,
+        Error: From<S::Error>,
         F: Fn() -> S,
     {
         let store = store_builder();
@@ -173,7 +172,7 @@ impl GenesisStoreBuilder {
 impl<S> TestBuilder<S>
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     fn new(store_builder: fn() -> S, count: usize, with_faulty_validators: usize) -> Self {
         let mut key_pairs = Vec::new();
@@ -366,7 +365,7 @@ async fn test_rocksdb_initiating_valid_transfer() {
 async fn run_test_initiating_valid_transfer<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut sender = builder
@@ -407,7 +406,7 @@ async fn test_rocksdb_rotate_key_pair() {
 async fn run_test_rotate_key_pair<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut sender = builder
@@ -453,7 +452,7 @@ async fn test_rocksdb_transfer_ownership() {
 async fn run_test_transfer_ownership<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut sender = builder
@@ -500,7 +499,7 @@ async fn test_rocksdb_share_ownership() {
 async fn run_test_share_ownership<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut sender = builder
@@ -568,7 +567,7 @@ async fn test_rocksdb_open_chain_then_close_it() {
 async fn run_test_open_chain_then_close_it<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     // New chains use the admin chain to verify their creation certificate.
@@ -612,7 +611,7 @@ async fn test_rocksdb_transfer_then_open_chain() {
 async fn run_test_transfer_then_open_chain<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     // New chains use the admin chain to verify their creation certificate.
@@ -680,7 +679,7 @@ async fn test_rocksdb_open_chain_then_transfer() {
 async fn run_test_open_chain_then_transfer<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     // New chains use the admin chain to verify their creation certificate.
@@ -738,7 +737,7 @@ async fn test_rocksdb_close_chain() {
 async fn run_test_close_chain<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut sender = builder
@@ -787,7 +786,7 @@ async fn test_rocksdb_initiating_valid_transfer_too_many_faults() {
 async fn run_test_initiating_valid_transfer_too_many_faults<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 2);
     let mut sender = builder
@@ -820,7 +819,7 @@ async fn test_rocksdb_bidirectional_transfer() {
 async fn run_test_bidirectional_transfer<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut client1 = builder
@@ -886,7 +885,7 @@ async fn test_rocksdb_receiving_unconfirmed_transfer() {
 async fn run_test_receiving_unconfirmed_transfer<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut client1 = builder
@@ -928,7 +927,7 @@ async fn run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances<S>
     store_builder: fn() -> S,
 ) where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut client1 = builder
@@ -1018,7 +1017,7 @@ async fn test_rocksdb_change_voting_rights() {
 async fn run_test_change_voting_rights<S>(store_builder: fn() -> S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1);
     let mut admin = builder

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -16,7 +16,6 @@ use linera_base::{
     },
 };
 use linera_storage2::{chain::Event, MemoryStoreClient, RocksdbStoreClient, Store};
-use linera_views::views;
 use std::collections::BTreeMap;
 use test_log::test;
 
@@ -25,7 +24,7 @@ use test_log::test;
 fn init_worker<S>(client: S, allow_inactive_chains: bool) -> (Committee, WorkerState<S>)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let key_pair = KeyPair::generate();
     let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
@@ -39,7 +38,7 @@ async fn init_worker_with_chains<S, I>(client: S, balances: I) -> (Committee, Wo
 where
     I: IntoIterator<Item = (ChainDescription, PublicKey, Balance)>,
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let (committee, worker) = init_worker(client, /* allow_inactive_chains */ false);
     for (description, pubk, balance) in balances {
@@ -67,7 +66,7 @@ async fn init_worker_with_chain<S>(
 ) -> (Committee, WorkerState<S>)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     init_worker_with_chains(client, [(description, owner, balance)]).await
 }
@@ -210,7 +209,7 @@ async fn test_rocksdb_handle_block_proposal_bad_signature() {
 async fn run_test_handle_block_proposal_bad_signature<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient = Address::Account(ChainId::root(2));
@@ -275,7 +274,7 @@ async fn test_rocksdb_handle_block_proposal_zero_amount() {
 async fn run_test_handle_block_proposal_zero_amount<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient = Address::Account(ChainId::root(2));
@@ -337,7 +336,7 @@ async fn test_rocksdb_handle_block_proposal_unknown_sender() {
 async fn run_test_handle_block_proposal_unknown_sender<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient = Address::Account(ChainId::root(2));
@@ -401,7 +400,7 @@ async fn test_rocksdb_handle_block_proposal_with_chaining() {
 async fn run_test_handle_block_proposal_with_chaining<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient = Address::Account(ChainId::root(2));
@@ -505,7 +504,7 @@ async fn test_rocksdb_handle_block_proposal_with_incoming_messages() {
 async fn run_test_handle_block_proposal_with_incoming_messages<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
@@ -888,7 +887,7 @@ async fn test_rocksdb_handle_block_proposal_exceed_balance() {
 async fn run_test_handle_block_proposal_exceed_balance<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient = Address::Account(ChainId::root(2));
@@ -946,7 +945,7 @@ async fn test_rocksdb_handle_block_proposal() {
 async fn run_test_handle_block_proposal<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient = Address::Account(ChainId::root(2));
@@ -1006,7 +1005,7 @@ async fn test_rocksdb_handle_block_proposal_replay() {
 async fn run_test_handle_block_proposal_replay<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient = Address::Account(ChainId::root(2));
@@ -1067,7 +1066,7 @@ async fn test_rocksdb_handle_certificate_unknown_sender() {
 async fn run_test_handle_certificate_unknown_sender<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1109,7 +1108,7 @@ async fn test_rocksdb_handle_certificate_bad_block_height() {
 async fn run_test_handle_certificate_bad_block_height<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1163,7 +1162,7 @@ async fn test_rocksdb_handle_certificate_with_anticipated_incoming_message() {
 async fn run_test_handle_certificate_with_anticipated_incoming_message<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1276,7 +1275,7 @@ async fn test_rocksdb_handle_certificate_receiver_balance_overflow() {
 async fn run_test_handle_certificate_receiver_balance_overflow<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1356,7 +1355,7 @@ async fn test_rocksdb_handle_certificate_receiver_equal_sender() {
 async fn run_test_handle_certificate_receiver_equal_sender<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let key_pair = KeyPair::generate();
     let name = key_pair.public();
@@ -1426,7 +1425,7 @@ async fn test_rocksdb_handle_cross_chain_request() {
 async fn run_test_handle_cross_chain_request<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1507,7 +1506,7 @@ async fn test_rocksdb_handle_cross_chain_request_no_recipient_chain() {
 async fn run_test_handle_cross_chain_request_no_recipient_chain<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker(client, /* allow_inactive_chains */ false);
@@ -1561,7 +1560,7 @@ async fn run_test_handle_cross_chain_request_no_recipient_chain_with_inactive_ch
     client: S,
 ) where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker(client, /* allow_inactive_chains */ true);
@@ -1619,7 +1618,7 @@ async fn test_rocksdb_handle_certificate_to_active_recipient() {
 async fn run_test_handle_certificate_to_active_recipient<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
@@ -1740,7 +1739,7 @@ async fn test_rocksdb_handle_certificate_to_inactive_recipient() {
 async fn run_test_handle_certificate_to_inactive_recipient<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1792,7 +1791,7 @@ async fn test_rocksdb_chain_creation_with_committee_creation() {
 async fn run_test_chain_creation_with_committee_creation<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -2264,7 +2263,7 @@ async fn test_rocksdb_transfers_and_committee_creation() {
 async fn run_test_transfers_and_committee_creation<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
@@ -2452,7 +2451,7 @@ async fn test_rocksdb_transfers_and_committee_removal() {
 async fn run_test_transfers_and_committee_removal<S>(client: S)
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -6,7 +6,6 @@ use crate::node::ValidatorNode;
 use futures::{future, StreamExt};
 use linera_base::{committee::Committee, error::Error, messages::*};
 use linera_storage2::Store;
-use linera_views::views;
 use std::{collections::HashMap, hash::Hash, time::Duration};
 
 /// Used for `communicate_chain_updates`
@@ -91,7 +90,7 @@ impl<A, S> ValidatorUpdater<A, S>
 where
     A: ValidatorNode + Clone + Send + Sync + 'static,
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     pub async fn send_certificate(
         &mut self,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -8,10 +8,7 @@ use linera_storage2::{
     chain::{ChainStateView, OutboxStateView},
     Store,
 };
-use linera_views::{
-    views,
-    views::{AppendOnlyLogView, View},
-};
+use linera_views::views::{AppendOnlyLogView, View};
 use std::{collections::VecDeque, sync::Arc};
 
 #[cfg(test)]
@@ -88,7 +85,7 @@ impl<Client> WorkerState<Client> {
 impl<Client> WorkerState<Client>
 where
     Client: Store + Clone + Send + Sync + 'static,
-    Error: From<<Client::Context as views::Context>::Error>,
+    Error: From<Client::Error>,
 {
     // NOTE: This only works for non-sharded workers!
     pub(crate) async fn fully_handle_certificate(
@@ -354,7 +351,7 @@ where
 impl<Client> ValidatorWorker for WorkerState<Client>
 where
     Client: Store + Clone + Send + Sync + 'static,
-    Error: From<<Client::Context as views::Context>::Error>,
+    Error: From<Client::Error>,
 {
     async fn handle_block_proposal(
         &mut self,

--- a/linera-service/src/client.rs
+++ b/linera-service/src/client.rs
@@ -26,7 +26,6 @@ use linera_service::{
     storage::{Runnable, StorageConfig},
 };
 use linera_storage2::Store;
-use linera_views::views;
 use log::*;
 use std::{
     collections::{HashMap, HashSet},
@@ -146,7 +145,7 @@ impl ClientContext {
     async fn process_inboxes_and_force_validator_updates<S>(&mut self, storage: &S)
     where
         S: Store + Clone + Send + Sync + 'static,
-        Error: From<<S::Context as views::Context>::Error>,
+        Error: From<S::Error>,
     {
         for chain_id in self.wallet_state.chain_ids() {
             let mut client = self.make_chain_client(storage.clone(), chain_id);
@@ -285,7 +284,7 @@ impl ClientContext {
         P: ValidatorNodeProvider + Send + 'static,
         P::Node: ValidatorNode + Send + Sync + 'static + Clone,
         S: Store + Clone + Send + Sync + 'static,
-        Error: From<<S::Context as views::Context>::Error>,
+        Error: From<S::Error>,
     {
         self.wallet_state.update_from_state(state).await
     }
@@ -306,7 +305,7 @@ impl ClientContext {
         certificates: Vec<Certificate>,
     ) where
         S: Store + Clone + Send + Sync + 'static,
-        Error: From<<S::Context as views::Context>::Error>,
+        Error: From<S::Error>,
     {
         // First instantiate a local node on top of storage.
         let worker = WorkerState::new("Temporary client node".to_string(), None, storage)
@@ -329,7 +328,7 @@ impl ClientContext {
     async fn ensure_admin_subscription<S>(&mut self, storage: &S) -> Vec<Certificate>
     where
         S: Store + Clone + Send + Sync + 'static,
-        Error: From<<S::Context as views::Context>::Error>,
+        Error: From<S::Error>,
     {
         let mut certificates = Vec::new();
         for chain_id in self.wallet_state.chain_ids() {
@@ -349,7 +348,7 @@ impl ClientContext {
     async fn push_to_all_chains<S>(&mut self, storage: &S, certificate: &Certificate)
     where
         S: Store + Clone + Send + Sync + 'static,
-        Error: From<<S::Context as views::Context>::Error>,
+        Error: From<S::Error>,
     {
         for chain_id in self.wallet_state.chain_ids() {
             let mut client_state = self.make_chain_client(storage.clone(), chain_id);
@@ -542,7 +541,7 @@ struct Job(ClientContext, ClientCommand);
 impl<S> Runnable<S> for Job
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     type Output = ();
 

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -14,7 +14,6 @@ use linera_core::{
     node::ValidatorNode,
 };
 use linera_storage2::Store;
-use linera_views::views;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -158,7 +157,7 @@ impl WalletState {
         P: ValidatorNodeProvider + Send + 'static,
         P::Node: ValidatorNode + Send + Sync + 'static + Clone,
         S: Store + Clone + Send + Sync + 'static,
-        linera_base::error::Error: From<<S::Context as views::Context>::Error>,
+        linera_base::error::Error: From<S::Error>,
     {
         let chain = self
             .chains
@@ -218,7 +217,7 @@ impl GenesisConfig {
     pub async fn initialize_store<S>(&self, store: &mut S) -> Result<(), anyhow::Error>
     where
         S: Store + Clone + Send + Sync + 'static,
-        linera_base::error::Error: From<<S::Context as views::Context>::Error>,
+        linera_base::error::Error: From<S::Error>,
     {
         for (description, owner, balance) in &self.chains {
             store

--- a/linera-service/src/network.rs
+++ b/linera-service/src/network.rs
@@ -12,7 +12,6 @@ use futures::{channel::mpsc, sink::SinkExt, stream::StreamExt};
 use linera_base::{error::*, messages::*, rpc};
 use linera_core::{node::ValidatorNode, worker::*};
 use linera_storage2::Store;
-use linera_views::views;
 use log::*;
 use serde::{Deserialize, Serialize};
 use std::{io, time::Duration};
@@ -146,7 +145,7 @@ impl<S> Server<S> {
 impl<S> Server<S>
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     async fn forward_cross_chain_queries(
         network: ValidatorInternalNetworkConfig,
@@ -237,7 +236,7 @@ struct RunningServerState<S> {
 impl<S> MessageHandler for RunningServerState<S>
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     fn handle_message(
         &mut self,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -17,7 +17,6 @@ use linera_service::{
     transport,
 };
 use linera_storage2::Store;
-use linera_views::views;
 use log::*;
 use std::{
     path::{Path, PathBuf},
@@ -77,7 +76,7 @@ impl ServerContext {
 impl<S> Runnable<S> for ServerContext
 where
     S: Store + Clone + Send + Sync + 'static,
-    Error: From<<S::Context as views::Context>::Error>,
+    Error: From<S::Error>,
 {
     type Output = ();
 

--- a/linera-storage2/src/memory.rs
+++ b/linera-storage2/src/memory.rs
@@ -34,6 +34,7 @@ impl ChainStateViewContext for MemoryContext<ChainId> {}
 #[async_trait]
 impl Store for MemoryStoreClient {
     type Context = MemoryContext<ChainId>;
+    type Error = MemoryViewError;
 
     async fn load_chain(
         &self,

--- a/linera-storage2/src/rocksdb.rs
+++ b/linera-storage2/src/rocksdb.rs
@@ -55,6 +55,7 @@ impl ChainStateViewContext for RocksdbContext<ChainId> {}
 #[async_trait]
 impl Store for RocksdbStoreClient {
     type Context = RocksdbContext<ChainId>;
+    type Error = RocksdbViewError;
 
     async fn load_chain(
         &self,


### PR DESCRIPTION
Because `?` requires `UserError: From<LibraryError>`, I don't think we can remove the trait entirely. However, adding an alias for the error type makes the expression much nicer.