### PR TITLE
Allow committing while keeping ownership of the view

### DIFF
--- a/linera-views/src/hash.rs
+++ b/linera-views/src/hash.rs
@@ -50,7 +50,7 @@ where
 impl<C, T> HashView<C> for RegisterView<C, T>
 where
     C: HashingContext + RegisterOperations<T> + Send + Sync,
-    T: Default + Send + Sync + Serialize,
+    T: Clone + Default + Send + Sync + Serialize,
 {
     async fn hash(&mut self) -> Result<<C::Hasher as Hasher>::Output, C::Error> {
         let mut hasher = C::Hasher::default();

--- a/linera-views/src/macros.rs
+++ b/linera-views/src/macros.rs
@@ -33,6 +33,13 @@ where
         $( self.$field.rollback(); )*
     }
 
+    async fn commit_and_reset(&mut self, batch: &mut C::Batch) -> Result<(), C::Error> {
+        use $crate::views::View;
+
+        $( self.$field.commit_and_reset(batch).await?; )*
+        Ok(())
+    }
+
     async fn commit(self, batch: &mut C::Batch) -> Result<(), C::Error> {
         use $crate::views::View;
 


### PR DESCRIPTION
# Motivation

The `View::commit` method takes ownership of the view, so if more changes need to be done to the same view later a new instance has to be created to reload the view. This is a bit more complicated because that requires access to the view's context, which might not be easily accessible when the new instance needs to be created.

# Solution

Change all `View` implementations to implement `commit_and_reset` instead of `commit`, and add a default `commit` implementation that calls `commit_and_reset`.

The new `commit_and_reset` method does not take ownership of the view, so it can be reused to add more changes later. To support this, the internal staged changes of the view are cleared during the commit.

# Related Work

#114 contains code that touches the same code, so there will be conflicts. Therefore I left this PR as a draft and I can rebase after that PR has been merged.