### PR TITLE
Tweak view commits to reduce unnecessary work

### DIFF
--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -554,16 +554,20 @@ where
     }
 
     async fn commit(mut self, batch: &mut C::Batch) -> Result<(), C::Error> {
-        self.context
-            .delete_front(&mut self.stored_indices, batch, self.front_delete_count)
-            .await?;
-        self.context
-            .append_back(
-                &mut self.stored_indices,
-                batch,
-                self.new_back_values.into_iter().collect(),
-            )
-            .await?;
+        if self.front_delete_count > 0 {
+            self.context
+                .delete_front(&mut self.stored_indices, batch, self.front_delete_count)
+                .await?;
+        }
+        if !self.new_back_values.is_empty() {
+            self.context
+                .append_back(
+                    &mut self.stored_indices,
+                    batch,
+                    self.new_back_values.into_iter().collect(),
+                )
+                .await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
# Motivation

Some views call some storage operations even if they're not necessary. This might lead to unnecessary calls inside the storage layer implementation, if it's not coded to handle these empty calls.

# Solution

Check if the calls are actually necessary, and avoid them if needed. Specifically:

- don't call `AppendOnlyLogOperations::append` if there are no new values to append
- don't call `QueueOperations::delete_front` if there are no elements to be removed
- don't call `QueueOperations::append_back` if there are no new elements to append

# Alternatives

This micro-optimization could be done inside the actual `*Operations` implementations. However, I thought that it made more sense to do it once inside the respective `View` implementations instead of in each storage layer implementation.