### PR TITLE
Implement reset_to_default operation : PR 3

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -8,7 +8,7 @@ use linera_storage2::{
     chain::{ChainStateView, OutboxStateView},
     Store,
 };
-use linera_views::views::{AppendOnlyLogView, View};
+use linera_views::views::{LogView, View};
 use std::{collections::VecDeque, sync::Arc};
 
 #[cfg(test)]
@@ -119,7 +119,7 @@ where
 
     async fn make_cross_chain_request(
         &mut self,
-        confirmed_log: &mut AppendOnlyLogView<Client::Context, HashValue>,
+        confirmed_log: &mut LogView<Client::Context, HashValue>,
         application_id: ApplicationId,
         origin: Origin,
         recipient: ChainId,

--- a/linera-storage2/src/chain.rs
+++ b/linera-storage2/src/chain.rs
@@ -17,9 +17,8 @@ use linera_base::{
 use linera_views::{
     impl_view,
     views::{
-        AppendOnlyLogOperations, AppendOnlyLogView, CollectionOperations, CollectionView,
-        MapOperations, MapView, QueueOperations, QueueView, RegisterOperations, RegisterView,
-        ScopedView,
+        CollectionOperations, CollectionView, LogOperations, LogView, MapOperations, MapView,
+        QueueOperations, QueueView, RegisterOperations, RegisterView, ScopedView,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -38,9 +37,9 @@ pub struct ChainStateView<C> {
 
     /// Hashes of all certified blocks for this sender.
     /// This ends with `block_hash` and has length `usize::from(next_block_height)`.
-    pub confirmed_log: ScopedView<3, AppendOnlyLogView<C, HashValue>>,
+    pub confirmed_log: ScopedView<3, LogView<C, HashValue>>,
     /// Hashes of all certified blocks known as a receiver (local ordering).
-    pub received_log: ScopedView<4, AppendOnlyLogView<C, HashValue>>,
+    pub received_log: ScopedView<4, LogView<C, HashValue>>,
 
     /// Communication state of applications.
     pub communication_states:
@@ -59,7 +58,7 @@ impl_view!(
     RegisterOperations<ExecutionState>,
     RegisterOperations<Option<HashValue>>,
     RegisterOperations<ChainTipState>,
-    AppendOnlyLogOperations<HashValue>,
+    LogOperations<HashValue>,
     CollectionOperations<ApplicationId>,
     CommunicationStateViewContext,
 );

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -5,7 +5,7 @@ use crate::{
     hash::HashingContext,
     localstack,
     views::{
-        AppendOnlyLogOperations, CollectionOperations, Context, MapOperations, QueueOperations,
+        CollectionOperations, Context, LogOperations, MapOperations, QueueOperations,
         RegisterOperations, ScopedOperations, ViewError,
     },
 };
@@ -457,7 +457,7 @@ where
 }
 
 #[async_trait]
-impl<E, T> AppendOnlyLogOperations<T> for DynamoDbContext<E>
+impl<E, T> LogOperations<T> for DynamoDbContext<E>
 where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
     E: Clone + Send + Sync,

--- a/linera-views/src/hash.rs
+++ b/linera-views/src/hash.rs
@@ -60,9 +60,9 @@ where
 }
 
 #[async_trait]
-impl<C, T> HashView<C> for AppendOnlyLogView<C, T>
+impl<C, T> HashView<C> for LogView<C, T>
 where
-    C: HashingContext + AppendOnlyLogOperations<T> + Send + Sync,
+    C: HashingContext + LogOperations<T> + Send + Sync,
     T: Send + Sync + Clone + Serialize,
 {
     async fn hash(&mut self) -> Result<<C::Hasher as Hasher>::Output, C::Error> {

--- a/linera-views/src/macros.rs
+++ b/linera-views/src/macros.rs
@@ -46,6 +46,10 @@ where
         $( self.$field.delete(batch).await?; )*
         Ok(())
     }
+
+    fn reset_to_default(&mut self) {
+        $( self.$field.reset_to_default(); )*
+    }
 }
 
 #[$crate::async_trait]

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -4,7 +4,7 @@
 use crate::{
     hash::HashingContext,
     views::{
-        AppendOnlyLogOperations, CollectionOperations, Context, MapOperations, QueueOperations,
+        CollectionOperations, Context, LogOperations, MapOperations, QueueOperations,
         RegisterOperations, ScopedOperations, ViewError,
     },
 };
@@ -150,7 +150,7 @@ where
 }
 
 #[async_trait]
-impl<E, T> AppendOnlyLogOperations<T> for MemoryContext<E>
+impl<E, T> LogOperations<T> for MemoryContext<E>
 where
     T: Clone + Send + Sync + 'static,
     E: Clone + Send + Sync,

--- a/linera-views/src/rocksdb.rs
+++ b/linera-views/src/rocksdb.rs
@@ -4,7 +4,7 @@
 use crate::{
     hash::HashingContext,
     views::{
-        AppendOnlyLogOperations, CollectionOperations, Context, MapOperations, QueueOperations,
+        CollectionOperations, Context, LogOperations, MapOperations, QueueOperations,
         RegisterOperations, ScopedOperations, ViewError,
     },
 };
@@ -241,7 +241,7 @@ where
 }
 
 #[async_trait]
-impl<E, T> AppendOnlyLogOperations<T> for RocksdbContext<E>
+impl<E, T> LogOperations<T> for RocksdbContext<E>
 where
     T: Serialize + DeserializeOwned + Send + Sync + 'static,
     E: Clone + Send + Sync,


### PR DESCRIPTION
The commits are merged into just one.

---------------------------------------------------------

    Formatting work.

    Rename AppendOnlyLogView to LogView.

    Application of cargo fmt.

    Further correction + the renaming.

    More correction.

    Some correction of the comment.

    Put loops into place.

    Restructuration of the lambda + renaming.

    Renaming of need_delete.

    Eliminate unused code.

    More formatting correction.

    Some additional test.

    Correct the AppendOnly for the need_delete.

    eliminate a stored_indices by way of having a need_delete.

    Applying the clippy + fmt.

    Add stronger test checks.

    Some stronger tests.

    Apply clippy and formatting.

    Change of the reading of the data to avoid an error.

    Add one more test and steps toard cleaning this up.

    Address some bug.

    Some more correction.

    Some correction from clippy.

    Update linera-views/src/views.rs
    Co-authored-by: Janito Vaqueiro Ferreira Filho <janito.vff@gmail.com>

    Several more correction and now it should be correct.

    Correct the description.

    Simplification of the remove_entry code.

    Next step.

    Add the reset_to_default to the code.