### PR TITLE
make RegisterOperation::set accept a reference

### DIFF
--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -468,8 +468,8 @@ where
         Ok(value)
     }
 
-    async fn set(&mut self, batch: &mut Self::Batch, value: T) -> Result<(), Self::Error> {
-        self.put_item_batch(batch, &(), &value);
+    async fn set(&mut self, batch: &mut Self::Batch, value: &T) -> Result<(), Self::Error> {
+        self.put_item_batch(batch, &(), value);
         Ok(())
     }
 

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -144,9 +144,9 @@ where
             .await)
     }
 
-    async fn set(&mut self, _batch: &mut Self::Batch, value: T) -> Result<(), MemoryViewError> {
+    async fn set(&mut self, _batch: &mut Self::Batch, value: &T) -> Result<(), MemoryViewError> {
         let mut map = self.map.write().await;
-        map.insert(self.base_key.clone(), Box::new(value));
+        map.insert(self.base_key.clone(), Box::new(value.clone()));
         Ok(())
     }
 

--- a/linera-views/src/rocksdb.rs
+++ b/linera-views/src/rocksdb.rs
@@ -254,8 +254,8 @@ where
         Ok(value)
     }
 
-    async fn set(&mut self, batch: &mut Self::Batch, value: T) -> Result<(), RocksdbViewError> {
-        batch.write_key(self.base_key.clone(), &value)?;
+    async fn set(&mut self, batch: &mut Self::Batch, value: &T) -> Result<(), RocksdbViewError> {
+        batch.write_key(self.base_key.clone(), value)?;
         Ok(())
     }
 

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -162,7 +162,7 @@ pub trait RegisterOperations<T>: Context {
     async fn get(&mut self) -> Result<T, Self::Error>;
 
     /// Set the value in the register. Crash-resistant implementations should only write to `batch`.
-    async fn set(&mut self, batch: &mut Self::Batch, value: T) -> Result<(), Self::Error>;
+    async fn set(&mut self, batch: &mut Self::Batch, value: &T) -> Result<(), Self::Error>;
 
     /// Delete the register. Crash-resistant implementations should only write to `batch`.
     async fn delete(&mut self, batch: &mut Self::Batch) -> Result<(), Self::Error>;
@@ -193,14 +193,14 @@ where
 
     async fn commit(mut self, batch: &mut C::Batch) -> Result<(), C::Error> {
         if let Some(value) = self.update {
-            self.context.set(batch, value).await?;
+            self.context.set(batch, &value).await?;
         }
         Ok(())
     }
 
     async fn flush(&mut self, batch: &mut C::Batch) -> Result<(), C::Error> {
         if let Some(value) = self.update.take() {
-            self.context.set(batch, value.clone()).await?;
+            self.context.set(batch, &value).await?;
             self.stored_value = value;
         }
         Ok(())


### PR DESCRIPTION
The goal is to avoid cloning in `flush` (at least for production databases) so that we can merge `flush` and `commit`.