### PR TITLE
Refactorization of the memory/rocksdb/dynamo_db code

### DIFF
--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -329,7 +329,7 @@ where
         &self.extra
     }
 
-    fn get_base_key(&self) -> Vec<u8> {
+    fn base_key(&self) -> Vec<u8> {
         self.base_key.clone()
     }
 

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -54,7 +54,7 @@ where
         &self.extra
     }
 
-    fn get_base_key(&self) -> Vec<u8> {
+    fn base_key(&self) -> Vec<u8> {
         self.base_key.clone()
     }
 

--- a/linera-views/src/rocksdb.rs
+++ b/linera-views/src/rocksdb.rs
@@ -159,7 +159,7 @@ where
         &self.extra
     }
 
-    fn get_base_key(&self) -> Vec<u8> {
+    fn base_key(&self) -> Vec<u8> {
         self.base_key.clone()
     }
 


### PR DESCRIPTION
Several decisions were made:
* Introduction of `get_sub_keys` / `find_keys_with_prefix`. One is from rocksdb the other from dynamodb. There is use case for both so now all provide it. Also we want to avoid doing bcs in *Operations code. And of course we want to avoid deserializing just to serialize just after.
* No further restructuration of code like Rocksdb. Possibly we can collapse the hierarchy but maybe for another PR.
* In Rocksdb the `get_sub_keys` depends on the `find_keys_with_prefix` which is suboptimal. We should build just one Vector. But I had a problem with threads and so this is better left for another day.
* The `MapOperations` and similar were just changed to depend on a generic context. This simplified the needed code change. Not sure what would have been best.

 