### PR TITLE
Update `Swatinem/rust-cache` GitHub Action to v2

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -20,7 +20,7 @@ jobs:
         toolchain: 1.64.0
     - name: Report warnings as errors
       run: echo 'RUSTFLAGS=-D warnings' >> $GITHUB_ENV
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --locked
     - name: Setup local DynamoDB instance

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -19,7 +19,7 @@ jobs:
           toolchain: 1.64.0
       - name: Report warnings as errors
         run: echo 'RUSTFLAGS=-D warnings' >> $GITHUB_ENV
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Build binaries
         run: cargo build --release --locked --bin client --bin proxy --bin server
       - name: Install Kind

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
         components: clippy, rustfmt
     - name: Report warnings as errors
       run: echo 'RUSTFLAGS=-D warnings' >> $GITHUB_ENV
-    - uses: Swatinem/rust-cache@v1
+    - uses: Swatinem/rust-cache@v2
     - name: Build
       run: cargo build --locked
     - name: Run tests


### PR DESCRIPTION
# Motivation

CI has been showing some warnings related to deprecated calls when using the [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) action. A new major version was released that might fix those issues, ~~and possibly make the CI builds faster because it seems to have tweaked the caching mechanism~~.

# Solution

Use the latest major version currently available.