### PR TITLE
Change Docker images to use Ubuntu as base

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11 as base
+FROM ubuntu:22.04 as base
 
 RUN apt-get update && apt-get install -y curl
 
@@ -8,7 +8,7 @@ COPY fetch-config-file.sh /opt/zefchain/
 
 WORKDIR /opt/zefchain
 
-FROM debian:11 as setup
+FROM ubuntu:22.04 as setup
 
 RUN apt-get update && apt-get install -y mini-httpd
 


### PR DESCRIPTION
# Motivation

The Kubernetes GitHub Action workflow is currently failing due to a mismatch in the version of `glibc`. This happens because the binaries are first built in the Ubuntu system and then moved into Docker containers based on Debian 11.

# Solution

Update the Docker images to be based on Ubuntu so that the same version of `glibc` is used.