### PR TITLE
Logs aren't printed if Kubernetes CI workflow fails

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -53,10 +53,13 @@ jobs:
         run: |
           kubectl wait --for condition=Complete --timeout 180s job/client
       - name: Print client test logs
+        if: always()
         run: |
           kubectl logs --tail 500 -l app=client
       - name: Clean cluster
+        if: always()
         run: |
           kubectl delete -f docker/zefchain-k8s.yml
       - name: Delete cluster
+        if: always()
         run: kind delete cluster


### PR DESCRIPTION
# Motivation

There were a few recent failures in the Kubernetes CI workflow, and it was hard to debug because the logs are only printed if the job succeeds.

# Solution

Ensure that the final steps are always executed, so that the logs are printed (if any) and the environment is cleaned up if needed.