### PR TITLE
chore: pre-push git hook

### DIFF
--- a/install_hooks.sh
+++ b/install_hooks.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 if cat <<EOF > $SCRIPT_DIR/.git/hooks/pre-push
 #!/bin/sh
 #
-# This precommit runs a cargo-clippy and cargo +nightly fmt before making a commit.
+# This pre-push hook runs a cargo-clippy and cargo +nightly fmt before pushing code to remote.
 # This is to prevent commits being pushed which will fail CI.
 
 cargo clippy --all-targets || { echo "Error: clippy did not pass - aborting push. Please run 'cargo clippy --all-targets'." ; exit 1 ; }


### PR DESCRIPTION
The motivation here is that I've pushed code one too many times where either forgot to run clippy or format. I don't want to run these checks every time I commit - but I do want to do this before I push. This script installs a pre-push hook that will automatically run the checks for you - we could optionally also have it perform the formatting but I thought it would be better if the hooks didn't touch code and instead acted as a safeguard. We might also like to run `cargo test` as well.

If you have the hook installed but you are in a hurry - you can run `git push --no-verify` which will skip the checks.

