### PR TITLE
Reorder CI steps to fail faster

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,14 +24,14 @@ jobs:
     - name: Report warnings as errors
       run: echo 'RUSTFLAGS=-D warnings' >> $GITHUB_ENV
     - uses: Swatinem/rust-cache@v2
+    - name: Rustfmt
+      run: cargo fmt -- --check --config unstable_features=true --config imports_granularity=Crate
+    - name: Clippy
+      run: cargo clippy --all-targets
     - name: Build
       run: cargo build --locked
     - name: Run tests
       run: cargo test --locked
-    - name: Clippy
-      run: cargo clippy --all-targets
-    - name: Rustfmt
-      run: cargo fmt -- --check --config unstable_features=true --config imports_granularity=Crate
 
   check-for-unused-dependencies:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivation

CI currently takes quite a bit of time, and sometimes it fails on the short linting steps after successfully passing the long testing steps.

# Solution

Run the linting steps first so that the longer steps are only executed if the fast steps succeed.