### PR TITLE
Merged the gRPC Proxy and the Simple Proxy under a single binary

### DIFF
--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -54,7 +54,3 @@ path = "src/server.rs"
 [[bin]]
 name = "proxy"
 path = "src/proxy.rs"
-
-[[bin]]
-name = "grpc-proxy"
-path = "src/grpc_proxy.rs"

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -5,4 +5,5 @@
 #![deny(warnings)]
 
 pub mod config;
+pub mod grpc_proxy;
 pub mod storage;

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -1,13 +1,17 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use futures::{future::BoxFuture, FutureExt, SinkExt, StreamExt};
 use linera_rpc::{
     config::{
-        NetworkProtocol, ShardConfig, ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig,
+        NetworkProtocol, ShardConfig, ValidatorInternalNetworkPreConfig,
+        ValidatorPublicNetworkPreConfig,
     },
-    transport::MessageHandler,
+    transport::{MessageHandler, TransportProtocol},
     Message,
 };
-use linera_service::config::{Import, ValidatorServerConfig};
+use linera_service::{
+    config::{Import, ValidatorServerConfig},
+    grpc_proxy::GrpcProxy,
+};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -22,13 +26,66 @@ pub struct ProxyOptions {
     config_path: PathBuf,
 }
 
-#[derive(Clone)]
-pub struct Proxy {
-    public_config: ValidatorPublicNetworkConfig,
-    internal_config: ValidatorInternalNetworkConfig,
+/// A Linera Proxy, either gRPC or over 'Simple Transport', meaning TCP or UDP.
+/// The proxy can be configured to have a gRPC ingress and egress, or a combination
+/// of TCP / UDP ingress and egress.
+enum Proxy {
+    Simple(SimpleProxy),
+    Grpc(GrpcProxy),
 }
 
-impl MessageHandler for Proxy {
+impl Proxy {
+    /// Run the proxy.
+    async fn run(self) -> Result<()> {
+        match self {
+            Proxy::Simple(simple_proxy) => simple_proxy.run().await,
+            Proxy::Grpc(grpc_proxy) => grpc_proxy.run().await,
+        }
+    }
+
+    /// Constructs and configures the [`Proxy`] given [`ProxyOptions`].
+    fn from_options(options: ProxyOptions) -> Result<Self> {
+        let config = ValidatorServerConfig::read(&options.config_path)?;
+        let internal_protocol = config.internal_network.protocol;
+        let external_protocol = config.validator.network.protocol;
+
+        let proxy = match (internal_protocol, external_protocol) {
+            (NetworkProtocol::Grpc, NetworkProtocol::Grpc) => Self::Grpc(GrpcProxy::new(
+                config.validator.network,
+                config.internal_network,
+            )),
+            (
+                NetworkProtocol::Simple(internal_transport),
+                NetworkProtocol::Simple(public_transport),
+            ) => Self::Simple(SimpleProxy {
+                internal_config: config
+                    .internal_network
+                    .clone_with_protocol(internal_transport),
+                public_config: config
+                    .validator
+                    .network
+                    .clone_with_protocol(public_transport),
+            }),
+            _ => {
+                bail!(
+                    "network protocol mismatch: cannot have {} and {} ",
+                    internal_protocol,
+                    external_protocol,
+                );
+            }
+        };
+
+        Ok(proxy)
+    }
+}
+
+#[derive(Clone)]
+pub struct SimpleProxy {
+    public_config: ValidatorPublicNetworkPreConfig<TransportProtocol>,
+    internal_config: ValidatorInternalNetworkPreConfig<TransportProtocol>,
+}
+
+impl MessageHandler for SimpleProxy {
     fn handle_message(&mut self, message: Message) -> BoxFuture<Option<Message>> {
         let shard = self.select_shard_for(&message);
         let protocol = self.internal_config.protocol;
@@ -50,18 +107,16 @@ impl MessageHandler for Proxy {
     }
 }
 
-impl Proxy {
+impl SimpleProxy {
     async fn run(self) -> Result<()> {
         let address = format!("0.0.0.0:{}", self.public_config.port);
-        match self.public_config.protocol {
-            NetworkProtocol::Simple(protocol) => {
-                protocol.spawn_server(&address, self).await?.join().await?;
-            }
-            NetworkProtocol::Grpc => {
-                unimplemented!()
-            }
-        }
-
+        log::info!("Starting simple proxy on {}...", &address);
+        self.public_config
+            .protocol
+            .spawn_server(&address, self)
+            .await?
+            .join()
+            .await?;
         Ok(())
     }
 
@@ -85,13 +140,9 @@ impl Proxy {
     async fn try_proxy_message(
         message: Message,
         shard: ShardConfig,
-        protocol: NetworkProtocol,
+        protocol: TransportProtocol,
     ) -> Result<Option<Message>> {
         let shard_address = format!("{}:{}", shard.host, shard.port);
-        let protocol = match protocol {
-            NetworkProtocol::Simple(protocol) => protocol,
-            NetworkProtocol::Grpc => todo!(),
-        };
 
         let mut connection = protocol.connect(shard_address).await?;
         connection.send(message).await?;
@@ -106,15 +157,11 @@ async fn main() -> Result<()> {
         .format_timestamp_millis()
         .init();
 
-    let options = ProxyOptions::from_args();
-    let config = ValidatorServerConfig::read(&options.config_path)?;
+    log::info!("Initialising proxy...");
 
-    let handler = Proxy {
-        public_config: config.validator.network,
-        internal_config: config.internal_network,
-    };
+    let proxy = Proxy::from_options(ProxyOptions::from_args())?;
 
-    if let Err(error) = handler.run().await {
+    if let Err(error) = proxy.run().await {
         log::error!("Failed to run proxy: {error}");
     }
 

--- a/linera-service/tests/test_readme.rs
+++ b/linera-service/tests/test_readme.rs
@@ -46,7 +46,6 @@ fn test_examples_in_readme_grpc() -> std::io::Result<()> {
 
     quote = quote.replace("tcp", "grpc");
     quote = quote.replace("udp", "grpc");
-    quote = quote.replace("./proxy", "./grpc-proxy");
     quote = quote.replace("# END_GRPC", "exit 0;");
 
     let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;


### PR DESCRIPTION
The two proxy implementations are now under a single binary.

This meant adding a new `Proxy` enum and doing some slight refactoring to the new `SimpleProxy` so that it is instantiated with a `TransportProtocol` instead of a `NetworkProtocol` (thus not having to do explicit matches every time you want the underlying transport).