### PR TITLE
Fix session data update when WASM application handles `call_session`

### DIFF
--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -13,12 +13,16 @@ use linera_base::{
     messages::{ApplicationId, BlockHeight, BytecodeId, ChainId, Destination, EffectId},
 };
 
-impl From<contract::SessionCallResult> for SessionCallResult {
+impl From<contract::SessionCallResult> for (SessionCallResult, Vec<u8>) {
     fn from(result: contract::SessionCallResult) -> Self {
-        SessionCallResult {
+        let session_call_result = SessionCallResult {
             inner: result.inner.into(),
             close_session: result.data.is_some(),
-        }
+        };
+
+        let updated_session_data = result.data.unwrap_or_default();
+
+        (session_call_result, updated_session_data)
     }
 }
 


### PR DESCRIPTION
# Motivation

`UserApplication::call_session` has a parameter that's a mutable reference to session data. This allows the application to change the session data while handling a session call. For a `WasmApplication`, the data can't be shared between the host and guest WASM runtime, so it has to be moved into the guest runtime and then moved out after execution finishes. However, the retrieved data was not written back to the parameter's reference.

# Solution

Return an opaque `impl Future` from `WasmRuntimeContext::call_session` so that the `GuestFuture` can be placed inside an `async` block. This block can then extract the updated session data after the WASM application has finished handling the session call, and write that data into the session data parameter reference.

# Related issues

Closes #236 .