### PR TITLE
Protoc GH action step now uses the workflow's token to avoid rate limiting

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       run: cargo build --locked
     - name: Setup local DynamoDB instance

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build binaries
         run: cargo build --release --locked --bin client --bin proxy --bin server
       - name: Install Kind

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Rustfmt
       run: cargo fmt -- --check --config unstable_features=true --config imports_granularity=Crate
     - name: Clippy
@@ -46,6 +48,8 @@ jobs:
         toolchain: nightly
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install cargo-udeps
       run: cargo install cargo-udeps --locked
     - name: Check for unused dependencies

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -26,6 +26,8 @@ jobs:
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build example contract
       run: |
         cargo build --target wasm32-unknown-unknown -p linera-sdk --examples


### PR DESCRIPTION
## Motivation

I'm [modifying our CI](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#example-1-passing-the-github_token-as-an-input) to forward a per-workflow token to avoid rate limiting with the Protoc GH action. The action is [OSS](https://github.com/arduino/setup-protoc) and they take security seriously - furthermore the token is not used for any modifications but so the action itself can make requests to the downstream Protoc repo regarding releases.

Workflows have been cancelled until we complete the TODOs. Closes #238.

## TODO

- [x] Verify GitHub Token default permission is set to restrictive. We should be fine any way because actions can have access to the token [even if it is not supplied explicitly](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). We can also [override it explicitly](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions).