### PR TITLE
Wiring push notifications with rest of codebase

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -68,14 +68,14 @@ pub struct NetworkActions {
     pub notifications: Vec<Notification>,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 /// Notify that a chain has a new certified block or a new message.
 pub struct Notification {
     pub chain_id: ChainId,
     pub reason: Reason,
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 #[allow(clippy::large_enum_variant)]
 /// Reason for the notification.
 pub enum Reason {

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -53,9 +53,28 @@ message SubscriptionRequest {
   repeated ChainId chain_ids = 1;
 }
 
-// A notification message that a client should poll a chain.
+// Notify that a chain has a new certified block or a new message.
 message Notification {
   ChainId chain_id = 1;
+  Reason reason = 2;
+}
+
+// Reason for the notification.
+message Reason {
+  oneof inner {
+    NewBlock new_block = 1;
+    NewMessage new_message = 2;
+  }
+}
+
+message NewBlock {
+  BlockHeight height = 1;
+}
+
+message NewMessage {
+  ApplicationId application_id = 1;
+  Origin origin = 2;
+  BlockHeight height = 3;
 }
 
 // A wrapper around ChainInfoResponse which contains a serialized error variant

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -19,6 +19,13 @@ pub struct CrossChainConfig {
     pub(crate) retry_delay_ms: u64,
 }
 
+#[derive(Clone, Debug, StructOpt)]
+pub struct NotificationConfig {
+    /// Number of notifications allowed before blocking the main server loop
+    #[structopt(long = "notification_queue_size", default_value = "1000")]
+    pub(crate) notification_queue_size: usize,
+}
+
 pub type ShardId = usize;
 
 /// The network configuration of a shard.

--- a/linera-rpc/src/pool.rs
+++ b/linera-rpc/src/pool.rs
@@ -3,7 +3,8 @@
 
 use crate::grpc_network::{
     grpc::{
-        validator_node_client::ValidatorNodeClient, validator_worker_client::ValidatorWorkerClient,
+        notifier_service_client::NotifierServiceClient, validator_node_client::ValidatorNodeClient,
+        validator_worker_client::ValidatorWorkerClient,
     },
     GrpcError,
 };
@@ -41,6 +42,15 @@ impl Connect for ValidatorNodeClient<Channel> {
 
     async fn connect(address: Self::Address) -> Result<Self, GrpcError> {
         Ok(ValidatorNodeClient::connect(address).await?)
+    }
+}
+
+#[async_trait]
+impl Connect for NotifierServiceClient<Channel> {
+    type Address = String;
+
+    async fn connect(address: Self::Address) -> Result<Self, GrpcError> {
+        Ok(NotifierServiceClient::connect(address).await?)
     }
 }
 


### PR DESCRIPTION
# Motivation
The infrastructure for Push Notifications has been implemented in the codebase (gRPC services and servers) without the utility of the Push Notifications actually being used anywhere.

# Solution
This PR wires Push Notifications up with the rest of the codebase, expanding on the original `Notification` protobuf messages and expanding `GrpcServer::handle_network_actions` to also forward `Notification`.