### PR TITLE
Add more application calls to fungible token example

### DIFF
--- a/linera-sdk/examples/fungible/contract.rs
+++ b/linera-sdk/examples/fungible/contract.rs
@@ -67,6 +67,9 @@ impl Contract for FungibleToken {
             ApplicationCall::Transfer(transfer) => {
                 result = self.handle_application_transfer(context, transfer)?;
             }
+            ApplicationCall::Delegated(transfer) => {
+                result.execution_result = self.handle_signed_transfer(transfer)?;
+            }
         }
 
         Ok(result)
@@ -242,6 +245,8 @@ pub enum ApplicationCall {
     Balance,
     /// A transfer from the application's account.
     Transfer(ApplicationTransfer),
+    /// A signed transfer operation delegated to the application.
+    Delegated(SignedTransfer),
 }
 
 /// A cross-application transfer request.


### PR DESCRIPTION
# Motivation

While developing a crowd-funding application (issue #336), and I ran into two shortcomings. The first was that I wasn't able to read the application's balance. The second was that I wasn't able to link transfers to the token application to pledges in the crowd-funding application. One way around this would be to allow other applications to send funds from user accounts.

# Solution

Create an `ApplicationCall` enumeration with different requests other applications can make to the token application. Besides the original request to transfer funds from the application's account, it's now possible to query the application's balance and to send delegated transfers.