### PR TITLE
Support publishing bytecode repeatedly on the same chain

### DIFF
--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -55,7 +55,7 @@ where
     publisher.receive_certificate(cert).await.unwrap();
     publisher.process_inbox().await.unwrap();
 
-    let (bytecode_id, _) = publisher
+    let (bytecode_id, cert) = publisher
         .publish_bytecode(
             Bytecode::load_from_file(
                 "../target/wasm32-unknown-unknown/release/examples/counter_contract.wasm",
@@ -68,6 +68,9 @@ where
         )
         .await
         .unwrap();
+    // Receive our own cert to broadcast the bytecode location.
+    publisher.receive_certificate(cert).await.unwrap();
+    publisher.process_inbox().await.unwrap();
 
     creator.synchronize_and_recompute_balance().await.unwrap();
     creator.process_inbox().await.unwrap();

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -146,6 +146,19 @@ where
         Ok(())
     }
 
+    /// Returns all the known locations of published bytecode.
+    pub async fn bytecode_locations(
+        &mut self,
+    ) -> Result<Vec<(BytecodeId, BytecodeLocation)>, SystemExecutionError> {
+        let mut locations = Vec::new();
+        for id in self.published_bytecodes.indices().await? {
+            if let Some(location) = self.published_bytecodes.get(&id).await? {
+                locations.push((id, location));
+            }
+        }
+        Ok(locations)
+    }
+
     /// Register an existing application.
     ///
     /// Keeps track of an existing application that the current chain is seeing for the first time.

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -524,12 +524,20 @@ SystemEffect:
     5:
       BytecodePublished: UNIT
     6:
+      BytecodeLocations:
+        STRUCT:
+          - locations:
+              SEQ:
+                TUPLE:
+                  - TYPENAME: BytecodeId
+                  - TYPENAME: BytecodeLocation
+    7:
       RegisterApplications:
         STRUCT:
           - applications:
               SEQ:
                 TYPENAME: UserApplicationDescription
-    7:
+    8:
       Notify:
         STRUCT:
           - id:

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -219,7 +219,7 @@ where
         Ok(())
     }
 
-    /// Execute a function on each index seralization. The order is in which values
+    /// Execute a function on each index serialization. The order is in which values
     /// are passed is not the one of the index but its serialization. However said
     /// order will always be the same
     pub async fn for_each_raw_index_value<F>(&self, mut f: F) -> Result<(), ViewError>


### PR DESCRIPTION
The solution is for the publisher to make two blocks:
* one to upload the bytecode (and schedule a message to self)
* one to broadcast the entire set of bytecode locations