### PR TITLE
Removed unecessary creation of flushing futures which are never used

### DIFF
--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -239,10 +239,6 @@ where
                 .await
                 .expect("sinks are never closed so call to `feed` should not fail");
         }
-
-        // TODO(#293): Explain why we need these (without .await) or simplify the code.
-        let _ = cross_chain_sender.flush();
-        let _ = notification_sender.flush();
     }
 
     async fn forward_cross_chain_queries(


### PR DESCRIPTION
# Motivation

While creating the gRPC implementation of our networking some futures concerning flushing were created that were never actually consumed.

# Solution

We can simple remove the creation of the future. They are basically a no-op so there is no functional change here. 

# Future work

The `mpsc` channels used forward network actions use `feed` instead of `send` as `send` ends up blocking the tests. It is not clear why this is happening and even though this works - we should try to understand what is really happening here.

