### PR TITLE
Change API `CollectionView::load_entry(&self)` introduced in #402 

### DIFF
--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -56,9 +56,7 @@ pub enum ViewError {
     #[error("failed to serialize value to calculate its hash")]
     Serialization(#[from] bcs::Error),
 
-    #[error(
-        "trying to flush or delete a collection view while some entries are still being accessed"
-    )]
+    #[error("trying to access a collection view while some entries are still being accessed")]
     CannotAcquireCollectionEntry,
 
     #[error("IO error")]


### PR DESCRIPTION
Of course, I was too quick closing #402 and should have written unit tests:
* This PR changes `CollectionView::load_entry` into `try_load_entry` because we don't really want to debug deadlock in our applications. Note: I don't see how we can do better. The issue is related to lifetimes and would be the same with `DashMap`.
* Adds missing unit tests for #402