### PR TITLE
Implement `get_mut` for `MapView`

### DIFF
--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -157,7 +157,6 @@ where
         Ok(self.context.read_key(&key).await?)
     }
 
-
     async fn load_value(&mut self, short_key: &[u8]) -> Result<(), ViewError> {
         if !self.was_cleared && !self.updates.contains_key(short_key) {
             let key = self.context.base_tag_index(KeyTag::Index as u8, short_key);
@@ -180,7 +179,7 @@ where
             };
             return Ok(value);
         }
-        return Ok(None);
+        Ok(None)
     }
 
     /// Return the list of indices in the map.

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -536,13 +536,21 @@ where
         {
             let mut view = store.load(1).await.unwrap();
             view.map.insert(&"Konnichiwa".to_string(), 5).unwrap();
-            let value = view.map.get_mut(&"Konnichiwa".to_string()).await.unwrap().unwrap();
+            let value = view
+                .map
+                .get_mut(&"Konnichiwa".to_string())
+                .await
+                .unwrap()
+                .unwrap();
             *value = 6;
             view.save().await.unwrap();
         }
         {
             let view = store.load(1).await.unwrap();
-            assert_eq!(view.map.get(&"Konnichiwa".to_string()).await.unwrap(), Some(6));
+            assert_eq!(
+                view.map.get(&"Konnichiwa".to_string()).await.unwrap(),
+                Some(6)
+            );
         }
     }
     {


### PR DESCRIPTION
This actually comes from practical experience with smart contracts.
We may want to get a value as a `&mut T` for editing it instead of having some `get/insert` pattern.

This address one issue mentioned in #234 