### PR TITLE
Removed #![deny(Warnings)] from linera-service

### DIFF
--- a/linera-service/src/client.rs
+++ b/linera-service/src/client.rs
@@ -2,8 +2,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![deny(warnings)]
-
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::StreamExt;

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -2,8 +2,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![deny(warnings)]
-
 pub mod config;
 pub mod grpc_proxy;
 pub mod node_service;

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -2,8 +2,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![deny(warnings)]
-
 use anyhow::{anyhow, ensure};
 use async_trait::async_trait;
 use futures::future::join_all;


### PR DESCRIPTION
# Motivation

 It's quite frustrating not compiling with warnings during development, and what I usually do is comment it out during development and then remember to un-comment it before committing.

# Solution

Remove `#![deny(Warnings)]` from `linera-service`, instead catching unused warnings in CI given the `RUSTFLAGS: "-D warnings"` `env` variable.