### PR TITLE
Reduce bytecode sizes in `linera-examples`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Build example applications
       run: |
         cd linera-examples
-        RUSTFLAGS="-C opt-level=z -C debuginfo=0" cargo build --release --target wasm32-unknown-unknown
+        cargo build --release --target wasm32-unknown-unknown
     - name: Compile the workspace with the default features (test)
       run: |
         cargo test --locked --no-run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Some tests require the application examples from `linera-examples` to be compile
 can be done manually with
 ```
 cd linera-examples
-RUSTFLAGS="-C opt-level=z -C debuginfo=0" cargo build --release --target wasm32-unknown-unknown
+cargo build --release --target wasm32-unknown-unknown
 ```
 The Rust flags are suggested to reduce the size of the WASM bytecodes.
 

--- a/linera-examples/Cargo.toml
+++ b/linera-examples/Cargo.toml
@@ -11,6 +11,9 @@ members = [
 
 [profile.release]
 debug = true
+lto = true
+opt-level = 'z'
+strip = 'debuginfo'
 
 [profile.bench]
 debug = true

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -246,7 +246,6 @@ pub mod test {
         log::info!("Building example applications with cargo");
         let status = std::process::Command::new("cargo")
             .current_dir("../linera-examples")
-            .env("RUSTFLAGS", "-C opt-level=z -C debuginfo=0")
             .args(["build", "--release", "--target", "wasm32-unknown-unknown"])
             .status()?;
         assert!(status.success());


### PR DESCRIPTION
Changes to the workspace reduce bytecode size in linera-examples from 95%-99%.

```
Before: 
5.3M Feb 20 20:33 counter2_contract.wasm*
4.6M Feb 20 20:33 counter2_service.wasm*
4.1M Feb 20 20:33 counter_contract.wasm*
3.5M Feb 20 20:33 counter_service.wasm*
 12M Feb 20 20:33 crowd-funding2_contract.wasm*
9.3M Feb 20 20:33 crowd-funding2_service.wasm*
 11M Feb 20 20:33 crowd-funding_contract.wasm*
8.2M Feb 20 20:33 crowd-funding_service.wasm*
 12M Feb 20 20:33 fungible2_contract.wasm*
8.9M Feb 20 20:33 fungible2_service.wasm*
9.7M Feb 20 20:33 fungible_contract.wasm*
8.2M Feb 20 20:33 fungible_service.wasm*
4.2M Feb 20 20:33 meta_counter_contract.wasm*
3.6M Feb 20 20:33 meta_counter_service.wasm*

After: 
118K Feb 20 20:35 counter2_contract.wasm*
 65K Feb 20 20:35 counter2_service.wasm*
 96K Feb 20 20:35 counter_contract.wasm*
 45K Feb 20 20:35 counter_service.wasm*
249K Feb 20 20:35 crowd-funding2_contract.wasm*
130K Feb 20 20:35 crowd-funding2_service.wasm*
198K Feb 20 20:35 crowd-funding_contract.wasm*
 99K Feb 20 20:35 crowd-funding_service.wasm*
265K Feb 20 20:35 fungible2_contract.wasm*
112K Feb 20 20:35 fungible2_service.wasm*
228K Feb 20 20:35 fungible_contract.wasm*
100K Feb 20 20:35 fungible_service.wasm*
109K Feb 20 20:35 meta_counter_contract.wasm*
 53K Feb 20 20:35 meta_counter_service.wasm*
```