### PR TITLE
App explorer with GraphQLView

### DIFF
--- a/linera-examples/Cargo.lock
+++ b/linera-examples/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
  "futures",
  "hex",
  "linera-sdk",
- "serde",
+ "linera-views",
  "serde_json",
  "thiserror",
  "webassembly-test",

--- a/linera-examples/counter-graphql/Cargo.toml
+++ b/linera-examples/counter-graphql/Cargo.toml
@@ -11,7 +11,7 @@ bcs = "0.1.3"
 futures = "0.3.17"
 hex = "0.4.3"
 linera-sdk = { path = "../../linera-sdk" }
-serde = { version = "1.0.130", features = ["derive"] }
+linera-views = { path = "../../linera-views" }
 serde_json = "1.0.93"
 thiserror = "1.0.31"
 

--- a/linera-examples/counter-graphql/src/state.rs
+++ b/linera-examples/counter-graphql/src/state.rs
@@ -1,10 +1,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Deserialize, Serialize};
+use linera_views::{
+    common::Context,
+    register_view::RegisterView,
+    views::{GraphQLView, RootView, View},
+};
 
 /// The application state.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct Counter {
-    pub value: u128,
+#[derive(RootView, GraphQLView, Debug)]
+pub struct Counter<C> {
+    pub value: RegisterView<C, u64>,
 }

--- a/linera-examples/counter/src/service.rs
+++ b/linera-examples/counter/src/service.rs
@@ -8,6 +8,7 @@ mod state;
 use self::state::Counter;
 use async_trait::async_trait;
 use linera_sdk::{QueryContext, Service, SimpleStateStorage};
+use std::sync::Arc;
 use thiserror::Error;
 
 linera_sdk::service!(Counter);
@@ -18,7 +19,7 @@ impl Service for Counter {
     type Storage = SimpleStateStorage<Self>;
 
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         _context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error> {
@@ -42,12 +43,13 @@ mod tests {
     use super::{Counter, Error};
     use futures::FutureExt;
     use linera_sdk::{ChainId, QueryContext, Service};
+    use std::sync::Arc;
     use webassembly_test::webassembly_test;
 
     #[webassembly_test]
     fn query() {
         let value = 61_098_721_u128;
-        let counter = Counter { value };
+        let counter = Arc::new(Counter { value });
 
         let result = counter
             .query_application(&dummy_query_context(), &[])
@@ -63,7 +65,7 @@ mod tests {
     #[webassembly_test]
     fn invalid_query() {
         let value = 4_u128;
-        let counter = Counter { value };
+        let counter = Arc::new(Counter { value });
 
         let dummy_argument = [2];
         let result = counter

--- a/linera-examples/counter2/src/service.rs
+++ b/linera-examples/counter2/src/service.rs
@@ -6,6 +6,7 @@
 mod state;
 
 use self::state::Counter;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use linera_sdk::{
@@ -28,7 +29,7 @@ where
     type Storage = ViewStateStorage<Self>;
 
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         _context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error> {
@@ -55,6 +56,7 @@ mod tests {
     use futures_util::FutureExt;
     use linera_sdk::{ChainId, QueryContext, Service};
     use linera_views::{memory::get_memory_context, views::View};
+    use std::sync::Arc;
     use webassembly_test::webassembly_test;
 
     #[webassembly_test]
@@ -68,6 +70,7 @@ mod tests {
             .unwrap()
             .expect("Failed to load Counter");
         counter.value.set(value);
+        let counter = Arc::new(counter);
         let result = counter
             .query_application(&dummy_query_context(), &[])
             .now_or_never()
@@ -90,6 +93,7 @@ mod tests {
             .unwrap()
             .expect("Failed to load Counter");
         counter.value.set(value);
+        let counter = Arc::new(counter);
 
         let dummy_argument = [2];
         let result = counter

--- a/linera-examples/crowd-funding/src/service.rs
+++ b/linera-examples/crowd-funding/src/service.rs
@@ -9,6 +9,7 @@ use self::state::CrowdFunding;
 use async_trait::async_trait;
 use linera_sdk::{QueryContext, Service, SimpleStateStorage};
 use serde::Deserialize;
+use std::sync::Arc;
 use thiserror::Error;
 
 linera_sdk::service!(CrowdFunding);
@@ -19,7 +20,7 @@ impl Service for CrowdFunding {
     type Storage = SimpleStateStorage<Self>;
 
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         _context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error> {

--- a/linera-examples/crowd-funding2/src/service.rs
+++ b/linera-examples/crowd-funding2/src/service.rs
@@ -13,6 +13,7 @@ use linera_sdk::{
 };
 use linera_views::{common::Context, views::ViewError};
 use serde::Deserialize;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// Alias to the application type, so that the boilerplate module can reference it.
@@ -29,7 +30,7 @@ where
     type Storage = ViewStateStorage<Self>;
 
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         _context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error> {

--- a/linera-examples/fungible/src/service.rs
+++ b/linera-examples/fungible/src/service.rs
@@ -8,6 +8,7 @@ mod state;
 use self::state::FungibleToken;
 use async_trait::async_trait;
 use linera_sdk::{QueryContext, Service, SimpleStateStorage};
+use std::sync::Arc;
 use thiserror::Error;
 
 linera_sdk::service!(FungibleToken);
@@ -18,7 +19,7 @@ impl Service for FungibleToken {
     type Storage = SimpleStateStorage<Self>;
 
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         _context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error> {

--- a/linera-examples/fungible2/src/service.rs
+++ b/linera-examples/fungible2/src/service.rs
@@ -7,6 +7,7 @@ mod state;
 
 use self::state::FungibleToken;
 use linera_views::common::Context;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use linera_sdk::{
@@ -28,7 +29,7 @@ where
     type Storage = ViewStateStorage<Self>;
 
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         _context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error> {

--- a/linera-examples/meta-counter/src/service.rs
+++ b/linera-examples/meta-counter/src/service.rs
@@ -8,6 +8,7 @@ mod state;
 use self::state::MetaCounter;
 use async_trait::async_trait;
 use linera_sdk::{service::system_api, ApplicationId, QueryContext, Service, SimpleStateStorage};
+use std::sync::Arc;
 use thiserror::Error;
 
 linera_sdk::service!(MetaCounter);
@@ -25,7 +26,7 @@ impl Service for MetaCounter {
     type Storage = SimpleStateStorage<Self>;
 
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         _context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error> {

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -14,7 +14,7 @@ use async_trait::async_trait;
 use custom_debug_derive::Debug;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use std::{error::Error, fmt};
+use std::{error::Error, fmt, sync::Arc};
 
 pub use self::{
     exported_future::ExportedFuture,
@@ -99,7 +99,7 @@ pub trait Service {
     /// Allow an end user to execute read-only queries on the state of this application.
     /// NOTE: This is not meant to be metered and may not be exposed by validators.
     async fn query_application(
-        &self,
+        self: Arc<Self>,
         context: &QueryContext,
         argument: &[u8],
     ) -> Result<Vec<u8>, Self::Error>;

--- a/linera-sdk/src/service/system_api.rs
+++ b/linera-sdk/src/service/system_api.rs
@@ -107,7 +107,7 @@ pub async fn lock_and_load_view<State: View<ReadableWasmContext>>() -> State {
 }
 
 /// Load the service state, without locking it for writes.
-pub async fn unlock_view<State: View<ReadableWasmContext>>(_state: State) {
+pub async fn unlock_view() {
     let future = system::Unlock::new();
     future::poll_fn(|_context| future.poll().into()).await;
 }


### PR DESCRIPTION
# Motivation

Since we have enabled users to query applications with GraphQL, we now need a way to make it easy to users to generate GraphQL Objects from their state. 

# Solution

First, a `async_graphql::Schema` needs to own the underlying query root. For this reason we update the definition of `Service::query_application` to take `self: Arc<Self>` instead of just `self`.

Next, we update the `counter-graphql` example to use `#[derive(GraphQLView)` and implement a correct yet naive implementation of `query_application` which simply deserializes bytes into a `GraphQLQuery` and executes it's, serializing the response.

# Next steps

The code required to execute the query in the `Service` is trivial and we can code generate to provide a better user experience. The next steps here are introducing `linera-sdk-derive` which will define a `#[derive(GraphQLService)]` macro allowing users to opt-in to automating GraphQL service creation while giving them the flexibility to create custom implementations if they so choose.