### PR TITLE
Made specifying a ChainID in the core GraphQL APIs optional

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -164,8 +164,9 @@ where
     /// Obtain a `ChainStateView` for a given `ChainId`.
     pub async fn chain_state_view(
         &self,
-        chain_id: ChainId,
+        chain_id: Option<ChainId>,
     ) -> Result<Arc<ChainStateView<S::Context>>, NodeError> {
+        let chain_id = chain_id.unwrap_or(self.chain_id);
         let chain_state_view = self
             .node_client
             .storage_client()

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -80,11 +80,17 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
-    async fn chain(&self, chain_id: ChainId) -> Result<Arc<ChainStateView<S::Context>>, Error> {
+    async fn chain(
+        &self,
+        chain_id: Option<ChainId>,
+    ) -> Result<Arc<ChainStateView<S::Context>>, Error> {
         Ok(self.0.lock().await.chain_state_view(chain_id).await?)
     }
 
-    async fn applications(&self, chain_id: ChainId) -> Result<Vec<ApplicationOverview>, Error> {
+    async fn applications(
+        &self,
+        chain_id: Option<ChainId>,
+    ) -> Result<Vec<ApplicationOverview>, Error> {
         let applications = self
             .0
             .lock()


### PR DESCRIPTION
# Motivation

ChainIDs are long and hard to remember. Especially when specifying them as query strings.


# Solutions

An easy win while we address the issue of long IDs more holistically is to make the specification of ChainIDs optional, with the `null` value defaulting to the ChainID of the current context (i.e. the ChainID of the client).