### PR TITLE
Make MemoryStore handle Wasm runtime options like the other stores

### DIFF
--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -29,7 +29,10 @@ use crate::client::client_tests::MakeDynamoDbStoreClient;
 
 #[test(tokio::test)]
 async fn test_memory_create_application() -> Result<(), anyhow::Error> {
-    run_test_create_application(MakeMemoryStoreClient).await
+    for &wasm_runtime in WasmRuntime::ALL {
+        run_test_create_application(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime)).await?
+    }
+    Ok(())
 }
 
 #[test(tokio::test)]
@@ -117,7 +120,13 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_run_application_with_dependency() -> Result<(), anyhow::Error> {
-    run_test_run_application_with_dependency(MakeMemoryStoreClient).await
+    for &wasm_runtime in WasmRuntime::ALL {
+        run_test_run_application_with_dependency(MakeMemoryStoreClient::with_wasm_runtime(
+            wasm_runtime,
+        ))
+        .await?
+    }
+    Ok(())
 }
 
 #[test(tokio::test)]
@@ -241,7 +250,10 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_cross_chain_message() -> Result<(), anyhow::Error> {
-    run_test_cross_chain_message(MakeMemoryStoreClient).await
+    for &wasm_runtime in WasmRuntime::ALL {
+        run_test_cross_chain_message(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime)).await?
+    }
+    Ok(())
 }
 
 #[test(tokio::test)]

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -39,8 +39,11 @@ async fn test_memory_handle_certificates_to_create_application_both() -> Result<
 async fn test_memory_handle_certificates_to_create_application(
     use_view: bool,
 ) -> Result<(), anyhow::Error> {
-    let client = MemoryStoreClient::default();
-    run_test_handle_certificates_to_create_application(client, use_view).await
+    for &wasm_runtime in WasmRuntime::ALL {
+        let client = MemoryStoreClient::new(Some(wasm_runtime));
+        run_test_handle_certificates_to_create_application(client, use_view).await?;
+    }
+    Ok(())
 }
 
 #[test(tokio::test)]

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -302,7 +302,7 @@ impl IntoApplicationIdAndOperation for (UserApplicationId, Vec<u8>) {
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_bad_signature() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_bad_signature(client).await;
 }
 
@@ -376,7 +376,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_zero_amount() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_zero_amount(client).await;
 }
 
@@ -447,7 +447,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_ticks() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_ticks(client).await;
 }
 
@@ -546,7 +546,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_unknown_sender() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_unknown_sender(client).await;
 }
 
@@ -619,7 +619,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_with_chaining() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_with_chaining(client).await;
 }
 
@@ -732,7 +732,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_with_incoming_messages() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_with_incoming_messages(client).await;
 }
 
@@ -1224,7 +1224,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_exceed_balance() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_exceed_balance(client).await;
 }
 
@@ -1291,7 +1291,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal(client).await;
 }
 
@@ -1360,7 +1360,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_replay() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_block_proposal_replay(client).await;
 }
 
@@ -1432,7 +1432,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_unknown_sender() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_certificate_unknown_sender(client).await;
 }
 
@@ -1489,7 +1489,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_bad_block_height() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_certificate_bad_block_height(client).await;
 }
 
@@ -1558,7 +1558,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_with_anticipated_incoming_message() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_certificate_with_anticipated_incoming_message(client).await;
 }
 
@@ -1716,7 +1716,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_receiver_balance_overflow() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_certificate_receiver_balance_overflow(client).await;
 }
 
@@ -1809,7 +1809,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_receiver_equal_sender() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_certificate_receiver_equal_sender(client).await;
 }
 
@@ -1920,7 +1920,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_cross_chain_request() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_cross_chain_request(client).await;
 }
 
@@ -2043,7 +2043,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_cross_chain_request_no_recipient_chain() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_cross_chain_request_no_recipient_chain(client).await;
 }
 
@@ -2112,7 +2112,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_cross_chain_request_no_recipient_chain_on_client() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(client).await;
 }
 
@@ -2198,7 +2198,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_to_active_recipient() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_certificate_to_active_recipient(client).await;
 }
 
@@ -2389,7 +2389,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_to_inactive_recipient() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_handle_certificate_to_inactive_recipient(client).await;
 }
 
@@ -2453,7 +2453,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_chain_creation_with_committee_creation() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_chain_creation_with_committee_creation(client).await;
 }
 
@@ -2988,7 +2988,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_transfers_and_committee_creation() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_transfers_and_committee_creation(client).await;
 }
 
@@ -3196,7 +3196,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_transfers_and_committee_removal() {
-    let client = MemoryStoreClient::default();
+    let client = MemoryStoreClient::new(None);
     run_test_transfers_and_committee_removal(client).await;
 }
 
@@ -3474,7 +3474,7 @@ where
 #[test(tokio::test)]
 async fn test_cross_chain_helper() {
     // Make a committee and worker (only used for signing certificates)
-    let (committee, worker) = init_worker(MemoryStoreClient::default(), true);
+    let (committee, worker) = init_worker(MemoryStoreClient::new(None), true);
     let committees = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
 
     let key_pair0 = KeyPair::generate();

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -79,7 +79,7 @@ impl StorageConfig {
         use StorageConfig::*;
         match self {
             Memory => {
-                let mut client = MemoryStoreClient::default();
+                let mut client = MemoryStoreClient::new(wasm_runtime);
                 config.initialize_store(&mut client).await?;
                 job.run(client).await
             }

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -28,7 +28,6 @@ struct DynamoDbStore {
     context: DynamoDbContext<()>,
     guards: ChainGuards,
     user_applications: Arc<DashMap<UserApplicationId, UserApplicationCode>>,
-    #[cfg_attr(not(any(feature = "wasmer", feature = "wasmtime")), allow(dead_code))]
     wasm_runtime: Option<WasmRuntime>,
 }
 
@@ -231,8 +230,7 @@ impl Store for DynamoDbStoreClient {
         Ok(())
     }
 
-    #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
-    fn wasm_runtime(&self) -> WasmRuntime {
-        self.0.wasm_runtime.unwrap_or_default()
+    fn wasm_runtime(&self) -> Option<WasmRuntime> {
+        self.0.wasm_runtime
     }
 }

--- a/linera-storage/src/rocksdb.rs
+++ b/linera-storage/src/rocksdb.rs
@@ -23,7 +23,6 @@ struct RocksdbStore {
     db: RocksdbClient,
     guards: ChainGuards,
     user_applications: Arc<DashMap<UserApplicationId, UserApplicationCode>>,
-    #[cfg_attr(not(any(feature = "wasmer", feature = "wasmtime")), allow(dead_code))]
     wasm_runtime: Option<WasmRuntime>,
 }
 
@@ -120,8 +119,7 @@ impl Store for RocksdbStoreClient {
         Ok(())
     }
 
-    #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
-    fn wasm_runtime(&self) -> WasmRuntime {
-        self.0.wasm_runtime.unwrap_or_default()
+    fn wasm_runtime(&self) -> Option<WasmRuntime> {
+        self.0.wasm_runtime
     }
 }


### PR DESCRIPTION
For some reasons, MemoryStore was using the static constant `WasmRuntime::default()` instead of a runtime option. This PR makes it work like the other store.