### PR TITLE
Expose ExecuteOperation API through GraphQL mutations

### DIFF
--- a/linera-base/src/committee.rs
+++ b/linera-base/src/committee.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::data_types::ValidatorName;
+use async_graphql::InputObject;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -16,7 +17,7 @@ pub struct ValidatorState {
 }
 
 /// A set of validators (identified by their public keys) and their voting rights.
-#[derive(Eq, PartialEq, Hash, Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug, Default, Serialize, Deserialize, InputObject)]
 pub struct Committee {
     /// The validators in the committee.
     pub validators: BTreeMap<ValidatorName, ValidatorState>,

--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -8,7 +8,7 @@ use generic_array::typenum::Unsigned;
 #[cfg(not(target_arch = "wasm32"))]
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{num::ParseIntError, str::FromStr};
 use thiserror::Error;
 
 #[cfg(any(test, feature = "test"))]
@@ -53,6 +53,8 @@ pub enum CryptoError {
         expected = dalek::PUBLIC_KEY_LENGTH,
     )]
     IncorrectPublicKeySize(usize),
+    #[error("Could not parse integer")]
+    ParseIntError(#[from] ParseIntError),
 }
 
 impl PublicKey {

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -156,6 +156,14 @@ impl std::str::FromStr for ValidatorName {
     }
 }
 
+impl std::str::FromStr for Epoch {
+    type Err = CryptoError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Epoch(s.parse()?))
+    }
+}
+
 impl BlockHeight {
     #[inline]
     pub fn max() -> Self {

--- a/linera-base/src/graphql.rs
+++ b/linera-base/src/graphql.rs
@@ -1,6 +1,6 @@
 use crate::{
     committee::{Committee, ValidatorState},
-    crypto::CryptoHash,
+    crypto::{CryptoHash, Signature},
     data_types::{BlockHeight, ChainDescription, ChainId, Epoch, Owner, Timestamp, ValidatorName},
 };
 use async_graphql::{scalar, Object};
@@ -12,6 +12,7 @@ scalar!(ChainId);
 scalar!(CryptoHash);
 scalar!(Epoch);
 scalar!(Owner);
+scalar!(Signature);
 scalar!(Timestamp);
 scalar!(ValidatorName);
 

--- a/linera-chain/src/graphql.rs
+++ b/linera-chain/src/graphql.rs
@@ -1,6 +1,6 @@
 use crate::{
     chain::{ChannelStateView, CommunicationStateView},
-    data_types::{Event, Medium, Origin, Target},
+    data_types::{Certificate, Event, Medium, Origin, Target},
     inbox::InboxStateView,
     outbox::OutboxStateView,
     ChainManager,
@@ -12,6 +12,7 @@ use linera_views::{collection_view::ReadGuardedView, common::Context, views::Vie
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
+scalar!(Certificate);
 scalar!(ChainManager);
 scalar!(Event);
 scalar!(Medium);

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -1,6 +1,7 @@
 use crate::{
-    system::Balance, ApplicationId, ChainOwnership, ChannelId, ChannelName, ExecutionStateView,
-    SystemExecutionStateView, UserApplicationDescription, UserApplicationId,
+    system::{Amount, Balance, Recipient, UserData},
+    ApplicationId, Bytecode, BytecodeId, ChainOwnership, ChannelId, ChannelName,
+    ExecutionStateView, SystemExecutionStateView, UserApplicationDescription, UserApplicationId,
 };
 use async_graphql::{scalar, Error};
 use linera_base::{
@@ -10,12 +11,17 @@ use linera_base::{
 use linera_views::{common::Context, views::ViewError};
 use std::collections::BTreeMap;
 
+scalar!(Amount);
 scalar!(ApplicationId);
+scalar!(Bytecode);
+scalar!(BytecodeId);
 scalar!(Balance);
 scalar!(ChainOwnership);
 scalar!(ChannelName);
+scalar!(Recipient);
 scalar!(UserApplicationDescription);
 scalar!(UserApplicationId);
+scalar!(UserData);
 
 #[async_graphql::Object]
 impl<C: Send + Sync + Context> ExecutionStateView<C>

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -29,6 +29,7 @@ use std::{
 };
 use thiserror::Error;
 
+use async_graphql::Enum;
 #[cfg(any(test, feature = "test"))]
 use std::collections::BTreeSet;
 
@@ -211,7 +212,7 @@ pub struct SystemResponse {
 }
 
 /// The channels available in the system application.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Enum, Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum SystemChannel {
     /// Channel used to broadcast reconfigurations.
     Admin,


### PR DESCRIPTION
# Motivation
We have a core system API which is expressed via the `SystemOperation` enum. This system API needs to exposed to the outside world so that it can be easily consumed programatically.

# Solution
A set of GraphQL mutations have been created which correspond directly to each operation, or variant of the SystemOperation enum, and the requisite types have been modified to behave as GraphQL primitives.

# FAQ
- Is any of this final: No, both the APIs and the underlying data structures may (and probably will) change to provide a better developer experience.
- Why has the implementation diverged from the underlying enum variant in methods like `transfer` and `claim`: This is an example of where due to the constraints of GraphQL, it made sense to modify the external API to make it more usable. Over time this will probably happen more often.