### PR TITLE
Set the default build target for linera-examples to Wasm

### DIFF
--- a/linera-examples/.cargo/config.toml
+++ b/linera-examples/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"


### PR DESCRIPTION
# Motivation

Every time we build `linera-examples` we need to specify the build target to Wasm, this is an inconvenience.


# Solution

`.cargo/config.toml` specifies the default build target to `wasm32-unknown-unknown`.