### PR TITLE
Binary arguments now use default value for wasm_runtime arg

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -637,6 +637,22 @@ impl WasmRuntime {
     ];
 }
 
+pub trait WithWasmDefault {
+    fn with_wasm_default(self) -> Self;
+}
+
+impl WithWasmDefault for Option<WasmRuntime> {
+    #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+    fn with_wasm_default(self) -> Self {
+        Some(self.unwrap_or_default())
+    }
+
+    #[cfg(not(any(feature = "wasmer", feature = "wasmtime")))]
+    fn with_wasm_default(self) -> Self {
+        None
+    }
+}
+
 impl FromStr for WasmRuntime {
     type Err = InvalidWasmRuntime;
 

--- a/linera-service/src/client.rs
+++ b/linera-service/src/client.rs
@@ -25,7 +25,7 @@ use linera_core::{
 };
 use linera_execution::{
     system::{Account, Amount, Balance, Recipient, SystemOperation, UserData},
-    ApplicationId, Bytecode, Operation, WasmRuntime,
+    ApplicationId, Bytecode, Operation, WasmRuntime, WithWasmDefault,
 };
 use linera_rpc::{
     config::NetworkProtocol, grpc_network::GrpcMassClient, mass::MassClient,
@@ -1011,7 +1011,8 @@ async fn main() -> Result<(), anyhow::Error> {
         }
         command => {
             let genesis_config = context.genesis_config.clone();
-            let wasm_runtime = options.wasm_runtime;
+            let wasm_runtime = options.wasm_runtime.with_wasm_default();
+
             options
                 .storage_config
                 .run_with_storage(&genesis_config, wasm_runtime, Job(context, command))

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures::future::join_all;
 use linera_base::{crypto::KeyPair, data_types::ValidatorName};
 use linera_core::worker::WorkerState;
-use linera_execution::WasmRuntime;
+use linera_execution::{WasmRuntime, WithWasmDefault};
 use linera_rpc::{
     config::{
         CrossChainConfig, NetworkProtocol, NotificationConfig, ShardConfig, ShardId,
@@ -378,6 +378,7 @@ async fn main() {
                 shard,
                 grace_period_micros: grace_period,
             };
+            let wasm_runtime = wasm_runtime.with_wasm_default();
             storage_config
                 .run_with_storage(&genesis_config, wasm_runtime, job)
                 .await


### PR DESCRIPTION
# Motivation

It is tedious to always specify a wasm runtime - binaries should have a default option.

# Solution

Introduce a trait and a method `Option<WasmRuntime>::with_wasm_default()`