### PR TITLE
Report all missing bytecode at once, instead of only the first one encountered.

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -15,7 +15,7 @@ use linera_chain::data_types::{BlockProposal, Certificate, LiteVote};
 use linera_storage::Store;
 use linera_views::views::ViewError;
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, HashMap, HashSet},
     hash::Hash,
     time::Duration,
 };
@@ -146,7 +146,7 @@ where
                         return Err(NodeError::InvalidChainInfoResponse);
                     }
                 }
-                let unique_locations: BTreeSet<_> = locations.iter().cloned().collect();
+                let unique_locations: HashSet<_> = locations.iter().cloned().collect();
                 if locations.len() > unique_locations.len() {
                     log::warn!("locations requested by validator contain duplicates");
                     return Err(NodeError::InvalidChainInfoResponse);

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -107,7 +107,7 @@ impl From<&UserApplicationDescription> for UserApplicationId {
 pub struct BytecodeId(pub EffectId);
 
 /// A reference to where the application bytecode is stored.
-#[derive(Clone, Copy, Debug, Ord, PartialOrd, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct BytecodeLocation {
     /// The certificate that published the bytecode.
     pub certificate_hash: CryptoHash,


### PR DESCRIPTION
# Motivation

If we only return an error about the first bytecode blob we're missing, retrying might fail again, with the next.

# Solution

A worker will only append a certificate to a chain once all bytecode blobs referred to by any incoming `BytecodePublished`, `BytecodeLocations` or `RegisterApplications` effects have been stored. If any are missing, it lists all missing ones in the error.

Similarly, the required blocks must be provided (unless already stored) when proposing a new block.

That way, when an application's bytecode is actually needed, it is guaranteed to be there.

Closes https://github.com/linera-io/linera-protocol/issues/474