### PR TITLE
Use read-only view methods.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -153,16 +153,17 @@ where
 
     /// Verify that this chain is up-to-date and all the messages executed ahead of time
     /// have been properly received by now.
-    pub async fn validate_incoming_messages(&self) -> Result<(), ChainError> {
+    pub async fn validate_incoming_messages(&mut self) -> Result<(), ChainError> {
+        let chain_id = self.chain_id();
         for id in self.communication_states.indices().await? {
-            let state = self.communication_states.try_load_entry(&id).await?;
+            let state = self.communication_states.load_entry(&id).await?;
             for origin in state.inboxes.indices().await? {
                 let inbox = state.inboxes.try_load_entry(&origin).await?;
                 let event = inbox.removed_events.front().await?;
                 ensure!(
                     event.is_none(),
                     ChainError::MissingCrossChainUpdate {
-                        chain_id: self.chain_id(),
+                        chain_id,
                         application_id: id,
                         origin,
                         height: event.unwrap().height,
@@ -174,26 +175,26 @@ where
     }
 
     pub async fn next_block_height_to_receive(
-        &self,
+        &mut self,
         application_id: ApplicationId,
         origin: Origin,
     ) -> Result<BlockHeight, ChainError> {
         let communication_state = self
             .communication_states
-            .try_load_entry(&application_id)
+            .load_entry(&application_id)
             .await?;
         let inbox = communication_state.inboxes.try_load_entry(&origin).await?;
         inbox.next_block_height_to_receive()
     }
 
     pub async fn last_anticipated_block_height(
-        &self,
+        &mut self,
         application_id: ApplicationId,
         origin: Origin,
     ) -> Result<Option<BlockHeight>, ChainError> {
         let communication_state = self
             .communication_states
-            .try_load_entry(&application_id)
+            .load_entry(&application_id)
             .await?;
         let inbox = communication_state.inboxes.try_load_entry(&origin).await?;
         match inbox.removed_events.back().await? {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3498,7 +3498,7 @@ where
 
     {
         // The admin chain has an anticipated message.
-        let admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
+        let mut admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
         assert!(admin_chain.validate_incoming_messages().await.is_err());
     }
 
@@ -3511,7 +3511,7 @@ where
 
     {
         // The admin chain has no more anticipated messages.
-        let admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
+        let mut admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
         admin_chain.validate_incoming_messages().await.unwrap();
     }
 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -331,9 +331,9 @@ where
     ) -> Result<(), NodeError> {
         let mut info = BTreeMap::new();
         {
-            let chain = self.store.load_chain(chain_id).await?;
+            let mut chain = self.store.load_chain(chain_id).await?;
             for id in chain.communication_states.indices().await? {
-                let state = chain.communication_states.try_load_entry(&id).await?;
+                let state = chain.communication_states.load_entry(&id).await?;
                 for origin in state.inboxes.indices().await? {
                     let inbox = state.inboxes.try_load_entry(&origin).await?;
                     let next_height = info.entry(origin.sender).or_default();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -340,7 +340,7 @@ where
     }
 
     async fn create_cross_chain_request(
-        &self,
+        &mut self,
         confirmed_log: &mut LogView<Client::Context, CryptoHash>,
         height_map: Vec<(ApplicationId, Medium, Vec<BlockHeight>)>,
         sender: ChainId,
@@ -369,14 +369,14 @@ where
 
     /// Load pending cross-chain requests.
     async fn create_network_actions(
-        &self,
+        &mut self,
         chain: &mut ChainStateView<Client::Context>,
     ) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
         for application_id in chain.communication_states.indices().await? {
             let state = chain
                 .communication_states
-                .try_load_entry(&application_id)
+                .load_entry(&application_id)
                 .await?;
             for target in state.outboxes.indices().await? {
                 let outbox = state.outboxes.try_load_entry(&target).await?;
@@ -884,7 +884,7 @@ where
             for application_id in chain.communication_states.indices().await? {
                 let state = chain
                     .communication_states
-                    .try_load_entry(&application_id)
+                    .load_entry(&application_id)
                     .await?;
                 for origin in state.inboxes.indices().await? {
                     let inbox = state.inboxes.try_load_entry(&origin).await?;


### PR DESCRIPTION
# Motivation

`load_entry_mut` clears the hash, and can cause it to be recomputed later.

# Solution

Use `try_load_entry` instead.

The downside is that this has to acquire a lock, and (since it's non-blocking) can fail.

Closes https://github.com/linera-io/linera-protocol/issues/458.