### PR TITLE
Display panics from WASM applications

### DIFF
--- a/linera-sdk/src/log.rs
+++ b/linera-sdk/src/log.rs
@@ -39,6 +39,7 @@ impl ServiceLogger {
     pub fn install() {
         log::set_logger(&SERVICE_LOGGER).expect("Failed to initialize service logger");
         log::set_max_level(LevelFilter::Trace);
+        panic::set_hook(Box::new(log_panic));
     }
 }
 


### PR DESCRIPTION
# Motivation

Linera applications written in Rust may `panic` with an error message. However, that message is never shown, which makes debugging it more difficult than it should be.

# Solution

Update the `ContractLogger` and the `ServiceLogger` types to not only install `log` handlers, but also hook a panic handler than will log the panic message.

# Related Issues

Closes #534 