### PR TITLE
remove write permissions of GITHUB_TOKEN by default

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -20,7 +20,11 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
 
+permissions:
+  contents: read
+
 jobs:
+
   build:
     runs-on: ubuntu-latest-8-cores
     steps:

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -16,7 +16,11 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
 
+permissions:
+  contents: read
+
 jobs:
+
   integration-test-with-kind:
     runs-on: ubuntu-latest-4-cores
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,6 +20,9 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
 
+permissions:
+  contents: read
+
 jobs:
 
   test:


### PR DESCRIPTION
We currently do this in the UI but I need to make some exceptions in a next PR (#541).