### PR TITLE
Print build output in case of failure to build examples

### DIFF
--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -259,7 +259,15 @@ pub mod test {
             .current_dir("../linera-examples")
             .args(["build", "--release", "--target", "wasm32-unknown-unknown"])
             .output()?;
-        assert!(output.status.success());
+        if !output.status.success() {
+            panic!(
+                "Failed to build example applications.\n\n\
+                stdout:\n-------\n{}\n\n\
+                stderr:\n-------\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
# Motivation

Some of the unit tests will compile one or more examples from `linera-examples` to use inside the test. However, if the compilation fails, it's not possible to figure out why without manually compiling them separately afterwards.

# Solution

Print the standard output and standard error streams of the build process if it fails.