### PR TITLE
OpenChain defaults to wallet default chain

### DIFF
--- a/linera-service/src/client.rs
+++ b/linera-service/src/client.rs
@@ -474,9 +474,9 @@ enum ClientCommand {
     /// Open (i.e. activate) a new chain deriving the UID from an existing one.
     #[structopt(name = "open_chain")]
     OpenChain {
-        /// Sending chain id (must be one of our chains)
+        /// Sending chain id (must be one of our chains).
         #[structopt(long = "from")]
-        sender: ChainId,
+        sender: Option<ChainId>,
 
         /// Public key of the new owner (otherwise create a key pair and remember it)
         #[structopt(long = "to-public-key")]
@@ -673,6 +673,12 @@ where
             }
 
             OpenChain { sender, public_key } => {
+                let sender = sender.unwrap_or_else(|| {
+                    context
+                        .wallet_state
+                        .default_chain()
+                        .expect("No chain specified in wallet with no default chain")
+                });
                 let mut chain_client = context.make_chain_client(storage, sender);
                 let (new_public_key, key_pair) = match public_key {
                     Some(key) => (key, None),

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -39,6 +39,21 @@ do
     done
 done
 
+sleep 1;
+
+sleep 2;
+
+# Create second wallet with unassigned key.
+KEY=$(./client --wallet wallet_2.json --genesis genesis.json keygen)
+
+# Open chain on behalf of wallet 2.
+CHAIN_AND_CERT=$(./client --wallet wallet.json --genesis genesis.json open_chain --to-public-key "$KEY")
+CHAIN=$(echo "$CHAIN_AND_CERT" | sed -n '1 p')
+CERT=$(echo "$CHAIN_AND_CERT" | sed -n '2 p')
+
+# Assign newly created chain to unassigned key.
+./client --wallet wallet_2.json --genesis genesis.json --storage rocksdb:client_2.db assign --key "$KEY" --chain "$CHAIN" --certificate "$CERT"
+
 while :; do
     sleep 5
 done


### PR DESCRIPTION
# Motivation

1. Opening a chain should default to default chain  so that the user doesn't need to specify it every time.
2. The `run_local` script should create a second wallet for testing purposes.

# Solution

This PR introduces two minor changes:
1. Opening a chain now defaults to wallet default chain if unspecified
2. `run_local.sh` now creates a second wallet, `wallet_2.json` and opens a chain for the second wallet.