### PR TITLE
Added set-default command to wallet to change the default chain

### DIFF
--- a/linera-service/src/client.rs
+++ b/linera-service/src/client.rs
@@ -637,6 +637,7 @@ enum ClientCommand {
 #[derive(StructOpt)]
 enum WalletCommand {
     Show { chain_id: Option<ChainId> },
+    SetDefault { chain_id: ChainId },
 }
 
 struct Job(ClientContext, ClientCommand);
@@ -1132,6 +1133,11 @@ async fn main() -> Result<(), anyhow::Error> {
         ClientCommand::Wallet(wallet_command) => match wallet_command {
             WalletCommand::Show { chain_id } => {
                 context.wallet_state.pretty_print(chain_id);
+                Ok(())
+            }
+            WalletCommand::SetDefault { chain_id } => {
+                context.wallet_state.set_default_chain(chain_id)?;
+                context.save_wallet();
                 Ok(())
             }
         },

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use comfy_table::{
     modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Color, ContentArrangement,
     Table,
@@ -179,6 +179,14 @@ impl WalletState {
             next_block_height: BlockHeight(0),
         };
         self.insert(user_chain);
+        Ok(())
+    }
+
+    pub fn set_default_chain(&mut self, chain_id: ChainId) -> Result<(), anyhow::Error> {
+        if !self.chains.contains_key(&chain_id) {
+            bail!("Chain {} cannot be assigned as the default chain since it does not exist in the wallet.", &chain_id);
+        }
+        self.default = Some(chain_id);
         Ok(())
     }
 


### PR DESCRIPTION
# Motivation

A user might want to change the default chain in their wallet. (Came up while I was writing docs).

# Solution

Add a command for them to do so without messing about with JSON files.