### PR TITLE
Make the metrics host and port configurable per shard.

### DIFF
--- a/configuration/validator_1.toml
+++ b/configuration/validator_1.toml
@@ -3,23 +3,29 @@ host = "127.0.0.1"
 port = 9100
 internal_host = "127.0.0.1"
 internal_port = 10100
-metrics_host = "127.0.0.1"
-metrics_port = 11100
 external_protocol = "Grpc"
 internal_protocol = "Grpc"
 
 [[shards]]
 host = "127.0.0.1"
 port = 9101
+metrics_host = "127.0.0.1"
+metrics_port = 11101
 
 [[shards]]
 host = "127.0.0.1"
 port = 9102
+metrics_host = "127.0.0.1"
+metrics_port = 11102
 
 [[shards]]
 host = "127.0.0.1"
 port = 9103
+metrics_host = "127.0.0.1"
+metrics_port = 11103
 
 [[shards]]
 host = "127.0.0.1"
 port = 9104
+metrics_host = "127.0.0.1"
+metrics_port = 11104

--- a/configuration/validator_2.toml
+++ b/configuration/validator_2.toml
@@ -3,23 +3,29 @@ host = "127.0.0.1"
 port = 9200
 internal_host = "127.0.0.1"
 internal_port = 10200
-metrics_host = "127.0.0.1"
-metrics_port = 11200
 external_protocol = "Grpc"
 internal_protocol = "Grpc"
 
 [[shards]]
 host = "127.0.0.1"
 port = 9201
+metrics_host = "127.0.0.1"
+metrics_port = 11201
 
 [[shards]]
 host = "127.0.0.1"
 port = 9202
+metrics_host = "127.0.0.1"
+metrics_port = 11202
 
 [[shards]]
 host = "127.0.0.1"
 port = 9203
+metrics_host = "127.0.0.1"
+metrics_port = 11203
 
 [[shards]]
 host = "127.0.0.1"
 port = 9204
+metrics_host = "127.0.0.1"
+metrics_port = 11204

--- a/configuration/validator_3.toml
+++ b/configuration/validator_3.toml
@@ -3,23 +3,29 @@ host = "127.0.0.1"
 port = 9300
 internal_host = "127.0.0.1"
 internal_port = 10300
-metrics_host = "127.0.0.1"
-metrics_port = 11300
 external_protocol = "Grpc"
 internal_protocol = "Grpc"
 
 [[shards]]
 host = "127.0.0.1"
 port = 9301
+metrics_host = "127.0.0.1"
+metrics_port = 11301
 
 [[shards]]
 host = "127.0.0.1"
 port = 9302
+metrics_host = "127.0.0.1"
+metrics_port = 11302
 
 [[shards]]
 host = "127.0.0.1"
 port = 9303
+metrics_host = "127.0.0.1"
+metrics_port = 11303
 
 [[shards]]
 host = "127.0.0.1"
 port = 9304
+metrics_host = "127.0.0.1"
+metrics_port = 11304

--- a/configuration/validator_4.toml
+++ b/configuration/validator_4.toml
@@ -3,23 +3,29 @@ host = "127.0.0.1"
 port = 9400
 internal_host = "127.0.0.1"
 internal_port = 10400
-metrics_host = "127.0.0.1"
-metrics_port = 11400
 external_protocol = "Grpc"
 internal_protocol = "Grpc"
 
 [[shards]]
 host = "127.0.0.1"
 port = 9401
+metrics_host = "127.0.0.1"
+metrics_port = 11401
 
 [[shards]]
 host = "127.0.0.1"
 port = 9402
+metrics_host = "127.0.0.1"
+metrics_port = 11402
 
 [[shards]]
 host = "127.0.0.1"
 port = 9403
+metrics_host = "127.0.0.1"
+metrics_port = 11403
 
 [[shards]]
 host = "127.0.0.1"
 port = 9404
+metrics_host = "127.0.0.1"
+metrics_port = 11404

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -20,8 +20,6 @@ host = "validator-${server}"
 port = 9100
 internal_host = "validator-${server}"
 internal_port = 10100
-metrics_host = "validator-${server}"
-metrics_port = 11100
 external_protocol = { Simple = "Tcp" }
 internal_protocol = { Simple = "Tcp" }
 EOF
@@ -31,6 +29,8 @@ EOF
 [[shards]]
 host = "server-${server}-shard-${shard}.server-${server}"
 port = 9100
+metrics_host = "server-${server}-shard-${shard}.server-${server}"
+metrics_port = 11100
 EOF
         done
         echo "validator_${server}.toml"

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -35,6 +35,10 @@ pub struct ShardConfig {
     pub host: String,
     /// The port.
     pub port: u16,
+    /// The host on which metrics are served.
+    pub metrics_host: String,
+    /// The port on which metrics are served.
+    pub metrics_port: Option<u16>,
 }
 
 impl ShardConfig {
@@ -81,10 +85,6 @@ pub struct ValidatorInternalNetworkPreConfig<P> {
     pub host: String,
     /// The port the proxy listens on on the internal network.
     pub port: u16,
-    /// The host on which metrics are served.
-    pub metrics_host: String,
-    /// The port on which metrics are served.
-    pub metrics_port: Option<u16>,
 }
 
 impl<P> ValidatorInternalNetworkPreConfig<P> {
@@ -94,8 +94,6 @@ impl<P> ValidatorInternalNetworkPreConfig<P> {
             shards: self.shards.clone(),
             host: self.host.clone(),
             port: self.port,
-            metrics_host: self.metrics_host.clone(),
-            metrics_port: self.metrics_port,
         }
     }
 }

--- a/linera-service/tests/integration_tests.rs
+++ b/linera-service/tests/integration_tests.rs
@@ -446,20 +446,21 @@ impl TestRunner {
                 port = {port}
                 internal_host = "127.0.0.1"
                 internal_port = {internal_port}
-                metrics_host = "127.0.0.1"
-                metrics_port = {metrics_port}
                 external_protocol = {external_protocol}
                 internal_protocol = {internal_protocol}
             "#
         );
         for k in 1..=4 {
             let shard_port = port + k;
+            let shard_metrics_port = metrics_port + k;
             content.push_str(&format!(
                 r#"
                 
                 [[shards]]
                 host = "127.0.0.1"
                 port = {shard_port}
+                metrics_host = "127.0.0.1"
+                metrics_port = {shard_metrics_port}
                 "#
             ));
         }


### PR DESCRIPTION
This was not done earlier because we didn't have the TOML file yet and it would have made the config string even longer.