### PR TITLE
Small simplification of the protocol code.

### DIFF
--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -40,12 +40,6 @@ where
     C: Context + Clone + Send + Sync + 'static,
     ViewError: From<C::Error>,
 {
-    pub async fn block_heights(&self) -> Result<Vec<BlockHeight>, ViewError> {
-        let count = self.queue.count();
-        let heights = self.queue.read_front(count).await?;
-        Ok(heights)
-    }
-
     /// Schedule a message at the given height if we haven't already.
     /// Return true if a change was made.
     pub(crate) fn schedule_message(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -387,7 +387,7 @@ where
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
         for target in chain.outboxes.indices().await? {
             let outbox = chain.outboxes.load_entry(&target).await?;
-            let heights = outbox.block_heights().await?;
+            let heights = outbox.queue.elements().await?;
             heights_by_recipient
                 .entry(target.recipient)
                 .or_default()
@@ -971,8 +971,7 @@ where
             let mut messages = Vec::new();
             for origin in chain.inboxes.indices().await? {
                 let inbox = chain.inboxes.load_entry(&origin).await?;
-                let count = inbox.added_events.count();
-                for event in inbox.added_events.read_front(count).await? {
+                for event in inbox.added_events.elements().await? {
                     messages.push(Message {
                         origin: origin.clone(),
                         event: event.clone(),


### PR DESCRIPTION
The view code was providing a solution, so I thought it was better to use it instead of reinventing it.
Also, I use `elements` instead of `indices` since indices are indices to something and here it is not a map or something like that.