### PR TITLE
Remove redundant id field from OpenChain effect.

### DIFF
--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2441,7 +2441,6 @@ where
                 direct_outgoing_effect(
                     user_id,
                     SystemEffect::OpenChain {
-                        id: user_id,
                         public_key: key_pair.public(),
                         epoch: Epoch::from(0),
                         committees: committees.clone(),

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -169,9 +169,8 @@ pub enum SystemEffect {
         recipient: Recipient,
         user_data: UserData,
     },
-    /// Creates (or activate) a new chain by installing the given authentication key.
+    /// Creates (or activates) a new chain by installing the given authentication key.
     OpenChain {
-        id: ChainId,
         public_key: PublicKey,
         admin_id: ChainId,
         epoch: Epoch,
@@ -470,7 +469,6 @@ where
                     Destination::Recipient(*id),
                     false,
                     SystemEffect::OpenChain {
-                        id: *id,
                         public_key: *public_key,
                         committees: committees.clone(),
                         admin_id: *admin_id,
@@ -848,7 +846,6 @@ where
     pub fn open_chain(
         &mut self,
         effect_id: EffectId,
-        chain_id: ChainId,
         public_key: PublicKey,
         epoch: Epoch,
         committees: BTreeMap<Epoch, Committee>,
@@ -860,7 +857,6 @@ where
         assert!(!self.ownership.get().is_active());
         assert!(self.committees.get().is_empty());
         let description = ChainDescription::Child(effect_id);
-        assert_eq!(chain_id, description.into());
         self.description.set(Some(description));
         self.epoch.set(Some(epoch));
         self.committees.set(committees);

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -567,8 +567,6 @@ SystemEffect:
     2:
       OpenChain:
         STRUCT:
-          - id:
-              TYPENAME: ChainId
           - public_key:
               TYPENAME: PublicKey
           - admin_id:


### PR DESCRIPTION
# Motivation

The `OpenChain` effect is always about the chain it is sent to, and can be computed from the effect ID, so its `id` field is redundant.

# Solution

Remove the `id` field, and use the information from the effect ID.