### PR TITLE
make the crowd-funding app multi-chain

### DIFF
--- a/linera-examples/crowd-funding/src/contract.rs
+++ b/linera-examples/crowd-funding/src/contract.rs
@@ -137,6 +137,8 @@ impl CrowdFunding {
         // The campaign chain.
         let chain_id = system_api::current_application_id().creation.chain_id;
         // First, move the funds to the campaign chain (under the same owner).
+        // TODO(#589): Simplify this when the messaging system guarantees atomic delivery
+        // of all messages created in the same operation/effect.
         let destination = fungible::Destination::Account(Account { chain_id, owner });
         let call = fungible::ApplicationCall::Transfer {
             owner,
@@ -144,7 +146,7 @@ impl CrowdFunding {
             destination,
         };
         self.call_application(
-            true,
+            /* authenticated by owner */ true,
             self.parameters.unwrap().token,
             &bcs::to_bytes(&call).unwrap(),
             vec![],
@@ -154,7 +156,7 @@ impl CrowdFunding {
         let effect = Effect::PledgeWithAccount { owner, amount };
         result
             .effects
-            .push((chain_id.into(), true, bcs::to_bytes(&effect).unwrap()));
+            .push((chain_id.into(), /* authenticated by owner */ true, bcs::to_bytes(&effect).unwrap()));
         Ok(())
     }
 

--- a/linera-examples/crowd-funding/src/contract.rs
+++ b/linera-examples/crowd-funding/src/contract.rs
@@ -75,7 +75,7 @@ impl Contract for CrowdFunding {
             bcs::from_bytes(effect).map_err(Error::InvalidEffect)?;
         ensure!(
             context.chain_id == system_api::current_application_id().creation.chain_id,
-            Error::AdminChainOnly
+            Error::CampaignChainOnly
         );
         self.execute_pledge_with_account(owner, amount).await?;
         Ok(ExecutionResult::default())
@@ -94,10 +94,10 @@ impl Contract for CrowdFunding {
 
         match call {
             ApplicationCall::PledgeWithSessions { source } => {
-                // Only sessions on the admin chain are supported.
+                // Only sessions on the campaign chain are supported.
                 ensure!(
                     context.chain_id == system_api::current_application_id().creation.chain_id,
-                    Error::AdminChainOnly
+                    Error::CampaignChainOnly
                 );
                 // In real-life applications, the source could be constrained so that a
                 // refund cannot be used as a transfer.
@@ -160,7 +160,7 @@ impl CrowdFunding {
         Ok(())
     }
 
-    /// Adds a pledge from a local account to the admin chain.
+    /// Adds a pledge from a local account to the campaign chain.
     async fn execute_pledge_with_account(
         &mut self,
         owner: AccountOwner,
@@ -367,7 +367,7 @@ impl CrowdFunding {
 pub enum Error {
     /// Action can only be executed on the chain that created the crowd-funding campaign
     #[error("Action can only be executed on the chain that created the crowd-funding campaign")]
-    AdminChainOnly,
+    CampaignChainOnly,
 
     /// Crowd-funding application doesn't support any cross-application sessions.
     #[error("Crowd-funding application doesn't support any cross-application sessions")]

--- a/linera-examples/crowd-funding/src/contract.rs
+++ b/linera-examples/crowd-funding/src/contract.rs
@@ -6,7 +6,7 @@
 mod state;
 
 use async_trait::async_trait;
-use crowd_funding::{ApplicationCall, Operation};
+use crowd_funding::{ApplicationCall, Effect, Operation};
 use fungible::{Account, AccountOwner, Destination};
 use linera_sdk::{
     base::{Amount, SessionId},
@@ -42,54 +42,76 @@ impl Contract for CrowdFunding {
 
     async fn execute_operation(
         &mut self,
-        _context: &OperationContext,
+        context: &OperationContext,
         operation_bytes: &[u8],
     ) -> Result<ExecutionResult, Self::Error> {
         let operation: Operation =
             bcs::from_bytes(operation_bytes).map_err(Error::InvalidOperation)?;
 
+        let mut result = ExecutionResult::default();
+
         match operation {
             Operation::PledgeWithTransfer { owner, amount } => {
-                self.execute_pledge_with_transfer(owner, amount).await?
+                if context.chain_id == system_api::current_application_id().creation.chain_id {
+                    self.execute_pledge_with_account(owner, amount).await?;
+                } else {
+                    self.execute_pledge_with_transfer(&mut result, owner, amount)
+                        .await?;
+                }
             }
             Operation::Collect => self.collect_pledges().await?,
             Operation::Cancel => self.cancel_campaign().await?,
         }
 
-        Ok(ExecutionResult::default())
+        Ok(result)
     }
 
     async fn execute_effect(
         &mut self,
-        _context: &EffectContext,
-        _effect: &[u8],
+        context: &EffectContext,
+        effect: &[u8],
     ) -> Result<ExecutionResult, Self::Error> {
-        Err(Error::EffectsNotSupported)
+        let Effect::PledgeWithAccount { owner, amount } =
+            bcs::from_bytes(effect).map_err(Error::InvalidEffect)?;
+        ensure!(
+            context.chain_id == system_api::current_application_id().creation.chain_id,
+            Error::AdminChainOnly
+        );
+        self.execute_pledge_with_account(owner, amount).await?;
+        Ok(ExecutionResult::default())
     }
 
     async fn handle_application_call(
         &mut self,
-        _context: &CalleeContext,
+        context: &CalleeContext,
         argument: &[u8],
         sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error> {
         let call: ApplicationCall =
             bcs::from_bytes(argument).map_err(Error::InvalidCrossApplicationCall)?;
 
+        let mut result = ApplicationCallResult::default();
+
         match call {
             ApplicationCall::PledgeWithSessions { source } => {
+                // Only sessions on the admin chain are supported.
+                ensure!(
+                    context.chain_id == system_api::current_application_id().creation.chain_id,
+                    Error::AdminChainOnly
+                );
                 // In real-life applications, the source could be constrained so that a
                 // refund cannot be used as a transfer.
                 self.execute_pledge_with_sessions(source, sessions).await?
             }
             ApplicationCall::PledgeWithTransfer { owner, amount } => {
-                self.execute_pledge_with_transfer(owner, amount).await?
+                self.execute_pledge_with_transfer(&mut result.execution_result, owner, amount)
+                    .await?;
             }
             ApplicationCall::Collect => self.collect_pledges().await?,
             ApplicationCall::Cancel => self.cancel_campaign().await?,
         }
 
-        Ok(ApplicationCallResult::default())
+        Ok(result)
     }
 
     async fn handle_session_call(
@@ -104,8 +126,40 @@ impl Contract for CrowdFunding {
 }
 
 impl CrowdFunding {
-    /// Adds a pledge from a transfer.
+    /// Adds a pledge from a remote account.
     async fn execute_pledge_with_transfer(
+        &mut self,
+        result: &mut ExecutionResult,
+        owner: AccountOwner,
+        amount: Amount,
+    ) -> Result<(), Error> {
+        ensure!(amount > Amount::zero(), Error::EmptyPledge);
+        // The campaign chain.
+        let chain_id = system_api::current_application_id().creation.chain_id;
+        // First, move the funds to the campaign chain (under the same owner).
+        let destination = fungible::Destination::Account(Account { chain_id, owner });
+        let call = fungible::ApplicationCall::Transfer {
+            owner,
+            amount,
+            destination,
+        };
+        self.call_application(
+            true,
+            self.parameters.unwrap().token,
+            &bcs::to_bytes(&call).unwrap(),
+            vec![],
+        )
+        .await;
+        // Second, schedule the attribution of the funds to the (remote) campaign.
+        let effect = Effect::PledgeWithAccount { owner, amount };
+        result
+            .effects
+            .push((chain_id.into(), true, bcs::to_bytes(&effect).unwrap()));
+        Ok(())
+    }
+
+    /// Adds a pledge from a local account to the admin chain.
+    async fn execute_pledge_with_account(
         &mut self,
         owner: AccountOwner,
         amount: Amount,
@@ -309,9 +363,9 @@ impl CrowdFunding {
 /// An error that can occur during the contract execution.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Crowd-funding application doesn't support any cross-chain effects.
-    #[error("Crowd-funding application doesn't support any cross-chain effects")]
-    EffectsNotSupported,
+    /// Action can only be executed on the chain that created the crowd-funding campaign
+    #[error("Action can only be executed on the chain that created the crowd-funding campaign")]
+    AdminChainOnly,
 
     /// Crowd-funding application doesn't support any cross-application sessions.
     #[error("Crowd-funding application doesn't support any cross-application sessions")]
@@ -324,6 +378,10 @@ pub enum Error {
     /// Crowd-funding campaigns can't start after its deadline.
     #[error("Crowd-funding campaign can not start after its deadline")]
     DeadlineInThePast,
+
+    /// Effect bytes does not deserialize into an [`Effect`].
+    #[error("Requested effect is invalid")]
+    InvalidEffect(bcs::Error),
 
     /// Operation bytes does not deserialize into an [`Operation`].
     #[error("Requested operation is invalid")]

--- a/linera-examples/crowd-funding/src/lib.rs
+++ b/linera-examples/crowd-funding/src/lib.rs
@@ -2,28 +2,54 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fungible::AccountOwner;
-use linera_sdk::base::Amount;
+use linera_sdk::base::{Amount, ApplicationId, Timestamp};
 use serde::{Deserialize, Serialize};
 
-/// A cross-application call.
-#[derive(Deserialize, Serialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum ApplicationCall {
-    PledgeWithTransfer { owner: AccountOwner, amount: Amount },
-    PledgeWithSessions { source: AccountOwner },
-    Collect,
-    Cancel,
+/// The initialization parameters of a crowd-funding campaign. As usual, these are meant
+/// to be BCS-serialized and passed when instantiating the bytecode.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct Parameters {
+    /// The receiver of the pledges of a successful campaign (same chain as the campaign).
+    pub owner: AccountOwner,
+    /// The token to use for pledges.
+    pub token: ApplicationId,
+    /// The deadline of the campaign, after which it can be cancelled if it hasn't met its target.
+    pub deadline: Timestamp,
+    /// The funding target of the campaign.
+    pub target: Amount,
 }
 
 /// Operations that can be sent to the application.
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Operation {
-    /// Pledge some tokens to the campaign.
+    /// Pledge some tokens to the campaign (from an account on the current chain to the campaign chain).
     PledgeWithTransfer { owner: AccountOwner, amount: Amount },
-    /// Collect the pledges after the campaign has reached its target.
+    /// Collect the pledges after the campaign has reached its target (campaign chain only).
     Collect,
-    /// Cancel the campaign and refund all pledges after the campaign has reached its deadline.
+    /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
+    Cancel,
+}
+
+/// Effects that can be processed by the application.
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum Effect {
+    /// Pledge some tokens to the campaign (from an account on the receiver chain).
+    PledgeWithAccount { owner: AccountOwner, amount: Amount },
+}
+
+/// A cross-application call. This is meant to mimic operations, except triggered by another contract.
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum ApplicationCall {
+    /// Pledge some tokens to the campaign (from an account on the current chain).
+    PledgeWithTransfer { owner: AccountOwner, amount: Amount },
+    /// Pledge some tokens to the campaign from a session (for now, campaign chain only).
+    PledgeWithSessions { source: AccountOwner },
+    /// Collect the pledges after the campaign has reached its target (campaign chain only).
+    Collect,
+    /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
     Cancel,
 }
 

--- a/linera-examples/crowd-funding/src/state.rs
+++ b/linera-examples/crowd-funding/src/state.rs
@@ -1,23 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crowd_funding::Parameters;
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, ApplicationId, Timestamp};
+use linera_sdk::base::Amount;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-
-/// The parameters required to create a crowd-funding campaign.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct Parameters {
-    /// The receiver of the pledges of a successful campaign.
-    pub owner: AccountOwner,
-    /// The token to use for pledges.
-    pub token: ApplicationId,
-    /// The deadline of the campaign, after which it can be cancelled if it hasn't met its target.
-    pub deadline: Timestamp,
-    /// The funding target of the campaign.
-    pub target: Amount,
-}
 
 /// The status of a crowd-funding campaign.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]

--- a/linera-examples/crowd-funding2/src/state.rs
+++ b/linera-examples/crowd-funding2/src/state.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crowd_funding::Parameters;
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, ApplicationId, Timestamp};
+use linera_sdk::base::Amount;
 use linera_views::{
     common::Context,
     map_view::MapView,
@@ -10,19 +11,6 @@ use linera_views::{
     views::{RootView, View},
 };
 use serde::{Deserialize, Serialize};
-
-/// The parameters required to create a crowd-funding campaign.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct Parameters {
-    /// The receiver of the pledges of a successful campaign.
-    pub owner: AccountOwner,
-    /// The token to use for pledges.
-    pub token: ApplicationId,
-    /// The deadline of the campaign, after which it can be cancelled if it hasn't met its target.
-    pub deadline: Timestamp,
-    /// The funding target of the campaign.
-    pub target: Amount,
-}
 
 /// The status of a crowd-funding campaign.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]


### PR DESCRIPTION
* The "campaign chain" is the one that instantiated the bytecode. We can find it by calling: `system_api::current_application_id().creation.chain_id`
* Making a pledge from a different chain requires two steps:
    * first, transferring the funds to the campaign chain (under the same owner),
    * second, actually pledging the funds. Both steps are messages but not triggered but the same app (first is fungible and second is crowd-funding). This works because we now respect the ordering of messages in this case (after #592).