### PR TITLE
Added `linera project test`

### DIFF
--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -35,7 +35,7 @@ use linera_service::{
 use linera_storage::Store;
 use linera_views::views::ViewError;
 use std::{
-    fs,
+    env, fs,
     num::NonZeroU16,
     path::PathBuf,
     time::{Duration, Instant},
@@ -776,6 +776,10 @@ enum WalletCommand {
 enum ProjectCommand {
     /// Create a new Linera project.
     New { path: PathBuf },
+    /// Test a Linera project.
+    ///
+    /// Equivalent to running `cargo test` with the appropriate test runner.
+    Test { path: Option<PathBuf> },
 }
 
 struct Job(ClientContext, ClientCommand);
@@ -1312,6 +1316,11 @@ async fn main() -> Result<(), anyhow::Error> {
             ProjectCommand::New { path } => {
                 Project::new(path.clone())?;
                 Ok(())
+            }
+            ProjectCommand::Test { path } => {
+                let path = path.clone().unwrap_or_else(|| env::current_dir().unwrap());
+                let project = Project::from_existing_project(path)?;
+                Ok(project.test()?)
             }
         },
 


### PR DESCRIPTION
# Motivation

Users need an easy way to unit test their applications.

# Solution

Add `linera project test` which:
1. Tries to find the `linera-test-runner` binary, if it cannot find it downloads it using `cargo install`
2. Runs the tests with the runner piping stdin and stdout.
3. Fails if the underlying tests fail.

# Note

Strictly speaking this is waiting on the crate `linera-test-runner` to be installed. But I tested it out without the `linera-test-runner` and by putting it manually in `~/.cargo/bin` and both have the desired behaviour.

Integration tests will be added as soon as the crate is available, otherwise they will fail.