### PR TITLE
Use hyphens for CLI commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ trap 'kill $(jobs -p)' EXIT
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
-./linera --wallet wallet.json create_genesis_config 10 --genesis genesis.json --initial-funding 10 --committee committee.json
+./linera --wallet wallet.json create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json
 
 # Start servers and create initial chains in DB
 for I in 1 2 3 4
@@ -73,7 +73,7 @@ done
 # Command line prefix for client calls
 CLIENT=(./linera --storage rocksdb:linera.db --wallet wallet.json --max-pending-messages 10000)
 
-${CLIENT[@]} query_validators
+${CLIENT[@]} query-validators
 
 # Give some time for server startup
 sleep 1
@@ -81,16 +81,16 @@ sleep 1
 # Query balance for first and last user chain, root chains 0 and 9
 CHAIN1="e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
 CHAIN2="256e1dbc00482ddd619c293cc0df94d366afe7980022bb22d99e33036fd465dd"
-${CLIENT[@]} query_balance "$CHAIN1"
-${CLIENT[@]} query_balance "$CHAIN2"
+${CLIENT[@]} query-balance "$CHAIN1"
+${CLIENT[@]} query-balance "$CHAIN2"
 
 # Transfer 10 units then 5 back
 ${CLIENT[@]} transfer 10 --from "$CHAIN1" --to "$CHAIN2"
 ${CLIENT[@]} transfer 5 --from "$CHAIN2" --to "$CHAIN1"
 
 # Query balances again
-${CLIENT[@]} query_balance "$CHAIN1"
-${CLIENT[@]} query_balance "$CHAIN2"
+${CLIENT[@]} query-balance "$CHAIN1"
+${CLIENT[@]} query-balance "$CHAIN2"
 
 cd ../..
 ```

--- a/docker/run-client.sh
+++ b/docker/run-client.sh
@@ -22,7 +22,7 @@ ${CLIENT[@]} transfer 5 --from "$CHAIN2" --to "$CHAIN1"
 ${CLIENT[@]} benchmark --max-in-flight 50
 
 # Create derived chain
-CHAIN3="`${CLIENT[@]} open_chain --from "$CHAIN1"`"
+CHAIN3="`${CLIENT[@]} open-chain --from "$CHAIN1"`"
 
 # Inspect state of derived chain
 fgrep '"chain_id":"'$CHAIN3'"' wallet.json

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -544,7 +544,6 @@ struct ClientOptions {
 #[derive(StructOpt)]
 enum ClientCommand {
     /// Transfer funds
-    #[structopt(name = "transfer")]
     Transfer {
         /// Sending chain id (must be one of our chains)
         #[structopt(long = "from")]
@@ -559,7 +558,6 @@ enum ClientCommand {
     },
 
     /// Open (i.e. activate) a new chain deriving the UID from an existing one.
-    #[structopt(name = "open_chain")]
     OpenChain {
         /// Sending chain id (must be one of our chains).
         #[structopt(long = "from")]
@@ -570,9 +568,8 @@ enum ClientCommand {
         public_key: Option<PublicKey>,
     },
 
-    /// Close (i.e. deactivate) an existing chain. (Consider `spend_and_transfer`
-    /// instead for real-life use cases.)
-    #[structopt(name = "close_chain")]
+    /// Close (i.e. deactivate) an existing chain.
+    // TODO: Consider `spend-and-transfer` instead for real-life use cases.
     CloseChain {
         /// Sending chain id (must be one of our chains)
         #[structopt(long = "from")]
@@ -580,7 +577,6 @@ enum ClientCommand {
     },
 
     /// Read the balance of the chain from the local state of the client.
-    #[structopt(name = "query_balance")]
     QueryBalance {
         /// Chain id
         chain_id: Option<ChainId>,
@@ -588,46 +584,41 @@ enum ClientCommand {
 
     /// Synchronize the local state of the chain (including a conservative estimation of the
     /// available balance) with a quorum validators.
-    #[structopt(name = "sync_balance")]
-    SynchronizeBalance {
+    SyncBalance {
         /// Chain id
         chain_id: Option<ChainId>,
     },
 
     /// Show the current set of validators for a chain.
-    #[structopt(name = "query_validators")]
     QueryValidators {
         /// Chain id
         chain_id: Option<ChainId>,
     },
 
     /// Add or modify a validator (admin only)
-    #[structopt(name = "set_validator")]
     SetValidator {
         /// The public key of the validator.
-        #[structopt(long = "name")]
+        #[structopt(long)]
         name: ValidatorName,
 
         /// Network address
-        #[structopt(long = "address")]
-        network_address: String,
+        #[structopt(long)]
+        address: String,
 
         /// Voting power
-        #[structopt(long = "votes", default_value = "1")]
+        #[structopt(long, default_value = "1")]
         votes: u64,
     },
 
     /// Remove a validator (admin only)
-    #[structopt(name = "remove_validator")]
     RemoveValidator {
         /// The public key of the validator.
-        #[structopt(long = "name")]
+        #[structopt(long)]
         name: ValidatorName,
     },
 
     /// Send one transfer per chain in bulk mode
     #[cfg(feature = "benchmark")]
-    #[structopt(name = "benchmark")]
     Benchmark {
         /// Maximum number of blocks in flight
         #[structopt(long, default_value = "200")]
@@ -641,7 +632,6 @@ enum ClientCommand {
     /// Create genesis configuration for a Linera deployment.
     /// Create initial user chains and print information to be used for initialization of validator setup.
     /// This will also create an initial wallet for the owner of the initial "root" chains.
-    #[structopt(name = "create_genesis_config")]
     CreateGenesisConfig {
         /// Sets the file describing the public configurations of all validators
         #[structopt(long = "committee")]
@@ -668,7 +658,6 @@ enum ClientCommand {
     },
 
     /// Watch the network for notifications.
-    #[structopt(name = "watch")]
     Watch {
         /// The collection of Chain IDs to watch.
         chain_ids: Vec<ChainId>,
@@ -679,14 +668,12 @@ enum ClientCommand {
     },
 
     /// Acts as a Synchronizer on the network.
-    #[structopt(name = "synchronize")]
     Synchronize {
         /// The collection of Chain IDs to synchronize for.
         chain_ids: Vec<ChainId>,
     },
 
     /// Run a GraphQL service on the local node of a given chain.
-    #[structopt(name = "service")]
     Service {
         /// Chain id
         chain_id: Option<ChainId>,
@@ -697,7 +684,6 @@ enum ClientCommand {
     },
 
     /// Publish bytecode.
-    #[structopt(name = "publish_bytecode")]
     PublishBytecode {
         contract: PathBuf,
         service: PathBuf,
@@ -705,21 +691,19 @@ enum ClientCommand {
     },
 
     /// Create an application.
-    #[structopt(name = "create_application")]
     CreateApplication {
         bytecode_id: BytecodeId,
         /// The initialization arguments, passed to the contract's `initialize` method on the chain
         /// that creates the application. (But not on other chains, when it is registered there.)
         arguments: String,
         creator: Option<ChainId>,
-        #[structopt(long = "parameters")]
+        #[structopt(long)]
         parameters: Option<String>,
-        #[structopt(long = "required-application-ids")]
+        #[structopt(long)]
         required_application_ids: Option<Vec<UserApplicationId>>,
     },
 
     /// Create an application, and publish the required bytecode.
-    #[structopt(name = "publish_and_create")]
     PublishAndCreate {
         contract: PathBuf,
         service: PathBuf,
@@ -734,11 +718,9 @@ enum ClientCommand {
     },
 
     /// Create an unassigned key-pair.
-    #[structopt(name = "keygen")]
     KeyGen,
 
     /// Assign a key to a chain given a certificate.
-    #[structopt(name = "assign")]
     Assign {
         #[structopt(long)]
         key: PublicKey,
@@ -748,11 +730,9 @@ enum ClientCommand {
     },
 
     /// Show the contents of the wallet.
-    #[structopt(name = "wallet")]
     Wallet(WalletCommand),
 
     /// Manage Linera projects.
-    #[structopt(name = "project")]
     Project(ProjectCommand),
 }
 
@@ -864,7 +844,7 @@ where
                 context.save_wallet();
             }
 
-            SynchronizeBalance { chain_id } => {
+            SyncBalance { chain_id } => {
                 let mut chain_client = context.make_chain_client(storage, chain_id);
                 info!("Synchronize chain information");
                 let time_start = Instant::now();
@@ -917,13 +897,13 @@ where
                 match command {
                     SetValidator {
                         name,
-                        network_address,
+                        address,
                         votes,
                     } => {
                         validators.insert(
                             name,
                             ValidatorState {
-                                network_address,
+                                network_address: address,
                                 votes,
                             },
                         );

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -718,7 +718,7 @@ enum ClientCommand {
     },
 
     /// Create an unassigned key-pair.
-    KeyGen,
+    Keygen,
 
     /// Assign a key to a chain given a certificate.
     Assign {
@@ -1233,7 +1233,7 @@ where
                 context.save_wallet();
             }
 
-            CreateGenesisConfig { .. } | KeyGen | Wallet(_) | Project(_) => unreachable!(),
+            CreateGenesisConfig { .. } | Keygen | Wallet(_) | Project(_) => unreachable!(),
         }
         Ok(())
     }
@@ -1296,7 +1296,7 @@ async fn main() -> Result<(), anyhow::Error> {
         },
 
         command => match command {
-            ClientCommand::KeyGen => {
+            ClientCommand::Keygen => {
                 let mut context = ClientContext::from_options(&options)?;
                 let key_pair = KeyPair::generate();
                 let public = key_pair.public();

--- a/linera-service/tests/integration_tests.rs
+++ b/linera-service/tests/integration_tests.rs
@@ -478,8 +478,8 @@ impl Client {
         .await;
     }
 
-    async fn key_gen(&self) -> anyhow::Result<Owner> {
-        let stdout = Self::run_command(self.run().await.arg("key-gen")).await;
+    async fn keygen(&self) -> anyhow::Result<Owner> {
+        let stdout = Self::run_command(self.run().await.arg("keygen")).await;
         Ok(Owner::from_str(stdout.trim())?)
     }
 
@@ -831,7 +831,7 @@ impl NodeService {
                     &error_string[(error_string.len() - 5000)..]
                 );
             }
-            panic!("publish_and_create failed: {}", error_string);
+            panic!("publishBytecode failed: {}", error_string);
         }
         serde_json::from_value(response_body["data"]["publishBytecode"].clone()).unwrap()
     }
@@ -863,7 +863,7 @@ impl NodeService {
             .unwrap();
         let response_body: Value = response.json().await.unwrap();
         if let Some(errors) = response_body.get("errors") {
-            panic!("create_application failed: {}", errors);
+            panic!("createApplication failed: {}", errors);
         }
         serde_json::from_value(response_body["data"]["createApplication"].clone()).unwrap()
     }
@@ -993,7 +993,7 @@ async fn test_end_to_end_multiple_wallets() {
     let chain_1 = *client_1.get_wallet().chain_ids().first().unwrap();
 
     // Generate a key for Client 2.
-    let client_2_key = client_2.key_gen().await.unwrap();
+    let client_2_key = client_2.keygen().await.unwrap();
 
     // Open chain on behalf of Client 2.
     let (effect_id, chain_2) = client_1
@@ -1122,7 +1122,7 @@ async fn test_end_to_end_social_user_pub_sub() {
     let (contract, service) = runner.build_application("social").await;
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let client2key = client2.key_gen().await.unwrap();
+    let client2key = client2.keygen().await.unwrap();
 
     // Open chain on behalf of Client 2.
     let (effect_id, chain2) = client1.open_chain(chain1, Some(client2key)).await.unwrap();

--- a/linera-service/tests/integration_tests.rs
+++ b/linera-service/tests/integration_tests.rs
@@ -249,7 +249,7 @@ impl Client {
     async fn create_genesis_config(&self) {
         self.run()
             .await
-            .args(["create_genesis_config", "10"])
+            .args(["create-genesis-config", "10"])
             .args(["--initial-funding", "10"])
             .args(["--committee", "committee.json"])
             .args(["--genesis", "genesis.json"])
@@ -301,7 +301,7 @@ impl Client {
         let stdout = Self::run_command(
             self.run_with_storage()
                 .await
-                .arg("publish_and_create")
+                .arg("publish-and-create")
                 .args([contract, service])
                 .arg(arg.to_string())
                 .args(publisher.into().iter().map(ChainId::to_string)),
@@ -319,7 +319,7 @@ impl Client {
         let stdout = Self::run_command(
             self.run_with_storage()
                 .await
-                .arg("publish_bytecode")
+                .arg("publish-bytecode")
                 .args([contract, service])
                 .args(publisher.into().iter().map(ChainId::to_string)),
         )
@@ -336,7 +336,7 @@ impl Client {
         let stdout = Self::run_command(
             self.run_with_storage()
                 .await
-                .arg("create_application")
+                .arg("create-application")
                 .args([bytecode_id, arg.to_string()])
                 .args(creator.into().iter().map(ChainId::to_string)),
         )
@@ -382,7 +382,7 @@ impl Client {
 
     async fn query_validators(&self, chain_id: Option<ChainId>) {
         let mut command = self.run_with_storage().await;
-        command.arg("query_validators");
+        command.arg("query-validators");
         if let Some(chain_id) = chain_id {
             command.arg(&chain_id.to_string());
         }
@@ -393,7 +393,7 @@ impl Client {
         let stdout = Self::run_command(
             self.run_with_storage()
                 .await
-                .arg("query_balance")
+                .arg("query-balance")
                 .arg(&chain_id.to_string()),
         )
         .await;
@@ -432,7 +432,7 @@ impl Client {
     ) -> anyhow::Result<(EffectId, ChainId)> {
         let mut command = self.run_with_storage().await;
         command
-            .arg("open_chain")
+            .arg("open-chain")
             .args(["--from", &from.to_string()]);
 
         if let Some(owner) = to_owner {
@@ -460,7 +460,7 @@ impl Client {
         Self::run_command(
             self.run_with_storage()
                 .await
-                .arg("set_validator")
+                .arg("set-validator")
                 .args(["--name", name])
                 .args(["--address", &address])
                 .args(["--votes", &votes.to_string()]),
@@ -472,14 +472,14 @@ impl Client {
         Self::run_command(
             self.run_with_storage()
                 .await
-                .arg("remove_validator")
+                .arg("remove-validator")
                 .args(["--name", name]),
         )
         .await;
     }
 
-    async fn keygen(&self) -> anyhow::Result<Owner> {
-        let stdout = Self::run_command(self.run().await.arg("keygen")).await;
+    async fn key_gen(&self) -> anyhow::Result<Owner> {
+        let stdout = Self::run_command(self.run().await.arg("key-gen")).await;
         Ok(Owner::from_str(stdout.trim())?)
     }
 
@@ -502,7 +502,7 @@ impl Client {
         Self::run_command(
             self.run_with_storage()
                 .await
-                .arg("sync_balance")
+                .arg("sync-balance")
                 .arg(&chain_id.to_string()),
         )
         .await;
@@ -993,7 +993,7 @@ async fn test_end_to_end_multiple_wallets() {
     let chain_1 = *client_1.get_wallet().chain_ids().first().unwrap();
 
     // Generate a key for Client 2.
-    let client_2_key = client_2.keygen().await.unwrap();
+    let client_2_key = client_2.key_gen().await.unwrap();
 
     // Open chain on behalf of Client 2.
     let (effect_id, chain_2) = client_1
@@ -1122,7 +1122,7 @@ async fn test_end_to_end_social_user_pub_sub() {
     let (contract, service) = runner.build_application("social").await;
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let client2key = client2.keygen().await.unwrap();
+    let client2key = client2.key_gen().await.unwrap();
 
     // Open chain on behalf of Client 2.
     let (effect_id, chain2) = client1.open_chain(chain1, Some(client2key)).await.unwrap();

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -24,7 +24,7 @@ set -x
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
-./linera --wallet wallet.json create_genesis_config 10 --genesis genesis.json --initial-funding 10 --committee committee.json
+./linera --wallet wallet.json create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json
 
 # Initialise the second wallet.
 ./linera --wallet wallet_2.json wallet init --genesis genesis.json
@@ -43,7 +43,7 @@ done
 sleep 3;
 
 # Create second wallet with unassigned key.
-KEY=$(./linera --wallet wallet_2.json keygen)
+KEY=$(./linera --wallet wallet_2.json key-gen)
 
 # Open chain on behalf of wallet 2.
 EFFECT_AND_CHAIN=$(./linera --wallet wallet.json open_chain --to-public-key "$KEY")

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -43,10 +43,10 @@ done
 sleep 3;
 
 # Create second wallet with unassigned key.
-KEY=$(./linera --wallet wallet_2.json key-gen)
+KEY=$(./linera --wallet wallet_2.json keygen)
 
 # Open chain on behalf of wallet 2.
-EFFECT_AND_CHAIN=$(./linera --wallet wallet.json open_chain --to-public-key "$KEY")
+EFFECT_AND_CHAIN=$(./linera --wallet wallet.json open-chain --to-public-key "$KEY")
 EFFECT=$(echo "$EFFECT_AND_CHAIN" | sed -n '1 p')
 
 # Assign newly created chain to unassigned key.


### PR DESCRIPTION
# Motivation

We currently use both underscores (`_`) and hyphens (`-`) for our CLI commands and options.

# Solution

Use hyphens everywhere. That seems to be most common, and is also `structopt`'s default.