### PR TITLE
Centralize dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,7 +2694,7 @@ dependencies = [
  "linera-views-derive",
  "linked-hash-map",
  "metrics",
- "rand 0.8.5",
+ "rand 0.7.3",
  "rocksdb",
  "serde",
  "sha3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,16 +3035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
-dependencies = [
- "overload",
- "winapi",
-]
-
-[[package]]
 name = "num"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,12 +3210,6 @@ name = "os_str_bytes"
 version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -5115,7 +5099,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
- "valuable",
 ]
 
 [[package]]
@@ -5129,32 +5112,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -5270,12 +5239,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,101 @@ exclude = [
 ]
 resolver = "2"
 
+[workspace.dependencies]
+anyhow = "1.0.57"
+async-graphql = "5.0.5"
+async-graphql-axum = "5.0.5"
+async-lock = "2.6.0"
+async-trait = "0.1.52"
+aws-config = "0.14.0"
+aws-sdk-dynamodb = "0.14.0"
+aws-sdk-s3 = "0.14.0"
+aws-smithy-http = "0.44.0"
+aws-types = "0.14.0"
+axum = "0.6.2"
+bcs = "0.1.3"
+bincode = "1.3.3"
+bytes = "1.2.1"
+cargo_toml = "0.15.2"
+chrono = "0.4.23"
+colored = "2.0.0"
+comfy-table = "6.1.4"
+convert_case = "0.6.0"
+criterion = "0.4.0"
+custom_debug_derive = "0.5.1"
+dashmap = "5.4.0"
+derive_more = "0.99.17"
+dirs = "5.0.0"
+ed25519 = "1.2.0"
+ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
+futures = "0.3.24"
+generic-array = { version = "0.14.4", features = ["serde"] }
+hex = "0.4.3"
+http = "0.2.7"
+log = "0.4.14"
+lru = "0.9.0"
+metrics = "0.20.1"
+metrics-exporter-tcp = "0.7.0"
+metrics-util = "0.14.0"
+linked-hash-map = "0.5.3"
+once_cell = "1.17.1"
+parse_duration = "2.1.1"
+portable-atomic = "0.3.19"
+proc-macro2 = "1.0"
+proptest = "1.0.0"
+prost = "0.11"
+quote = "1.0"
+rand = "0.7.3"
+reqwest = "0.11.14"
+rocksdb = "0.19.0"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_bytes = "0.11.8"
+serde_json = "1.0.93"
+serde_yaml = "0.8.21"
+serde-name = "0.2.0"
+serde-reflection = "0.3.5"
+sha3 = "0.10.6"
+similar-asserts = "1.1.0"
+static_assertions = "1.1.0"
+structopt = "0.3.23"
+syn = "1.0.107"
+tempfile = "3.2.0"
+test-case = "3.0.0"
+test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
+test-strategy = "0.2.0"
+thiserror = "1.0.38"
+tonic = "0.8"
+tonic-build = "0.8"
+tonic-health = "0.8"
+tokio = "1.25.0"
+tokio-stream = "0.1.11"
+tokio-test = "0.4.2"
+tokio-util = "0.6.9"
+toml = "0.7.3"
+tower-http = "0.4.0"
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter"] }
+wasm-encoder = "0.24.1"
+wasmer = { version = "3.1.1", features = ["singlepass"] }
+wasmer-middlewares = "3.1.1"
+wasmparser = "0.101.1"
+wasmtime = "1.0"
+wit-bindgen-guest-rust = { git = "https://github.com/jvff/wit-bindgen", rev = "b3f43500ec4a65379b65148e32941117c17bc2f1" }
+wit-bindgen-host-wasmer-rust = { git = "https://github.com/jvff/wit-bindgen", rev = "b3f43500ec4a65379b65148e32941117c17bc2f1" }
+wit-bindgen-host-wasmtime-rust = { git = "https://github.com/jvff/wit-bindgen", rev = "b3f43500ec4a65379b65148e32941117c17bc2f1" }
+
+linera-base = { path = "./linera-base" }
+linera-chain = { path = "./linera-chain" }
+linera-core = { path = "./linera-core", default-features = false }
+linera-execution = { path = "./linera-execution", default-features = false }
+linera-rpc = { path = "./linera-rpc" }
+linera-storage = { path = "./linera-storage", default-features = false }
+linera-views = { path = "./linera-views" }
+linera-views-derive = { path = "./linera-views-derive" }
+
+fungible = { path = "./linera-examples/fungible" }
+social = { path = "./linera-examples/social" }
+
 [profile.release]
 debug = true
 

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -8,26 +8,26 @@ edition = "2021"
 test = ["test-strategy", "proptest"]
 
 [dependencies]
-async-graphql = "5.0.5"
-bcs = "0.1.3"
-ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
-generic-array = { version = "0.14.4", features = ["serde"] }
-hex = "0.4.3"
-proptest = { version = "1.0.0", optional = true }
-serde = { version = "1.0.130", features = ["derive"] }
-serde_bytes = "0.11.8"
-serde-name = "0.2.0"
-sha3 = "0.10.6"
-test-strategy = { version = "0.2.0", optional = true }
-thiserror = "1.0.31"
+async-graphql = { workspace = true }
+bcs = { workspace = true }
+ed25519-dalek = { workspace = true }
+generic-array = { workspace = true }
+hex = { workspace = true }
+proptest = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde-name = { workspace = true }
+sha3 = { workspace = true }
+test-strategy = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-chrono = "0.4.23"
-rand = "0.7.3"
+chrono = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
-custom_debug_derive = "0.5.1"
-linera-base = { path = ".", features = ["test"] }
+custom_debug_derive = { workspace = true }
+linera-base = { workspace = true, features = ["test"] }
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -8,19 +8,19 @@ edition = "2021"
 test = ["tokio/macros", "async-lock", "linera-base/test", "linera-execution/test"]
 
 [dependencies]
-async-trait = "0.1.52"
+async-trait = { workspace = true }
 async-lock = { version = "2.6.0", optional = true }
-async-graphql = "5.0.5"
-linera-base = { path = "../linera-base" }
-linera-execution = { path = "../linera-execution", default-features = false }
-linera-views = { path = "../linera-views", features = ["metrics"] }
-tracing = "0.1.37"
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.31"
-tokio = "1.25.0"
+async-graphql = { workspace = true }
+linera-base = { workspace = true }
+linera-execution = { workspace = true }
+linera-views = { workspace = true, features = ["metrics"] }
+tracing = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 
 [dev-dependencies]
-linera-chain = { path = ".", features = ["test"] }
+linera-chain = { workspace = true, features = ["test"] }
 
 [package.metadata.cargo-machete]
 ignored = ["async-trait"]

--- a/linera-examples/Cargo.lock
+++ b/linera-examples/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "thiserror",
 ]
 
@@ -195,7 +195,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -349,7 +349,7 @@ checksum = "e31225543cb46f81a7e224762764f4a6a0f097b1db0b175f69e8065efaa42de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -811,12 +811,12 @@ dependencies = [
 
 [[package]]
 name = "custom_debug_derive"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b35d34eb004bf2d33c093f1c55ee77829e8654644288d3b6afd8c2d99d23729"
+checksum = "08a9f3941234c9f62ceaa2782974827749de9b0a8a6487275a278da068e1baf7"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 
@@ -844,7 +844,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -861,7 +861,7 @@ checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -885,7 +885,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -896,7 +896,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -922,7 +922,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -977,7 +977,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1049,7 +1049,7 @@ checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1070,7 +1070,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1260,7 +1260,7 @@ checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1802,7 +1802,7 @@ dependencies = [
  "linera-views-derive",
  "linked-hash-map",
  "metrics",
- "rand 0.8.5",
+ "rand 0.7.3",
  "rocksdb",
  "serde",
  "sha3",
@@ -1822,7 +1822,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1975,7 +1975,7 @@ checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2182,7 +2182,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2245,7 +2245,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2316,7 +2316,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2344,9 +2344,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2582,7 +2582,7 @@ checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2733,7 +2733,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2889,7 +2889,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2900,7 +2900,7 @@ checksum = "bafede0d0a2f21910f36d47b1558caae3076ed80f6f3ad0fc85a91e6ba7e5938"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2921,6 +2921,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2928,7 +2939,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -2969,7 +2980,7 @@ checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2981,27 +2992,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3052,7 +3063,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3159,7 +3170,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3314,7 +3325,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -3338,7 +3349,7 @@ checksum = "c5020cfa87c7cecefef118055d44e3c1fc122c7ec25701d528ee458a0b45f38f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3359,7 +3370,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3486,7 +3497,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3780,7 +3791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e64391864794db026d27b15cbe6edd3c25864222bd90229dfa1a26ebf30705"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4029,7 +4040,7 @@ version = "0.2.0"
 source = "git+https://github.com/jvff/wit-bindgen?rev=b3f43500ec4a65379b65148e32941117c17bc2f1#b3f43500ec4a65379b65148e32941117c17bc2f1"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
  "wit-bindgen-core",
  "wit-bindgen-gen-guest-rust",
 ]
@@ -4053,7 +4064,7 @@ version = "0.2.0"
 source = "git+https://github.com/jvff/wit-bindgen?rev=b3f43500ec4a65379b65148e32941117c17bc2f1#b3f43500ec4a65379b65148e32941117c17bc2f1"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
  "wit-bindgen-core",
  "wit-bindgen-gen-host-wasmer-rust",
 ]
@@ -4076,7 +4087,7 @@ version = "0.2.0"
 source = "git+https://github.com/jvff/wit-bindgen?rev=b3f43500ec4a65379b65148e32941117c17bc2f1#b3f43500ec4a65379b65148e32941117c17bc2f1"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.107",
  "wit-bindgen-core",
  "wit-bindgen-gen-host-wasmtime-rust",
 ]
@@ -4110,7 +4121,7 @@ checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]
 

--- a/linera-examples/Cargo.toml
+++ b/linera-examples/Cargo.toml
@@ -15,6 +15,25 @@ members = [
         "social",
 ]
 
+[workspace.dependencies]
+async-graphql = { version = "5.0.7", default-features = false }
+async-trait = "0.1.52"
+bcs = "0.1.3"
+futures = "0.3.17"
+futures-util = "0.3.26"
+hex = "0.4.3"
+linera-sdk = { path = "../linera-sdk" }
+linera-views = { path = "../linera-views" }
+log = "0.4.17"
+serde = { version = "1.0.152", features = ["derive"] }
+serde_json = "1.0.93"
+thiserror = "1.0.31"
+tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
+webassembly-test = "0.1.0"
+
+crowd-funding = { path = "./crowd-funding" }
+fungible = { path = "./fungible" }
+
 [profile.release]
 debug = true
 lto = true

--- a/linera-examples/counter-graphql/Cargo.toml
+++ b/linera-examples/counter-graphql/Cargo.toml
@@ -5,20 +5,20 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-graphql = { version = "5.0.7", default-features = false }
-async-trait = "0.1.52"
-bcs = "0.1.3"
-futures = "0.3.17"
-hex = "0.4.3"
-linera-sdk = { path = "../../linera-sdk" }
-linera-views = { path = "../../linera-views" }
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.93"
-thiserror = "1.0.31"
+async-graphql = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+linera-sdk = { workspace = true }
+linera-views = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test"] }
-webassembly-test = "0.1.0"
+linera-sdk = { workspace = true, features = ["test"] }
+webassembly-test = { workspace = true }
 
 [[bin]]
 name = "counter_graphql_contract"

--- a/linera-examples/counter/Cargo.toml
+++ b/linera-examples/counter/Cargo.toml
@@ -5,17 +5,17 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-futures = "0.3.17"
-linera-sdk = { path = "../../linera-sdk" }
-log = "0.4.17"
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.31"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+futures = { workspace = true }
+linera-sdk = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test"] }
-webassembly-test = "0.1.0"
+linera-sdk = { workspace = true, features = ["test"] }
+webassembly-test = { workspace = true }
 
 [[bin]]
 name = "counter_contract"

--- a/linera-examples/counter2/Cargo.toml
+++ b/linera-examples/counter2/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-linera-sdk = { path = "../../linera-sdk" }
-linera-views = { path = "../../linera-views" }
-thiserror = "1.0.31"
-futures-util = "0.3.26"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+linera-sdk = { workspace = true }
+linera-views = { workspace = true }
+thiserror = { workspace = true }
+futures-util = { workspace = true }
 
 [dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test"] }
-webassembly-test = "0.1.0"
+linera-sdk = { workspace = true, features = ["test"] }
+webassembly-test = { workspace = true }
 
 [[bin]]
 name = "counter2_contract"

--- a/linera-examples/crowd-funding/Cargo.toml
+++ b/linera-examples/crowd-funding/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-fungible = { path = "../fungible" }
-linera-sdk = { path = "../../linera-sdk" }
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.31"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+fungible = { workspace = true }
+linera-sdk = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [[bin]]
 name = "crowd-funding_contract"

--- a/linera-examples/crowd-funding2/Cargo.toml
+++ b/linera-examples/crowd-funding2/Cargo.toml
@@ -5,14 +5,14 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-crowd-funding = { path = "../crowd-funding" }
-fungible = { path = "../fungible" }
-linera-sdk = { path = "../../linera-sdk" }
-linera-views = { path = "../../linera-views" }
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.31"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+crowd-funding = { workspace = true }
+fungible = { workspace = true }
+linera-sdk = { workspace = true }
+linera-views = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [[bin]]
 name = "crowd-funding2_contract"

--- a/linera-examples/fungible/Cargo.toml
+++ b/linera-examples/fungible/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-graphql = { version = "5.0.6", default-features = false }
-async-trait = "0.1.52"
-bcs = "0.1.3"
-linera-sdk = { path = "../../linera-sdk" }
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.31"
+async-graphql = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+linera-sdk = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test", "wasmer", "wasmtime"] }
-tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
+linera-sdk = { workspace = true, features = ["test", "wasmer", "wasmtime"] }
+tokio = { workspace = true }
 
 [[bin]]
 name = "fungible_contract"

--- a/linera-examples/fungible2/Cargo.toml
+++ b/linera-examples/fungible2/Cargo.toml
@@ -5,14 +5,14 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-graphql = { version = "5.0.6", default-features = false }
-async-trait = "0.1.52"
-bcs = "0.1.3"
-fungible = { path = "../fungible" }
-linera-sdk = { path = "../../linera-sdk" }
-linera-views = { path = "../../linera-views" }
-thiserror = "1.0.31"
-serde_json = "1.0.93"
+async-graphql = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+fungible = { workspace = true }
+linera-sdk = { workspace = true }
+linera-views = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
 
 [[bin]]
 name = "fungible2_contract"

--- a/linera-examples/meta-counter/Cargo.toml
+++ b/linera-examples/meta-counter/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-linera-sdk = { path = "../../linera-sdk" }
-log = "0.4.17"
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.31"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+linera-sdk = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test"] }
-webassembly-test = "0.1.0"
+linera-sdk = { workspace = true, features = ["test"] }
+webassembly-test = { workspace = true }
 
 [[bin]]
 name = "meta_counter_contract"

--- a/linera-examples/reentrant-counter/Cargo.toml
+++ b/linera-examples/reentrant-counter/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-futures = "0.3.17"
-linera-sdk = { path = "../../linera-sdk" }
-serde = { version = "1.0.130", features = ["derive"] }
-thiserror = "1.0.31"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+futures = { workspace = true }
+linera-sdk = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test"] }
-webassembly-test = "0.1.0"
+linera-sdk = { workspace = true, features = ["test"] }
+webassembly-test = { workspace = true }
 
 [[bin]]
 name = "reentrant-counter_contract"

--- a/linera-examples/reentrant-counter2/Cargo.toml
+++ b/linera-examples/reentrant-counter2/Cargo.toml
@@ -5,16 +5,16 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-futures = "0.3.17"
-linera-sdk = { path = "../../linera-sdk" }
-linera-views = { path = "../../linera-views" }
-thiserror = "1.0.31"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+futures = { workspace = true }
+linera-sdk = { workspace = true }
+linera-views = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test"] }
-webassembly-test = "0.1.0"
+linera-sdk = { workspace = true, features = ["test"] }
+webassembly-test = { workspace = true }
 
 [[bin]]
 name = "reentrant-counter2_contract"

--- a/linera-examples/social/Cargo.toml
+++ b/linera-examples/social/Cargo.toml
@@ -5,18 +5,18 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
-async-graphql = { version = "5.0.7", default-features = false }
-async-trait = "0.1.52"
-bcs = "0.1.3"
-linera-sdk = { path = "../../linera-sdk" }
-linera-views = { path = "../../linera-views" }
-thiserror = "1.0.31"
-serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.93"
+async-graphql = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+linera-sdk = { workspace = true }
+linera-views = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
-linera-sdk = { path = "../../linera-sdk", features = ["test"] }
-webassembly-test = "0.1.0"
+linera-sdk = { workspace = true, features = ["test"] }
+webassembly-test = { workspace = true }
 
 [[bin]]
 name = "social_contract"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -11,41 +11,41 @@ wasmer = ["dep:wasmer", "wasm-encoder", "wasmer-middlewares", "wasmparser", "wit
 wasmtime = ["dep:wasmtime", "wasm-encoder", "wasmparser", "wit-bindgen-host-wasmtime-rust"]
 
 [dependencies]
-anyhow = "1.0.57"
-async-lock = { version = "2.6.0", optional = true }
-async-trait = "0.1.52"
-async-graphql = "5.0.5"
-bcs = "0.1.3"
-custom_debug_derive = "0.5.0"
-dashmap = "5.3.4"
-derive_more = "0.99.17"
-futures = "0.3.24"
-linera-base = { path = "../linera-base" }
-linera-views = { path = "../linera-views", features = ["metrics"] }
-linera-views-derive = { path = "../linera-views-derive" }
-once_cell = "1.17.1"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_bytes = "0.11.8"
-thiserror = "1.0.31"
-tokio = { version = "1.25.0", features = ["fs"] }
-tracing = "0.1.37"
-wasm-encoder = { version = "0.24.1", optional = true }
-wasmer = { version = "3.0.0-rc.2", optional = true, features = ["singlepass"] }
-wasmer-middlewares = { version = "3.1.1", optional = true }
-wasmparser = { version = "0.101.1", optional = true }
-wasmtime = { version = "1.0", optional = true }
-wit-bindgen-host-wasmer-rust = { git = "https://github.com/jvff/wit-bindgen", rev = "b3f43500ec4a65379b65148e32941117c17bc2f1", optional = true }
-wit-bindgen-host-wasmtime-rust = { git = "https://github.com/jvff/wit-bindgen", rev = "b3f43500ec4a65379b65148e32941117c17bc2f1", optional = true }
+anyhow = { workspace = true }
+async-lock = { workspace = true, optional = true }
+async-trait = { workspace = true }
+async-graphql = { workspace = true }
+bcs = { workspace = true }
+custom_debug_derive = { workspace = true }
+dashmap = { workspace = true }
+derive_more = { workspace = true }
+futures = { workspace = true }
+linera-base = { workspace = true }
+linera-views = { workspace = true, features = ["metrics"] }
+linera-views-derive = { workspace = true }
+once_cell = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+tracing = { workspace = true }
+wasm-encoder = { workspace = true, optional = true }
+wasmer = { workspace = true, optional = true }
+wasmer-middlewares = { workspace = true, optional = true }
+wasmparser = { workspace = true, optional = true }
+wasmtime = { workspace = true, optional = true }
+wit-bindgen-host-wasmer-rust = { workspace = true, optional = true }
+wit-bindgen-host-wasmtime-rust = { workspace = true, optional = true }
 
 [dev-dependencies]
-anyhow = "1.0.57"
-bcs = "0.1.3"
-linera-base = { path = "../linera-base", features = ["test"] }
-linera-execution = { path = ".", default-features = false, features = ["test"] }
-test-case = "3.0.0"
-test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
-tokio = { version = "1.25.0", features = ["full", "test-util"] }
+anyhow = { workspace = true }
+bcs = { workspace = true }
+linera-base = { workspace = true, features = ["test"] }
+linera-execution = { workspace = true, features = ["test"] }
+test-case = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -8,44 +8,44 @@ edition = "2021"
 test = ["linera-base/test", "linera-chain/test", "linera-core/test", "linera-execution/test", "linera-storage/test"]
 
 [dependencies]
-anyhow = "1.0.57"
-async-trait = "0.1.52"
-bcs = "0.1.3"
-bincode = "1.3.3"
-bytes = "1.2.1"
-dashmap = "5.4.0"
-ed25519 = "1.2.0"
-ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
-futures = "0.3.17"
-http = "0.2"
-linera-base = { path = "../linera-base" }
-linera-chain = { path = "../linera-chain" }
-linera-core = { path = "../linera-core", default-features = false }
-linera-execution = { path = "../linera-execution", default-features = false }
-linera-storage = { path = "../linera-storage", default-features = false }
-linera-views = { path = "../linera-views" }
-tracing = "0.1.37"
-proptest = { version = "1.0.0", optional = true }
-prost = "0.11"
-serde = { version = "1.0.130", features = ["derive"] }
-structopt = "0.3.23"
-thiserror = "1.0.31"
-tokio = "1.25.0"
-tokio-util = { version = "0.6.9", features = ["codec", "net"] }
-tonic = "0.8"
-tonic-health = "0.8"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+bincode = { workspace = true }
+bytes = { workspace = true }
+dashmap = { workspace = true }
+ed25519 = { workspace = true }
+ed25519-dalek = { workspace = true }
+futures = { workspace = true }
+http = { workspace = true }
+linera-base = { workspace = true }
+linera-chain = { workspace = true }
+linera-core = { workspace = true }
+linera-execution = { workspace = true }
+linera-storage = { workspace = true }
+linera-views = { workspace = true }
+tracing = { workspace = true }
+proptest = { workspace = true, optional = true }
+prost = { workspace = true }
+serde = { workspace = true }
+structopt = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true, features = ["codec", "net"] }
+tonic = { workspace = true }
+tonic-health = { workspace = true }
 
 [dev-dependencies]
-linera-rpc = { path = ".", features = ["test"] }
-proptest = "1.0.0"
-serde-reflection = "0.3.5"
-serde_yaml = "0.8.21"
-similar-asserts = "1.1.0"
-structopt = "0.3.23"
-test-strategy = "0.2.0"
+linera-rpc = { workspace = true, features = ["test"] }
+proptest = { workspace = true }
+serde-reflection = { workspace = true }
+serde_yaml = { workspace = true }
+similar-asserts = { workspace = true }
+structopt = { workspace = true }
+test-strategy = { workspace = true }
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["proptest", "prost"]

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -13,25 +13,25 @@ wasmtime = ["linera-core/wasmtime", "linera-execution/wasmtime", "linera-storage
 test = []
 
 [dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-custom_debug_derive = "0.5.0"
-futures = "0.3.17"
-log = "0.4.14"
-serde = { version = "1.0.130", features = ["derive"] }
-linera-base = { path = "../linera-base" }
-linera-views = { path = "../linera-views" }
-wit-bindgen-guest-rust = { git = "https://github.com/jvff/wit-bindgen", rev = "b3f43500ec4a65379b65148e32941117c17bc2f1" }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+custom_debug_derive = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+serde = { workspace = true }
+linera-base = { workspace = true }
+linera-views = { workspace = true }
+wit-bindgen-guest-rust = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-anyhow = "1.0.57"
-cargo_toml = "0.15.2"
-dashmap = "5.4.0"
-linera-base = { path = "../linera-base" }
-linera-chain = { path = "../linera-chain" }
-linera-core = { path = "../linera-core", default-features = false, features = ["test"] }
-linera-execution = { path = "../linera-execution", default-features = false }
-linera-storage = { path = "../linera-storage", default-features = false }
-tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
-wasmtime = "1.0"
-wit-bindgen-host-wasmtime-rust = { git = "https://github.com/jvff/wit-bindgen", rev = "b3f43500ec4a65379b65148e32941117c17bc2f1" }
+anyhow = { workspace = true }
+cargo_toml = { workspace = true }
+dashmap = { workspace = true }
+linera-base = { workspace = true }
+linera-chain = { workspace = true }
+linera-core = { workspace = true, features = ["test"] }
+linera-execution = { workspace = true }
+linera-storage = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wasmtime = { workspace = true }
+wit-bindgen-host-wasmtime-rust = { workspace = true }

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -19,11 +19,8 @@ use linera_execution::{
     system::{SystemChannel, SystemEffect, SystemOperation},
     Bytecode, Effect, Query, Response,
 };
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
-use tokio::sync::Mutex;
+use std::{path::PathBuf, sync::Arc};
+use tokio::{fs, sync::Mutex};
 
 /// A reference to a single microchain inside a [`TestValidator`].
 pub struct ActiveChain {
@@ -166,12 +163,11 @@ impl ActiveChain {
     ///
     /// Returns a tuple with the loaded contract and service [`Bytecode`]s.
     async fn find_current_bytecodes(&self) -> (Bytecode, Bytecode) {
-        let mut cargo_manifest =
-            Manifest::from_path("Cargo.toml").expect("Failed to load Cargo.toml manifest");
-
-        cargo_manifest
-            .complete_from_path(Path::new("."))
-            .expect("Failed to populate manifest with information inferred from the repository");
+        let manifest_path = fs::canonicalize("Cargo.toml")
+            .await
+            .expect("Failed to get absolute path of Cargo manifest");
+        let cargo_manifest =
+            Manifest::from_path(manifest_path).expect("Failed to load Cargo.toml manifest");
 
         let binaries: Vec<_> = cargo_manifest
             .bin

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -12,55 +12,55 @@ wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
 aws = ["linera-views/aws", "linera-core/aws", "linera-storage/aws"]
 
 [dependencies]
-anyhow = "1.0.57"
-async-graphql = "5.0.5"
-async-graphql-axum = "5.0.5"
-async-trait = "0.1.52"
-axum = { version = "0.6.2", features = ["ws", "headers"] }
-bcs = "0.1.3"
-chrono = "0.4.23"
-colored = "2.0.0"
-futures = "0.3.17"
-hex = "0.4.3"
-linera-base = { path = "../linera-base" }
-linera-chain = { path = "../linera-chain" }
-linera-core = { path = "../linera-core", default-features = false }
-linera-execution = { path = "../linera-execution", default-features = false }
-linera-rpc = { path = "../linera-rpc" }
-linera-storage = { path = "../linera-storage", default-features = false }
-linera-views = { path = "../linera-views" }
-metrics-exporter-tcp = "0.7.0"
-tracing = "0.1.37"
-parse_duration = "2.1.1"
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
-structopt = "0.3.23"
-thiserror = "1.0.38"
-tokio = { version = "1.25.0", features = ["full"] }
-tokio-stream = "0.1.11"
-toml = "0.7.3"
-tonic = "0.8"
-tonic-health = "0.8"
-tower-http = { version = "0.4.0", features = ["cors"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-comfy-table = "6.1.4"
-dirs = "5.0.0"
+anyhow = { workspace = true }
+async-graphql = { workspace = true }
+async-graphql-axum = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true, features = ["ws", "headers"] }
+bcs = { workspace = true }
+chrono = { workspace = true }
+colored = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+linera-base = { workspace = true }
+linera-chain = { workspace = true }
+linera-core = { workspace = true }
+linera-execution = { workspace = true }
+linera-rpc = { workspace = true }
+linera-storage = { workspace = true }
+linera-views = { workspace = true }
+metrics-exporter-tcp = { workspace = true }
+tracing = { workspace = true }
+parse_duration = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+structopt = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true }
+toml = { workspace = true }
+tonic = { workspace = true }
+tonic-health = { workspace = true }
+tower-http = { workspace = true, features = ["cors"] }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
+comfy-table = { workspace = true }
+dirs = { workspace = true }
 
 [dev-dependencies]
-linera-base = { path = "../linera-base", features = ["test"] }
-linera-chain = { path = "../linera-chain", features = ["test"] }
-linera-core = { path = "../linera-core", default-features = false, features = ["test"] }
-linera-execution = { path = "../linera-execution", default-features = false, features = ["test"] }
-linera-rpc = { path = "../linera-rpc", features = ["test"] }
-linera-storage = { path = "../linera-storage", default-features = false, features = ["test"] }
-linera-views = { path = "../linera-views", features = ["test"] }
-once_cell = "1.17.1"
-proptest = "1.0.0"
-reqwest = { version = "0.11.14", features = ["json"] }
-tempfile = "3.2.0"
-test-log = { version = "0.2.11", default-features = false, features = ["trace"] }
-test-strategy = "0.2.0"
-tokio = { version = "1.25.0", features = ["full", "test-util"] }
+linera-base = { workspace = true, features = ["test"] }
+linera-chain = { workspace = true, features = ["test"] }
+linera-core = { workspace = true, features = ["test"] }
+linera-execution = { workspace = true, features = ["test"] }
+linera-rpc = { workspace = true, features = ["test"] }
+linera-storage = { workspace = true, features = ["test"] }
+linera-views = { workspace = true, features = ["test"] }
+once_cell = { workspace = true }
+proptest = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+tempfile = { workspace = true }
+test-log = { workspace = true, features = ["trace"] }
+test-strategy = { workspace = true }
+tokio = { workspace = true, features = ["full", "test-util"] }
 
 [[bin]]
 name = "linera"

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -12,22 +12,22 @@ wasmtime = ["linera-execution/wasmtime"]
 aws = ["linera-views/aws"]
 
 [dependencies]
-async-lock = "2.6.0"
-async-trait = "0.1.52"
-bcs = "0.1.3"
-dashmap = "5.3.4"
-futures = "0.3.17"
-linera-base = { path = "../linera-base" }
-linera-chain = { path = "../linera-chain" }
-linera-execution = { path = "../linera-execution", default-features = false }
-linera-views = { path = "../linera-views", features = ["metrics"] }
-metrics = "0.20.1"
-tracing = "0.1.37"
-rocksdb = "0.19.0"
-serde = { version = "1.0.130", features = ["derive"] }
-tokio = { version = "1.25.0", features = ["macros"] }
+async-lock = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+dashmap = { workspace = true }
+futures = { workspace = true }
+linera-base = { workspace = true }
+linera-chain = { workspace = true }
+linera-execution = { workspace = true }
+linera-views = { workspace = true, features = ["metrics"] }
+metrics = { workspace = true }
+tracing = { workspace = true }
+rocksdb = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 
 [dev-dependencies]
-anyhow = "1.0.57"
-linera-storage = { path = ".", default-features = false, features = ["test"] }
-tempfile = "3.2.0"
+anyhow = { workspace = true }
+linera-storage = { workspace = true, features = ["test"] }
+tempfile = { workspace = true }

--- a/linera-views-derive/Cargo.toml
+++ b/linera-views-derive/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.107", features = ["full", "extra-traits"] }
-quote = "1.0"
-proc-macro2 = "1.0"
-convert_case = "0.6.0"
-serde = { version =  "1.0.152", features = ["derive"] }
-async-graphql = "5.0.5"
+syn = { workspace = true, features = ["full", "extra-traits"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+convert_case = { workspace = true }
+serde = { workspace = true }
+async-graphql = { workspace = true }

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1.25.0", features = ["rt", "sync"] }
 anyhow = { version = "1.0.57", optional = true }
 tracing = "0.1.37"
 http = "0.2.7"
-rand = "0.8.5"
+rand = "0.7.3"
 rocksdb = "0.19.0"
 aws-config = { version = "0.14.0", optional = true }
 aws-sdk-dynamodb = { version = "0.14.0", optional = true }

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -11,35 +11,35 @@ db_timings = []
 metrics = ["dep:hex", "dep:metrics"]
 
 [dependencies]
-static_assertions = "1.1.0"
-async-lock = "2.6.0"
-async-trait = "0.1.52"
-bcs = "0.1.3"
-futures = "0.3.17"
-generic-array = { version = "0.14.4", features = ["serde"] }
-hex = { version = "0.4.3", optional = true }
-linera-base = { path = "../linera-base" }
-linera-views-derive = { path = "../linera-views-derive" }
-metrics = { version = "0.20.1", optional = true }
-serde = { version = "1.0.130", features = ["derive"] }
-sha3 = "0.10.6"
-thiserror = "1.0.31"
-linked-hash-map = "0.5.3"
+static_assertions = { workspace = true }
+async-lock = { workspace = true }
+async-trait = { workspace = true }
+bcs = { workspace = true }
+futures = { workspace = true }
+generic-array = { workspace = true }
+hex = { workspace = true, optional = true }
+linera-base = { workspace = true }
+linera-views-derive = { workspace = true }
+metrics = { workspace = true, optional = true }
+serde = { workspace = true }
+sha3 = { workspace = true }
+thiserror = { workspace = true }
+linked-hash-map = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.25.0", features = ["rt", "sync"] }
-anyhow = { version = "1.0.57", optional = true }
-tracing = "0.1.37"
-http = "0.2.7"
-rand = "0.7.3"
-rocksdb = "0.19.0"
-aws-config = { version = "0.14.0", optional = true }
-aws-sdk-dynamodb = { version = "0.14.0", optional = true }
-aws-sdk-s3 = { version = "0.14.0", optional = true }
-aws-smithy-http = { version = "0.44.0", optional = true }
-aws-types = { version = "0.14.0", optional = true }
-tokio-test = "0.4.2"
+tokio = { workspace = true, features = ["rt", "sync"] }
+anyhow = { workspace = true, optional = true }
+tracing = { workspace = true }
+http = { workspace = true }
+rand = { workspace = true }
+rocksdb = { workspace = true }
+aws-config = { workspace = true, optional = true }
+aws-sdk-dynamodb = { workspace = true, optional = true }
+aws-sdk-s3 = { workspace = true, optional = true }
+aws-smithy-http = { workspace = true, optional = true }
+aws-types = { workspace = true, optional = true }
+tokio-test = { workspace = true }
 
 [dev-dependencies]
-linera-views = { path = ".", features = ["test"] }
-tempfile = "3.2.0"
+linera-views = { workspace = true, features = ["test"] }
+tempfile = { workspace = true }

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -163,8 +163,8 @@ pub async fn list_tables(client: &aws_sdk_dynamodb::Client) -> Result<Vec<String
 pub fn random_shuffle<R: RngCore, T: Clone>(rng: &mut R, values: &mut Vec<T>) {
     let n = values.len();
     for _ in 0..4 * n {
-        let index1: usize = rng.gen_range(0..n);
-        let index2: usize = rng.gen_range(0..n);
+        let index1: usize = rng.gen_range(0, n);
+        let index2: usize = rng.gen_range(0, n);
         if index1 != index2 {
             let val1 = values.get(index1).unwrap().clone();
             let val2 = values.get(index2).unwrap().clone();
@@ -178,7 +178,7 @@ pub fn random_shuffle<R: RngCore, T: Clone>(rng: &mut R, values: &mut Vec<T>) {
 pub fn get_random_byte_vector<R: RngCore>(rng: &mut R, key_prefix: &[u8], n: usize) -> Vec<u8> {
     let mut v = key_prefix.to_vec();
     for _ in 0..n {
-        let val = rng.gen_range(0..256) as u8;
+        let val = rng.gen_range(0, 256) as u8;
         v.push(val);
     }
     v
@@ -256,7 +256,7 @@ pub fn span_random_reordering_put_delete<R: RngCore>(
     }
     let mut pos_remove_vector = vec![Vec::new(); n];
     for (i, pos) in indices_rev.iter().enumerate().take(k) {
-        let idx = rng.gen_range(*pos..n);
+        let idx = rng.gen_range(*pos, n);
         pos_remove_vector[idx].push(i);
     }
     let mut operations = Vec::new();

--- a/linera-views/tests/queueview_tests.rs
+++ b/linera-views/tests/queueview_tests.rs
@@ -26,14 +26,14 @@ async fn queue_view_mutability_check() {
         let elements = view.queue.elements().await.unwrap();
         assert_eq!(elements, vector);
         //
-        let count_oper = rng.gen_range(0..25);
+        let count_oper = rng.gen_range(0, 25);
         let mut new_vector = vector.clone();
         for _ in 0..count_oper {
-            let thr = rng.gen_range(0..5);
+            let thr = rng.gen_range(0, 5);
             let count = view.queue.count();
             if thr == 0 {
                 // inserting random stuff
-                let n_ins = rng.gen_range(0..10);
+                let n_ins = rng.gen_range(0, 10);
                 for _ in 0..n_ins {
                     let val = rng.gen::<u8>();
                     view.queue.push_back(val);
@@ -43,7 +43,7 @@ async fn queue_view_mutability_check() {
             if thr == 1 {
                 // deleting some entries
                 if count > 0 {
-                    let n_remove = rng.gen_range(0..count);
+                    let n_remove = rng.gen_range(0, count);
                     for _ in 0..n_remove {
                         view.queue.delete_front();
                         // slow but we do not care for tests.
@@ -53,7 +53,7 @@ async fn queue_view_mutability_check() {
             }
             if thr == 2 && count > 0 {
                 // changing some random entries
-                let pos = rng.gen_range(0..count);
+                let pos = rng.gen_range(0, count);
                 let val = rng.gen::<u8>();
                 let mut iter = view.queue.iter_mut().await.unwrap();
                 (for _ in 0..pos {

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -842,7 +842,7 @@ where
             subview.push(value_usize as u32);
         }
         //
-        let thr = rng.gen_range(0..20);
+        let thr = rng.gen_range(0, 20);
         if thr == 0 {
             view.save().await.unwrap();
         }
@@ -886,7 +886,7 @@ where
             DeletePrefix { key_prefix: _ } => {}
         }
         //
-        let thr = rng.gen_range(0..10);
+        let thr = rng.gen_range(0, 10);
         if thr == 0 {
             view.save().await.unwrap();
         }
@@ -911,7 +911,7 @@ where
         view.log.push(value_usize as u32);
         view.queue.push_back(value_usize as u64);
         //
-        let thr = rng.gen_range(0..20);
+        let thr = rng.gen_range(0, 20);
         if thr == 0 {
             view.save().await.unwrap();
         }
@@ -978,7 +978,7 @@ async fn check_hash_memoization_persistence<S>(
         let str1 = format!("{:?}", &pair.1);
         let pair0_first_u8 = *pair.0.first().unwrap();
         let pair1_first_u8 = *pair.1.first().unwrap();
-        let thr = rng.gen_range(0..7);
+        let thr = rng.gen_range(0, 7);
         if thr < 3 {
             let mut view = store.load(1).await.unwrap();
             view.x1.set(pair0_first_u8 as u64);
@@ -1032,7 +1032,7 @@ async fn check_hash_memoization_persistence<S>(
             let indices = view.collection.indices().await.unwrap();
             let siz = indices.len();
             if siz > 0 {
-                let pos = rng.gen_range(0..siz);
+                let pos = rng.gen_range(0, siz);
                 let x = &indices[pos];
                 view.collection.remove_entry(x).unwrap();
                 let hash_new = view.hash().await.unwrap();


### PR DESCRIPTION
# Motivation

While investigating the Rust compiler crashes and compilation breakages caused by `cargo update`, I learned that it's possible to centralize the dependency versions of all crates in a workspace. Cargo has a feature called ["workspace dependency inheritance"](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace), where the dependency is defined in the workspace, and all crates in the workspace can just reference the dependency.

This makes it easier to keep versions consistent, to update dependencies, and to debug issues when upgrading dependencies.

# Solution

List all dependencies in the workspace manifest, and update all crates to inherit the necessary dependencies.

Features usually still need to be enabled per crate, but I did provide some defaults for all crates:

- `serde/derive`
- `generic-array/serde`
- `test-log/trace`
- `tracing-subscriber/env-filter`
- `wasmer/singlepass`
- `ed25519-dalek/{batch, serde}`
- disabled the default features of `linera-{core, execution, storage}`