### PR TITLE
Associated types in Contract

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "futures",
  "linera-sdk",
  "linera-views",
+ "serde",
  "serde_json",
  "thiserror",
  "webassembly-test",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2079,6 +2079,7 @@ dependencies = [
  "linera-sdk",
  "log",
  "serde",
+ "serde_json",
  "thiserror",
  "webassembly-test",
 ]

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -117,15 +117,14 @@ mod tests {
         let mut counter = create_and_initialize_counter(initial_value);
 
         let increment = 42_308_u64;
-        let operation = bcs::to_bytes(&increment).expect("Increment value is not serializable");
 
         let result = counter
-            .execute_operation(&dummy_operation_context(), &operation)
+            .execute_operation(&dummy_operation_context(), increment)
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), ExecutionResult::default());
+        assert_eq!(result.unwrap(), ExecutionResult::<()>::default());
         assert_eq!(counter.value, initial_value + increment);
     }
 
@@ -135,7 +134,7 @@ mod tests {
         let mut counter = create_and_initialize_counter(initial_value);
 
         let result = counter
-            .execute_effect(&dummy_effect_context(), &[])
+            .execute_effect(&dummy_effect_context(), ())
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
@@ -149,16 +148,15 @@ mod tests {
         let mut counter = create_and_initialize_counter(initial_value);
 
         let increment = 8_u64;
-        let argument = bcs::to_bytes(&increment).expect("Increment value is not serializable");
 
         let result = counter
-            .handle_application_call(&dummy_callee_context(), &argument, vec![])
+            .handle_application_call(&dummy_callee_context(), increment, vec![])
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
         let expected_value = initial_value + increment;
         let expected_result = ApplicationCallResult {
-            value: bcs::to_bytes(&expected_value).expect("Expected value is not serializable"),
+            value: Some(expected_value),
             create_sessions: vec![],
             execution_result: ExecutionResult::default(),
         };
@@ -174,7 +172,7 @@ mod tests {
         let mut counter = create_and_initialize_counter(initial_value);
 
         let result = counter
-            .handle_session_call(&dummy_callee_context(), Session::default(), &[], vec![])
+            .handle_session_call(&dummy_callee_context(), Session::default(), (), vec![])
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
@@ -184,11 +182,9 @@ mod tests {
 
     fn create_and_initialize_counter(initial_value: u64) -> Counter {
         let mut counter = Counter::default();
-        let initial_argument =
-            serde_json::to_vec(&initial_value).expect("Initial value is not serializable");
 
         let result = counter
-            .initialize(&dummy_operation_context(), &initial_argument)
+            .initialize(&dummy_operation_context(), initial_value)
             .now_or_never()
             .expect("Initialization of counter state should not await anything");
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -19,13 +19,14 @@ linera_sdk::contract!(Counter);
 impl Contract for Counter {
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
+    type InitializationArguments = u64;
 
     async fn initialize(
         &mut self,
         _context: &OperationContext,
-        argument: &[u8],
+        argument: u64,
     ) -> Result<ExecutionResult, Self::Error> {
-        self.value = serde_json::from_slice(argument)?;
+        self.value = argument;
         Ok(ExecutionResult::default())
     }
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -23,6 +23,7 @@ impl Contract for Counter {
     type Operation = u64;
     type ApplicationCallArguments = u64;
     type Effect = ();
+    type SessionCall = ();
 
     async fn initialize(
         &mut self,
@@ -68,7 +69,7 @@ impl Contract for Counter {
         &mut self,
         _context: &CalleeContext,
         _session: Session,
-        _argument: &[u8],
+        _argument: (),
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, Self::Error> {
         Err(Error::SessionsNotSupported)

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -25,6 +25,7 @@ impl Contract for Counter {
     type Effect = ();
     type SessionCall = ();
     type Response = u64;
+    type SessionState = ();
 
     async fn initialize(
         &mut self,
@@ -57,7 +58,8 @@ impl Contract for Counter {
         _context: &CalleeContext,
         increment: u64,
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         log::error!("incrementing by {:?}", increment);
         self.value += increment;
         Ok(ApplicationCallResult {
@@ -69,10 +71,11 @@ impl Contract for Counter {
     async fn handle_session_call(
         &mut self,
         _context: &CalleeContext,
-        _session: Session,
+        _session: Session<Self::SessionState>,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -24,6 +24,7 @@ impl Contract for Counter {
     type ApplicationCallArguments = u64;
     type Effect = ();
     type SessionCall = ();
+    type Response = u64;
 
     async fn initialize(
         &mut self,
@@ -56,11 +57,11 @@ impl Contract for Counter {
         _context: &CalleeContext,
         increment: u64,
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
         log::error!("incrementing by {:?}", increment);
         self.value += increment;
         Ok(ApplicationCallResult {
-            value: bcs::to_bytes(&self.value).expect("Serialization should not fail"),
+            value: Some(self.value),
             ..ApplicationCallResult::default()
         })
     }
@@ -71,7 +72,7 @@ impl Contract for Counter {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -29,7 +29,7 @@ impl Contract for Counter {
         &mut self,
         _context: &OperationContext,
         argument: u64,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         self.value = argument;
         Ok(ExecutionResult::default())
     }
@@ -38,7 +38,7 @@ impl Contract for Counter {
         &mut self,
         _context: &OperationContext,
         operation: u64,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         self.value += operation;
         Ok(ExecutionResult::default())
     }
@@ -47,7 +47,7 @@ impl Contract for Counter {
         &mut self,
         _context: &EffectContext,
         _effect: (),
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         Err(Error::EffectsNotSupported)
     }
 
@@ -56,7 +56,7 @@ impl Contract for Counter {
         _context: &CalleeContext,
         increment: u64,
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
         log::error!("incrementing by {:?}", increment);
         self.value += increment;
         Ok(ApplicationCallResult {
@@ -71,7 +71,7 @@ impl Contract for Counter {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -22,6 +22,7 @@ impl Contract for Counter {
     type InitializationArguments = u64;
     type Operation = u64;
     type ApplicationCallArguments = u64;
+    type Effect = ();
 
     async fn initialize(
         &mut self,
@@ -44,7 +45,7 @@ impl Contract for Counter {
     async fn execute_effect(
         &mut self,
         _context: &EffectContext,
-        _effect: &[u8],
+        _effect: (),
     ) -> Result<ExecutionResult, Self::Error> {
         Err(Error::EffectsNotSupported)
     }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -20,6 +20,7 @@ impl Contract for Counter {
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
     type InitializationArguments = u64;
+    type Operation = u64;
     type ApplicationCallArguments = u64;
 
     async fn initialize(
@@ -34,9 +35,9 @@ impl Contract for Counter {
     async fn execute_operation(
         &mut self,
         _context: &OperationContext,
-        operation: &[u8],
+        operation: u64,
     ) -> Result<ExecutionResult, Self::Error> {
-        self.value += bcs::from_bytes::<u64>(operation)?;
+        self.value += operation;
         Ok(ExecutionResult::default())
     }
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -20,6 +20,7 @@ impl Contract for Counter {
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
     type InitializationArguments = u64;
+    type ApplicationCallArguments = u64;
 
     async fn initialize(
         &mut self,
@@ -50,11 +51,9 @@ impl Contract for Counter {
     async fn handle_application_call(
         &mut self,
         _context: &CalleeContext,
-        argument: &[u8],
+        increment: u64,
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error> {
-        log::error!("received {:?}", argument);
-        let increment: u64 = bcs::from_bytes(argument)?;
         log::error!("incrementing by {:?}", increment);
         self.value += increment;
         Ok(ApplicationCallResult {

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -26,15 +26,14 @@ linera_sdk::contract!(CrowdFunding<ViewStorageContext>);
 impl Contract for CrowdFunding<ViewStorageContext> {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
+    type InitializationArguments = InitializationArguments;
 
     async fn initialize(
         &mut self,
         _context: &OperationContext,
-        argument: &[u8],
+        argument: InitializationArguments,
     ) -> Result<ExecutionResult, Self::Error> {
-        self.initialization_arguments.set(Some(
-            serde_json::from_slice(argument).map_err(Error::InvalidInitializationArguments)?,
-        ));
+        self.initialization_arguments.set(Some(argument));
 
         ensure!(
             self.get_initialization_arguments().deadline > system_api::current_system_time(),
@@ -420,7 +419,7 @@ pub enum Error {
 
     /// Failure to deserialize the initialization arguments.
     #[error("Crowd-funding campaign arguments are invalid")]
-    InvalidInitializationArguments(serde_json::Error),
+    InvalidInitializationArguments(#[from] serde_json::Error),
 
     /// Failure to deserialize the parameters.
     #[error("Crowd-funding parameters are invalid")]

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -27,6 +27,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
     type InitializationArguments = InitializationArguments;
+    type ApplicationCallArguments = ApplicationCall;
 
     async fn initialize(
         &mut self,
@@ -89,12 +90,9 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     async fn handle_application_call(
         &mut self,
         context: &CalleeContext,
-        argument: &[u8],
+        call: ApplicationCall,
         sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error> {
-        let call: ApplicationCall =
-            bcs::from_bytes(argument).map_err(Error::InvalidCrossApplicationCall)?;
-
         let mut result = ApplicationCallResult::default();
 
         match call {
@@ -492,4 +490,8 @@ pub enum Error {
     /// Can't pledge to or collect pledges from a cancelled campaign.
     #[error("Crowd-funding campaign has been cancelled")]
     Cancelled,
+
+    /// Failed to deserialize BCS bytes
+    #[error("Failed to deserialize BCS bytes")]
+    BcsError(#[from] bcs::Error),
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -31,6 +31,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     type ApplicationCallArguments = ApplicationCall;
     type Effect = Effect;
     type SessionCall = ();
+    type Response = ();
 
     async fn initialize(
         &mut self,
@@ -92,7 +93,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         context: &CalleeContext,
         call: ApplicationCall,
         sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
         let mut result = ApplicationCallResult::default();
         match call {
             ApplicationCall::PledgeWithSessions { source } => {
@@ -122,7 +123,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -27,6 +27,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
     type InitializationArguments = InitializationArguments;
+    type Operation = Operation;
     type ApplicationCallArguments = ApplicationCall;
 
     async fn initialize(
@@ -47,11 +48,8 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     async fn execute_operation(
         &mut self,
         context: &OperationContext,
-        operation_bytes: &[u8],
+        operation: Operation,
     ) -> Result<ExecutionResult, Self::Error> {
-        let operation: Operation =
-            bcs::from_bytes(operation_bytes).map_err(Error::InvalidOperation)?;
-
         let mut result = ExecutionResult::default();
 
         match operation {

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -30,6 +30,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     type Operation = Operation;
     type ApplicationCallArguments = ApplicationCall;
     type Effect = Effect;
+    type SessionCall = ();
 
     async fn initialize(
         &mut self,
@@ -120,7 +121,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         &mut self,
         _context: &CalleeContext,
         _session: Session,
-        _argument: &[u8],
+        _argument: (),
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, Self::Error> {
         Err(Error::SessionsNotSupported)

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -159,10 +159,10 @@ impl CrowdFunding<ViewStorageContext> {
         self.call_application(
             /* authenticated by owner */ true,
             Self::fungible_id()?,
-            &bcs::to_bytes(&call).unwrap(),
+            &call,
             vec![],
         )
-        .await;
+        .await?;
         // Second, schedule the attribution of the funds to the (remote) campaign.
         let effect = Effect::PledgeWithAccount { owner, amount };
         result.effects.push((
@@ -325,11 +325,14 @@ impl CrowdFunding<ViewStorageContext> {
     /// Queries the token application to determine the total amount of tokens in custody.
     async fn balance(&mut self) -> Result<Amount, Error> {
         let owner = AccountOwner::Application(system_api::current_application_id());
-        let query_bytes = bcs::to_bytes(&fungible::ApplicationCall::Balance { owner })
-            .map_err(Error::InvalidBalanceQuery)?;
         let (response, _sessions) = self
-            .call_application(true, Self::fungible_id()?, &query_bytes, vec![])
-            .await;
+            .call_application(
+                true,
+                Self::fungible_id()?,
+                &fungible::ApplicationCall::Balance { owner },
+                vec![],
+            )
+            .await?;
 
         bcs::from_bytes(&response).map_err(Error::InvalidBalance)
     }
@@ -348,7 +351,7 @@ impl CrowdFunding<ViewStorageContext> {
         };
         let transfer_bytes = bcs::to_bytes(&transfer).map_err(Error::InvalidTransfer)?;
         self.call_application(true, Self::fungible_id()?, &transfer_bytes, vec![])
-            .await;
+            .await?;
         Ok(())
     }
 
@@ -370,7 +373,7 @@ impl CrowdFunding<ViewStorageContext> {
         };
         let transfer_bytes = bcs::to_bytes(&transfer).map_err(Error::InvalidTransfer)?;
         self.call_application(true, Self::fungible_id()?, &transfer_bytes, vec![])
-            .await;
+            .await?;
         Ok(())
     }
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -29,6 +29,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     type InitializationArguments = InitializationArguments;
     type Operation = Operation;
     type ApplicationCallArguments = ApplicationCall;
+    type Effect = Effect;
 
     async fn initialize(
         &mut self,
@@ -71,9 +72,9 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     async fn execute_effect(
         &mut self,
         context: &EffectContext,
-        effect: &[u8],
+        effect: Effect,
     ) -> Result<ExecutionResult, Self::Error> {
-        match bcs::from_bytes(effect).map_err(Error::InvalidEffect)? {
+        match effect {
             Effect::PledgeWithAccount { owner, amount } => {
                 ensure!(
                     context.chain_id == system_api::current_application_id().creation.chain_id,

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -32,6 +32,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     type Effect = Effect;
     type SessionCall = ();
     type Response = ();
+    type SessionState = ();
 
     async fn initialize(
         &mut self,
@@ -93,7 +94,8 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         context: &CalleeContext,
         call: ApplicationCall,
         sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         let mut result = ApplicationCallResult::default();
         match call {
             ApplicationCall::PledgeWithSessions { source } => {
@@ -120,10 +122,11 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     async fn handle_session_call(
         &mut self,
         _context: &CalleeContext,
-        _session: Session,
+        _session: Session<Self::SessionState>,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -36,7 +36,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         &mut self,
         _context: &OperationContext,
         argument: InitializationArguments,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         self.initialization_arguments.set(Some(argument));
 
         ensure!(
@@ -51,7 +51,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         &mut self,
         context: &OperationContext,
         operation: Operation,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         let mut result = ExecutionResult::default();
 
         match operation {
@@ -74,7 +74,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         &mut self,
         context: &EffectContext,
         effect: Effect,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         match effect {
             Effect::PledgeWithAccount { owner, amount } => {
                 ensure!(
@@ -92,9 +92,8 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         context: &CalleeContext,
         call: ApplicationCall,
         sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
         let mut result = ApplicationCallResult::default();
-
         match call {
             ApplicationCall::PledgeWithSessions { source } => {
                 // Only sessions on the campaign chain are supported.
@@ -123,7 +122,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }
@@ -140,7 +139,7 @@ impl CrowdFunding<ViewStorageContext> {
     /// Adds a pledge from a local account to the remote campaign chain.
     async fn execute_pledge_with_transfer(
         &mut self,
-        result: &mut ExecutionResult,
+        result: &mut ExecutionResult<Effect>,
         owner: AccountOwner,
         amount: Amount,
     ) -> Result<(), Error> {
@@ -168,7 +167,7 @@ impl CrowdFunding<ViewStorageContext> {
         result.effects.push((
             chain_id.into(),
             /* authenticated by owner */ true,
-            bcs::to_bytes(&effect).unwrap(),
+            effect,
         ));
         Ok(())
     }

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -40,7 +40,7 @@ pub enum Operation {
 }
 
 /// Effects that can be processed by the application.
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Effect {
     /// Pledge some tokens to the campaign (from an account on the receiver chain).

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -31,6 +31,7 @@ impl Contract for FungibleToken<ViewStorageContext> {
     type ApplicationCallArguments = ApplicationCall;
     type Operation = Operation;
     type Effect = Effect;
+    type SessionCall = SessionCall;
 
     async fn initialize(
         &mut self,
@@ -161,10 +162,9 @@ impl Contract for FungibleToken<ViewStorageContext> {
         &mut self,
         _context: &CalleeContext,
         session: Session,
-        argument: &[u8],
+        request: SessionCall,
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, Self::Error> {
-        let request = SessionCall::from_bcs_bytes(argument).map_err(Error::InvalidSessionCall)?;
         match request {
             SessionCall::Balance => self.handle_session_balance(session.data),
             SessionCall::Transfer {

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -30,6 +30,7 @@ impl Contract for FungibleToken<ViewStorageContext> {
     type InitializationArguments = InitialState;
     type ApplicationCallArguments = ApplicationCall;
     type Operation = Operation;
+    type Effect = Effect;
 
     async fn initialize(
         &mut self,
@@ -85,9 +86,8 @@ impl Contract for FungibleToken<ViewStorageContext> {
     async fn execute_effect(
         &mut self,
         context: &EffectContext,
-        effect: &[u8],
+        effect: Effect,
     ) -> Result<ExecutionResult, Self::Error> {
-        let effect = Effect::from_bcs_bytes(effect).map_err(Error::InvalidEffect)?;
         match effect {
             Effect::Credit { owner, amount } => {
                 self.credit(owner, amount).await;

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -29,6 +29,7 @@ impl Contract for FungibleToken<ViewStorageContext> {
     type Storage = ViewStateStorage<Self>;
     type InitializationArguments = InitialState;
     type ApplicationCallArguments = ApplicationCall;
+    type Operation = Operation;
 
     async fn initialize(
         &mut self,
@@ -51,9 +52,8 @@ impl Contract for FungibleToken<ViewStorageContext> {
     async fn execute_operation(
         &mut self,
         context: &OperationContext,
-        operation: &[u8],
+        operation: Self::Operation,
     ) -> Result<ExecutionResult, Self::Error> {
-        let operation = Operation::from_bcs_bytes(operation).map_err(Error::InvalidOperation)?;
         match operation {
             Operation::Transfer {
                 owner,

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -27,14 +27,13 @@ linera_sdk::contract!(FungibleToken<ViewStorageContext>);
 impl Contract for FungibleToken<ViewStorageContext> {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
+    type InitializationArguments = InitialState;
 
     async fn initialize(
         &mut self,
         context: &OperationContext,
-        argument: &[u8],
+        mut state: InitialState,
     ) -> Result<ExecutionResult, Self::Error> {
-        let mut state: InitialState =
-            serde_json::from_slice(argument).map_err(Error::InvalidInitialState)?;
         // If initial accounts are empty, creator gets 1M tokens to act like a faucet.
         if state.accounts.is_empty() {
             if let Some(owner) = context.authenticated_signer {
@@ -304,7 +303,7 @@ impl FungibleToken<ViewStorageContext> {
 pub enum Error {
     /// Invalid serialized initial state.
     #[error("Serialized initial state is invalid")]
-    InvalidInitialState(#[source] serde_json::Error),
+    InvalidInitialState(#[from] serde_json::Error),
 
     /// Invalid serialized [`SignedTransfer`].
     #[error("Operation is not a valid serialized signed transfer")]

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Operation {
 }
 
 /// An effect.
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum Effect {
     /// Credit the given account.
     Credit { owner: AccountOwner, amount: Amount },

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -12,7 +12,7 @@ use linera_sdk::{
     test::{ActiveChain, TestValidator},
 };
 
-/// Test transfering tokens across microchains.
+/// Test transferring tokens across microchains.
 ///
 /// Creates the application on a `sender_chain`, initializing it with a single account with some
 /// tokens for that chain's owner. Transfers some of those tokens to a new `receiver_chain`, and

--- a/examples/meta-counter/Cargo.toml
+++ b/examples/meta-counter/Cargo.toml
@@ -10,6 +10,7 @@ bcs = { workspace = true }
 linera-sdk = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -38,7 +38,7 @@ impl Contract for MetaCounter {
         &mut self,
         _context: &OperationContext,
         _argument: (),
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         Self::counter_id()?;
         Ok(ExecutionResult::default())
     }
@@ -47,16 +47,16 @@ impl Contract for MetaCounter {
         &mut self,
         _context: &OperationContext,
         (recipient_id, operation): (ChainId, u64),
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         log::trace!("effect: {:?}", operation);
-        Ok(ExecutionResult::default().with_effect(recipient_id, &operation))
+        Ok(ExecutionResult::default().with_effect(recipient_id, operation))
     }
 
     async fn execute_effect(
         &mut self,
         _context: &EffectContext,
         effect: u64,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         log::trace!("executing {:?} via {:?}", effect, Self::counter_id()?);
         self.call_application(true, Self::counter_id()?, &effect, vec![])
             .await?;
@@ -68,7 +68,7 @@ impl Contract for MetaCounter {
         _context: &CalleeContext,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
         Err(Error::CallsNotSupported)
     }
 
@@ -78,7 +78,7 @@ impl Contract for MetaCounter {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -33,6 +33,7 @@ impl Contract for MetaCounter {
     type ApplicationCallArguments = ();
     type Effect = u64;
     type SessionCall = ();
+    type Response = ();
 
     async fn initialize(
         &mut self,
@@ -68,7 +69,7 @@ impl Contract for MetaCounter {
         _context: &CalleeContext,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
         Err(Error::CallsNotSupported)
     }
 
@@ -78,7 +79,7 @@ impl Contract for MetaCounter {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use linera_sdk::{
     base::{ApplicationId, ChainId, SessionId},
     contract::system_api,
-    ensure, ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult,
+    ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult,
     OperationContext, Session, SessionCallResult, SimpleStateStorage,
 };
 use thiserror::Error;
@@ -28,13 +28,13 @@ impl MetaCounter {
 impl Contract for MetaCounter {
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
+    type InitializationArguments = ();
 
     async fn initialize(
         &mut self,
         _context: &OperationContext,
-        argument: &[u8],
+        _argument: (),
     ) -> Result<ExecutionResult, Self::Error> {
-        ensure!(argument.is_empty(), Error::Initialization);
         Self::counter_id()?;
         Ok(ExecutionResult::default())
     }
@@ -94,7 +94,7 @@ pub enum Error {
     SessionsNotSupported,
 
     #[error("Error during the initialization")]
-    Initialization,
+    Initialization(#[from] serde_json::Error),
 
     #[error("Invalid application parameters")]
     Parameters,

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -32,6 +32,7 @@ impl Contract for MetaCounter {
     type Operation = (ChainId, u64);
     type ApplicationCallArguments = ();
     type Effect = u64;
+    type SessionCall = ();
 
     async fn initialize(
         &mut self,
@@ -76,7 +77,7 @@ impl Contract for MetaCounter {
         &mut self,
         _context: &CalleeContext,
         _session: Session,
-        _argument: &[u8],
+        _argument: (),
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, Self::Error> {
         Err(Error::SessionsNotSupported)

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -58,9 +58,8 @@ impl Contract for MetaCounter {
         effect: u64,
     ) -> Result<ExecutionResult, Self::Error> {
         log::trace!("executing {:?} via {:?}", effect, Self::counter_id()?);
-        let as_bytes = bcs::to_bytes(&effect)?;
-        self.call_application(true, Self::counter_id()?, &as_bytes, vec![])
-            .await;
+        self.call_application(true, Self::counter_id()?, &effect, vec![])
+            .await?;
         Ok(ExecutionResult::default())
     }
 

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -34,6 +34,7 @@ impl Contract for MetaCounter {
     type Effect = u64;
     type SessionCall = ();
     type Response = ();
+    type SessionState = ();
 
     async fn initialize(
         &mut self,
@@ -69,17 +70,19 @@ impl Contract for MetaCounter {
         _context: &CalleeContext,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         Err(Error::CallsNotSupported)
     }
 
     async fn handle_session_call(
         &mut self,
         _context: &CalleeContext,
-        _session: Session,
+        _session: Session<Self::SessionState>,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -29,6 +29,7 @@ impl Contract for MetaCounter {
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
     type InitializationArguments = ();
+    type ApplicationCallArguments = ();
 
     async fn initialize(
         &mut self,
@@ -64,7 +65,7 @@ impl Contract for MetaCounter {
     async fn handle_application_call(
         &mut self,
         _context: &CalleeContext,
-        _argument: &[u8],
+        _argument: (),
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error> {
         Err(Error::CallsNotSupported)
@@ -95,6 +96,9 @@ pub enum Error {
 
     #[error("Error during the initialization")]
     Initialization(#[from] serde_json::Error),
+
+    #[error("Error while deserializing BCS bytes")]
+    BcsError(#[from] bcs::Error),
 
     #[error("Invalid application parameters")]
     Parameters,

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -29,6 +29,7 @@ impl Contract for MetaCounter {
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
     type InitializationArguments = ();
+    type Operation = (ChainId, u64);
     type ApplicationCallArguments = ();
 
     async fn initialize(
@@ -43,10 +44,8 @@ impl Contract for MetaCounter {
     async fn execute_operation(
         &mut self,
         _context: &OperationContext,
-        operation: &[u8],
+        (recipient_id, operation): (ChainId, u64),
     ) -> Result<ExecutionResult, Self::Error> {
-        let (recipient_id, operation) =
-            bcs::from_bytes::<(ChainId, u64)>(operation).map_err(|_| Error::Operation)?;
         log::trace!("effect: {:?}", operation);
         Ok(ExecutionResult::default().with_effect(recipient_id, &operation))
     }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -31,6 +31,7 @@ impl Contract for MetaCounter {
     type InitializationArguments = ();
     type Operation = (ChainId, u64);
     type ApplicationCallArguments = ();
+    type Effect = u64;
 
     async fn initialize(
         &mut self,
@@ -53,10 +54,11 @@ impl Contract for MetaCounter {
     async fn execute_effect(
         &mut self,
         _context: &EffectContext,
-        effect: &[u8],
+        effect: u64,
     ) -> Result<ExecutionResult, Self::Error> {
         log::trace!("executing {:?} via {:?}", effect, Self::counter_id()?);
-        self.call_application(true, Self::counter_id()?, effect, vec![])
+        let as_bytes = bcs::to_bytes(&effect)?;
+        self.call_application(true, Self::counter_id()?, &as_bytes, vec![])
             .await;
         Ok(ExecutionResult::default())
     }

--- a/examples/reentrant-counter/Cargo.toml
+++ b/examples/reentrant-counter/Cargo.toml
@@ -11,6 +11,7 @@ futures = { workspace = true }
 linera-sdk = { workspace = true }
 linera-views = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/examples/reentrant-counter/Cargo.toml
+++ b/examples/reentrant-counter/Cargo.toml
@@ -25,3 +25,6 @@ path = "src/contract.rs"
 [[bin]]
 name = "reentrant_counter_service"
 path = "src/service.rs"
+
+[package.metadata.cargo-machete]
+ignored = ["serde"]

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -30,7 +30,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         &mut self,
         _context: &OperationContext,
         argument: u128,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         self.value.set(argument);
         Ok(ExecutionResult::default())
     }
@@ -39,7 +39,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         &mut self,
         _context: &OperationContext,
         increment: u128,
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         let first_half = increment / 2;
         let second_half = increment - first_half;
         let second_half_as_bytes = bcs::to_bytes(&second_half).expect("Failed to serialize `u128`");
@@ -62,7 +62,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         &mut self,
         _context: &EffectContext,
         _effect: (),
-    ) -> Result<ExecutionResult, Self::Error> {
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         Err(Error::EffectsNotSupported)
     }
 
@@ -71,7 +71,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         _context: &CalleeContext,
         increment: u128,
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
         let value = self.value.get_mut();
         *value += increment;
         Ok(ApplicationCallResult {
@@ -86,7 +86,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -21,6 +21,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
     type InitializationArguments = u128;
+    type Operation = u128;
     type ApplicationCallArguments = u128;
 
     async fn initialize(
@@ -35,10 +36,8 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     async fn execute_operation(
         &mut self,
         _context: &OperationContext,
-        operation: &[u8],
+        increment: u128,
     ) -> Result<ExecutionResult, Self::Error> {
-        let increment: u128 = bcs::from_bytes(operation)?;
-
         let first_half = increment / 2;
         let second_half = increment - first_half;
         let second_half_as_bytes = bcs::to_bytes(&second_half).expect("Failed to serialize `u128`");

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -44,7 +44,6 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         let first_half = increment / 2;
         let second_half = increment - first_half;
-        let second_half_as_bytes = bcs::to_bytes(&second_half).expect("Failed to serialize `u128`");
 
         let value = self.value.get_mut();
         *value += first_half;
@@ -52,7 +51,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         self.call_application(
             false,
             system_api::current_application_id(),
-            &second_half_as_bytes,
+            &second_half,
             vec![],
         )
         .await?;

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -21,6 +21,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
     type InitializationArguments = u128;
+    type ApplicationCallArguments = u128;
 
     async fn initialize(
         &mut self,
@@ -67,10 +68,9 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     async fn handle_application_call(
         &mut self,
         _context: &CalleeContext,
-        argument: &[u8],
+        increment: u128,
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error> {
-        let increment: u128 = bcs::from_bytes(argument)?;
         let value = self.value.get_mut();
         *value += increment;
         Ok(ApplicationCallResult {

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -24,6 +24,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     type Operation = u128;
     type ApplicationCallArguments = u128;
     type Effect = ();
+    type SessionCall = ();
 
     async fn initialize(
         &mut self,
@@ -83,7 +84,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         &mut self,
         _context: &CalleeContext,
         _session: Session,
-        _argument: &[u8],
+        _argument: (),
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, Self::Error> {
         Err(Error::SessionsNotSupported)

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -53,7 +53,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
             &second_half_as_bytes,
             vec![],
         )
-        .await;
+        .await?;
 
         Ok(ExecutionResult::default())
     }

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -23,6 +23,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     type InitializationArguments = u128;
     type Operation = u128;
     type ApplicationCallArguments = u128;
+    type Effect = ();
 
     async fn initialize(
         &mut self,
@@ -59,7 +60,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     async fn execute_effect(
         &mut self,
         _context: &EffectContext,
-        _effect: &[u8],
+        _effect: (),
     ) -> Result<ExecutionResult, Self::Error> {
         Err(Error::EffectsNotSupported)
     }

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -26,6 +26,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     type Effect = ();
     type SessionCall = ();
     type Response = u128;
+    type SessionState = ();
 
     async fn initialize(
         &mut self,
@@ -72,7 +73,8 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         _context: &CalleeContext,
         increment: u128,
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         let value = self.value.get_mut();
         *value += increment;
         Ok(ApplicationCallResult {
@@ -84,10 +86,11 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     async fn handle_session_call(
         &mut self,
         _context: &CalleeContext,
-        _session: Session,
+        _session: Session<Self::SessionState>,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -20,13 +20,14 @@ linera_sdk::contract!(ReentrantCounter<ViewStorageContext>);
 impl Contract for ReentrantCounter<ViewStorageContext> {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
+    type InitializationArguments = u128;
 
     async fn initialize(
         &mut self,
         _context: &OperationContext,
-        argument: &[u8],
+        argument: u128,
     ) -> Result<ExecutionResult, Self::Error> {
-        self.value.set(serde_json::from_slice(argument)?);
+        self.value.set(argument);
         Ok(ExecutionResult::default())
     }
 

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -25,6 +25,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
     type ApplicationCallArguments = u128;
     type Effect = ();
     type SessionCall = ();
+    type Response = u128;
 
     async fn initialize(
         &mut self,
@@ -71,11 +72,11 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         _context: &CalleeContext,
         increment: u128,
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
         let value = self.value.get_mut();
         *value += increment;
         Ok(ApplicationCallResult {
-            value: bcs::to_bytes(&value).expect("Serialization should not fail"),
+            value: Some(*value),
             ..ApplicationCallResult::default()
         })
     }
@@ -86,7 +87,7 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -33,11 +33,12 @@ where
 {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
+    type InitializationArguments = ();
 
     async fn initialize(
         &mut self,
         _context: &OperationContext,
-        _argument: &[u8],
+        _argument: (),
     ) -> Result<ExecutionResult, Self::Error> {
         Ok(ExecutionResult::default())
     }
@@ -159,6 +160,10 @@ pub enum Error {
     /// View error.
     #[error(transparent)]
     View(#[from] ViewError),
+
+    /// Invalid serialized initialization argument.
+    #[error("Invalid initialization argument")]
+    InvalidInitializationArgument(#[from] serde_json::Error),
 }
 
 #[cfg(test)]

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -39,6 +39,7 @@ where
     type Effect = Effect;
     type SessionCall = ();
     type Response = ();
+    type SessionState = ();
 
     async fn initialize(
         &mut self,
@@ -89,17 +90,19 @@ where
         _context: &CalleeContext,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         Err(Error::ApplicationCallsNotSupported)
     }
 
     async fn handle_session_call(
         &mut self,
         _context: &CalleeContext,
-        _session: Session,
+        _session: Session<Self::SessionState>,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
+    {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -10,7 +10,7 @@ use linera_sdk::{
     base::{ChannelName, Destination, SessionId},
     contract::system_api,
     views::ViewStorageContext,
-    ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult, FromBcsBytes,
+    ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult,
     OperationContext, Session, SessionCallResult, ViewStateStorage,
 };
 use linera_views::{common::Context, views::ViewError};
@@ -36,6 +36,7 @@ where
     type InitializationArguments = ();
     type Operation = Operation;
     type ApplicationCallArguments = ();
+    type Effect = Effect;
 
     async fn initialize(
         &mut self,
@@ -64,10 +65,10 @@ where
     async fn execute_effect(
         &mut self,
         context: &EffectContext,
-        effect: &[u8],
+        effect: Effect,
     ) -> Result<ExecutionResult, Self::Error> {
         let mut result = ExecutionResult::default();
-        match Effect::from_bcs_bytes(effect).map_err(Error::InvalidEffect)? {
+        match effect {
             Effect::RequestSubscribe => result.subscribe.push((
                 ChannelName::from(POSTS_CHANNEL_NAME.to_vec()),
                 context.effect_id.chain_id,

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -34,6 +34,7 @@ where
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
     type InitializationArguments = ();
+    type ApplicationCallArguments = ();
 
     async fn initialize(
         &mut self,
@@ -82,7 +83,7 @@ where
     async fn handle_application_call(
         &mut self,
         _context: &CalleeContext,
-        _argument: &[u8],
+        _argument: (),
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error> {
         Err(Error::ApplicationCallsNotSupported)
@@ -164,6 +165,10 @@ pub enum Error {
     /// Invalid serialized initialization argument.
     #[error("Invalid initialization argument")]
     InvalidInitializationArgument(#[from] serde_json::Error),
+
+    /// Failed to deserialize BCS bytes
+    #[error("Failed to deserialize BCS bytes")]
+    BcsError(#[from] bcs::Error),
 }
 
 #[cfg(test)]

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -37,6 +37,7 @@ where
     type Operation = Operation;
     type ApplicationCallArguments = ();
     type Effect = Effect;
+    type SessionCall = ();
 
     async fn initialize(
         &mut self,
@@ -95,7 +96,7 @@ where
         &mut self,
         _context: &CalleeContext,
         _session: Session,
-        _argument: &[u8],
+        _argument: (),
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, Self::Error> {
         Err(Error::SessionsNotSupported)

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -34,6 +34,7 @@ where
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
     type InitializationArguments = ();
+    type Operation = Operation;
     type ApplicationCallArguments = ();
 
     async fn initialize(
@@ -47,9 +48,9 @@ where
     async fn execute_operation(
         &mut self,
         _context: &OperationContext,
-        operation: &[u8],
+        operation: Operation,
     ) -> Result<ExecutionResult, Self::Error> {
-        match Operation::from_bcs_bytes(operation).map_err(Error::InvalidOperation)? {
+        match operation {
             Operation::RequestSubscribe(chain_id) => {
                 Ok(ExecutionResult::default().with_effect(chain_id, &Effect::RequestSubscribe))
             }

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -38,6 +38,7 @@ where
     type ApplicationCallArguments = ();
     type Effect = Effect;
     type SessionCall = ();
+    type Response = ();
 
     async fn initialize(
         &mut self,
@@ -88,7 +89,7 @@ where
         _context: &CalleeContext,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response>, Self::Error> {
         Err(Error::ApplicationCallsNotSupported)
     }
 
@@ -98,7 +99,7 @@ where
         _session: Session,
         _argument: (),
         _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect>, Self::Error> {
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response>, Self::Error> {
         Err(Error::SessionsNotSupported)
     }
 }

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -21,7 +21,7 @@ pub enum Operation {
 }
 
 /// An effect of the application on one chain, to be handled on another chain.
-#[derive(PartialEq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum Effect {
     /// The origin chain wants to subscribe to the target chain.
     RequestSubscribe,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -225,7 +225,7 @@ where
         .create_application(
             bytecode_id2,
             bcs::to_bytes(&application_id1)?,
-            vec![],
+            serde_json::to_vec(&()).unwrap(),
             vec![application_id1],
         )
         .await
@@ -599,7 +599,12 @@ where
     receiver.process_inbox().await.unwrap();
 
     let (application_id, _cert) = receiver
-        .create_application(bytecode_id, vec![], vec![], vec![])
+        .create_application(
+            bytecode_id,
+            vec![],
+            serde_json::to_vec(&()).unwrap(),
+            vec![],
+        )
         .await?;
 
     // Request to subscribe to the sender.

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -29,6 +29,7 @@ custom_debug_derive = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 linera-base = { workspace = true }
 linera-views = { workspace = true }
 wit-bindgen-guest-rust = { workspace = true }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -84,7 +84,8 @@ impl<T: DeserializeOwned> From<wit_types::Session> for Session<T> {
     fn from(session: wit_types::Session) -> Self {
         Session {
             kind: session.kind,
-            data: bcs::from_bytes(&session.data).expect("TODO"),
+            // TODO(#743): Do we need explicit error handling?
+            data: bcs::from_bytes(&session.data).expect("session type deserialization failed"),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -14,6 +14,7 @@ use linera_base::{
 };
 
 use crate::{CalleeContext, EffectContext, OperationContext, Session};
+use serde::de::DeserializeOwned;
 use std::task::Poll;
 
 impl From<wit_types::OperationContext> for OperationContext {
@@ -79,11 +80,11 @@ impl From<wit_types::SessionId> for SessionId {
     }
 }
 
-impl From<wit_types::Session> for Session {
+impl<T: DeserializeOwned> From<wit_types::Session> for Session<T> {
     fn from(session: wit_types::Session) -> Self {
         Session {
             kind: session.kind,
-            data: session.data,
+            data: bcs::from_bytes(&session.data).expect("TODO"),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -96,7 +96,10 @@ where
 
         let value = result
             .value
-            .map(|v| bcs::to_bytes(&v).expect("TODO"))
+            // TODO(#743): Do we need explicit error handling?
+            .map(|v| {
+                bcs::to_bytes(&v).expect("failed to serialize Value for ApplicationCallResult")
+            })
             .unwrap_or_default();
 
         wit_types::ApplicationCallResult {
@@ -111,7 +114,8 @@ impl<T: Serialize> From<Session<T>> for wit_types::Session {
     fn from(new_session: Session<T>) -> Self {
         wit_types::Session {
             kind: new_session.kind,
-            data: bcs::to_bytes(&new_session.data).expect("TODO"),
+            // TODO(#743): Do we need explicit error handling?
+            data: bcs::to_bytes(&new_session.data).expect("session type serialization failed"),
         }
     }
 }
@@ -126,7 +130,10 @@ impl<Effect: Serialize + DeserializeOwned + Debug, Value: Serialize, Session: Se
                 result
                     .new_state
                     .as_ref()
-                    .map(|new_state| bcs::to_bytes(new_state).expect("TODO"))
+                    // TODO(#743): Do we need explicit error handling?
+                    .map(|new_state| {
+                        bcs::to_bytes(new_state).expect("session type serialization failed")
+                    })
                     .unwrap_or_default(),
             ),
         }
@@ -144,7 +151,8 @@ impl<Effect: Debug + Serialize + DeserializeOwned> From<ExecutionResult<Effect>>
                 (
                     destination.into(),
                     authenticated,
-                    bcs::to_bytes(&effect).expect("TODO"),
+                    // TODO(#743): Do we need explicit error handling?
+                    bcs::to_bytes(&effect).expect("effect serialization failed"),
                 )
             })
             .collect();

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -283,13 +283,19 @@ where
             future: ExportedFuture::new(Application::Storage::execute_with_state(
                 move |application| {
                     async move {
+                        let application_call_args: Application::ApplicationCallArguments =
+                            bcs::from_bytes(&argument)?;
                         let forwarded_sessions = forwarded_sessions
                             .into_iter()
                             .map(SessionId::from)
                             .collect();
 
                         application
-                            .handle_application_call(&context.into(), &argument, forwarded_sessions)
+                            .handle_application_call(
+                                &context.into(),
+                                application_call_args,
+                                forwarded_sessions,
+                            )
                             .await
                     }
                     .boxed()

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -269,9 +269,17 @@ where
 ///
 /// Loads the `Application` state and calls its
 /// [`handle_application_call`][Contract::handle_application_call] method.
+#[allow(clippy::type_complexity)]
 pub struct HandleApplicationCall<Application: Contract> {
     future: ExportedFuture<
-        Result<ApplicationCallResult<Application::Effect, Application::Response>, String>,
+        Result<
+            ApplicationCallResult<
+                Application::Effect,
+                Application::Response,
+                Application::SessionState,
+            >,
+            String,
+        >,
     >,
     _application: PhantomData<Application>,
 }
@@ -283,6 +291,7 @@ where
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
     Application::Effect: 'static,
     Application::Response: 'static,
+    Application::SessionState: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -332,9 +341,17 @@ where
 ///
 /// Loads the `Application` state and calls its
 /// [`handle_session_call`][Contract::handle_session_call] method.
+#[allow(clippy::type_complexity)]
 pub struct HandleSessionCall<Application: Contract> {
     future: ExportedFuture<
-        Result<SessionCallResult<Application::Effect, Application::Response>, String>,
+        Result<
+            SessionCallResult<
+                Application::Effect,
+                Application::Response,
+                Application::SessionState,
+            >,
+            String,
+        >,
     >,
     _application: PhantomData<Application>,
 }
@@ -346,6 +363,7 @@ where
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
     Application::Effect: 'static,
     Application::Response: 'static,
+    Application::SessionState: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -142,6 +142,7 @@ where
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
     Application::Effect: 'static,
+    Application::Response: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -187,6 +188,7 @@ where
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
     Application::Effect: 'static,
+    Application::Response: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -233,6 +235,7 @@ where
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
     Application::Effect: 'static,
+    Application::Response: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -267,7 +270,9 @@ where
 /// Loads the `Application` state and calls its
 /// [`handle_application_call`][Contract::handle_application_call] method.
 pub struct HandleApplicationCall<Application: Contract> {
-    future: ExportedFuture<Result<ApplicationCallResult<Application::Effect>, String>>,
+    future: ExportedFuture<
+        Result<ApplicationCallResult<Application::Effect, Application::Response>, String>,
+    >,
     _application: PhantomData<Application>,
 }
 
@@ -277,6 +282,7 @@ where
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
     Application::Effect: 'static,
+    Application::Response: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -327,7 +333,9 @@ where
 /// Loads the `Application` state and calls its
 /// [`handle_session_call`][Contract::handle_session_call] method.
 pub struct HandleSessionCall<Application: Contract> {
-    future: ExportedFuture<Result<SessionCallResult<Application::Effect>, String>>,
+    future: ExportedFuture<
+        Result<SessionCallResult<Application::Effect, Application::Response>, String>,
+    >,
     _application: PhantomData<Application>,
 }
 
@@ -337,6 +345,7 @@ where
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
     Application::Effect: 'static,
+    Application::Response: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -131,8 +131,8 @@ where
 /// [`Contract::initialize`].
 ///
 /// Loads the `Application` state and calls its [`initialize`][Contract::initialize] method.
-pub struct Initialize<Application> {
-    future: ExportedFuture<Result<ExecutionResult, String>>,
+pub struct Initialize<Application: Contract> {
+    future: ExportedFuture<Result<ExecutionResult<Application::Effect>, String>>,
     _application: PhantomData<Application>,
 }
 
@@ -141,6 +141,7 @@ where
     Application: Contract + Send,
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
+    Application::Effect: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -175,8 +176,8 @@ where
 ///
 /// Loads the `Application` state and calls its
 /// [`execute_operation`][Contract::execute_operation] method.
-pub struct ExecuteOperation<Application> {
-    future: ExportedFuture<Result<ExecutionResult, String>>,
+pub struct ExecuteOperation<Application: Contract> {
+    future: ExportedFuture<Result<ExecutionResult<Application::Effect>, String>>,
     _application: PhantomData<Application>,
 }
 
@@ -185,6 +186,7 @@ where
     Application: Contract + Send,
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
+    Application::Effect: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -220,8 +222,8 @@ where
 ///
 /// Loads the `Application` state and calls its [`execute_effect`][Contract::execute_effect]
 /// method.
-pub struct ExecuteEffect<Application> {
-    future: ExportedFuture<Result<ExecutionResult, String>>,
+pub struct ExecuteEffect<Application: Contract> {
+    future: ExportedFuture<Result<ExecutionResult<Application::Effect>, String>>,
     _application: PhantomData<Application>,
 }
 
@@ -230,6 +232,7 @@ where
     Application: Contract + Send,
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
+    Application::Effect: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -263,8 +266,8 @@ where
 ///
 /// Loads the `Application` state and calls its
 /// [`handle_application_call`][Contract::handle_application_call] method.
-pub struct HandleApplicationCall<Application> {
-    future: ExportedFuture<Result<ApplicationCallResult, String>>,
+pub struct HandleApplicationCall<Application: Contract> {
+    future: ExportedFuture<Result<ApplicationCallResult<Application::Effect>, String>>,
     _application: PhantomData<Application>,
 }
 
@@ -273,6 +276,7 @@ where
     Application: Contract + Send,
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
+    Application::Effect: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///
@@ -322,8 +326,8 @@ where
 ///
 /// Loads the `Application` state and calls its
 /// [`handle_session_call`][Contract::handle_session_call] method.
-pub struct HandleSessionCall<Application> {
-    future: ExportedFuture<Result<SessionCallResult, String>>,
+pub struct HandleSessionCall<Application: Contract> {
+    future: ExportedFuture<Result<SessionCallResult<Application::Effect>, String>>,
     _application: PhantomData<Application>,
 }
 
@@ -332,6 +336,7 @@ where
     Application: Contract + Send,
     Application::Error: 'static,
     Application::Storage: ContractStateStorage<Application> + Send + 'static,
+    Application::Effect: 'static,
 {
     /// Creates the exported future that the host can poll.
     ///

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -347,6 +347,7 @@ where
             future: ExportedFuture::new(Application::Storage::execute_with_state(
                 move |application| {
                     async move {
+                        let argument: Application::SessionCall = bcs::from_bytes(&argument)?;
                         let forwarded_sessions = forwarded_sessions
                             .into_iter()
                             .map(SessionId::from)
@@ -356,7 +357,7 @@ where
                             .handle_session_call(
                                 &context.into(),
                                 session.into(),
-                                &argument,
+                                argument,
                                 forwarded_sessions,
                             )
                             .await

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -150,7 +150,12 @@ where
         Initialize {
             future: ExportedFuture::new(Application::Storage::execute_with_state(
                 move |application| {
-                    async move { application.initialize(&context.into(), &argument).await }.boxed()
+                    async move {
+                        let init_args: Application::InitializationArguments =
+                            serde_json::from_slice(&argument)?;
+                        application.initialize(&context.into(), init_args).await
+                    }
+                    .boxed()
                 },
             )),
             _application: PhantomData,

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -195,8 +195,9 @@ where
             future: ExportedFuture::new(Application::Storage::execute_with_state(
                 move |application| {
                     async move {
+                        let operation: Application::Operation = bcs::from_bytes(&operation)?;
                         application
-                            .execute_operation(&context.into(), &operation)
+                            .execute_operation(&context.into(), operation)
                             .await
                     }
                     .boxed()

--- a/linera-sdk/src/contract/exported_futures.rs
+++ b/linera-sdk/src/contract/exported_futures.rs
@@ -239,8 +239,11 @@ where
         ExecuteEffect {
             future: ExportedFuture::new(Application::Storage::execute_with_state(
                 move |application| {
-                    async move { application.execute_effect(&context.into(), &effect).await }
-                        .boxed()
+                    async move {
+                        let effect: Application::Effect = bcs::from_bytes(&effect)?;
+                        application.execute_effect(&context.into(), effect).await
+                    }
+                    .boxed()
                 },
             )),
             _application: PhantomData,

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -85,6 +85,8 @@ pub trait Contract: Sized {
     type Storage;
     /// Initialization Arguments.
     type InitializationArguments: DeserializeOwned + Send;
+    /// Execute Operation Arguments.
+    type Operation: DeserializeOwned + Send;
     /// Application Call Arguments.
     type ApplicationCallArguments: DeserializeOwned + Serialize + Send;
 
@@ -115,7 +117,7 @@ pub trait Contract: Sized {
     async fn execute_operation(
         &mut self,
         context: &OperationContext,
-        operation: &[u8],
+        operation: Self::Operation,
     ) -> Result<ExecutionResult, Self::Error>;
 
     /// Applies an effect originating from a cross-chain message.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -80,11 +80,13 @@ pub struct ViewStateStorage<A>(std::marker::PhantomData<A>);
 #[async_trait]
 pub trait Contract: Sized {
     /// Message reports for application execution errors.
-    type Error: Error + From<serde_json::Error>;
+    type Error: Error + From<serde_json::Error> + From<bcs::Error>;
     /// The desired storage backend to use to store the application's state.
     type Storage;
     /// Initialization Arguments.
     type InitializationArguments: DeserializeOwned + Send;
+    /// Application Call Arguments.
+    type ApplicationCallArguments: DeserializeOwned + Serialize + Send;
 
     /// Initializes the application on the chain that created it.
     ///
@@ -156,7 +158,7 @@ pub trait Contract: Sized {
     async fn handle_application_call(
         &mut self,
         context: &CalleeContext,
-        argument: &[u8],
+        argument: Self::ApplicationCallArguments,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error>;
 

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -89,6 +89,8 @@ pub trait Contract: Sized {
     type Operation: DeserializeOwned + Send;
     /// Application Call Arguments.
     type ApplicationCallArguments: DeserializeOwned + Serialize + Send;
+    /// The Application Effect.
+    type Effect: DeserializeOwned + Send;
 
     /// Initializes the application on the chain that created it.
     ///
@@ -137,7 +139,7 @@ pub trait Contract: Sized {
     async fn execute_effect(
         &mut self,
         context: &EffectContext,
-        effect: &[u8],
+        effect: Self::Effect,
     ) -> Result<ExecutionResult, Self::Error>;
 
     /// Handles a call from another application.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -91,6 +91,8 @@ pub trait Contract: Sized {
     type ApplicationCallArguments: DeserializeOwned + Serialize + Send;
     /// The Application Effect.
     type Effect: DeserializeOwned + Send;
+    /// A Session Call.
+    type SessionCall: DeserializeOwned + Send;
 
     /// Initializes the application on the chain that created it.
     ///
@@ -202,7 +204,7 @@ pub trait Contract: Sized {
         &mut self,
         context: &CalleeContext,
         session: Session,
-        argument: &[u8],
+        argument: Self::SessionCall,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, Self::Error>;
 }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -306,6 +306,10 @@ where
         let mut client = self.client.lock().await;
         client.synchronize_from_validators().await?;
         client.process_inbox().await?;
+        let initialization_argument = match initialization_argument.len() {
+            0 => serde_json::to_vec(&()).unwrap(),
+            _ => initialization_argument,
+        };
         let (application_id, _) = client
             .create_application(
                 bytecode_id,


### PR DESCRIPTION
# Motivation

Our existing Contracts receive and return vectors of bytes. This results application writers to have to constantly implement serde themselves.

# Solution

Introduce associated types in contracts with the appropriate trait bounds.

# Limitations

There is still an open questions regarding error management when converting to and from wit types, this issue is intended to tackle this and we can merge this PR regardless for now: #743.