### PR TITLE
Fix e2e tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,15 +46,6 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build WASM test runner
-      # use debug mode to avoid building wasmtime in release mode
-      run: |
-        cargo build --locked --bin test-runner
-    - name: Run WASM application tests
-      run: |
-        cd examples
-        CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=../target/debug/test-runner cargo test --target wasm32-unknown-unknown
-        cargo test --target x86_64-unknown-linux-gnu
     - name: Build example applications
       run: |
         cd examples
@@ -71,6 +62,15 @@ jobs:
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test -p linera-execution --features wasmtime
+    - name: Build WASM test runner
+      # use debug mode to avoid building wasmtime in release mode
+      run: |
+        cargo build --locked --bin test-runner
+    - name: Run WASM application tests
+      run: |
+        cd examples
+        CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=../target/debug/test-runner cargo test --target wasm32-unknown-unknown
+        cargo test --target x86_64-unknown-linux-gnu
 
   lint:
     runs-on: ubuntu-latest-4-cores

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: warn
 
 permissions:
   contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2554,6 +2554,7 @@ dependencies = [
  "linera-views",
  "proptest",
  "prost 0.11.9",
+ "rand 0.7.3",
  "serde",
  "serde-reflection",
  "serde_yaml",

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -955,7 +955,7 @@ where
     }
 
     /// Attempts to update all validators about the local chain.
-    pub async fn update_validators_about_local_chain(&mut self) -> Result<()> {
+    pub async fn update_validators(&mut self) -> Result<()> {
         let mut committee = self.local_committee().await?;
         committee.quorum_threshold = committee.total_votes;
         self.communicate_chain_updates(

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -991,7 +991,7 @@ where
     }
 
     /// Attempts to synchronize with validators and re-compute our balance.
-    pub async fn synchronize_and_recompute_balance(&mut self) -> Result<Balance> {
+    pub async fn synchronize_from_validators(&mut self) -> Result<Balance> {
         self.find_received_certificates().await?;
         self.prepare_chain().await?;
         self.local_balance().await

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -190,9 +190,12 @@ impl CrossChainRequest {
     /// Returns true if the cross-chain request has messages lower or equal than `height`.
     pub fn has_messages_lower_or_equal_than(&self, height: BlockHeight) -> bool {
         match self {
-            CrossChainRequest::UpdateRecipient { height_map, .. } => height_map
-                .iter()
-                .any(|(_, heights)| matches!(heights.get(0), Some(h) if *h <= height)),
+            CrossChainRequest::UpdateRecipient { height_map, .. } => {
+                height_map.iter().any(|(_, heights)| {
+                    debug_assert!(heights.windows(2).all(|w| w[0] <= w[1]));
+                    matches!(heights.get(0), Some(h) if *h <= height)
+                })
+            }
             _ => false,
         }
     }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -198,7 +198,7 @@ where
     );
     assert_eq!(sender.local_balance().await.unwrap(), Balance::from(4));
     assert_eq!(
-        sender.synchronize_and_recompute_balance().await.unwrap(),
+        sender.synchronize_from_validators().await.unwrap(),
         Balance::from(4)
     );
     // Can still use the chain.
@@ -259,7 +259,7 @@ where
     );
     assert_eq!(sender.local_balance().await.unwrap(), Balance::from(4));
     assert_eq!(
-        sender.synchronize_and_recompute_balance().await.unwrap(),
+        sender.synchronize_from_validators().await.unwrap(),
         Balance::from(4)
     );
     // Cannot use the chain any more.
@@ -316,7 +316,7 @@ where
     );
     assert_eq!(sender.local_balance().await.unwrap(), Balance::from(4));
     assert_eq!(
-        sender.synchronize_and_recompute_balance().await.unwrap(),
+        sender.synchronize_from_validators().await.unwrap(),
         Balance::from(4)
     );
     // Can still use the chain with the old client.
@@ -343,7 +343,7 @@ where
     // the blocks yet.
     assert!(client.local_balance().await.is_err());
     assert_eq!(
-        client.synchronize_and_recompute_balance().await.unwrap(),
+        client.synchronize_from_validators().await.unwrap(),
         Balance::from(2)
     );
     assert_eq!(client.local_balance().await.unwrap(), Balance::from(2));
@@ -375,7 +375,7 @@ where
     // the next round to succeed.
     builder.set_fault_type(.., FaultType::Honest).await;
     assert_eq!(
-        client.synchronize_and_recompute_balance().await.unwrap(),
+        client.synchronize_from_validators().await.unwrap(),
         Balance::from(2)
     );
     client.clear_pending_block().await;
@@ -391,7 +391,7 @@ where
 
     // The other client doesn't know the new round number yet:
     assert_eq!(
-        sender.synchronize_and_recompute_balance().await.unwrap(),
+        sender.synchronize_from_validators().await.unwrap(),
         Balance::from(1)
     );
     sender.clear_pending_block().await;
@@ -408,7 +408,7 @@ where
     // That's it, we spent all our money on this test!
     assert_eq!(sender.local_balance().await.unwrap(), Balance::from(0));
     assert_eq!(
-        client.synchronize_and_recompute_balance().await.unwrap(),
+        client.synchronize_from_validators().await.unwrap(),
         Balance::from(0)
     );
     Ok(())
@@ -457,7 +457,7 @@ where
         .await?;
     client.receive_certificate(certificate).await.unwrap();
     assert_eq!(
-        client.synchronize_and_recompute_balance().await.unwrap(),
+        client.synchronize_from_validators().await.unwrap(),
         Balance::from(0)
     );
     assert_eq!(client.local_balance().await.unwrap(), Balance::from(0));
@@ -801,7 +801,7 @@ where
     assert_eq!(client2.local_balance().await.unwrap(), Balance::from(0));
     // Force synchronization of local balance.
     assert_eq!(
-        client2.synchronize_and_recompute_balance().await.unwrap(),
+        client2.synchronize_from_validators().await.unwrap(),
         Balance::from(3)
     );
     assert_eq!(client2.local_balance().await.unwrap(), Balance::from(3));
@@ -833,7 +833,7 @@ where
     assert!(client2.pending_block.is_none());
     assert_eq!(client2.local_balance().await.unwrap(), Balance::from(2));
     assert_eq!(
-        client1.synchronize_and_recompute_balance().await.unwrap(),
+        client1.synchronize_from_validators().await.unwrap(),
         Balance::from(1)
     );
     // Local balance from client2 is now consolidated.
@@ -990,7 +990,7 @@ where
     client2.clear_pending_block().await;
     // Retrying the whole command works after synchronization.
     assert_eq!(
-        client2.synchronize_and_recompute_balance().await.unwrap(),
+        client2.synchronize_from_validators().await.unwrap(),
         Balance::from(2)
     );
     let certificate = client2
@@ -1080,7 +1080,7 @@ where
     assert!(user.receive_certificate(cert).await.is_err());
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(0));
     assert_eq!(
-        user.synchronize_and_recompute_balance().await.unwrap(),
+        user.synchronize_from_validators().await.unwrap(),
         Balance::from(3)
     );
 
@@ -1109,12 +1109,12 @@ where
     assert!(admin.receive_certificate(cert).await.is_err());
     // Transfer is blocked because the epoch #0 has been retired by admin.
     assert_eq!(
-        admin.synchronize_and_recompute_balance().await.unwrap(),
+        admin.synchronize_from_validators().await.unwrap(),
         Balance::from(0)
     );
 
     // Have the user receive the notification to migrate to epoch #1.
-    user.synchronize_and_recompute_balance().await.unwrap();
+    user.synchronize_from_validators().await.unwrap();
     user.process_inbox().await.unwrap();
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(1));
 
@@ -1131,7 +1131,7 @@ where
     admin.receive_certificate(cert).await.unwrap();
     // Transfer goes through and the previous one as well thanks to block chaining.
     assert_eq!(
-        admin.synchronize_and_recompute_balance().await.unwrap(),
+        admin.synchronize_from_validators().await.unwrap(),
         Balance::from(3)
     );
     Ok(())

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -91,7 +91,7 @@ where
     publisher.receive_certificate(cert).await.unwrap();
     publisher.process_inbox().await.unwrap();
 
-    creator.synchronize_and_recompute_balance().await.unwrap();
+    creator.synchronize_from_validators().await.unwrap();
     creator.process_inbox().await.unwrap();
 
     let initial_value = 10_u128;
@@ -215,7 +215,7 @@ where
     publisher.process_inbox().await.unwrap();
 
     // Creator receives the bytecodes then creates the app.
-    creator.synchronize_and_recompute_balance().await.unwrap();
+    creator.synchronize_from_validators().await.unwrap();
     creator.process_inbox().await.unwrap();
     let initial_value = 10_u128;
     let (application_id1, _) = creator
@@ -353,7 +353,7 @@ where
     publisher.process_inbox().await.unwrap();
 
     // Creator receives the bytecodes then creates the app.
-    creator.synchronize_and_recompute_balance().await.unwrap();
+    creator.synchronize_from_validators().await.unwrap();
     creator.process_inbox().await.unwrap();
     let initial_value = 100_u128;
     let (application_id, _) = creator
@@ -508,7 +508,7 @@ where
                 if matches!(applications[0], UserApplicationDescription{ bytecode_id: b_id, .. } if b_id == bytecode_id)
             ) && *destination == Destination::Recipient(receiver.chain_id())
         }));
-    receiver.synchronize_and_recompute_balance().await.unwrap();
+    receiver.synchronize_from_validators().await.unwrap();
     receiver.receive_certificate(cert).await.unwrap();
     let certs = receiver.process_inbox().await.unwrap();
     assert_eq!(certs.len(), 1);
@@ -663,7 +663,7 @@ where
         .await?;
 
     // Subscribe the receiver. This also registers the application.
-    sender.synchronize_and_recompute_balance().await.unwrap();
+    sender.synchronize_from_validators().await.unwrap();
     sender.receive_certificate(cert).await.unwrap();
     let _certs = sender.process_inbox().await.unwrap();
 
@@ -715,7 +715,7 @@ where
         .await?;
 
     // Unsubscribe the receiver.
-    sender.synchronize_and_recompute_balance().await.unwrap();
+    sender.synchronize_from_validators().await.unwrap();
     sender.receive_certificate(cert).await.unwrap();
     let _certs = sender.process_inbox().await.unwrap();
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -364,7 +364,7 @@ where
                     .push(notifier);
             } else {
                 // No need to wait. Also, cross-chain requests may not trigger the
-                // notifier later if we register it.
+                // notifier later, even if we register it.
                 if let Err(()) = notifier.send(()) {
                     warn!("Failed to notify message delivery to caller");
                 }

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -33,6 +33,7 @@ linera-views = { workspace = true }
 tracing = { workspace = true }
 proptest = { workspace = true, optional = true }
 prost = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 structopt = { workspace = true }
 thiserror = { workspace = true }

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -23,6 +23,10 @@ pub struct CrossChainConfig {
     /// Introduce a delay before sending every cross-chain message (e.g. for testing purpose).
     #[structopt(long = "cross-chain-sender-delay-ms", default_value = "0")]
     pub(crate) sender_delay_ms: u64,
+
+    /// Drop cross-chain messages randomly at the given rate (0 <= rate < 1) (meant for testing).
+    #[structopt(long = "cross-chain-sender-failure-rate", default_value = "0.0")]
+    pub(crate) sender_failure_rate: f32,
 }
 
 #[derive(Clone, Debug, StructOpt)]

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -12,12 +12,12 @@ use linera_views::views::ViewError;
 use std::{ops::DerefMut, sync::Arc};
 use tracing::{debug, warn};
 
-/// A `ChainLeader` is a process that listens to notifications from validators and reacts appropriately.
-pub struct ChainLeader<P, S> {
+/// A `ChainListener` is a process that listens to notifications from validators and reacts appropriately.
+pub struct ChainListener<P, S> {
     client: Arc<Mutex<ChainClient<P, S>>>,
 }
 
-impl<P, S> ChainLeader<P, S>
+impl<P, S> ChainListener<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Store + Clone + Send + Sync + 'static,

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -56,7 +56,7 @@ where
             }
             let mut client = self.client.lock().await;
             if tracker.insert(notification.clone()) {
-                if let Err(e) = client.synchronize_and_recompute_balance().await {
+                if let Err(e) = client.synchronize_from_validators().await {
                     warn!(
                         "Failed to synchronize and recompute balance for notification {:?} \
                             with error: {:?}",

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -68,7 +68,7 @@ where
                 }
                 match &notification.reason {
                     Reason::NewBlock { .. } => {
-                        if let Err(e) = client.update_validators_about_local_chain().await {
+                        if let Err(e) = client.update_validators().await {
                             warn!(
                                 "Failed to update validators about the local chain after \
                                          receiving notification {:?} with error: {:?}",

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! This module provides the executables needed to operate a Linera service, including a placeholder wallet acting as a GraphQL service for user interfaces.
 
-pub mod chain_leader;
+pub mod chain_listener;
 pub mod config;
 pub mod grpc_proxy;
 pub mod node_service;

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -214,10 +214,7 @@ impl ClientContext {
         for chain_id in self.wallet_state.chain_ids() {
             let mut chain_client = self.make_chain_client(storage.clone(), chain_id);
             chain_client.process_inbox().await.unwrap();
-            chain_client
-                .update_validators_about_local_chain()
-                .await
-                .unwrap();
+            chain_client.update_validators().await.unwrap();
             self.update_wallet_from_client(&mut chain_client).await;
         }
     }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -476,7 +476,7 @@ impl ClientContext {
         info!("{}", "Bytecode published successfully!".green().bold());
 
         info!("Synchronizing...");
-        chain_client.synchronize_and_recompute_balance().await?;
+        chain_client.synchronize_from_validators().await?;
         chain_client.process_inbox().await?;
         Ok(bytecode_id)
     }
@@ -850,10 +850,7 @@ where
                 let mut chain_client = context.make_chain_client(storage, chain_id);
                 info!("Synchronize chain information");
                 let time_start = Instant::now();
-                let balance = chain_client
-                    .synchronize_and_recompute_balance()
-                    .await
-                    .unwrap();
+                let balance = chain_client.synchronize_from_validators().await.unwrap();
                 let time_total = time_start.elapsed().as_micros();
                 info!("Chain balance synchronized after {} us", time_total);
                 println!("{}", balance);
@@ -1087,7 +1084,7 @@ where
                 };
 
                 info!("Synchronizing...");
-                chain_client.synchronize_and_recompute_balance().await?;
+                chain_client.synchronize_from_validators().await?;
                 chain_client.process_inbox().await?;
 
                 info!("Creating application...");

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -27,6 +27,7 @@ use linera_execution::{
 };
 use linera_rpc::node_provider::NodeProvider;
 use linera_service::{
+    chain_listener::ChainListenerConfig,
     config::{CommitteeConfig, Export, GenesisConfig, Import, UserChain, WalletState},
     node_service::NodeService,
     project::Project,
@@ -672,6 +673,9 @@ enum ClientCommand {
         /// Chain id
         chain_id: Option<ChainId>,
 
+        #[structopt(flatten)]
+        config: ChainListenerConfig,
+
         /// The port on which to run the server
         #[structopt(long = "port", default_value = "8080")]
         port: NonZeroU16,
@@ -1032,9 +1036,13 @@ where
                 // Not saving the wallet because `connect()` has no effect on `chain_client`.
             }
 
-            Service { chain_id, port } => {
+            Service {
+                chain_id,
+                config,
+                port,
+            } => {
                 let chain_client = context.make_chain_client(storage, chain_id);
-                let service = NodeService::new(chain_client, port);
+                let service = NodeService::new(chain_client, config, port);
                 service
                     .run(context, |context, client| {
                         Box::pin(async {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -134,6 +134,7 @@ where
     ) -> Result<CryptoHash, Error> {
         let operation = Operation::System(system_operation);
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
         client.process_inbox().await?;
         Ok(client.execute_operation(operation).await?.value.hash())
     }
@@ -156,6 +157,8 @@ where
         user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
+        client.process_inbox().await?;
         let certificate = client
             .transfer(owner, amount, recipient, user_data.unwrap_or_default())
             .await?;
@@ -174,6 +177,8 @@ where
         user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
+        client.process_inbox().await?;
         let certificate = client
             .claim(
                 owner,
@@ -190,6 +195,8 @@ where
     /// This will automatically subscribe to the future committees created by `admin_id`.
     async fn open_chain(&self, public_key: PublicKey) -> Result<ChainId, Error> {
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
+        client.process_inbox().await?;
         let (effect_id, _) = client.open_chain(public_key).await?;
         Ok(ChainId::child(effect_id))
     }
@@ -197,6 +204,8 @@ where
     /// Closes the chain.
     async fn close_chain(&self) -> Result<CryptoHash, Error> {
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
+        client.process_inbox().await?;
         let certificate = client.close_chain().await?;
         Ok(certificate.value.hash())
     }
@@ -268,6 +277,8 @@ where
         service: Bytecode,
     ) -> Result<BytecodeId, Error> {
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
+        client.process_inbox().await?;
         let (bytecode_id, _) = client.publish_bytecode(contract, service).await?;
         Ok(bytecode_id)
     }
@@ -280,6 +291,8 @@ where
         required_application_ids: Vec<UserApplicationId>,
     ) -> Result<ApplicationId, Error> {
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
+        client.process_inbox().await?;
         let (application_id, _) = client
             .create_application(
                 bytecode_id,
@@ -541,6 +554,7 @@ where
             .collect();
 
         let mut client = self.client.lock().await;
+        client.synchronize_and_recompute_balance().await?;
         client.process_inbox().await?;
         let hash = client.execute_operations(operations).await?.value.hash();
         Ok(async_graphql::Response::new(hash.to_value()))

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -134,7 +134,7 @@ where
     ) -> Result<CryptoHash, Error> {
         let operation = Operation::System(system_operation);
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         Ok(client.execute_operation(operation).await?.value.hash())
     }
@@ -157,7 +157,7 @@ where
         user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let certificate = client
             .transfer(owner, amount, recipient, user_data.unwrap_or_default())
@@ -177,7 +177,7 @@ where
         user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let certificate = client
             .claim(
@@ -195,7 +195,7 @@ where
     /// This will automatically subscribe to the future committees created by `admin_id`.
     async fn open_chain(&self, public_key: PublicKey) -> Result<ChainId, Error> {
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let (effect_id, _) = client.open_chain(public_key).await?;
         Ok(ChainId::child(effect_id))
@@ -204,7 +204,7 @@ where
     /// Closes the chain.
     async fn close_chain(&self) -> Result<CryptoHash, Error> {
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let certificate = client.close_chain().await?;
         Ok(certificate.value.hash())
@@ -277,7 +277,7 @@ where
         service: Bytecode,
     ) -> Result<BytecodeId, Error> {
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let (bytecode_id, _) = client.publish_bytecode(contract, service).await?;
         Ok(bytecode_id)
@@ -291,7 +291,7 @@ where
         required_application_ids: Vec<UserApplicationId>,
     ) -> Result<ApplicationId, Error> {
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let (application_id, _) = client
             .create_application(
@@ -554,7 +554,7 @@ where
             .collect();
 
         let mut client = self.client.lock().await;
-        client.synchronize_and_recompute_balance().await?;
+        client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let hash = client.execute_operations(operations).await?.value.hash();
         Ok(async_graphql::Response::new(hash.to_value()))

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::chain_leader::ChainLeader;
+use crate::chain_listener::ChainListener;
 use async_graphql::{
     futures_util::Stream,
     http::GraphiQLSource,
@@ -476,7 +476,8 @@ where
 
         info!("GraphiQL IDE: http://localhost:{}", port);
 
-        let sync_fut = Box::pin(ChainLeader::new(self.client.clone()).run(context, wallet_updater));
+        let sync_fut =
+            Box::pin(ChainListener::new(self.client.clone()).run(context, wallet_updater));
         let serve_fut =
             Server::bind(&SocketAddr::from(([127, 0, 0, 1], port))).serve(app.into_make_service());
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -6,14 +6,11 @@ use async_graphql::InputType;
 use linera_base::identifiers::{ChainId, EffectId, Owner};
 use linera_execution::Bytecode;
 use linera_service::config::WalletState;
-#[cfg(feature = "aws")]
-use linera_views::test_utils::LocalStackTestContext;
 use once_cell::sync::{Lazy, OnceCell};
 use serde_json::{json, Value};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     env, fs,
-    io::Write,
     ops::RangeInclusive,
     path::PathBuf,
     process::Stdio,
@@ -41,95 +38,6 @@ const CARGO_ENV: &str = "INTEGRATION_TEST_CARGO_PARAMS";
 /// The name of the environment variable that allows specifying additional arguments to be passed
 /// to the binary when starting a server.
 const SERVER_ENV: &str = "INTEGRATION_TEST_SERVER_PARAMS";
-
-#[test_log::test(tokio::test)]
-async fn test_examples_in_readme() -> std::io::Result<()> {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
-
-    let dir = tempdir().unwrap();
-    let file = std::io::BufReader::new(std::fs::File::open("../README.md")?);
-    let mut quotes = get_bash_quotes(file)?;
-    // Check that we have the expected number of examples starting with "```bash".
-    assert_eq!(quotes.len(), 1);
-    let quote = quotes.pop().unwrap();
-
-    let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
-    write!(&mut test_script, "{}", quote)?;
-
-    let status = Command::new("bash")
-        .current_dir("..") // root of the repo
-        .arg("-e")
-        .arg("-x")
-        .arg(dir.path().join("test.sh"))
-        .status()
-        .await?;
-    assert!(status.success());
-    Ok(())
-}
-
-#[allow(clippy::while_let_on_iterator)]
-fn get_bash_quotes(reader: impl std::io::BufRead) -> std::io::Result<Vec<String>> {
-    let mut result = Vec::new();
-    let mut lines = reader.lines();
-
-    while let Some(line) = lines.next() {
-        let line = line?;
-        if line.starts_with("```bash") {
-            let mut quote = String::new();
-            while let Some(line) = lines.next() {
-                let line = line?;
-                if line.starts_with("```") {
-                    break;
-                }
-                quote += &line;
-                quote += "\n";
-            }
-            result.push(quote);
-        }
-    }
-
-    Ok(result)
-}
-
-#[cfg(feature = "aws")]
-mod aws_test {
-    use super::*;
-
-    const ROCKSDB_STORAGE: &str = "--storage rocksdb:server_\"$I\"_\"$J\".db";
-    const DYNAMO_DB_STORAGE: &str = "--storage dynamodb:server-\"$I\":localstack";
-
-    const BUILD: &str = "cargo build";
-    const AWS_BUILD: &str = "cargo build --features aws";
-
-    #[test_log::test(tokio::test)]
-    async fn test_examples_in_readme_with_dynamo_db() -> anyhow::Result<()> {
-        let _guard = INTEGRATION_TEST_GUARD.lock().await;
-
-        let _localstack_guard = LocalStackTestContext::new().await?;
-        let dir = tempdir().unwrap();
-        let file = std::io::BufReader::new(std::fs::File::open("../README.md")?);
-        let mut quotes = get_bash_quotes(file)?;
-        // Check that we have the expected number of examples starting with "```bash".
-        assert_eq!(quotes.len(), 1);
-        let quote = quotes.pop().unwrap();
-        assert_eq!(quote.matches(ROCKSDB_STORAGE).count(), 1);
-        let quote = quote.replace(ROCKSDB_STORAGE, DYNAMO_DB_STORAGE);
-        let quote = quote.replace(BUILD, AWS_BUILD);
-
-        let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
-        write!(&mut test_script, "{}", quote)?;
-
-        let status = Command::new("bash")
-            .current_dir("..") // root of the repo
-            .arg("-e")
-            .arg("-x")
-            .arg(dir.path().join("test.sh"))
-            .status()
-            .await?;
-        assert!(status.success());
-        Ok(())
-    }
-}
 
 #[derive(Copy, Clone)]
 enum Network {

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(feature = "aws")]
+use linera_views::test_utils::LocalStackTestContext;
+use once_cell::sync::Lazy;
+use std::io::Write;
+use tempfile::tempdir;
+use tokio::{process::Command, sync::Mutex};
+
+/// A static lock to prevent integration tests from running in parallel.
+static INTEGRATION_TEST_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[test_log::test(tokio::test)]
+async fn test_examples_in_readme() -> std::io::Result<()> {
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+
+    let dir = tempdir().unwrap();
+    let file = std::io::BufReader::new(std::fs::File::open("../README.md")?);
+    let mut quotes = get_bash_quotes(file)?;
+    // Check that we have the expected number of examples starting with "```bash".
+    assert_eq!(quotes.len(), 1);
+    let quote = quotes.pop().unwrap();
+
+    let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
+    write!(&mut test_script, "{}", quote)?;
+
+    let status = Command::new("bash")
+        .current_dir("..") // root of the repo
+        .arg("-e")
+        .arg("-x")
+        .arg(dir.path().join("test.sh"))
+        .status()
+        .await?;
+    assert!(status.success());
+    Ok(())
+}
+
+#[allow(clippy::while_let_on_iterator)]
+fn get_bash_quotes(reader: impl std::io::BufRead) -> std::io::Result<Vec<String>> {
+    let mut result = Vec::new();
+    let mut lines = reader.lines();
+
+    while let Some(line) = lines.next() {
+        let line = line?;
+        if line.starts_with("```bash") {
+            let mut quote = String::new();
+            while let Some(line) = lines.next() {
+                let line = line?;
+                if line.starts_with("```") {
+                    break;
+                }
+                quote += &line;
+                quote += "\n";
+            }
+            result.push(quote);
+        }
+    }
+
+    Ok(result)
+}
+
+#[cfg(feature = "aws")]
+mod aws_test {
+    use super::*;
+
+    const ROCKSDB_STORAGE: &str = "--storage rocksdb:server_\"$I\"_\"$J\".db";
+    const DYNAMO_DB_STORAGE: &str = "--storage dynamodb:server-\"$I\":localstack";
+
+    const BUILD: &str = "cargo build";
+    const AWS_BUILD: &str = "cargo build --features aws";
+
+    #[test_log::test(tokio::test)]
+    async fn test_examples_in_readme_with_dynamo_db() -> anyhow::Result<()> {
+        let _guard = INTEGRATION_TEST_GUARD.lock().await;
+
+        let _localstack_guard = LocalStackTestContext::new().await?;
+        let dir = tempdir().unwrap();
+        let file = std::io::BufReader::new(std::fs::File::open("../README.md")?);
+        let mut quotes = get_bash_quotes(file)?;
+        // Check that we have the expected number of examples starting with "```bash".
+        assert_eq!(quotes.len(), 1);
+        let quote = quotes.pop().unwrap();
+        assert_eq!(quote.matches(ROCKSDB_STORAGE).count(), 1);
+        let quote = quote.replace(ROCKSDB_STORAGE, DYNAMO_DB_STORAGE);
+        let quote = quote.replace(BUILD, AWS_BUILD);
+
+        let mut test_script = std::fs::File::create(dir.path().join("test.sh"))?;
+        write!(&mut test_script, "{}", quote)?;
+
+        let status = Command::new("bash")
+            .current_dir("..") // root of the repo
+            .arg("-e")
+            .arg("-x")
+            .arg(dir.path().join("test.sh"))
+            .status()
+            .await?;
+        assert!(status.success());
+        Ok(())
+    }
+}


### PR DESCRIPTION
The actual fix is 6721bbbb623884fa77b2169da65bf750f582a436 : we cannot assume that the chain listener will be faster than the graphql API to synchronize and process inboxes.

I managed to consistently reproduce the latest error seen in CI by introducing a delay in the listener (11fb2b240876ae202fdf05410fb6f6ccc6441d6b). The error disappears after the fix.

Other related improvements in the PR include:
* Dropping cross-chain messages at random (note: we don't handle that in the e2e tests yet)
* Making sure that e2e tests if client commands or servers crash.
* Fix the benchmark command (broken by a race condition with the readme test)
* Exit NodeService as soon as listener or graphql stops
* Some CI nits
* Some renamings in client commands

Synchronizing from validators is expensive. I created #680 to remember to optimize networking in the future.