### PR TITLE
Fix race condition in e2e tests

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -410,7 +410,10 @@ where
         info
     }
 
-    async fn local_chain_info(&mut self, chain_id: ChainId) -> Result<ChainInfo, NodeError> {
+    pub(crate) async fn local_chain_info(
+        &mut self,
+        chain_id: ChainId,
+    ) -> Result<ChainInfo, NodeError> {
         let query = ChainInfoQuery::new(chain_id);
         Ok(self.handle_chain_info_query(query).await?.info)
     }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -118,7 +118,7 @@ where
 {
     /// Subscribes to notifications from the current chain.
     async fn notifications(&self) -> Result<impl Stream<Item = Notification>, Error> {
-        Ok(self.client.lock().await.listen().await?)
+        Ok(ChainClient::listen(self.client.clone()).await?)
     }
 }
 


### PR DESCRIPTION
Hopefully the last one this time!

What was happening is that we were calling `synchronize_from_validators` immediately after receiving the first notification from a validator V. However, this function only has to talk to a quorum. So it may miss the new message if V is 
not part of the quorum.

The fix is to do what we had in mind anyway: synchronize blocks with the author of the notification that we just received.