### PR TITLE
Send only one ConfirmUpdatedRecipient per UpdateRecipient.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -194,17 +194,17 @@ where
 
     pub async fn next_block_height_to_receive(
         &mut self,
-        origin: Origin,
+        origin: &Origin,
     ) -> Result<BlockHeight, ChainError> {
-        let inbox = self.inboxes.load_entry(&origin).await?;
+        let inbox = self.inboxes.load_entry(origin).await?;
         inbox.next_block_height_to_receive()
     }
 
     pub async fn last_anticipated_block_height(
         &mut self,
-        origin: Origin,
+        origin: &Origin,
     ) -> Result<Option<BlockHeight>, ChainError> {
-        let inbox = self.inboxes.load_entry(&origin).await?;
+        let inbox = self.inboxes.load_entry(origin).await?;
         match inbox.removed_events.back().await? {
             Some(event) => Ok(Some(event.height)),
             None => Ok(None),
@@ -224,7 +224,7 @@ where
     ) -> Result<(), ChainError> {
         let chain_id = self.chain_id();
         ensure!(
-            height >= self.next_block_height_to_receive(origin.clone()).await?,
+            height >= self.next_block_height_to_receive(origin).await?,
             ChainError::InternalError("Trying to receive blocks in the wrong order".to_string())
         );
         tracing::trace!(

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -285,8 +285,10 @@ where
         ensure!(
             !events.is_empty(),
             ChainError::InternalError(format!(
-                "The block received by {:?} from {:?} at height {:?} was entirely ignored. This should not happen",
-                chain_id, origin, height))
+                "The block received by {:?} from {:?} at height {:?} was entirely ignored. \
+                This should not happen",
+                chain_id, origin, height
+            ))
         );
         // Process the inbox events and update the inbox state.
         let inbox = self.inboxes.load_entry_mut(origin).await?;

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -555,7 +555,7 @@ impl Certificate {
     }
 
     /// Returns the certificate without the full value.
-    pub fn without_value(&self) -> LiteCertificate {
+    pub fn lite_certificate(&self) -> LiteCertificate {
         LiteCertificate {
             value: self.lite_value(),
             signatures: self.signatures.clone(),
@@ -566,13 +566,6 @@ impl Certificate {
         LiteValue {
             value_hash: self.value.hash(),
             chain_id: self.value.chain_id(),
-        }
-    }
-
-    pub fn lite_certificate(&self) -> LiteCertificate {
-        LiteCertificate {
-            value: self.lite_value(),
-            signatures: self.signatures.clone(),
         }
     }
 }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -550,33 +550,30 @@ impl Certificate {
 
     /// Verifies the certificate.
     pub fn check<'a>(&'a self, committee: &Committee) -> Result<&'a HashedValue, ChainError> {
-        check_signatures(&self.lite(), &self.signatures, committee)?;
+        check_signatures(&self.lite_value(), &self.signatures, committee)?;
         Ok(&self.value)
     }
 
     /// Returns the certificate without the full value.
     pub fn without_value(&self) -> LiteCertificate {
         LiteCertificate {
-            value: self.lite(),
+            value: self.lite_value(),
             signatures: self.signatures.clone(),
         }
     }
 
-    pub fn lite(&self) -> LiteValue {
+    pub fn lite_value(&self) -> LiteValue {
         LiteValue {
             value_hash: self.value.hash(),
             chain_id: self.value.chain_id(),
         }
     }
 
-    pub fn split(self) -> (LiteCertificate, HashedValue) {
-        (
-            LiteCertificate {
-                value: self.lite(),
-                signatures: self.signatures,
-            },
-            self.value,
-        )
+    pub fn lite_certificate(&self) -> LiteCertificate {
+        LiteCertificate {
+            value: self.lite_value(),
+            signatures: self.signatures.clone(),
+        }
     }
 }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -9,7 +9,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId},
 };
 use linera_chain::{
-    data_types::{Certificate, ChainAndHeight, HashedValue, Medium, Message, Origin},
+    data_types::{Certificate, ChainAndHeight, HashedValue, Medium, Message},
     ChainManagerInfo, ChainStateView,
 };
 use linera_execution::{
@@ -169,11 +169,11 @@ pub enum CrossChainRequest {
         recipient: ChainId,
         certificates: Vec<Certificate>,
     },
-    /// Acknowledge the height of the highest confirmed block communicated with `UpdateRecipient`.
+    /// Acknowledge the height of the highest confirmed blocks communicated with `UpdateRecipient`.
     ConfirmUpdatedRecipient {
-        origin: Origin,
+        sender: ChainId,
         recipient: ChainId,
-        height: BlockHeight,
+        latest_heights: Vec<(Medium, BlockHeight)>,
     },
 }
 
@@ -183,7 +183,7 @@ impl CrossChainRequest {
         use CrossChainRequest::*;
         match self {
             UpdateRecipient { recipient, .. } => *recipient,
-            ConfirmUpdatedRecipient { origin, .. } => origin.sender,
+            ConfirmUpdatedRecipient { sender, .. } => *sender,
         }
     }
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -539,7 +539,7 @@ where
             if let Some(blob) =
                 Self::try_download_blob_from(name, &mut client, chain_id, location).await
             {
-                storage.write_value(blob.clone()).await?;
+                storage.write_value(&blob).await?;
                 return Ok(Some(blob));
             }
         }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2796,7 +2796,7 @@ where
         matches!(
             user_chain
                 .inboxes
-                .load_entry_mut(&admin_channel_origin.clone())
+                .load_entry_mut(&admin_channel_origin)
                 .await
                 .unwrap()
                 .added_events

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -128,7 +128,7 @@ where
         loop {
             let mut result = match self
                 .client
-                .handle_lite_certificate(certificate.without_value())
+                .handle_lite_certificate(certificate.lite_certificate())
                 .await
             {
                 Ok(response) => Ok(response),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -517,9 +517,9 @@ where
         // Persist certificate and blobs.
         for value in blobs {
             self.cache_recent_value(value.clone());
-            self.storage.write_value(value.clone()).await?;
+            self.storage.write_value(value).await?;
         }
-        self.storage.write_certificate(certificate.clone()).await?;
+        self.storage.write_certificate(&certificate).await?;
         // Execute the block and update inboxes.
         chain.remove_events_from_inboxes(block).await?;
         let verified_effects = chain.execute_block(block).await?;
@@ -702,7 +702,7 @@ where
                 )
                 .await?;
             last_updated_height = Some(block.height);
-            self.storage.write_certificate(certificate).await?;
+            self.storage.write_certificate(&certificate).await?;
         }
         // Be ready to confirm the highest processed block so far. It could be from a previous update.
         let cross_chain_requests =
@@ -913,7 +913,7 @@ where
         self.check_no_missing_bytecode(block, blobs).await?;
         // Write the values so that the bytecode is available during execution.
         for value in blobs {
-            self.storage.write_value(value.clone()).await?;
+            self.storage.write_value(value).await?;
         }
         let time_till_block = block.timestamp.saturating_diff_micros(Timestamp::now());
         ensure!(

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -111,11 +111,16 @@ message UpdateRecipientEntry {
   repeated BlockHeight heights = 2;
 }
 
-// Acknowledge the height of the highest confirmed block communicated with `UpdateRecipient`.
+// Acknowledge the height of the highest confirmed blocks communicated with `UpdateRecipient`.
 message ConfirmUpdatedRecipient {
-  Origin origin = 1;
+  ChainId sender = 1;
   ChainId recipient = 2;
-  BlockHeight height = 3;
+  repeated ConfirmUpdatedRecipientEntry latest_heights = 3;
+}
+
+message ConfirmUpdatedRecipientEntry {
+  Medium medium = 1;
+  BlockHeight height = 2;
 }
 
 // Message to obtain information on a chain.

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -256,7 +256,7 @@ where
 
         while let Some((cross_chain_request, shard_id)) = receiver.next().await {
             if rand::thread_rng().gen::<f32>() < cross_chain_sender_failure_rate {
-                warn!("Dropped 1 cross-message intentionally.");
+                warn!("Dropped 1 cross-chain message intentionally.");
                 continue;
             }
 

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -230,12 +230,15 @@ CrossChainRequest:
     1:
       ConfirmUpdatedRecipient:
         STRUCT:
-          - origin:
-              TYPENAME: Origin
+          - sender:
+              TYPENAME: ChainId
           - recipient:
               TYPENAME: ChainId
-          - height:
-              TYPENAME: BlockHeight
+          - latest_heights:
+              SEQ:
+                TUPLE:
+                  - TYPENAME: Medium
+                  - TYPENAME: BlockHeight
 CryptoHash:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -36,7 +36,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
-    /// Creates a new instance of the node service given a client chain.
+    /// Creates a new chain listener given a client chain.
     pub fn new(config: ChainListenerConfig, client: Arc<Mutex<ChainClient<P, S>>>) -> Self {
         Self { config, client }
     }

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -229,7 +229,7 @@ where
     /// ```
     pub async fn get_mut(&mut self, short_key: Vec<u8>) -> Result<Option<&mut V>, ViewError> {
         self.load_value(&short_key).await?;
-        if let Some(update) = self.updates.get_mut(&short_key.clone()) {
+        if let Some(update) = self.updates.get_mut(&short_key) {
             let value = match update {
                 Update::Removed => None,
                 Update::Set(value) => Some(value),


### PR DESCRIPTION
# Motivation

We already merged the `UpdateRecipient` messages, so that a single one summarizes all updates for the same recipient. But as a response, currently multiple `ConfirmUpdatedRecipient` are sent.

# Solution

Merge the `ConfirmUpdatedRecipient` messages, so that only one response is necessary for each update message.

Closes https://github.com/linera-io/linera-protocol/issues/442