### PR TITLE
Remove generics from application views

### DIFF
--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -11,19 +11,17 @@ use fungible::{Account, AccountOwner, Destination};
 use linera_sdk::{
     base::{Amount, ApplicationId, SessionId},
     contract::system_api,
-    ensure,
-    views::ViewStorageContext,
-    ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult, FromBcsBytes,
-    OperationContext, Session, SessionCallResult, ViewStateStorage,
+    ensure, ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult,
+    FromBcsBytes, OperationContext, Session, SessionCallResult, ViewStateStorage,
 };
 use linera_views::views::View;
 use state::{CrowdFunding, Status};
 use thiserror::Error;
 
-linera_sdk::contract!(CrowdFunding<ViewStorageContext>);
+linera_sdk::contract!(CrowdFunding);
 
 #[async_trait]
-impl Contract for CrowdFunding<ViewStorageContext> {
+impl Contract for CrowdFunding {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 
@@ -131,7 +129,7 @@ impl Contract for CrowdFunding<ViewStorageContext> {
     }
 }
 
-impl CrowdFunding<ViewStorageContext> {
+impl CrowdFunding {
     fn fungible_id() -> Result<ApplicationId, Error> {
         // TODO(#723): We should be able to pull the fungible ID from the
         // `required_application_ids` of the application description.

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -9,17 +9,15 @@ use async_graphql::{EmptySubscription, Object, Schema};
 use async_trait::async_trait;
 use crowd_funding::Operation;
 use fungible::AccountOwner;
-use linera_sdk::{
-    base::Amount, views::ViewStorageContext, QueryContext, Service, ViewStateStorage,
-};
+use linera_sdk::{base::Amount, QueryContext, Service, ViewStateStorage};
 use state::CrowdFunding;
 use std::sync::Arc;
 use thiserror::Error;
 
-linera_sdk::service!(CrowdFunding<ViewStorageContext>);
+linera_sdk::service!(CrowdFunding);
 
 #[async_trait]
-impl Service for CrowdFunding<ViewStorageContext> {
+impl Service for CrowdFunding {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -8,7 +8,7 @@ use linera_sdk::base::Amount;
 use linera_views::{
     map_view::MapView,
     register_view::RegisterView,
-    views::{GraphQLView, RootView, View},
+    views::{GraphQLView, RootView},
 };
 use serde::{Deserialize, Serialize};
 

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -4,12 +4,11 @@
 use async_graphql::scalar;
 use crowd_funding::InitializationArguments;
 use fungible::AccountOwner;
-use linera_sdk::base::Amount;
-use linera_views::{
-    map_view::MapView,
-    register_view::RegisterView,
-    views::{GraphQLView, RootView},
+use linera_sdk::{
+    base::Amount,
+    views::{MapView, RegisterView, ViewStorageContext},
 };
+use linera_views::views::{GraphQLView, RootView};
 use serde::{Deserialize, Serialize};
 
 /// The status of a crowd-funding campaign.
@@ -28,13 +27,14 @@ scalar!(Status);
 
 /// The crowd-funding campaign's state.
 #[derive(RootView, GraphQLView)]
-pub struct CrowdFunding<C> {
+#[view(context = "ViewStorageContext")]
+pub struct CrowdFunding {
     /// The status of the campaign.
-    pub status: RegisterView<C, Status>,
+    pub status: RegisterView<Status>,
     /// The map of pledges that will be collected if the campaign succeeds.
-    pub pledges: MapView<C, AccountOwner, Amount>,
+    pub pledges: MapView<AccountOwner, Amount>,
     /// The initialization arguments that determine the details the campaign.
-    pub initialization_arguments: RegisterView<C, Option<InitializationArguments>>,
+    pub initialization_arguments: RegisterView<Option<InitializationArguments>>,
 }
 
 #[allow(dead_code)]

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -14,17 +14,16 @@ use fungible::{
 use linera_sdk::{
     base::{Amount, ApplicationId, Owner, SessionId},
     contract::system_api,
-    views::ViewStorageContext,
     ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult, FromBcsBytes,
     OperationContext, Session, SessionCallResult, ViewStateStorage,
 };
 use std::str::FromStr;
 use thiserror::Error;
 
-linera_sdk::contract!(FungibleToken<ViewStorageContext>);
+linera_sdk::contract!(FungibleToken);
 
 #[async_trait]
-impl Contract for FungibleToken<ViewStorageContext> {
+impl Contract for FungibleToken {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 
@@ -180,7 +179,7 @@ impl Contract for FungibleToken<ViewStorageContext> {
     }
 }
 
-impl FungibleToken<ViewStorageContext> {
+impl FungibleToken {
     /// Verifies that a transfer is authenticated for this local account.
     fn check_account_authentication(
         authenticated_application_id: Option<ApplicationId>,

--- a/examples/fungible/src/service.rs
+++ b/examples/fungible/src/service.rs
@@ -9,16 +9,14 @@ use self::state::FungibleToken;
 use async_graphql::{EmptySubscription, Object, Schema};
 use async_trait::async_trait;
 use fungible::{Account, AccountOwner, Operation};
-use linera_sdk::{
-    base::Amount, views::ViewStorageContext, QueryContext, Service, ViewStateStorage,
-};
+use linera_sdk::{base::Amount, QueryContext, Service, ViewStateStorage};
 use std::sync::Arc;
 use thiserror::Error;
 
-linera_sdk::service!(FungibleToken<ViewStorageContext>);
+linera_sdk::service!(FungibleToken);
 
 #[async_trait]
-impl Service for FungibleToken<ViewStorageContext> {
+impl Service for FungibleToken {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 

--- a/examples/fungible/src/state.rs
+++ b/examples/fungible/src/state.rs
@@ -6,7 +6,7 @@ use linera_sdk::base::Amount;
 use linera_views::{
     common::Context,
     map_view::MapView,
-    views::{GraphQLView, RootView, View},
+    views::{GraphQLView, RootView},
 };
 use thiserror::Error;
 

--- a/examples/fungible/src/state.rs
+++ b/examples/fungible/src/state.rs
@@ -2,26 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fungible::{AccountOwner, InitialState};
-use linera_sdk::base::Amount;
-use linera_views::{
-    common::Context,
-    map_view::MapView,
-    views::{GraphQLView, RootView},
+use linera_sdk::{
+    base::Amount,
+    views::{MapView, ViewStorageContext},
 };
+use linera_views::views::{GraphQLView, RootView};
 use thiserror::Error;
 
 /// The application state.
 #[derive(RootView, GraphQLView)]
-pub struct FungibleToken<C> {
-    accounts: MapView<C, AccountOwner, Amount>,
+#[view(context = "ViewStorageContext")]
+pub struct FungibleToken {
+    accounts: MapView<AccountOwner, Amount>,
 }
 
 #[allow(dead_code)]
-impl<C> FungibleToken<C>
-where
-    C: Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
-{
+impl FungibleToken {
     /// Initializes the application state with some accounts with initial balances.
 
     pub(crate) async fn initialize_accounts(&mut self, state: InitialState) {

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -8,16 +8,15 @@ mod state;
 use self::state::ReentrantCounter;
 use async_trait::async_trait;
 use linera_sdk::{
-    base::SessionId, contract::system_api, views::ViewStorageContext, ApplicationCallResult,
-    CalleeContext, Contract, EffectContext, ExecutionResult, OperationContext, Session,
-    SessionCallResult, ViewStateStorage,
+    base::SessionId, contract::system_api, ApplicationCallResult, CalleeContext, Contract,
+    EffectContext, ExecutionResult, OperationContext, Session, SessionCallResult, ViewStateStorage,
 };
 use thiserror::Error;
 
-linera_sdk::contract!(ReentrantCounter<ViewStorageContext>);
+linera_sdk::contract!(ReentrantCounter);
 
 #[async_trait]
-impl Contract for ReentrantCounter<ViewStorageContext> {
+impl Contract for ReentrantCounter {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 

--- a/examples/reentrant-counter/src/state.rs
+++ b/examples/reentrant-counter/src/state.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_views::{register_view::RegisterView, views::RootView};
+use linera_sdk::views::{RegisterView, ViewStorageContext};
+use linera_views::views::RootView;
 
 /// The application state.
-#[derive(Debug, RootView)]
-pub struct ReentrantCounter<C> {
-    pub value: RegisterView<C, u128>,
+#[derive(RootView)]
+#[view(context = "ViewStorageContext")]
+pub struct ReentrantCounter {
+    pub value: RegisterView<u128>,
 }

--- a/examples/reentrant-counter/src/state.rs
+++ b/examples/reentrant-counter/src/state.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_views::{
-    register_view::RegisterView,
-    views::{RootView, View},
-};
+use linera_views::{register_view::RegisterView, views::RootView};
 
 /// The application state.
 #[derive(Debug, RootView)]

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -9,11 +9,10 @@ use async_trait::async_trait;
 use linera_sdk::{
     base::{ChannelName, Destination, SessionId},
     contract::system_api,
-    views::ViewStorageContext,
     ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult, FromBcsBytes,
     OperationContext, Session, SessionCallResult, ViewStateStorage,
 };
-use linera_views::{common::Context, views::ViewError};
+use linera_views::views::ViewError;
 use social::{Effect, Key, Operation, OwnPost};
 use state::Social;
 use thiserror::Error;
@@ -23,14 +22,10 @@ const POSTS_CHANNEL_NAME: &[u8] = b"posts";
 /// The number of recent posts sent in each cross-chain message.
 const RECENT_POSTS: usize = 10;
 
-linera_sdk::contract!(Social<ViewStorageContext>);
+linera_sdk::contract!(Social);
 
 #[async_trait]
-impl<C> Contract for Social<C>
-where
-    C: Context + Send + Sync + Clone + 'static,
-    ViewError: From<<C as Context>::Error>,
-{
+impl Contract for Social {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 
@@ -98,11 +93,7 @@ where
     }
 }
 
-impl<C> Social<C>
-where
-    C: Context + Send + Sync + Clone + 'static,
-    ViewError: From<<C as Context>::Error>,
-{
+impl Social {
     async fn execute_post_operation(&mut self, text: String) -> Result<ExecutionResult, Error> {
         let timestamp = system_api::current_system_time();
         self.own_posts.push(OwnPost { timestamp, text });

--- a/examples/social/src/service.rs
+++ b/examples/social/src/service.rs
@@ -7,19 +7,17 @@ mod state;
 
 use async_graphql::{EmptySubscription, Object, Schema};
 use async_trait::async_trait;
-use linera_sdk::{
-    base::ChainId, views::ViewStorageContext, QueryContext, Service, ViewStateStorage,
-};
+use linera_sdk::{base::ChainId, QueryContext, Service, ViewStateStorage};
 use linera_views::views::ViewError;
 use social::Operation;
 use state::Social;
 use std::sync::Arc;
 use thiserror::Error;
 
-linera_sdk::service!(Social<ViewStorageContext>);
+linera_sdk::service!(Social);
 
 #[async_trait]
-impl Service for Social<ViewStorageContext> {
+impl Service for Social {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 

--- a/examples/social/src/state.rs
+++ b/examples/social/src/state.rs
@@ -1,18 +1,16 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_views::{
-    log_view::LogView,
-    map_view::CustomMapView,
-    views::{GraphQLView, RootView},
-};
+use linera_sdk::views::{CustomMapView, LogView, ViewStorageContext};
+use linera_views::views::{GraphQLView, RootView};
 use social::{Key, OwnPost};
 
 /// The application state.
-#[derive(RootView, GraphQLView, Debug)]
-pub struct Social<C> {
+#[derive(RootView, GraphQLView)]
+#[view(context = "ViewStorageContext")]
+pub struct Social {
     /// Our posts.
-    pub own_posts: LogView<C, OwnPost>,
+    pub own_posts: LogView<OwnPost>,
     /// Posts we received from authors we subscribed to.
-    pub received_posts: CustomMapView<C, Key, String>,
+    pub received_posts: CustomMapView<Key, String>,
 }

--- a/examples/social/src/state.rs
+++ b/examples/social/src/state.rs
@@ -4,7 +4,7 @@
 use linera_views::{
     log_view::LogView,
     map_view::CustomMapView,
-    views::{GraphQLView, RootView, View},
+    views::{GraphQLView, RootView},
 };
 use social::{Key, OwnPost};
 

--- a/linera-sdk/src/views/mod.rs
+++ b/linera-sdk/src/views/mod.rs
@@ -7,6 +7,7 @@ mod conversions_from_wit;
 mod system_api;
 
 pub use self::system_api::{KeyValueStore, ViewStorageContext};
+pub use linera_views::*;
 
 // Import the views system interface.
 wit_bindgen_guest_rust::import!("view_system_api.wit");

--- a/linera-sdk/src/views/mod.rs
+++ b/linera-sdk/src/views/mod.rs
@@ -11,3 +11,49 @@ pub use linera_views::*;
 
 // Import the views system interface.
 wit_bindgen_guest_rust::import!("view_system_api.wit");
+
+/// An alias to [`collection_view::ByteCollectionView`] that uses the WebAssembly specific
+/// [`ViewStorageContext`].
+pub type ByteCollectionView<V> = collection_view::ByteCollectionView<ViewStorageContext, V>;
+
+/// An alias to [`map_view::ByteMapView`] that uses the WebAssembly specific [`ViewStorageContext`].
+pub type ByteMapView<V> = map_view::ByteMapView<ViewStorageContext, V>;
+
+/// An alias to [`set_view::ByteSetView`] that uses the WebAssembly specific [`ViewStorageContext`].
+pub type ByteSetView = set_view::ByteSetView<ViewStorageContext>;
+
+/// An alias to [`collection_view::CollectionView`] that uses the WebAssembly specific
+/// [`ViewStorageContext`].
+pub type CollectionView<K, V> = collection_view::CollectionView<ViewStorageContext, K, V>;
+
+/// An alias to [`collection_view::CustomCollectionView`] that uses the WebAssembly specific
+/// [`ViewStorageContext`].
+pub type CustomCollectionView<K, V> =
+    collection_view::CustomCollectionView<ViewStorageContext, K, V>;
+
+/// An alias to [`map_view::CustomMapView`] that uses the WebAssembly specific
+/// [`ViewStorageContext`].
+pub type CustomMapView<K, V> = map_view::CustomMapView<ViewStorageContext, K, V>;
+
+/// An alias to [`set_view::CustomSetView`] that uses the WebAssembly specific [`ViewStorageContext`].
+pub type CustomSetView<W> = set_view::CustomSetView<ViewStorageContext, W>;
+
+/// An alias to [`log_view::LogView`] that uses the WebAssembly specific [`ViewStorageContext`].
+pub type LogView<T> = log_view::LogView<ViewStorageContext, T>;
+
+/// An alias to [`map_view::MapView`] that uses the WebAssembly specific [`ViewStorageContext`].
+pub type MapView<K, V> = map_view::MapView<ViewStorageContext, K, V>;
+
+/// An alias to [`queue_view::QueueView`] that uses the WebAssembly specific [`ViewStorageContext`].
+pub type QueueView<T> = queue_view::QueueView<ViewStorageContext, T>;
+
+/// An alias to [`collection_view::ReadGuardedView`] that uses the WebAssembly specific
+/// [`ViewStorageContext`].
+pub type ReadGuardedView<'a, W> = collection_view::ReadGuardedView<'a, W>;
+
+/// An alias to [`register_view::RegisterView`] that uses the WebAssembly specific
+/// [`ViewStorageContext`].
+pub type RegisterView<T> = register_view::RegisterView<ViewStorageContext, T>;
+
+/// An alias to [`set_view::SetView`] that uses the WebAssembly specific [`ViewStorageContext`].
+pub type SetView<W> = set_view::SetView<ViewStorageContext, W>;

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -656,320 +656,392 @@ pub mod tests {
     }
 
     #[test]
-    #[rustfmt::skip]
     fn test_generate_view_code() {
-        let input: ItemStruct = parse_quote!(
-            struct TestView<C> {
-                register: RegisterView<C, usize>,
-                collection: CollectionView<C, usize, RegisterView<C, usize>>,
-            }
-        );
-        let output = generate_view_code(input, true);
+        for context in SpecificContextInfo::test_cases() {
+            let input = context.test_view_input();
+            let output = generate_view_code(input, true);
 
-        let expected = quote!(
-            #[async_trait::async_trait]
-            impl<C> linera_views::views::View<C> for TestView<C>
-            where
-                C: linera_views::common::Context + Send + Sync + Clone + 'static,
-                linera_views::views::ViewError: From<C::Error>,
-            {
-                fn context(&self) -> &C {
-                    use linera_views::views::View;
-                    self.register.context()
-                }
-                async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
-                    use linera_views::{futures::join, common::Context};
-                    linera_views::increment_counter(
-                        linera_views::LOAD_VIEW_COUNTER,
-                        stringify!(TestView),
-                        &context.base_key(),
-                    );
-                    let index = 0;
-                    let base_key = context.derive_key(&index)?;
-                    let register_fut =
-                        RegisterView::load(context.clone_with_base_key(base_key));
-                    let index = 1;
-                    let base_key = context.derive_key(&index)?;
-                    let collection_fut =
-                        CollectionView::load(context.clone_with_base_key(base_key));
-                    let result = join!(register_fut, collection_fut);
-                    let register = result.0?;
-                    let collection = result.1?;
-                    Ok(Self {
-                        register,
-                        collection
-                    })
-                }
-                fn rollback(&mut self) {
-                    self.register.rollback();
-                    self.collection.rollback();
-                }
-                fn flush(
-                    &mut self,
-                    batch: &mut linera_views::batch::Batch
-                ) -> Result<(), linera_views::views::ViewError> {
-                    use linera_views::views::View;
-                    self.register.flush(batch)?;
-                    self.collection.flush(batch)?;
-                    Ok(())
-                }
-                fn delete(self, batch: &mut linera_views::batch::Batch) {
-                    use linera_views::views::View;
-                    self.register.delete(batch);
-                    self.collection.delete(batch);
-                }
-                fn clear(&mut self) {
-                    self.register.clear();
-                    self.collection.clear();
-                }
-            }
-        );
+            let SpecificContextInfo {
+                context,
+                constraints,
+                generics,
+                ..
+            } = context;
 
-        assert_eq!(output.to_string(), expected.to_string());
-    }
-
-    #[test]
-    #[rustfmt::skip]
-    fn test_generate_hash_view_code() {
-        let input: ItemStruct = parse_quote!(
-            struct TestView<C> {
-                register: RegisterView<C, usize>,
-                collection: CollectionView<C, usize, RegisterView<C, usize>>,
-            }
-        );
-        let output = generate_hash_view_code(input);
-
-        let expected = quote!(
-            #[async_trait::async_trait]
-            impl<C> linera_views::views::HashableView<C> for TestView<C>
-            where
-                C: linera_views::common::Context + Send + Sync + Clone + 'static,
-                linera_views::views::ViewError: From<C::Error>,
-            {
-                type Hasher = linera_views::sha3::Sha3_256;
-                async fn hash_mut(
-                    &mut self
-                ) -> Result<<Self::Hasher as linera_views::views::Hasher>::Output,
-                    linera_views::views::ViewError
-                > {
-                    use linera_views::views::{Hasher, HashableView};
-                    use std::io::Write;
-                    let mut hasher = Self::Hasher::default();
-                    hasher.write_all(self.register.hash_mut().await?.as_ref())?;
-                    hasher.write_all(self.collection.hash_mut().await?.as_ref())?;
-                    Ok(hasher.finalize())
-                }
-                async fn hash(
-                    &self
-                ) -> Result<<Self::Hasher as linera_views::views::Hasher>::Output,
-                    linera_views::views::ViewError
-                > {
-                    use linera_views::views::{Hasher, HashableView};
-                    use std::io::Write;
-                    let mut hasher = Self::Hasher::default();
-                    hasher.write_all(self.register.hash().await?.as_ref())?;
-                    hasher.write_all(self.collection.hash().await?.as_ref())?;
-                    Ok(hasher.finalize())
-                }
-            }
-        );
-
-        assert_eq!(output.to_string(), expected.to_string());
-    }
-
-    #[test]
-    #[rustfmt::skip]
-    fn test_generate_save_delete_view_code() {
-        let input: ItemStruct = parse_quote!(
-            struct TestView<C> {
-                register: RegisterView<C, usize>,
-                collection: CollectionView<C, usize, RegisterView<C, usize>>,
-            }
-        );
-        let output = generate_save_delete_view_code(input);
-
-        let expected = quote!(
-            #[async_trait::async_trait]
-            impl<C> linera_views::views::RootView<C> for TestView<C>
-            where
-                C: linera_views::common::Context + Send + Sync + Clone + 'static,
-                linera_views::views::ViewError: From<C::Error>,
-            {
-                async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
-                    use linera_views::{common::Context, batch::Batch, views::View};
-                    linera_views::increment_counter(
-                        linera_views::SAVE_VIEW_COUNTER,
-                        stringify!(TestView),
-                        &self.context().base_key(),
-                    );
-                    let mut batch = Batch::new();
-                    self.register.flush(&mut batch)?;
-                    self.collection.flush(&mut batch)?;
-                    self.context().write_batch(batch).await?;
-                    Ok(())
-                }
-                async fn write_delete(self) -> Result<(), linera_views::views::ViewError> {
-                    use linera_views::{common::Context, batch::Batch, views::View};
-                    let context = self.context().clone();
-                    let batch = Batch::build(move |batch| {
-                        Box::pin(async move {
-                            self.register.delete(batch);
-                            self.collection.delete(batch);
-                            Ok(())
-                        })
-                    })
-                    .await?;
-                    context.write_batch(batch).await?;
-                    Ok(())
-                }
-            }
-        );
-
-        assert_eq!(output.to_string(), expected.to_string());
-    }
-
-    #[test]
-    #[rustfmt::skip]
-    fn test_generate_crypto_hash_code() {
-        let input: ItemStruct = parse_quote!(
-            struct TestView<C> {
-                register: RegisterView<C, usize>,
-                collection: CollectionView<C, usize, RegisterView<C, usize>>,
-            }
-        );
-        let output = generate_crypto_hash_code(input);
-
-        let expected = quote!(
-            #[async_trait::async_trait]
-            impl<C> linera_views::views::CryptoHashView<C> for TestView<C>
-            where
-                C: linera_views::common::Context + Send + Sync + Clone + 'static,
-                linera_views::views::ViewError: From<C::Error>,
-            {
-                async fn crypto_hash(
-                    &self
-                ) -> Result<linera_base::crypto::CryptoHash, linera_views::views::ViewError>
+            let expected = quote!(
+                #[async_trait::async_trait]
+                impl #generics linera_views::views::View<#context> for TestView #generics
+                #constraints
                 {
-                    use linera_base::crypto::{BcsHashable, CryptoHash};
-                    use linera_views::{
-                        batch::Batch,
-                        generic_array::GenericArray,
-                        sha3::{digest::OutputSizeUser, Sha3_256},
-                        views::HashableView,
-                    };
-                    use serde::{Serialize, Deserialize};
-                    #[derive(Serialize, Deserialize)]
-                    struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
-                    impl BcsHashable for TestViewHash {}
-                    let hash = self.hash().await?;
-                    Ok(CryptoHash::new(&TestViewHash(hash)))
-                }
-            }
-        );
-
-        assert_eq!(output.to_string(), expected.to_string());
-    }
-
-    #[test]
-    #[rustfmt::skip]
-    fn test_generate_graphql_code() {
-        let input: ItemStruct = parse_quote!(
-            struct TestView<C> {
-                raw: String,
-                register: RegisterView<C, Option<usize>>,
-                collection: CollectionView<C, String, SomeOtherView<C>>,
-                set: SetView<C, HashSet<usize>>,
-                log: LogView<C, usize>,
-                queue: QueueView<C, usize>,
-                map: MapView<C, String, usize>
-            }
-        );
-
-        let output = generate_graphql_code(input);
-
-        let expected = quote!(
-            pub struct SomeOtherViewEntry<'a, C>
-                where
-                    C: Sync + Send + linera_views::common::Context + 'static,
-                    linera_views::views::ViewError: From<C::Error>,
-            {
-                string: String,
-                guard: linera_views::collection_view::ReadGuardedView<'a, SomeOtherView<C>>,
-            }
-            #[async_graphql::Object]
-            impl<'a, C> SomeOtherViewEntry<'a, C>
-                where
-                    C: Sync + Send + linera_views::common::Context + 'static + Clone,
-                    linera_views::views::ViewError: From<C::Error>,
-            {
-                async fn string(&self) -> &String {
-                    &self.string
-                }
-                async fn some_other_view(&self) -> &SomeOtherView<C> {
-                    use std::ops::Deref;
-                    self.guard.deref()
-                }
-            }
-            #[async_graphql::Object]
-            impl<C> TestView<C>
-                where
-                    C: linera_views::common::Context + Send + Sync + Clone + 'static,
-                    linera_views::views::ViewError: From<C::Error>,
-            {
-                async fn raw(&self) -> &String {
-                    &self.raw
-                }
-                async fn register(&self) -> &Option<usize> {
-                    self.register.get()
-                }
-                async fn collection(
-                    &self,
-                    string: String
-                ) -> Result<SomeOtherViewEntry<C>, async_graphql::Error> {
-                    Ok(SomeOtherViewEntry {
-                        string: string.clone(),
-                        guard: self.collection.try_load_entry(&string).await?,
-                    })
-                }
-                async fn set(&self) -> Result<Vec<HashSet<usize>>, async_graphql::Error> {
-                    Ok(self.set.indices().await?)
-                }
-                async fn log(
-                    &self,
-                    start: Option<usize>,
-                    end: Option<usize>
-                ) -> Result<Vec<usize>, async_graphql::Error> {
-                    let range = std::ops::Range {
-                        start: start.unwrap_or(0),
-                        end: end.unwrap_or(self.log.count()),
-                    };
-                    Ok(self.log.read(range).await?)
-                }
-                async fn queue(&self, count: Option<usize>) -> Result<Vec<usize>, async_graphql::Error> {
-                    let count = count.unwrap_or_else(|| self.queue.count());
-                    Ok(self.queue.read_front(count).await?)
-                }
-                async fn map(&self, string: String) -> Result<Option<usize>, async_graphql::Error> {
-                    Ok(self.map.get(&string).await?)
-                }
-                async fn map_keys(&self, count: Option<u64>)
-                    -> Result<Vec<String>, async_graphql::Error>
-                {
-                    let count = count.unwrap_or(u64::MAX).try_into().unwrap_or(usize::MAX);
-                    let mut keys = vec![];
-                    if count == 0 {
-                        return Ok(keys);
+                    fn context(&self) -> &#context {
+                        use linera_views::views::View;
+                        self.register.context()
                     }
-                    self.map.for_each_index_while(|key| {
-                        keys.push(key);
-                        Ok(keys.len() < count)
-                    }).await?;
-                    Ok(keys)
+                    async fn load(
+                        context: #context
+                    ) -> Result<Self, linera_views::views::ViewError> {
+                        use linera_views::{futures::join, common::Context};
+                        linera_views::increment_counter(
+                            linera_views::LOAD_VIEW_COUNTER,
+                            stringify!(TestView),
+                            &context.base_key(),
+                        );
+                        let index = 0;
+                        let base_key = context.derive_key(&index)?;
+                        let register_fut =
+                            RegisterView::load(context.clone_with_base_key(base_key));
+                        let index = 1;
+                        let base_key = context.derive_key(&index)?;
+                        let collection_fut =
+                            CollectionView::load(context.clone_with_base_key(base_key));
+                        let result = join!(register_fut, collection_fut);
+                        let register = result.0?;
+                        let collection = result.1?;
+                        Ok(Self {
+                            register,
+                            collection
+                        })
+                    }
+                    fn rollback(&mut self) {
+                        self.register.rollback();
+                        self.collection.rollback();
+                    }
+                    fn flush(
+                        &mut self,
+                        batch: &mut linera_views::batch::Batch
+                    ) -> Result<(), linera_views::views::ViewError> {
+                        use linera_views::views::View;
+                        self.register.flush(batch)?;
+                        self.collection.flush(batch)?;
+                        Ok(())
+                    }
+                    fn delete(self, batch: &mut linera_views::batch::Batch) {
+                        use linera_views::views::View;
+                        self.register.delete(batch);
+                        self.collection.delete(batch);
+                    }
+                    fn clear(&mut self) {
+                        self.register.clear();
+                        self.collection.clear();
+                    }
+                }
+            );
+
+            assert_eq!(output.to_string(), expected.to_string());
+        }
+    }
+
+    #[test]
+    fn test_generate_hash_view_code() {
+        for context in SpecificContextInfo::test_cases() {
+            let input = context.test_view_input();
+            let output = generate_hash_view_code(input);
+
+            let SpecificContextInfo {
+                context,
+                constraints,
+                generics,
+                ..
+            } = context;
+
+            let expected = quote!(
+                #[async_trait::async_trait]
+                impl #generics linera_views::views::HashableView<#context> for TestView #generics
+                #constraints
+                {
+                    type Hasher = linera_views::sha3::Sha3_256;
+                    async fn hash_mut(
+                        &mut self
+                    ) -> Result<<Self::Hasher as linera_views::views::Hasher>::Output,
+                        linera_views::views::ViewError
+                    > {
+                        use linera_views::views::{Hasher, HashableView};
+                        use std::io::Write;
+                        let mut hasher = Self::Hasher::default();
+                        hasher.write_all(self.register.hash_mut().await?.as_ref())?;
+                        hasher.write_all(self.collection.hash_mut().await?.as_ref())?;
+                        Ok(hasher.finalize())
+                    }
+                    async fn hash(
+                        &self
+                    ) -> Result<<Self::Hasher as linera_views::views::Hasher>::Output,
+                        linera_views::views::ViewError
+                    > {
+                        use linera_views::views::{Hasher, HashableView};
+                        use std::io::Write;
+                        let mut hasher = Self::Hasher::default();
+                        hasher.write_all(self.register.hash().await?.as_ref())?;
+                        hasher.write_all(self.collection.hash().await?.as_ref())?;
+                        Ok(hasher.finalize())
+                    }
+                }
+            );
+
+            assert_eq!(output.to_string(), expected.to_string());
+        }
+    }
+
+    #[test]
+    fn test_generate_save_delete_view_code() {
+        for context in SpecificContextInfo::test_cases() {
+            let input = context.test_view_input();
+            let output = generate_save_delete_view_code(input);
+
+            let SpecificContextInfo {
+                context,
+                constraints,
+                generics,
+                ..
+            } = context;
+
+            let expected = quote!(
+                #[async_trait::async_trait]
+                impl #generics linera_views::views::RootView<#context> for TestView #generics
+                #constraints
+                {
+                    async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
+                        use linera_views::{common::Context, batch::Batch, views::View};
+                        linera_views::increment_counter(
+                            linera_views::SAVE_VIEW_COUNTER,
+                            stringify!(TestView),
+                            &self.context().base_key(),
+                        );
+                        let mut batch = Batch::new();
+                        self.register.flush(&mut batch)?;
+                        self.collection.flush(&mut batch)?;
+                        self.context().write_batch(batch).await?;
+                        Ok(())
+                    }
+                    async fn write_delete(self) -> Result<(), linera_views::views::ViewError> {
+                        use linera_views::{common::Context, batch::Batch, views::View};
+                        let context = self.context().clone();
+                        let batch = Batch::build(move |batch| {
+                            Box::pin(async move {
+                                self.register.delete(batch);
+                                self.collection.delete(batch);
+                                Ok(())
+                            })
+                        })
+                        .await?;
+                        context.write_batch(batch).await?;
+                        Ok(())
+                    }
+                }
+            );
+
+            assert_eq!(output.to_string(), expected.to_string());
+        }
+    }
+
+    #[test]
+    fn test_generate_crypto_hash_code() {
+        for context in SpecificContextInfo::test_cases() {
+            let input = context.test_view_input();
+            let output = generate_crypto_hash_code(input);
+
+            let SpecificContextInfo {
+                context,
+                constraints,
+                generics,
+                ..
+            } = context;
+
+            let expected = quote!(
+                #[async_trait::async_trait]
+                impl #generics linera_views::views::CryptoHashView<#context> for TestView #generics
+                #constraints
+                {
+                    async fn crypto_hash(
+                        &self
+                    ) -> Result<linera_base::crypto::CryptoHash, linera_views::views::ViewError>
+                    {
+                        use linera_base::crypto::{BcsHashable, CryptoHash};
+                        use linera_views::{
+                            batch::Batch,
+                            generic_array::GenericArray,
+                            sha3::{digest::OutputSizeUser, Sha3_256},
+                            views::HashableView,
+                        };
+                        use serde::{Serialize, Deserialize};
+                        #[derive(Serialize, Deserialize)]
+                        struct TestViewHash(GenericArray<u8, <Sha3_256 as OutputSizeUser>::OutputSize>);
+                        impl BcsHashable for TestViewHash {}
+                        let hash = self.hash().await?;
+                        Ok(CryptoHash::new(&TestViewHash(hash)))
+                    }
+                }
+            );
+
+            assert_eq!(output.to_string(), expected.to_string());
+        }
+    }
+
+    #[test]
+    fn test_generate_graphql_code() {
+        for context in SpecificContextInfo::test_cases() {
+            let SpecificContextInfo {
+                attribute,
+                context,
+                constraints,
+                generics,
+                generics_with_lifetime,
+            } = context;
+
+            let input: ItemStruct = parse_quote!(
+                #attribute
+                struct TestView #generics {
+                    raw: String,
+                    register: RegisterView<#context, Option<usize>>,
+                    collection: CollectionView<#context, String, SomeOtherView<#context>>,
+                    set: SetView<#context, HashSet<usize>>,
+                    log: LogView<#context, usize>,
+                    queue: QueueView<#context, usize>,
+                    map: MapView<#context, String, usize>
+                }
+            );
+
+            let output = generate_graphql_code(input);
+
+            let expected = quote! {
+                pub struct SomeOtherViewEntry #generics_with_lifetime
+                #constraints
+                {
+                    string: String,
+                    guard: linera_views::collection_view::ReadGuardedView<'a, SomeOtherView<#context>>,
+                }
+                #[async_graphql::Object]
+                impl #generics_with_lifetime SomeOtherViewEntry #generics_with_lifetime
+                #constraints
+                {
+                    async fn string(&self) -> &String {
+                        &self.string
+                    }
+                    async fn some_other_view(&self) -> &SomeOtherView<#context> {
+                        use std::ops::Deref;
+                        self.guard.deref()
+                    }
+                }
+                #[async_graphql::Object]
+                impl #generics TestView #generics
+                #constraints
+                {
+                    async fn raw(&self) -> &String {
+                        &self.raw
+                    }
+                    async fn register(&self) -> &Option<usize> {
+                        self.register.get()
+                    }
+                    async fn collection(
+                        &self,
+                        string: String,
+                    ) -> Result<SomeOtherViewEntry #generics, async_graphql::Error> {
+                        Ok(SomeOtherViewEntry {
+                            string: string.clone(),
+                            guard: self.collection.try_load_entry(&string).await?,
+                        })
+                    }
+                    async fn set(&self) -> Result<Vec<HashSet<usize>>, async_graphql::Error> {
+                        Ok(self.set.indices().await?)
+                    }
+                    async fn log(
+                        &self,
+                        start: Option<usize>,
+                        end: Option<usize>
+                    ) -> Result<Vec<usize>, async_graphql::Error> {
+                        let range = std::ops::Range {
+                            start: start.unwrap_or(0),
+                            end: end.unwrap_or(self.log.count()),
+                        };
+                        Ok(self.log.read(range).await?)
+                    }
+                    async fn queue(&self, count: Option<usize>) -> Result<Vec<usize>, async_graphql::Error> {
+                        let count = count.unwrap_or_else(|| self.queue.count());
+                        Ok(self.queue.read_front(count).await?)
+                    }
+                    async fn map(&self, string: String) -> Result<Option<usize>, async_graphql::Error> {
+                        Ok(self.map.get(&string).await?)
+                    }
+                    async fn map_keys(&self, count: Option<u64>)
+                        -> Result<Vec<String>, async_graphql::Error>
+                    {
+                        let count = count.unwrap_or(u64::MAX).try_into().unwrap_or(usize::MAX);
+                        let mut keys = vec![];
+                        if count == 0 {
+                            return Ok(keys);
+                        }
+                        self.map.for_each_index_while(|key| {
+                            keys.push(key);
+                            Ok(keys.len() < count)
+                        }).await?;
+                        Ok(keys)
+                    }
+                }
+            };
+
+            assert_eq_no_whitespace(output.to_string(), expected.to_string())
+        }
+    }
+
+    pub struct SpecificContextInfo {
+        attribute: TokenStream2,
+        context: Type,
+        generics: TokenStream2,
+        generics_with_lifetime: TokenStream2,
+        constraints: TokenStream2,
+    }
+
+    impl SpecificContextInfo {
+        pub fn empty() -> Self {
+            SpecificContextInfo {
+                attribute: quote! {},
+                context: syn::parse_str("C").unwrap(),
+                generics: quote! { <C> },
+                generics_with_lifetime: quote! { <'a, C> },
+                constraints: quote! {
+                    where
+                        C: linera_views::common::Context + Send + Sync + Clone + 'static,
+                        linera_views::views::ViewError: From<C::Error>,
+                },
+            }
+        }
+
+        pub fn new(context: &str) -> Self {
+            SpecificContextInfo {
+                attribute: quote! { #[view(context = #context)] },
+                context: syn::parse_str(context).unwrap(),
+                generics: quote! {},
+                generics_with_lifetime: quote! { <'a,> },
+                constraints: quote! {},
+            }
+        }
+
+        pub fn test_cases() -> impl Iterator<Item = Self> {
+            Some(Self::empty()).into_iter().chain(
+                [
+                    "CustomContext",
+                    "custom::path::to::ContextType",
+                    "custom::GenericContext<T>",
+                ]
+                .into_iter()
+                .map(Self::new),
+            )
+        }
+
+        pub fn test_view_input(&self) -> ItemStruct {
+            let SpecificContextInfo {
+                attribute,
+                context,
+                generics,
+                ..
+            } = self;
+
+            parse_quote! {
+                #attribute
+                struct TestView #generics {
+                    register: RegisterView<#context, usize>,
+                    collection: CollectionView<#context, usize, RegisterView<#context, usize>>,
                 }
             }
-
-        );
-
-        assert_eq_no_whitespace(output.to_string(), expected.to_string())
+        }
     }
 }


### PR DESCRIPTION
# Motivation

It can be confusing for new users of the SDK to understand why they need to use generic context types when writing applications with views.

# Solution

Provide view type aliases and alternative derive macros that don't require a generic context type parameter.

# Related Work

Blocked by #727 
Blocked by #737 
Closes #675 