### PR TITLE
Allow creating lite certificates without cloning the signatures.

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -45,9 +45,9 @@ pub trait ValidatorNode {
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a certificate without a value.
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'a>,
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a certificate.
@@ -256,9 +256,9 @@ where
         Ok(response)
     }
 
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'a>,
     ) -> Result<ChainInfoResponse, NodeError> {
         let mut node = self.node.lock().await;
         let mut notifications = Vec::new();

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -45,9 +45,9 @@ pub trait ValidatorNode {
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a certificate without a value.
-    async fn handle_lite_certificate<'a>(
+    async fn handle_lite_certificate(
         &mut self,
-        certificate: LiteCertificate<'a>,
+        certificate: LiteCertificate<'_>,
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a certificate.
@@ -256,9 +256,9 @@ where
         Ok(response)
     }
 
-    async fn handle_lite_certificate<'a>(
+    async fn handle_lite_certificate(
         &mut self,
-        certificate: LiteCertificate<'a>,
+        certificate: LiteCertificate<'_>,
     ) -> Result<ChainInfoResponse, NodeError> {
         let mut node = self.node.lock().await;
         let mut notifications = Vec::new();

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -74,10 +74,11 @@ where
         .await
     }
 
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'a>,
     ) -> Result<ChainInfoResponse, NodeError> {
+        let certificate = certificate.cloned();
         self.spawn_and_receive(move |validator, sender| {
             validator.do_handle_lite_certificate(certificate, sender)
         })
@@ -177,7 +178,7 @@ where
 
     async fn do_handle_lite_certificate(
         self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'_>,
         sender: oneshot::Sender<Result<ChainInfoResponse, NodeError>>,
     ) -> Result<(), Result<ChainInfoResponse, NodeError>> {
         let mut validator = self.client.lock().await;

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -74,9 +74,9 @@ where
         .await
     }
 
-    async fn handle_lite_certificate<'a>(
+    async fn handle_lite_certificate(
         &mut self,
-        certificate: LiteCertificate<'a>,
+        certificate: LiteCertificate<'_>,
     ) -> Result<ChainInfoResponse, NodeError> {
         let certificate = certificate.cloned();
         self.spawn_and_receive(move |validator, sender| {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -65,9 +65,9 @@ pub trait ValidatorWorker {
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError>;
 
     /// Processes a certificate, e.g. to extend a chain with a confirmed block.
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'a>,
         notify_message_delivery: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError>;
 
@@ -920,9 +920,9 @@ where
     // Other fields will be included in handle_certificate's span.
     #[instrument(skip_all, fields(hash = %certificate.value.value_hash))]
     /// Processes a certificate, e.g. to extend a chain with a confirmed block.
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'a>,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let value = self

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -42,9 +42,9 @@ impl ValidatorNode for Client {
         }
     }
 
-    async fn handle_lite_certificate<'a>(
+    async fn handle_lite_certificate(
         &mut self,
-        certificate: LiteCertificate<'a>,
+        certificate: LiteCertificate<'_>,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
             Client::Grpc(grpc_client) => grpc_client.handle_lite_certificate(certificate).await,

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -42,9 +42,9 @@ impl ValidatorNode for Client {
         }
     }
 
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'a>,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
             Client::Grpc(grpc_client) => grpc_client.handle_lite_certificate(certificate).await,

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -193,7 +193,7 @@ impl TryFrom<CrossChainRequest> for grpc::CrossChainRequest {
     }
 }
 
-impl TryFrom<grpc::LiteCertificate> for LiteCertificate {
+impl<'a> TryFrom<grpc::LiteCertificate> for LiteCertificate<'a> {
     type Error = ProtoConversionError;
 
     fn try_from(certificate: grpc::LiteCertificate) -> Result<Self, Self::Error> {
@@ -206,10 +206,10 @@ impl TryFrom<grpc::LiteCertificate> for LiteCertificate {
     }
 }
 
-impl TryFrom<LiteCertificate> for grpc::LiteCertificate {
+impl<'a> TryFrom<LiteCertificate<'a>> for grpc::LiteCertificate {
     type Error = ProtoConversionError;
 
-    fn try_from(certificate: LiteCertificate) -> Result<Self, Self::Error> {
+    fn try_from(certificate: LiteCertificate<'a>) -> Result<Self, Self::Error> {
         Ok(Self {
             hash: certificate.value.value_hash.as_bytes().to_vec(),
             chain_id: Some(certificate.value.chain_id.into()),
@@ -445,7 +445,7 @@ pub mod tests {
     use linera_chain::data_types::{Block, BlockAndRound, HashedValue};
     use linera_core::data_types::ChainInfo;
     use serde::{Deserialize, Serialize};
-    use std::fmt::Debug;
+    use std::{borrow::Cow, fmt::Debug};
 
     #[derive(Debug, Serialize, Deserialize)]
     struct Foo(String);
@@ -582,10 +582,10 @@ pub mod tests {
                 value_hash: CryptoHash::new(&Foo("value".into())),
                 chain_id: ChainId::root(0),
             },
-            signatures: vec![(
+            signatures: Cow::Owned(vec![(
                 ValidatorName::from(key_pair.public()),
                 Signature::new(&Foo("test".into()), &key_pair),
-            )],
+            )]),
         };
 
         round_trip_check::<_, grpc::LiteCertificate>(certificate_validated);

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -577,9 +577,9 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: data_types::LiteCertificate,
+        certificate: data_types::LiteCertificate<'a>,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         client_delegate!(self, handle_lite_certificate, certificate)
     }

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -577,9 +577,9 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
-    async fn handle_lite_certificate<'a>(
+    async fn handle_lite_certificate(
         &mut self,
-        certificate: data_types::LiteCertificate<'a>,
+        certificate: data_types::LiteCertificate<'_>,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         client_delegate!(self, handle_lite_certificate, certificate)
     }

--- a/linera-rpc/src/rpc.rs
+++ b/linera-rpc/src/rpc.rs
@@ -19,7 +19,7 @@ pub enum RpcMessage {
     // Inbound
     BlockProposal(Box<BlockProposal>),
     Certificate(Box<Certificate>, Vec<HashedValue>),
-    LiteCertificate(Box<LiteCertificate>),
+    LiteCertificate(Box<LiteCertificate<'static>>),
     ChainInfoQuery(Box<ChainInfoQuery>),
     // Outbound
     Vote(Box<LiteVote>),
@@ -54,8 +54,8 @@ impl From<BlockProposal> for RpcMessage {
     }
 }
 
-impl From<LiteCertificate> for RpcMessage {
-    fn from(certificate: LiteCertificate) -> Self {
+impl From<LiteCertificate<'static>> for RpcMessage {
+    fn from(certificate: LiteCertificate<'static>) -> Self {
         RpcMessage::LiteCertificate(Box::new(certificate))
     }
 }

--- a/linera-rpc/src/simple_network.rs
+++ b/linera-rpc/src/simple_network.rs
@@ -409,11 +409,11 @@ impl ValidatorNode for SimpleClient {
     }
 
     /// Processes a hash certificate.
-    async fn handle_lite_certificate(
+    async fn handle_lite_certificate<'a>(
         &mut self,
-        certificate: LiteCertificate,
+        certificate: LiteCertificate<'a>,
     ) -> Result<ChainInfoResponse, NodeError> {
-        self.send_recv_info(certificate.into()).await
+        self.send_recv_info(certificate.cloned().into()).await
     }
 
     /// Processes a certificate.

--- a/linera-rpc/src/simple_network.rs
+++ b/linera-rpc/src/simple_network.rs
@@ -409,9 +409,9 @@ impl ValidatorNode for SimpleClient {
     }
 
     /// Processes a hash certificate.
-    async fn handle_lite_certificate<'a>(
+    async fn handle_lite_certificate(
         &mut self,
-        certificate: LiteCertificate<'a>,
+        certificate: LiteCertificate<'_>,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.send_recv_info(certificate.cloned().into()).await
     }


### PR DESCRIPTION
# Motivation

Currently [`DbStoreClient::write_certificate` clones the list of signatures](https://github.com/linera-io/linera-protocol/blob/a6958ea72271a38bb3528d9f1b03d23d7f55839d/linera-storage/src/lib.rs#L315) before serializing it.

# Solution

Put the signatures in `LiteCertificate` into a `Cow`. When deserializing, it is owned, but when it is taken from a `&Certificate`, it is borrowed and doesn't need to be cloned.