### PR TITLE
fix computation of effect_id while executing system operations

### DIFF
--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -71,9 +71,8 @@ impl Contract for ReentrantCounter<ViewStorageContext> {
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, Self::Error> {
         let increment: u128 = bcs::from_bytes(argument)?;
-        let mut value = *self.value.get();
-        value += increment;
-        self.value.set(value);
+        let value = self.value.get_mut();
+        *value += increment;
         Ok(ApplicationCallResult {
             value: bcs::to_bytes(&value).expect("Serialization should not fail"),
             ..ApplicationCallResult::default()

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -407,11 +407,14 @@ where
         // Second, execute the operations in the block and remember the recipients to notify.
         for (index, operation) in block.operations.iter().enumerate() {
             let index = u32::try_from(index).map_err(|_| ArithmeticError::Overflow)?;
+            let next_effect_index =
+                u32::try_from(effects.len()).map_err(|_| ArithmeticError::Overflow)?;
             let context = OperationContext {
                 chain_id,
                 height: block.height,
                 index,
                 authenticated_signer: block.authenticated_signer,
+                next_effect_index,
             };
             let results = self
                 .execution_state

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -382,6 +382,18 @@ impl Value {
             && self.block.chain_id == effect_id.chain_id
             && self.effects.len() > usize::try_from(effect_id.index).unwrap_or(usize::MAX)
     }
+
+    /// Skip `n-1` effects from the end of the block and return the effect ID, if any.
+    pub fn nth_last_effect_id(&self, n: u32) -> Option<EffectId> {
+        if n == 0 {
+            return None;
+        }
+        Some(EffectId {
+            chain_id: self.block.chain_id,
+            height: self.block.height,
+            index: u32::try_from(self.effects.len()).ok()?.checked_sub(n)?,
+        })
+    }
 }
 
 impl HashedValue {
@@ -459,6 +471,11 @@ impl HashedValue {
     /// Returns whether this value contains the effect with the specified ID.
     pub fn has_effect(&self, effect_id: &EffectId) -> bool {
         self.value.has_effect(effect_id)
+    }
+
+    /// Skip `n-1` effects from the end of the block and return the effect ID, if any.
+    pub fn nth_last_effect_id(&self, n: u32) -> Option<EffectId> {
+        self.value.nth_last_effect_id(n)
     }
 }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -40,18 +40,18 @@ use test_case::test_case;
 #[cfg(feature = "aws")]
 use {linera_storage::DynamoDbStoreClient, linera_views::test_utils::LocalStackTestContext};
 
-#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::WasmerWithSanitizer ; "wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::WasmtimeWithSanitizer ; "wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_memory_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
     let client = MemoryStoreClient::new(Some(wasm_runtime));
-    run_test_handle_certificates_to_create_application(client).await
+    run_test_handle_certificates_to_create_application(client, wasm_runtime).await
 }
 
-#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::WasmerWithSanitizer ; "wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::WasmtimeWithSanitizer ; "wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_rocksdb_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
@@ -62,12 +62,12 @@ async fn test_rocksdb_handle_certificates_to_create_application(
         Some(wasm_runtime),
         TEST_CACHE_SIZE,
     );
-    run_test_handle_certificates_to_create_application(client).await
+    run_test_handle_certificates_to_create_application(client, wasm_runtime).await
 }
 
 #[cfg(feature = "aws")]
-#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::WasmerWithSanitizer ; "wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::WasmtimeWithSanitizer ; "wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
@@ -81,11 +81,12 @@ async fn test_dynamo_db_handle_certificates_to_create_application(
         Some(wasm_runtime),
     )
     .await?;
-    run_test_handle_certificates_to_create_application(client).await
+    run_test_handle_certificates_to_create_application(client, wasm_runtime).await
 }
 
 async fn run_test_handle_certificates_to_create_application<S>(
     client: S,
+    wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error>
 where
     S: Store + Clone + Send + Sync + 'static,
@@ -117,7 +118,7 @@ where
     let application = Arc::new(WasmApplication::new(
         contract_bytecode.clone(),
         service_bytecode.clone(),
-        WasmRuntime::default_with_sanitizer(),
+        wasm_runtime,
     )?);
 
     // Publish some bytecode.

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -411,8 +411,15 @@ where
             initial_value_bytes.clone(),
         )
         .await?;
-    let create_block_proposal =
-        HashedValue::new_confirmed(create_block, vec![], creator_state.crypto_hash().await?);
+    let create_block_proposal = HashedValue::new_confirmed(
+        create_block,
+        vec![OutgoingEffect {
+            destination: Destination::Recipient(creator_chain.into()),
+            authenticated_signer: None,
+            effect: Effect::System(SystemEffect::ApplicationCreated),
+        }],
+        creator_state.crypto_hash().await?,
+    );
     let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
 
     let info = worker
@@ -447,6 +454,7 @@ where
         authenticated_signer: None,
         height: run_block.height,
         index: 0,
+        next_effect_index: 0,
     };
     creator_state.add_fuel(10_000_000);
     creator_state

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -119,6 +119,7 @@ where
             authenticated_signer: None,
             height: application_description.creation.height,
             index: application_description.creation.index,
+            next_effect_index: 0,
         };
 
         let action = UserAction::Initialize(&context, initialization_argument);

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -219,6 +219,8 @@ pub struct OperationContext {
     pub height: BlockHeight,
     /// The current index of the operation.
     pub index: u32,
+    /// The index of the next effect to be created.
+    pub next_effect_index: u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -472,12 +474,12 @@ impl<Effect> Default for RawExecutionResult<Effect> {
     }
 }
 
-impl From<OperationContext> for EffectId {
-    fn from(context: OperationContext) -> Self {
-        Self {
-            chain_id: context.chain_id,
-            height: context.height,
-            index: context.index,
+impl OperationContext {
+    fn next_effect_id(&self) -> EffectId {
+        EffectId {
+            chain_id: self.chain_id,
+            height: self.height,
+            index: self.next_effect_index,
         }
     }
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -42,6 +42,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         height: BlockHeight(0),
         index: 0,
         authenticated_signer: None,
+        next_effect_index: 0,
     };
 
     let result = view
@@ -213,6 +214,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         height: BlockHeight(0),
         index: 0,
         authenticated_signer: Some(owner),
+        next_effect_index: 0,
     };
     let result = view
         .execute_operation(
@@ -281,6 +283,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         height: BlockHeight(0),
         index: 0,
         authenticated_signer: Some(owner),
+        next_effect_index: 0,
     };
 
     let result = view

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -36,6 +36,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         height: BlockHeight(0),
         index: 0,
         authenticated_signer: None,
+        next_effect_index: 0,
     };
     let results = view
         .execute_operation(&context, &Operation::System(operation))

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -63,6 +63,7 @@ async fn test_fuel_for_counter_wasm_application(
         height: BlockHeight(0),
         index: 0,
         authenticated_signer: None,
+        next_effect_index: 0,
     };
     let increments = [2_u128, 9, 7, 1000];
     for increment in &increments {

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -614,6 +614,8 @@ SystemEffect:
         STRUCT:
           - operation_index: U32
     7:
+      ApplicationCreated: UNIT
+    8:
       BytecodeLocations:
         STRUCT:
           - locations:
@@ -621,13 +623,13 @@ SystemEffect:
                 TUPLE:
                   - TYPENAME: BytecodeId
                   - TYPENAME: BytecodeLocation
-    8:
+    9:
       RegisterApplications:
         STRUCT:
           - applications:
               SEQ:
                 TYPENAME: UserApplicationDescription
-    9:
+    10:
       Notify:
         STRUCT:
           - id:


### PR DESCRIPTION
We've been mixing up the concepts of `EffectId` (where the index ranges over `Vec<Effect>`) and `OperationId` (where the index ranges over `Vec<Operation>`). In this PR, I tried to clean up things and not to create an actual type `OperationId`. As a consequence, I switched application-ids to use the effect counter instead of the operation counter and created a new effect for published applications.