### PR TITLE
Implement the pre_load_multi_key and a direct_load_entry_mut.

### DIFF
--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -367,6 +367,7 @@ where
     /// # let context = create_test_context();
     ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   coll.pre_load_multi_entry(vec![vec![0,1],vec![2,3]]).await.unwrap();
+    ///   let view = coll.load_entry_mut(vec![0,1]).await.unwrap();
     ///   let value = view.get_mut();
     ///   assert_eq!(*value, String::default());
     /// # })
@@ -415,9 +416,11 @@ where
     /// # let context = create_test_context();
     ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   coll.pre_load_multi_entry(vec![vec![0,1],vec![2,3]]).await.unwrap();
-    ///   let value = coll.direct_load_entry_mut(vec![0,1]).unwrap();
+    ///   let view = coll.direct_load_entry_mut(vec![0,1]).unwrap();
+    ///   let value = view.get_mut();
     ///   assert_eq!(*value, String::default());
-    ///   let value = coll.direct_load_entry_mut(vec![2,3]).unwrap();
+    ///   let view = coll.direct_load_entry_mut(vec![2,3]).unwrap();
+    ///   let value = view.get_mut();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -405,7 +405,7 @@ where
         Ok(())
     }
 
-    /// Pre load the list of entries into the database in order to have direct access to the views.
+    /// Load the entry that has been pre-loaded. If missing, then an exception is raised.
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::{create_test_context, MemoryContext};

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -97,6 +97,10 @@ pub enum ViewError {
     /// The database is corrupt: Some entries are missing
     #[error("Missing database entries")]
     MissingEntries,
+
+    /// The entry is missing in updates
+    #[error("Missing entry in updates")]
+    MissingInUpdates,
 }
 
 impl ViewError {


### PR DESCRIPTION
This is part of the steps for accelerating the operations on the chain.
By doing it, we can avoid having loops of async operation.