### PR TITLE
Add `docs.rs` metadata to SDK and views manifest files

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,8 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  LINERA_CRATES: base chain core execution rpc sdk service storage views views-derive
+  VERSION: 0.1.0
 
 permissions:
   contents: read
@@ -47,3 +49,41 @@ jobs:
         publish_branch: gh-pages
         publish_dir: ./target/doc
         destination_dir: 364a04086bc8f2bf91ec3406a2aac5f7e4e675b9
+
+  docsrs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+    - name: Checkout docs.rs tool repository
+      run: |
+        cd ${{ runner.temp }}
+        git clone https://github.com/rust-lang/docs.rs docsrs
+        cd docsrs
+        git submodule update --init
+    - name: Generate standalone packages
+      run: |
+        for crate in $LINERA_CRATES; do
+            cargo publish -p "linera-${crate}" --dry-run --target-dir "${{ runner.temp }}/crates/linera-${crate}" --no-verify
+        done
+    - name: Extract packaged crates
+      run: |
+        for crate in $LINERA_CRATES; do
+            pushd "${{ runner.temp }}/crates/linera-${crate}/package"
+            tar -xzvf "linera-${crate}-${VERSION}.crate"
+            popd
+        done
+    - name: Build documentation using docs.rs
+      run: |
+        cd ${{ runner.temp }}/docsrs
+        cp .env.sample .env
+        mkdir -p ignored/cratesfyi-prefix/crates.io-index
+        . ./.env
+        docker-compose up -d db s3
+        cargo run -- database migrate
+        for crate in $LINERA_CRATES; do
+            cargo run -- build crate --local "${{ runner.temp }}/crates/linera-${crate}/package/linera-${crate}-${VERSION}"
+        done

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -13,6 +13,10 @@ edition = "2021"
 [package.metadata.cargo-udeps.ignore]
 development = ["linera-sdk"]
 
+[package.metadata.docs.rs]
+features = ["test", "wasmer"]
+targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu"]
+
 [features]
 wasmer = ["linera-core/wasmer", "linera-execution/wasmer", "linera-storage/wasmer"]
 wasmtime = ["linera-core/wasmtime", "linera-execution/wasmtime", "linera-storage/wasmtime"]

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -10,6 +10,10 @@ documentation = "https://docs.rs/linera-views/latest/linera_views/"
 license = "Apache-2.0"
 edition = "2021"
 
+[package.metadata.docs.rs]
+features = ["aws", "test"]
+targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+
 [features]
 test = ["anyhow", "tokio/macros", "tokio/parking_lot"]
 aws = ["aws-config", "aws-sdk-dynamodb", "aws-sdk-s3", "aws-smithy-http", "aws-types"]


### PR DESCRIPTION
# Motivation

Current documentation in docs.rs for `linera-sdk` and `linera-views` was only built for `x86_64-unknown-linux-gnu` and doesn't include any features. This makes it impossible to view the documentation for test helper types and functions.

# Solution

Add metadata to be read by docs.rs that adds target architectures and features.

# Note

I'm not sure how to test this, and I'm a bit worried it might break documentation if there are conflicts between features and the WebAssembly architecture.