### PR TITLE
synchronize node service with validators on startup

### DIFF
--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1037,7 +1037,8 @@ where
                 config,
                 port,
             } => {
-                let chain_client = context.make_chain_client(storage, chain_id);
+                let mut chain_client = context.make_chain_client(storage, chain_id);
+                chain_client.synchronize_from_validators().await?;
                 let service = NodeService::new(chain_client, config, port);
                 service
                     .run(context, |context, client| {


### PR DESCRIPTION
We need this to show accurate chain state in GraphiQL after performing CLI commands.

Also filed #704 because I tried the using the CLI in parallel with the node service during debugging and (as expected) it goes horribly wrong.