### PR TITLE
Fix counter UI + misc

### DIFF
--- a/examples/counter/src/service.rs
+++ b/examples/counter/src/service.rs
@@ -46,9 +46,8 @@ struct MutationRoot;
 
 #[Object]
 impl MutationRoot {
-    #[allow(unused)]
-    async fn execute_operation(&self, operation: u64) -> Vec<u8> {
-        bcs::to_bytes(&operation).unwrap()
+    async fn increment(&self, value: u64) -> Vec<u8> {
+        bcs::to_bytes(&value).unwrap()
     }
 }
 
@@ -58,7 +57,6 @@ struct QueryRoot {
 
 #[Object]
 impl QueryRoot {
-    #[allow(unused)]
     async fn value(&self) -> &u64 {
         &self.value
     }

--- a/examples/counter/web-frontend/src/App.js
+++ b/examples/counter/web-frontend/src/App.js
@@ -15,7 +15,7 @@ const GET_COUNTER_VALUE = gql`
 
 const INCREMENT_COUNTER = gql`
   mutation {
-    executeOperation(operation: { increment: 1 })
+    increment(value: 1)
   }
 `;
 

--- a/examples/counter/web-frontend/src/App.js
+++ b/examples/counter/web-frontend/src/App.js
@@ -21,7 +21,7 @@ const INCREMENT_COUNTER = gql`
 
 const NOTIFICATION_SUBSCRIPTION = gql`
   subscription {
-    notifications()
+    notifications
   }
 `;
 

--- a/examples/fungible/web-frontend/src/App.js
+++ b/examples/fungible/web-frontend/src/App.js
@@ -21,7 +21,7 @@ const MAKE_PAYMENT = gql`
 
 const NOTIFICATION_SUBSCRIPTION = gql`
   subscription {
-    notifications(chainIds: [])
+    notifications
   }
 `;
 

--- a/examples/social/src/service.rs
+++ b/examples/social/src/service.rs
@@ -41,17 +41,14 @@ struct MutationRoot;
 
 #[Object]
 impl MutationRoot {
-    #[allow(unused)]
     async fn subscribe(&self, chain_id: ChainId) -> Vec<u8> {
         bcs::to_bytes(&Operation::RequestSubscribe(chain_id)).unwrap()
     }
 
-    #[allow(unused)]
     async fn unsubscribe(&self, chain_id: ChainId) -> Vec<u8> {
         bcs::to_bytes(&Operation::RequestUnsubscribe(chain_id)).unwrap()
     }
 
-    #[allow(unused)]
     async fn post(&self, text: String) -> Vec<u8> {
         bcs::to_bytes(&Operation::Post(text)).unwrap()
     }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1131,6 +1131,10 @@ where
                     .publish_bytecode(&mut chain_client, contract, service)
                     .await?;
 
+                // Saving wallet state in case the next step fails.
+                context.update_wallet_from_client(&mut chain_client).await;
+                context.save_wallet();
+
                 info!("Creating application...");
                 let (application_id, _) = chain_client
                     .create_application(

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1198,9 +1198,12 @@ where
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
+    let env_filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(env_filter)
         .init();
     let options = ClientOptions::from_args();
 

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -166,9 +166,12 @@ impl SimpleProxy {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let env_filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(env_filter)
         .init();
 
     let proxy = Proxy::from_options(ProxyOptions::from_args())?;

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -329,9 +329,12 @@ fn parse_duration(s: &str) -> Result<u64, parse_duration::parse::Error> {
 
 #[tokio::main]
 async fn main() {
+    let env_filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_env_filter(env_filter)
         .init();
     let options = ServerOptions::from_args();
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -881,7 +881,7 @@ impl Application {
     }
 
     async fn increment_counter_value(&self, increment: u64) {
-        let query_string = format!("mutation {{ executeOperation(operation: {}) }}", increment);
+        let query_string = format!("mutation {{ increment(value: {})}}", increment);
         self.query_application(&query_string).await;
     }
 }


### PR DESCRIPTION
* Fix the syntax for the notification requests that was broken in https://github.com/ma2bd/linera-protocol/commit/6dcfec496ad735b415bd8131f3a3e2a6c6e4e53a
* Use an `async-graphql` hack called `MergedObject`s to extend `ChainStainView` with a `chainId` field.
* Make sure the default logging level for binaries is INFO.
* Rename `execution_operation` into `increment` in the counter GraphQL.
* Make sure to save the intermediate wallet state in publish-and-create (in case of a failure later)