### PR TITLE
Add initial integration tests for Crowd Funding application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "bcs",
+ "futures",
  "linera-sdk",
  "linera-views",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ name = "linera-sdk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-graphql",
  "async-trait",
  "bcs",
  "cargo_toml",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1166,6 +1166,7 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "bcs",
+ "fungible",
  "linera-sdk",
  "linera-views",
  "serde",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -736,6 +736,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "fungible",
+ "futures",
  "linera-sdk",
  "linera-views",
  "serde",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1746,6 +1746,7 @@ name = "linera-sdk"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-graphql",
  "async-trait",
  "bcs",
  "cargo_toml",

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -29,17 +29,12 @@ async fn single_chain_test() {
         .await;
 
     let final_value = initial_state + increment;
-    let value: serde_json::Value = chain.query(application_id, "query { value }").await;
-    let state_value = value
-        .as_object()
-        .expect("Failed to obtain the first object")
-        .get("data")
-        .expect("Failed to obtain \"data\"")
-        .as_object()
-        .expect("Failed to obtain the second object")
-        .get("value")
-        .expect("Failed to obtain \"value\"")
-        .as_u64()
-        .expect("Failed to get the u64");
+    let response = chain
+        .query(application_id, "query { value }".into())
+        .await
+        .data
+        .into_json()
+        .expect("Unexpected non-JSON query response");
+    let state_value = response["value"].as_u64().expect("Failed to get the u64");
     assert_eq!(state_value, final_value);
 }

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -29,12 +29,7 @@ async fn single_chain_test() {
         .await;
 
     let final_value = initial_state + increment;
-    let response = chain
-        .query(application_id, "query { value }".into())
-        .await
-        .data
-        .into_json()
-        .expect("Unexpected non-JSON query response");
+    let response = chain.graphql_query(application_id, "query { value }").await;
     let state_value = response["value"].as_u64().expect("Failed to get the u64");
     assert_eq!(state_value, final_value);
 }

--- a/examples/crowd-funding/Cargo.toml
+++ b/examples/crowd-funding/Cargo.toml
@@ -15,6 +15,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+fungible = { workspace = true, features = ["test"] }
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true }
+
 [[bin]]
 name = "crowd_funding_contract"
 path = "src/contract.rs"

--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -11,6 +11,7 @@ use linera_sdk::{
     base::{Amount, Timestamp},
     test::TestValidator,
 };
+use std::iter;
 
 /// Test creating a campaign and collecting pledges.
 ///
@@ -105,6 +106,105 @@ async fn collect_pledges() {
         assert_eq!(
             FungibleTokenAbi::query_account(token_id, &campaign_chain, backer_account).await,
             Some(Amount::from(0)),
+        );
+    }
+}
+
+/// Test creating a campaign and cancelling it.
+///
+/// Creates a campaign on a `campaign_chain` and sets up the fungible token to use with three
+/// backer chains. Pledges part of each backer's balance to the campaign and then completes it,
+/// collecting the pledges. The final balance of each backer and the campaign owner is checked.
+#[tokio::test]
+async fn cancel_successful_campaign() {
+    let initial_amount = Amount::from_tokens(100);
+    let target_amount = Amount::from_tokens(220);
+    let pledge_amount = Amount::from_tokens(75);
+
+    let (validator, bytecode_id) = TestValidator::with_current_bytecode().await;
+
+    let fungible_publisher_chain = validator.new_chain().await;
+    let mut campaign_chain = validator.new_chain().await;
+    let campaign_account = AccountOwner::from(campaign_chain.public_key());
+
+    let fungible_bytecode_id = fungible_publisher_chain
+        .publish_bytecodes_in("../fungible")
+        .await;
+
+    let (token_id, backers) = FungibleTokenAbi::create_with_accounts(
+        &validator,
+        fungible_bytecode_id,
+        iter::repeat(initial_amount).take(3),
+    )
+    .await;
+
+    let campaign_state = InitializationArgument {
+        owner: campaign_account,
+        deadline: Timestamp::from(10),
+        target: target_amount,
+    };
+    let campaign_id = campaign_chain
+        .create_application::<CrowdFundingAbi>(
+            bytecode_id,
+            token_id,
+            campaign_state,
+            vec![token_id.forget_abi()],
+        )
+        .await;
+
+    let mut pledges_and_transfers = Vec::new();
+
+    for (backer_chain, backer_account, _balance) in &backers {
+        backer_chain.register_application(campaign_id).await;
+
+        let pledge_effects = backer_chain
+            .add_block(|block| {
+                block.with_operation(
+                    campaign_id,
+                    Operation::PledgeWithTransfer {
+                        owner: *backer_account,
+                        amount: pledge_amount,
+                    },
+                );
+            })
+            .await;
+
+        assert_eq!(pledge_effects.len(), 3);
+        pledges_and_transfers.extend(pledge_effects);
+    }
+
+    campaign_chain
+        .add_block(|block| {
+            block.with_incoming_messages(pledges_and_transfers);
+        })
+        .await;
+
+    assert_eq!(
+        FungibleTokenAbi::query_account(token_id, &campaign_chain, campaign_account).await,
+        None
+    );
+
+    campaign_chain
+        .add_block(|block| {
+            block
+                .with_timestamp(Timestamp::from(20))
+                .with_operation(campaign_id, Operation::Cancel);
+        })
+        .await;
+
+    assert_eq!(
+        FungibleTokenAbi::query_account(token_id, &campaign_chain, campaign_account).await,
+        Some(Amount::from(0)),
+    );
+
+    for (backer_chain, backer_account, initial_amount) in backers {
+        assert_eq!(
+            FungibleTokenAbi::query_account(token_id, &backer_chain, backer_account).await,
+            Some(initial_amount.saturating_sub(pledge_amount)),
+        );
+        assert_eq!(
+            FungibleTokenAbi::query_account(token_id, &campaign_chain, backer_account).await,
+            Some(pledge_amount),
         );
     }
 }

--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the Fungible Token application.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use crowd_funding::{CrowdFundingAbi, InitializationArgument, Operation};
+use fungible::{AccountOwner, FungibleTokenAbi};
+use linera_sdk::{
+    base::{Amount, Timestamp},
+    test::TestValidator,
+};
+
+/// Test creating a campaign and collecting pledges.
+///
+/// Creates a campaign on a `campaign_chain` and sets up the fungible token to use with three
+/// backer chains. Pledges part of each backer's balance to the campaign and then completes it,
+/// collecting the pledges. The final balance of each backer and the campaign owner is checked.
+#[tokio::test]
+async fn collect_pledges() {
+    let initial_amount = Amount::from_tokens(100);
+    let target_amount = Amount::from_tokens(220);
+    let pledge_amount = Amount::from_tokens(75);
+
+    let (validator, bytecode_id) = TestValidator::with_current_bytecode().await;
+
+    let fungible_publisher_chain = validator.new_chain().await;
+    let mut campaign_chain = validator.new_chain().await;
+    let campaign_account = AccountOwner::from(campaign_chain.public_key());
+
+    let fungible_bytecode_id = fungible_publisher_chain
+        .publish_bytecodes_in("../fungible")
+        .await;
+
+    let (token_id, backers) = FungibleTokenAbi::create_with_accounts(
+        &validator,
+        fungible_bytecode_id,
+        iter::repeat(initial_amount).take(3),
+    )
+    .await;
+
+    let campaign_state = InitializationArgument {
+        owner: campaign_account,
+        deadline: Timestamp::from(u64::MAX),
+        target: target_amount,
+    };
+    let campaign_id = campaign_chain
+        .create_application::<CrowdFundingAbi>(
+            bytecode_id,
+            token_id,
+            campaign_state,
+            vec![token_id.forget_abi()],
+        )
+        .await;
+
+    let mut pledges_and_transfers = Vec::new();
+
+    for (backer_chain, backer_account, _balance) in &backers {
+        backer_chain.register_application(campaign_id).await;
+
+        let pledge_effects = backer_chain
+            .add_block(|block| {
+                block.with_operation(
+                    campaign_id,
+                    Operation::PledgeWithTransfer {
+                        owner: *backer_account,
+                        amount: pledge_amount,
+                    },
+                );
+            })
+            .await;
+
+        assert_eq!(pledge_effects.len(), 3);
+        pledges_and_transfers.extend(pledge_effects);
+    }
+
+    campaign_chain
+        .add_block(|block| {
+            block.with_incoming_messages(pledges_and_transfers);
+        })
+        .await;
+
+    assert_eq!(
+        FungibleTokenAbi::query_account(token_id, &campaign_chain, campaign_account).await,
+        None
+    );
+
+    campaign_chain
+        .add_block(|block| {
+            block.with_operation(campaign_id, Operation::Collect);
+        })
+        .await;
+
+    assert_eq!(
+        FungibleTokenAbi::query_account(token_id, &campaign_chain, campaign_account).await,
+        Some(pledge_amount.saturating_mul(backers.len() as u128)),
+    );
+
+    for (backer_chain, backer_account, initial_amount) in backers {
+        assert_eq!(
+            FungibleTokenAbi::query_account(token_id, &backer_chain, backer_account).await,
+            Some(initial_amount.saturating_sub(pledge_amount)),
+        );
+        assert_eq!(
+            FungibleTokenAbi::query_account(token_id, &campaign_chain, backer_account).await,
+            Some(Amount::from(0)),
+        );
+    }
+}

--- a/examples/fungible/Cargo.toml
+++ b/examples/fungible/Cargo.toml
@@ -11,6 +11,7 @@ test = []
 async-graphql = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
+futures = { workspace = true }
 linera-sdk = { workspace = true }
 linera-views = { workspace = true }
 serde = { workspace = true }

--- a/examples/fungible/Cargo.toml
+++ b/examples/fungible/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
+[features]
+test = []
+
 [dependencies]
 async-graphql = { workspace = true }
 async-trait = { workspace = true }
@@ -15,6 +18,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true }
 

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -317,14 +317,7 @@ impl FungibleTokenAbi {
             "query {{ accounts(accountOwner: {}) }}",
             account_owner.to_value()
         );
-
-        let value = chain
-            .query(application_id, Request::from(query))
-            .await
-            .data
-            .into_json()
-            .ok()?;
-
+        let value = chain.graphql_query(application_id, query).await;
         let balance = value.as_object()?.get("accounts")?.as_str()?;
 
         Some(

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -314,18 +314,18 @@ impl FungibleTokenAbi {
         account_owner: AccountOwner,
     ) -> Option<Amount> {
         let query = format!(
-            "query {{ accounts(accountOwner: {} ) }}",
+            "query {{ accounts(accountOwner: {}) }}",
             account_owner.to_value()
         );
 
-        let value: serde_json::Value = chain.query(application_id, query).await;
+        let value = chain
+            .query(application_id, Request::from(query))
+            .await
+            .data
+            .into_json()
+            .ok()?;
 
-        let balance = value
-            .as_object()?
-            .get("data")?
-            .as_object()?
-            .get("accounts")?
-            .as_str()?;
+        let balance = value.as_object()?.get("accounts")?.as_str()?;
 
         Some(
             balance

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -69,8 +69,8 @@ async fn test_cross_chain_transfer() {
 }
 
 /// Query the balance of an account owned by `account_owner` on a specific `chain`.
-async fn query_account(
-    application_id: ApplicationId,
+async fn query_account<Abi>(
+    application_id: ApplicationId<Abi>,
     chain: ActiveChain,
     account_owner: AccountOwner,
 ) -> Option<Amount> {

--- a/examples/social/tests/cross_chain.rs
+++ b/examples/social/tests/cross_chain.rs
@@ -48,14 +48,24 @@ async fn test_cross_chain_posting() {
     chain1.handle_received_effects().await;
 
     // Querying the own posts
-    let query_string = "query { ownPosts(start: 0, end:1) { timestamp, text } }";
-    let value: serde_json::Value = chain2.query(application_id, query_string).await;
-    let value = value["data"]["ownPosts"][0]["text"].clone();
+    let query = "query { ownPosts(start: 0, end: 1) { timestamp, text } }";
+    let response = chain2
+        .query(application_id, query.into())
+        .await
+        .data
+        .into_json()
+        .expect("Unexpected non-JSON query response");
+    let value = response["ownPosts"][0]["text"].clone();
     assert_eq!(value, "Linera is the new Mastodon".to_string());
 
     // Now handling the received messages
-    let query_string = "query { receivedPostsKeys { timestamp, author, index } }";
-    let value: serde_json::Value = chain1.query(application_id, query_string).await;
-    let author = value["data"]["receivedPostsKeys"][0]["author"].clone();
+    let query = "query { receivedPostsKeys { timestamp, author, index } }";
+    let response = chain1
+        .query(application_id, query.into())
+        .await
+        .data
+        .into_json()
+        .expect("Unexpected non-JSON query response");
+    let author = response["receivedPostsKeys"][0]["author"].clone();
     assert_eq!(author, chain2.id().to_string());
 }

--- a/examples/social/tests/cross_chain.rs
+++ b/examples/social/tests/cross_chain.rs
@@ -49,23 +49,13 @@ async fn test_cross_chain_posting() {
 
     // Querying the own posts
     let query = "query { ownPosts(start: 0, end: 1) { timestamp, text } }";
-    let response = chain2
-        .query(application_id, query.into())
-        .await
-        .data
-        .into_json()
-        .expect("Unexpected non-JSON query response");
+    let response = chain2.graphql_query(application_id, query).await;
     let value = response["ownPosts"][0]["text"].clone();
     assert_eq!(value, "Linera is the new Mastodon".to_string());
 
     // Now handling the received messages
     let query = "query { receivedPostsKeys { timestamp, author, index } }";
-    let response = chain1
-        .query(application_id, query.into())
-        .await
-        .data
-        .into_json()
-        .expect("Unexpected non-JSON query response");
+    let response = chain1.graphql_query(application_id, query).await;
     let author = response["receivedPostsKeys"][0]["author"].clone();
     assert_eq!(author, chain2.id().to_string());
 }

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -34,6 +34,7 @@ linera-views = { workspace = true }
 wit-bindgen-guest-rust = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+async-graphql = { workspace = true }
 anyhow = { workspace = true }
 cargo_toml = { workspace = true }
 dashmap = { workspace = true }

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -76,6 +76,17 @@ impl BlockBuilder {
         self
     }
 
+    /// Adds a request to register an application on this chain.
+    pub fn with_request_for_application<Abi>(
+        &mut self,
+        application: ApplicationId<Abi>,
+    ) -> &mut Self {
+        self.with_system_operation(SystemOperation::RequestApplication {
+            chain_id: application.creation.chain_id,
+            application_id: application.forget_abi(),
+        })
+    }
+
     /// Adds a user `operation` to this block.
     ///
     /// The operation is serialized using [`bcs`] and added to the block, marked to be executed by

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -80,13 +80,13 @@ impl BlockBuilder {
     ///
     /// The operation is serialized using [`bcs`] and added to the block, marked to be executed by
     /// `application`.
-    pub fn with_operation(
+    pub fn with_operation<Abi>(
         &mut self,
-        application_id: ApplicationId,
+        application_id: ApplicationId<Abi>,
         operation: impl ToBcsBytes,
     ) -> &mut Self {
         self.block.operations.push(Operation::User {
-            application_id,
+            application_id: application_id.forget_abi(),
             bytes: operation
                 .to_bcs_bytes()
                 .expect("Failed to serialize operation"),

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -70,6 +70,12 @@ impl BlockBuilder {
         }
     }
 
+    /// Configures the timestamp of this block.
+    pub fn with_timestamp(&mut self, timestamp: Timestamp) -> &mut Self {
+        self.block.timestamp = timestamp;
+        self
+    }
+
     /// Adds a [`SystemOperation`] to this block.
     pub(crate) fn with_system_operation(&mut self, operation: SystemOperation) -> &mut Self {
         self.block.operations.push(operation.into());

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -120,6 +120,18 @@ impl BlockBuilder {
         self
     }
 
+    /// Adds multiple messages sent by the effects referenced by the [`EffectId`]s to this block.
+    ///
+    /// The blocks that produce the effects must have already been executed by the test validator,
+    /// so that the messages are already in the inbox of the microchain this block belongs to.
+    pub fn with_incoming_messages(
+        &mut self,
+        effect_ids: impl IntoIterator<Item = EffectId>,
+    ) -> &mut Self {
+        self.incoming_messages.extend(effect_ids);
+        self
+    }
+
     /// Adds the `messages` directly to this block.
     ///
     /// This is an internal method that bypasses the check to see if the messages are already

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -222,7 +222,7 @@ impl ActiveChain {
     }
 
     /// Returns the height of the tip of this microchain.
-    async fn tip_height(&self) -> BlockHeight {
+    pub async fn get_tip_height(&self) -> BlockHeight {
         self.tip
             .lock()
             .await

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -300,6 +300,10 @@ impl ActiveChain {
         let parameters = serde_json::to_vec(&parameters).unwrap();
         let initialization_argument = serde_json::to_vec(&initialization_argument).unwrap();
 
+        for &dependency in &required_application_ids {
+            self.register_application(dependency).await;
+        }
+
         self.add_block(|block| {
             if let Some(effect_id) = bytecode_location_effect {
                 block.with_incoming_message(effect_id);

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -454,4 +454,22 @@ impl ActiveChain {
             Response::System(_) => unreachable!("User query returned a system response"),
         }
     }
+
+    /// Executes a GraphQL `query` on an `application`'s state on this microchain.
+    ///
+    /// Returns the deserialized GraphQL JSON response from the `application`.
+    pub async fn graphql_query<Abi>(
+        &self,
+        application_id: ApplicationId<Abi>,
+        query: impl Into<async_graphql::Request>,
+    ) -> serde_json::Value
+    where
+        Abi: ServiceAbi<Query = async_graphql::Request, QueryResponse = async_graphql::Response>,
+    {
+        self.query(application_id, query.into())
+            .await
+            .data
+            .into_json()
+            .expect("Unexpected non-JSON query response")
+    }
 }

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -6,7 +6,7 @@
 //! This allows manipulating a test microchain.
 
 use super::{BlockBuilder, TestValidator};
-use crate::ContractAbi;
+use crate::{ContractAbi, ServiceAbi};
 use cargo_toml::Manifest;
 use linera_base::{
     crypto::{KeyPair, PublicKey},
@@ -19,8 +19,6 @@ use linera_execution::{
     system::{SystemChannel, SystemEffect, SystemExecutionError, SystemOperation},
     Bytecode, Effect, Query, Response,
 };
-use serde::de::DeserializeOwned;
-use serde_json::json;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
@@ -424,17 +422,16 @@ impl ActiveChain {
 
     /// Executes a `query` on an `application`'s state on this microchain.
     ///
-    /// Returns the deserialized `Output` response from the `application`.
-    pub async fn query<Abi, Output>(
+    /// Returns the deserialized response from the `application`.
+    pub async fn query<Abi>(
         &self,
         application_id: ApplicationId<Abi>,
-        query: impl AsRef<str>,
-    ) -> Output
+        query: Abi::Query,
+    ) -> Abi::QueryResponse
     where
-        Output: DeserializeOwned,
+        Abi: ServiceAbi,
     {
-        let query_bytes = serde_json::to_vec(&json!({ "query": query.as_ref() }))
-            .expect("Failed to serialize query");
+        let query_bytes = serde_json::to_vec(&query).expect("Failed to serialize query");
 
         let response = self
             .validator

--- a/linera-sdk/src/test/integration/validator.rs
+++ b/linera-sdk/src/test/integration/validator.rs
@@ -83,7 +83,7 @@ impl TestValidator {
     /// calling this method published on it.
     ///
     /// Returns the new [`TestValidator`] and the [`BytecodeId`] of the published bytecode.
-    pub async fn with_current_bytecode() -> (TestValidator, BytecodeId) {
+    pub async fn with_current_bytecode<Abi>() -> (TestValidator, BytecodeId<Abi>) {
         let validator = TestValidator::default();
         let publisher = validator.new_chain().await;
 
@@ -102,7 +102,7 @@ impl TestValidator {
     pub async fn with_current_application<A>(
         parameters: A::Parameters,
         initialization_argument: A::InitializationArgument,
-    ) -> (TestValidator, ApplicationId)
+    ) -> (TestValidator, ApplicationId<A>)
     where
         A: ContractAbi,
     {


### PR DESCRIPTION
# Motivation

The Crowd-Funding application didn't have any integration tests. This was because a few features were missing from the integration test framework to allow writing the tests smoothly.

# Solution

Write two initial integration tests, and implement the necessary features in the test framework to get them to work. This includes:

1. Refactoring the helper function to publish bytecodes to receive the path where the bytecodes should be built and obtained. This allows building and publishing bytecodes from other repositories.
2. Adding ABI support to the test helper functions, making them more type-safe and consistent with the application.
3. Being able to set a block's timestamp, to simulate time in the tests.
4. Returning effect IDs from blocks added to chains, to avoid manually crafting `EffectId`s and catch-all `handle_incoming_messages()` calls.
5. Updating the Fungible application to have a `test` feature with some helper methods for initializing tokens and for querying balances.