### PR TITLE
Make crowd funding multi-chain + add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crowd-funding"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "bcs",
+ "fungible",
+ "hex",
+ "linera-sdk",
+ "linera-views",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,6 +2676,7 @@ dependencies = [
  "chrono",
  "colored",
  "comfy-table",
+ "crowd-funding",
  "dirs",
  "fungible",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ linera-views = { version = "0.1.0", path = "./linera-views" }
 linera-views-derive = { version = "0.1.0", path = "./linera-views-derive" }
 
 fungible = { path = "./examples/fungible" }
+crowd-funding = { path = "./examples/crowd-funding" }
 social = { path = "./examples/social" }
 
 [profile.release]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -727,6 +727,7 @@ dependencies = [
 name = "crowd-funding"
 version = "0.1.0"
 dependencies = [
+ "async-graphql",
  "async-trait",
  "bcs",
  "fungible",
@@ -734,6 +735,7 @@ dependencies = [
  "linera-sdk",
  "linera-views",
  "serde",
+ "serde_json",
  "thiserror",
 ]
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -730,6 +730,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "fungible",
+ "hex",
  "linera-sdk",
  "linera-views",
  "serde",

--- a/examples/crowd-funding/Cargo.toml
+++ b/examples/crowd-funding/Cargo.toml
@@ -5,13 +5,15 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
+async-graphql = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
-fungible = { workspace = true }
 hex = { workspace = true }
+fungible = { workspace = true }
 linera-sdk = { workspace = true }
 linera-views = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [[bin]]

--- a/examples/crowd-funding/Cargo.toml
+++ b/examples/crowd-funding/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 async-trait = { workspace = true }
 bcs = { workspace = true }
 fungible = { workspace = true }
+hex = { workspace = true }
 linera-sdk = { workspace = true }
 linera-views = { workspace = true }
 serde = { workspace = true }

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use async_graphql::SimpleObject;
 use fungible::AccountOwner;
 use linera_sdk::base::{Amount, ChainId, Timestamp};
 use serde::{Deserialize, Serialize};
 
 /// The initialization arguments required to create a crowd-funding campaign.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, SimpleObject)]
 pub struct InitializationArguments {
     /// The receiver of the pledges of a successful campaign.
     pub owner: AccountOwner,
@@ -61,19 +62,4 @@ pub enum ApplicationCall {
     Collect,
     /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
     Cancel,
-}
-
-/// Queries that can be made to the [`CrowdFunding`] application service.
-#[derive(Clone, Copy, Debug, Deserialize)]
-pub enum Query {
-    /// The current [`Status`] of the crowd-funding campaign.
-    Status,
-    /// The total amount pledged to the crowd-funding campaign.
-    Pledged,
-    /// The crowd-funding campaign's target.
-    Target,
-    /// The crowd-funding campaign's deadline.
-    Deadline,
-    /// The recipient of the pledged amount.
-    Owner,
 }

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -2,21 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, ApplicationId, Timestamp};
+use linera_sdk::base::{Amount, Timestamp};
 use serde::{Deserialize, Serialize};
 
-/// The initialization parameters of a crowd-funding campaign. As usual, these are meant
-/// to be BCS-serialized and passed when instantiating the bytecode.
+/// The initialization arguments required to create a crowd-funding campaign.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct Parameters {
-    /// The receiver of the pledges of a successful campaign (same chain as the campaign).
+pub struct InitializationArguments {
+    /// The receiver of the pledges of a successful campaign.
     pub owner: AccountOwner,
-    /// The token to use for pledges.
-    pub token: ApplicationId,
     /// The deadline of the campaign, after which it can be cancelled if it hasn't met its target.
     pub deadline: Timestamp,
     /// The funding target of the campaign.
     pub target: Amount,
+}
+
+impl std::fmt::Display for InitializationArguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let bytes = bcs::to_bytes(self).expect("Serialization failed");
+        write!(f, "{}", hex::encode(bytes))
+    }
 }
 
 /// Operations that can be sent to the application.

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, Timestamp};
+use linera_sdk::base::{Amount, ChainId, Timestamp};
 use serde::{Deserialize, Serialize};
 
 /// The initialization arguments required to create a crowd-funding campaign.
@@ -33,6 +33,9 @@ pub enum Operation {
     Collect,
     /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
     Cancel,
+    /// Inform a chain about this crowd funding campaign.
+    // TODO(#718): This is currently the only way to make the app available on another chain.
+    Notify { chain_id: ChainId },
 }
 
 /// Effects that can be processed by the application.
@@ -41,6 +44,9 @@ pub enum Operation {
 pub enum Effect {
     /// Pledge some tokens to the campaign (from an account on the receiver chain).
     PledgeWithAccount { owner: AccountOwner, amount: Amount },
+    /// Notify a chain that this crowd-funding campaign exists.
+    // TODO(#718): This is currently the only way to make the app available on another chain.
+    Notify,
 }
 
 /// A cross-application call. This is meant to mimic operations, except triggered by another contract.

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -2,28 +2,54 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use fungible::AccountOwner;
-use linera_sdk::base::Amount;
+use linera_sdk::base::{Amount, ApplicationId, Timestamp};
 use serde::{Deserialize, Serialize};
 
-/// A cross-application call.
-#[derive(Deserialize, Serialize)]
-#[allow(clippy::large_enum_variant)]
-pub enum ApplicationCall {
-    PledgeWithTransfer { owner: AccountOwner, amount: Amount },
-    PledgeWithSessions { source: AccountOwner },
-    Collect,
-    Cancel,
+/// The initialization parameters of a crowd-funding campaign. As usual, these are meant
+/// to be BCS-serialized and passed when instantiating the bytecode.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct Parameters {
+    /// The receiver of the pledges of a successful campaign (same chain as the campaign).
+    pub owner: AccountOwner,
+    /// The token to use for pledges.
+    pub token: ApplicationId,
+    /// The deadline of the campaign, after which it can be cancelled if it hasn't met its target.
+    pub deadline: Timestamp,
+    /// The funding target of the campaign.
+    pub target: Amount,
 }
 
 /// Operations that can be sent to the application.
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum Operation {
-    /// Pledge some tokens to the campaign.
+    /// Pledge some tokens to the campaign (from an account on the current chain to the campaign chain).
     PledgeWithTransfer { owner: AccountOwner, amount: Amount },
-    /// Collect the pledges after the campaign has reached its target.
+    /// Collect the pledges after the campaign has reached its target (campaign chain only).
     Collect,
-    /// Cancel the campaign and refund all pledges after the campaign has reached its deadline.
+    /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
+    Cancel,
+}
+
+/// Effects that can be processed by the application.
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum Effect {
+    /// Pledge some tokens to the campaign (from an account on the receiver chain).
+    PledgeWithAccount { owner: AccountOwner, amount: Amount },
+}
+
+/// A cross-application call. This is meant to mimic operations, except triggered by another contract.
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::large_enum_variant)]
+pub enum ApplicationCall {
+    /// Pledge some tokens to the campaign (from an account on the current chain).
+    PledgeWithTransfer { owner: AccountOwner, amount: Amount },
+    /// Pledge some tokens to the campaign from a session (for now, campaign chain only).
+    PledgeWithSessions { source: AccountOwner },
+    /// Collect the pledges after the campaign has reached its target (campaign chain only).
+    Collect,
+    /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
     Cancel,
 }
 

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -32,9 +32,9 @@ impl Service for CrowdFunding<ReadOnlyViewStorageContext> {
         let response = match query {
             Query::Status => bcs::to_bytes(&self.status.get()),
             Query::Pledged => bcs::to_bytes(&self.pledged().await),
-            Query::Target => bcs::to_bytes(&self.parameters().target),
-            Query::Deadline => bcs::to_bytes(&self.parameters().deadline),
-            Query::Owner => bcs::to_bytes(&self.parameters().owner),
+            Query::Target => bcs::to_bytes(&self.initialization_arguments().target),
+            Query::Deadline => bcs::to_bytes(&self.initialization_arguments().deadline),
+            Query::Owner => bcs::to_bytes(&self.initialization_arguments().owner),
         }?;
 
         Ok(response)

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crowd_funding::Parameters;
+use crowd_funding::InitializationArguments;
 use fungible::AccountOwner;
 use linera_sdk::base::Amount;
 use linera_views::{
@@ -31,8 +31,8 @@ pub struct CrowdFunding<C> {
     pub status: RegisterView<C, Status>,
     /// The map of pledges that will be collected if the campaign succeeds.
     pub pledges: MapView<C, AccountOwner, Amount>,
-    /// The parameters that determine the details the campaign.
-    pub parameters: RegisterView<C, Option<Parameters>>,
+    /// The initialization arguments that determine the details the campaign.
+    pub initialization_arguments: RegisterView<C, Option<InitializationArguments>>,
 }
 
 #[allow(dead_code)]
@@ -48,9 +48,9 @@ where
     C: Context + Send + Sync + Clone + 'static,
     linera_views::views::ViewError: From<C::Error>,
 {
-    /// Retrieves the campaign [`Parameters`] stored in the application's state.
-    pub fn parameters(&self) -> &Parameters {
-        self.parameters
+    /// Retrieves the campaign [`InitializationArguments`] stored in the application's state.
+    pub fn initialization_arguments(&self) -> &InitializationArguments {
+        self.initialization_arguments
             .get()
             .as_ref()
             .expect("Application was not initialized")

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crowd_funding::Parameters;
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, ApplicationId, Timestamp};
+use linera_sdk::base::Amount;
 use linera_views::{
     common::Context,
     map_view::MapView,
@@ -10,19 +11,6 @@ use linera_views::{
     views::{RootView, View},
 };
 use serde::{Deserialize, Serialize};
-
-/// The parameters required to create a crowd-funding campaign.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
-pub struct Parameters {
-    /// The receiver of the pledges of a successful campaign.
-    pub owner: AccountOwner,
-    /// The token to use for pledges.
-    pub token: ApplicationId,
-    /// The deadline of the campaign, after which it can be cancelled if it hasn't met its target.
-    pub deadline: Timestamp,
-    /// The funding target of the campaign.
-    pub target: Amount,
-}
 
 /// The status of a crowd-funding campaign.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]

--- a/examples/crowd-funding/src/state.rs
+++ b/examples/crowd-funding/src/state.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use async_graphql::scalar;
 use crowd_funding::InitializationArguments;
 use fungible::AccountOwner;
 use linera_sdk::base::Amount;
 use linera_views::{
-    common::Context,
     map_view::MapView,
     register_view::RegisterView,
-    views::{RootView, View},
+    views::{GraphQLView, RootView, View},
 };
 use serde::{Deserialize, Serialize};
 
@@ -24,8 +24,10 @@ pub enum Status {
     Cancelled,
 }
 
+scalar!(Status);
+
 /// The crowd-funding campaign's state.
-#[derive(RootView)]
+#[derive(RootView, GraphQLView)]
 pub struct CrowdFunding<C> {
     /// The status of the campaign.
     pub status: RegisterView<C, Status>,
@@ -40,19 +42,5 @@ impl Status {
     /// Returns `true` if the campaign status is [`Status::Complete`].
     pub fn is_complete(&self) -> bool {
         matches!(self, Status::Complete)
-    }
-}
-
-impl<C> CrowdFunding<C>
-where
-    C: Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
-{
-    /// Retrieves the campaign [`InitializationArguments`] stored in the application's state.
-    pub fn initialization_arguments(&self) -> &InitializationArguments {
-        self.initialization_arguments
-            .get()
-            .as_ref()
-            .expect("Application was not initialized")
     }
 }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -68,6 +68,7 @@ test-log = { workspace = true, features = ["trace"] }
 test-strategy = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 fungible = { workspace = true }
+crowd-funding = { workspace = true }
 
 [[bin]]
 name = "linera"

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -148,6 +148,18 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    /// Processes the inbox and returns the lists of certificate hashes that were created, if any.
+    async fn process_inbox(&self) -> Result<Vec<CryptoHash>, Error> {
+        let mut client = self.client.lock().await;
+        client.synchronize_from_validators().await?;
+        let certificates = client.process_inbox().await?;
+        let hashes = certificates
+            .into_iter()
+            .map(|cert| cert.value.hash())
+            .collect();
+        Ok(hashes)
+    }
+
     /// Transfers `amount` units of value from the given owner's account to the recipient.
     /// If no owner is given, try to take the units out of the unattributed account.
     async fn transfer(

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -864,7 +864,7 @@ impl Application {
         serde_json::from_value(response_body["accounts"].clone()).unwrap_or_default()
     }
 
-    async fn assert_fungible_app_has_accounts(
+    async fn assert_fungible_account_balances(
         &self,
         accounts: impl IntoIterator<Item = (AccountOwner, Amount)>,
     ) {
@@ -1258,7 +1258,7 @@ async fn test_end_to_end_fungible() {
     let mut node_service2 = client2.run_node_service(chain2, 8081).await;
 
     let app1 = node_service1.make_application(&application_id).await;
-    app1.assert_fungible_app_has_accounts([
+    app1.assert_fungible_account_balances([
         (account_owner1, Amount::from(5)),
         (account_owner2, Amount::from(2)),
     ])
@@ -1279,7 +1279,7 @@ async fn test_end_to_end_fungible() {
     app1.query_application(&query_string).await;
 
     // Checking the final values on chain1 and chain2.
-    app1.assert_fungible_app_has_accounts([
+    app1.assert_fungible_account_balances([
         (account_owner1, Amount::from(4)),
         (account_owner2, Amount::from(2)),
     ])
@@ -1288,7 +1288,7 @@ async fn test_end_to_end_fungible() {
     // Fungible didn't exist on chain2 initially but now it does and we can talk to it.
     let app2 = node_service2.make_application(&application_id).await;
 
-    app2.assert_fungible_app_has_accounts(BTreeMap::from([
+    app2.assert_fungible_account_balances(BTreeMap::from([
         (account_owner1, Amount::from(0)),
         (account_owner2, Amount::from(1)),
     ]))
@@ -1317,12 +1317,12 @@ async fn test_end_to_end_fungible() {
     node_service2.process_inbox().await;
 
     // Checking the final value
-    app1.assert_fungible_app_has_accounts([
+    app1.assert_fungible_account_balances([
         (account_owner1, Amount::from(4)),
         (account_owner2, Amount::from(0)),
     ])
     .await;
-    app2.assert_fungible_app_has_accounts([
+    app2.assert_fungible_account_balances([
         (account_owner1, Amount::from(0)),
         (account_owner2, Amount::from(3)),
     ])
@@ -1448,7 +1448,7 @@ async fn test_end_to_end_crowd_funding() {
 
     // The rich gets their money back.
     app_fungible1
-        .assert_fungible_app_has_accounts([(account_owner1, Amount::from(6))])
+        .assert_fungible_account_balances([(account_owner1, Amount::from(6))])
         .await;
 
     node_service1.assert_is_running();


### PR DESCRIPTION
* Import changes for previous draft PR #634 to make the crowd-funding app multi-chain
* Fix another (theoretical) race condition in e2e tests by adding manual "process_inbox" commands
* Fix the injection of the application id of fungible in crowd-funding (must parameters instead of initialization arguments)
* Add command "notify" to make campaigns multi-user before the real fix (#718)
* Add support for missing CLI arguments in e2e test
* Finally import GraphQL changes and fix e2e test from #716 