### PR TITLE
Retry disconnected notification streams.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,7 +2518,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-graphql",
- "async-stream",
  "async-trait",
  "bcs",
  "criterion",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1680,7 +1680,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-graphql",
- "async-stream",
  "async-trait",
  "dashmap",
  "futures",

--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Integration tests for the Fungible Token application.
+//! Integration tests for the Counter application.
 
 #![cfg(not(target_arch = "wasm32"))]
 

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -24,7 +24,6 @@ aws = ["linera-views/aws", "linera-storage/aws"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 async-graphql = { workspace = true }
-async-stream = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
 linera-base = { workspace = true }

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -477,9 +477,11 @@ impl GrpcClient {
     /// Logs a warning on unexpected status codes.
     fn is_retryable(status: &Status) -> bool {
         match status.code() {
-            Code::DeadlineExceeded | Code::Aborted | Code::Unavailable => true,
-            Code::Unknown
-            | Code::Ok
+            Code::DeadlineExceeded | Code::Aborted | Code::Unavailable | Code::Unknown => {
+                info!("Notification stream interrupted: {}; retrying", status);
+                true
+            }
+            Code::Ok
             | Code::Cancelled
             | Code::NotFound
             | Code::AlreadyExists


### PR DESCRIPTION
# Motivation

gRPC notification streams can fail or end for different reasons. We currently don't retry on any of them.

# Solution

Retry for some gRPC error codes.

This also replaces `async_stream::stream!` with `futures::stream::unfold` to remove one dependency and use fewer macros.

Closes https://github.com/linera-io/linera-protocol/issues/687.