### PR TITLE
Added advisory locking to wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,6 +1775,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-lock"
+version = "2.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f59be9010c5418713a48aac4c1b897d85dafd958055683dc31bdae553536647b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "file-per-thread-logger"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2661,6 +2671,7 @@ dependencies = [
  "colored",
  "comfy-table",
  "dirs",
+ "file-lock",
  "fungible",
  "futures",
  "hex",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -51,6 +51,7 @@ tower-http = { workspace = true, features = ["cors"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 comfy-table = { workspace = true }
 dirs = { workspace = true }
+file-lock = "2.1.9"
 
 [dev-dependencies]
 linera-base = { workspace = true, features = ["test"] }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -377,7 +377,7 @@ impl Client {
     }
 
     fn get_wallet(&self) -> WalletState {
-        WalletState::read(self.tmp_dir.path().join(&self.wallet).as_path()).unwrap()
+        WalletState::from_file(self.tmp_dir.path().join(&self.wallet).as_path()).unwrap()
     }
 
     fn get_owner(&self) -> Option<Owner> {


### PR DESCRIPTION
# Motivation

Multiple instances of `linera` could access the same wallet, causing concurrent modifications of the underlying wallet file resulting in UB.

# Solution

Use advisory locking with the `file-lock` crate. A temporary file is created while the wallet is being written to avoiding unintentionally wiping out the contents of the wallet.