### PR TITLE
Allow requesting an application to register it on a chain.

### DIFF
--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -63,11 +63,6 @@ impl Contract for CrowdFunding<ViewStorageContext> {
             }
             Operation::Collect => self.collect_pledges().await?,
             Operation::Cancel => self.cancel_campaign().await?,
-            Operation::Notify { chain_id } => {
-                let effect_bytes =
-                    bcs::to_bytes(&Effect::Notify).expect("Serializing the effect should not fail");
-                result.effects.push((chain_id.into(), false, effect_bytes));
-            }
         }
 
         Ok(result)
@@ -79,7 +74,6 @@ impl Contract for CrowdFunding<ViewStorageContext> {
         effect: &[u8],
     ) -> Result<ExecutionResult, Self::Error> {
         match bcs::from_bytes(effect).map_err(Error::InvalidEffect)? {
-            Effect::Notify => {}
             Effect::PledgeWithAccount { owner, amount } => {
                 ensure!(
                     context.chain_id == system_api::current_application_id().creation.chain_id,

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -3,7 +3,7 @@
 
 use async_graphql::SimpleObject;
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, ChainId, Timestamp};
+use linera_sdk::base::{Amount, Timestamp};
 use serde::{Deserialize, Serialize};
 
 /// The initialization arguments required to create a crowd-funding campaign.
@@ -34,9 +34,6 @@ pub enum Operation {
     Collect,
     /// Cancel the campaign and refund all pledges after the campaign has reached its deadline (campaign chain only).
     Cancel,
-    /// Inform a chain about this crowd funding campaign.
-    // TODO(#718): This is currently the only way to make the app available on another chain.
-    Notify { chain_id: ChainId },
 }
 
 /// Effects that can be processed by the application.
@@ -45,9 +42,6 @@ pub enum Operation {
 pub enum Effect {
     /// Pledge some tokens to the campaign (from an account on the receiver chain).
     PledgeWithAccount { owner: AccountOwner, amount: Amount },
-    /// Notify a chain that this crowd-funding campaign exists.
-    // TODO(#718): This is currently the only way to make the app available on another chain.
-    Notify,
 }
 
 /// A cross-application call. This is meant to mimic operations, except triggered by another contract.

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -10,9 +10,8 @@ use async_trait::async_trait;
 use crowd_funding::Operation;
 use fungible::AccountOwner;
 use linera_sdk::{
-    base::{Amount, ChainId},
-    service::system_api::ReadOnlyViewStorageContext,
-    QueryContext, Service, ViewStateStorage,
+    base::Amount, service::system_api::ReadOnlyViewStorageContext, QueryContext, Service,
+    ViewStateStorage,
 };
 use state::CrowdFunding;
 use std::sync::Arc;
@@ -52,10 +51,6 @@ impl MutationRoot {
 
     async fn cancel(&self) -> Vec<u8> {
         bcs::to_bytes(&Operation::Cancel {}).unwrap()
-    }
-
-    async fn notify(&self, chain_id: ChainId) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Notify { chain_id }).unwrap()
     }
 }
 

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1162,6 +1162,22 @@ where
         Ok(())
     }
 
+    /// Requests a `RegisterApplications` effect from another chain so the application can be used
+    /// on this one.
+    pub async fn request_application(
+        &mut self,
+        application_id: UserApplicationId,
+        chain_id: Option<ChainId>,
+    ) -> Result<Certificate> {
+        let chain_id = chain_id.unwrap_or(application_id.creation.chain_id);
+        let messages = self.pending_messages().await?;
+        let operations = vec![Operation::System(SystemOperation::RequestApplication {
+            application_id,
+            chain_id,
+        })];
+        self.execute_block(messages, operations).await
+    }
+
     /// Sends tokens to a chain.
     pub async fn transfer_to_account(
         &mut self,

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -634,6 +634,10 @@ SystemEffect:
         STRUCT:
           - id:
               TYPENAME: ChainId
+    11:
+      RequestApplication:
+        NEWTYPE:
+          TYPENAME: UserApplicationId
 SystemOperation:
   ENUM:
     0:
@@ -736,6 +740,13 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: UserApplicationId
+    12:
+      RequestApplication:
+        STRUCT:
+          - chain_id:
+              TYPENAME: ChainId
+          - application_id:
+              TYPENAME: UserApplicationId
 Timestamp:
   NEWTYPESTRUCT: U64
 UserApplicationDescription:

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -316,6 +316,22 @@ where
             .await?;
         Ok(application_id)
     }
+
+    /// Requests a `RegisterApplications` effect from another chain so the application can be used
+    /// on this one.
+    async fn request_application(
+        &self,
+        application_id: UserApplicationId,
+        target_chain_id: Option<ChainId>,
+    ) -> Result<CryptoHash, Error> {
+        let mut client = self.client.lock().await;
+        client.synchronize_from_validators().await?;
+        client.process_inbox().await?;
+        let certificate = client
+            .request_application(application_id, target_chain_id)
+            .await?;
+        Ok(certificate.value.hash())
+    }
 }
 
 #[Object]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1185,7 +1185,6 @@ async fn test_end_to_end_social_user_pub_sub() {
 
     // Request the application so chain 2 has it, too.
     node_service2.request_application(&application_id).await;
-    node_service1.process_inbox().await; // Respond with RegisterApplications.
 
     let app2 = node_service2.make_application(&application_id).await;
     let subscribe = format!("mutation {{ subscribe(chainId: \"{chain1}\") }}");
@@ -1482,7 +1481,6 @@ async fn test_end_to_end_crowd_funding() {
     node_service2
         .request_application(&application_id_crowd)
         .await;
-    node_service1.process_inbox().await; // Respond with RegisterApplications.
 
     let app_crowd2 = node_service2.make_application(&application_id_crowd).await;
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1488,10 +1488,11 @@ async fn test_end_to_end_crowd_funding() {
     );
     app_fungible1.query_application(&query_string).await;
 
-    // Inviting chain2 to the campaign.
-    // TODO(#718): There should be a better way for chain2 to learn about the campaign.
-    let query_string = format!("mutation {{ notify(chainId: {}) }}", chain2.to_value());
-    app_crowd1.query_application(&query_string).await;
+    // Register the campaign on chain2.
+    node_service2
+        .request_application(&application_id_crowd)
+        .await;
+    node_service1.process_inbox().await; // Respond with RegisterApplications.
 
     let app_crowd2 = node_service2.make_application(&application_id_crowd).await;
 


### PR DESCRIPTION
# Motivation

If an application was created on chain A, currently the only way to use it on chain B is for B to receive an application effect from A. And there's no way to request that.

# Solution

Add a `RequestApplication` operation and system effect to request a particular application by ID from another chain. If processed, it is answered with a `RegisterApplications` effect that contains the requested application and its dependencies. So in the example above:
* B could execute a `RequestApplication { chain_id: A, application_id }` operation.
* That would trigger a `RequestApplication(application_id)` effect to A.
* A would process it and send a `RegisterApplications` back to B.
* After processing that, the application can be used on B.

Partly addresses https://github.com/linera-io/linera-protocol/issues/718.