### PR TITLE
Reintroduce a missing entry in Cargo.toml

### DIFF
--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -20,6 +20,7 @@ linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
 
 [dev-dependencies]
+linera-sdk = { workspace = true, features = ["test"] }
 webassembly-test = { workspace = true }
 
 [[bin]]


### PR DESCRIPTION
This is for the compilation of `cargo test` in `counter` that fails.