### PR TITLE
Fix some commands so they work with non-owned chains.

### DIFF
--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -141,6 +141,14 @@ impl WalletState {
         self.chains.keys().copied().collect()
     }
 
+    /// Returns the list of all chain IDs for which we have a secret key.
+    pub fn own_chain_ids(&self) -> Vec<ChainId> {
+        self.chains
+            .iter()
+            .filter_map(|(chain_id, chain)| chain.key_pair.is_some().then_some(*chain_id))
+            .collect()
+    }
+
     pub fn num_chains(&self) -> usize {
         self.chains.len()
     }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -229,7 +229,7 @@ impl ClientContext {
         S: Store + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        for chain_id in self.wallet_state.chain_ids() {
+        for chain_id in self.wallet_state.own_chain_ids() {
             let mut chain_client = self.make_chain_client(storage.clone(), chain_id);
             chain_client.process_inbox().await.unwrap();
             chain_client.update_validators().await.unwrap();
@@ -449,7 +449,7 @@ impl ClientContext {
         S: Store + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        for chain_id in self.wallet_state.chain_ids() {
+        for chain_id in self.wallet_state.own_chain_ids() {
             let mut chain_client = self.make_chain_client(storage.clone(), chain_id);
             chain_client
                 .receive_certificate(certificate.clone())

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1078,11 +1078,19 @@ async fn test_reconfiguration(network: Network) {
     runner.run_local_net().await;
 
     let chain_1 = client.get_wallet().default_chain().unwrap();
-    let chain_2 = client.open_and_assign(&client_2).await;
 
-    let node_service_2 = match network {
-        Network::Grpc => Some(client_2.run_node_service(chain_2, 8081).await),
-        Network::Simple => None,
+    let (node_service_2, chain_2) = match network {
+        Network::Grpc => {
+            let chain_2 = client.open_and_assign(&client_2).await;
+            let node_service_2 = client_2.run_node_service(chain_2, 8081).await;
+            (Some(node_service_2), chain_2)
+        }
+        Network::Simple => {
+            client
+                .transfer(10, ChainId::root(9), ChainId::root(8))
+                .await;
+            (None, ChainId::root(9))
+        }
     };
 
     client.query_validators(None).await;


### PR DESCRIPTION
# Motivation

Some commands panicked if there were any chains that we don't have the private key to.

# Solution

Apply those commands only to owned chains.

This also updates the reconfiguration test so that the node service has the key and can receive new committees. That means the other client does not have the key to that chain when it uses those commands.