### PR TITLE
Hooks script now uses cargo machete like CI

### DIFF
--- a/scripts/install_hooks.sh
+++ b/scripts/install_hooks.sh
@@ -12,7 +12,7 @@ cargo clippy --all-targets || { echo "Error: clippy did not pass - aborting push
 
 cargo +nightly fmt -- --check --config unstable_features=true --config imports_granularity=Crate || { echo "Error: format check failed - aborting push. Please run 'cargo +nightly fmt'." ; exit 1 ; }
 
-cargo +nightly udeps --all-targets || { echo "Error: dependency check failed - aborting push." ; exit 1 ; }
+cargo machete || { echo "Error: dependency check failed - aborting push." ; exit 1 ; }
 EOF
 then
 	chmod +x $ROOT_DIR/.git/hooks/pre-push


### PR DESCRIPTION
# Motivation

Pre-Push hooks were using `udeps` being inconsistent with CI.

# Solution

Change it to Machete