### PR TITLE
Implement `try_load_multi_entry_*` for `ReentrantCollectionView`

### DIFF
--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2734,7 +2734,7 @@ where
         assert_eq!(
             admin_chain
                 .channels
-                .load_entry_mut(&admin_channel_full_name)
+                .try_load_entry_mut(&admin_channel_full_name)
                 .await
                 .unwrap()
                 .subscribers

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -435,7 +435,7 @@ where
     ) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
         for target in chain.outboxes.indices().await? {
-            let outbox = chain.outboxes.load_entry(&target).await?;
+            let outbox = chain.outboxes.try_load_entry(&target).await?;
             let heights = outbox.queue.elements().await?;
             heights_by_recipient
                 .entry(target.recipient)

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -167,9 +167,9 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -187,10 +187,10 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   let view = coll.load_entry(vec![0,1]).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   let subview = view.load_entry(vec![0, 1]).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -207,9 +207,9 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   let view = coll.try_load_entry(vec![0,1]).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   let subview = view.try_load_entry(vec![0, 1]).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -267,13 +267,13 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   *value = String::from("Hello");
-    ///   coll.reset_entry_to_default(vec![0,1]).await.unwrap();
-    ///   let view = coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   view.reset_entry_to_default(vec![0, 1]).await.unwrap();
+    ///   let subview = view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -292,12 +292,12 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   assert_eq!(*value, String::default());
-    ///   coll.remove_entry(vec![0,1]);
-    ///   let keys = coll.keys().await.unwrap();
+    ///   view.remove_entry(vec![0, 1]);
+    ///   let keys = view.keys().await.unwrap();
     ///   assert_eq!(keys.len(), 0);
     /// # })
     /// ```
@@ -367,11 +367,11 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   coll.load_entry_mut(vec![0,2]).await.unwrap();
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   view.load_entry_mut(vec![0, 2]).await.unwrap();
     ///   let mut count = 0;
-    ///   coll.for_each_key_while(|_key| {
+    ///   view.for_each_key_while(|_key| {
     ///     count += 1;
     ///     Ok(count < 1)
     ///   }).await.unwrap();
@@ -432,11 +432,11 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   coll.load_entry_mut(vec![0,2]).await.unwrap();
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   view.load_entry_mut(vec![0, 2]).await.unwrap();
     ///   let mut count = 0;
-    ///   coll.for_each_key(|_key| {
+    ///   view.for_each_key(|_key| {
     ///     count += 1;
     ///     Ok(())
     ///   }).await.unwrap();
@@ -462,11 +462,11 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(vec![0,1]).await.unwrap();
-    ///   coll.load_entry_mut(vec![0,2]).await.unwrap();
-    ///   let keys = coll.keys().await.unwrap();
-    ///   assert_eq!(keys, vec![vec![0,1],vec![0,2]]);
+    ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
+    ///   view.load_entry_mut(vec![0, 2]).await.unwrap();
+    ///   let keys = view.keys().await.unwrap();
+    ///   assert_eq!(keys, vec![vec![0, 1], vec![0, 2]]);
     /// # })
     /// ```
     pub async fn keys(&self) -> Result<Vec<Vec<u8>>, ViewError> {
@@ -594,9 +594,9 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -618,10 +618,10 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
-    ///   let view = coll.load_entry(&23).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
+    ///   let subview = view.load_entry(&23).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -643,9 +643,9 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   let view = coll.try_load_entry(&23).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   let subview = view.try_load_entry(&23).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -666,13 +666,13 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   *value = String::from("Hello");
-    ///   coll.reset_entry_to_default(&23).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   view.reset_entry_to_default(&23).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -693,12 +693,12 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   assert_eq!(*value, String::default());
-    ///   coll.remove_entry(&23);
-    ///   let keys = coll.indices().await.unwrap();
+    ///   view.remove_entry(&23);
+    ///   let keys = view.indices().await.unwrap();
     ///   assert_eq!(keys.len(), 0);
     /// # })
     /// ```
@@ -734,10 +734,10 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
-    ///   coll.load_entry_mut(&25).await.unwrap();
-    ///   let indices = coll.indices().await.unwrap();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
+    ///   view.load_entry_mut(&25).await.unwrap();
+    ///   let indices = view.indices().await.unwrap();
     ///   assert_eq!(indices.len(), 2);
     /// # })
     /// ```
@@ -769,11 +769,11 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
-    ///   coll.load_entry_mut(&24).await.unwrap();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
+    ///   view.load_entry_mut(&24).await.unwrap();
     ///   let mut count = 0;
-    ///   coll.for_each_index_while(|_key| {
+    ///   view.for_each_index_while(|_key| {
     ///     count += 1;
     ///     Ok(count < 1)
     ///   }).await.unwrap();
@@ -802,11 +802,11 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
-    ///   coll.load_entry_mut(&28).await.unwrap();
+    ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
+    ///   view.load_entry_mut(&28).await.unwrap();
     ///   let mut count = 0;
-    ///   coll.for_each_index(|_key| {
+    ///   view.for_each_index(|_key| {
     ///     count += 1;
     ///     Ok(())
     ///   }).await.unwrap();
@@ -906,9 +906,9 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -930,10 +930,10 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
-    ///   let view = coll.load_entry(&23).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
+    ///   let subview = view.load_entry(&23).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -955,9 +955,9 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   let view = coll.try_load_entry(&23).await.unwrap();
-    ///   let value = view.get();
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   let subview = view.try_load_entry(&23).await.unwrap();
+    ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -978,13 +978,13 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   *value = String::from("Hello");
-    ///   coll.reset_entry_to_default(&23).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   view.reset_entry_to_default(&23).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
@@ -1005,12 +1005,12 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   let view = coll.load_entry_mut(&23).await.unwrap();
-    ///   let value = view.get_mut();
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   let subview = view.load_entry_mut(&23).await.unwrap();
+    ///   let value = subview.get_mut();
     ///   assert_eq!(*value, String::default());
-    ///   coll.remove_entry(&23);
-    ///   let keys = coll.indices().await.unwrap();
+    ///   view.remove_entry(&23);
+    ///   let keys = view.indices().await.unwrap();
     ///   assert_eq!(keys.len(), 0);
     /// # })
     /// ```
@@ -1045,11 +1045,11 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
-    ///   coll.load_entry_mut(&25).await.unwrap();
-    ///   let indices = coll.indices().await.unwrap();
-    ///   assert_eq!(indices, vec![23,25]);
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
+    ///   view.load_entry_mut(&25).await.unwrap();
+    ///   let indices = view.indices().await.unwrap();
+    ///   assert_eq!(indices, vec![23, 25]);
     /// # })
     /// ```
     pub async fn indices(&self) -> Result<Vec<I>, ViewError> {
@@ -1080,16 +1080,16 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&28).await.unwrap();
-    ///   coll.load_entry_mut(&24).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&28).await.unwrap();
+    ///   view.load_entry_mut(&24).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
     ///   let mut part_indices = Vec::new();
-    ///   coll.for_each_index_while(|index| {
+    ///   view.for_each_index_while(|index| {
     ///     part_indices.push(index);
     ///     Ok(part_indices.len() < 2)
     ///   }).await.unwrap();
-    ///   assert_eq!(part_indices, vec![23,24]);
+    ///   assert_eq!(part_indices, vec![23, 24]);
     /// # })
     /// ```
     pub async fn for_each_index_while<F>(&self, mut f: F) -> Result<(), ViewError>
@@ -1114,16 +1114,16 @@ where
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_test_context();
-    ///   let mut coll : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
-    ///   coll.load_entry_mut(&28).await.unwrap();
-    ///   coll.load_entry_mut(&24).await.unwrap();
-    ///   coll.load_entry_mut(&23).await.unwrap();
+    ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
+    ///   view.load_entry_mut(&28).await.unwrap();
+    ///   view.load_entry_mut(&24).await.unwrap();
+    ///   view.load_entry_mut(&23).await.unwrap();
     ///   let mut indices = Vec::new();
-    ///   coll.for_each_index(|index| {
+    ///   view.for_each_index(|index| {
     ///     indices.push(index);
     ///     Ok(())
     ///   }).await.unwrap();
-    ///   assert_eq!(indices, vec![23,24,28]);
+    ///   assert_eq!(indices, vec![23, 24, 28]);
     /// # })
     /// ```
     pub async fn for_each_index<F>(&self, mut f: F) -> Result<(), ViewError>

--- a/linera-views/tests/reentrant_tests.rs
+++ b/linera-views/tests/reentrant_tests.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_views::{
+    memory::create_test_context,
+    reentrant_collection_view::ReentrantCollectionView,
+    register_view::RegisterView,
+    views::{CryptoHashRootView, RootView, View},
+};
+use rand::{Rng, SeedableRng};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(CryptoHashRootView)]
+pub struct StateView<C> {
+    pub v: ReentrantCollectionView<C, u8, RegisterView<C, u32>>,
+}
+
+#[tokio::test]
+async fn reentrant_collection_view_check() {
+    let context = create_test_context();
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    let mut map = BTreeMap::<u8, u32>::new();
+    let n = 20;
+    let nmax: u8 = 25;
+    for _ in 0..n {
+        let mut view = StateView::load(context.clone()).await.unwrap();
+        let save = rng.gen::<bool>();
+        //
+        let count_oper = rng.gen_range(0, 25);
+        let mut new_map = map.clone();
+        for _ in 0..count_oper {
+            let thr = rng.gen_range(0, 5);
+            if thr == 0 {
+                // deleting random stuff
+                let pos = rng.gen_range(0, nmax);
+                view.v.remove_entry(&pos).unwrap();
+                new_map.remove(&pos);
+            }
+            if thr == 1 {
+                // getting an array of reference
+                let mut indices = Vec::new();
+                let mut set_indices = BTreeSet::new();
+                let mut values = Vec::new();
+                let n_ins = rng.gen_range(0, 5);
+                for _i in 0..n_ins {
+                    let pos = rng.gen_range(0, nmax);
+                    indices.push(pos);
+                    set_indices.insert(pos);
+                    let value = rng.gen::<u32>();
+                    values.push(value);
+                }
+                // Only if all indices are distinct can the query
+                if set_indices.len() == n_ins {
+                    let mut subviews = view.v.try_load_entries_mut(indices.clone()).await.unwrap();
+                    for i in 0..n_ins {
+                        let index = indices[i];
+                        let value = values[i];
+                        *subviews[i].get_mut() = value;
+                        new_map.insert(index, value);
+                    }
+                }
+            }
+            if thr == 2 {
+                // changing some random entries
+                let n_ins = rng.gen_range(0, 5);
+                for _i in 0..n_ins {
+                    let pos = rng.gen_range(0, nmax);
+                    let value = rng.gen::<u32>();
+                    let mut subview = view.v.try_load_entry_mut(&pos).await.unwrap();
+                    *subview.get_mut() = value;
+                    new_map.insert(pos, value);
+                }
+            }
+            if thr == 3 {
+                // Doing the clearing
+                view.clear();
+                new_map.clear();
+            }
+            if thr == 4 {
+                // Doing the rollback
+                view.rollback();
+                new_map = map.clone();
+            }
+            // Checking the keys
+            let keys_view = view.v.indices().await.unwrap();
+            let keys_view = keys_view.into_iter().collect::<BTreeSet<_>>();
+            let keys_map = new_map.clone().into_keys().collect::<BTreeSet<_>>();
+            assert_eq!(keys_view, keys_map);
+            // Checking the try_load_entries on all indices
+            let indices = keys_map.clone().into_iter().collect::<Vec<_>>();
+            let subviews = view.v.try_load_entries(indices.clone()).await.unwrap();
+            for i in 0..keys_map.len() {
+                let index: u8 = indices[i];
+                let value_view = *subviews[i].get();
+                let value_map = match new_map.get(&index) {
+                    None => 0,
+                    Some(value) => *value,
+                };
+                assert_eq!(value_view, value_map);
+            }
+        }
+        if save {
+            map = new_map.clone();
+            view.save().await.unwrap();
+        }
+    }
+}


### PR DESCRIPTION
The PR implements the multi loading for the `ReentrantCollectionView`.

But it does more:
* It also replaces the `channels` and `outboxes` by a `ReentrantCollectionView`.
* The `ReentrantCollectionView` and `ReentrantCustomCollectionView` are now supported by the `GraphQL` macros.
* The `chain.rs` code has been restructured for accounting of that and should work better out of it.

This is an improvement with respect to preceding code, more improvements are needed using async streams. That being said, I think the API is of general interest whether we end up using only async streams or not.