### PR TITLE
Use `read_multi_key_bytes` for the `RegisterView`

### DIFF
--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     batch::Batch,
-    common::{Context, HasherOutput, MIN_VIEW_TAG},
+    common::{from_bytes_opt, Context, HasherOutput, MIN_VIEW_TAG},
     views::{HashableView, Hasher, View, ViewError},
 };
 use async_lock::Mutex;
@@ -42,10 +42,12 @@ where
     }
 
     async fn load(context: C) -> Result<Self, ViewError> {
-        let key = context.base_tag(KeyTag::Value as u8);
-        let stored_value = Box::new(context.read_key(&key).await?.unwrap_or_default());
-        let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_key(&key).await?;
+        let key1 = context.base_tag(KeyTag::Value as u8);
+        let key2 = context.base_tag(KeyTag::Hash as u8);
+        let keys = vec![key1, key2];
+        let values_bytes = context.read_multi_key_bytes(keys).await?;
+        let stored_value = Box::new(from_bytes_opt(values_bytes[0].clone())?.unwrap_or_default());
+        let hash = from_bytes_opt(values_bytes[1].clone())?;
         Ok(Self {
             context,
             stored_value,


### PR DESCRIPTION
It is similar to the one for `QueueView` and `LogView`. This gain some more asynchronicity to the load operation, which is a significant gain.