### PR TITLE
Remove SystemExecutionState::available_fuel.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -383,8 +383,9 @@ where
             ChainError::InvalidBlockTimestamp
         );
         self.execution_state.system.timestamp.set(block.timestamp);
-        self.execution_state.add_fuel(10_000_000);
         let mut effects = Vec::new();
+        let available_fuel = 10_000_000;
+        let mut remaining_fuel = available_fuel;
         for message in &block.incoming_messages {
             // Execute the received effect.
             let context = EffectContext {
@@ -400,7 +401,7 @@ where
             };
             let results = self
                 .execution_state
-                .execute_effect(&context, &message.event.effect)
+                .execute_effect(&context, &message.event.effect, &mut remaining_fuel)
                 .await?;
             self.process_execution_results(&mut effects, context.height, results)
                 .await?;
@@ -419,7 +420,7 @@ where
             };
             let results = self
                 .execution_state
-                .execute_operation(&context, operation)
+                .execute_operation(&context, operation, &mut remaining_fuel)
                 .await?;
             self.process_execution_results(&mut effects, context.height, results)
                 .await?;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -149,7 +149,7 @@ where
         timestamp: Timestamp::from(1),
         registry: ApplicationRegistry::default(),
     };
-    let publisher_state_hash = make_state_hash(publisher_system_state.clone(), 10_000_000).await;
+    let publisher_state_hash = make_state_hash(publisher_system_state.clone()).await;
     let publish_block_proposal = HashedValue::new_confirmed(
         publish_block,
         vec![OutgoingEffect {
@@ -212,7 +212,7 @@ where
         .registry
         .published_bytecodes
         .insert(bytecode_id, bytecode_location);
-    let publisher_state_hash = make_state_hash(publisher_system_state.clone(), 20_000_000).await;
+    let publisher_state_hash = make_state_hash(publisher_system_state.clone()).await;
     let broadcast_block_proposal = HashedValue::new_confirmed(
         broadcast_block,
         vec![OutgoingEffect {
@@ -271,9 +271,7 @@ where
         timestamp: Timestamp::from(2),
         registry: ApplicationRegistry::default(),
     };
-    let creator_state = ExecutionStateView::from_system_state(creator_system_state.clone())
-        .await
-        .with_fuel(10_000_000);
+    let creator_state = ExecutionStateView::from_system_state(creator_system_state.clone()).await;
     let subscribe_block_proposal = HashedValue::new_confirmed(
         subscribe_block,
         vec![OutgoingEffect {
@@ -319,7 +317,7 @@ where
         Timestamp::from(3),
     );
     publisher_system_state.timestamp = Timestamp::from(3);
-    let publisher_state_hash = make_state_hash(publisher_system_state, 30_000_000).await;
+    let publisher_state_hash = make_state_hash(publisher_system_state).await;
     let accept_block_proposal = HashedValue::new_confirmed(
         accept_block,
         vec![OutgoingEffect {
@@ -401,9 +399,7 @@ where
         .known_applications
         .insert(application_id, application_description.clone());
     creator_system_state.timestamp = Timestamp::from(4);
-    let mut creator_state = ExecutionStateView::from_system_state(creator_system_state)
-        .await
-        .with_fuel(20_000_000);
+    let mut creator_state = ExecutionStateView::from_system_state(creator_system_state).await;
     creator_state
         .simulate_initialization(
             application,
@@ -456,7 +452,6 @@ where
         index: 0,
         next_effect_index: 0,
     };
-    creator_state.add_fuel(10_000_000);
     creator_state
         .execute_operation(
             &operation_context,
@@ -464,6 +459,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
+            &mut 10_000_000,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(5));

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -48,10 +48,9 @@ struct Dummy;
 
 impl BcsSignable for Dummy {}
 
-async fn make_state_hash(state: SystemExecutionState, fuel: u64) -> CryptoHash {
+async fn make_state_hash(state: SystemExecutionState) -> CryptoHash {
     ExecutionStateView::from_system_state(state)
         .await
-        .with_fuel(fuel)
         .crypto_hash()
         .await
         .expect("hashing from memory should not fail")
@@ -262,8 +261,7 @@ async fn make_transfer_certificate_for_epoch<S>(
         )],
         Recipient::Burn => Vec::new(),
     };
-    let available_fuel = (block.height.0 + 1) * 10_000_000;
-    let state_hash = make_state_hash(system_state, available_fuel).await;
+    let state_hash = make_state_hash(system_state).await;
     let value = HashedValue::new_confirmed(block, effects, state_hash);
     make_certificate(committee, worker, value)
 }
@@ -527,7 +525,7 @@ where
             timestamp: Timestamp::from(block_0_time),
             registry: ApplicationRegistry::default(),
         };
-        let state_hash = make_state_hash(system_state, 10_000_000).await;
+        let state_hash = make_state_hash(system_state).await;
         let value = HashedValue::new_confirmed(block, vec![], state_hash);
         make_certificate(&committee, &worker, value)
     };
@@ -840,21 +838,18 @@ where
                     },
                 ),
             ],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(epoch),
-                    description: Some(ChainDescription::Root(1)),
-                    admin_id: Some(ChainId::root(0)),
-                    subscriptions: BTreeSet::new(),
-                    committees: [(epoch, committee.clone())].into_iter().collect(),
-                    ownership: ChainOwnership::single(sender_key_pair.public()),
-                    balance: Balance::from(3),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                10_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(epoch),
+                description: Some(ChainDescription::Root(1)),
+                admin_id: Some(ChainId::root(0)),
+                subscriptions: BTreeSet::new(),
+                committees: [(epoch, committee.clone())].into_iter().collect(),
+                ownership: ChainOwnership::single(sender_key_pair.public()),
+                balance: Balance::from(3),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -885,21 +880,18 @@ where
                     amount: Amount::from(3),
                 },
             )],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(epoch),
-                    description: Some(ChainDescription::Root(1)),
-                    admin_id: Some(ChainId::root(0)),
-                    subscriptions: BTreeSet::new(),
-                    committees: [(epoch, committee.clone())].into_iter().collect(),
-                    ownership: ChainOwnership::single(sender_key_pair.public()),
-                    balance: Balance::from(0),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                20_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(epoch),
+                description: Some(ChainDescription::Root(1)),
+                admin_id: Some(ChainId::root(0)),
+                subscriptions: BTreeSet::new(),
+                committees: [(epoch, committee.clone())].into_iter().collect(),
+                ownership: ChainOwnership::single(sender_key_pair.public()),
+                balance: Balance::from(0),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -1174,21 +1166,18 @@ where
                         amount: Amount::from(1),
                     },
                 )],
-                make_state_hash(
-                    SystemExecutionState {
-                        epoch: Some(epoch),
-                        description: Some(ChainDescription::Root(2)),
-                        admin_id: Some(ChainId::root(0)),
-                        subscriptions: BTreeSet::new(),
-                        committees: [(epoch, committee.clone())].into_iter().collect(),
-                        ownership: ChainOwnership::single(recipient_key_pair.public()),
-                        balance: Balance::from(0),
-                        balances: BTreeMap::new(),
-                        timestamp: Timestamp::from(0),
-                        registry: ApplicationRegistry::default(),
-                    },
-                    10_000_000,
-                )
+                make_state_hash(SystemExecutionState {
+                    epoch: Some(epoch),
+                    description: Some(ChainDescription::Root(2)),
+                    admin_id: Some(ChainId::root(0)),
+                    subscriptions: BTreeSet::new(),
+                    committees: [(epoch, committee.clone())].into_iter().collect(),
+                    ownership: ChainOwnership::single(recipient_key_pair.public()),
+                    balance: Balance::from(0),
+                    balances: BTreeMap::new(),
+                    timestamp: Timestamp::from(0),
+                    registry: ApplicationRegistry::default(),
+                })
                 .await,
             ),
         );
@@ -2557,21 +2546,18 @@ where
                     },
                 ),
             ],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(0)),
-                    description: Some(ChainDescription::Root(0)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    committees: committees.clone(),
-                    ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(2),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                10_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(0)),
+                description: Some(ChainDescription::Root(0)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                committees: committees.clone(),
+                ownership: ChainOwnership::single(key_pair.public()),
+                balance: Balance::from(2),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -2648,22 +2634,19 @@ where
                     },
                 ),
             ],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(1)),
-                    description: Some(ChainDescription::Root(0)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    // The root chain knows both committees at the end.
-                    committees: committees2.clone(),
-                    ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(0),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                20_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(1)),
+                description: Some(ChainDescription::Root(0)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                // The root chain knows both committees at the end.
+                committees: committees2.clone(),
+                ownership: ChainOwnership::single(key_pair.public()),
+                balance: Balance::from(0),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -2704,22 +2687,19 @@ where
                 user_id,
                 SystemEffect::Notify { id: user_id },
             )],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(1)),
-                    description: Some(ChainDescription::Root(0)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    // The root chain knows both committees at the end.
-                    committees: committees2.clone(),
-                    ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(0),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                30_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(1)),
+                description: Some(ChainDescription::Root(0)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                // The root chain knows both committees at the end.
+                committees: committees2.clone(),
+                ownership: ChainOwnership::single(key_pair.public()),
+                balance: Balance::from(0),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -2877,27 +2857,24 @@ where
                 timestamp: Timestamp::from(0),
             },
             Vec::new(),
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(1)),
-                    description: Some(user_description),
-                    admin_id: Some(admin_id),
-                    subscriptions: [ChannelSubscription {
-                        chain_id: admin_id,
-                        name: SystemChannel::Admin.name(),
-                    }]
-                    .into_iter()
-                    .collect(),
-                    // Finally the child knows about both committees and has the money.
-                    committees: committees2.clone(),
-                    ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(2),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                10_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(1)),
+                description: Some(user_description),
+                admin_id: Some(admin_id),
+                subscriptions: [ChannelSubscription {
+                    chain_id: admin_id,
+                    name: SystemChannel::Admin.name(),
+                }]
+                .into_iter()
+                .collect(),
+                // Finally the child knows about both committees and has the money.
+                committees: committees2.clone(),
+                ownership: ChainOwnership::single(key_pair.public()),
+                balance: Balance::from(2),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -3041,21 +3018,18 @@ where
                     amount: Amount::from(1),
                 },
             )],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(0)),
-                    description: Some(ChainDescription::Root(1)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    committees: committees.clone(),
-                    ownership: ChainOwnership::single(key_pair1.public()),
-                    balance: Balance::from(2),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                10_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(0)),
+                description: Some(ChainDescription::Root(1)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                committees: committees.clone(),
+                ownership: ChainOwnership::single(key_pair1.public()),
+                balance: Balance::from(2),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -3090,21 +3064,18 @@ where
                     committees: committees2.clone(),
                 },
             )],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(1)),
-                    description: Some(ChainDescription::Root(0)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    committees: committees2.clone(),
-                    ownership: ChainOwnership::single(key_pair0.public()),
-                    balance: Balance::from(0),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                10_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(1)),
+                description: Some(ChainDescription::Root(0)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                committees: committees2.clone(),
+                ownership: ChainOwnership::single(key_pair0.public()),
+                balance: Balance::from(0),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -3238,21 +3209,18 @@ where
                     amount: Amount::from(1),
                 },
             )],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(0)),
-                    description: Some(ChainDescription::Root(1)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    committees: committees.clone(),
-                    ownership: ChainOwnership::single(key_pair1.public()),
-                    balance: Balance::from(2),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                10_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(0)),
+                description: Some(ChainDescription::Root(1)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                committees: committees.clone(),
+                ownership: ChainOwnership::single(key_pair1.public()),
+                balance: Balance::from(2),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -3304,21 +3272,18 @@ where
                     },
                 ),
             ],
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(1)),
-                    description: Some(ChainDescription::Root(0)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    committees: committees3.clone(),
-                    ownership: ChainOwnership::single(key_pair0.public()),
-                    balance: Balance::from(0),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                10_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(1)),
+                description: Some(ChainDescription::Root(0)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                committees: committees3.clone(),
+                ownership: ChainOwnership::single(key_pair0.public()),
+                balance: Balance::from(0),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );
@@ -3383,21 +3348,18 @@ where
                 timestamp: Timestamp::from(0),
             },
             Vec::new(),
-            make_state_hash(
-                SystemExecutionState {
-                    epoch: Some(Epoch::from(1)),
-                    description: Some(ChainDescription::Root(0)),
-                    admin_id: Some(admin_id),
-                    subscriptions: BTreeSet::new(),
-                    committees: committees3.clone(),
-                    ownership: ChainOwnership::single(key_pair0.public()),
-                    balance: Balance::from(1),
-                    balances: BTreeMap::new(),
-                    timestamp: Timestamp::from(0),
-                    registry: ApplicationRegistry::default(),
-                },
-                20_000_000,
-            )
+            make_state_hash(SystemExecutionState {
+                epoch: Some(Epoch::from(1)),
+                description: Some(ChainDescription::Root(0)),
+                admin_id: Some(admin_id),
+                subscriptions: BTreeSet::new(),
+                committees: committees3.clone(),
+                ownership: ChainOwnership::single(key_pair0.public()),
+                balance: Balance::from(1),
+                balances: BTreeMap::new(),
+                timestamp: Timestamp::from(0),
+                registry: ApplicationRegistry::default(),
+            })
             .await,
         ),
     );

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -52,6 +52,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![],
             },
+            &mut 10_000_000,
         )
         .await;
 
@@ -223,6 +224,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![1],
             },
+            &mut 10_000_000,
         )
         .await
         .unwrap();
@@ -293,6 +295,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
                 application_id: app_id,
                 bytes: vec![],
             },
+            &mut 10_000_000,
         )
         .await;
 

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -39,7 +39,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         next_effect_index: 0,
     };
     let results = view
-        .execute_operation(&context, &Operation::System(operation))
+        .execute_operation(&context, &Operation::System(operation), &mut 10_000_000)
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Balance::from(0));
@@ -78,7 +78,7 @@ async fn test_simple_system_effect() -> anyhow::Result<()> {
         authenticated_signer: None,
     };
     let results = view
-        .execute_effect(&context, &Effect::System(effect))
+        .execute_effect(&context, &Effect::System(effect), &mut 10_000_000)
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Balance::from(4));

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -23,14 +23,14 @@ use test_case::test_case;
 /// called correctly and consume the expected amount of fuel.
 ///
 /// To update the bytecode files, run `linera-execution/update_wasm_fixtures.sh`.
-#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer, 9_968_006; "wasmer"))]
-#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::WasmerWithSanitizer, 9_967_655; "wasmer_with_sanitizer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime, 9_967_655 ; "wasmtime"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::WasmtimeWithSanitizer, 9_967_655 ; "wasmtime_with_sanitizer"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer, 31_994; "wasmer"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmRuntime::WasmerWithSanitizer, 32_345; "wasmer_with_sanitizer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime, 32_345 ; "wasmtime"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::WasmtimeWithSanitizer, 32_345 ; "wasmtime_with_sanitizer"))]
 #[test_log::test(tokio::test)]
 async fn test_fuel_for_counter_wasm_application(
     wasm_runtime: WasmRuntime,
-    expected_gas: u64,
+    expected_fuel: u64,
 ) -> anyhow::Result<()> {
     let state = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
@@ -38,8 +38,7 @@ async fn test_fuel_for_counter_wasm_application(
     };
     let mut view =
         ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await
-            .with_fuel(10_000_000);
+            .await;
     let app_desc = create_dummy_user_application_description();
     let app_id = view
         .system
@@ -66,6 +65,8 @@ async fn test_fuel_for_counter_wasm_application(
         next_effect_index: 0,
     };
     let increments = [2_u64, 9, 7, 1000];
+    let available_fuel = 10_000_000;
+    let mut remaining_fuel = available_fuel;
     for increment in &increments {
         let operation = bcs::to_bytes(increment).expect("Serialization of u64 failed");
         let result = view
@@ -75,6 +76,7 @@ async fn test_fuel_for_counter_wasm_application(
                     application_id: app_id,
                     bytes: operation,
                 },
+                &mut remaining_fuel,
             )
             .await?;
         assert_eq!(
@@ -83,7 +85,7 @@ async fn test_fuel_for_counter_wasm_application(
         );
     }
 
-    assert_eq!(*view.available_fuel.get(), expected_gas);
+    assert_eq!(available_fuel - remaining_fuel, expected_fuel);
 
     let context = QueryContext {
         chain_id: ChainId::root(0),


### PR DESCRIPTION
# Motivation

We will likely have different pricing categories, like storage and messaging, in addition to the fuel for Wasm execution. Pre-paying all of them is complicated for the user. It's easier to specify a cost limit in the block proposal, or just compute the cost locally before submitting it.

# Solution

Remove `available_fuel` from the execution state. The limit is per block instead.