### PR TITLE
Resolve a bug in GraphQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2781,6 +2781,7 @@ version = "0.1.0"
 dependencies = [
  "async-graphql",
  "convert_case 0.6.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
+heck = "0.4.1"
 anyhow = "1.0.57"
 async-graphql = "5.0.7"
 async-graphql-axum = "5.0.5"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1370,6 +1370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1807,6 +1813,7 @@ version = "0.1.0"
 dependencies = [
  "async-graphql",
  "convert_case 0.6.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "serde",
@@ -1829,7 +1836,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7cbe0895b566d675ec18881efb52b0871b4f487f7d23df9a2d837fc543ebc4"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "linera-wit-bindgen-core",
  "linera-wit-bindgen-gen-rust-lib",
 ]
@@ -1840,7 +1847,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95d531afaf2990383a8a0c3dbdd200dfd4c4ccd58c62e43f9efd74d5b0b70927"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "linera-wit-bindgen-core",
  "linera-wit-bindgen-gen-rust-lib",
 ]
@@ -1851,7 +1858,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95dbd8133b71d70b457b233848eac2227c0d90d99a318e0cd0688d44db97e08d"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "linera-wit-bindgen-core",
  "linera-wit-bindgen-gen-rust-lib",
 ]
@@ -1862,7 +1869,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "722e038115235d09f1d6351ff97b9663dd2fcf0245076c551700e8aefa191767"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "linera-wit-bindgen-core",
 ]
 

--- a/linera-views-derive/Cargo.toml
+++ b/linera-views-derive/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [dependencies]
 syn = { workspace = true, features = ["full", "extra-traits"] }
+heck = { workspace = true }
 quote = { workspace = true }
 proc-macro2 = { workspace = true }
 convert_case = { workspace = true }

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -5,9 +5,11 @@
 
 pub(crate) mod util;
 
+extern crate heck;
 extern crate proc_macro;
 extern crate syn;
-use crate::util::{capitalize_first_character, concat, snakify, string_to_ident};
+use crate::util::{concat, snakify, string_to_ident};
+use heck::AsUpperCamelCase;
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
@@ -392,8 +394,9 @@ fn generate_graphql_code_for_field(
 
             let index_name = snakify(index_ident);
 
-            let camel_index_name = capitalize_first_character(&format!("{}", field_name));
-            let entry_name = format!("{}{}{}", struct_name, camel_index_name, "Entry");
+            let camel_index_name = format!("{}", field_name);
+            let camel_index_name = AsUpperCamelCase(&camel_index_name);
+            let entry_name = format!("{}{}Entry", struct_name, camel_index_name);
             let entry_name = string_to_ident(&entry_name);
             let context_generics = context_constraints.as_ref().map(|_| quote! { <#context> });
 

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -7,7 +7,7 @@ pub(crate) mod util;
 
 extern crate proc_macro;
 extern crate syn;
-use crate::util::{concat, create_entry_name, snakify};
+use crate::util::{capitalize_first_character, concat, snakify, string_to_ident};
 use proc_macro::TokenStream;
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote};
@@ -345,6 +345,7 @@ fn generic_offset(
 }
 
 fn generate_graphql_code_for_field(
+    struct_name: syn::Ident,
     context: Type,
     context_constraints: Option<TokenStream2>,
     field: Field,
@@ -390,7 +391,10 @@ fn generate_graphql_code_for_field(
                 .unwrap_or_else(|| panic!("no generic type specified for '{}'", view_name));
 
             let index_name = snakify(index_ident);
-            let entry_name = create_entry_name(generic_ident);
+
+            let camel_index_name = capitalize_first_character(&format!("{}", field_name));
+            let entry_name = format!("{}{}{}", struct_name, camel_index_name, "Entry");
+            let entry_name = string_to_ident(&entry_name);
             let context_generics = context_constraints.as_ref().map(|_| quote! { <#context> });
 
             let r#impl = quote! {
@@ -588,8 +592,12 @@ fn generate_graphql_code(input: ItemStruct) -> TokenStream2 {
     let mut structs = vec![];
 
     for field in input.fields {
-        let (r#impl, r#struct) =
-            generate_graphql_code_for_field(context.clone(), context_constraints.clone(), field);
+        let (r#impl, r#struct) = generate_graphql_code_for_field(
+            struct_name.clone(),
+            context.clone(),
+            context_constraints.clone(),
+            field,
+        );
         impls.push(r#impl);
         if let Some(r#struct) = r#struct {
             structs.push(r#struct);
@@ -944,7 +952,7 @@ pub mod tests {
                 let output = generate_graphql_code(input);
 
                 let expected = quote! {
-                    pub struct SomeOtherViewEntry #generics_with_lifetime
+                    pub struct TestViewCollectionEntry #generics_with_lifetime
                     #constraints
                     {
                         string: String,
@@ -954,7 +962,7 @@ pub mod tests {
                         >,
                     }
                     #[async_graphql::Object]
-                    impl #generics_with_lifetime SomeOtherViewEntry #generics_with_lifetime
+                    impl #generics_with_lifetime TestViewCollectionEntry #generics_with_lifetime
                     #constraints
                     {
                         async fn string(&self) -> &String {
@@ -980,8 +988,8 @@ pub mod tests {
                         async fn collection(
                             &self,
                             string: String,
-                        ) -> Result<SomeOtherViewEntry #generics, async_graphql::Error> {
-                            Ok(SomeOtherViewEntry {
+                        ) -> Result<TestViewCollectionEntry #generics, async_graphql::Error> {
+                            Ok(TestViewCollectionEntry {
                                 string: string.clone(),
                                 guard: self.collection.try_load_entry(&string).await?,
                             })

--- a/linera-views-derive/src/util.rs
+++ b/linera-views-derive/src/util.rs
@@ -10,9 +10,18 @@ pub fn snakify(r#type: &Type) -> Ident {
     transform_type_to_ident(r#type, |s: String| s.to_case(Case::Snake))
 }
 
-/// Extracts the first `Ident` in a type and append the string 'Element' to the end.
-pub fn create_entry_name(r#type: &Type) -> Ident {
-    transform_type_to_ident(r#type, |s: String| format!("{}{}", s, "Entry"))
+/// Capitalize the first character of a string
+pub fn capitalize_first_character(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().chain(c).collect(),
+    }
+}
+
+/// Convert a string into an identifier
+pub fn string_to_ident(s: &str) -> Ident {
+    syn::Ident::new(s, Span::call_site())
 }
 
 /// Extends an identifier with a suffix.

--- a/linera-views-derive/src/util.rs
+++ b/linera-views-derive/src/util.rs
@@ -10,15 +10,6 @@ pub fn snakify(r#type: &Type) -> Ident {
     transform_type_to_ident(r#type, |s: String| s.to_case(Case::Snake))
 }
 
-/// Capitalize the first character of a string
-pub fn capitalize_first_character(s: &str) -> String {
-    let mut c = s.chars();
-    match c.next() {
-        None => String::new(),
-        Some(f) => f.to_uppercase().chain(c).collect(),
-    }
-}
-
 /// Convert a string into an identifier
 pub fn string_to_ident(s: &str) -> Ident {
     syn::Ident::new(s, Span::call_site())


### PR DESCRIPTION
The problem is the following. The following code does not compile
```rust
struct TestView<C> {
  view: RegisterView<C, String>,
}

#[derive(GraphQLView)]
struct BlockView<C> {
  bids: CollectionView<C,String, TestView<C>>,
  asks: CollectionView<C,String, TestView<C>>,
}
```
The reason is that the code for `TestViewEntry` is generated two times.
The solution is to generate two codes: `TestViewBlockViewbidsEntry` and `TestViewBlockViewasksEntry` so as to avoid the namespace collision.

This is the only solution that makes sense. This is because the generated code refers both to the key and to the value. So, we cannot generate a `TestViewEntry` at the level of the `TestView`.