### PR TITLE
Use `try_load_entries_*` more systematically

### DIFF
--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1684,7 +1684,7 @@ where
         BlockHeight::from(0),
         chain
             .inboxes
-            .load_entry_mut(&Origin::chain(ChainId::root(3)))
+            .try_load_entry_mut(&Origin::chain(ChainId::root(3)))
             .await
             .unwrap()
             .next_block_height_to_receive()
@@ -1693,7 +1693,7 @@ where
     assert_eq!(
         chain
             .inboxes
-            .load_entry_mut(&Origin::chain(ChainId::root(3)))
+            .try_load_entry_mut(&Origin::chain(ChainId::root(3)))
             .await
             .unwrap()
             .added_events
@@ -1703,7 +1703,7 @@ where
     assert!(matches!(
         chain
             .inboxes
-            .load_entry_mut(&Origin::chain(ChainId::root(3)))
+            .try_load_entry_mut(&Origin::chain(ChainId::root(3)))
             .await
             .unwrap()
             .removed_events
@@ -1901,7 +1901,7 @@ where
         BlockHeight::from(1),
         chain
             .inboxes
-            .load_entry_mut(&Origin::chain(ChainId::root(1)))
+            .try_load_entry_mut(&Origin::chain(ChainId::root(1)))
             .await
             .unwrap()
             .next_block_height_to_receive()
@@ -1910,7 +1910,7 @@ where
     assert!(matches!(
         chain
             .inboxes
-            .load_entry_mut(&Origin::chain(ChainId::root(1)))
+            .try_load_entry_mut(&Origin::chain(ChainId::root(1)))
             .await
             .unwrap()
             .added_events
@@ -2023,7 +2023,7 @@ where
         BlockHeight::from(1),
         chain
             .inboxes
-            .load_entry_mut(&Origin::chain(ChainId::root(1)))
+            .try_load_entry_mut(&Origin::chain(ChainId::root(1)))
             .await
             .unwrap()
             .next_block_height_to_receive()
@@ -2032,7 +2032,7 @@ where
     assert!(matches!(
         chain
             .inboxes
-            .load_entry_mut(&Origin::chain(ChainId::root(1)))
+            .try_load_entry_mut(&Origin::chain(ChainId::root(1)))
             .await
             .unwrap()
             .added_events
@@ -2771,7 +2771,7 @@ where
         matches!(
             user_chain
                 .inboxes
-                .load_entry_mut(&Origin::chain(admin_id))
+                .try_load_entry_mut(&Origin::chain(admin_id))
                 .await
                 .unwrap()
                 .added_events
@@ -2796,7 +2796,7 @@ where
         matches!(
             user_chain
                 .inboxes
-                .load_entry_mut(&admin_channel_origin)
+                .try_load_entry_mut(&admin_channel_origin)
                 .await
                 .unwrap()
                 .added_events
@@ -2811,7 +2811,7 @@ where
         assert_eq!(
             user_chain
                 .inboxes
-                .load_entry_mut(&admin_channel_origin)
+                .try_load_entry_mut(&admin_channel_origin)
                 .await
                 .unwrap()
                 .removed_events
@@ -2931,7 +2931,7 @@ where
         {
             let inbox = user_chain
                 .inboxes
-                .load_entry_mut(&Origin::chain(admin_id))
+                .try_load_entry_mut(&Origin::chain(admin_id))
                 .await
                 .unwrap();
             assert_eq!(
@@ -2944,7 +2944,7 @@ where
         {
             let inbox = user_chain
                 .inboxes
-                .load_entry_mut(&admin_channel_origin)
+                .try_load_entry_mut(&admin_channel_origin)
                 .await
                 .unwrap();
             assert_eq!(
@@ -3140,7 +3140,7 @@ where
     matches!(
         admin_chain
             .inboxes
-            .load_entry_mut(&Origin::chain(user_id))
+            .try_load_entry_mut(&Origin::chain(user_id))
             .await
             .unwrap()
             .added_events

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -342,9 +342,10 @@ where
     ) -> Result<(), NodeError> {
         let mut info = BTreeMap::new();
         {
-            let mut chain = self.store.load_chain(chain_id).await?;
-            for origin in chain.inboxes.indices().await? {
-                let inbox = chain.inboxes.load_entry(&origin).await?;
+            let chain = self.store.load_chain(chain_id).await?;
+            let origins = chain.inboxes.indices().await?;
+            let inboxes = chain.inboxes.try_load_entries(origins.clone()).await?;
+            for (origin, inbox) in origins.into_iter().zip(inboxes) {
                 let next_height = info.entry(origin.sender).or_default();
                 let inbox_next_height = inbox.next_block_height_to_receive()?;
                 if inbox_next_height > *next_height {


### PR DESCRIPTION
After the previous merge, I realize that there are more places where we can use `try_load_entries` and reduce the asynchronicity burden.
