### PR TITLE
Remove Balance, use Amount for everything and make it 128 bits.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -121,6 +121,7 @@ jobs:
         cd examples
         cargo fmt -- --check --config unstable_features=true --config imports_granularity=Crate
         cargo clippy --all-targets --all-features --target wasm32-unknown-unknown --locked
+        cargo clippy --all-targets --all-features --target x86_64-unknown-linux-gnu --locked
     - name: Run clippy
       run: |
         cargo clippy --all-targets --all-features --tests --locked

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -40,7 +40,7 @@ async fn cross_chain_transfer() {
                 application_id,
                 Operation::Transfer {
                     owner: sender_account,
-                    amount: transfer_amount.into(),
+                    amount: transfer_amount,
                     target_account: Account {
                         chain_id: receiver_chain.id(),
                         owner: receiver_account,
@@ -81,11 +81,11 @@ async fn query_account(
         .get("data")?
         .as_object()?
         .get("accounts")?
-        .as_i64()?;
+        .as_str()?;
 
     Some(
-        u64::try_from(balance)
-            .expect("Account balance should be non-negative")
-            .into(),
+        balance
+            .parse()
+            .expect("Account balance cannot be parsed as a number"),
     )
 }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -14,7 +14,10 @@ use chrono::NaiveDateTime;
 
 use crate::doc_scalar;
 
-/// A non-negative amount of money.
+/// A non-negative amount of tokens.
+///
+/// This is a fixed-point fraction, with [`Amount::DECIMAL_PLACES`] digits after the point.
+/// [`Amount::ONE`] is one whole token, divisible into `10.pow(Amount::DECIMAL_PLACES)` parts.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug)]
 pub struct Amount(u128);
 
@@ -370,7 +373,7 @@ impl Amount {
     }
 }
 
-doc_scalar!(Amount, "A non-negative amount of money.");
+doc_scalar!(Amount, "A non-negative amount of tokens.");
 doc_scalar!(BlockHeight, "A block height to identify blocks in a chain");
 doc_scalar!(
     Timestamp,

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
-use linera_base::{
-    data_types::{Amount, Balance},
-    identifiers::ChainDescription,
-};
+use linera_base::{data_types::Amount, identifiers::ChainDescription};
 use linera_core::client::{
     self,
     client_test_utils::{MakeMemoryStoreClient, NodeProvider, StoreBuilder, TestBuilder},
@@ -39,11 +36,11 @@ where
     futures::executor::block_on(async move {
         let mut builder = TestBuilder::new(store_builder, 4, 1).await.unwrap();
         let chain1 = builder
-            .add_initial_chain(ChainDescription::Root(1), Balance::from(10))
+            .add_initial_chain(ChainDescription::Root(1), Amount::from(10))
             .await
             .unwrap();
         let chain2 = builder
-            .add_initial_chain(ChainDescription::Root(2), Balance::from(0))
+            .add_initial_chain(ChainDescription::Root(2), Amount::from(0))
             .await
             .unwrap();
         (chain1, chain2)
@@ -68,7 +65,7 @@ where
 
     chain2.receive_certificate(cert).await.unwrap();
     chain2.process_inbox().await.unwrap();
-    assert_eq!(chain1.local_balance().await.unwrap(), Balance::from(9));
+    assert_eq!(chain1.local_balance().await.unwrap(), Amount::from(9));
 
     let account = Recipient::Account(Account::chain(chain1.chain_id()));
     let cert = chain1
@@ -81,7 +78,7 @@ where
 
     chain1.receive_certificate(cert).await.unwrap();
     chain1.process_inbox().await.unwrap();
-    assert_eq!(chain1.local_balance().await.unwrap(), Balance::from(10));
+    assert_eq!(chain1.local_balance().await.unwrap(), Amount::from(10));
 }
 
 fn criterion_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -16,7 +16,7 @@ use futures::{
 };
 use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
-    data_types::{Amount, Balance, BlockHeight, RoundNumber, Timestamp},
+    data_types::{Amount, BlockHeight, RoundNumber, Timestamp},
     identifiers::{BytecodeId, ChainId, EffectId, Owner},
 };
 use linera_chain::{
@@ -1128,7 +1128,7 @@ where
         Ok(response)
     }
 
-    pub async fn local_balance(&mut self) -> Result<Balance> {
+    pub async fn local_balance(&mut self) -> Result<Amount> {
         ensure!(
             self.chain_info().await?.next_block_height == self.next_block_height,
             "The local node is behind the trusted state in wallet and needs synchronization with validators"
@@ -1202,7 +1202,7 @@ where
     }
 
     /// Attempts to synchronize with validators and re-compute our balance.
-    pub async fn synchronize_from_validators(&mut self) -> Result<Balance> {
+    pub async fn synchronize_from_validators(&mut self) -> Result<Amount> {
         self.find_received_certificates().await?;
         self.prepare_chain().await?;
         self.local_balance().await

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -5,7 +5,7 @@
 use crate::node::NodeError;
 use linera_base::{
     crypto::{BcsSignable, CryptoHash, KeyPair, Signature},
-    data_types::{Balance, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
 use linera_chain::{
@@ -126,7 +126,7 @@ pub struct ChainInfo {
     /// The state of the chain authentication.
     pub manager: ChainManagerInfo,
     /// The current balance.
-    pub system_balance: Balance,
+    pub system_balance: Amount,
     /// The last block hash, if any.
     pub block_hash: Option<CryptoHash>,
     /// The earliest possible timestamp for the next block.

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -285,11 +285,11 @@ struct GenesisStoreBuilder {
 struct GenesisAccount {
     description: ChainDescription,
     public_key: PublicKey,
-    balance: Balance,
+    balance: Amount,
 }
 
 impl GenesisStoreBuilder {
-    fn add(&mut self, description: ChainDescription, public_key: PublicKey, balance: Balance) {
+    fn add(&mut self, description: ChainDescription, public_key: PublicKey, balance: Amount) {
         self.accounts.push(GenesisAccount {
             description,
             public_key,
@@ -389,7 +389,7 @@ where
     pub async fn add_initial_chain(
         &mut self,
         description: ChainDescription,
-        balance: Balance,
+        balance: Amount,
     ) -> Result<ChainClient<NodeProvider<B::Store>, B::Store>, anyhow::Error> {
         let key_pair = KeyPair::generate();
         let public_key = key_pair.public();
@@ -405,7 +405,7 @@ where
                         self.admin_id,
                         description,
                         public_key,
-                        Balance::from(0),
+                        Amount::from(0),
                         Timestamp::from(0),
                     )
                     .await

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -53,7 +53,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let certificate = sender
         .transfer_to_account(
@@ -66,7 +66,7 @@ where
         .unwrap();
     assert_eq!(sender.next_block_height, BlockHeight::from(1));
     assert!(sender.pending_block.is_none());
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(1));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(1));
     assert_eq!(
         builder
             .check_that_validators_have_certificate(sender.chain_id, BlockHeight::from(0), 3)
@@ -102,11 +102,11 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let owner = sender.identity().await?;
     let mut receiver = builder
-        .add_initial_chain(ChainDescription::Root(2), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(2), Amount::from(0))
         .await?;
     let cert = sender
         .transfer_to_account(
@@ -117,11 +117,11 @@ where
         )
         .await
         .unwrap();
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(1));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(1));
     receiver.receive_certificate(cert).await?;
     receiver.process_inbox().await?;
     // The received amount is not in the unprotected balance.
-    assert_eq!(receiver.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(receiver.local_balance().await.unwrap(), Amount::from(0));
 
     // First attempt that should be skipped.
     sender
@@ -151,7 +151,7 @@ where
 
     sender.receive_certificate(cert).await?;
     sender.process_inbox().await?;
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(3));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(3));
 
     Ok(())
 }
@@ -180,7 +180,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let new_key_pair = KeyPair::generate();
     let new_owner = Owner::from(new_key_pair.public());
@@ -196,10 +196,10 @@ where
             .value,
         certificate.value
     );
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(4));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(4));
     assert_eq!(
         sender.synchronize_from_validators().await.unwrap(),
-        Balance::from(4)
+        Amount::from(4)
     );
     // Can still use the chain.
     sender
@@ -238,7 +238,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
 
     let new_key_pair = KeyPair::generate();
@@ -257,10 +257,10 @@ where
             .value,
         certificate.value
     );
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(4));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(4));
     assert_eq!(
         sender.synchronize_from_validators().await.unwrap(),
-        Balance::from(4)
+        Amount::from(4)
     );
     // Cannot use the chain any more.
     assert!(sender
@@ -299,7 +299,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 0).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let new_key_pair = KeyPair::generate();
     let certificate = sender.share_ownership(new_key_pair.public()).await.unwrap();
@@ -314,10 +314,10 @@ where
             .value,
         certificate.value
     );
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(4));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(4));
     assert_eq!(
         sender.synchronize_from_validators().await.unwrap(),
-        Balance::from(4)
+        Amount::from(4)
     );
     // Can still use the chain with the old client.
     sender
@@ -344,9 +344,9 @@ where
     assert!(client.local_balance().await.is_err());
     assert_eq!(
         client.synchronize_from_validators().await.unwrap(),
-        Balance::from(2)
+        Amount::from(2)
     );
-    assert_eq!(client.local_balance().await.unwrap(), Balance::from(2));
+    assert_eq!(client.local_balance().await.unwrap(), Amount::from(2));
 
     // We need at least three validators for making a transfer.
     builder.set_fault_type(..2, FaultType::Offline).await;
@@ -376,7 +376,7 @@ where
     builder.set_fault_type(.., FaultType::Honest).await;
     assert_eq!(
         client.synchronize_from_validators().await.unwrap(),
-        Balance::from(2)
+        Amount::from(2)
     );
     client.clear_pending_block().await;
     client
@@ -392,7 +392,7 @@ where
     // The other client doesn't know the new round number yet:
     assert_eq!(
         sender.synchronize_from_validators().await.unwrap(),
-        Balance::from(1)
+        Amount::from(1)
     );
     sender.clear_pending_block().await;
     sender
@@ -406,10 +406,10 @@ where
         .unwrap();
 
     // That's it, we spent all our money on this test!
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(0));
     assert_eq!(
         client.synchronize_from_validators().await.unwrap(),
-        Balance::from(0)
+        Amount::from(0)
     );
     Ok(())
 }
@@ -439,10 +439,10 @@ where
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
     builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(0))
         .await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let new_key_pair = KeyPair::generate();
     // Open the new chain.
@@ -458,9 +458,9 @@ where
     client.receive_certificate(certificate).await.unwrap();
     assert_eq!(
         client.synchronize_from_validators().await.unwrap(),
-        Balance::from(0)
+        Amount::from(0)
     );
-    assert_eq!(client.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client.local_balance().await.unwrap(), Amount::from(0));
     client.close_chain().await.unwrap();
     Ok(())
 }
@@ -490,10 +490,10 @@ where
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
     builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(0))
         .await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let new_key_pair = KeyPair::generate();
     let new_id = ChainId::child(EffectId {
@@ -537,7 +537,7 @@ where
         .make_client(new_id, new_key_pair, None, BlockHeight::from(0))
         .await?;
     client.receive_certificate(certificate).await.unwrap();
-    assert_eq!(client.local_balance().await.unwrap(), Balance::from(3));
+    assert_eq!(client.local_balance().await.unwrap(), Amount::from(3));
     client
         .transfer_to_account(
             None,
@@ -575,10 +575,10 @@ where
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
     builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(0))
         .await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let new_key_pair = KeyPair::generate();
     // Open the new chain.
@@ -606,12 +606,12 @@ where
         .receive_certificate(creation_certificate)
         .await
         .unwrap();
-    assert_eq!(client.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client.local_balance().await.unwrap(), Amount::from(0));
     client
         .receive_certificate(transfer_certificate)
         .await
         .unwrap();
-    assert_eq!(client.local_balance().await.unwrap(), Balance::from(3));
+    assert_eq!(client.local_balance().await.unwrap(), Amount::from(3));
     client
         .transfer_to_account(
             None,
@@ -621,7 +621,7 @@ where
         )
         .await
         .unwrap();
-    assert_eq!(client.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client.local_balance().await.unwrap(), Amount::from(0));
     Ok(())
 }
 
@@ -649,7 +649,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     let certificate = sender.close_chain().await.unwrap();
     assert!(certificate.value.is_confirmed());
@@ -707,7 +707,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 2).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(4))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(4))
         .await?;
     assert!(sender
         .transfer_to_account_unsafe_unconfirmed(
@@ -720,7 +720,7 @@ where
         .is_err());
     assert_eq!(sender.next_block_height, BlockHeight::from(0));
     assert!(sender.pending_block.is_some());
-    assert_eq!(sender.local_balance().await.unwrap(), Balance::from(4));
+    assert_eq!(sender.local_balance().await.unwrap(), Amount::from(4));
     Ok(())
 }
 
@@ -748,12 +748,12 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut client1 = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(3))
         .await?;
     let mut client2 = builder
-        .add_initial_chain(ChainDescription::Root(2), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(2), Amount::from(0))
         .await?;
-    assert_eq!(client1.local_balance().await.unwrap(), Balance::from(3));
+    assert_eq!(client1.local_balance().await.unwrap(), Amount::from(3));
     assert_eq!(
         client1
             .query_application(&Query::System(SystemQuery))
@@ -761,7 +761,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(1),
-            balance: Balance::from(3),
+            balance: Amount::from(3),
         })
     );
 
@@ -777,7 +777,7 @@ where
 
     assert_eq!(client1.next_block_height, BlockHeight::from(1));
     assert!(client1.pending_block.is_none());
-    assert_eq!(client1.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client1.local_balance().await.unwrap(), Amount::from(0));
     assert_eq!(
         client1
             .query_application(&Query::System(SystemQuery))
@@ -785,7 +785,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(1),
-            balance: Balance::from(0),
+            balance: Amount::from(0),
         })
     );
 
@@ -798,13 +798,13 @@ where
         certificate.value
     );
     // Local balance is lagging.
-    assert_eq!(client2.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::from(0));
     // Force synchronization of local balance.
     assert_eq!(
         client2.synchronize_from_validators().await.unwrap(),
-        Balance::from(3)
+        Amount::from(3)
     );
-    assert_eq!(client2.local_balance().await.unwrap(), Balance::from(3));
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::from(3));
     // The local balance from the client is reflecting incoming messages but the
     // SystemResponse only reads the ChainState.
     assert_eq!(
@@ -814,7 +814,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(2),
-            balance: Balance::from(0),
+            balance: Amount::from(0),
         })
     );
 
@@ -831,10 +831,10 @@ where
         .unwrap();
     assert_eq!(client2.next_block_height, BlockHeight::from(1));
     assert!(client2.pending_block.is_none());
-    assert_eq!(client2.local_balance().await.unwrap(), Balance::from(2));
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::from(2));
     assert_eq!(
         client1.synchronize_from_validators().await.unwrap(),
-        Balance::from(1)
+        Amount::from(1)
     );
     // Local balance from client2 is now consolidated.
     assert_eq!(
@@ -844,7 +844,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(2),
-            balance: Balance::from(2),
+            balance: Amount::from(2),
         })
     );
     Ok(())
@@ -874,10 +874,10 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut client1 = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(3))
         .await?;
     let mut client2 = builder
-        .add_initial_chain(ChainDescription::Root(2), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(2), Amount::from(0))
         .await?;
     let certificate = client1
         .transfer_to_account_unsafe_unconfirmed(
@@ -889,12 +889,12 @@ where
         .await
         .unwrap();
     // Transfer was executed locally.
-    assert_eq!(client1.local_balance().await.unwrap(), Balance::from(1));
+    assert_eq!(client1.local_balance().await.unwrap(), Amount::from(1));
     assert_eq!(client1.next_block_height, BlockHeight::from(1));
     assert!(client1.pending_block.is_none());
     // Let the receiver confirm in last resort.
     client2.receive_certificate(certificate).await.unwrap();
-    assert_eq!(client2.local_balance().await.unwrap(), Balance::from(2));
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::from(2));
     Ok(())
 }
 
@@ -936,13 +936,13 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut client1 = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(3))
         .await?;
     let mut client2 = builder
-        .add_initial_chain(ChainDescription::Root(2), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(2), Amount::from(0))
         .await?;
     let mut client3 = builder
-        .add_initial_chain(ChainDescription::Root(3), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(3), Amount::from(0))
         .await?;
 
     // Transferring funds from client1 to client2.
@@ -974,7 +974,7 @@ where
         .await
         .unwrap();
     // Client2 does not know about the money yet.
-    assert_eq!(client2.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::from(0));
     // Sending money from client2 fails, as a consequence.
     assert!(client2
         .transfer_to_account_unsafe_unconfirmed(
@@ -991,7 +991,7 @@ where
     // Retrying the whole command works after synchronization.
     assert_eq!(
         client2.synchronize_from_validators().await.unwrap(),
-        Balance::from(2)
+        Amount::from(2)
     );
     let certificate = client2
         .transfer_to_account(
@@ -1003,17 +1003,17 @@ where
         .await
         .unwrap();
     // Blocks were executed locally.
-    assert_eq!(client1.local_balance().await.unwrap(), Balance::from(1));
+    assert_eq!(client1.local_balance().await.unwrap(), Amount::from(1));
     assert_eq!(client1.next_block_height, BlockHeight::from(2));
     assert!(client1.pending_block.is_none());
-    assert_eq!(client2.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::from(0));
     assert_eq!(client2.next_block_height, BlockHeight::from(1));
     assert!(client2.pending_block.is_none());
     // Last one was not confirmed remotely, hence a conservative balance.
-    assert_eq!(client2.local_balance().await.unwrap(), Balance::from(0));
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::from(0));
     // Let the receiver confirm in last resort.
     client3.receive_certificate(certificate).await.unwrap();
-    assert_eq!(client3.local_balance().await.unwrap(), Balance::from(2));
+    assert_eq!(client3.local_balance().await.unwrap(), Amount::from(2));
     Ok(())
 }
 
@@ -1041,10 +1041,10 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut admin = builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(3))
         .await?;
     let mut user = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(0))
         .await?;
 
     // Create a new committee.
@@ -1081,7 +1081,7 @@ where
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(0));
     assert_eq!(
         user.synchronize_from_validators().await.unwrap(),
-        Balance::from(3)
+        Amount::from(3)
     );
 
     // User is a genesis chain so the migration message is not even in the inbox yet.
@@ -1110,7 +1110,7 @@ where
     // Transfer is blocked because the epoch #0 has been retired by admin.
     assert_eq!(
         admin.synchronize_from_validators().await.unwrap(),
-        Balance::from(0)
+        Amount::from(0)
     );
 
     // Have the user receive the notification to migrate to epoch #1.
@@ -1132,7 +1132,7 @@ where
     // Transfer goes through and the previous one as well thanks to block chaining.
     assert_eq!(
         admin.synchronize_from_validators().await.unwrap(),
-        Balance::from(3)
+        Amount::from(3)
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -12,7 +12,7 @@ use crate::client::client_tests::{
     MakeMemoryStoreClient, MakeRocksdbStoreClient, StoreBuilder, TestBuilder, ROCKSDB_SEMAPHORE,
 };
 use linera_base::{
-    data_types::{Amount, Balance},
+    data_types::Amount,
     identifiers::{ChainDescription, ChainId, Destination, Owner},
 };
 use linera_chain::data_types::OutgoingEffect;
@@ -59,10 +59,10 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut publisher = builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(3))
         .await?;
     let mut creator = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(0))
         .await?;
 
     let cert = creator
@@ -162,15 +162,15 @@ where
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // Will publish the bytecodes.
     let mut publisher = builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(3))
         .await?;
     // Will create the apps and use them to send a message.
     let mut creator = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(0))
         .await?;
     // Will receive the message.
     let mut receiver = builder
-        .add_initial_chain(ChainDescription::Root(2), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(2), Amount::from(0))
         .await?;
     let receiver_id = ChainId::root(2);
 
@@ -296,11 +296,11 @@ where
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // Will publish the bytecodes.
     let mut publisher = builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(3))
         .await?;
     // Will create the apps and use them to send a message.
     let mut creator = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(0))
         .await?;
 
     let cert = creator
@@ -397,10 +397,10 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(3))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(3))
         .await?;
     let mut receiver = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(0))
         .await?;
 
     let (bytecode_id, pub_cert) = {
@@ -574,10 +574,10 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut sender = builder
-        .add_initial_chain(ChainDescription::Root(0), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(0), Amount::from(0))
         .await?;
     let mut receiver = builder
-        .add_initial_chain(ChainDescription::Root(1), Balance::from(0))
+        .add_initial_chain(ChainDescription::Root(1), Amount::from(0))
         .await?;
 
     let (bytecode_id, pub_cert) = {

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -12,7 +12,7 @@
 use super::{init_worker_with_chains, make_block, make_certificate, make_state_hash};
 use linera_base::{
     crypto::KeyPair,
-    data_types::{Balance, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, Destination, EffectId},
 };
 use linera_chain::data_types::{
@@ -103,9 +103,9 @@ where
             (
                 publisher_chain,
                 publisher_key_pair.public(),
-                Balance::from(0),
+                Amount::from(0),
             ),
-            (creator_chain, creator_key_pair.public(), Balance::from(0)),
+            (creator_chain, creator_key_pair.public(), Amount::from(0)),
         ],
     )
     .await;
@@ -144,7 +144,7 @@ where
         subscriptions: BTreeSet::new(),
         committees: [(Epoch::from(0), committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(publisher_key_pair.public()),
-        balance: Balance::from(0),
+        balance: Amount::from(0),
         balances: BTreeMap::new(),
         timestamp: Timestamp::from(1),
         registry: ApplicationRegistry::default(),
@@ -167,7 +167,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::from(publisher_chain), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(1), info.next_block_height);
     assert_eq!(Timestamp::from(1), info.timestamp);
     assert_eq!(Some(publish_certificate.value.hash()), info.block_hash);
@@ -230,7 +230,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::from(publisher_chain), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(2), info.next_block_height);
     assert_eq!(Timestamp::from(1), info.timestamp);
     assert_eq!(Some(broadcast_certificate.value.hash()), info.block_hash);
@@ -266,7 +266,7 @@ where
         subscriptions: [publisher_channel].into_iter().collect(),
         committees: [(Epoch::from(0), committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(creator_key_pair.public()),
-        balance: Balance::from(0),
+        balance: Amount::from(0),
         balances: BTreeMap::new(),
         timestamp: Timestamp::from(2),
         registry: ApplicationRegistry::default(),
@@ -291,7 +291,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::from(creator_chain), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(1), info.next_block_height);
     assert_eq!(Timestamp::from(2), info.timestamp);
     assert_eq!(Some(subscribe_certificate.value.hash()), info.block_hash);
@@ -339,7 +339,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::from(publisher_chain), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(3), info.next_block_height);
     assert_eq!(Timestamp::from(3), info.timestamp);
     assert_eq!(Some(accept_certificate.value.hash()), info.block_hash);
@@ -428,7 +428,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::root(2), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(2), info.next_block_height);
     assert_eq!(Timestamp::from(4), info.timestamp);
     assert_eq!(Some(create_certificate.value.hash()), info.block_hash);
@@ -477,7 +477,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::root(2), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(3), info.next_block_height);
     assert_eq!(Some(run_certificate.value.hash()), info.block_hash);
     assert_eq!(Timestamp::from(5), info.timestamp);

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -79,7 +79,7 @@ where
 /// Same as `init_worker` but also instantiate some initial chains.
 async fn init_worker_with_chains<S, I>(client: S, balances: I) -> (Committee, WorkerState<S>)
 where
-    I: IntoIterator<Item = (ChainDescription, PublicKey, Balance)>,
+    I: IntoIterator<Item = (ChainDescription, PublicKey, Amount)>,
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
@@ -106,7 +106,7 @@ async fn init_worker_with_chain<S>(
     client: S,
     description: ChainDescription,
     owner: PublicKey,
-    balance: Balance,
+    balance: Amount,
 ) -> (Committee, WorkerState<S>)
 where
     S: Store + Clone + Send + Sync + 'static,
@@ -196,7 +196,7 @@ async fn make_transfer_certificate<S>(
     amount: Amount,
     incoming_messages: Vec<Message>,
     committee: &Committee,
-    balance: Balance,
+    balance: Amount,
     worker: &WorkerState<S>,
     previous_confirmed_block: Option<&Certificate>,
 ) -> Certificate {
@@ -224,7 +224,7 @@ async fn make_transfer_certificate_for_epoch<S>(
     incoming_messages: Vec<Message>,
     epoch: Epoch,
     committee: &Committee,
-    balance: Balance,
+    balance: Amount,
     worker: &WorkerState<S>,
     previous_confirmed_block: Option<&Certificate>,
 ) -> Certificate {
@@ -326,12 +326,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -405,12 +405,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -474,7 +474,7 @@ where
     ViewError: From<S::ContextError>,
 {
     let key_pair = KeyPair::generate();
-    let balance = Balance::from(5);
+    let balance = Amount::from(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public(), balance)];
     let epoch = Epoch::from(0);
     let (committee, mut worker) = init_worker_with_chains(client, balances).await;
@@ -586,12 +586,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -664,7 +664,7 @@ where
         vec![(
             ChainDescription::Root(1),
             sender_key_pair.public(),
-            Balance::from(5),
+            Amount::from(5),
         )],
     )
     .await;
@@ -683,7 +683,7 @@ where
         Amount::from(1),
         Vec::new(),
         &committee,
-        Balance::from(4),
+        Amount::from(4),
         &worker,
         None,
     )
@@ -785,12 +785,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(6),
+                Amount::from(6),
             ),
             (
                 ChainDescription::Root(2),
                 recipient_key_pair.public(),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -848,7 +848,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: [(epoch, committee.clone())].into_iter().collect(),
                     ownership: ChainOwnership::single(sender_key_pair.public()),
-                    balance: Balance::from(3),
+                    balance: Amount::from(3),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -893,7 +893,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: [(epoch, committee.clone())].into_iter().collect(),
                     ownership: ChainOwnership::single(sender_key_pair.public()),
-                    balance: Balance::from(0),
+                    balance: Amount::from(0),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -1182,7 +1182,7 @@ where
                         subscriptions: BTreeSet::new(),
                         committees: [(epoch, committee.clone())].into_iter().collect(),
                         ownership: ChainOwnership::single(recipient_key_pair.public()),
-                        balance: Balance::from(0),
+                        balance: Amount::from(0),
                         balances: BTreeMap::new(),
                         timestamp: Timestamp::from(0),
                         registry: ApplicationRegistry::default(),
@@ -1267,12 +1267,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -1338,7 +1338,7 @@ where
         vec![(
             ChainDescription::Root(1),
             sender_key_pair.public(),
-            Balance::from(5),
+            Amount::from(5),
         )],
     )
     .await;
@@ -1414,12 +1414,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -1489,7 +1489,7 @@ where
         vec![(
             ChainDescription::Root(2),
             PublicKey::debug(2),
-            Balance::from(0),
+            Amount::from(0),
         )],
     )
     .await;
@@ -1500,7 +1500,7 @@ where
         Amount::from(5),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -1552,12 +1552,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -1569,7 +1569,7 @@ where
         Amount::from(5),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -1627,12 +1627,12 @@ where
             (
                 ChainDescription::Root(1),
                 key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -1658,7 +1658,7 @@ where
             },
         }],
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -1672,10 +1672,7 @@ where
         .load_active_chain(ChainId::root(1))
         .await
         .unwrap();
-    assert_eq!(
-        Balance::from(0),
-        *chain.execution_state.system.balance.get()
-    );
+    assert_eq!(Amount::from(0), *chain.execution_state.system.balance.get());
     assert_eq!(
         BlockHeight::from(1),
         chain.tip_state.get().next_block_height
@@ -1777,12 +1774,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(1),
+                Amount::from(1),
             ),
             (
                 ChainDescription::Root(2),
                 PublicKey::debug(2),
-                Balance::max(),
+                Amount::max(),
             ),
         ],
     )
@@ -1795,7 +1792,7 @@ where
         Amount::from(1),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -1810,7 +1807,7 @@ where
         .await
         .unwrap();
     assert_eq!(
-        Balance::from(0),
+        Amount::from(0),
         *new_sender_chain.execution_state.system.balance.get()
     );
     assert_eq!(
@@ -1828,7 +1825,7 @@ where
         .await
         .unwrap();
     assert_eq!(
-        Balance::max(),
+        Amount::max(),
         *new_recipient_chain.execution_state.system.balance.get()
     );
 }
@@ -1870,7 +1867,7 @@ where
     let key_pair = KeyPair::generate();
     let name = key_pair.public();
     let (committee, mut worker) =
-        init_worker_with_chain(client, ChainDescription::Root(1), name, Balance::from(1)).await;
+        init_worker_with_chain(client, ChainDescription::Root(1), name, Amount::from(1)).await;
 
     let certificate = make_transfer_certificate(
         ChainDescription::Root(1),
@@ -1879,7 +1876,7 @@ where
         Amount::from(1),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -1893,10 +1890,7 @@ where
         .load_active_chain(ChainId::root(1))
         .await
         .unwrap();
-    assert_eq!(
-        Balance::from(0),
-        *chain.execution_state.system.balance.get()
-    );
+    assert_eq!(Amount::from(0), *chain.execution_state.system.balance.get());
     assert_eq!(
         BlockHeight::from(1),
         chain
@@ -1981,7 +1975,7 @@ where
         vec![(
             ChainDescription::Root(2),
             PublicKey::debug(2),
-            Balance::from(1),
+            Amount::from(1),
         )],
     )
     .await;
@@ -1992,7 +1986,7 @@ where
         Amount::from(10),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -2011,10 +2005,7 @@ where
         .load_active_chain(ChainId::root(2))
         .await
         .unwrap();
-    assert_eq!(
-        Balance::from(1),
-        *chain.execution_state.system.balance.get()
-    );
+    assert_eq!(Amount::from(1), *chain.execution_state.system.balance.get());
     assert_eq!(
         BlockHeight::from(0),
         chain.tip_state.get().next_block_height
@@ -2101,7 +2092,7 @@ where
         Amount::from(10),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -2166,7 +2157,7 @@ where
         Amount::from(10),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -2241,12 +2232,12 @@ where
             (
                 ChainDescription::Root(1),
                 sender_key_pair.public(),
-                Balance::from(5),
+                Amount::from(5),
             ),
             (
                 ChainDescription::Root(2),
                 recipient_key_pair.public(),
-                Balance::from(0),
+                Amount::from(0),
             ),
         ],
     )
@@ -2258,7 +2249,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(1),
-            balance: Balance::from(5),
+            balance: Amount::from(5),
         })
     );
     assert_eq!(
@@ -2268,7 +2259,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(2),
-            balance: Balance::from(0),
+            balance: Amount::from(0),
         })
     );
 
@@ -2279,7 +2270,7 @@ where
         Amount::from(5),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -2291,7 +2282,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::root(1), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(1), info.next_block_height);
     assert_eq!(Some(certificate.value.hash()), info.block_hash);
     assert!(info.manager.pending().is_none());
@@ -2302,7 +2293,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(1),
-            balance: Balance::from(0),
+            balance: Amount::from(0),
         })
     );
 
@@ -2327,7 +2318,7 @@ where
             },
         }],
         &committee,
-        Balance::from(4),
+        Amount::from(4),
         &worker,
         None,
     )
@@ -2344,7 +2335,7 @@ where
             .unwrap(),
         Response::System(SystemResponse {
             chain_id: ChainId::root(2),
-            balance: Balance::from(4),
+            balance: Amount::from(4),
         })
     );
 
@@ -2356,7 +2347,7 @@ where
             .unwrap();
         assert_eq!(
             *recipient_chain.execution_state.system.balance.get(),
-            Balance::from(4)
+            Amount::from(4)
         );
         assert_eq!(
             recipient_chain
@@ -2424,7 +2415,7 @@ where
         vec![(
             ChainDescription::Root(1),
             sender_key_pair.public(),
-            Balance::from(5),
+            Amount::from(5),
         )],
     )
     .await;
@@ -2435,7 +2426,7 @@ where
         Amount::from(5),
         Vec::new(),
         &committee,
-        Balance::from(0),
+        Amount::from(0),
         &worker,
         None,
     )
@@ -2447,7 +2438,7 @@ where
         .unwrap()
         .info;
     assert_eq!(ChainId::root(1), info.chain_id);
-    assert_eq!(Balance::from(0), info.system_balance);
+    assert_eq!(Amount::from(0), info.system_balance);
     assert_eq!(BlockHeight::from(1), info.next_block_height);
     assert_eq!(Some(certificate.value.hash()), info.block_hash);
     assert!(info.manager.pending().is_none());
@@ -2493,7 +2484,7 @@ where
         vec![(
             ChainDescription::Root(0),
             key_pair.public(),
-            Balance::from(2),
+            Amount::from(2),
         )],
     )
     .await;
@@ -2565,7 +2556,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(2),
+                    balance: Amount::from(2),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -2657,7 +2648,7 @@ where
                     // The root chain knows both committees at the end.
                     committees: committees2.clone(),
                     ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(0),
+                    balance: Amount::from(0),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -2713,7 +2704,7 @@ where
                     // The root chain knows both committees at the end.
                     committees: committees2.clone(),
                     ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(0),
+                    balance: Amount::from(0),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -2891,7 +2882,7 @@ where
                     // Finally the child knows about both committees and has the money.
                     committees: committees2.clone(),
                     ownership: ChainOwnership::single(key_pair.public()),
-                    balance: Balance::from(2),
+                    balance: Amount::from(2),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -2999,12 +2990,12 @@ where
             (
                 ChainDescription::Root(0),
                 key_pair0.public(),
-                Balance::from(0),
+                Amount::from(0),
             ),
             (
                 ChainDescription::Root(1),
                 key_pair1.public(),
-                Balance::from(3),
+                Amount::from(3),
             ),
         ],
     )
@@ -3049,7 +3040,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair1.public()),
-                    balance: Balance::from(2),
+                    balance: Amount::from(2),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -3098,7 +3089,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: committees2.clone(),
                     ownership: ChainOwnership::single(key_pair0.public()),
-                    balance: Balance::from(0),
+                    balance: Amount::from(0),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -3127,7 +3118,7 @@ where
     );
     assert_eq!(
         *user_chain.execution_state.system.balance.get(),
-        Balance::from(2)
+        Amount::from(2)
     );
     assert_eq!(
         *user_chain.execution_state.system.epoch.get(),
@@ -3196,12 +3187,12 @@ where
             (
                 ChainDescription::Root(0),
                 key_pair0.public(),
-                Balance::from(0),
+                Amount::from(0),
             ),
             (
                 ChainDescription::Root(1),
                 key_pair1.public(),
-                Balance::from(3),
+                Amount::from(3),
             ),
         ],
     )
@@ -3246,7 +3237,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair1.public()),
-                    balance: Balance::from(2),
+                    balance: Amount::from(2),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -3312,7 +3303,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: committees3.clone(),
                     ownership: ChainOwnership::single(key_pair0.public()),
-                    balance: Balance::from(0),
+                    balance: Amount::from(0),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -3342,7 +3333,7 @@ where
         );
         assert_eq!(
             *user_chain.execution_state.system.balance.get(),
-            Balance::from(2)
+            Amount::from(2)
         );
         assert_eq!(
             *user_chain.execution_state.system.epoch.get(),
@@ -3391,7 +3382,7 @@ where
                     subscriptions: BTreeSet::new(),
                     committees: committees3.clone(),
                     ownership: ChainOwnership::single(key_pair0.public()),
-                    balance: Balance::from(1),
+                    balance: Amount::from(1),
                     balances: BTreeMap::new(),
                     timestamp: Timestamp::from(0),
                     registry: ApplicationRegistry::default(),
@@ -3444,7 +3435,7 @@ async fn test_cross_chain_helper() {
         Vec::new(),
         Epoch::from(0),
         &committee,
-        Balance::from(1),
+        Amount::from(1),
         &worker,
         None,
     )
@@ -3457,7 +3448,7 @@ async fn test_cross_chain_helper() {
         Vec::new(),
         Epoch::from(0),
         &committee,
-        Balance::from(1),
+        Amount::from(1),
         &worker,
         Some(&certificate0),
     )
@@ -3470,7 +3461,7 @@ async fn test_cross_chain_helper() {
         Vec::new(),
         Epoch::from(1),
         &committee,
-        Balance::from(1),
+        Amount::from(1),
         &worker,
         Some(&certificate1),
     )
@@ -3484,7 +3475,7 @@ async fn test_cross_chain_helper() {
         Vec::new(),
         Epoch::from(0),
         &committee,
-        Balance::from(1),
+        Amount::from(1),
         &worker,
         Some(&certificate2),
     )

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use async_graphql::{Error, Object};
 use linera_base::{
-    data_types::{Balance, Timestamp},
+    data_types::{Amount, Timestamp},
     doc_scalar,
     identifiers::{ChainDescription, ChainId},
 };
@@ -93,7 +93,7 @@ where
         self.ownership.get()
     }
 
-    async fn balance(&self) -> &Balance {
+    async fn balance(&self) -> &Amount {
         self.balance.get()
     }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -39,7 +39,7 @@ use dashmap::DashMap;
 use derive_more::Display;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{ArithmeticError, Balance, BlockHeight, Timestamp},
+    data_types::{Amount, ArithmeticError, BlockHeight, Timestamp},
     hex_debug,
     identifiers::{BytecodeId, ChainId, ChannelName, Destination, EffectId, Owner, SessionId},
 };
@@ -267,7 +267,7 @@ pub trait BaseRuntime: Send + Sync {
     fn application_parameters(&self) -> Vec<u8>;
 
     /// Reads the system balance.
-    fn read_system_balance(&self) -> Balance;
+    fn read_system_balance(&self) -> Amount;
 
     /// Reads the system timestamp.
     fn read_system_timestamp(&self) -> Timestamp;

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -319,7 +319,7 @@ where
             .clone()
     }
 
-    fn read_system_balance(&self) -> linera_base::data_types::Balance {
+    fn read_system_balance(&self) -> linera_base::data_types::Amount {
         *self.execution_state_mut().system.balance.get()
     }
 

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -13,7 +13,7 @@ use crate::{
     CallResult, CalleeContext, EffectContext, EffectId, OperationContext, QueryContext, SessionId,
     UserApplicationId,
 };
-use linera_base::{crypto::CryptoHash, data_types::Balance, identifiers::ChainId};
+use linera_base::{crypto::CryptoHash, data_types::Amount, identifiers::ChainId};
 
 impl From<OperationContext> for contract::OperationContext {
     fn from(host: OperationContext) -> Self {
@@ -223,18 +223,18 @@ impl From<CallResult> for contract_system_api::CallResult {
     }
 }
 
-impl From<Balance> for service_system_api::Balance {
-    fn from(host: Balance) -> Self {
-        service_system_api::Balance {
+impl From<Amount> for service_system_api::Amount {
+    fn from(host: Amount) -> Self {
+        service_system_api::Amount {
             lower_half: host.lower_half(),
             upper_half: host.upper_half(),
         }
     }
 }
 
-impl From<Balance> for contract_system_api::Balance {
-    fn from(host: Balance) -> Self {
-        contract_system_api::Balance {
+impl From<Amount> for contract_system_api::Amount {
+    fn from(host: Amount) -> Self {
+        contract_system_api::Amount {
             lower_half: host.lower_half(),
             upper_half: host.upper_half(),
         }

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -39,7 +39,7 @@ macro_rules! impl_contract_system_api {
 
             fn read_system_balance(
                 &mut self,
-            ) -> Result<contract_system_api::Balance, Self::Error> {
+            ) -> Result<contract_system_api::Amount, Self::Error> {
                 Ok(self.runtime().read_system_balance().into())
             }
 
@@ -200,7 +200,7 @@ macro_rules! impl_service_system_api {
                 self.runtime().application_parameters()
             }
 
-            fn read_system_balance(&mut self) -> service_system_api::Balance {
+            fn read_system_balance(&mut self) -> service_system_api::Amount {
                 self.runtime().read_system_balance().into()
             }
 

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
-    data_types::{Amount, Balance, BlockHeight},
+    data_types::{Amount, BlockHeight},
     identifiers::{ChainDescription, ChainId, EffectId},
 };
 use linera_execution::{
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 async fn test_simple_system_operation() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    state.balance = Balance::from(4);
+    state.balance = Amount::from(4);
     let mut view =
         ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
             .await;
@@ -42,7 +42,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         .execute_operation(&context, &Operation::System(operation))
         .await
         .unwrap();
-    assert_eq!(view.system.balance.get(), &Balance::from(0));
+    assert_eq!(view.system.balance.get(), &Amount::from(0));
     assert_eq!(
         results,
         vec![ExecutionResult::System(RawExecutionResult::default())]
@@ -81,7 +81,7 @@ async fn test_simple_system_effect() -> anyhow::Result<()> {
         .execute_effect(&context, &Effect::System(effect))
         .await
         .unwrap();
-    assert_eq!(view.system.balance.get(), &Balance::from(4));
+    assert_eq!(view.system.balance.get(), &Amount::from(4));
     assert_eq!(
         results,
         vec![ExecutionResult::System(RawExecutionResult::default())]
@@ -93,7 +93,7 @@ async fn test_simple_system_effect() -> anyhow::Result<()> {
 async fn test_simple_system_query() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    state.balance = Balance::from(4);
+    state.balance = Amount::from(4);
     let mut view =
         ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
             .await;
@@ -108,7 +108,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         response,
         Response::System(SystemResponse {
             chain_id: ChainId::root(0),
-            balance: Balance::from(4)
+            balance: Amount::from(4)
         })
     );
     Ok(())

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -7,7 +7,7 @@ Account:
         OPTION:
           TYPENAME: Owner
 Amount:
-  NEWTYPESTRUCT: U64
+  NEWTYPESTRUCT: U128
 ApplicationId:
   ENUM:
     0:
@@ -16,8 +16,6 @@ ApplicationId:
       User:
         NEWTYPE:
           TYPENAME: UserApplicationId
-Balance:
-  NEWTYPESTRUCT: U128
 Block:
   STRUCT:
     - chain_id:
@@ -116,7 +114,7 @@ ChainInfo:
     - manager:
         TYPENAME: ChainManagerInfo
     - system_balance:
-        TYPENAME: Balance
+        TYPENAME: Amount
     - block_hash:
         OPTION:
           TYPENAME: CryptoHash

--- a/linera-sdk/contract_system_api.wit
+++ b/linera-sdk/contract_system_api.wit
@@ -1,7 +1,7 @@
 chain-id: func() -> chain-id
 application-id: func() -> application-id
 application-parameters: func() -> list<u8>
-read-system-balance: func() -> balance
+read-system-balance: func() -> amount
 read-system-timestamp: func() -> timestamp
 
 log: func(message: string, level: log-level)
@@ -78,7 +78,7 @@ record crypto-hash {
     part4: u64,
 }
 
-record balance {
+record amount {
     lower-half: u64,
     upper-half: u64,
 }

--- a/linera-sdk/mock_system_api.wit
+++ b/linera-sdk/mock_system_api.wit
@@ -1,7 +1,7 @@
 mocked-chain-id: func() -> chain-id
 mocked-application-id: func() -> application-id
 mocked-application-parameters: func() -> list<u8>
-mocked-read-system-balance: func() -> balance
+mocked-read-system-balance: func() -> amount
 mocked-read-system-timestamp: func() -> timestamp
 
 mocked-log: func(message: string, level: log-level)
@@ -60,7 +60,7 @@ record crypto-hash {
     part4: u64,
 }
 
-record balance {
+record amount {
     lower-half: u64,
     upper-half: u64,
 }

--- a/linera-sdk/service_system_api.wit
+++ b/linera-sdk/service_system_api.wit
@@ -1,7 +1,7 @@
 chain-id: func() -> chain-id
 application-id: func() -> application-id
 application-parameters: func() -> list<u8>
-read-system-balance: func() -> balance
+read-system-balance: func() -> amount
 read-system-timestamp: func() -> timestamp
 
 log: func(message: string, level: log-level)
@@ -77,7 +77,7 @@ record crypto-hash {
     part4: u64,
 }
 
-record balance {
+record amount {
     lower-half: u64,
     upper-half: u64,
 }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Balance, BlockHeight},
+    data_types::{Amount, BlockHeight},
     identifiers::{ApplicationId, BytecodeId, ChainId, EffectId, Owner, SessionId},
 };
 
@@ -135,10 +135,10 @@ impl From<wit_system_api::CryptoHash> for CryptoHash {
     }
 }
 
-impl From<wit_system_api::Balance> for Balance {
-    fn from(balance: wit_system_api::Balance) -> Self {
+impl From<wit_system_api::Amount> for Amount {
+    fn from(balance: wit_system_api::Amount) -> Self {
         let value = ((balance.upper_half as u128) << 64) | (balance.lower_half as u128);
-        Balance::from(value)
+        Amount::from(value)
     }
 }
 

--- a/linera-sdk/src/contract/system_api.rs
+++ b/linera-sdk/src/contract/system_api.rs
@@ -7,7 +7,7 @@ use super::contract_system_api as wit;
 use crate::views::ViewStorageContext;
 use futures::future;
 use linera_base::{
-    data_types::{Balance, Timestamp},
+    data_types::{Amount, Timestamp},
     identifiers::{ApplicationId, ChainId, SessionId},
 };
 use linera_views::views::{RootView, View};
@@ -90,7 +90,7 @@ pub fn current_application_parameters() -> Vec<u8> {
 }
 
 /// Retrieves the current system balance.
-pub fn current_system_balance() -> Balance {
+pub fn current_system_balance() -> Amount {
     wit::read_system_balance().into()
 }
 

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::QueryContext;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Balance, BlockHeight},
+    data_types::{Amount, BlockHeight},
     identifiers::{ApplicationId, BytecodeId, ChainId, EffectId},
 };
 use linera_views::views::ViewError;
@@ -65,10 +65,10 @@ impl From<wit_system_api::EffectId> for EffectId {
     }
 }
 
-impl From<wit_system_api::Balance> for Balance {
-    fn from(balance: wit_system_api::Balance) -> Self {
+impl From<wit_system_api::Amount> for Amount {
+    fn from(balance: wit_system_api::Amount) -> Self {
         let value = ((balance.upper_half as u128) << 64) | (balance.lower_half as u128);
-        Balance::from(value)
+        Amount::from(value)
     }
 }
 

--- a/linera-sdk/src/service/system_api.rs
+++ b/linera-sdk/src/service/system_api.rs
@@ -7,7 +7,7 @@ use super::service_system_api as wit;
 use crate::views::ViewStorageContext;
 use futures::future;
 use linera_base::{
-    data_types::{Balance, Timestamp},
+    data_types::{Amount, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
 use linera_views::views::{View, ViewError};
@@ -75,7 +75,7 @@ pub fn current_application_parameters() -> Vec<u8> {
 }
 
 /// Retrieves the current system balance.
-pub fn current_system_balance() -> Balance {
+pub fn current_system_balance() -> Amount {
     wit::read_system_balance().into()
 }
 

--- a/linera-sdk/src/test/unit/conversions_to_wit.rs
+++ b/linera-sdk/src/test/unit/conversions_to_wit.rs
@@ -6,7 +6,7 @@
 use super::wit;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::Balance,
+    data_types::Amount,
     identifiers::{ApplicationId, ChainId, EffectId},
 };
 
@@ -48,9 +48,9 @@ impl From<EffectId> for wit::EffectId {
     }
 }
 
-impl From<Balance> for wit::Balance {
-    fn from(balance: Balance) -> Self {
-        wit::Balance {
+impl From<Amount> for wit::Amount {
+    fn from(balance: Amount) -> Self {
+        wit::Amount {
             lower_half: balance.lower_half(),
             upper_half: balance.upper_half(),
         }

--- a/linera-sdk/src/test/unit/mod.rs
+++ b/linera-sdk/src/test/unit/mod.rs
@@ -19,7 +19,7 @@ mod conversions_to_wit;
 use self::mock_system_api as wit;
 use futures::FutureExt;
 use linera_base::{
-    data_types::{Balance, Timestamp},
+    data_types::{Amount, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
 use linera_views::{
@@ -31,7 +31,7 @@ use linera_views::{
 static mut MOCK_CHAIN_ID: Option<ChainId> = None;
 static mut MOCK_APPLICATION_ID: Option<ApplicationId> = None;
 static mut MOCK_APPLICATION_PARAMETERS: Option<Vec<u8>> = None;
-static mut MOCK_SYSTEM_BALANCE: Option<Balance> = None;
+static mut MOCK_SYSTEM_BALANCE: Option<Amount> = None;
 static mut MOCK_SYSTEM_TIMESTAMP: Option<Timestamp> = None;
 static mut MOCK_LOG_COLLECTOR: Vec<(log::Level, String)> = Vec::new();
 static mut MOCK_APPLICATION_STATE: Option<Vec<u8>> = None;
@@ -57,7 +57,7 @@ pub fn mock_application_parameters(application_parameters: impl Into<Option<Vec<
 }
 
 /// Sets the mocked system balance.
-pub fn mock_system_balance(system_balance: impl Into<Option<Balance>>) {
+pub fn mock_system_balance(system_balance: impl Into<Option<Amount>>) {
     unsafe { MOCK_SYSTEM_BALANCE = system_balance.into() };
 }
 
@@ -126,7 +126,7 @@ impl wit::MockSystemApi for MockSystemApi {
             .into()
     }
 
-    fn mocked_read_system_balance() -> wit::Balance {
+    fn mocked_read_system_balance() -> wit::Amount {
         unsafe { MOCK_SYSTEM_BALANCE }
             .expect(
                 "Unexpected call to the `read_system_balance` system API. \

--- a/linera-sdk/wasm-tests/src/lib.rs
+++ b/linera-sdk/wasm-tests/src/lib.rs
@@ -10,7 +10,7 @@
 
 use futures::FutureExt;
 use linera_sdk::{
-    base::{ApplicationId, Balance, BlockHeight, BytecodeId, ChainId, EffectId, Timestamp},
+    base::{Amount, ApplicationId, BlockHeight, BytecodeId, ChainId, EffectId, Timestamp},
     contract, service, test, ContractLogger, ServiceLogger,
 };
 use linera_views::{
@@ -80,7 +80,7 @@ fn mock_application_parameters() {
 /// Test if the system balance getter API is mocked successfully.
 #[webassembly_test]
 fn mock_system_balance() {
-    let balance = Balance::from(0x00010203_04050607_08090a0b_0c0d0e0f);
+    let balance = Amount::from(0x00010203_04050607_08090a0b_0c0d0e0f);
 
     test::mock_system_balance(balance);
 

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -10,7 +10,7 @@ use comfy_table::{
 use file_lock::{FileLock, FileOptions};
 use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
-    data_types::{Balance, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_core::client::{ChainClient, ValidatorNodeProvider};
@@ -389,7 +389,7 @@ Next Block Height:  {}"#,
 pub struct GenesisConfig {
     pub committee: CommitteeConfig,
     pub admin_id: ChainId,
-    pub chains: Vec<(ChainDescription, PublicKey, Balance, Timestamp)>,
+    pub chains: Vec<(ChainDescription, PublicKey, Amount, Timestamp)>,
 }
 
 impl Import for GenesisConfig {}

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -9,7 +9,7 @@ use colored::Colorize;
 use futures::{lock::Mutex, StreamExt};
 use linera_base::{
     crypto::{KeyPair, PublicKey},
-    data_types::{Amount, Balance, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, EffectId},
 };
 use linera_chain::data_types::Certificate;
@@ -676,7 +676,7 @@ enum ClientCommand {
 
         /// Known initial balance of the chain
         #[structopt(long, default_value = "0")]
-        initial_funding: Balance,
+        initial_funding: Amount,
 
         /// The start timestamp: no blocks can be created before this time.
         #[structopt(long)]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -20,7 +20,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Balance, Timestamp},
+    data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
 use linera_chain::{
@@ -129,7 +129,7 @@ pub trait Store: Sized {
         admin_id: ChainId,
         description: ChainDescription,
         public_key: PublicKey,
-        balance: Balance,
+        balance: Amount,
         timestamp: Timestamp,
     ) -> Result<(), ChainError>
     where


### PR DESCRIPTION
# Motivation

Distinguishing between `Balance` and `Amount` for money amounts in different contexts is confusing, and having them have different bit lengths unnecessarily restricts amounts that can e.g. be transferred.

# Solution

Merge the types into a single `struct Amount(u128)` that represents a fixed-point fraction with a divisibility of 10^18. To avoid any loss of precision represent it as a string in JSON and GraphQL.