### PR TITLE
Avoid recompiling WASM bytecodes

### DIFF
--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -41,7 +41,7 @@ use super::{
     common::{self, ApplicationRuntimeContext, WasmRuntimeContext},
     WasmApplication, WasmExecutionError,
 };
-use crate::{ContractRuntime, ExecutionError, ServiceRuntime, SessionId};
+use crate::{Bytecode, ContractRuntime, ExecutionError, ServiceRuntime, SessionId};
 use linera_views::{batch::Batch, views::ViewError};
 use std::{error::Error, future::Future, task::Poll};
 use wasmtime::{Config, Engine, Linker, Module, Store, Trap};
@@ -81,29 +81,61 @@ impl<'runtime> ApplicationRuntimeContext for Service<'runtime> {
 }
 
 impl WasmApplication {
-    /// Prepares a runtime instance to call into the WASM contract.
-    pub fn prepare_contract_runtime_with_wasmtime<'runtime>(
-        &self,
-        runtime: &'runtime dyn ContractRuntime,
-    ) -> Result<WasmRuntimeContext<'runtime, Contract<'runtime>>, WasmExecutionError> {
+    /// Creates a new [`WasmApplication`] using Wasmtime with the provided bytecodes.
+    pub fn new_with_wasmtime(
+        contract_bytecode: Bytecode,
+        service_bytecode: Bytecode,
+    ) -> Result<Self, WasmExecutionError> {
+        let contract_engine = Self::create_wasmtime_engine_for_contracts()?;
+        let contract_module = Module::new(&contract_engine, contract_bytecode)?;
+
+        let service_engine = Self::create_wasmtime_engine_for_services()?;
+        let service_module = Module::new(&service_engine, service_bytecode)?;
+
+        Ok(WasmApplication::Wasmtime {
+            contract_engine,
+            contract_module,
+            service_module,
+            service_engine,
+        })
+    }
+
+    /// Creates an [`Engine`] instance configured to run application contracts.
+    fn create_wasmtime_engine_for_contracts() -> Result<Engine, WasmExecutionError> {
         let mut config = Config::default();
         config
             .consume_fuel(true)
             .cranelift_nan_canonicalization(true);
 
-        let engine = Engine::new(&config).map_err(WasmExecutionError::CreateWasmtimeEngine)?;
-        let mut linker = Linker::new(&engine);
+        Engine::new(&config).map_err(WasmExecutionError::CreateWasmtimeEngine)
+    }
+
+    /// Creates an [`Engine`] instance configured to run application services.
+    fn create_wasmtime_engine_for_services() -> Result<Engine, WasmExecutionError> {
+        Ok(Engine::default())
+    }
+
+    /// Prepares a runtime instance to call into the WASM contract.
+    pub fn prepare_contract_runtime_with_wasmtime<'runtime>(
+        contract_engine: &Engine,
+        contract_module: &Module,
+        runtime: &'runtime dyn ContractRuntime,
+    ) -> Result<WasmRuntimeContext<'runtime, Contract<'runtime>>, WasmExecutionError> {
+        let mut linker = Linker::new(contract_engine);
 
         contract_system_api::add_to_linker(&mut linker, ContractState::system_api)?;
         view_system_api::add_to_linker(&mut linker, ContractState::views_api)?;
 
-        let module = Module::new(&engine, &self.contract_bytecode)?;
         let waker_forwarder = WakerForwarder::default();
         let (future_queue, queued_future_factory) = HostFutureQueue::new();
         let state = ContractState::new(runtime, waker_forwarder.clone(), queued_future_factory);
-        let mut store = Store::new(&engine, state);
-        let (contract, _instance) =
-            contract::Contract::instantiate(&mut store, &module, &mut linker, ContractState::data)?;
+        let mut store = Store::new(contract_engine, state);
+        let (contract, _instance) = contract::Contract::instantiate(
+            &mut store,
+            contract_module,
+            &mut linker,
+            ContractState::data,
+        )?;
         let application = Contract { contract };
 
         store
@@ -121,22 +153,25 @@ impl WasmApplication {
 
     /// Prepares a runtime instance to call into the WASM service.
     pub fn prepare_service_runtime_with_wasmtime<'runtime>(
-        &self,
+        service_engine: &Engine,
+        service_module: &Module,
         runtime: &'runtime dyn ServiceRuntime,
     ) -> Result<WasmRuntimeContext<'runtime, Service<'runtime>>, WasmExecutionError> {
-        let engine = Engine::default();
-        let mut linker = Linker::new(&engine);
+        let mut linker = Linker::new(service_engine);
 
         service_system_api::add_to_linker(&mut linker, ServiceState::system_api)?;
         view_system_api::add_to_linker(&mut linker, ServiceState::views_api)?;
 
-        let module = Module::new(&engine, &self.service_bytecode)?;
         let waker_forwarder = WakerForwarder::default();
         let (future_queue, _queued_future_factory) = HostFutureQueue::new();
         let state = ServiceState::new(runtime, waker_forwarder.clone());
-        let mut store = Store::new(&engine, state);
-        let (service, _instance) =
-            service::Service::instantiate(&mut store, &module, &mut linker, ServiceState::data)?;
+        let mut store = Store::new(service_engine, state);
+        let (service, _instance) = service::Service::instantiate(
+            &mut store,
+            service_module,
+            &mut linker,
+            ServiceState::data,
+        )?;
         let application = Service { service };
 
         Ok(WasmRuntimeContext {


### PR DESCRIPTION
# Motivation

`WasmApplication` only stored the bytecodes for the application, which meant that it recompiled them for every execution. This is inefficient.

# Solution

Store the compiled `Module` (together with the required `Engine` instance) in `WasmApplication`.

# Related Work

Part of #739 
Closes #750 by including it