### PR TITLE
Reduce asynchronicity in `confirmed_log`

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -413,9 +413,14 @@ where
     ) -> Result<CrossChainRequest, WorkerError> {
         let heights =
             BTreeSet::from_iter(height_map.iter().flat_map(|(_, heights)| heights).copied());
-        let mut keys = Vec::new();
+        let mut heights_red = Vec::new();
         for height in heights {
-            if let Some(key) = confirmed_log.get(height.try_into()?).await? {
+            heights_red.push(height.try_into()?);
+        }
+        let values = confirmed_log.multi_get(heights_red).await?;
+        let mut keys = Vec::new();
+        for value in values {
+            if let Some(key) = value {
                 keys.push(key);
             }
         }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -418,12 +418,7 @@ where
             heights_red.push(height.try_into()?);
         }
         let values = confirmed_log.multi_get(heights_red).await?;
-        let mut keys = Vec::new();
-        for value in values {
-            if let Some(key) = value {
-                keys.push(key);
-            }
-        }
+        let keys = values.into_iter().flatten();
         let certificates = self.storage.read_certificates(keys).await?;
         Ok(CrossChainRequest::UpdateRecipient {
             height_map,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -413,11 +413,11 @@ where
     ) -> Result<CrossChainRequest, WorkerError> {
         let heights =
             BTreeSet::from_iter(height_map.iter().flat_map(|(_, heights)| heights).copied());
-        let mut heights_red = Vec::new();
+        let mut heights_usize = Vec::new();
         for height in heights {
-            heights_red.push(height.try_into()?);
+            heights_usize.push(height.try_into()?);
         }
-        let values = confirmed_log.multi_get(heights_red).await?;
+        let values = confirmed_log.multi_get(heights_usize).await?;
         let keys = values.into_iter().flatten();
         let certificates = self.storage.read_certificates(keys).await?;
         Ok(CrossChainRequest::UpdateRecipient {

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -212,8 +212,7 @@ where
         } else {
             let mut keys = Vec::new();
             let mut positions = Vec::new();
-            let mut pos = 0;
-            for index in indices {
+            for (pos,index) in indices.into_iter().enumerate() {
                 if index < self.stored_count {
                     let key = self.context.derive_tag_key(KeyTag::Index as u8, &index)?;
                     keys.push(key);
@@ -222,7 +221,6 @@ where
                 } else {
                     result.push(self.new_values.get(index - self.stored_count).cloned());
                 }
-                pos += 1;
             }
             let values = self.context.read_multi_key(keys).await?;
             for (pos, value) in positions.into_iter().zip(values) {

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -212,7 +212,7 @@ where
         } else {
             let mut keys = Vec::new();
             let mut positions = Vec::new();
-            for (pos,index) in indices.into_iter().enumerate() {
+            for (pos, index) in indices.into_iter().enumerate() {
                 if index < self.stored_count {
                     let key = self.context.derive_tag_key(KeyTag::Index as u8, &index)?;
                     keys.push(key);


### PR DESCRIPTION
The loop over the heights is ridiculous in terms of asynchronicity. Though the solution requires the introduction of a `multi_get` for `LogView`.