### PR TITLE
Improve the storage writing

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -528,7 +528,8 @@ where
         }
         let mut batch = Batch::new();
         self.storage.write_values_batch(blobs, &mut batch)?;
-        self.storage.write_certificate_batch(&certificate, &mut batch)?;
+        self.storage
+            .write_certificate_batch(&certificate, &mut batch)?;
         self.storage.write_batch(batch).await?;
         // Execute the block and update inboxes.
         chain.remove_events_from_inboxes(block).await?;
@@ -714,7 +715,8 @@ where
                     certificate.value.hash(),
                 )
                 .await?;
-            self.storage.write_certificate_batch(&certificate, &mut batch)?;
+            self.storage
+                .write_certificate_batch(&certificate, &mut batch)?;
         }
         self.storage.write_batch(batch).await?;
         if !self.allow_inactive_chains && !chain.is_active() {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -24,6 +24,7 @@ use linera_execution::{
 };
 use linera_storage::Store;
 use linera_views::{
+    batch::Batch,
     log_view::LogView,
     views::{RootView, View, ViewError},
 };
@@ -525,8 +526,10 @@ where
         for value in blobs {
             self.cache_recent_value(value.clone());
         }
-        self.storage.write_values(blobs).await?;
-        self.storage.write_certificate(&certificate).await?;
+        let mut batch = Batch::new();
+        self.storage.write_values_batch(blobs, &mut batch)?;
+        self.storage.write_certificate_batch(&certificate, &mut batch)?;
+        self.storage.write_batch(batch).await?;
         // Execute the block and update inboxes.
         chain.remove_events_from_inboxes(block).await?;
         let verified_effects = chain.execute_block(block).await?;
@@ -698,6 +701,7 @@ where
             return Ok(None);
         };
         // Process the received messages in certificates.
+        let mut batch = Batch::new();
         for certificate in certificates {
             let block = certificate.value.block();
             // Update the staged chain state with the received block.
@@ -710,8 +714,9 @@ where
                     certificate.value.hash(),
                 )
                 .await?;
-            self.storage.write_certificate(&certificate).await?;
+            self.storage.write_certificate_batch(&certificate, &mut batch)?;
         }
+        self.storage.write_batch(batch).await?;
         if !self.allow_inactive_chains && !chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by
             // now. Accordingly, do not send a confirmation, so that the

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -525,8 +525,12 @@ where
         for value in blobs {
             self.cache_recent_value(value.clone());
         }
-        self.storage.write_values(blobs).await?;
-        self.storage.write_certificate(&certificate).await?;
+        let (result_blob, result_certificate) = tokio::join!(
+            self.storage.write_values(blobs),
+            self.storage.write_certificate(&certificate)
+        );
+        result_blob?;
+        result_certificate?;
         // Execute the block and update inboxes.
         chain.remove_events_from_inboxes(block).await?;
         let verified_effects = chain.execute_block(block).await?;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -79,7 +79,11 @@ pub trait Store: Sized {
     async fn write_values(&self, values: &[HashedValue]) -> Result<(), ViewError>;
 
     /// Writes several values in a batch
-    fn write_values_batch(&self, values: &[HashedValue], batch: &mut Batch) -> Result<(), ViewError>;
+    fn write_values_batch(
+        &self,
+        values: &[HashedValue],
+        batch: &mut Batch,
+    ) -> Result<(), ViewError>;
 
     /// Reads the certificate with the given hash.
     async fn read_certificate(&self, hash: CryptoHash) -> Result<Certificate, ViewError>;
@@ -88,7 +92,11 @@ pub trait Store: Sized {
     async fn write_certificate(&self, certificate: &Certificate) -> Result<(), ViewError>;
 
     /// Writes the given certificate to the batch
-    fn write_certificate_batch(&self, certificate: &Certificate, batch: &mut Batch) -> Result<(), ViewError>;
+    fn write_certificate_batch(
+        &self,
+        certificate: &Certificate,
+        batch: &mut Batch,
+    ) -> Result<(), ViewError>;
 
     /// Writes the batch
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewError>;
@@ -300,7 +308,11 @@ where
         self.write_batch(batch).await
     }
 
-    fn write_values_batch(&self, values: &[HashedValue], batch: &mut Batch) -> Result<(), ViewError> {
+    fn write_values_batch(
+        &self,
+        values: &[HashedValue],
+        batch: &mut Batch,
+    ) -> Result<(), ViewError> {
         for value in values {
             let id = value.block().chain_id.to_string();
             increment_counter!(WRITE_VALUE_COUNTER, &[("chain_id", id)]);
@@ -346,7 +358,11 @@ where
         Ok(())
     }
 
-    fn write_certificate_batch(&self, certificate: &Certificate, batch: &mut Batch) -> Result<(), ViewError> {
+    fn write_certificate_batch(
+        &self,
+        certificate: &Certificate,
+        batch: &mut Batch,
+    ) -> Result<(), ViewError> {
         let id = certificate.value.block().chain_id.to_string();
         increment_counter!(WRITE_CERTIFICATE_COUNTER, &[("chain_id", id)]);
         let hash = certificate.value.hash();

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -78,13 +78,6 @@ pub trait Store: Sized {
     /// Writes several values
     async fn write_values(&self, values: &[HashedValue]) -> Result<(), ViewError>;
 
-    /// Writes several values in a batch
-    fn write_values_batch(
-        &self,
-        values: &[HashedValue],
-        batch: &mut Batch,
-    ) -> Result<(), ViewError>;
-
     /// Reads the certificate with the given hash.
     async fn read_certificate(&self, hash: CryptoHash) -> Result<Certificate, ViewError>;
 
@@ -93,9 +86,6 @@ pub trait Store: Sized {
 
     /// Writes a vector of certficates.
     async fn write_certificates(&self, certificate: &[Certificate]) -> Result<(), ViewError>;
-
-    /// Writes the batch
-    async fn write_batch(&self, batch: Batch) -> Result<(), ViewError>;
 
     /// Loads the view of a chain state and checks that it is active.
     async fn load_active_chain(
@@ -289,33 +279,17 @@ where
     }
 
     async fn write_value(&self, value: &HashedValue) -> Result<(), ViewError> {
-        let id = value.block().chain_id.to_string();
-        increment_counter!(WRITE_VALUE_COUNTER, &[("chain_id", id)]);
-        let value_key = bcs::to_bytes(&BaseKey::Value(value.hash()))?;
         let mut batch = Batch::new();
-        batch.put_key_value(value_key.to_vec(), value)?;
-        self.client.client.write_batch(batch, &[]).await?;
-        Ok(())
+        self.write_value_batch(value, &mut batch)?;
+        self.write_batch(batch).await
     }
 
     async fn write_values(&self, values: &[HashedValue]) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        self.write_values_batch(values, &mut batch)?;
-        self.write_batch(batch).await
-    }
-
-    fn write_values_batch(
-        &self,
-        values: &[HashedValue],
-        batch: &mut Batch,
-    ) -> Result<(), ViewError> {
         for value in values {
-            let id = value.block().chain_id.to_string();
-            increment_counter!(WRITE_VALUE_COUNTER, &[("chain_id", id)]);
-            let value_key = bcs::to_bytes(&BaseKey::Value(value.hash()))?;
-            batch.put_key_value(value_key.to_vec(), value)?;
+            self.write_value_batch(value, &mut batch)?;
         }
-        Ok(())
+        self.write_batch(batch).await
     }
 
     async fn read_certificate(&self, hash: CryptoHash) -> Result<Certificate, ViewError> {
@@ -355,11 +329,6 @@ where
         self.write_batch(batch).await
     }
 
-    async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {
-        self.client.client.write_batch(batch, &[]).await?;
-        Ok(())
-    }
-
     fn wasm_runtime(&self) -> Option<WasmRuntime> {
         self.client.wasm_runtime
     }
@@ -371,6 +340,13 @@ where
     ViewError: From<<CL as KeyValueStoreClient>::Error>,
     <CL as KeyValueStoreClient>::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
 {
+    fn write_value_batch(&self, value: &HashedValue, batch: &mut Batch) -> Result<(), ViewError> {
+        let id = value.block().chain_id.to_string();
+        increment_counter!(WRITE_VALUE_COUNTER, &[("chain_id", id)]);
+        let value_key = bcs::to_bytes(&BaseKey::Value(value.hash()))?;
+        batch.put_key_value(value_key.to_vec(), value)?;
+        Ok(())
+    }
 
     fn write_certificate_batch(
         &self,
@@ -384,6 +360,11 @@ where
         let value_key = bcs::to_bytes(&BaseKey::Value(hash))?;
         batch.put_key_value(cert_key.to_vec(), &certificate.lite_certificate())?;
         batch.put_key_value(value_key.to_vec(), &certificate.value)?;
+        Ok(())
+    }
+
+    async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {
+        self.client.client.write_batch(batch, &[]).await?;
         Ok(())
     }
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -84,7 +84,7 @@ pub trait Store: Sized {
     /// Writes the given certificate.
     async fn write_certificate(&self, certificate: &Certificate) -> Result<(), ViewError>;
 
-    /// Writes a vector of certficates.
+    /// Writes a vector of certificates.
     async fn write_certificates(&self, certificate: &[Certificate]) -> Result<(), ViewError>;
 
     /// Loads the view of a chain state and checks that it is active.
@@ -280,14 +280,14 @@ where
 
     async fn write_value(&self, value: &HashedValue) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        self.write_value_batch(value, &mut batch)?;
+        self.add_value_to_batch(value, &mut batch)?;
         self.write_batch(batch).await
     }
 
     async fn write_values(&self, values: &[HashedValue]) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for value in values {
-            self.write_value_batch(value, &mut batch)?;
+            self.add_value_to_batch(value, &mut batch)?;
         }
         self.write_batch(batch).await
     }
@@ -317,14 +317,14 @@ where
 
     async fn write_certificate(&self, certificate: &Certificate) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        self.write_certificate_batch(certificate, &mut batch)?;
+        self.add_certificate_to_batch(certificate, &mut batch)?;
         self.write_batch(batch).await
     }
 
     async fn write_certificates(&self, certificates: &[Certificate]) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for certificate in certificates {
-            self.write_certificate_batch(certificate, &mut batch)?;
+            self.add_certificate_to_batch(certificate, &mut batch)?;
         }
         self.write_batch(batch).await
     }
@@ -340,7 +340,7 @@ where
     ViewError: From<<CL as KeyValueStoreClient>::Error>,
     <CL as KeyValueStoreClient>::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
 {
-    fn write_value_batch(&self, value: &HashedValue, batch: &mut Batch) -> Result<(), ViewError> {
+    fn add_value_to_batch(&self, value: &HashedValue, batch: &mut Batch) -> Result<(), ViewError> {
         let id = value.block().chain_id.to_string();
         increment_counter!(WRITE_VALUE_COUNTER, &[("chain_id", id)]);
         let value_key = bcs::to_bytes(&BaseKey::Value(value.hash()))?;
@@ -348,7 +348,7 @@ where
         Ok(())
     }
 
-    fn write_certificate_batch(
+    fn add_certificate_to_batch(
         &self,
         certificate: &Certificate,
         batch: &mut Batch,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -350,7 +350,7 @@ where
     async fn write_certificates(&self, certificates: &[Certificate]) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for certificate in certificates {
-            self.write_certificate_batch(&certificate, &mut batch)?;
+            self.write_certificate_batch(certificate, &mut batch)?;
         }
         self.write_batch(batch).await
     }


### PR DESCRIPTION
There was more asynchronicity that could be eliminated from the storage writing by using the batches.