### PR TITLE
Cache compiled bytecodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "linera-views-derive",
  "linera-wit-bindgen-host-wasmer-rust",
  "linera-wit-bindgen-host-wasmtime-rust",
+ "lru",
  "once_cell",
  "serde",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,6 +2593,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "bcs",
+ "bytes",
  "counter",
  "custom_debug_derive",
  "dashmap",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1728,6 +1728,7 @@ dependencies = [
  "linera-views",
  "linera-views-derive",
  "linera-wit-bindgen-host-wasmer-rust",
+ "lru",
  "once_cell",
  "serde",
  "serde_bytes",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1720,6 +1720,7 @@ dependencies = [
  "async-lock",
  "async-trait",
  "bcs",
+ "bytes",
  "custom_debug_derive",
  "dashmap",
  "derive_more",

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -111,11 +111,14 @@ where
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
     let contract_bytecode = Bytecode::load_from_file(contract_path).await?;
     let service_bytecode = Bytecode::load_from_file(service_path).await?;
-    let application = Arc::new(WasmApplication::new(
-        contract_bytecode.clone(),
-        service_bytecode.clone(),
-        wasm_runtime,
-    )?);
+    let application = Arc::new(
+        WasmApplication::new(
+            contract_bytecode.clone(),
+            service_bytecode.clone(),
+            wasm_runtime,
+        )
+        .await?,
+    );
 
     // Publish some bytecode.
     let publish_operation = SystemOperation::PublishBytecode {

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -29,6 +29,7 @@ futures = { workspace = true }
 linera-base = { workspace = true }
 linera-views = { workspace = true, features = ["metrics"] }
 linera-views-derive = { workspace = true }
+lru = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -13,7 +13,10 @@ edition = "2021"
 [features]
 default = ["wasmer"]
 test = ["tokio/macros", "async-lock"]
-wasmer = ["dep:wasmer", "wasm-encoder", "wasmer-middlewares", "wasmparser", "wit-bindgen-host-wasmer-rust"]
+wasmer = [
+    "bytes", "dep:wasmer", "wasm-encoder", "wasmer-middlewares", "wasmparser",
+    "wit-bindgen-host-wasmer-rust",
+]
 wasmtime = ["dep:wasmtime", "wasm-encoder", "wasmparser", "wit-bindgen-host-wasmtime-rust"]
 
 [dependencies]
@@ -22,6 +25,7 @@ async-lock = { workspace = true, optional = true }
 async-trait = { workspace = true }
 async-graphql = { workspace = true }
 bcs = { workspace = true }
+bytes = { workspace = true, optional = true }
 custom_debug_derive = { workspace = true }
 dashmap = { workspace = true }
 derive_more = { workspace = true }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -37,17 +37,13 @@ use thiserror::Error;
 pub enum WasmApplication {
     #[cfg(feature = "wasmer")]
     Wasmer {
-        contract_engine: ::wasmer::Engine,
-        contract_module: ::wasmer::Module,
-        service_engine: ::wasmer::Engine,
-        service_module: ::wasmer::Module,
+        contract: (::wasmer::Engine, ::wasmer::Module),
+        service: ::wasmer::Module,
     },
     #[cfg(feature = "wasmtime")]
     Wasmtime {
-        contract_engine: ::wasmtime::Engine,
-        contract_module: ::wasmtime::Module,
-        service_engine: ::wasmtime::Engine,
-        service_module: ::wasmtime::Module,
+        contract: ::wasmtime::Module,
+        service: ::wasmtime::Module,
     },
 }
 
@@ -124,23 +120,14 @@ impl UserApplication for WasmApplication {
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
         let result = match self {
             #[cfg(feature = "wasmtime")]
-            WasmApplication::Wasmtime {
-                contract_engine,
-                contract_module,
-                ..
-            } => {
-                Self::prepare_contract_runtime_with_wasmtime(
-                    contract_engine,
-                    contract_module,
-                    runtime,
-                )?
-                .initialize(context, argument)
-                .await?
+            WasmApplication::Wasmtime { contract, .. } => {
+                Self::prepare_contract_runtime_with_wasmtime(contract, runtime)?
+                    .initialize(context, argument)
+                    .await?
             }
             #[cfg(feature = "wasmer")]
             WasmApplication::Wasmer {
-                contract_engine,
-                contract_module,
+                contract: (contract_engine, contract_module),
                 ..
             } => {
                 Self::prepare_contract_runtime_with_wasmer(
@@ -163,23 +150,14 @@ impl UserApplication for WasmApplication {
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
         let result = match self {
             #[cfg(feature = "wasmtime")]
-            WasmApplication::Wasmtime {
-                contract_engine,
-                contract_module,
-                ..
-            } => {
-                Self::prepare_contract_runtime_with_wasmtime(
-                    contract_engine,
-                    contract_module,
-                    runtime,
-                )?
-                .execute_operation(context, operation)
-                .await?
+            WasmApplication::Wasmtime { contract, .. } => {
+                Self::prepare_contract_runtime_with_wasmtime(contract, runtime)?
+                    .execute_operation(context, operation)
+                    .await?
             }
             #[cfg(feature = "wasmer")]
             WasmApplication::Wasmer {
-                contract_engine,
-                contract_module,
+                contract: (contract_engine, contract_module),
                 ..
             } => {
                 Self::prepare_contract_runtime_with_wasmer(
@@ -202,23 +180,14 @@ impl UserApplication for WasmApplication {
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
         let result = match self {
             #[cfg(feature = "wasmtime")]
-            WasmApplication::Wasmtime {
-                contract_engine,
-                contract_module,
-                ..
-            } => {
-                Self::prepare_contract_runtime_with_wasmtime(
-                    contract_engine,
-                    contract_module,
-                    runtime,
-                )?
-                .execute_message(context, message)
-                .await?
+            WasmApplication::Wasmtime { contract, .. } => {
+                Self::prepare_contract_runtime_with_wasmtime(contract, runtime)?
+                    .execute_message(context, message)
+                    .await?
             }
             #[cfg(feature = "wasmer")]
             WasmApplication::Wasmer {
-                contract_engine,
-                contract_module,
+                contract: (contract_engine, contract_module),
                 ..
             } => {
                 Self::prepare_contract_runtime_with_wasmer(
@@ -242,23 +211,14 @@ impl UserApplication for WasmApplication {
     ) -> Result<ApplicationCallResult, ExecutionError> {
         let result = match self {
             #[cfg(feature = "wasmtime")]
-            WasmApplication::Wasmtime {
-                contract_engine,
-                contract_module,
-                ..
-            } => {
-                Self::prepare_contract_runtime_with_wasmtime(
-                    contract_engine,
-                    contract_module,
-                    runtime,
-                )?
-                .handle_application_call(context, argument, forwarded_sessions)
-                .await?
+            WasmApplication::Wasmtime { contract, .. } => {
+                Self::prepare_contract_runtime_with_wasmtime(contract, runtime)?
+                    .handle_application_call(context, argument, forwarded_sessions)
+                    .await?
             }
             #[cfg(feature = "wasmer")]
             WasmApplication::Wasmer {
-                contract_engine,
-                contract_module,
+                contract: (contract_engine, contract_module),
                 ..
             } => {
                 Self::prepare_contract_runtime_with_wasmer(
@@ -283,23 +243,14 @@ impl UserApplication for WasmApplication {
     ) -> Result<SessionCallResult, ExecutionError> {
         let result = match self {
             #[cfg(feature = "wasmtime")]
-            WasmApplication::Wasmtime {
-                contract_engine,
-                contract_module,
-                ..
-            } => {
-                Self::prepare_contract_runtime_with_wasmtime(
-                    contract_engine,
-                    contract_module,
-                    runtime,
-                )?
-                .handle_session_call(context, session_state, argument, forwarded_sessions)
-                .await?
+            WasmApplication::Wasmtime { contract, .. } => {
+                Self::prepare_contract_runtime_with_wasmtime(contract, runtime)?
+                    .handle_session_call(context, session_state, argument, forwarded_sessions)
+                    .await?
             }
             #[cfg(feature = "wasmer")]
             WasmApplication::Wasmer {
-                contract_engine,
-                contract_module,
+                contract: (contract_engine, contract_module),
                 ..
             } => {
                 Self::prepare_contract_runtime_with_wasmer(
@@ -322,26 +273,14 @@ impl UserApplication for WasmApplication {
     ) -> Result<Vec<u8>, ExecutionError> {
         let result = match self {
             #[cfg(feature = "wasmtime")]
-            WasmApplication::Wasmtime {
-                service_engine,
-                service_module,
-                ..
-            } => {
-                Self::prepare_service_runtime_with_wasmtime(
-                    service_engine,
-                    service_module,
-                    runtime,
-                )?
-                .query_application(context, argument)
-                .await?
+            WasmApplication::Wasmtime { service, .. } => {
+                Self::prepare_service_runtime_with_wasmtime(service, runtime)?
+                    .query_application(context, argument)
+                    .await?
             }
             #[cfg(feature = "wasmer")]
-            WasmApplication::Wasmer {
-                service_engine,
-                service_module,
-                ..
-            } => {
-                Self::prepare_service_runtime_with_wasmer(service_engine, service_module, runtime)?
+            WasmApplication::Wasmer { service, .. } => {
+                Self::prepare_service_runtime_with_wasmer(service, runtime)?
                     .query_application(context, argument)
                     .await?
             }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -38,7 +38,7 @@ use thiserror::Error;
 pub enum WasmApplication {
     #[cfg(feature = "wasmer")]
     Wasmer {
-        contract: Arc<(::wasmer::Engine, ::wasmer::Module)>,
+        contract: (::wasmer::Engine, ::wasmer::Module),
         service: Arc<::wasmer::Module>,
     },
     #[cfg(feature = "wasmtime")]

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -13,6 +13,7 @@
 mod async_boundary;
 mod async_determinism;
 mod common;
+mod module_cache;
 mod sanitizer;
 #[macro_use]
 mod system_api;

--- a/linera-execution/src/wasm/module_cache.rs
+++ b/linera-execution/src/wasm/module_cache.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A cache of compiled WebAssembly modules.
+//!
+//! The cache is limited by the total size of cached bytecodes. Note that this is a heuristic to
+//! estimate the total memory usage by the cache, since it's currently not possible to determine
+//! the size of a generic `Module`.
+
+use crate::{wasm::WasmExecutionError, Bytecode};
+use lru::LruCache;
+use std::sync::Arc;
+
+/// The default maximum size of the bytecodes stored in cache.
+const DEFAULT_MAX_CACHE_SIZE: u64 = 512 /* MiB */ * 1024 /* KiB */ * 1024 /* bytes */;
+
+/// A cache of compiled WebAssembly modules.
+///
+/// The cache prioritizes entries based on their [`Metadata`].
+pub struct ModuleCache<Module> {
+    modules: LruCache<Bytecode, Arc<Module>>,
+    total_size: u64,
+    max_size: u64,
+}
+
+impl<Module> Default for ModuleCache<Module> {
+    fn default() -> Self {
+        ModuleCache {
+            modules: LruCache::unbounded(),
+            total_size: 0,
+            max_size: DEFAULT_MAX_CACHE_SIZE,
+        }
+    }
+}
+
+impl<Module> ModuleCache<Module> {
+    /// Returns a `Module` for the requested `bytecode`, creating it with `module_builder` and
+    /// adding it to the cache if it doesn't already exist in the cache.
+    pub fn get_or_insert_with<E>(
+        &mut self,
+        bytecode: Bytecode,
+        module_builder: impl FnOnce(Bytecode) -> Result<Module, E>,
+    ) -> Result<Arc<Module>, WasmExecutionError>
+    where
+        WasmExecutionError: From<E>,
+    {
+        if let Some(module) = self.get(&bytecode) {
+            Ok(module)
+        } else {
+            let module = Arc::new(module_builder(bytecode.clone())?);
+            self.insert(bytecode, module.clone());
+            Ok(module)
+        }
+    }
+
+    /// Returns a `Module` for the requested `bytecode` if it's in the cache.
+    pub fn get(&mut self, bytecode: &Bytecode) -> Option<Arc<Module>> {
+        self.modules.get(bytecode).cloned()
+    }
+
+    /// Inserts a `bytecode` and its compiled `module` in the cache.
+    pub fn insert(&mut self, bytecode: Bytecode, module: Arc<Module>) {
+        let bytecode_size = bytecode.as_ref().len() as u64;
+
+        if self.total_size + bytecode_size > self.max_size {
+            self.reduce_size_to(self.max_size - bytecode_size);
+        }
+
+        self.modules.put(bytecode, module);
+    }
+
+    /// Evicts entries from the cache so that the total size of cached bytecodes is less than
+    /// `new_size`.
+    fn reduce_size_to(&mut self, new_size: u64) {
+        while self.total_size > new_size {
+            let (bytecode, _module) = self
+                .modules
+                .pop_lru()
+                .expect("Empty cache should have a `total_size` of zero");
+            let bytecode_size = bytecode.as_ref().len() as u64;
+
+            self.total_size -= bytecode_size;
+        }
+    }
+}

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -203,11 +203,9 @@ pub trait Store: Sized {
             .map_err(|_| linera_base::data_types::ArithmeticError::Overflow)?;
         match operations.get(index) {
             Some(Operation::System(SystemOperation::PublishBytecode { contract, service })) => {
-                Ok(Arc::new(WasmApplication::new(
-                    contract.clone(),
-                    service.clone(),
-                    wasm_runtime,
-                )?))
+                Ok(Arc::new(
+                    WasmApplication::new(contract.clone(), service.clone(), wasm_runtime).await?,
+                ))
             }
             _ => Err(ExecutionError::InvalidBytecodeId(*bytecode_id)),
         }


### PR DESCRIPTION
# Motivation

Different applications are able to use the same bytecode for execution. It's therefore possible to reuse the compiled WebAssembly module for a bytecode between two applications.

# Solution

Create a `ModuleCache` type that caches compiled WebAssembly modules for specific bytecodes. The cache attempts to limit its total memory usage, but it does so based on the bytecode size instead of trying to measure the module's size.

# Related Issues

Closes #739 