### PR TITLE
Implement Service ABIs using associated types in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3091,6 +3091,7 @@ dependencies = [
 name = "meta-counter"
 version = "0.1.0"
 dependencies = [
+ "async-graphql",
  "async-trait",
  "bcs",
  "counter",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
 name = "meta-counter"
 version = "0.1.0"
 dependencies = [
+ "async-graphql",
  "async-trait",
  "bcs",
  "counter",

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::base::ContractAbi;
+use async_graphql::{Request, Response};
+use linera_sdk::base::{ContractAbi, ServiceAbi};
 
 pub struct CounterAbi;
 
@@ -14,4 +15,10 @@ impl ContractAbi for CounterAbi {
     type SessionCall = ();
     type Response = u64;
     type SessionState = ();
+}
+
+impl ServiceAbi for CounterAbi {
+    type Query = Request;
+    type QueryResponse = Response;
+    type Parameters = ();
 }

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::SimpleObject;
+use async_graphql::{Request, Response, SimpleObject};
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, ApplicationId, ContractAbi, Timestamp};
+use linera_sdk::base::{Amount, ApplicationId, ContractAbi, ServiceAbi, Timestamp};
 use serde::{Deserialize, Serialize};
 
 pub struct CrowdFundingAbi;
@@ -17,6 +17,12 @@ impl ContractAbi for CrowdFundingAbi {
     type SessionCall = ();
     type Response = ();
     type SessionState = ();
+}
+
+impl ServiceAbi for CrowdFundingAbi {
+    type Query = Request;
+    type QueryResponse = Response;
+    type Parameters = ApplicationId;
 }
 
 /// The initialization data required to create a crowd-funding campaign.

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{scalar, InputObject};
-use linera_sdk::base::{Amount, ApplicationId, ChainId, ContractAbi, Owner};
+use async_graphql::{scalar, InputObject, Request, Response};
+use linera_sdk::base::{Amount, ApplicationId, ChainId, ContractAbi, Owner, ServiceAbi};
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeMap, str::FromStr};
 
@@ -17,6 +17,12 @@ impl ContractAbi for FungibleTokenAbi {
     type SessionCall = SessionCall;
     type Response = Amount;
     type SessionState = Amount;
+}
+
+impl ServiceAbi for FungibleTokenAbi {
+    type Query = Request;
+    type QueryResponse = Response;
+    type Parameters = ();
 }
 
 /// An operation.

--- a/examples/meta-counter/Cargo.toml
+++ b/examples/meta-counter/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dependencies]
+async-graphql = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 counter = { workspace = true }

--- a/examples/meta-counter/src/lib.rs
+++ b/examples/meta-counter/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::base::{ApplicationId, ChainId, ContractAbi};
+use linera_sdk::base::{ApplicationId, ChainId, ContractAbi, ServiceAbi};
 
 pub struct MetaCounterAbi;
 
@@ -14,4 +14,10 @@ impl ContractAbi for MetaCounterAbi {
     type SessionCall = ();
     type Response = ();
     type SessionState = ();
+}
+
+impl ServiceAbi for MetaCounterAbi {
+    type Query = Vec<u8>;
+    type QueryResponse = Vec<u8>;
+    type Parameters = ApplicationId;
 }

--- a/examples/meta-counter/src/lib.rs
+++ b/examples/meta-counter/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use async_graphql::{Request, Response};
 use linera_sdk::base::{ApplicationId, ChainId, ContractAbi, ServiceAbi};
-
 pub struct MetaCounterAbi;
 
 impl ContractAbi for MetaCounterAbi {
@@ -17,7 +17,7 @@ impl ContractAbi for MetaCounterAbi {
 }
 
 impl ServiceAbi for MetaCounterAbi {
-    type Query = Vec<u8>;
-    type QueryResponse = Vec<u8>;
+    type Query = Request;
+    type QueryResponse = Response;
     type Parameters = ApplicationId;
 }

--- a/examples/meta-counter/src/service.rs
+++ b/examples/meta-counter/src/service.rs
@@ -6,6 +6,7 @@
 mod state;
 
 use self::state::MetaCounter;
+use async_graphql::{Request, Response};
 use async_trait::async_trait;
 use linera_sdk::{
     base::{ApplicationId, WithServiceAbi},
@@ -36,12 +37,14 @@ impl Service for MetaCounter {
     async fn query_application(
         self: Arc<Self>,
         _context: &QueryContext,
-        argument: Vec<u8>,
-    ) -> Result<Vec<u8>, Self::Error> {
+        request: Request,
+    ) -> Result<Response, Self::Error> {
+        let argument = serde_json::to_vec(&request).unwrap();
         let value = system_api::query_application(Self::counter_id()?, &argument)
             .await
             .map_err(|_| Error::InternalQuery)?;
-        Ok(value)
+        let response = serde_json::from_slice(&value).unwrap();
+        Ok(response)
     }
 }
 

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -29,7 +29,7 @@ impl Contract for ReentrantCounter {
     async fn initialize(
         &mut self,
         _context: &OperationContext,
-        value: u128,
+        value: u64,
     ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         self.value.set(value);
         Ok(ExecutionResult::default())
@@ -38,7 +38,7 @@ impl Contract for ReentrantCounter {
     async fn execute_operation(
         &mut self,
         _context: &OperationContext,
-        increment: u128,
+        increment: u64,
     ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         let first_half = increment / 2;
         let second_half = increment - first_half;
@@ -68,7 +68,7 @@ impl Contract for ReentrantCounter {
     async fn handle_application_call(
         &mut self,
         _context: &CalleeContext,
-        increment: u128,
+        increment: u64,
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error>
     {

--- a/examples/reentrant-counter/src/lib.rs
+++ b/examples/reentrant-counter/src/lib.rs
@@ -1,17 +1,23 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::base::ContractAbi;
+use linera_sdk::base::{ContractAbi, ServiceAbi};
 
 pub struct ReentrantCounterAbi;
 
 impl ContractAbi for ReentrantCounterAbi {
-    type InitializationArgument = u128;
+    type InitializationArgument = u64;
     type Parameters = ();
-    type Operation = u128;
-    type ApplicationCall = u128;
+    type Operation = u64;
+    type ApplicationCall = u64;
     type Effect = ();
     type SessionCall = ();
-    type Response = u128;
+    type Response = u64;
     type SessionState = ();
+}
+
+impl ServiceAbi for ReentrantCounterAbi {
+    type Query = ();
+    type QueryResponse = u64;
+    type Parameters = ();
 }

--- a/examples/reentrant-counter/src/service.rs
+++ b/examples/reentrant-counter/src/service.rs
@@ -7,11 +7,15 @@ mod state;
 
 use self::state::ReentrantCounter;
 use async_trait::async_trait;
-use linera_sdk::{QueryContext, Service, ViewStateStorage};
+use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
 use std::sync::Arc;
 use thiserror::Error;
 
 linera_sdk::service!(ReentrantCounter);
+
+impl WithServiceAbi for ReentrantCounter {
+    type Abi = reentrant_counter::ReentrantCounterAbi;
+}
 
 #[async_trait]
 impl Service for ReentrantCounter {
@@ -21,27 +25,24 @@ impl Service for ReentrantCounter {
     async fn query_application(
         self: Arc<Self>,
         _context: &QueryContext,
-        argument: &[u8],
-    ) -> Result<Vec<u8>, Self::Error> {
-        let value = self.value.get();
-        match argument {
-            &[] => Ok(bcs::to_bytes(&value).expect("Serialization should not fail")),
-            _ => Err(Error::InvalidQuery),
-        }
+        _argument: (),
+    ) -> Result<u64, Self::Error> {
+        Ok(*self.value.get())
     }
 }
 
 /// An error that can occur during the contract execution.
-#[derive(Debug, Error, Eq, PartialEq)]
+#[derive(Debug, Error)]
 pub enum Error {
-    /// Invalid query argument; Counter application only supports a single (empty) query.
-    #[error("Invalid query argument; Counter application only supports a single (empty) query")]
-    InvalidQuery,
+    /// Invalid query argument in reentrant-counter app: could not deserialize GraphQL request.
+    #[error(
+        "Invalid query argument in reentrant-counter app: could not deserialize GraphQL request."
+    )]
+    InvalidQuery(#[from] serde_json::Error),
 }
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod tests {
-    use super::Error;
     use crate::ReentrantCounter;
     use futures::FutureExt;
     use linera_sdk::{base::ChainId, test, views::ViewStorageContext, QueryContext, Service};
@@ -52,7 +53,7 @@ mod tests {
     #[webassembly_test]
     fn query() {
         test::mock_key_value_store();
-        let value = 61_098_721_u128;
+        let value = 61_098_721_u64;
         let mut counter = ReentrantCounter::load(ViewStorageContext::default())
             .now_or_never()
             .unwrap()
@@ -60,34 +61,11 @@ mod tests {
         counter.value.set(value);
         let counter = Arc::new(counter);
         let result = counter
-            .query_application(&dummy_query_context(), &[])
+            .query_application(&dummy_query_context(), ())
             .now_or_never()
             .expect("Query should not await anything");
 
-        let expected_response =
-            bcs::to_bytes(&value).expect("Counter value could not be serialized");
-
-        assert_eq!(result, Ok(expected_response));
-    }
-
-    #[webassembly_test]
-    fn invalid_query() {
-        test::mock_key_value_store();
-        let value = 4_u128;
-        let mut counter = ReentrantCounter::load(ViewStorageContext::default())
-            .now_or_never()
-            .unwrap()
-            .expect("Failed to load Counter");
-        counter.value.set(value);
-        let counter = Arc::new(counter);
-
-        let dummy_argument = [2];
-        let result = counter
-            .query_application(&dummy_query_context(), &dummy_argument)
-            .now_or_never()
-            .expect("Query should not await anything");
-
-        assert_eq!(result, Err(Error::InvalidQuery));
+        assert_eq!(result.unwrap(), value);
     }
 
     fn dummy_query_context() -> QueryContext {

--- a/examples/reentrant-counter/src/state.rs
+++ b/examples/reentrant-counter/src/state.rs
@@ -8,5 +8,5 @@ use linera_views::views::RootView;
 #[derive(RootView)]
 #[view(context = "ViewStorageContext")]
 pub struct ReentrantCounter {
-    pub value: RegisterView<u128>,
+    pub value: RegisterView<u64>,
 }

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_graphql::{InputObject, SimpleObject};
-use linera_sdk::base::{ChainId, ContractAbi, Timestamp};
+use async_graphql::{InputObject, Request, Response, SimpleObject};
+use linera_sdk::base::{ChainId, ContractAbi, ServiceAbi, Timestamp};
 use linera_views::{common::CustomSerialize, views};
 use serde::{Deserialize, Serialize};
 
@@ -17,6 +17,12 @@ impl ContractAbi for SocialAbi {
     type SessionCall = ();
     type Response = ();
     type SessionState = ();
+}
+
+impl ServiceAbi for SocialAbi {
+    type Query = Request;
+    type QueryResponse = Response;
+    type Parameters = ();
 }
 
 /// An operation that can be executed by the application.

--- a/linera-base/src/abi.rs
+++ b/linera-base/src/abi.rs
@@ -7,7 +7,7 @@
 use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
-/// A trait that includes all the types exported by a Linera application.
+/// A trait that includes all the types exported by a Linera application contract.
 pub trait ContractAbi {
     /// Initialization argument passed to a new application on the chain that created it
     /// (e.g. an initial amount of tokens minted).
@@ -68,4 +68,33 @@ where
     type SessionCall = <<A as WithContractAbi>::Abi as ContractAbi>::SessionCall;
     type Response = <<A as WithContractAbi>::Abi as ContractAbi>::Response;
     type SessionState = <<A as WithContractAbi>::Abi as ContractAbi>::SessionState;
+}
+
+/// A trait that includes all the types exported by a Linera application service.
+pub trait ServiceAbi {
+    /// The type of a query receivable by the application's service.
+    type Query: DeserializeOwned + Send + Sync + Debug + 'static;
+
+    /// The response type of the application's service.
+    type QueryResponse: Serialize + Send + Sync + Debug + 'static;
+
+    /// Immutable parameters specific to this application (e.g. the name of a token).
+    type Parameters: Serialize + DeserializeOwned + Send + Sync + Debug + 'static;
+}
+
+/// Marker trait to help importing service types.
+pub trait WithServiceAbi {
+    /// The service types to import.
+    type Abi: ServiceAbi;
+}
+
+impl<A> ServiceAbi for A
+where
+    A: WithServiceAbi,
+{
+    type Query = <<A as WithServiceAbi>::Abi as ServiceAbi>::Query;
+
+    type QueryResponse = <<A as WithServiceAbi>::Abi as ServiceAbi>::QueryResponse;
+
+    type Parameters = <<A as WithServiceAbi>::Abi as ServiceAbi>::Parameters;
 }

--- a/linera-sdk/src/service/exported_futures.rs
+++ b/linera-sdk/src/service/exported_futures.rs
@@ -35,10 +35,13 @@ where
     ) -> ExportedFuture<Result<Vec<u8>, String>> {
         ExportedFuture::new(async move {
             let application: Arc<Application> = Arc::new(system_api::load().await);
-            application
-                .query_application(&context.into(), &argument)
+            let argument: Application::Query =
+                serde_json::from_slice(&argument).map_err(|e| e.to_string())?;
+            let query_response = application
+                .query_application(&context.into(), argument)
                 .await
-                .map_err(|error| error.to_string())
+                .map_err(|error| error.to_string())?;
+            serde_json::to_vec(&query_response).map_err(|e| e.to_string())
         })
     }
 }
@@ -53,13 +56,16 @@ where
     ) -> ExportedFuture<Result<Vec<u8>, String>> {
         ExportedFuture::new(async move {
             let application: Arc<Application> = Arc::new(system_api::lock_and_load_view().await);
+            let argument: Application::Query =
+                serde_json::from_slice(&argument).map_err(|e| e.to_string())?;
             let result = application
-                .query_application(&context.into(), &argument)
+                .query_application(&context.into(), argument)
                 .await;
             if result.is_ok() {
                 system_api::unlock_view().await;
             }
-            result.map_err(|error| error.to_string())
+            let query_response = result.map_err(|error| error.to_string())?;
+            serde_json::to_vec(&query_response).map_err(|e| e.to_string())
         })
     }
 }


### PR DESCRIPTION
# Motivation

Application authors should not have to write boilerplate code to serialize and deserialize requests coming into services.

# Solution

Use associated types in Services to define types and perform serde in the background.