### PR TITLE
More ABI-safe functions in examples and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_bytes",
+ "serde_json",
  "test-case",
  "test-log",
  "thiserror",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1727,6 +1727,7 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_bytes",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -3,7 +3,10 @@
 
 use async_graphql::{Request, Response};
 use linera_sdk::base::{ContractAbi, ServiceAbi};
+use serde::{Deserialize, Serialize};
 
+// TODO(#768): Remove the derive macros.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct CounterAbi;
 
 impl ContractAbi for CounterAbi {

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -6,11 +6,13 @@ use fungible::AccountOwner;
 use linera_sdk::base::{Amount, ApplicationId, ContractAbi, ServiceAbi, Timestamp};
 use serde::{Deserialize, Serialize};
 
+// TODO(#768): Remove the derive macros.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct CrowdFundingAbi;
 
 impl ContractAbi for CrowdFundingAbi {
     type InitializationArgument = InitializationArgument;
-    type Parameters = ApplicationId;
+    type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
     type Operation = Operation;
     type ApplicationCall = ApplicationCall;
     type Effect = Effect;
@@ -20,9 +22,9 @@ impl ContractAbi for CrowdFundingAbi {
 }
 
 impl ServiceAbi for CrowdFundingAbi {
+    type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
     type Query = Request;
     type QueryResponse = Response;
-    type Parameters = ApplicationId;
 }
 
 /// The initialization data required to create a crowd-funding campaign.

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -6,6 +6,8 @@ use linera_sdk::base::{Amount, ApplicationId, ChainId, ContractAbi, Owner, Servi
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeMap, str::FromStr};
 
+// TODO(#768): Remove the derive macros.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct FungibleTokenAbi;
 
 impl ContractAbi for FungibleTokenAbi {

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 linera_sdk::contract!(MetaCounter);
 
 impl MetaCounter {
-    fn counter_id() -> Result<ApplicationId, Error> {
+    fn counter_id() -> Result<ApplicationId<counter::CounterAbi>, Error> {
         Self::parameters()
     }
 }
@@ -55,7 +55,7 @@ impl Contract for MetaCounter {
         effect: u64,
     ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
         log::trace!("executing {:?} via {:?}", effect, Self::counter_id()?);
-        self.call_application::<counter::CounterAbi>(true, Self::counter_id()?, &effect, vec![])
+        self.call_application(true, Self::counter_id()?, &effect, vec![])
             .await?;
         Ok(ExecutionResult::default())
     }

--- a/examples/meta-counter/src/lib.rs
+++ b/examples/meta-counter/src/lib.rs
@@ -3,11 +3,15 @@
 
 use async_graphql::{Request, Response};
 use linera_sdk::base::{ApplicationId, ChainId, ContractAbi, ServiceAbi};
+use serde::{Deserialize, Serialize};
+
+// TODO(#768): Remove the derive macros.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct MetaCounterAbi;
 
 impl ContractAbi for MetaCounterAbi {
     type InitializationArgument = ();
-    type Parameters = ApplicationId;
+    type Parameters = ApplicationId<counter::CounterAbi>;
     type Operation = (ChainId, u64);
     type ApplicationCall = ();
     type Effect = u64;
@@ -19,5 +23,5 @@ impl ContractAbi for MetaCounterAbi {
 impl ServiceAbi for MetaCounterAbi {
     type Query = Request;
     type QueryResponse = Response;
-    type Parameters = ApplicationId;
+    type Parameters = ApplicationId<counter::CounterAbi>;
 }

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -9,7 +9,6 @@ use self::state::ReentrantCounter;
 use async_trait::async_trait;
 use linera_sdk::{
     base::{SessionId, WithContractAbi},
-    contract::system_api,
     ApplicationCallResult, CalleeContext, Contract, EffectContext, ExecutionResult,
     OperationContext, SessionCallResult, ViewStateStorage,
 };
@@ -46,13 +45,8 @@ impl Contract for ReentrantCounter {
         let value = self.value.get_mut();
         *value += first_half;
 
-        self.call_application::<Self>(
-            false,
-            system_api::current_application_id(),
-            &second_half,
-            vec![],
-        )
-        .await?;
+        self.call_application(false, Self::current_application_id(), &second_half, vec![])
+            .await?;
 
         Ok(ExecutionResult::default())
     }

--- a/examples/reentrant-counter/src/lib.rs
+++ b/examples/reentrant-counter/src/lib.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_sdk::base::{ContractAbi, ServiceAbi};
+use serde::{Deserialize, Serialize};
 
+// TODO(#768): Remove the derive macros.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct ReentrantCounterAbi;
 
 impl ContractAbi for ReentrantCounterAbi {

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -6,6 +6,8 @@ use linera_sdk::base::{ChainId, ContractAbi, ServiceAbi, Timestamp};
 use linera_views::{common::CustomSerialize, views};
 use serde::{Deserialize, Serialize};
 
+// TODO(#768): Remove the derive macros.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 pub struct SocialAbi;
 
 impl ContractAbi for SocialAbi {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -20,7 +20,7 @@ use linera_base::{
 use linera_execution::{
     committee::Epoch,
     system::{Account, Recipient, SystemOperation, UserData},
-    Operation, Query, Response, SystemQuery, SystemResponse,
+    Operation, SystemQuery, SystemResponse,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -755,14 +755,11 @@ where
         .await?;
     assert_eq!(client1.local_balance().await.unwrap(), Amount::from(3));
     assert_eq!(
-        client1
-            .query_application(&Query::System(SystemQuery))
-            .await
-            .unwrap(),
-        Response::System(SystemResponse {
+        client1.query_system_application(SystemQuery).await.unwrap(),
+        SystemResponse {
             chain_id: ChainId::root(1),
             balance: Amount::from(3),
-        })
+        }
     );
 
     let certificate = client1
@@ -779,14 +776,11 @@ where
     assert!(client1.pending_block.is_none());
     assert_eq!(client1.local_balance().await.unwrap(), Amount::from(0));
     assert_eq!(
-        client1
-            .query_application(&Query::System(SystemQuery))
-            .await
-            .unwrap(),
-        Response::System(SystemResponse {
+        client1.query_system_application(SystemQuery).await.unwrap(),
+        SystemResponse {
             chain_id: ChainId::root(1),
             balance: Amount::from(0),
-        })
+        }
     );
 
     assert_eq!(
@@ -808,14 +802,11 @@ where
     // The local balance from the client is reflecting incoming messages but the
     // SystemResponse only reads the ChainState.
     assert_eq!(
-        client2
-            .query_application(&Query::System(SystemQuery))
-            .await
-            .unwrap(),
-        Response::System(SystemResponse {
+        client2.query_system_application(SystemQuery).await.unwrap(),
+        SystemResponse {
             chain_id: ChainId::root(2),
             balance: Amount::from(0),
-        })
+        }
     );
 
     // Send back some money.
@@ -838,14 +829,11 @@ where
     );
     // Local balance from client2 is now consolidated.
     assert_eq!(
-        client2
-            .query_application(&Query::System(SystemQuery))
-            .await
-            .unwrap(),
-        Response::System(SystemResponse {
+        client2.query_system_application(SystemQuery).await.unwrap(),
+        SystemResponse {
             chain_id: ChainId::root(2),
             balance: Amount::from(2),
-        })
+        }
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -194,7 +194,7 @@ where
         None,
         Timestamp::from(1),
     );
-    let bytecode_id = BytecodeId(EffectId {
+    let bytecode_id = BytecodeId::new(EffectId {
         chain_id: publisher_chain.into(),
         height: publish_block_height,
         index: 0,

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -32,6 +32,7 @@ linera-views-derive = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tracing = { workspace = true }

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -47,7 +47,7 @@ impl ApplicationId {
 
 /// Alias for `linera_base::identifiers::ApplicationId`. Use this alias in the core
 /// protocol where the distinction with the more general enum [`ApplicationId`] matters.
-pub type UserApplicationId = linera_base::identifiers::ApplicationId;
+pub type UserApplicationId<A = ()> = linera_base::identifiers::ApplicationId<A>;
 
 /// Description of the necessary information to run a user application.
 #[allow(clippy::large_enum_variant)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -38,6 +38,7 @@ use custom_debug_derive::Debug;
 use dashmap::DashMap;
 use derive_more::Display;
 use linera_base::{
+    abi::Abi,
     crypto::CryptoHash,
     data_types::{Amount, ArithmeticError, BlockHeight, Timestamp},
     hex_debug,
@@ -524,6 +525,22 @@ impl From<SystemOperation> for Operation {
 }
 
 impl Operation {
+    pub fn system(operation: SystemOperation) -> Self {
+        Operation::System(operation)
+    }
+
+    pub fn user<A: Abi>(
+        application_id: UserApplicationId<A>,
+        operation: &A::Operation,
+    ) -> Result<Self, bcs::Error> {
+        let application_id = application_id.forget_abi();
+        let bytes = bcs::to_bytes(&operation)?;
+        Ok(Operation::User {
+            application_id,
+            bytes,
+        })
+    }
+
     pub fn application_id(&self) -> ApplicationId {
         match self {
             Self::System(_) => ApplicationId::System,
@@ -539,6 +556,22 @@ impl From<SystemEffect> for Effect {
 }
 
 impl Effect {
+    pub fn system(effect: SystemEffect) -> Self {
+        Effect::System(effect)
+    }
+
+    pub fn user<A: Abi>(
+        application_id: UserApplicationId<A>,
+        effect: &A::Effect,
+    ) -> Result<Self, bcs::Error> {
+        let application_id = application_id.forget_abi();
+        let bytes = bcs::to_bytes(&effect)?;
+        Ok(Effect::User {
+            application_id,
+            bytes,
+        })
+    }
+
     pub fn application_id(&self) -> ApplicationId {
         match self {
             Self::System(_) => ApplicationId::System,
@@ -554,6 +587,22 @@ impl From<SystemQuery> for Query {
 }
 
 impl Query {
+    pub fn system(query: SystemQuery) -> Self {
+        Query::System(query)
+    }
+
+    pub fn user<A: Abi>(
+        application_id: UserApplicationId<A>,
+        query: &A::Query,
+    ) -> Result<Self, serde_json::Error> {
+        let application_id = application_id.forget_abi();
+        let bytes = serde_json::to_vec(&query)?;
+        Ok(Query::User {
+            application_id,
+            bytes,
+        })
+    }
+
     pub fn application_id(&self) -> ApplicationId {
         match self {
             Self::System(_) => ApplicationId::System,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -826,7 +826,7 @@ where
                 result.unsubscribe.push((subscription.name.clone(), *id));
             }
             BytecodePublished { operation_index } => {
-                let bytecode_id = BytecodeId(context.effect_id);
+                let bytecode_id = BytecodeId::new(context.effect_id);
                 let bytecode_location = BytecodeLocation {
                     certificate_hash: context.certificate_hash,
                     operation_index: *operation_index,

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -21,7 +21,7 @@ fn effect_id(index: u32) -> EffectId {
 }
 
 fn bytecode_id(index: u32) -> BytecodeId {
-    BytecodeId(effect_id(index))
+    BytecodeId::new(effect_id(index))
 }
 
 fn app_id(index: u32) -> UserApplicationId {

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -127,7 +127,7 @@ impl From<contract_system_api::ApplicationId> for UserApplicationId {
 
 impl From<contract_system_api::EffectId> for BytecodeId {
     fn from(guest: contract_system_api::EffectId) -> Self {
-        BytecodeId(guest.into())
+        BytecodeId::new(guest.into())
     }
 }
 
@@ -171,7 +171,7 @@ impl From<service_system_api::ApplicationId> for UserApplicationId {
 
 impl From<service_system_api::EffectId> for BytecodeId {
     fn from(guest: service_system_api::EffectId) -> Self {
-        BytecodeId(guest.into())
+        BytecodeId::new(guest.into())
     }
 }
 

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -108,7 +108,7 @@ impl From<SessionId> for contract_system_api::SessionId {
 impl From<UserApplicationId> for contract::ApplicationId {
     fn from(host: UserApplicationId) -> Self {
         contract::ApplicationId {
-            bytecode_id: host.bytecode_id.0.into(),
+            bytecode_id: host.bytecode_id.effect_id.into(),
             creation: host.creation.into(),
         }
     }
@@ -117,7 +117,7 @@ impl From<UserApplicationId> for contract::ApplicationId {
 impl From<UserApplicationId> for service_system_api::ApplicationId {
     fn from(host: UserApplicationId) -> Self {
         service_system_api::ApplicationId {
-            bytecode_id: host.bytecode_id.0.into(),
+            bytecode_id: host.bytecode_id.effect_id.into(),
             creation: host.creation.into(),
         }
     }
@@ -126,7 +126,7 @@ impl From<UserApplicationId> for service_system_api::ApplicationId {
 impl From<UserApplicationId> for contract_system_api::ApplicationId {
     fn from(host: UserApplicationId) -> Self {
         contract_system_api::ApplicationId {
-            bytecode_id: host.bytecode_id.0.into(),
+            bytecode_id: host.bytecode_id.effect_id.into(),
             creation: host.creation.into(),
         }
     }

--- a/linera-execution/tests/utils.rs
+++ b/linera-execution/tests/utils.rs
@@ -4,7 +4,7 @@
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
     data_types::BlockHeight,
-    identifiers::{ChainId, EffectId},
+    identifiers::{BytecodeId, ChainId, EffectId},
 };
 use linera_execution::{BytecodeLocation, UserApplicationDescription};
 use serde::{Deserialize, Serialize};
@@ -13,12 +13,11 @@ pub fn create_dummy_user_application_description() -> UserApplicationDescription
     let chain_id = ChainId::root(1);
     let certificate_hash = CryptoHash::new(&FakeCertificate);
     UserApplicationDescription {
-        bytecode_id: EffectId {
+        bytecode_id: BytecodeId::new(EffectId {
             chain_id,
             height: BlockHeight(1),
             index: 0,
-        }
-        .into(),
+        }),
         bytecode_location: BytecodeLocation {
             certificate_hash,
             operation_index: 0,

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -67,8 +67,9 @@ Bytecode:
   STRUCT:
     - bytes: BYTES
 BytecodeId:
-  NEWTYPESTRUCT:
-    TYPENAME: EffectId
+  STRUCT:
+    - effect_id:
+        TYPENAME: EffectId
 BytecodeLocation:
   STRUCT:
     - certificate_hash:

--- a/linera-sdk/src/bin/test-runner/mock_system_api.rs
+++ b/linera-sdk/src/bin/test-runner/mock_system_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use linera_base::identifiers::{ApplicationId, ChainId, EffectId};
+use linera_base::identifiers::{ApplicationId, BytecodeId, ChainId, EffectId};
 use linera_views::batch::WriteOperation;
 use std::any::Any;
 use wasmtime::{Caller, Extern, Func, Linker};
@@ -760,12 +760,11 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                 );
 
                 let application_id = ApplicationId {
-                    bytecode_id: EffectId {
+                    bytecode_id: BytecodeId::new(EffectId {
                         chain_id: bytecode_chain_id,
                         height: (application_bytecode_height as u64).into(),
                         index: application_bytecode_index as u32,
-                    }
-                    .into(),
+                    }),
                     creation: EffectId {
                         chain_id: creation_chain_id,
                         height: (application_creation_height as u64).into(),
@@ -836,7 +835,7 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                 let application_id = caller.data().get::<Query>(handle).application_id;
 
                 let application_id_bytecode_chain_id: [u64; 4] =
-                    application_id.bytecode_id.0.chain_id.0.into();
+                    application_id.bytecode_id.effect_id.chain_id.0.into();
 
                 let application_id_creation_chain_id: [u64; 4] =
                     application_id.creation.chain_id.0.into();
@@ -866,8 +865,8 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                             application_id_bytecode_chain_id[1] as i64,
                             application_id_bytecode_chain_id[2] as i64,
                             application_id_bytecode_chain_id[3] as i64,
-                            application_id.bytecode_id.0.height.0 as i64,
-                            application_id.bytecode_id.0.index as i32,
+                            application_id.bytecode_id.effect_id.height.0 as i64,
+                            application_id.bytecode_id.effect_id.index as i32,
                             application_id_creation_chain_id[0] as i64,
                             application_id_creation_chain_id[1] as i64,
                             application_id_creation_chain_id[2] as i64,

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -63,7 +63,7 @@ impl From<wit_types::CalleeContext> for CalleeContext {
 impl From<wit_types::ApplicationId> for ApplicationId {
     fn from(application_id: wit_types::ApplicationId) -> Self {
         ApplicationId {
-            bytecode_id: BytecodeId(application_id.bytecode_id.into()),
+            bytecode_id: BytecodeId::new(application_id.bytecode_id.into()),
             creation: application_id.creation.into(),
         }
     }
@@ -108,7 +108,7 @@ impl From<wit_system_api::EffectId> for EffectId {
 impl From<wit_system_api::ApplicationId> for ApplicationId {
     fn from(application_id: wit_system_api::ApplicationId) -> Self {
         ApplicationId {
-            bytecode_id: BytecodeId(application_id.bytecode_id.into()),
+            bytecode_id: BytecodeId::new(application_id.bytecode_id.into()),
             creation: application_id.creation.into(),
         }
     }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -42,7 +42,7 @@ impl From<CryptoHash> for wit_types::CryptoHash {
 impl From<ApplicationId> for wit_system_api::ApplicationId {
     fn from(application_id: ApplicationId) -> wit_system_api::ApplicationId {
         wit_system_api::ApplicationId {
-            bytecode_id: application_id.bytecode_id.0.into(),
+            bytecode_id: application_id.bytecode_id.effect_id.into(),
             creation: application_id.creation.into(),
         }
     }

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -49,7 +49,7 @@ impl From<wit_system_api::CryptoHash> for CryptoHash {
 impl From<wit_system_api::ApplicationId> for ApplicationId {
     fn from(application_id: wit_system_api::ApplicationId) -> Self {
         ApplicationId {
-            bytecode_id: BytecodeId(application_id.bytecode_id.into()),
+            bytecode_id: BytecodeId::new(application_id.bytecode_id.into()),
             creation: application_id.creation.into(),
         }
     }

--- a/linera-sdk/src/service/conversions_to_wit.rs
+++ b/linera-sdk/src/service/conversions_to_wit.rs
@@ -62,7 +62,7 @@ impl From<Poll<Result<Vec<u8>, String>>> for wit_types::PollQuery {
 impl From<ApplicationId> for wit_system_api::ApplicationId {
     fn from(application_id: ApplicationId) -> wit_system_api::ApplicationId {
         wit_system_api::ApplicationId {
-            bytecode_id: application_id.bytecode_id.0.into(),
+            bytecode_id: application_id.bytecode_id.effect_id.into(),
             creation: application_id.creation.into(),
         }
     }

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -141,7 +141,7 @@ impl ActiveChain {
         })
         .await;
 
-        BytecodeId(publish_effect_id)
+        BytecodeId::new(publish_effect_id)
     }
 
     /// Compiles the crate calling this method to generate the WebAssembly binaries.
@@ -274,7 +274,7 @@ impl ActiveChain {
         A: ContractAbi,
     {
         let bytecode_location_effect = if self.needs_bytecode_location(bytecode_id).await {
-            self.subscribe_to_published_bytecodes_from(bytecode_id.0.chain_id)
+            self.subscribe_to_published_bytecodes_from(bytecode_id.effect_id.chain_id)
                 .await;
             Some(self.find_bytecode_location(bytecode_id).await)
         } else {
@@ -329,12 +329,12 @@ impl ActiveChain {
 
     /// Finds the effect that sends the message with the bytecode location of `bytecode_id`.
     async fn find_bytecode_location(&self, bytecode_id: BytecodeId) -> EffectId {
-        for height in bytecode_id.0.height.0.. {
+        for height in bytecode_id.effect_id.height.0.. {
             let certificate = self
                 .validator
                 .worker()
                 .await
-                .read_certificate(bytecode_id.0.chain_id, height.into())
+                .read_certificate(bytecode_id.effect_id.chain_id, height.into())
                 .await
                 .expect("Failed to load certificate to search for bytecode location")
                 .expect("Bytecode location not found");
@@ -349,7 +349,7 @@ impl ActiveChain {
 
             if let Some(index) = effect_index {
                 return EffectId {
-                    chain_id: bytecode_id.0.chain_id,
+                    chain_id: bytecode_id.effect_id.chain_id,
                     height: BlockHeight(height),
                     index: index.try_into().expect(
                         "Incompatible `EffectId` index types in \

--- a/linera-sdk/src/test/unit/conversions_from_wit.rs
+++ b/linera-sdk/src/test/unit/conversions_from_wit.rs
@@ -33,7 +33,7 @@ impl From<wit::ApplicationId> for ApplicationId {
 
 impl From<wit::EffectId> for BytecodeId {
     fn from(effect_id: wit::EffectId) -> Self {
-        EffectId::from(effect_id).into()
+        BytecodeId::new(EffectId::from(effect_id))
     }
 }
 

--- a/linera-sdk/src/test/unit/conversions_to_wit.rs
+++ b/linera-sdk/src/test/unit/conversions_to_wit.rs
@@ -32,7 +32,7 @@ impl From<CryptoHash> for wit::CryptoHash {
 impl From<ApplicationId> for wit::ApplicationId {
     fn from(application_id: ApplicationId) -> Self {
         wit::ApplicationId {
-            bytecode_id: application_id.bytecode_id.0.into(),
+            bytecode_id: application_id.bytecode_id.effect_id.into(),
             creation: application_id.creation.into(),
         }
     }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -34,7 +34,10 @@ use tonic_health::proto::{
 use tracing::{info, warn};
 
 #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
-use linera_base::data_types::{Amount, Timestamp};
+use linera_base::{
+    data_types::{Amount, Timestamp},
+    identifiers::ApplicationId,
+};
 
 /// A static lock to prevent integration tests from running in parallel.
 static INTEGRATION_TEST_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
@@ -1508,7 +1511,10 @@ async fn test_end_to_end_crowd_funding() {
             contract_crowd,
             service_crowd,
             // TODO(#723): This hack will disappear soon.
-            &application_id_fungible.parse().unwrap(),
+            &application_id_fungible
+                .parse::<ApplicationId>()
+                .unwrap()
+                .with_abi(),
             &state_crowd,
             vec![application_id_fungible.clone()],
             None,


### PR DESCRIPTION
* Add optional phantom data types to BytecodeId, ApplicationId, and EffectId
* Use the ABI information to remove more serialization/deserialization operations in the contracts and client tests

Possible follow-up tasks: worker tests, Wasm integration tests, Wasm unit tests
Also created #768 which will be tedious but is not urgent.