### PR TITLE
Split values into several small ones if too big

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -32,6 +32,7 @@ jobs:
     - uses: actions-rs/toolchain@v1
       with:
         profile: minimal
+        target: wasm32-unknown-unknown
     - uses: Swatinem/rust-cache@v2
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
@@ -39,7 +40,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       run: |
-        cargo build --locked --no-default-features --features aws
+        cargo build --locked --features aws
     - name: Setup local DynamoDB instance
       run: |
         docker run --rm -d --name local-dynamodb -p 8000:8000/tcp amazon/dynamodb-local
@@ -50,4 +51,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: test
         LOCALSTACK_ENDPOINT: http://localhost:8000
       run: |
-        cargo test --locked --no-default-features --features aws -- dynamo
+        cargo test --locked --features aws -- dynamo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,6 @@ name = "linera-storage"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-lock",
  "async-trait",
  "bcs",
  "dashmap",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1674,7 +1674,6 @@ dependencies = [
 name = "linera-storage"
 version = "0.2.0"
 dependencies = [
- "async-lock",
  "async-trait",
  "bcs",
  "dashmap",
@@ -1709,6 +1708,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-test",

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -31,6 +31,9 @@ impl KeyValueStore {
 #[async_trait]
 impl KeyValueStoreClient for KeyValueStore {
     const MAX_CONNECTIONS: usize = 1;
+    // The KeyValueStoreClient of the system_api does not have splitting limits.
+    // Those are done by the lower ranked parts of the system.
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = ViewError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -19,7 +19,6 @@ aws = ["linera-views/aws"]
 rocksdb = ["linera-views/rocksdb"]
 
 [dependencies]
-async-lock = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 dashmap = { workspace = true }

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient};
-use async_lock::{Mutex, RwLock};
 use linera_execution::WasmRuntime;
-use linera_views::memory::MemoryClient;
-use std::{collections::BTreeMap, sync::Arc};
+use linera_views::memory::{create_memory_test_client, MemoryClient};
+use std::sync::Arc;
 
 type MemoryStore = DbStore<MemoryClient>;
 
@@ -21,11 +20,7 @@ impl MemoryStoreClient {
 
 impl MemoryStore {
     pub fn new(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let state = Arc::new(Mutex::new(BTreeMap::new()));
-        let guard = state
-            .try_lock_arc()
-            .expect("We should be able to acquire what we just created");
-        let client = Arc::new(RwLock::new(guard));
+        let client = create_memory_test_client();
         Self {
             client,
             guards: ChainGuards::default(),

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -35,6 +35,7 @@ serde = { workspace = true }
 sha3 = { workspace = true }
 thiserror = { workspace = true }
 linked-hash-map = { workspace = true }
+tempfile = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt", "sync"] }
@@ -52,4 +53,3 @@ tokio-test = { workspace = true }
 
 [dev-dependencies]
 linera-views = { path = ".", features = ["test"] }
-tempfile = { workspace = true }

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -247,7 +247,7 @@ where
 
     async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let mut big_key = key.to_vec();
-        big_key.extend(&[0,0,0,0]);
+        big_key.extend(&[0, 0, 0, 0]);
         let value = self.client.read_key_bytes(&big_key).await?;
         let Some(value) = value else {
             return Ok(None);
@@ -283,7 +283,7 @@ where
         let mut big_keys = Vec::new();
         for key in &keys {
             let mut big_key = key.clone();
-            big_key.extend(&[0,0,0,0]);
+            big_key.extend(&[0, 0, 0, 0]);
             big_keys.push(big_key);
         }
         let values = self.client.read_multi_key_bytes(big_keys).await?;
@@ -368,15 +368,13 @@ where
                 key = big_key[..len - 4].to_vec();
                 big_value.extend(value[4..].to_vec());
                 pos = 1;
-            } else {
-                if big_key[..len - 4] == key {
-                    if idx == pos && idx < count {
-                        big_value.extend(value);
-                        pos += 1;
-                    }
-                } else {
-                    pos = 0; // To avoid 
+            } else if big_key[..len - 4] == key {
+                if idx == pos && idx < count {
+                    big_value.extend(value);
+                    pos += 1;
                 }
+            } else {
+                pos = 0;
             }
             if pos == count {
                 key_values.push((mem::take(&mut key), mem::take(&mut big_value)));
@@ -391,12 +389,12 @@ where
             match operation {
                 WriteOperation::Delete { key } => {
                     let mut big_key = key.to_vec();
-                    big_key.extend(&[0,0,0,0]);
+                    big_key.extend(&[0, 0, 0, 0]);
                     batch_new.delete_key(big_key);
                 }
                 WriteOperation::Put { key, value } => {
                     let mut big_key = key.clone();
-                    big_key.extend(&[0,0,0,0]);
+                    big_key.extend(&[0, 0, 0, 0]);
                     let mut first_chunk = Vec::new();
                     let mut pos: u32 = 0;
                     for value_chunk in value.chunks(K::MAX_VALUE_SIZE) {
@@ -404,8 +402,7 @@ where
                         if pos == 0 {
                             first_chunk = value_chunk.to_vec();
                         } else {
-                            batch_new
-                                .put_key_value_bytes(big_key_segment, value_chunk.to_vec());
+                            batch_new.put_key_value_bytes(big_key_segment, value_chunk.to_vec());
                         }
                         pos += 1;
                     }

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -75,7 +75,7 @@ const MAX_CONNECTIONS: usize = 50;
 
 /// The limit on size is 400 kB for DynamoDb
 /// Which is 409600 bytes. To be safe, we remove 600 bytes. This is a lot actually.
-/// In theory, we just need to remove 1 + 4 bytes
+/// In theory, we just need to remove 4 bytes
 const MAX_VALUE_SIZE: usize = 409000;
 
 /// Builds the key attributes for a table item.

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -748,6 +748,9 @@ where
     ViewError: From<C::Error>,
 {
     const MAX_CONNECTIONS: usize = C::MAX_CONNECTIONS;
+    // Since the KeyValueStoreClient is based on another context
+    // the splitting is done by the lower ranked context
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = ViewError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_interval, ContextFromDb, KeyValueStoreClient},
+    common::{
+        get_interval, ContextFromDb, DatabaseConsistencyError, KeyValueStoreClient,
+        KeyValueStoreClientBigValue,
+    },
     views::ViewError,
 };
 use async_lock::{Mutex, MutexGuardArc, RwLock};
@@ -16,34 +19,18 @@ use thiserror::Error;
 pub type MemoryStoreMap = BTreeMap<Vec<u8>, Vec<u8>>;
 
 /// A virtual DB client where data are persisted in memory.
-pub type MemoryClient = Arc<RwLock<MutexGuardArc<MemoryStoreMap>>>;
-
-/// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type MemoryContext<E> = ContextFromDb<E, MemoryClient>;
-
-impl<E> MemoryContext<E> {
-    /// Creates a [`MemoryContext`].
-    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
-        Self {
-            db: Arc::new(RwLock::new(guard)),
-            base_key: Vec::new(),
-            extra,
-        }
-    }
-}
-
-/// Provides a `MemoryContext<()>` that can be used for tests.
-pub fn create_test_context() -> MemoryContext<()> {
-    let state = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = state
-        .try_lock_arc()
-        .expect("We should acquire the lock just after creating the object");
-    MemoryContext::new(guard, ())
-}
+pub type MemoryClientInternal = Arc<RwLock<MutexGuardArc<MemoryStoreMap>>>;
 
 #[async_trait]
-impl KeyValueStoreClient for MemoryClient {
+impl KeyValueStoreClient for MemoryClientInternal {
     const MAX_CONNECTIONS: usize = 1;
+    // For the memory container, memory is the limit and so usize::MAX
+    // could be used. But when memory is used for tests we want to exercise
+    // the splitting mechanism and so we set it artificially to 100.
+    #[cfg(any(test, feature = "test"))]
+    const MAX_VALUE_SIZE: usize = 100;
+    #[cfg(not(any(test, feature = "test")))]
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -121,12 +108,135 @@ impl KeyValueStoreClient for MemoryClient {
     }
 }
 
+/// Implementation of the MemoryClient from the existing one.
+#[derive(Clone)]
+pub struct MemoryClient {
+    client: KeyValueStoreClientBigValue<MemoryClientInternal>,
+}
+
+#[async_trait]
+impl KeyValueStoreClient for MemoryClient {
+    const MAX_CONNECTIONS: usize = MemoryClientInternal::MAX_CONNECTIONS;
+    const MAX_VALUE_SIZE: usize = MemoryClientInternal::MAX_VALUE_SIZE;
+    type Error = MemoryContextError;
+    type Keys = Vec<Vec<u8>>;
+    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
+        self.client.read_key_bytes(key).await
+    }
+
+    async fn read_multi_key_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {
+        self.client.read_multi_key_bytes(keys).await
+    }
+
+    async fn find_keys_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::Keys, MemoryContextError> {
+        self.client.find_keys_by_prefix(key_prefix).await
+    }
+
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, MemoryContextError> {
+        self.client.find_key_values_by_prefix(key_prefix).await
+    }
+
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
+        self.client.write_batch(batch, base_key).await
+    }
+
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+        self.client.clear_journal(base_key).await
+    }
+}
+
+impl MemoryClient {
+    /// Create a MemoryClient from the guard
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>) -> Self {
+        let client = Arc::new(RwLock::new(guard));
+        MemoryClient {
+            client: KeyValueStoreClientBigValue::new(client),
+        }
+    }
+}
+
+/// An implementation of [`crate::common::Context`] that stores all values in memory.
+pub type MemoryContext<E> = ContextFromDb<E, MemoryClient>;
+
+impl<E> MemoryContext<E> {
+    /// Creates a [`MemoryContext`].
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
+        let db = MemoryClient::new(guard);
+        let base_key = Vec::new();
+        Self {
+            db,
+            base_key,
+            extra,
+        }
+    }
+}
+
+/// Provides a `MemoryContext<()>` that can be used for tests.
+/// It is not named create_memory_test_context because it is massively
+/// used
+pub fn create_test_context() -> MemoryContext<()> {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryContext::new(guard, ())
+}
+
+/// create a test memory client for working.
+pub fn create_memory_test_client() -> MemoryClient {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryClient::new(guard)
+}
+
+/// An implementation of [`crate::common::Context`] that stores all values in memory.
+pub type MemoryContextInternal<E> = ContextFromDb<E, MemoryClientInternal>;
+
+impl<E> MemoryContextInternal<E> {
+    /// Creates a [`MemoryContext`].
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
+        let db = Arc::new(RwLock::new(guard));
+        let base_key = Vec::new();
+        Self {
+            db,
+            base_key,
+            extra,
+        }
+    }
+}
+
+/// Provides a `MemoryContext<()>` that can be used for tests.
+pub fn create_test_context_internal() -> MemoryContextInternal<()> {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryContextInternal::new(guard, ())
+}
+
 /// The error type for [`MemoryContext`].
 #[derive(Error, Debug)]
 pub enum MemoryContextError {
     /// Serialization error with BCS.
     #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
+
+    /// The database is not consistent
+    #[error(transparent)]
+    DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
 impl From<MemoryContextError> for ViewError {

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -111,7 +111,6 @@ where
 
             tweaked_test_case.insert(commit_location + 1, CommitAndReload);
             tweaked_test_case.push(CommitAndReload);
-
             run_test_queue_operations(tweaked_test_case, contexts.new_context().await?).await?;
         }
     }
@@ -131,7 +130,6 @@ where
     let mut queue = QueueView::load(context.clone()).await?;
 
     check_queue_state(&mut queue, &expected_state).await?;
-
     for operation in operations {
         match operation {
             Operation::PushBack(new_item) => {

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -4,132 +4,183 @@
 use async_lock::{Mutex, RwLock};
 use linera_views::{
     batch::Batch,
-    common::{KeyIterable, KeyValueStoreClient},
+    common::{get_interval, KeyIterable, KeyValueIterable, KeyValueStoreClient},
     key_value_store_view::ViewContainer,
-    memory::MemoryContext,
-    test_utils::get_random_key_value_vec_prefix,
+    memory::{create_memory_test_client, create_test_context},
+    test_utils::{get_random_byte_vector, get_random_key_value_vec_prefix, get_small_key_space},
 };
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashSet},
     sync::Arc,
 };
 
 #[cfg(feature = "rocksdb")]
-use linera_views::rocksdb::DB;
+use linera_views::rocksdb::create_rocksdb_test_client;
 
 #[cfg(feature = "aws")]
-use linera_views::{
-    dynamo_db::DynamoDbClient, lru_caching::TEST_CACHE_SIZE, test_utils::LocalStackTestContext,
-};
+use linera_views::test_utils::create_dynamodb_test_client;
 
 #[cfg(test)]
-async fn test_ordering_keys_key_value_vec<OP: KeyValueStoreClient + Sync>(
+async fn test_readings_vec<OP: KeyValueStoreClient + Sync>(
     key_value_operation: OP,
     key_value_vec: Vec<(Vec<u8>, Vec<u8>)>,
 ) {
     // We need a nontrivial key_prefix because dynamo requires a non-trivial prefix
-    let key_prefix = vec![0];
     let mut batch = Batch::new();
-    for key_value in key_value_vec {
-        batch.put_key_value_bytes(key_value.0, key_value.1);
+    let mut keys = Vec::new();
+    let mut set_keys = HashSet::new();
+    for key_value in &key_value_vec {
+        keys.push(key_value.0.clone());
+        set_keys.insert(key_value.0.clone());
+        batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        println!(
+            "  key={:?} value={:?}",
+            key_value.0.clone(),
+            key_value.1.clone()
+        );
     }
     key_value_operation.write_batch(batch, &[]).await.unwrap();
-    let keys: Vec<Vec<u8>> = key_value_operation
-        .find_keys_by_prefix(&key_prefix)
-        .await
-        .unwrap()
-        .iterator()
-        .map(|x| {
-            let mut v = key_prefix.clone();
-            v.extend(x.unwrap());
-            v
-        })
-        .collect();
-    for i in 1..keys.len() {
-        let key1 = keys[i - 1].clone();
-        let key2 = keys[i].clone();
-        assert!(key1 < key2);
-    }
-    let mut map = HashMap::new();
+    let mut set = HashSet::new();
     for key in &keys {
         for u in 1..key.len() + 1 {
             let key_prefix = key[0..u].to_vec();
-            match map.get_mut(&key_prefix) {
-                Some(v) => {
-                    *v += 1;
-                }
-                None => {
-                    map.insert(key_prefix, 1);
-                }
-            }
+            set.insert(key_prefix);
         }
     }
-    for (key_prefix, value) in map {
-        let n_ent = key_value_operation
+    for key_prefix in set {
+        println!("key_prefix={:?}", key_prefix);
+        let len_prefix = key_prefix.len();
+        let mut keys_request = Vec::new();
+        for key in key_value_operation
             .find_keys_by_prefix(&key_prefix)
             .await
             .unwrap()
             .iterator()
-            .count();
-        assert_eq!(n_ent, value);
+        {
+            let key: Vec<u8> = key.unwrap().to_vec();
+            keys_request.push(key);
+        }
+        let mut key_values_request = Vec::new();
+        for key_value in key_value_operation
+            .find_key_values_by_prefix(&key_prefix)
+            .await
+            .unwrap()
+            .iterator()
+        {
+            let key_value = key_value.unwrap();
+            key_values_request.push((key_value.0.to_vec(), key_value.1.to_vec()));
+        }
+        // Check length coherency
+        let len = keys_request.len();
+        let len_kv = key_values_request.len();
+        assert_eq!(len, len_kv);
+        // Check find_keys / find_key_values
+        for i in 0..len {
+            let key1 = keys_request[i].clone();
+            let key2 = key_values_request[i].clone().0;
+            println!("A : key1={:?}", key1);
+            println!("    key2={:?}", key2);
+            assert_eq!(key1, key2);
+        }
+        // Check key ordering
+        for i in 1..len {
+            let key1 = keys_request[i - 1].clone();
+            let key2 = keys_request[i].clone();
+            assert!(key1 < key2);
+        }
+        // Check the obtained values
+        let mut set_key_value1 = HashSet::<(Vec<u8>, Vec<u8>)>::new();
+        for key_value in key_values_request {
+            set_key_value1.insert((key_value.0.to_vec(), key_value.1.to_vec()));
+        }
+        let mut set_key_value2 = HashSet::new();
+        for key_value in &key_value_vec {
+            if key_value.0.starts_with(&key_prefix) {
+                let key = key_value.0[len_prefix..].to_vec();
+                let value = key_value.1.clone();
+                set_key_value2.insert((key, value));
+            }
+        }
+        assert_eq!(set_key_value1, set_key_value2);
+    }
+    // Now checking the read_multi_key_bytes
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    for _ in 0..10 {
+        let mut keys = Vec::new();
+        let mut values = Vec::new();
+        for key_value in &key_value_vec {
+            let thr = rng.gen_range(0..2);
+            if thr == 0 {
+                // Put a key that is already present
+                keys.push(key_value.0.clone());
+                values.push(Some(key_value.1.clone()));
+            } else {
+                // Put a missing key
+                let len = key_value.0.len();
+                let pos = rng.gen_range(0..len);
+                let byte = *key_value.0.get(pos).unwrap();
+                let new_byte: u8 = if byte < 255 { byte + 1 } else { byte - 1 };
+                let mut new_key = key_value.0.clone();
+                *new_key.get_mut(pos).unwrap() = new_byte;
+                if !set_keys.contains(&new_key) {
+                    keys.push(new_key);
+                    values.push(None);
+                }
+            }
+        }
+        let values_read = key_value_operation
+            .read_multi_key_bytes(keys)
+            .await
+            .unwrap();
+        assert_eq!(values, values_read);
     }
 }
 
 #[cfg(test)]
-async fn test_ordering_keys<OP: KeyValueStoreClient + Sync>(key_value_operation: OP) {
+async fn test_readings_random<OP: KeyValueStoreClient + Sync>(
+    key_value_operation: OP,
+    len_value: usize,
+) {
     let key_prefix = vec![0];
     let n = 1000;
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
-    let key_value_vec = get_random_key_value_vec_prefix(&mut rng, key_prefix.clone(), n);
-    test_ordering_keys_key_value_vec(key_value_operation, key_value_vec).await;
+    let key_value_vec =
+        get_random_key_value_vec_prefix(&mut rng, key_prefix.clone(), 8, len_value, n);
+    test_readings_vec(key_value_operation, key_value_vec).await;
 }
 
 #[tokio::test]
-async fn test_ordering_memory() {
-    let map = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = map.clone().lock_arc().await;
-    let key_value_operation = Arc::new(RwLock::new(guard));
-    test_ordering_keys(key_value_operation).await;
+async fn test_readings_memory() {
+    for len_value in [50, 1000] {
+        let key_value_operation = create_memory_test_client();
+        test_readings_random(key_value_operation, len_value).await;
+    }
 }
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
-async fn test_ordering_rocksdb() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let mut options = rocksdb::Options::default();
-    options.create_if_missing(true);
-    let key_value_operation = Arc::new(DB::open(&options, &dir).unwrap());
-    //
-    test_ordering_keys(key_value_operation).await;
+async fn test_readings_rocksdb() {
+    let key_value_operation = create_rocksdb_test_client();
+    test_readings_random(key_value_operation, 8).await;
 }
 
 #[cfg(feature = "aws")]
 #[tokio::test]
-async fn test_ordering_dynamodb() {
-    let localstack = LocalStackTestContext::new().await.unwrap();
-    let (key_value_operation, _) = DynamoDbClient::from_config(
-        localstack.dynamo_db_config(),
-        "test_table".parse().expect("Invalid table name"),
-        TEST_CACHE_SIZE,
-    )
-    .await
-    .unwrap();
-    //
-    test_ordering_keys(key_value_operation).await;
+async fn test_readings_dynamodb() {
+    let key_value_operation = create_dynamodb_test_client().await;
+    test_readings_random(key_value_operation, 8).await;
 }
 
 #[tokio::test]
-async fn test_ordering_key_value_store_view_memory() {
-    let map = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = map.clone().lock_arc().await;
-    let context = MemoryContext::new(guard, ());
+async fn test_readings_key_value_store_view_memory() {
+    let context = create_test_context();
     let key_value_operation = ViewContainer::new(context).await.unwrap();
-    test_ordering_keys(key_value_operation).await;
+    test_readings_random(key_value_operation, 8).await;
 }
 
 #[tokio::test]
-async fn test_ordering_memory_specific() {
+async fn test_readings_memory_specific() {
     let map = Arc::new(Mutex::new(BTreeMap::new()));
     let guard = map.clone().lock_arc().await;
     let key_value_operation = Arc::new(RwLock::new(guard));
@@ -139,5 +190,103 @@ async fn test_ordering_memory_specific() {
         (vec![0, 2], Vec::new()),
         (vec![0, 2, 0], Vec::new()),
     ];
-    test_ordering_keys_key_value_vec(key_value_operation, key_value_vec).await;
+    test_readings_vec(key_value_operation, key_value_vec).await;
+}
+
+#[cfg(test)]
+async fn test_writings_random<OP: KeyValueStoreClient + Sync>(key_value_operation: OP) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    let mut kv_state = BTreeMap::new();
+    let n_oper = 100;
+    let siz_batch = 10;
+    // key space has size 4^4 = 256 so we necessarily encounter collisions
+    let key_prefix = vec![0];
+    for _ in 0..n_oper {
+        let mut batch = Batch::new();
+        for _ in 0..siz_batch {
+            let thr = rng.gen_range(0..8);
+            // Inserting a key
+            if thr < 5 {
+                // Insert
+                let key = get_small_key_space(&mut rng, &key_prefix, 4);
+                let len_value = rng.gen_range(0..500); // Could need to be split
+                let value = get_random_byte_vector(&mut rng, &[], len_value);
+                batch.put_key_value_bytes(key.clone(), value.clone());
+                kv_state.insert(key, value);
+            }
+            if thr == 6 {
+                // key might be missing, no matter, it has to work
+                let key = get_small_key_space(&mut rng, &key_prefix, 4);
+                kv_state.remove(&key);
+                batch.delete_key(key);
+            }
+            if thr == 7 {
+                let len = rng.gen_range(1..4); // We want a non-trivial range
+                let delete_key_prefix = get_small_key_space(&mut rng, &key_prefix, len);
+                batch.delete_key_prefix(delete_key_prefix.clone());
+                let key_list = kv_state
+                    .range(get_interval(delete_key_prefix))
+                    .map(|x| x.0.to_vec())
+                    .collect::<Vec<_>>();
+                for key in key_list {
+                    kv_state.remove(&key);
+                }
+            }
+        }
+        key_value_operation.write_batch(batch, &[]).await.unwrap();
+        // Checking the consistency
+        let mut key_values = BTreeMap::new();
+        for key_value in key_value_operation
+            .find_key_values_by_prefix(&key_prefix)
+            .await
+            .unwrap()
+            .iterator()
+        {
+            let key_value = key_value.unwrap();
+            let mut key = key_prefix.clone();
+            key.extend(key_value.0);
+            key_values.insert(key, key_value.1.to_vec());
+        }
+        assert_eq!(key_values, kv_state);
+    }
+}
+
+#[tokio::test]
+async fn test_writings_memory() {
+    let key_value_operation = create_memory_test_client();
+    test_writings_random(key_value_operation).await;
+}
+
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn test_writings_rocksdb() {
+    let key_value_operation = create_rocksdb_test_client();
+    test_writings_random(key_value_operation).await;
+}
+
+#[cfg(feature = "aws")]
+#[tokio::test]
+async fn test_writings_dynamodb() {
+    let key_value_operation = create_dynamodb_test_client().await;
+    test_writings_random(key_value_operation).await;
+}
+
+#[tokio::test]
+async fn test_big_value_read_write() {
+    use rand::{distributions::Alphanumeric, Rng};
+    let context = create_test_context();
+    for count in [50, 1024] {
+        let rng = rand::rngs::StdRng::seed_from_u64(2);
+        let test_string = rng
+            .sample_iter(&Alphanumeric)
+            .take(count)
+            .map(char::from)
+            .collect::<String>();
+        let mut batch = Batch::new();
+        let key = vec![43, 23, 56];
+        batch.put_key_value(key.clone(), &test_string).unwrap();
+        context.db.write_batch(batch, &[]).await.unwrap();
+        let read_string = context.db.read_key::<String>(&key).await.unwrap().unwrap();
+        assert_eq!(read_string, test_string);
+    }
 }


### PR DESCRIPTION
This is following the problem of WASM contract that are too big and that such commonly used databases such as DynamoDB have very small maximal size for the values, that is 400kB.

The idea is to split the value into several blocks.