### PR TITLE
Added tests for `linera project new`

### DIFF
--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -11,202 +11,6 @@ use std::{
 };
 use tracing::debug;
 
-const CARGO_TOML: &str = r#"
-[package]
-name = "{project-name}"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-async-trait = "0.1.52"
-bcs = "0.1.3"
-futures = "0.3.17"
-{linera-sdk-dep}
-serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.93"
-thiserror = "1.0.31"
-
-[dev-dependencies]
-{linera-sdk-dev-dep}
-webassembly-test = "0.1.0"
-
-[[bin]]
-name = "{project-name}_contract"
-path = "src/contract.rs"
-
-[[bin]]
-name = "{project-name}_service"
-path = "src/service.rs"
-"#;
-
-const STATE: &str = r#"
-use serde::{Deserialize, Serialize};
-
-/// The application state.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct State {
-    // Add fields here.
-}
-"#;
-
-const LIB: &str = r#"
-use linera_sdk::base::{ContractAbi, ServiceAbi};
-
-pub struct StateAbi;
-
-impl ContractAbi for StateAbi {
-    type InitializationArgument = ();
-    type Parameters = ();
-    type Operation = ();
-    type ApplicationCall = ();
-    type Effect = ();
-    type SessionCall = ();
-    type Response = ();
-    type SessionState = ();
-}
-
-impl ServiceAbi for StateAbi {
-    type Query = ();
-    type QueryResponse = ();
-    type Parameters = ();
-}
-"#;
-
-const CONTRACT: &str = r#"
-#![cfg_attr(target_arch = "wasm32", no_main)]
-
-mod state;
-
-use self::state::State;
-use async_trait::async_trait;
-use linera_sdk::{
-    base::{SessionId, WithContractAbi},
-    ApplicationCallResult, CalleeContext, Contract, EffectContext,
-    ExecutionResult, OperationContext, SessionCallResult, SimpleStateStorage,
-};
-use thiserror::Error;
-
-linera_sdk::contract!(State);
-
-impl WithContractAbi for State {
-    type Abi = {project-name}::StateAbi;
-}
-
-#[async_trait]
-impl Contract for State {
-    type Error = Error;
-    type Storage = SimpleStateStorage<Self>;
-
-    async fn initialize(
-        &mut self,
-        _context: &OperationContext,
-        _argument: (),
-    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
-        Ok(ExecutionResult::default())
-    }
-
-    async fn execute_operation(
-        &mut self,
-        _context: &OperationContext,
-        _operation: (),
-    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
-        Ok(ExecutionResult::default())
-    }
-
-    async fn execute_effect(
-        &mut self,
-        _context: &EffectContext,
-        _effect: (),
-    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {
-        Ok(ExecutionResult::default())
-    }
-
-    async fn handle_application_call(
-        &mut self,
-        _context: &CalleeContext,
-        _argument: (),
-        _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error> {
-        Ok(ApplicationCallResult::default())
-    }
-
-    async fn handle_session_call(
-        &mut self,
-        _context: &CalleeContext,
-        _session: (),
-        _argument: (),
-        _forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error> {
-        Ok(SessionCallResult::default())
-    }
-}
-
-/// An error that can occur during the contract execution.
-#[derive(Debug, Error)]
-pub enum Error {
-    /// Failed to deserialize BCS bytes
-    #[error("Failed to deserialize BCS bytes")]
-    BcsError(#[from] bcs::Error),
-
-    /// Failed to deserialize JSON string
-    #[error("Failed to deserialize JSON string")]
-    JsonError(#[from] serde_json::Error),
-
-    // Add more error variants here.
-}
-"#;
-
-const SERVICE: &str = r#"
-#![cfg_attr(target_arch = "wasm32", no_main)]
-
-mod state;
-
-use self::state::State;
-use async_trait::async_trait;
-use linera_sdk::{base::WithServiceAbi, QueryContext, Service, SimpleStateStorage};
-use std::sync::Arc;
-use thiserror::Error;
-
-linera_sdk::service!(State);
-
-impl WithServiceAbi for State {
-    type Abi = {project-name}::StateAbi;
-}
-
-#[async_trait]
-impl Service for State {
-    type Error = Error;
-    type Storage = SimpleStateStorage<Self>;
-
-    async fn query_application(
-        self: Arc<Self>,
-        _context: &QueryContext,
-        _argument: (),
-    ) -> Result<(), Self::Error> {
-        Err(Error::QueriesNotSupported)
-    }
-}
-
-/// An error that can occur while querying the service.
-#[derive(Debug, Error)]
-pub enum Error {
-    /// Query not supported by the application.
-    #[error("Queries not supported by application")]
-    QueriesNotSupported,
-
-    /// Invalid query argument; could not deserialize request.
-    #[error("Invalid query argument; could not deserialize request")]
-    InvalidQuery(#[from] serde_json::Error),
-
-    // Add error variants here.
-}
-"#;
-
-const CONFIG: &str = r#"
-[build]
-target = "wasm32-unknown-unknown"
-"#;
-
 pub struct Project {
     root: PathBuf,
 }
@@ -318,32 +122,43 @@ impl Project {
 
     fn create_cargo_toml(project_root: &Path, project_name: &str) -> Result<()> {
         let toml_path = project_root.join("Cargo.toml");
-        let toml_contents = CARGO_TOML.replace("{project-name}", project_name);
-        let toml_contents = Self::add_linera_sdk_dependency(&toml_contents);
+        let (linera_sdk_dep, linera_sdk_dev_dep) = Self::linera_sdk_dependencies();
+        let toml_contents = format!(
+            include_str!("../template/Cargo.toml"),
+            project_name = project_name,
+            linera_sdk_dep = linera_sdk_dep,
+            linera_sdk_dev_dep = linera_sdk_dev_dep
+        );
         Self::write_string_to_file(&toml_path, &toml_contents)
     }
 
     fn create_state_file(source_directory: &Path) -> Result<()> {
         let state_path = source_directory.join("state.rs");
-        Self::write_string_to_file(&state_path, STATE)
+        Self::write_string_to_file(&state_path, include_str!("../template/state"))
     }
 
     fn create_lib_file(source_directory: &Path) -> Result<()> {
         let state_path = source_directory.join("lib.rs");
-        Self::write_string_to_file(&state_path, LIB)
+        Self::write_string_to_file(&state_path, include_str!("../template/lib"))
     }
 
     fn create_contract_file(source_directory: &Path, project_name: &str) -> Result<()> {
         let project_name = project_name.replace('-', "_");
         let contract_path = source_directory.join("contract.rs");
-        let contract_contents = CONTRACT.replace("{project-name}", &project_name);
+        let contract_contents = format!(
+            include_str!("../template/contract"),
+            project_name = project_name
+        );
         Self::write_string_to_file(&contract_path, &contract_contents)
     }
 
     fn create_service_file(source_directory: &Path, project_name: &str) -> Result<()> {
         let project_name = project_name.replace('-', "_");
         let service_path = source_directory.join("service.rs");
-        let service_contents = SERVICE.replace("{project-name}", &project_name);
+        let service_contents = format!(
+            include_str!("../template/service"),
+            project_name = project_name
+        );
         Self::write_string_to_file(&service_path, &service_contents)
     }
 
@@ -351,7 +166,7 @@ impl Project {
         let config_dir_path = project_root.join(".cargo");
         let config_file_path = config_dir_path.join("config.toml");
         std::fs::create_dir(&config_dir_path)?;
-        Self::write_string_to_file(&config_file_path, CONFIG)
+        Self::write_string_to_file(&config_file_path, include_str!("../template/config.toml"))
     }
 
     fn write_string_to_file(path: &Path, content: &str) -> Result<()> {
@@ -365,7 +180,7 @@ impl Project {
     /// Uses the directory of `linera-service` at compile time to figure out
     /// where `linera-sdk` is.
     #[cfg(debug_assertions)]
-    fn add_linera_sdk_dependency(cargo_toml: &str) -> String {
+    fn linera_sdk_dependencies() -> (String, String) {
         let linera_service_path: PathBuf = env!("CARGO_MANIFEST_DIR")
             .parse()
             .expect("the CARGO_MANIFEST_DIR should always be a valid path");
@@ -378,12 +193,11 @@ impl Project {
             "linera-sdk = {{ path = \"{}\" }}",
             linera_sdk_path.display()
         );
-        let with_sdk_dependency = cargo_toml.replace("{linera-sdk-dep}", &linera_sdk_dep);
         let linera_sdk_dev_dep = format!(
             "linera-sdk = {{ path = \"{}\", features = [\"test\"] }}",
             linera_sdk_path.display()
         );
-        with_sdk_dependency.replace("{linera-sdk-dev-dep}", &linera_sdk_dev_dep)
+        (linera_sdk_dep, linera_sdk_dev_dep)
     }
 
     /// Adds ['linera-sdk'] dependencies in `release` mode.
@@ -391,21 +205,17 @@ impl Project {
     /// Includes the contents of `linera-sdk`'s `Cargo.toml` at compile time
     /// to figure out the latest version.
     #[cfg(not(debug_assertions))]
-    fn add_linera_sdk_dependency(cargo_toml: &str) -> String {
+    fn linera_sdk_dependencies() -> (String, String) {
         let content = include_str!("../../linera-sdk/Cargo.toml");
         let sdk_cargo_toml: toml::Value = toml::from_str(content)
             .expect("there was an error parsing a TOML file included at compile-time - this should never happen.");
         let version = sdk_cargo_toml["package"]["version"].as_str()
             .expect("there was an error finding the version in a TOML file included at compile-time - this should never happen.");
-        let with_sdk_dependency =
-            cargo_toml.replace("{linera-sdk-dep}", &format!("linera-sdk = \"{}\"", version));
-        let with_sdk_dev_dependency = with_sdk_dependency.replace(
-            "{linera-sdk-dev-dep}",
-            &format!(
-                "linera-sdk = {{ version = \"{}\", features = [\"test\"] }}",
-                version
-            ),
+        let linera_sdk_dep = format!("linera-sdk = \"{}\"", version);
+        let linera_sdk_dev_dep = format!(
+            "linera-sdk = {{ version = \"{}\", features = [\"test\"] }}",
+            version
         );
-        with_sdk_dev_dependency
+        (linera_sdk_dep, linera_sdk_dev_dep)
     }
 }

--- a/linera-service/template/Cargo.toml
+++ b/linera-service/template/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "{project_name}"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+async-trait = "0.1.52"
+bcs = "0.1.3"
+futures = "0.3.17"
+{linera_sdk_dep}
+serde = {{ version = "1.0.130", features = ["derive"] }}
+serde_json = "1.0.93"
+thiserror = "1.0.31"
+
+[dev-dependencies]
+{linera_sdk_dev_dep}
+webassembly-test = "0.1.0"
+
+[[bin]]
+name = "{project_name}_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "{project_name}_service"
+path = "src/service.rs"

--- a/linera-service/template/config.toml
+++ b/linera-service/template/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/linera-service/template/contract
+++ b/linera-service/template/contract
@@ -1,0 +1,81 @@
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use self::state::State;
+use async_trait::async_trait;
+use linera_sdk::{{
+    base::{{SessionId, WithContractAbi}},
+    ApplicationCallResult, CalleeContext, Contract, EffectContext,
+    ExecutionResult, OperationContext, SessionCallResult, SimpleStateStorage,
+}};
+use thiserror::Error;
+
+linera_sdk::contract!(State);
+
+impl WithContractAbi for State {{
+    type Abi = {project_name}::StateAbi;
+}}
+
+#[async_trait]
+impl Contract for State {{
+    type Error = Error;
+    type Storage = SimpleStateStorage<Self>;
+
+    async fn initialize(
+        &mut self,
+        _context: &OperationContext,
+        _argument: (),
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {{
+        Ok(ExecutionResult::default())
+    }}
+
+    async fn execute_operation(
+        &mut self,
+        _context: &OperationContext,
+        _operation: (),
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {{
+        Ok(ExecutionResult::default())
+    }}
+
+    async fn execute_effect(
+        &mut self,
+        _context: &EffectContext,
+        _effect: (),
+    ) -> Result<ExecutionResult<Self::Effect>, Self::Error> {{
+        Ok(ExecutionResult::default())
+    }}
+
+    async fn handle_application_call(
+        &mut self,
+        _context: &CalleeContext,
+        _argument: (),
+        _forwarded_sessions: Vec<SessionId>,
+    ) -> Result<ApplicationCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error> {{
+        Ok(ApplicationCallResult::default())
+    }}
+
+    async fn handle_session_call(
+        &mut self,
+        _context: &CalleeContext,
+        _session: (),
+        _argument: (),
+        _forwarded_sessions: Vec<SessionId>,
+    ) -> Result<SessionCallResult<Self::Effect, Self::Response, Self::SessionState>, Self::Error> {{
+        Ok(SessionCallResult::default())
+    }}
+}}
+
+/// An error that can occur during the contract execution.
+#[derive(Debug, Error)]
+pub enum Error {{
+    /// Failed to deserialize BCS bytes
+    #[error("Failed to deserialize BCS bytes")]
+    BcsError(#[from] bcs::Error),
+
+    /// Failed to deserialize JSON string
+    #[error("Failed to deserialize JSON string")]
+    JsonError(#[from] serde_json::Error),
+
+    // Add more error variants here.
+}}

--- a/linera-service/template/contract
+++ b/linera-service/template/contract
@@ -2,7 +2,7 @@
 
 mod state;
 
-use self::state::State;
+use self::state::Application;
 use async_trait::async_trait;
 use linera_sdk::{{
     base::{{SessionId, WithContractAbi}},
@@ -11,14 +11,14 @@ use linera_sdk::{{
 }};
 use thiserror::Error;
 
-linera_sdk::contract!(State);
+linera_sdk::contract!(Application);
 
-impl WithContractAbi for State {{
-    type Abi = {project_name}::StateAbi;
+impl WithContractAbi for Application {{
+    type Abi = {project_name}::ApplicationAbi;
 }}
 
 #[async_trait]
-impl Contract for State {{
+impl Contract for Application {{
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
 

--- a/linera-service/template/lib
+++ b/linera-service/template/lib
@@ -1,0 +1,20 @@
+use linera_sdk::base::{ContractAbi, ServiceAbi};
+
+pub struct StateAbi;
+
+impl ContractAbi for StateAbi {
+    type InitializationArgument = ();
+    type Parameters = ();
+    type Operation = ();
+    type ApplicationCall = ();
+    type Effect = ();
+    type SessionCall = ();
+    type Response = ();
+    type SessionState = ();
+}
+
+impl ServiceAbi for StateAbi {
+    type Query = ();
+    type QueryResponse = ();
+    type Parameters = ();
+}

--- a/linera-service/template/lib
+++ b/linera-service/template/lib
@@ -1,8 +1,8 @@
 use linera_sdk::base::{ContractAbi, ServiceAbi};
 
-pub struct StateAbi;
+pub struct ApplicationAbi;
 
-impl ContractAbi for StateAbi {
+impl ContractAbi for ApplicationAbi {
     type InitializationArgument = ();
     type Parameters = ();
     type Operation = ();
@@ -13,7 +13,7 @@ impl ContractAbi for StateAbi {
     type SessionState = ();
 }
 
-impl ServiceAbi for StateAbi {
+impl ServiceAbi for ApplicationAbi {
     type Query = ();
     type QueryResponse = ();
     type Parameters = ();

--- a/linera-service/template/service
+++ b/linera-service/template/service
@@ -1,0 +1,44 @@
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use self::state::State;
+use async_trait::async_trait;
+use linera_sdk::{{base::WithServiceAbi, QueryContext, Service, SimpleStateStorage}};
+use std::sync::Arc;
+use thiserror::Error;
+
+linera_sdk::service!(State);
+
+impl WithServiceAbi for State {{
+    type Abi = {project_name}::StateAbi;
+}}
+
+#[async_trait]
+impl Service for State {{
+    type Error = Error;
+    type Storage = SimpleStateStorage<Self>;
+
+    async fn query_application(
+        self: Arc<Self>,
+        _context: &QueryContext,
+        _argument: (),
+    ) -> Result<(), Self::Error> {{
+        Err(Error::QueriesNotSupported)
+    }}
+}}
+
+/// An error that can occur while querying the service.
+#[derive(Debug, Error)]
+pub enum Error {{
+    /// Query not supported by the application.
+    #[error("Queries not supported by application")]
+    QueriesNotSupported,
+
+    /// Invalid query argument; could not deserialize request.
+    #[error("Invalid query argument; could not deserialize request")]
+    InvalidQuery(#[from] serde_json::Error),
+
+    // Add error variants here.
+}}

--- a/linera-service/template/service
+++ b/linera-service/template/service
@@ -3,20 +3,20 @@
 
 mod state;
 
-use self::state::State;
+use self::state::Application;
 use async_trait::async_trait;
 use linera_sdk::{{base::WithServiceAbi, QueryContext, Service, SimpleStateStorage}};
 use std::sync::Arc;
 use thiserror::Error;
 
-linera_sdk::service!(State);
+linera_sdk::service!(Application);
 
-impl WithServiceAbi for State {{
-    type Abi = {project_name}::StateAbi;
+impl WithServiceAbi for Application {{
+    type Abi = {project_name}::ApplicationAbi;
 }}
 
 #[async_trait]
-impl Service for State {{
+impl Service for Application {{
     type Error = Error;
     type Storage = SimpleStateStorage<Self>;
 

--- a/linera-service/template/state
+++ b/linera-service/template/state
@@ -1,0 +1,7 @@
+use serde::{Deserialize, Serialize};
+
+/// The application state.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+pub struct State {
+    // Add fields here.
+}

--- a/linera-service/template/state
+++ b/linera-service/template/state
@@ -2,6 +2,6 @@ use serde::{Deserialize, Serialize};
 
 /// The application state.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
-pub struct State {
+pub struct Application {
     // Add fields here.
 }


### PR DESCRIPTION
# Motivation

`linera project new` is untested resulting in unintended regressions.

# Solution

Split `linera project new` into a 'debug' mode and 'release' where the former uses relative directories to `linera-sdk` and the latter uses `crates.io`.

Closes #653 .