### PR TITLE
Renaming, so that there is only one ApplicationId type.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -46,7 +46,6 @@ pub struct EffectId {
 /// A unique identifier for a user application.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
-#[serde(rename = "UserApplicationId")]
 pub struct ApplicationId<A = ()> {
     /// The bytecode to use for the application.
     pub bytecode_id: BytecodeId<A>,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -14,12 +14,12 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{ArithmeticError, BlockHeight, Timestamp},
     ensure,
-    identifiers::{ChainId, Destination, EffectId},
+    identifiers::{ApplicationId, ChainId, Destination, EffectId},
 };
 use linera_execution::{
-    system::SystemEffect, ApplicationId, Effect, EffectContext, ExecutionResult,
+    system::SystemEffect, ApplicationDescription, Effect, EffectContext, ExecutionResult,
     ExecutionRuntimeContext, ExecutionStateView, OperationContext, Query, QueryContext,
-    RawExecutionResult, Response, UserApplicationDescription, UserApplicationId,
+    RawExecutionResult, Response, SystemOrApplicationId,
 };
 use linera_views::{
     common::Context,
@@ -104,8 +104,8 @@ where
 
     pub async fn describe_application(
         &mut self,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, ChainError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, ChainError> {
         self.execution_state
             .system
             .registry
@@ -456,7 +456,7 @@ where
             match result {
                 ExecutionResult::System(result) => {
                     self.process_raw_execution_result(
-                        ApplicationId::System,
+                        SystemOrApplicationId::System,
                         Effect::System,
                         effects,
                         height,
@@ -466,7 +466,7 @@ where
                 }
                 ExecutionResult::User(application_id, result) => {
                     self.process_raw_execution_result(
-                        ApplicationId::User(application_id),
+                        SystemOrApplicationId::User(application_id),
                         |bytes| Effect::User {
                             application_id,
                             bytes,
@@ -484,7 +484,7 @@ where
 
     async fn process_raw_execution_result<E, F>(
         &mut self,
-        application_id: ApplicationId,
+        application_id: SystemOrApplicationId,
         lift: F,
         effects: &mut Vec<OutgoingEffect>,
         height: BlockHeight,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -12,7 +12,7 @@ use linera_base::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    ApplicationId, BytecodeLocation, Effect, Operation,
+    BytecodeLocation, Effect, Operation, SystemOrApplicationId,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -137,7 +137,7 @@ pub struct Target {
 /// A channel name together with its application id.
 pub struct ChannelFullName {
     /// The application owning the channel.
-    pub application_id: ApplicationId,
+    pub application_id: SystemOrApplicationId,
     /// The name of the channel.
     pub name: ChannelName,
 }

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use linera_base::crypto::{BcsSignable, CryptoHash};
-use linera_execution::{Effect, UserApplicationId};
+use linera_base::{
+    crypto::{BcsSignable, CryptoHash},
+    identifiers::ApplicationId,
+};
+use linera_execution::Effect;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -28,7 +31,7 @@ fn make_event(
         authenticated_signer: None,
         timestamp: Default::default(),
         effect: Effect::User {
-            application_id: UserApplicationId::default(),
+            application_id: ApplicationId::default(),
             bytes: effect.into(),
         },
     }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -18,7 +18,7 @@ use linera_base::{
     abi::{Abi, ContractAbi},
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{Amount, BlockHeight, RoundNumber, Timestamp},
-    identifiers::{BytecodeId, ChainId, EffectId, Owner},
+    identifiers::{ApplicationId, BytecodeId, ChainId, EffectId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -30,7 +30,6 @@ use linera_execution::{
     committee::{Committee, Epoch, ValidatorName, ValidatorState},
     system::{Account, Recipient, SystemChannel, SystemOperation, UserData},
     Bytecode, Effect, Operation, Query, Response, SystemEffect, SystemQuery, SystemResponse,
-    UserApplicationId,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -1145,7 +1144,7 @@ where
     /// Queries a user application.
     pub async fn query_user_application<A: Abi>(
         &mut self,
-        application_id: UserApplicationId<A>,
+        application_id: ApplicationId<A>,
         query: &A::Query,
     ) -> Result<A::QueryResponse> {
         let query = Query::user(application_id, query)?;
@@ -1197,7 +1196,7 @@ where
     /// on this one.
     pub async fn request_application(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: Option<ChainId>,
     ) -> Result<Certificate> {
         let chain_id = chain_id.unwrap_or(application_id.creation.chain_id);
@@ -1357,8 +1356,8 @@ where
         bytecode_id: BytecodeId<A>,
         parameters: &<A as ContractAbi>::Parameters,
         initialization_argument: &A::InitializationArgument,
-        required_application_ids: Vec<UserApplicationId>,
-    ) -> Result<(UserApplicationId<A>, Certificate)> {
+        required_application_ids: Vec<ApplicationId>,
+    ) -> Result<(ApplicationId<A>, Certificate)> {
         let initialization_argument = serde_json::to_vec(initialization_argument)?;
         let parameters = serde_json::to_vec(parameters)?;
         let (app_id, cert) = self
@@ -1378,8 +1377,8 @@ where
         bytecode_id: BytecodeId,
         parameters: Vec<u8>,
         initialization_argument: Vec<u8>,
-        required_application_ids: Vec<UserApplicationId>,
-    ) -> Result<(UserApplicationId, Certificate)> {
+        required_application_ids: Vec<ApplicationId>,
+    ) -> Result<(ApplicationId, Certificate)> {
         self.prepare_chain().await?;
         let messages = self.pending_messages().await?;
         let certificate = self
@@ -1398,7 +1397,7 @@ where
             .value
             .nth_last_effect_id(1)
             .ok_or_else(|| anyhow!("Failed to create application"))?;
-        let id = UserApplicationId {
+        let id = ApplicationId {
             bytecode_id,
             creation,
         };

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -12,7 +12,7 @@ use futures::{future, lock::Mutex, Stream};
 use linera_base::{
     crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight},
-    identifiers::{ChainId, EffectId},
+    identifiers::{ApplicationId, ChainId, EffectId},
 };
 use linera_chain::{
     data_types::{
@@ -21,8 +21,7 @@ use linera_chain::{
     ChainError, ChainManagerInfo,
 };
 use linera_execution::{
-    committee::ValidatorName, BytecodeLocation, Query, Response, UserApplicationDescription,
-    UserApplicationId,
+    committee::ValidatorName, ApplicationDescription, BytecodeLocation, Query, Response,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -424,8 +423,8 @@ where
     pub async fn describe_application(
         &self,
         chain_id: ChainId,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, NodeError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, NodeError> {
         let mut node = self.node.lock().await;
         let response = node
             .state

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -18,7 +18,7 @@ use linera_base::{
 };
 use linera_chain::data_types::OutgoingEffect;
 use linera_execution::{
-    Bytecode, Effect, Operation, SystemEffect, UserApplicationDescription, WasmRuntime,
+    ApplicationDescription, Bytecode, Effect, Operation, SystemEffect, WasmRuntime,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -429,7 +429,7 @@ where
             matches!(
                 effect,
                 Effect::System(SystemEffect::RegisterApplications { applications })
-                if matches!(applications[0], UserApplicationDescription{ bytecode_id: b_id, .. } if b_id == bytecode_id.forget_abi())
+                if matches!(applications[0], ApplicationDescription{ bytecode_id: b_id, .. } if b_id == bytecode_id.forget_abi())
             ) && *destination == Destination::Recipient(receiver.chain_id())
         }));
     receiver.synchronize_from_validators().await.unwrap();

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -13,7 +13,7 @@ use super::{init_worker_with_chains, make_block, make_certificate, make_state_ha
 use linera_base::{
     crypto::KeyPair,
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{BytecodeId, ChainDescription, ChainId, Destination, EffectId},
+    identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, Destination, EffectId},
 };
 use linera_chain::data_types::{
     ChannelFullName, Event, HashedValue, Message, Origin, OutgoingEffect,
@@ -21,10 +21,9 @@ use linera_chain::data_types::{
 use linera_execution::{
     committee::Epoch,
     system::{SystemChannel, SystemEffect, SystemOperation},
-    ApplicationId, ApplicationRegistry, Bytecode, BytecodeLocation, ChainOwnership,
+    ApplicationDescription, ApplicationRegistry, Bytecode, BytecodeLocation, ChainOwnership,
     ChannelSubscription, Effect, ExecutionStateView, Operation, OperationContext,
-    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmApplication,
-    WasmRuntime,
+    SystemExecutionState, SystemOrApplicationId, WasmApplication, WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, RocksdbStoreClient, Store};
 use linera_views::{
@@ -354,7 +353,7 @@ where
         initialization_argument: initial_value_bytes.clone(),
         required_application_ids: vec![],
     };
-    let application_id = UserApplicationId {
+    let application_id = ApplicationId {
         bytecode_id,
         creation: EffectId {
             chain_id: creator_chain.into(),
@@ -362,7 +361,7 @@ where
             index: 0,
         },
     };
-    let application_description = UserApplicationDescription {
+    let application_description = ApplicationDescription {
         bytecode_id,
         bytecode_location,
         creation: application_id.creation,
@@ -370,7 +369,7 @@ where
         parameters: vec![],
     };
     let publish_admin_channel = ChannelFullName {
-        application_id: ApplicationId::System,
+        application_id: SystemOrApplicationId::System,
         name: SystemChannel::PublishedBytecodes.name(),
     };
     let create_block = make_block(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -27,8 +27,8 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
     system::{Account, Recipient, SystemChannel, SystemEffect, SystemOperation, UserData},
-    ApplicationId, ApplicationRegistry, ChainOwnership, ChannelSubscription, Effect,
-    ExecutionStateView, Operation, Query, Response, SystemExecutionState, SystemQuery,
+    ApplicationRegistry, ChainOwnership, ChannelSubscription, Effect, ExecutionStateView,
+    Operation, Query, Response, SystemExecutionState, SystemOrApplicationId, SystemQuery,
     SystemResponse,
 };
 use linera_storage::{MemoryStoreClient, RocksdbStoreClient, Store};
@@ -2496,7 +2496,7 @@ where
         name: SystemChannel::Admin.name(),
     };
     let admin_channel_full_name = ChannelFullName {
-        application_id: ApplicationId::System,
+        application_id: SystemOrApplicationId::System,
         name: SystemChannel::Admin.name(),
     };
     let admin_channel_origin = Origin::channel(admin_id, admin_channel_full_name.clone());

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -9,7 +9,7 @@ use linera_base::{
     crypto::{CryptoHash, KeyPair},
     data_types::{ArithmeticError, BlockHeight, Timestamp},
     doc_scalar, ensure,
-    identifiers::{ChainId, Owner},
+    identifiers::{ApplicationId, ChainId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -20,7 +20,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    BytecodeLocation, Query, Response, UserApplicationDescription, UserApplicationId,
+    ApplicationDescription, BytecodeLocation, Query, Response,
 };
 use linera_storage::Store;
 use linera_views::{
@@ -392,8 +392,8 @@ where
     pub(crate) async fn describe_application(
         &mut self,
         chain_id: ChainId,
-        application_id: UserApplicationId,
-    ) -> Result<UserApplicationDescription, WorkerError> {
+        application_id: ApplicationId,
+    ) -> Result<ApplicationDescription, WorkerError> {
         let mut chain = self.storage.load_active_chain(chain_id).await?;
         let response = chain.describe_application(application_id).await?;
         Ok(response)

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -4,13 +4,13 @@
 use crate::{
     runtime::{ApplicationStatus, ExecutionRuntime, SessionManager},
     system::SystemExecutionStateView,
-    ContractRuntime, Effect, EffectContext, ExecutionError, ExecutionResult,
-    ExecutionRuntimeContext, Operation, OperationContext, Query, QueryContext, RawExecutionResult,
-    Response, SystemEffect, UserApplicationDescription, UserApplicationId,
+    ApplicationDescription, ContractRuntime, Effect, EffectContext, ExecutionError,
+    ExecutionResult, ExecutionRuntimeContext, Operation, OperationContext, Query, QueryContext,
+    RawExecutionResult, Response, SystemEffect,
 };
 use linera_base::{
     ensure,
-    identifiers::{ChainId, Owner},
+    identifiers::{ApplicationId, ChainId, Owner},
 };
 use linera_views::{
     common::Context,
@@ -36,9 +36,9 @@ pub struct ExecutionStateView<C> {
     /// System application.
     pub system: SystemExecutionStateView<C>,
     /// User applications (Simple based).
-    pub simple_users: ReentrantCollectionView<C, UserApplicationId, RegisterView<C, Vec<u8>>>,
+    pub simple_users: ReentrantCollectionView<C, ApplicationId, RegisterView<C, Vec<u8>>>,
     /// User applications (View based).
-    pub view_users: ReentrantCollectionView<C, UserApplicationId, KeyValueStoreView<C>>,
+    pub view_users: ReentrantCollectionView<C, ApplicationId, KeyValueStoreView<C>>,
     /// Fuel available for running applications.
     pub available_fuel: RegisterView<C, u64>,
 }
@@ -110,7 +110,7 @@ where
     pub async fn simulate_initialization(
         &mut self,
         application: UserApplicationCode,
-        application_description: UserApplicationDescription,
+        application_description: ApplicationDescription,
         initialization_argument: Vec<u8>,
     ) -> Result<(), ExecutionError> {
         let chain_id = application_description.creation.chain_id;
@@ -173,7 +173,7 @@ where
 
     async fn run_user_action(
         &mut self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         chain_id: ChainId,
         action: UserAction<'_>,
     ) -> Result<Vec<ExecutionResult>, ExecutionError> {
@@ -379,7 +379,7 @@ where
 
     pub async fn list_applications(
         &self,
-    ) -> Result<Vec<(UserApplicationId, UserApplicationDescription)>, ExecutionError> {
+    ) -> Result<Vec<(ApplicationId, ApplicationDescription)>, ExecutionError> {
         let mut applications = vec![];
         for index in self.system.registry.known_applications.indices().await? {
             let application_description =

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -4,8 +4,8 @@
 use crate::{
     committee::{Committee, Epoch, ValidatorName, ValidatorState},
     system::{Recipient, UserData},
-    ApplicationId, Bytecode, ChainOwnership, ChannelSubscription, ExecutionStateView,
-    SystemExecutionStateView, UserApplicationDescription,
+    ApplicationDescription, Bytecode, ChainOwnership, ChannelSubscription, ExecutionStateView,
+    SystemExecutionStateView, SystemOrApplicationId,
 };
 use async_graphql::{Error, Object};
 use linera_base::{
@@ -16,7 +16,10 @@ use linera_base::{
 use linera_views::{common::Context, views::ViewError};
 use std::collections::BTreeMap;
 
-doc_scalar!(ApplicationId, "A unique identifier for an application");
+doc_scalar!(
+    SystemOrApplicationId,
+    "A unique identifier for either a user application or the system"
+);
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
 doc_scalar!(ChainOwnership, "Represents the owner(s) of a chain");
 doc_scalar!(
@@ -25,7 +28,7 @@ doc_scalar!(
 );
 doc_scalar!(Recipient, "The recipient of a transfer");
 doc_scalar!(
-    UserApplicationDescription,
+    ApplicationDescription,
     "Description of the necessary information to run a user application"
 );
 doc_scalar!(UserData, "Optional user message attached to a transfer");

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -4,9 +4,9 @@
 
 use crate::{
     committee::{Committee, Epoch},
-    ApplicationRegistryView, Bytecode, BytecodeLocation, ChainOwnership, ChannelName,
-    ChannelSubscription, Destination, EffectContext, OperationContext, QueryContext,
-    RawExecutionResult, UserApplicationDescription, UserApplicationId,
+    ApplicationDescription, ApplicationId, ApplicationRegistryView, Bytecode, BytecodeLocation,
+    ChainOwnership, ChannelName, ChannelSubscription, Destination, EffectContext, OperationContext,
+    QueryContext, RawExecutionResult,
 };
 use async_graphql::Enum;
 use custom_debug_derive::Debug;
@@ -150,12 +150,12 @@ pub enum SystemOperation {
         #[serde(with = "serde_bytes")]
         #[debug(with = "hex_debug")]
         initialization_argument: Vec<u8>,
-        required_application_ids: Vec<UserApplicationId>,
+        required_application_ids: Vec<ApplicationId>,
     },
     /// Requests a message from another chain to register a user application on this chain.
     RequestApplication {
         chain_id: ChainId,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
     },
 }
 
@@ -207,13 +207,13 @@ pub enum SystemEffect {
     /// Shares information about some applications to help the recipient use them.
     /// Applications must be registered after their dependencies.
     RegisterApplications {
-        applications: Vec<UserApplicationDescription>,
+        applications: Vec<ApplicationDescription>,
     },
     /// Does nothing. Used to debug the intended recipients of a block.
     Notify { id: ChainId },
     /// Requests a `RegisterApplication` message from the target chain to register the specified
     /// application on the sender chain.
-    RequestApplication(UserApplicationId),
+    RequestApplication(ApplicationId),
 }
 
 impl SystemEffect {
@@ -412,7 +412,7 @@ pub enum SystemExecutionError {
     #[error("Attempt to create an application using unregistered bytecode identifier {0:?}")]
     UnknownBytecodeId(BytecodeId),
     #[error("Application {0:?} is not registered by the chain")]
-    UnknownApplicationId(Box<UserApplicationId>),
+    UnknownApplicationId(Box<ApplicationId>),
 }
 
 impl<C> SystemExecutionStateView<C>
@@ -441,7 +441,7 @@ where
     ) -> Result<
         (
             RawExecutionResult<SystemEffect>,
-            Option<(UserApplicationId, Vec<u8>)>,
+            Option<(ApplicationId, Vec<u8>)>,
         ),
         SystemExecutionError,
     > {
@@ -706,7 +706,7 @@ where
                 initialization_argument,
                 required_application_ids,
             } => {
-                let id = UserApplicationId {
+                let id = ApplicationId {
                     bytecode_id: *bytecode_id,
                     creation: context.next_effect_id(),
                 };

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    ApplicationRegistry, ApplicationRegistryView, BytecodeLocation, UserApplicationDescription,
-    UserApplicationId,
+    ApplicationDescription, ApplicationId, ApplicationRegistry, ApplicationRegistryView,
+    BytecodeLocation,
 };
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
@@ -24,15 +24,15 @@ fn bytecode_id(index: u32) -> BytecodeId {
     BytecodeId::new(effect_id(index))
 }
 
-fn app_id(index: u32) -> UserApplicationId {
-    UserApplicationId {
+fn app_id(index: u32) -> ApplicationId {
+    ApplicationId {
         bytecode_id: bytecode_id(0),
         creation: effect_id(index),
     }
 }
 
-fn app_description(index: u32, deps: Vec<u32>) -> UserApplicationDescription {
-    UserApplicationDescription {
+fn app_description(index: u32, deps: Vec<u32>) -> ApplicationDescription {
+    ApplicationDescription {
         bytecode_id: bytecode_id(0),
         bytecode_location: location(0),
         creation: effect_id(index),

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -11,12 +11,12 @@
 use super::{contract, contract_system_api, service_system_api};
 use crate::{
     ApplicationCallResult, ChannelName, Destination, RawExecutionResult, SessionCallResult,
-    SessionId, UserApplicationId,
+    SessionId,
 };
 use linera_base::{
     crypto::CryptoHash,
     data_types::BlockHeight,
-    identifiers::{BytecodeId, ChainId, EffectId},
+    identifiers::{ApplicationId, BytecodeId, ChainId, EffectId},
 };
 
 impl From<contract::SessionCallResult> for (SessionCallResult, Vec<u8>) {
@@ -116,9 +116,9 @@ impl From<contract_system_api::SessionId> for SessionId {
     }
 }
 
-impl From<contract_system_api::ApplicationId> for UserApplicationId {
+impl From<contract_system_api::ApplicationId> for ApplicationId {
     fn from(guest: contract_system_api::ApplicationId) -> Self {
-        UserApplicationId {
+        ApplicationId {
             bytecode_id: guest.bytecode_id.into(),
             creation: guest.creation.into(),
         }
@@ -160,9 +160,9 @@ impl From<contract_system_api::CryptoHash> for CryptoHash {
     }
 }
 
-impl From<service_system_api::ApplicationId> for UserApplicationId {
+impl From<service_system_api::ApplicationId> for ApplicationId {
     fn from(guest: service_system_api::ApplicationId) -> Self {
-        UserApplicationId {
+        ApplicationId {
             bytecode_id: guest.bytecode_id.into(),
             creation: guest.creation.into(),
         }

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -11,9 +11,12 @@
 use super::{contract, contract_system_api, service, service_system_api};
 use crate::{
     CallResult, CalleeContext, EffectContext, EffectId, OperationContext, QueryContext, SessionId,
-    UserApplicationId,
 };
-use linera_base::{crypto::CryptoHash, data_types::Amount, identifiers::ChainId};
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::Amount,
+    identifiers::{ApplicationId, ChainId},
+};
 
 impl From<OperationContext> for contract::OperationContext {
     fn from(host: OperationContext) -> Self {
@@ -105,8 +108,8 @@ impl From<SessionId> for contract_system_api::SessionId {
     }
 }
 
-impl From<UserApplicationId> for contract::ApplicationId {
-    fn from(host: UserApplicationId) -> Self {
+impl From<ApplicationId> for contract::ApplicationId {
+    fn from(host: ApplicationId) -> Self {
         contract::ApplicationId {
             bytecode_id: host.bytecode_id.effect_id.into(),
             creation: host.creation.into(),
@@ -114,8 +117,8 @@ impl From<UserApplicationId> for contract::ApplicationId {
     }
 }
 
-impl From<UserApplicationId> for service_system_api::ApplicationId {
-    fn from(host: UserApplicationId) -> Self {
+impl From<ApplicationId> for service_system_api::ApplicationId {
+    fn from(host: ApplicationId) -> Self {
         service_system_api::ApplicationId {
             bytecode_id: host.bytecode_id.effect_id.into(),
             creation: host.creation.into(),
@@ -123,8 +126,8 @@ impl From<UserApplicationId> for service_system_api::ApplicationId {
     }
 }
 
-impl From<UserApplicationId> for contract_system_api::ApplicationId {
-    fn from(host: UserApplicationId) -> Self {
+impl From<ApplicationId> for contract_system_api::ApplicationId {
+    fn from(host: ApplicationId) -> Self {
         contract_system_api::ApplicationId {
             bytecode_id: host.bytecode_id.effect_id.into(),
             creation: host.creation.into(),

--- a/linera-execution/tests/utils.rs
+++ b/linera-execution/tests/utils.rs
@@ -6,13 +6,13 @@ use linera_base::{
     data_types::BlockHeight,
     identifiers::{BytecodeId, ChainId, EffectId},
 };
-use linera_execution::{BytecodeLocation, UserApplicationDescription};
+use linera_execution::{ApplicationDescription, BytecodeLocation};
 use serde::{Deserialize, Serialize};
 
-pub fn create_dummy_user_application_description() -> UserApplicationDescription {
+pub fn create_dummy_user_application_description() -> ApplicationDescription {
     let chain_id = ChainId::root(1);
     let certificate_hash = CryptoHash::new(&FakeCertificate);
-    UserApplicationDescription {
+    ApplicationDescription {
         bytecode_id: BytecodeId::new(EffectId {
             chain_id,
             height: BlockHeight(1),

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -10,7 +10,7 @@ use linera_chain::{
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
     system::{Recipient, SystemChannel, SystemEffect, SystemOperation},
-    ApplicationId, Effect, Operation,
+    Effect, Operation, SystemOrApplicationId,
 };
 use linera_rpc::RpcMessage;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
@@ -37,7 +37,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Medium>(&samples)?;
     tracer.trace_type::<Destination>(&samples)?;
     tracer.trace_type::<ChainDescription>(&samples)?;
-    tracer.trace_type::<ApplicationId>(&samples)?;
+    tracer.trace_type::<SystemOrApplicationId>(&samples)?;
     tracer.trace_type::<ChainManagerInfo>(&samples)?;
     tracer.trace_type::<CrossChainRequest>(&samples)?;
     tracer.trace_type::<NodeError>(&samples)?;

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -8,14 +8,24 @@ Account:
           TYPENAME: Owner
 Amount:
   NEWTYPESTRUCT: U128
+ApplicationDescription:
+  STRUCT:
+    - bytecode_id:
+        TYPENAME: BytecodeId
+    - bytecode_location:
+        TYPENAME: BytecodeLocation
+    - creation:
+        TYPENAME: EffectId
+    - parameters: BYTES
+    - required_application_ids:
+        SEQ:
+          TYPENAME: ApplicationId
 ApplicationId:
-  ENUM:
-    0:
-      System: UNIT
-    1:
-      User:
-        NEWTYPE:
-          TYPENAME: UserApplicationId
+  STRUCT:
+    - bytecode_id:
+        TYPENAME: BytecodeId
+    - creation:
+        TYPENAME: EffectId
 Block:
   STRUCT:
     - chain_id:
@@ -186,7 +196,7 @@ ChainManagerInfo:
 ChannelFullName:
   STRUCT:
     - application_id:
-        TYPENAME: ApplicationId
+        TYPENAME: SystemOrApplicationId
     - name:
         TYPENAME: ChannelName
 ChannelName:
@@ -263,7 +273,7 @@ Effect:
       User:
         STRUCT:
           - application_id:
-              TYPENAME: UserApplicationId
+              TYPENAME: ApplicationId
           - bytes: BYTES
 EffectId:
   STRUCT:
@@ -467,7 +477,7 @@ Operation:
       User:
         STRUCT:
           - application_id:
-              TYPENAME: UserApplicationId
+              TYPENAME: ApplicationId
           - bytes: BYTES
 Origin:
   STRUCT:
@@ -638,7 +648,7 @@ SystemEffect:
         STRUCT:
           - applications:
               SEQ:
-                TYPENAME: UserApplicationDescription
+                TYPENAME: ApplicationDescription
     10:
       Notify:
         STRUCT:
@@ -647,7 +657,7 @@ SystemEffect:
     11:
       RequestApplication:
         NEWTYPE:
-          TYPENAME: UserApplicationId
+          TYPENAME: ApplicationId
 SystemOperation:
   ENUM:
     0:
@@ -749,34 +759,24 @@ SystemOperation:
           - initialization_argument: BYTES
           - required_application_ids:
               SEQ:
-                TYPENAME: UserApplicationId
+                TYPENAME: ApplicationId
     12:
       RequestApplication:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
           - application_id:
-              TYPENAME: UserApplicationId
+              TYPENAME: ApplicationId
+SystemOrApplicationId:
+  ENUM:
+    0:
+      System: UNIT
+    1:
+      User:
+        NEWTYPE:
+          TYPENAME: ApplicationId
 Timestamp:
   NEWTYPESTRUCT: U64
-UserApplicationDescription:
-  STRUCT:
-    - bytecode_id:
-        TYPENAME: BytecodeId
-    - bytecode_location:
-        TYPENAME: BytecodeLocation
-    - creation:
-        TYPENAME: EffectId
-    - parameters: BYTES
-    - required_application_ids:
-        SEQ:
-          TYPENAME: UserApplicationId
-UserApplicationId:
-  STRUCT:
-    - bytecode_id:
-        TYPENAME: BytecodeId
-    - creation:
-        TYPENAME: EffectId
 UserData:
   NEWTYPESTRUCT:
     OPTION:

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -10,7 +10,7 @@ use futures::{lock::Mutex, StreamExt};
 use linera_base::{
     crypto::{KeyPair, PublicKey},
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{BytecodeId, ChainDescription, ChainId, EffectId},
+    identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, EffectId},
 };
 use linera_chain::data_types::Certificate;
 use linera_core::{
@@ -23,7 +23,7 @@ use linera_core::{
 use linera_execution::{
     committee::{ValidatorName, ValidatorState},
     system::{Account, UserData},
-    Bytecode, UserApplicationId, WasmRuntime, WithWasmDefault,
+    Bytecode, WasmRuntime, WithWasmDefault,
 };
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_service::{
@@ -749,7 +749,7 @@ enum ClientCommand {
 
         /// The list of required dependencies of application, if any.
         #[structopt(long)]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 
     /// Create an application, and publish the required bytecode.
@@ -782,13 +782,13 @@ enum ClientCommand {
 
         /// The list of required dependencies of application, if any.
         #[structopt(long)]
-        required_application_ids: Option<Vec<UserApplicationId>>,
+        required_application_ids: Option<Vec<ApplicationId>>,
     },
 
     /// Request an application from another chain, so it can be used on this one.
     RequestApplication {
         /// The ID of the application to request.
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
 
         /// The target chain on which the application is already registered.
         /// If not specified, the chain on which the application was created is used.

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -32,8 +32,7 @@ use linera_core::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::{Recipient, SystemChannel, UserData},
-    Bytecode, Operation, Query, Response, SystemOperation, UserApplicationDescription,
-    UserApplicationId,
+    ApplicationDescription, Bytecode, Operation, Query, Response, SystemOperation,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -302,7 +301,7 @@ where
         bytecode_id: BytecodeId,
         parameters: String,
         initialization_argument: String,
-        required_application_ids: Vec<UserApplicationId>,
+        required_application_ids: Vec<ApplicationId>,
     ) -> Result<ApplicationId, Error> {
         let mut client = self.client.lock().await;
         client.synchronize_from_validators().await?;
@@ -322,7 +321,7 @@ where
     /// on this one.
     async fn request_application(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         target_chain_id: Option<ChainId>,
     ) -> Result<CryptoHash, Error> {
         let mut client = self.client.lock().await;
@@ -406,17 +405,13 @@ where
 
 #[derive(SimpleObject)]
 pub struct ApplicationOverview {
-    id: UserApplicationId,
-    description: UserApplicationDescription,
+    id: ApplicationId,
+    description: ApplicationDescription,
     link: String,
 }
 
 impl ApplicationOverview {
-    fn new(
-        id: UserApplicationId,
-        description: UserApplicationDescription,
-        port: NonZeroU16,
-    ) -> Self {
+    fn new(id: ApplicationId, description: ApplicationDescription, port: NonZeroU16) -> Self {
         Self {
             id,
             description,
@@ -579,7 +574,7 @@ where
     /// Handles queries for user applications.
     async fn user_application_query(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         request: &Request,
     ) -> Result<async_graphql::Response, NodeServiceError> {
         let bytes = serde_json::to_vec(&request)?;
@@ -598,7 +593,7 @@ where
     /// Handles mutations for user applications.
     async fn user_application_mutation(
         &self,
-        application_id: UserApplicationId,
+        application_id: ApplicationId,
         request: &Request,
     ) -> Result<async_graphql::Response, NodeServiceError> {
         let graphql_response = self.user_application_query(application_id, request).await?;
@@ -644,7 +639,7 @@ where
         let parsed_query = request.parsed_query()?;
         let operation_type = operation_type(parsed_query)?;
 
-        let application_id: UserApplicationId = application_id.parse()?;
+        let application_id: ApplicationId = application_id.parse()?;
 
         let response = match operation_type {
             OperationType::Query => {


### PR DESCRIPTION
`linera_execution`'s enum type becomes `SystemApplicationId`, so the `UserApplicationId` type alias can be removed and the type `ApplicationId` now refers to a user application everywhere. The `User` is also dropped from `ApplicationDescription`.