### PR TITLE
Turn Value back into an enum

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -3,8 +3,7 @@
 
 use crate::{
     data_types::{
-        Block, ChainAndHeight, ChannelFullName, Event, ExecutedBlock, Medium, Origin,
-        OutgoingEffect, Target,
+        Block, ChainAndHeight, ChannelFullName, Event, Medium, Origin, OutgoingEffect, Target,
     },
     inbox::{InboxError, InboxStateView},
     outbox::OutboxStateView,
@@ -251,11 +250,11 @@ where
     pub async fn receive_block(
         &mut self,
         origin: &Origin,
-        executed: ExecutedBlock,
+        height: BlockHeight,
+        timestamp: Timestamp,
+        effects: Vec<OutgoingEffect>,
         certificate_hash: CryptoHash,
     ) -> Result<(), ChainError> {
-        let height = executed.block.height;
-        let timestamp = executed.block.timestamp;
         let chain_id = self.chain_id();
         ensure!(
             height >= self.next_block_height_to_receive(origin).await?,
@@ -269,7 +268,7 @@ where
         );
         // Process immediate effects and create inbox events.
         let mut events = Vec::new();
-        for (index, outgoing_effect) in executed.effects.into_iter().enumerate() {
+        for (index, outgoing_effect) in effects.into_iter().enumerate() {
             let index = u32::try_from(index).map_err(|_| ArithmeticError::Overflow)?;
             let OutgoingEffect {
                 destination,

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -53,7 +53,7 @@ impl SingleOwnerManager {
         );
         if let Some(vote) = &self.pending {
             let block = match &vote.value.inner() {
-                Value::ConfirmedBlock { executed } => &executed.block,
+                Value::ConfirmedBlock { executed_block } => &executed_block.block,
                 Value::ValidatedBlock { .. } => return Err(ChainError::InvalidBlockProposal),
             };
             if block == new_block {
@@ -80,12 +80,12 @@ impl SingleOwnerManager {
         if let Some(key_pair) = key_pair {
             // Vote to confirm.
             let BlockAndRound { block, .. } = proposal.content;
-            let executed = ExecutedBlock {
+            let executed_block = ExecutedBlock {
                 block,
                 effects,
                 state_hash,
             };
-            let vote = Vote::new(HashedValue::new_confirmed(executed), key_pair);
+            let vote = Vote::new(HashedValue::new_confirmed(executed_block), key_pair);
             self.pending = Some(vote);
         }
     }

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -27,12 +27,12 @@ fn test_signed_values() {
         authenticated_signer: None,
         previous_block_hash: None,
     };
-    let executed = ExecutedBlock {
+    let executed_block = ExecutedBlock {
         block,
         effects: Vec::new(),
         state_hash: CryptoHash::new(&Dummy),
     };
-    let value = HashedValue::new_confirmed(executed);
+    let value = HashedValue::new_confirmed(executed_block);
 
     let v = LiteVote::new(value.lite(), &key1);
     assert!(v.check().is_ok());
@@ -67,12 +67,12 @@ fn test_certificates() {
         authenticated_signer: None,
         timestamp: Default::default(),
     };
-    let executed = ExecutedBlock {
+    let executed_block = ExecutedBlock {
         block,
         effects: Vec::new(),
         state_hash: CryptoHash::new(&Dummy),
     };
-    let value = HashedValue::new_confirmed(executed);
+    let value = HashedValue::new_confirmed(executed_block);
 
     let v1 = LiteVote::new(value.lite(), &key1);
     let v2 = LiteVote::new(value.lite(), &key2);

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -27,7 +27,12 @@ fn test_signed_values() {
         authenticated_signer: None,
         previous_block_hash: None,
     };
-    let value = HashedValue::new_confirmed(block, Vec::new(), CryptoHash::new(&Dummy));
+    let executed = ExecutedBlock {
+        block,
+        effects: Vec::new(),
+        state_hash: CryptoHash::new(&Dummy),
+    };
+    let value = HashedValue::new_confirmed(executed);
 
     let v = LiteVote::new(value.lite(), &key1);
     assert!(v.check().is_ok());
@@ -62,7 +67,12 @@ fn test_certificates() {
         authenticated_signer: None,
         timestamp: Default::default(),
     };
-    let value = HashedValue::new_confirmed(block, Vec::new(), CryptoHash::new(&Dummy));
+    let executed = ExecutedBlock {
+        block,
+        effects: Vec::new(),
+        state_hash: CryptoHash::new(&Dummy),
+    };
+    let value = HashedValue::new_confirmed(executed);
 
     let v1 = LiteVote::new(value.lite(), &key1);
     let v2 = LiteVote::new(value.lite(), &key2);

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -346,8 +346,8 @@ where
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), NodeError> {
         let mut node = self.node.lock().await;
-        let (executed, info) = node.state.stage_block_execution(block).await?;
-        Ok((executed, info))
+        let (executed_block, info) = node.state.stage_block_execution(block).await?;
+        Ok((executed_block, info))
     }
 
     async fn try_process_certificates<A>(

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -503,9 +503,9 @@ where
                         ..
                     } = response.info;
                     if let Some(cert) = requested_sent_certificates.pop() {
-                        if cert.value.is_confirmed()
-                            && cert.value.block().chain_id == chain_id
-                            && cert.value.block().height == block_height
+                        if cert.value().is_confirmed()
+                            && cert.value().chain_id() == chain_id
+                            && cert.value().height() == block_height
                         {
                             cert.check(&self.initial_committee).unwrap();
                             count += 1;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -17,7 +17,7 @@ use linera_base::{
     data_types::*,
     identifiers::{ChainDescription, ChainId, EffectId, Owner},
 };
-use linera_chain::data_types::Value;
+use linera_chain::data_types::{ExecutedBlock, Value};
 use linera_execution::{
     committee::{Committee, Epoch},
     pricing::Pricing,
@@ -558,8 +558,8 @@ where
     );
     assert!(matches!(
         &certificate.value(),
-        Value::ConfirmedBlock { executed } if matches!(
-            executed.block.operations[open_chain_effect_id.index as usize],
+        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. } } if matches!(
+            block.operations[open_chain_effect_id.index as usize],
             Operation::System(SystemOperation::OpenChain { .. }),
         ),
     ));
@@ -693,9 +693,8 @@ where
     let certificate = sender.close_chain().await.unwrap();
     assert!(matches!(
         &certificate.value(),
-        Value::ConfirmedBlock { executed } if matches!(
-            &executed.block.operations[..],
-            &[Operation::System(SystemOperation::CloseChain)]
+        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. } } if matches!(
+            &block.operations[..], &[Operation::System(SystemOperation::CloseChain)]
         ),
     ));
     assert_eq!(sender.next_block_height, BlockHeight::from(1));

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -457,7 +457,7 @@ where
     let certs = receiver.process_inbox().await.unwrap();
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed } => &executed.block.incoming_messages,
+        Value::ConfirmedBlock { executed_block } => &executed_block.block.incoming_messages,
         Value::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     assert!(messages.iter().any(|msg| matches!(
@@ -486,7 +486,7 @@ where
     let certs = receiver.process_inbox().await?;
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed } => &executed.block.incoming_messages,
+        Value::ConfirmedBlock { executed_block } => &executed_block.block.incoming_messages,
         Value::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     // The new block should _not_ contain another `RegisterApplications` effect, because the
@@ -621,7 +621,7 @@ where
 
     // There should be a message receiving the new post.
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed } => &executed.block.incoming_messages,
+        Value::ConfirmedBlock { executed_block } => &executed_block.block.incoming_messages,
         Value::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     assert!(messages

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -141,8 +141,9 @@ where
             };
             if let Err(NodeError::ApplicationBytecodesNotFound(locations)) = &result {
                 let required = match certificate.value() {
-                    Value::ConfirmedBlock { executed } | Value::ValidatedBlock { executed, .. } => {
-                        executed.block.bytecode_locations()
+                    Value::ConfirmedBlock { executed_block }
+                    | Value::ValidatedBlock { executed_block, .. } => {
+                        executed_block.block.bytecode_locations()
                     }
                 };
                 for location in locations {

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -4,7 +4,7 @@
 
 use linera_base::identifiers::{ChainDescription, Destination};
 use linera_chain::{
-    data_types::{HashedValue, Medium, ValueKind},
+    data_types::{HashedValue, Medium, Value},
     ChainManagerInfo,
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
@@ -33,7 +33,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Operation>(&samples)?;
     tracer.trace_type::<Effect>(&samples)?;
     tracer.trace_type::<HashedValue>(&samples)?;
-    tracer.trace_type::<ValueKind>(&samples)?;
+    tracer.trace_type::<Value>(&samples)?;
     tracer.trace_type::<Medium>(&samples)?;
     tracer.trace_type::<Destination>(&samples)?;
     tracer.trace_type::<ChainDescription>(&samples)?;

--- a/linera-rpc/src/rpc.rs
+++ b/linera-rpc/src/rpc.rs
@@ -37,7 +37,7 @@ impl RpcMessage {
         let chain_id = match self {
             RpcMessage::BlockProposal(proposal) => proposal.content.block.chain_id,
             RpcMessage::LiteCertificate(request) => request.certificate.value.chain_id,
-            RpcMessage::Certificate(request) => request.certificate.value.chain_id(),
+            RpcMessage::Certificate(request) => request.certificate.value().chain_id(),
             RpcMessage::ChainInfoQuery(query) => query.chain_id,
             RpcMessage::CrossChainRequest(request) => request.target_chain_id(),
             RpcMessage::Vote(_) | RpcMessage::Error(_) | RpcMessage::ChainInfoResponse(_) => {

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -290,6 +290,15 @@ Event:
         TYPENAME: Timestamp
     - effect:
         TYPENAME: Effect
+ExecutedBlock:
+  STRUCT:
+    - block:
+        TYPENAME: Block
+    - effects:
+        SEQ:
+          TYPENAME: OutgoingEffect
+    - state_hash:
+        TYPENAME: CryptoHash
 HandleCertificateRequest:
   STRUCT:
     - certificate:
@@ -803,23 +812,17 @@ ValidatorState:
     - network_address: STR
     - votes: U64
 Value:
-  STRUCT:
-    - block:
-        TYPENAME: Block
-    - effects:
-        SEQ:
-          TYPENAME: OutgoingEffect
-    - state_hash:
-        TYPENAME: CryptoHash
-    - kind:
-        TYPENAME: ValueKind
-ValueKind:
   ENUM:
     0:
       ValidatedBlock:
         STRUCT:
+          - executed:
+              TYPENAME: ExecutedBlock
           - round:
               TYPENAME: RoundNumber
     1:
-      ConfirmedBlock: UNIT
+      ConfirmedBlock:
+        STRUCT:
+          - executed:
+              TYPENAME: ExecutedBlock
 

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -816,13 +816,13 @@ Value:
     0:
       ValidatedBlock:
         STRUCT:
-          - executed:
+          - executed_block:
               TYPENAME: ExecutedBlock
           - round:
               TYPENAME: RoundNumber
     1:
       ConfirmedBlock:
         STRUCT:
-          - executed:
+          - executed_block:
               TYPENAME: ExecutedBlock
 

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -120,14 +120,14 @@ impl BlockBuilder {
     pub(crate) async fn sign(mut self) -> Certificate {
         self.collect_incoming_messages().await;
 
-        let (executed, _) = self
+        let (executed_block, _) = self
             .validator
             .worker()
             .await
             .stage_block_execution(self.block)
             .await
             .expect("Failed to execute block");
-        let value = HashedValue::new_confirmed(executed);
+        let value = HashedValue::new_confirmed(executed_block);
         let vote = LiteVote::new(value.lite(), self.validator.key_pair());
         let mut builder = SignatureAggregator::new(value, self.validator.committee());
         builder

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -212,9 +212,8 @@ impl ActiveChain {
             .await
             .as_ref()
             .expect("Block was not successfully added")
-            .value
-            .block()
-            .height
+            .value()
+            .height()
     }
 
     /// Subscribes this microchain to the bytecodes published on the `publisher_id` microchain.
@@ -339,7 +338,7 @@ impl ActiveChain {
                 .expect("Failed to load certificate to search for bytecode location")
                 .expect("Bytecode location not found");
 
-            let effect_index = certificate.value.effects().iter().position(|effect| {
+            let effect_index = certificate.value().effects().iter().position(|effect| {
                 matches!(
                     &effect.effect,
                     Effect::System(SystemEffect::BytecodeLocations { locations })

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -153,10 +153,7 @@ where
         let mut client = self.client.lock().await;
         client.synchronize_from_validators().await?;
         let certificates = client.process_inbox().await?;
-        let hashes = certificates
-            .into_iter()
-            .map(|cert| cert.value.hash())
-            .collect();
+        let hashes = certificates.into_iter().map(|cert| cert.hash()).collect();
         Ok(hashes)
     }
 
@@ -175,7 +172,7 @@ where
         let certificate = client
             .transfer(owner, amount, recipient, user_data.unwrap_or_default())
             .await?;
-        Ok(certificate.value.hash())
+        Ok(certificate.hash())
     }
 
     /// Claims `amount` units of value from the given owner's account in
@@ -201,7 +198,7 @@ where
                 user_data.unwrap_or_default(),
             )
             .await?;
-        Ok(certificate.value.hash())
+        Ok(certificate.hash())
     }
 
     /// Creates (or activates) a new chain by installing the given authentication key.
@@ -220,7 +217,7 @@ where
         client.synchronize_from_validators().await?;
         client.process_inbox().await?;
         let certificate = client.close_chain().await?;
-        Ok(certificate.value.hash())
+        Ok(certificate.hash())
     }
 
     /// Changes the authentication key of the chain.
@@ -331,7 +328,7 @@ where
         let certificate = client
             .request_application(application_id, target_chain_id)
             .await?;
-        Ok(certificate.value.hash())
+        Ok(certificate.hash())
     }
 }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -194,7 +194,7 @@ pub trait Store: Sized {
             })?
             .into_inner();
         let operations = match value {
-            Value::ConfirmedBlock { executed } => executed.block.operations,
+            Value::ConfirmedBlock { executed_block } => executed_block.block.operations,
             Value::ValidatedBlock { .. } => {
                 return Err(ExecutionError::InvalidBytecodeId(*bytecode_id));
             }


### PR DESCRIPTION
For chains with full consensus we will need additional `Value` variants, such as timeout certificates, which won't contain a block, effects and a state hash. So `Value` needs to be an `enum` again.