### PR TITLE
Fix `linera project test`

### DIFF
--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -9,11 +9,13 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use tracing::debug;
+use tracing::{debug, info};
 
 pub struct Project {
     root: PathBuf,
 }
+
+const RUNNER_BIN_NAME: &str = "test-runner";
 
 impl Project {
     pub fn new(root: PathBuf) -> Result<Self> {
@@ -89,19 +91,20 @@ impl Project {
     }
 
     fn install_test_runner() -> Result<()> {
-        println!("installing test runner...");
+        info!("installing test runner...");
         let cargo_install = Command::new("cargo")
-            .args(["install", "linera-test-runner"])
+            .args(["install", "linera-sdk"])
+            .args(["--bin", RUNNER_BIN_NAME])
             .spawn()?
             .wait()?;
         if !cargo_install.success() {
-            bail!("failed to install linera-test-runner")
+            bail!("failed to install {}", &RUNNER_BIN_NAME)
         }
         Ok(())
     }
 
     fn runner_path() -> Result<PathBuf> {
-        Self::cargo_home().map(|cargo_home| cargo_home.join("bin").join("linera-test-runner"))
+        Self::cargo_home().map(|cargo_home| cargo_home.join("bin").join(RUNNER_BIN_NAME))
     }
 
     fn cargo_home() -> Result<PathBuf> {

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -200,6 +200,21 @@ impl Client {
         tmp
     }
 
+    async fn test_project(&self, path: &Path) {
+        let mut command = self.run().await;
+        assert!(command
+            .current_dir(path)
+            .kill_on_drop(true)
+            .arg("project")
+            .arg("test")
+            .spawn()
+            .unwrap()
+            .wait()
+            .await
+            .unwrap()
+            .success());
+    }
+
     async fn run(&self) -> Command {
         let path = cargo_build_binary("linera").await;
         let mut command = Command::new(path);
@@ -1617,5 +1632,15 @@ async fn test_project_new() {
     let project_dir = tmp_dir.path().join("init-test");
     runner
         .build_application(project_dir.as_path(), "init-test", false)
+        .await;
+}
+
+#[test_log::test(tokio::test)]
+async fn test_project_test() {
+    let network = Network::Grpc;
+    let mut runner = TestRunner::new(network, 0);
+    let client = runner.make_client(network);
+    client
+        .test_project(&PathBuf::from_str("../examples/counter").unwrap())
         .await;
 }


### PR DESCRIPTION
# Motivation

The `linera project test` command was pointing to an empty crate.

# Solution
Now it's pointing to `linera-sdk` and pulling the `test-runner` binary.

Also we now have tests for `linera project test`.