### PR TITLE
Only send lite certificate if validator already signed it.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -602,6 +602,13 @@ impl Certificate {
     pub fn hash(&self) -> CryptoHash {
         self.value.hash
     }
+
+    /// Returns whether the validator is among the signatories of this certificate.
+    pub fn is_signed_by(&self, validator_name: &ValidatorName) -> bool {
+        self.signatures
+            .iter()
+            .any(|(name, _)| name == validator_name)
+    }
 }
 
 /// Verifies certificate signatures.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -485,8 +485,8 @@ where
         let mut tasks = vec![];
         let mut node = self.node.lock().await;
         for (location, chain_id) in blob_locations {
-            if let Some(blob) = node.state.recent_value(&location.certificate_hash) {
-                blobs.push(blob.clone());
+            if let Some(blob) = node.state.recent_value(&location.certificate_hash).await {
+                blobs.push(blob);
             } else {
                 let validators = validators.clone();
                 let storage = node.state.storage_client().clone();
@@ -503,9 +503,7 @@ where
         let mut node = self.node.lock().await;
         for result in results {
             if let Some(blob) = result? {
-                if node.state.recent_value(&blob.hash()).is_none() {
-                    node.state.cache_recent_value(blob.clone());
-                }
+                node.state.cache_recent_value(&blob).await;
                 blobs.push(blob);
             }
         }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -262,7 +262,7 @@ where
     ) -> Result<ChainInfoResponse, NodeError> {
         let mut node = self.node.lock().await;
         let mut notifications = Vec::new();
-        let full_cert = node.state.full_certificate(certificate)?;
+        let full_cert = node.state.full_certificate(certificate).await?;
         let response = node
             .state
             .fully_handle_certificate_with_notifications(


### PR DESCRIPTION
# Motivation

We are seeing a lot of "errors" and unnecessary round-trips because currently the client is always sending a `LiteCertificate` first, and if the validator doesn't have a value with that hash, it returns an error and the client sends the full certificate.

To make things worse, the caching mechanism doesn't work in many cases in the first place because if a worker is cloned the LRU cache is cloned, too, and the original worker won't have the entries that its clone will add to its cache.

# Solution

The client now only sends a `LiteCertificate` if the validator is among the signatories of the full certificate, which means it definitely has it. The validator looks it up in storage if it can't find it in the cache (which will still only return `ConfirmedBlock`s, not `ValidatedBlock`s).

The `WorkerState`s now share a single `Arc<Mutex<LruCache<_, _>>>`.

There is still room for improvement: The client now sends a full `Certificate` to the slowest third of the validators, even if they have voted in the meantime. And a `ConfirmedBlock` is in a validator's cache even if it only signed the corresponding `ValidatedBlock`.

Closes https://github.com/linera-io/linera-protocol/issues/459