### PR TITLE
Add a round number to ConfirmedBlock.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -437,6 +437,8 @@ impl Value {
 }
 
 impl HashedValue {
+    /// Creates a `ConfirmedBlock` with round 0.
+    #[cfg(any(test, feature = "test"))]
     pub fn new_confirmed(executed_block: ExecutedBlock) -> HashedValue {
         Value::ConfirmedBlock {
             executed_block,

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -97,7 +97,7 @@ impl ChainManager {
         }
     }
 
-    /// Verify the safety of the block w.r.t. voting rules.
+    /// Verifies the safety of the block w.r.t. voting rules.
     pub fn check_proposed_block(
         &self,
         new_block: &Block,

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -85,7 +85,11 @@ impl SingleOwnerManager {
                 effects,
                 state_hash,
             };
-            let vote = Vote::new(HashedValue::new_confirmed(executed_block), key_pair);
+            let value = HashedValue::from(Value::ConfirmedBlock {
+                executed_block,
+                round: RoundNumber(0),
+            });
+            let vote = Vote::new(value, key_pair);
             self.pending = Some(vote);
         }
     }

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -41,7 +41,7 @@ impl SingleOwnerManager {
         self.pending.as_ref()
     }
 
-    /// Verify the safety of the block w.r.t. voting rules.
+    /// Verifies the safety of the block w.r.t. voting rules.
     pub fn check_proposed_block(
         &self,
         new_block: &Block,
@@ -53,7 +53,7 @@ impl SingleOwnerManager {
         );
         if let Some(vote) = &self.pending {
             let block = match &vote.value.inner() {
-                Value::ConfirmedBlock { executed_block } => &executed_block.block,
+                Value::ConfirmedBlock { executed_block, .. } => &executed_block.block,
                 Value::ValidatedBlock { .. } => return Err(ChainError::InvalidBlockProposal),
             };
             if block == new_block {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -606,8 +606,12 @@ where
         match action {
             CommunicateAction::SubmitBlockForConfirmation(proposal) => {
                 let block = proposal.content.block;
+                let round = proposal.content.round;
                 let (executed_block, _) = self.node_client.stage_block_execution(block).await?;
-                let value = HashedValue::new_confirmed(executed_block);
+                let value = HashedValue::from(Value::ConfirmedBlock {
+                    executed_block,
+                    round,
+                });
                 let certificate = Certificate::new(value, signatures);
                 // Certificate is valid because
                 // * `communicate_with_quorum` ensured a sufficient "weight" of

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -635,7 +635,7 @@ where
         certificate: Certificate,
         mode: ReceiveCertificateMode,
     ) -> Result<()> {
-        let Value::ConfirmedBlock { executed_block } = certificate.value() else {
+        let Value::ConfirmedBlock { executed_block, .. } = certificate.value() else {
             bail!("Was expecting a confirmed chain operation");
         };
         let block = &executed_block.block;
@@ -718,7 +718,7 @@ where
                 .requested_sent_certificates.pop() else {
                 break;
             };
-            let Value::ConfirmedBlock { executed_block } = certificate.value() else {
+            let Value::ConfirmedBlock { executed_block, .. } = certificate.value() else {
                 return Err(NodeError::InvalidChainInfoResponse);
             };
             let block = &executed_block.block;
@@ -1040,7 +1040,7 @@ where
         // By now the block should be final.
         ensure!(
             matches!(
-                final_certificate.value(), Value::ConfirmedBlock { executed_block }
+                final_certificate.value(), Value::ConfirmedBlock { executed_block, .. }
                     if executed_block.block == proposal.content.block
             ),
             "A different operation was executed in parallel (consider retrying the operation)"

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -546,7 +546,7 @@ where
         let certificate = info
             .requested_sent_certificates
             .into_iter()
-            .find(|certificate| certificate.value.has_effect(effect_id))
+            .find(|certificate| certificate.value().has_effect(effect_id))
             .ok_or_else(|| {
                 ViewError::not_found("could not find certificate with effect {}", effect_id)
             })?;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -558,7 +558,7 @@ where
     );
     assert!(matches!(
         &certificate.value(),
-        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. } } if matches!(
+        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
             block.operations[open_chain_effect_id.index as usize],
             Operation::System(SystemOperation::OpenChain { .. }),
         ),
@@ -693,7 +693,7 @@ where
     let certificate = sender.close_chain().await.unwrap();
     assert!(matches!(
         &certificate.value(),
-        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. } } if matches!(
+        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
             &block.operations[..], &[Operation::System(SystemOperation::CloseChain)]
         ),
     ));

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -457,7 +457,7 @@ where
     let certs = receiver.process_inbox().await.unwrap();
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed_block } => &executed_block.block.incoming_messages,
+        Value::ConfirmedBlock { executed_block, .. } => &executed_block.block.incoming_messages,
         Value::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     assert!(messages.iter().any(|msg| matches!(
@@ -486,7 +486,7 @@ where
     let certs = receiver.process_inbox().await?;
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed_block } => &executed_block.block.incoming_messages,
+        Value::ConfirmedBlock { executed_block, .. } => &executed_block.block.incoming_messages,
         Value::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     // The new block should _not_ contain another `RegisterApplications` effect, because the
@@ -621,7 +621,7 @@ where
 
     // There should be a message receiving the new post.
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed_block } => &executed_block.block.incoming_messages,
+        Value::ConfirmedBlock { executed_block, .. } => &executed_block.block.incoming_messages,
         Value::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     assert!(messages

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -141,7 +141,7 @@ where
             };
             if let Err(NodeError::ApplicationBytecodesNotFound(locations)) = &result {
                 let required = match certificate.value() {
-                    Value::ConfirmedBlock { executed_block }
+                    Value::ConfirmedBlock { executed_block, .. }
                     | Value::ValidatedBlock { executed_block, .. } => {
                         executed_block.block.bytecode_locations()
                     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -471,7 +471,7 @@ where
         blobs: &[HashedValue],
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        let Value::ConfirmedBlock { executed_block } = certificate.value() else {
+        let Value::ConfirmedBlock { executed_block, .. } = certificate.value() else {
             panic!("Expecting a confirmation certificate");
         };
         let ExecutedBlock {
@@ -708,6 +708,7 @@ where
             match certificate.value.into_inner() {
                 Value::ConfirmedBlock {
                     executed_block: ExecutedBlock { block, effects, .. },
+                    ..
                 } => {
                     // Update the staged chain state with the received block.
                     chain

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -825,4 +825,6 @@ Value:
         STRUCT:
           - executed_block:
               TYPENAME: ExecutedBlock
+          - round:
+              TYPENAME: RoundNumber
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -951,10 +951,9 @@ where
                 let timestamp = match certificate.value() {
                     LineraValue::ConfirmedBlock {
                         executed_block: ExecutedBlock { block, .. },
+                        ..
                     } => block.timestamp,
-                    LineraValue::ValidatedBlock { .. } => {
-                        panic!("Unexpected certificate.")
-                    }
+                    _ => panic!("Unexpected certificate."),
                 };
                 context.update_wallet_for_new_chain(id, key_pair, timestamp);
                 // Print the new chain ID and effect ID on stdout for scripting purposes.
@@ -1031,7 +1030,7 @@ where
                     .unwrap()
                     .into_iter()
                     .map(|c| match c.value() {
-                        LineraValue::ConfirmedBlock { executed_block } => {
+                        LineraValue::ConfirmedBlock { executed_block, .. } => {
                             executed_block.effects.len()
                         }
                         LineraValue::ValidatedBlock { .. } => 0,
@@ -1385,8 +1384,9 @@ where
                 let timestamp = match certificate.value() {
                     LineraValue::ConfirmedBlock {
                         executed_block: ExecutedBlock { block, .. },
+                        ..
                     } => block.timestamp,
-                    LineraValue::ValidatedBlock { .. } => panic!("Unexpected certificate."),
+                    _ => panic!("Unexpected certificate."),
                 };
                 let chain_id = ChainId::child(effect_id);
                 context

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1142,7 +1142,10 @@ where
                             WorkerState::new("staging".to_string(), None, storage.clone())
                                 .stage_block_execution(proposal.content.block.clone())
                                 .await?;
-                        let value = HashedValue::new_confirmed(executed_block);
+                        let value = HashedValue::from(LineraValue::ConfirmedBlock {
+                            executed_block,
+                            round: RoundNumber(0),
+                        });
                         values.insert(value.hash(), value);
                     }
                 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -194,10 +194,8 @@ pub trait Store: Sized {
             })?
             .into_inner();
         let operations = match value {
-            Value::ConfirmedBlock { executed_block } => executed_block.block.operations,
-            Value::ValidatedBlock { .. } => {
-                return Err(ExecutionError::InvalidBytecodeId(*bytecode_id));
-            }
+            Value::ConfirmedBlock { executed_block, .. } => executed_block.block.operations,
+            _ => return Err(ExecutionError::InvalidBytecodeId(*bytecode_id)),
         };
         let index = usize::try_from(bytecode_location.operation_index)
             .map_err(|_| linera_base::data_types::ArithmeticError::Overflow)?;


### PR DESCRIPTION
Otherwise the `MultiOwnerManager` makes validators potentially double-sign, because they could sign different `ConfirmedBlock`s in different rounds.