### PR TITLE
rocksdb feature in linera-views

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ linera-core = { version = "0.1.0", path = "./linera-core", default-features = fa
 linera-execution = { version = "0.1.0", path = "./linera-execution", default-features = false }
 linera-rpc = { version = "0.1.0", path = "./linera-rpc" }
 linera-storage = { version = "0.1.0", path = "./linera-storage", default-features = false }
-linera-views = { version = "0.1.0", path = "./linera-views" }
+linera-views = { version = "0.1.0", path = "./linera-views", default-features = false }
 linera-views-derive = { version = "0.1.0", path = "./linera-views-derive" }
 
 counter = { path = "./examples/counter" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.3.24"
 futures-util = "0.3.26"
 hex = "0.4.3"
 linera-sdk = { version = "0.1.0", path = "../linera-sdk" }
-linera-views = { version = "0.1.0", path = "../linera-views" }
+linera-views = { version = "0.1.0", path = "../linera-views", default-features = false }
 log = "0.4.17"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -52,6 +52,7 @@ meta-counter = { workspace = true }
 reentrant-counter = { workspace = true }
 fungible = { workspace = true }
 linera-core = { workspace = true, features = ["test"] }
+linera-views = { workspace = true, features = ["rocksdb"] }
 metrics = { workspace = true }
 metrics-util = { workspace = true }
 portable-atomic = { workspace = true }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -60,7 +60,7 @@ linera-core = { workspace = true, features = ["test"] }
 linera-execution = { workspace = true, features = ["test"] }
 linera-rpc = { workspace = true, features = ["test"] }
 linera-storage = { workspace = true, features = ["test"] }
-linera-views = { workspace = true, features = ["test"] }
+linera-views = { workspace = true, features = ["rocksdb", "test"] }
 once_cell = { workspace = true }
 proptest = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -26,7 +26,7 @@ futures = { workspace = true }
 linera-base = { workspace = true }
 linera-chain = { workspace = true }
 linera-execution = { workspace = true }
-linera-views = { workspace = true, features = ["metrics"] }
+linera-views = { workspace = true, features = ["metrics", "rocksdb"] }
 metrics = { workspace = true }
 tracing = { workspace = true }
 rocksdb = { workspace = true }

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -11,7 +11,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [package.metadata.docs.rs]
-features = ["aws", "test"]
+default = ["rocksdb"]
+features = ["rocksdb", "aws", "test"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
 [features]
@@ -42,7 +43,7 @@ anyhow = { workspace = true, optional = true }
 tracing = { workspace = true }
 http = { workspace = true }
 rand = { workspace = true }
-rocksdb = { workspace = true }
+rocksdb = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true }
 aws-sdk-dynamodb = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -55,15 +55,18 @@ pub mod key_value_store_view;
 pub mod hashable_wrapper;
 
 /// Helper definitions for Rocksdb storage.
+#[cfg(feature = "rocksdb")]
 #[cfg(not(target_arch = "wasm32"))]
 pub mod rocksdb;
 
 /// Helper definitions for DynamoDB storage.
 #[cfg(feature = "aws")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod dynamo_db;
 
 /// Helper types for interfacing with a LocalStack instance.
 #[cfg(feature = "aws")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod localstack;
 
 /// Helper types for tests.

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -7,7 +7,6 @@ use linera_views::{
     common::{KeyIterable, KeyValueStoreClient},
     key_value_store_view::ViewContainer,
     memory::MemoryContext,
-    rocksdb::DB,
     test_utils::get_random_key_value_vec_prefix,
 };
 use rand::SeedableRng;
@@ -15,6 +14,9 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
 };
+
+#[cfg(feature = "rocksdb")]
+use linera_views::rocksdb::DB;
 
 #[cfg(feature = "aws")]
 use linera_views::{
@@ -91,6 +93,7 @@ async fn test_ordering_memory() {
     test_ordering_keys(key_value_operation).await;
 }
 
+#[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_ordering_rocksdb() {
     let dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
We sometime compile the linera-sdk for the native platform (for instance here: https://github.com/linera-io/linera-documentation/pull/20). In this PR, we try not always to compile rocksdb in this case.