### PR TITLE
After reaching quorum, wait for additional validators.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -432,7 +432,7 @@ where
             return Err(ChainError::InactiveChain(chain_id));
         };
 
-        let pricing = committee.pricing.clone();
+        let pricing = committee.pricing().clone();
         let credit: Amount = block
             .incoming_messages
             .iter()

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -51,6 +51,10 @@ pub mod client_test_utils;
 #[path = "unit_tests/client_tests.rs"]
 mod client_tests;
 
+/// The amount of time we wait for additional validators to contribute to the result, as a fraction
+/// of how long it took to reach a quorum.
+const QUORUM_GRACE_PERIOD: f64 = 0.2;
+
 /// Client to operate a chain by interacting with validators and the given local storage
 /// implementation.
 /// * The chain being operated is called the "local chain" or just the "chain".
@@ -577,6 +581,7 @@ where
                 let action = action.clone();
                 Box::pin(async move { updater.send_chain_update(chain_id, action).await })
             },
+            QUORUM_GRACE_PERIOD,
         )
         .await;
         let votes = match result {
@@ -826,6 +831,7 @@ where
                     chain_id, name, tracker, committees, max_epoch, client,
                 ))
             },
+            QUORUM_GRACE_PERIOD,
         )
         .await;
         let responses = match result {

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -366,7 +366,8 @@ where
     }
 
     pub fn with_pricing(mut self, pricing: Pricing) -> Self {
-        self.initial_committee.pricing = pricing;
+        let validators = self.initial_committee.validators().clone();
+        self.initial_committee = Committee::new(validators, pricing);
         self
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1099,7 +1099,7 @@ where
         .await?;
 
     // Create a new committee.
-    let validators = builder.initial_committee.validators;
+    let validators = builder.initial_committee.validators().clone();
     let committee = Committee::new(validators, Pricing::only_fuel());
     admin.stage_new_committee(committee).await.unwrap();
     assert_eq!(admin.next_block_height, BlockHeight::from(1));

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -35,22 +35,22 @@ doc_scalar!(ValidatorName, "The identity of a validator");
 impl Committee {
     #[graphql(derived(name = "validators"))]
     async fn _validators(&self) -> &BTreeMap<ValidatorName, ValidatorState> {
-        &self.validators
+        self.validators()
     }
 
     #[graphql(derived(name = "total_votes"))]
     async fn _total_votes(&self) -> u64 {
-        self.total_votes
+        self.total_votes()
     }
 
     #[graphql(derived(name = "quorum_threshold"))]
     async fn _quorum_threshold(&self) -> u64 {
-        self.quorum_threshold
+        self.quorum_threshold()
     }
 
     #[graphql(derived(name = "validity_threshold"))]
     async fn _validity_threshold(&self) -> u64 {
-        self.validity_threshold
+        self.validity_threshold()
     }
 }
 

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -205,9 +205,6 @@ Committee:
             TYPENAME: ValidatorName
           VALUE:
             TYPENAME: ValidatorState
-    - total_votes: U64
-    - quorum_threshold: U64
-    - validity_threshold: U64
     - pricing:
         TYPENAME: Pricing
 CrossChainRequest:


### PR DESCRIPTION
This introduces a short grace period, proportional to how long it took to reach a quorum, to allow additional validators to contribute signatures or chain information.

One place where this is useful is `send_certificate`: When updating validators, we re-send the full certificate to everyone whose signature isn't in it. With the grace period, often every validator will have signed it, and only `LiteCertificate`s need to be sent.

This also fixes a bug: We need to recompute the total and thresholds when adding and removing validators.