### PR TITLE
Rename Value to CertificateValue.

### DIFF
--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -4,8 +4,8 @@
 use super::Outcome;
 use crate::{
     data_types::{
-        Block, BlockAndRound, BlockProposal, Certificate, ExecutedBlock, HashedValue, LiteVote,
-        OutgoingEffect, Value, Vote,
+        Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, ExecutedBlock,
+        HashedValue, LiteVote, OutgoingEffect, Vote,
     },
     ChainError,
 };
@@ -49,7 +49,7 @@ impl MultiOwnerManager {
             }
         }
         if let Some(cert) = &self.locked {
-            if let Value::ValidatedBlock { round, .. } = cert.value() {
+            if let CertificateValue::ValidatedBlock { round, .. } = cert.value() {
                 if current_round < *round {
                     current_round = *round;
                 }
@@ -77,7 +77,7 @@ impl MultiOwnerManager {
             }
         }
         if let Some(certificate) = &self.locked {
-            if let Value::ValidatedBlock {
+            if let CertificateValue::ValidatedBlock {
                 round,
                 executed_block: ExecutedBlock { block, .. },
             } = certificate.value()
@@ -99,7 +99,7 @@ impl MultiOwnerManager {
     ) -> Result<Outcome, ChainError> {
         if let Some(Vote { value, .. }) = &self.pending {
             match value.inner() {
-                Value::ConfirmedBlock {
+                CertificateValue::ConfirmedBlock {
                     executed_block,
                     round,
                 } => {
@@ -107,14 +107,14 @@ impl MultiOwnerManager {
                         return Ok(Outcome::Skip);
                     }
                 }
-                Value::ValidatedBlock { round, .. } => ensure!(
+                CertificateValue::ValidatedBlock { round, .. } => ensure!(
                     new_round >= *round,
                     ChainError::InsufficientRound(round.try_sub_one().unwrap())
                 ),
             }
         }
         if let Some(Certificate { value, .. }) = &self.locked {
-            if let Value::ValidatedBlock { round, .. } = value.inner() {
+            if let CertificateValue::ValidatedBlock { round, .. } = value.inner() {
                 ensure!(
                     new_round >= *round,
                     ChainError::InsufficientRound(round.try_sub_one().unwrap())

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -4,8 +4,8 @@
 use super::Outcome;
 use crate::{
     data_types::{
-        Block, BlockAndRound, BlockProposal, ExecutedBlock, HashedValue, LiteVote, OutgoingEffect,
-        Value, Vote,
+        Block, BlockAndRound, BlockProposal, CertificateValue, ExecutedBlock, HashedValue,
+        LiteVote, OutgoingEffect, Vote,
     },
     ChainError,
 };
@@ -53,8 +53,10 @@ impl SingleOwnerManager {
         );
         if let Some(vote) = &self.pending {
             let block = match &vote.value.inner() {
-                Value::ConfirmedBlock { executed_block, .. } => &executed_block.block,
-                Value::ValidatedBlock { .. } => return Err(ChainError::InvalidBlockProposal),
+                CertificateValue::ConfirmedBlock { executed_block, .. } => &executed_block.block,
+                CertificateValue::ValidatedBlock { .. } => {
+                    return Err(ChainError::InvalidBlockProposal)
+                }
             };
             if block == new_block {
                 return Ok(Outcome::Skip);
@@ -85,7 +87,7 @@ impl SingleOwnerManager {
                 effects,
                 state_hash,
             };
-            let value = HashedValue::from(Value::ConfirmedBlock {
+            let value = HashedValue::from(CertificateValue::ConfirmedBlock {
                 executed_block,
                 round: RoundNumber(0),
             });

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -22,7 +22,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockAndRound, BlockProposal, Certificate, HashedValue, LiteVote, Message, Value,
+        Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, HashedValue, LiteVote,
+        Message,
     },
     ChainManagerInfo, ChainStateView,
 };
@@ -608,7 +609,7 @@ where
                 let block = proposal.content.block;
                 let round = proposal.content.round;
                 let (executed_block, _) = self.node_client.stage_block_execution(block).await?;
-                let value = HashedValue::from(Value::ConfirmedBlock {
+                let value = HashedValue::from(CertificateValue::ConfirmedBlock {
                     executed_block,
                     round,
                 });
@@ -639,7 +640,7 @@ where
         certificate: Certificate,
         mode: ReceiveCertificateMode,
     ) -> Result<()> {
-        let Value::ConfirmedBlock { executed_block, .. } = certificate.value() else {
+        let CertificateValue::ConfirmedBlock { executed_block, .. } = certificate.value() else {
             bail!("Was expecting a confirmed chain operation");
         };
         let block = &executed_block.block;
@@ -722,7 +723,7 @@ where
                 .requested_sent_certificates.pop() else {
                 break;
             };
-            let Value::ConfirmedBlock { executed_block, .. } = certificate.value() else {
+            let CertificateValue::ConfirmedBlock { executed_block, .. } = certificate.value() else {
                 return Err(NodeError::InvalidChainInfoResponse);
             };
             let block = &executed_block.block;
@@ -1018,7 +1019,7 @@ where
                     .expect("a certificate");
                 assert!(matches!(
                     certificate.value(),
-                    Value::ValidatedBlock { executed_block, .. }
+                    CertificateValue::ValidatedBlock { executed_block, .. }
                         if executed_block.block == proposal.content.block
                 ));
                 self.communicate_chain_updates(
@@ -1044,7 +1045,7 @@ where
         // By now the block should be final.
         ensure!(
             matches!(
-                final_certificate.value(), Value::ConfirmedBlock { executed_block, .. }
+                final_certificate.value(), CertificateValue::ConfirmedBlock { executed_block, .. }
                     if executed_block.block == proposal.content.block
             ),
             "A different operation was executed in parallel (consider retrying the operation)"

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -17,7 +17,7 @@ use linera_base::{
     data_types::*,
     identifiers::{ChainDescription, ChainId, EffectId, Owner},
 };
-use linera_chain::data_types::{ExecutedBlock, Value};
+use linera_chain::data_types::{CertificateValue, ExecutedBlock};
 use linera_execution::{
     committee::{Committee, Epoch},
     pricing::Pricing,
@@ -558,7 +558,7 @@ where
     );
     assert!(matches!(
         &certificate.value(),
-        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
+        CertificateValue::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
             block.operations[open_chain_effect_id.index as usize],
             Operation::System(SystemOperation::OpenChain { .. }),
         ),
@@ -693,7 +693,7 @@ where
     let certificate = sender.close_chain().await.unwrap();
     assert!(matches!(
         &certificate.value(),
-        Value::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
+        CertificateValue::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
             &block.operations[..], &[Operation::System(SystemOperation::CloseChain)]
         ),
     ));

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -16,7 +16,7 @@ use linera_base::{
     data_types::Amount,
     identifiers::{ChainDescription, ChainId, Destination, Owner},
 };
-use linera_chain::data_types::{OutgoingEffect, Value};
+use linera_chain::data_types::{CertificateValue, OutgoingEffect};
 use linera_execution::{
     pricing::Pricing, Bytecode, Effect, Operation, SystemEffect, UserApplicationDescription,
     WasmRuntime,
@@ -457,8 +457,10 @@ where
     let certs = receiver.process_inbox().await.unwrap();
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed_block, .. } => &executed_block.block.incoming_messages,
-        Value::ValidatedBlock { .. } => panic!("Unexpected value"),
+        CertificateValue::ConfirmedBlock { executed_block, .. } => {
+            &executed_block.block.incoming_messages
+        }
+        CertificateValue::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     assert!(messages.iter().any(|msg| matches!(
         &msg.event.effect,
@@ -486,8 +488,10 @@ where
     let certs = receiver.process_inbox().await?;
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed_block, .. } => &executed_block.block.incoming_messages,
-        Value::ValidatedBlock { .. } => panic!("Unexpected value"),
+        CertificateValue::ConfirmedBlock { executed_block, .. } => {
+            &executed_block.block.incoming_messages
+        }
+        CertificateValue::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     // The new block should _not_ contain another `RegisterApplications` effect, because the
     // application is already registered.
@@ -621,8 +625,10 @@ where
 
     // There should be a message receiving the new post.
     let messages = match certs[0].value() {
-        Value::ConfirmedBlock { executed_block, .. } => &executed_block.block.incoming_messages,
-        Value::ValidatedBlock { .. } => panic!("Unexpected value"),
+        CertificateValue::ConfirmedBlock { executed_block, .. } => {
+            &executed_block.block.incoming_messages
+        }
+        CertificateValue::ValidatedBlock { .. } => panic!("Unexpected value"),
     };
     assert!(messages
         .iter()

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -11,7 +11,7 @@ use linera_base::{
     data_types::BlockHeight,
     identifiers::{ChainDescription, ChainId, EffectId},
 };
-use linera_chain::data_types::{BlockProposal, Certificate, LiteVote, Value};
+use linera_chain::data_types::{BlockProposal, Certificate, CertificateValue, LiteVote};
 use linera_execution::committee::{Committee, ValidatorName};
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -181,8 +181,8 @@ where
             };
             if let Err(NodeError::ApplicationBytecodesNotFound(locations)) = &result {
                 let required = match certificate.value() {
-                    Value::ConfirmedBlock { executed_block, .. }
-                    | Value::ValidatedBlock { executed_block, .. } => {
+                    CertificateValue::ConfirmedBlock { executed_block, .. }
+                    | CertificateValue::ValidatedBlock { executed_block, .. } => {
                         executed_block.block.bytecode_locations()
                     }
                 };

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -4,7 +4,7 @@
 
 use linera_base::identifiers::{ChainDescription, Destination};
 use linera_chain::{
-    data_types::{HashedValue, Medium, Value},
+    data_types::{CertificateValue, HashedValue, Medium},
     ChainManagerInfo,
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
@@ -33,7 +33,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Operation>(&samples)?;
     tracer.trace_type::<Effect>(&samples)?;
     tracer.trace_type::<HashedValue>(&samples)?;
-    tracer.trace_type::<Value>(&samples)?;
+    tracer.trace_type::<CertificateValue>(&samples)?;
     tracer.trace_type::<Medium>(&samples)?;
     tracer.trace_type::<Destination>(&samples)?;
     tracer.trace_type::<ChainDescription>(&samples)?;

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -62,7 +62,7 @@ BlockProposal:
         TYPENAME: Signature
     - blobs:
         SEQ:
-          TYPENAME: Value
+          TYPENAME: CertificateValue
 Bytecode:
   STRUCT:
     - bytes: BYTES
@@ -78,12 +78,28 @@ BytecodeLocation:
 Certificate:
   STRUCT:
     - value:
-        TYPENAME: Value
+        TYPENAME: CertificateValue
     - signatures:
         SEQ:
           TUPLE:
             - TYPENAME: ValidatorName
             - TYPENAME: Signature
+CertificateValue:
+  ENUM:
+    0:
+      ValidatedBlock:
+        STRUCT:
+          - executed_block:
+              TYPENAME: ExecutedBlock
+          - round:
+              TYPENAME: RoundNumber
+    1:
+      ConfirmedBlock:
+        STRUCT:
+          - executed_block:
+              TYPENAME: ExecutedBlock
+          - round:
+              TYPENAME: RoundNumber
 ChainAndHeight:
   STRUCT:
     - chain_id:
@@ -145,7 +161,7 @@ ChainInfo:
           TYPENAME: ChainAndHeight
     - requested_blob:
         OPTION:
-          TYPENAME: Value
+          TYPENAME: CertificateValue
 ChainInfoQuery:
   STRUCT:
     - chain_id:
@@ -303,7 +319,7 @@ HandleCertificateRequest:
     - wait_for_outgoing_messages: BOOL
     - blobs:
         SEQ:
-          TYPENAME: Value
+          TYPENAME: CertificateValue
 HandleLiteCertificateRequest:
   STRUCT:
     - certificate:
@@ -365,7 +381,7 @@ MultiOwnerManagerInfo:
           TYPENAME: LiteVote
     - requested_pending_value:
         OPTION:
-          TYPENAME: Value
+          TYPENAME: CertificateValue
     - round:
         TYPENAME: RoundNumber
 NodeError:
@@ -568,7 +584,7 @@ SingleOwnerManagerInfo:
           TYPENAME: LiteVote
     - requested_pending_value:
         OPTION:
-          TYPENAME: Value
+          TYPENAME: CertificateValue
 SystemChannel:
   ENUM:
     0:
@@ -808,20 +824,4 @@ ValidatorState:
   STRUCT:
     - network_address: STR
     - votes: U64
-Value:
-  ENUM:
-    0:
-      ValidatedBlock:
-        STRUCT:
-          - executed_block:
-              TYPENAME: ExecutedBlock
-          - round:
-              TYPENAME: RoundNumber
-    1:
-      ConfirmedBlock:
-        STRUCT:
-          - executed_block:
-              TYPENAME: ExecutedBlock
-          - round:
-              TYPENAME: RoundNumber
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -12,7 +12,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, EffectId},
 };
-use linera_chain::data_types::{Certificate, ExecutedBlock, Value as LineraValue};
+use linera_chain::data_types::{Certificate, CertificateValue, ExecutedBlock};
 use linera_core::{
     client::{ChainClient, ValidatorNodeProvider},
     data_types::ChainInfoQuery,
@@ -961,7 +961,7 @@ where
                 context.update_wallet_from_client(&mut chain_client).await;
                 let id = ChainId::child(effect_id);
                 let timestamp = match certificate.value() {
-                    LineraValue::ConfirmedBlock {
+                    CertificateValue::ConfirmedBlock {
                         executed_block: ExecutedBlock { block, .. },
                         ..
                     } => block.timestamp,
@@ -1042,10 +1042,10 @@ where
                     .unwrap()
                     .into_iter()
                     .map(|c| match c.value() {
-                        LineraValue::ConfirmedBlock { executed_block, .. } => {
+                        CertificateValue::ConfirmedBlock { executed_block, .. } => {
                             executed_block.effects.len()
                         }
-                        LineraValue::ValidatedBlock { .. } => 0,
+                        CertificateValue::ValidatedBlock { .. } => 0,
                     })
                     .sum::<usize>();
                 info!("Subscribed {} chains to new committees", n);
@@ -1154,7 +1154,7 @@ where
                             WorkerState::new("staging".to_string(), None, storage.clone())
                                 .stage_block_execution(proposal.content.block.clone())
                                 .await?;
-                        let value = HashedValue::from(LineraValue::ConfirmedBlock {
+                        let value = HashedValue::from(CertificateValue::ConfirmedBlock {
                             executed_block,
                             round: RoundNumber(0),
                         });
@@ -1397,7 +1397,7 @@ where
                     .await
                     .context("could not find OpenChain effect")?;
                 let timestamp = match certificate.value() {
-                    LineraValue::ConfirmedBlock {
+                    CertificateValue::ConfirmedBlock {
                         executed_block: ExecutedBlock { block, .. },
                         ..
                     } => block.timestamp,


### PR DESCRIPTION
This is less ambiguous, especially since we also use `serde_json::Value`.