### PR TITLE
hack to avoid failing docrs tests due to the new feature

### DIFF
--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -60,7 +60,7 @@ linera-core = { workspace = true, features = ["test"] }
 linera-execution = { workspace = true, features = ["test"] }
 linera-rpc = { workspace = true, features = ["test"] }
 linera-storage = { workspace = true, features = ["test"] }
-linera-views = { workspace = true, features = ["rocksdb", "test"] }
+linera-views = { workspace = true, features = ["test"] }
 once_cell = { workspace = true }
 proptest = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }


### PR DESCRIPTION
I added a feature `linera-views/rocksdb` in a previous PR. For some reason, this makes `cargo publish --dry-run --no-verify` fail on `linera-service` (but not `linera-storage`). It would appear that removing `rocksdb` from the dev dependency of `linera-service` works around the issue (at least temporarily). The code still builds because the feature is added anyway by `linera-storage` via feature unification.

Note: It's unclear to me why `linera-storage` passes `cargo publish --dry-run --no-verify`. Perhaps an inconsistent behavior of `--no-verify`?