### PR TITLE
rename `Message` into `IncomingMessage`

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -39,7 +39,7 @@ pub struct Block {
     pub epoch: Epoch,
     /// A selection of incoming messages to be executed first. Successive messages of same
     /// sender and height are grouped together for conciseness.
-    pub incoming_messages: Vec<Message>,
+    pub incoming_messages: Vec<IncomingMessage>,
     /// The operations to execute.
     pub operations: Vec<Operation>,
     /// The block height.
@@ -89,7 +89,7 @@ pub struct BlockAndRound {
 
 /// A message received from a block of another chain.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
-pub struct Message {
+pub struct IncomingMessage {
     /// The origin of the message (chain and channel if any).
     pub origin: Origin,
     /// The content of the message to be delivered to the inbox identified by

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -395,7 +395,7 @@ where
         A: ValidatorNode + Send + Sync + 'static + Clone,
     {
         match notification.reason {
-            Reason::NewMessage { origin, height } => {
+            Reason::NewIncomingMessage { origin, height } => {
                 if Self::get_local_next_block_height(this.clone(), origin.sender, &mut local_node)
                     .await
                     > Some(height)

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -22,8 +22,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, HashedValue, LiteVote,
-        Message,
+        Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, HashedValue,
+        IncomingMessage, LiteVote,
     },
     ChainManagerInfo, ChainStateView,
 };
@@ -214,7 +214,7 @@ where
     ///
     /// Messages known to be redundant are filtered out: A `RegisterApplications` effect whose
     /// entries are already known never needs to be included in a block.
-    async fn pending_messages(&mut self) -> Result<Vec<Message>, NodeError> {
+    async fn pending_messages(&mut self) -> Result<Vec<IncomingMessage>, NodeError> {
         let query = ChainInfoQuery::new(self.chain_id).with_pending_messages();
         let response = self.node_client.handle_chain_info_query(query).await?;
         let mut pending_messages = vec![];
@@ -1092,7 +1092,7 @@ where
     /// Executes a new block
     async fn execute_block(
         &mut self,
-        incoming_messages: Vec<Message>,
+        incoming_messages: Vec<IncomingMessage>,
         operations: Vec<Operation>,
     ) -> Result<Certificate> {
         let timestamp = self.next_timestamp(&incoming_messages);
@@ -1114,7 +1114,7 @@ where
     ///
     /// This will usually be the current time according to the local clock, but may be slightly
     /// ahead to make sure it's not earlier than the incoming messages or the previous block.
-    fn next_timestamp(&self, incoming_messages: &[Message]) -> Timestamp {
+    fn next_timestamp(&self, incoming_messages: &[IncomingMessage]) -> Timestamp {
         incoming_messages
             .iter()
             .map(|msg| msg.event.timestamp)

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -9,7 +9,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId},
 };
 use linera_chain::{
-    data_types::{Certificate, ChainAndHeight, HashedValue, Medium, Message},
+    data_types::{Certificate, ChainAndHeight, HashedValue, IncomingMessage, Medium},
     ChainManagerInfo, ChainStateView,
 };
 use linera_execution::{
@@ -42,7 +42,7 @@ impl BlockHeightRange {
     }
 }
 
-/// Message to obtain information on a chain.
+/// Request information about a chain.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Arbitrary, Eq, PartialEq))]
 pub struct ChainInfoQuery {
@@ -138,7 +138,7 @@ pub struct ChainInfo {
     /// The current committees.
     pub requested_committees: Option<BTreeMap<Epoch, Committee>>,
     /// The received messages that are waiting be picked in the next block (if requested).
-    pub requested_pending_messages: Vec<Message>,
+    pub requested_pending_messages: Vec<IncomingMessage>,
     /// The response to `request_sent_certificates_in_range`
     pub requested_sent_certificates: Vec<Certificate>,
     /// The current number of received certificates (useful for `request_received_log_excluding_first_nth`)
@@ -157,7 +157,7 @@ pub struct ChainInfoResponse {
     pub signature: Option<Signature>,
 }
 
-/// An internal message between chains within a validator.
+/// An internal request between chains within a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Eq, PartialEq))]
 pub enum CrossChainRequest {

--- a/linera-core/src/tracker.rs
+++ b/linera-core/src/tracker.rs
@@ -21,7 +21,7 @@ impl NotificationTracker {
     pub fn insert(&mut self, notification: Notification) -> bool {
         match notification.reason {
             Reason::NewBlock { height } => self.insert_new_block(notification.chain_id, height),
-            Reason::NewMessage { height, origin } => {
+            Reason::NewIncomingMessage { height, origin } => {
                 self.insert_new_message(notification.chain_id, origin, height)
             }
         }
@@ -130,11 +130,11 @@ pub mod tests {
 
     #[test]
     fn test_application_origin() {
-        let reason_0 = Reason::NewMessage {
+        let reason_0 = Reason::NewIncomingMessage {
             origin: Origin::chain(ChainId::root(0)),
             height: BlockHeight::from(0),
         };
-        let reason_1 = Reason::NewMessage {
+        let reason_1 = Reason::NewIncomingMessage {
             origin: Origin::chain(ChainId::root(0)),
             height: BlockHeight::from(1),
         };

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -16,7 +16,7 @@ use linera_base::{
     identifiers::{BytecodeId, ChainDescription, ChainId, Destination, EffectId},
 };
 use linera_chain::data_types::{
-    ChannelFullName, Event, ExecutedBlock, HashedValue, Message, Origin, OutgoingEffect,
+    ChannelFullName, Event, ExecutedBlock, HashedValue, IncomingMessage, Origin, OutgoingEffect,
 };
 use linera_execution::{
     committee::Epoch,
@@ -170,7 +170,7 @@ where
     assert!(info.manager.pending().is_none());
 
     // Produce one more block to broadcast the bytecode ID.
-    let broadcast_message = Message {
+    let broadcast_message = IncomingMessage {
         origin: Origin::chain(publisher_chain.into()),
         event: Event {
             certificate_hash: publish_certificate.hash(),
@@ -292,7 +292,7 @@ where
     assert!(info.manager.pending().is_none());
 
     // Accept subscription
-    let accept_message = Message {
+    let accept_message = IncomingMessage {
         origin: Origin::chain(creator_chain.into()),
         event: Event {
             certificate_hash: subscribe_certificate.hash(),
@@ -371,7 +371,7 @@ where
         Epoch::from(0),
         creator_chain.into(),
         vec![create_operation],
-        vec![Message {
+        vec![IncomingMessage {
             origin: Origin::channel(publisher_chain.into(), publish_admin_channel),
             event: Event {
                 certificate_hash: broadcast_certificate.hash(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -20,7 +20,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         Block, BlockAndRound, BlockProposal, Certificate, ChainAndHeight, ChannelFullName, Event,
-        ExecutedBlock, HashedValue, LiteVote, Medium, Message, Origin, OutgoingEffect,
+        ExecutedBlock, HashedValue, IncomingMessage, LiteVote, Medium, Origin, OutgoingEffect,
         SignatureAggregator,
     },
     ChainError,
@@ -119,7 +119,7 @@ fn make_block(
     epoch: Epoch,
     chain_id: ChainId,
     operations: Vec<impl Into<Operation>>,
-    incoming_messages: Vec<Message>,
+    incoming_messages: Vec<IncomingMessage>,
     previous_confirmed_block: Option<&Certificate>,
     authenticated_signer: Option<Owner>,
     timestamp: Timestamp,
@@ -146,7 +146,7 @@ fn make_transfer_block_proposal(
     key_pair: &KeyPair,
     recipient: Recipient,
     amount: Amount,
-    incoming_messages: Vec<Message>,
+    incoming_messages: Vec<IncomingMessage>,
     previous_confirmed_block: Option<&Certificate>,
 ) -> BlockProposal {
     let block = make_block(
@@ -192,7 +192,7 @@ async fn make_transfer_certificate<S>(
     key_pair: &KeyPair,
     recipient: Recipient,
     amount: Amount,
-    incoming_messages: Vec<Message>,
+    incoming_messages: Vec<IncomingMessage>,
     committee: &Committee,
     balance: Amount,
     worker: &WorkerState<S>,
@@ -219,7 +219,7 @@ async fn make_transfer_certificate_for_epoch<S>(
     key_pair: &KeyPair,
     recipient: Recipient,
     amount: Amount,
-    incoming_messages: Vec<Message>,
+    incoming_messages: Vec<IncomingMessage>,
     epoch: Epoch,
     committee: &Committee,
     balance: Amount,
@@ -952,7 +952,7 @@ where
             Recipient::Account(Account::chain(ChainId::root(3))),
             Amount::from_tokens(5),
             vec![
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -966,7 +966,7 @@ where
                         }),
                     },
                 },
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -980,7 +980,7 @@ where
                         }),
                     },
                 },
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate1.value.hash(),
@@ -1011,7 +1011,7 @@ where
             Recipient::Account(Account::chain(ChainId::root(3))),
             Amount::from_tokens(6),
             vec![
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -1025,7 +1025,7 @@ where
                         }),
                     },
                 },
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -1039,7 +1039,7 @@ where
                         }),
                     },
                 },
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -1070,7 +1070,7 @@ where
             Recipient::Account(Account::chain(ChainId::root(3))),
             Amount::from_tokens(6),
             vec![
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate1.value.hash(),
@@ -1084,7 +1084,7 @@ where
                         }),
                     },
                 },
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -1098,7 +1098,7 @@ where
                         }),
                     },
                 },
-                Message {
+                IncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -1128,7 +1128,7 @@ where
             &recipient_key_pair,
             Recipient::Account(Account::chain(ChainId::root(3))),
             Amount::ONE,
-            vec![Message {
+            vec![IncomingMessage {
                 origin: Origin::chain(ChainId::root(1)),
                 event: Event {
                     certificate_hash: certificate0.value.hash(),
@@ -1186,7 +1186,7 @@ where
             &recipient_key_pair,
             Recipient::Account(Account::chain(ChainId::root(3))),
             Amount::from_tokens(3),
-            vec![Message {
+            vec![IncomingMessage {
                 origin: Origin::chain(ChainId::root(1)),
                 event: Event {
                     certificate_hash: certificate1.value.hash(),
@@ -1607,7 +1607,7 @@ where
         &key_pair,
         Recipient::Account(Account::chain(ChainId::root(2))),
         Amount::from_tokens(1000),
-        vec![Message {
+        vec![IncomingMessage {
             origin: Origin::chain(ChainId::root(3)),
             event: Event {
                 certificate_hash: CryptoHash::new(&Dummy),
@@ -2257,7 +2257,7 @@ where
         &recipient_key_pair,
         Recipient::Account(Account::chain(ChainId::root(3))),
         Amount::ONE,
-        vec![Message {
+        vec![IncomingMessage {
             origin: Origin::chain(ChainId::root(1)),
             event: Event {
                 certificate_hash: certificate.hash(),
@@ -2619,7 +2619,7 @@ where
             block: Block {
                 epoch: Epoch::from(1),
                 chain_id: admin_id,
-                incoming_messages: vec![Message {
+                incoming_messages: vec![IncomingMessage {
                     origin: Origin::chain(admin_id),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
@@ -2765,7 +2765,7 @@ where
                 epoch: Epoch::from(0),
                 chain_id: user_id,
                 incoming_messages: vec![
-                    Message {
+                    IncomingMessage {
                         origin: admin_channel_origin.clone(),
                         event: Event {
                             certificate_hash: certificate1.value.hash(),
@@ -2780,7 +2780,7 @@ where
                             }),
                         },
                     },
-                    Message {
+                    IncomingMessage {
                         origin: Origin::chain(admin_id),
                         event: Event {
                             certificate_hash: certificate1.value.hash(),
@@ -2794,7 +2794,7 @@ where
                             }),
                         },
                     },
-                    Message {
+                    IncomingMessage {
                         origin: Origin::chain(admin_id),
                         event: Event {
                             certificate_hash: certificate2.value.hash(),
@@ -3275,7 +3275,7 @@ where
             block: Block {
                 epoch: Epoch::from(1),
                 chain_id: admin_id,
-                incoming_messages: vec![Message {
+                incoming_messages: vec![IncomingMessage {
                     origin: Origin::chain(user_id),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -8,7 +8,7 @@ mod wasm;
 use crate::{
     data_types::*,
     worker::{
-        CrossChainUpdateHelper, Notification, Reason, Reason::NewMessage, ValidatorWorker,
+        CrossChainUpdateHelper, Notification, Reason, Reason::NewIncomingMessage, ValidatorWorker,
         WorkerError, WorkerState,
     },
 };
@@ -919,14 +919,14 @@ where
         vec![
             Notification {
                 chain_id: ChainId::root(2),
-                reason: NewMessage {
+                reason: NewIncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     height: BlockHeight(0)
                 }
             },
             Notification {
                 chain_id: ChainId::root(2),
-                reason: NewMessage {
+                reason: NewIncomingMessage {
                     origin: Origin::chain(ChainId::root(1)),
                     height: BlockHeight(1)
                 }
@@ -2134,7 +2134,7 @@ where
         actions.notifications,
         vec![Notification {
             chain_id: ChainId::root(2),
-            reason: Reason::NewMessage {
+            reason: Reason::NewIncomingMessage {
                 origin: Origin::chain(ChainId::root(1)),
                 height: BlockHeight::from(0),
             }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -118,7 +118,7 @@ doc_scalar!(
 /// Reason for the notification.
 pub enum Reason {
     NewBlock { height: BlockHeight },
-    NewMessage { origin: Origin, height: BlockHeight },
+    NewIncomingMessage { origin: Origin, height: BlockHeight },
 }
 
 /// Error type for [`ValidatorWorker`].
@@ -1068,7 +1068,7 @@ where
                     latest_heights.push((origin.medium.clone(), height));
                     notifications.push(Notification {
                         chain_id: recipient,
-                        reason: Reason::NewMessage { origin, height },
+                        reason: Reason::NewIncomingMessage { origin, height },
                     });
                 }
                 let cross_chain_requests = vec![CrossChainRequest::ConfirmUpdatedRecipient {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -14,7 +14,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, ExecutedBlock,
-        HashedValue, LiteCertificate, Medium, Message, Origin, Target,
+        HashedValue, IncomingMessage, LiteCertificate, Medium, Origin, Target,
     },
     ChainManagerOutcome, ChainStateView,
 };
@@ -765,13 +765,13 @@ where
         Ok(chain.execution_state.system.registry)
     }
 
-    /// Returns a [`Message`] that's awaiting to be received by the chain specified by `chain_id`.
+    /// Returns a [`IncomingMessage`] that's awaiting to be received by the chain specified by `chain_id`.
     #[cfg(any(test, feature = "test"))]
     pub async fn find_incoming_message(
         &self,
         chain_id: ChainId,
         effect_id: EffectId,
-    ) -> Result<Option<Message>, WorkerError> {
+    ) -> Result<Option<IncomingMessage>, WorkerError> {
         let Some(certificate) = self.read_certificate(effect_id.chain_id, effect_id.height).await?
             else { return Ok(None) };
 
@@ -810,7 +810,7 @@ where
 
         assert_eq!(event.effect, outgoing_effect.effect);
 
-        Ok(Some(Message { origin, event }))
+        Ok(Some(IncomingMessage { origin, event }))
     }
 }
 
@@ -989,7 +989,7 @@ where
             let inboxes = chain.inboxes.try_load_entries(&origins).await?;
             for (origin, inbox) in origins.into_iter().zip(inboxes) {
                 for event in inbox.added_events.elements().await? {
-                    messages.push(Message {
+                    messages.push(IncomingMessage {
                         origin: origin.clone(),
                         event: event.clone(),
                     });

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -70,7 +70,7 @@ message ChainInfoResult {
   }
 }
 
-// An internal message between chains within a validator.
+// An internal request between chains within a validator.
 message CrossChainRequest {
   oneof inner {
     UpdateRecipient update_recipient = 1;
@@ -94,7 +94,7 @@ message ConfirmUpdatedRecipient {
   bytes latest_heights = 3;
 }
 
-// Message to obtain information on a chain.
+// Request information on a chain.
 message ChainInfoQuery {
   // The chain id
   ChainId chain_id = 1;

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -24,7 +24,7 @@ Block:
         TYPENAME: Epoch
     - incoming_messages:
         SEQ:
-          TYPENAME: Message
+          TYPENAME: IncomingMessage
     - operations:
         SEQ:
           TYPENAME: Operation
@@ -151,7 +151,7 @@ ChainInfo:
               TYPENAME: Committee
     - requested_pending_messages:
         SEQ:
-          TYPENAME: Message
+          TYPENAME: IncomingMessage
     - requested_sent_certificates:
         SEQ:
           TYPENAME: Certificate
@@ -325,6 +325,12 @@ HandleLiteCertificateRequest:
     - certificate:
         TYPENAME: LiteCertificate
     - wait_for_outgoing_messages: BOOL
+IncomingMessage:
+  STRUCT:
+    - origin:
+        TYPENAME: Origin
+    - event:
+        TYPENAME: Event
 LiteCertificate:
   STRUCT:
     - value:
@@ -356,12 +362,6 @@ Medium:
       Channel:
         NEWTYPE:
           TYPENAME: ChannelFullName
-Message:
-  STRUCT:
-    - origin:
-        TYPENAME: Origin
-    - event:
-        TYPENAME: Event
 MultiOwnerManagerInfo:
   STRUCT:
     - owners:

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -12,7 +12,7 @@ use linera_base::{
     identifiers::{ApplicationId, ChainId, EffectId, Owner},
 };
 use linera_chain::data_types::{
-    Block, Certificate, HashedValue, LiteVote, Message, SignatureAggregator,
+    Block, Certificate, HashedValue, IncomingMessage, LiteVote, SignatureAggregator,
 };
 use linera_execution::{system::SystemOperation, Operation};
 use std::mem;
@@ -109,7 +109,7 @@ impl BlockBuilder {
     /// present in the inboxes of the microchain that owns this block.
     pub(crate) fn with_raw_messages(
         &mut self,
-        messages: impl IntoIterator<Item = Message>,
+        messages: impl IntoIterator<Item = IncomingMessage>,
     ) -> &mut Self {
         self.block.incoming_messages.extend(messages);
         self

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -68,7 +68,7 @@ where
                                 );
                             }
                         }
-                        Reason::NewMessage { .. } => {
+                        Reason::NewIncomingMessage { .. } => {
                             if let Err(e) = client.process_inbox().await {
                                 warn!(
                                     "Failed to process inbox after receiving new message: {:?} \


### PR DESCRIPTION
This is a preliminary step before renaming `Effect` into `Message`. It's also useful by itself.