### PR TITLE
linera project test also does integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "current_platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2711,7 @@ dependencies = [
  "comfy-table",
  "counter",
  "crowd-funding",
+ "current_platform",
  "dirs",
  "file-lock",
  "fungible",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -52,6 +52,7 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 comfy-table = { workspace = true }
 dirs = { workspace = true }
 file-lock = "2.1.9"
+current_platform = "0.2.0"
 
 [dev-dependencies]
 linera-base = { workspace = true, features = ["test"] }


### PR DESCRIPTION
# Motivation

Linera tests come in two categories, unit tests and integration tests. Currently `linera project test` only tests unit tests.

# Solution

Test integration tests.