### PR TITLE
rename binaries `proxy` and `server` into `linera-proxy` and `linera-server`

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -37,7 +37,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build binaries
         run: |
-          cargo build --release --locked --no-default-features --bin linera --bin proxy --bin server
+          cargo build --release --locked --no-default-features --bin linera --bin linera-proxy --bin linera-server
       - name: Install Kind
         run: |
           curl -sL -o /tmp/kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64
@@ -54,8 +54,8 @@ jobs:
       - name: Build and Load Docker images
         run: |
           cd docker
-          cp ../target/release/{linera,proxy,server} .
-          for image in linera proxy server setup; do
+          cp ../target/release/{linera,linera-proxy,linera-server} .
+          for image in linera linera-proxy linera-server setup; do
               docker build -t "zefchain-test-$image" --target "$image" .
               kind load docker-image "zefchain-test-$image"
           done

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ trap 'kill $(jobs -p)' EXIT
 # Create configuration files for 4 validators with 4 shards each.
 # * Private server states are stored in `server*.json`.
 # * `committee.json` is the public description of the Linera committee.
-./server generate --validators ../../configuration/validator_{1,2,3,4}.toml --committee committee.json
+./linera-server generate --validators ../../configuration/validator_{1,2,3,4}.toml --committee committee.json
 
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
@@ -62,11 +62,11 @@ trap 'kill $(jobs -p)' EXIT
 # Start servers and create initial chains in DB
 for I in 1 2 3 4
 do
-    ./proxy server_"$I".json &
+    ./linera-proxy server_"$I".json &
 
     for J in $(seq 0 3)
     do
-        ./server run --storage rocksdb:server_"$I"_"$J".db --server server_"$I".json --shard "$J" --genesis genesis.json &
+        ./linera-server run --storage rocksdb:server_"$I"_"$J".db --server server_"$I".json --shard "$J" --genesis genesis.json &
     done
 done
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,23 +14,23 @@ RUN apt-get update && apt-get install -y mini-httpd
 
 RUN mkdir -p /opt/zefchain
 
-COPY server /opt/zefchain/
-COPY client /opt/zefchain/
+COPY linera-server /opt/zefchain/
+COPY linera /opt/zefchain/
 COPY setup.sh /opt/zefchain/
 
 WORKDIR /opt/zefchain
 
 FROM base as client
 
-COPY client /opt/zefchain/
+COPY linera /opt/zefchain/
 COPY run-client.sh /opt/zefchain/
 
 FROM base as server
 
-COPY server /opt/zefchain/
+COPY linera-server /opt/zefchain/
 COPY run-server.sh /opt/zefchain/
 
 FROM base as proxy
 
-COPY proxy /opt/zefchain/
+COPY linera-proxy /opt/zefchain/
 COPY run-proxy.sh /opt/zefchain/

--- a/docker/run-proxy.sh
+++ b/docker/run-proxy.sh
@@ -4,4 +4,4 @@ SERVER_ID="$(hostname | cut -f2 -d-)"
 
 ./fetch-config-file.sh "server_${SERVER_ID}.json"
 
-./proxy "server_${SERVER_ID}.json"
+./linera-proxy "server_${SERVER_ID}.json"

--- a/docker/run-server.sh
+++ b/docker/run-server.sh
@@ -8,7 +8,7 @@ SHARD_ID="$(hostname | cut -f4 -d-)"
 ./fetch-config-file.sh genesis.json
 ./fetch-config-file.sh "server_${SERVER_ID}.json"
 
-./server run \
+./linera-server run \
     --storage "rocksdb:shard_data.db" \
     --server "server_${SERVER_ID}.json" \
     --shard "$SHARD_ID" \

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -78,9 +78,9 @@ name = "linera"
 path = "src/linera.rs"
 
 [[bin]]
-name = "server"
+name = "linera-server"
 path = "src/server.rs"
 
 [[bin]]
-name = "proxy"
+name = "linera-proxy"
 path = "src/proxy.rs"

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -666,7 +666,7 @@ impl TestRunner {
     }
 
     async fn generate_initial_validator_config(&self) -> Vec<String> {
-        let mut command = self.command_for_binary("server").await;
+        let mut command = self.command_for_binary("linera-server").await;
         command.arg("generate").arg("--validators");
         for i in 1..=self.num_initial_validators {
             command.arg(&self.configuration_string(i));
@@ -686,7 +686,7 @@ impl TestRunner {
 
     async fn generate_validator_config(&self, i: usize) -> String {
         let output = self
-            .command_for_binary("server")
+            .command_for_binary("linera-server")
             .await
             .arg("generate")
             .arg("--validators")
@@ -705,7 +705,7 @@ impl TestRunner {
 
     async fn run_proxy(&self, i: usize) -> Child {
         let child = self
-            .command_for_binary("proxy")
+            .command_for_binary("linera-proxy")
             .await
             .arg(format!("server_{}.json", i))
             .spawn()
@@ -744,7 +744,7 @@ impl TestRunner {
     }
 
     async fn run_server(&self, i: usize, j: usize) -> Child {
-        let mut command = self.command_for_binary("server").await;
+        let mut command = self.command_for_binary("linera-server").await;
         command.arg("run");
         if let Ok(var) = env::var(SERVER_ENV) {
             command.args(var.split_whitespace());

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -29,7 +29,7 @@ VALIDATOR_FILES=()
 for i in $(seq 1 $NUM_VALIDATORS); do
     VALIDATOR_FILES+=("$CONF_DIR/validator_$i.toml")
 done
-./server generate --validators "${VALIDATOR_FILES[@]}" --committee committee.json
+./linera-server generate --validators "${VALIDATOR_FILES[@]}" --committee committee.json
 
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
@@ -43,11 +43,11 @@ done
 # Start servers and create initial chains in DB
 for I in $(seq 1 $NUM_VALIDATORS)
 do
-    ./proxy server_"$I".json &
+    ./linera-proxy server_"$I".json &
 
     for J in $(seq 0 $((SHARDS_PER_VALIDATOR - 1)))
     do
-        ./server run --storage rocksdb:server_"$I"_"$J".db --server server_"$I".json --shard "$J" --genesis genesis.json &
+        ./linera-server run --storage rocksdb:server_"$I"_"$J".db --server server_"$I".json --shard "$J" --genesis genesis.json &
     done
 done
 
@@ -64,4 +64,3 @@ EFFECT=$(echo "$EFFECT_AND_CHAIN" | sed -n '1 p')
 ./linera --wallet wallet_2.json --storage rocksdb:linera_2.db assign --key "$KEY" --message-id "$EFFECT"
 
 read
-


### PR DESCRIPTION
This is needed so that `cargo install -p linera-service` is a good citizen and doesn't pollute the `PATH` of user shells.