### PR TITLE
Separate admin from other system operations.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -29,7 +29,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    system::{Account, Recipient, SystemChannel, SystemOperation, UserData},
+    system::{Account, AdminOperation, Recipient, SystemChannel, SystemOperation, UserData},
     Bytecode, Message, Operation, Query, Response, SystemMessage, SystemQuery, SystemResponse,
     UserApplicationId,
 };
@@ -1413,11 +1413,12 @@ where
         let messages = self.pending_messages().await?;
         self.execute_block(
             messages,
-            vec![Operation::System(SystemOperation::CreateCommittee {
-                admin_id: self.chain_id,
-                epoch: epoch.try_add_one()?,
-                committee,
-            })],
+            vec![Operation::System(SystemOperation::Admin(
+                AdminOperation::CreateCommittee {
+                    epoch: epoch.try_add_one()?,
+                    committee,
+                },
+            ))],
         )
         .await
     }
@@ -1493,10 +1494,9 @@ where
             .keys()
             .filter_map(|epoch| {
                 if *epoch != current_epoch {
-                    Some(Operation::System(SystemOperation::RemoveCommittee {
-                        admin_id: self.admin_id,
-                        epoch: *epoch,
-                    }))
+                    Some(Operation::System(SystemOperation::Admin(
+                        AdminOperation::RemoveCommittee { epoch: *epoch },
+                    )))
                 } else {
                     None
                 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -27,7 +27,9 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    system::{Account, Recipient, SystemChannel, SystemMessage, SystemOperation, UserData},
+    system::{
+        Account, AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation, UserData,
+    },
     ApplicationId, ApplicationRegistry, ChainOwnership, ChannelSubscription, ExecutionStateView,
     Message, Operation, Query, Response, SystemExecutionState, SystemQuery, SystemResponse,
 };
@@ -2555,11 +2557,10 @@ where
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
                 operations: vec![
-                    Operation::System(SystemOperation::CreateCommittee {
-                        admin_id,
+                    Operation::System(SystemOperation::Admin(AdminOperation::CreateCommittee {
                         epoch: Epoch::from(1),
                         committee: committee.clone(),
-                    }),
+                    })),
                     Operation::System(SystemOperation::Transfer {
                         owner: None,
                         recipient: Recipient::Account(Account::chain(user_id)),
@@ -2576,7 +2577,6 @@ where
                 channel_outgoing_message(
                     SystemChannel::Admin.name(),
                     SystemMessage::SetCommittees {
-                        admin_id,
                         epoch: Epoch::from(1),
                         committees: committees2.clone(),
                     },
@@ -2773,7 +2773,6 @@ where
                             authenticated_signer: None,
                             timestamp: Timestamp::from(0),
                             message: Message::System(SystemMessage::SetCommittees {
-                                admin_id,
                                 epoch: Epoch::from(1),
                                 committees: committees2.clone(),
                             }),
@@ -2997,11 +2996,12 @@ where
                 epoch: Epoch::from(0),
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
-                operations: vec![Operation::System(SystemOperation::CreateCommittee {
-                    admin_id,
-                    epoch: Epoch::from(1),
-                    committee: committee.clone(),
-                })],
+                operations: vec![Operation::System(SystemOperation::Admin(
+                    AdminOperation::CreateCommittee {
+                        epoch: Epoch::from(1),
+                        committee: committee.clone(),
+                    },
+                ))],
                 previous_block_hash: None,
                 height: BlockHeight::from(0),
                 authenticated_signer: None,
@@ -3010,7 +3010,6 @@ where
             messages: vec![channel_outgoing_message(
                 SystemChannel::Admin.name(),
                 SystemMessage::SetCommittees {
-                    admin_id,
                     epoch: Epoch::from(1),
                     committees: committees2.clone(),
                 },
@@ -3186,15 +3185,13 @@ where
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
                 operations: vec![
-                    Operation::System(SystemOperation::CreateCommittee {
-                        admin_id,
+                    Operation::System(SystemOperation::Admin(AdminOperation::CreateCommittee {
                         epoch: Epoch::from(1),
                         committee: committee.clone(),
-                    }),
-                    Operation::System(SystemOperation::RemoveCommittee {
-                        admin_id,
+                    })),
+                    Operation::System(SystemOperation::Admin(AdminOperation::RemoveCommittee {
                         epoch: Epoch::from(0),
-                    }),
+                    })),
                 ],
                 previous_block_hash: None,
                 height: BlockHeight::from(0),
@@ -3205,7 +3202,6 @@ where
                 channel_outgoing_message(
                     SystemChannel::Admin.name(),
                     SystemMessage::SetCommittees {
-                        admin_id,
                         epoch: Epoch::from(1),
                         committees: committees2.clone(),
                     },
@@ -3213,7 +3209,6 @@ where
                 channel_outgoing_message(
                     SystemChannel::Admin.name(),
                     SystemMessage::SetCommittees {
-                        admin_id,
                         epoch: Epoch::from(1),
                         committees: committees3.clone(),
                     },

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -771,7 +771,8 @@ where
         Ok(chain.execution_state.system.registry)
     }
 
-    /// Returns an [`IncomingMessage`] that's awaiting to be received by the chain specified by `chain_id`.
+    /// Returns an [`IncomingMessage`] that's awaiting to be received by the chain specified by
+    /// `chain_id`.
     #[cfg(any(test, feature = "test"))]
     pub async fn find_incoming_message(
         &self,

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -9,7 +9,7 @@ use linera_chain::{
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
-    system::{Recipient, SystemChannel, SystemMessage, SystemOperation},
+    system::{AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
     ApplicationId, Message, Operation,
 };
 use linera_rpc::RpcMessage;
@@ -29,6 +29,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Recipient>(&samples)?;
     tracer.trace_type::<SystemChannel>(&samples)?;
     tracer.trace_type::<SystemOperation>(&samples)?;
+    tracer.trace_type::<AdminOperation>(&samples)?;
     tracer.trace_type::<SystemMessage>(&samples)?;
     tracer.trace_type::<Operation>(&samples)?;
     tracer.trace_type::<Message>(&samples)?;

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -6,6 +6,20 @@ Account:
     - owner:
         OPTION:
           TYPENAME: Owner
+AdminOperation:
+  ENUM:
+    0:
+      CreateCommittee:
+        STRUCT:
+          - epoch:
+              TYPENAME: Epoch
+          - committee:
+              TYPENAME: Committee
+    1:
+      RemoveCommittee:
+        STRUCT:
+          - epoch:
+              TYPENAME: Epoch
 Amount:
   NEWTYPESTRUCT: U128
 ApplicationId:
@@ -629,8 +643,6 @@ SystemMessage:
     3:
       SetCommittees:
         STRUCT:
-          - admin_id:
-              TYPENAME: ChainId
           - epoch:
               TYPENAME: Epoch
           - committees:
@@ -738,43 +750,27 @@ SystemOperation:
               SEQ:
                 TYPENAME: PublicKey
     6:
-      CreateCommittee:
-        STRUCT:
-          - admin_id:
-              TYPENAME: ChainId
-          - epoch:
-              TYPENAME: Epoch
-          - committee:
-              TYPENAME: Committee
-    7:
       Subscribe:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
           - channel:
               TYPENAME: SystemChannel
-    8:
+    7:
       Unsubscribe:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
           - channel:
               TYPENAME: SystemChannel
-    9:
-      RemoveCommittee:
-        STRUCT:
-          - admin_id:
-              TYPENAME: ChainId
-          - epoch:
-              TYPENAME: Epoch
-    10:
+    8:
       PublishBytecode:
         STRUCT:
           - contract:
               TYPENAME: Bytecode
           - service:
               TYPENAME: Bytecode
-    11:
+    9:
       CreateApplication:
         STRUCT:
           - bytecode_id:
@@ -784,13 +780,17 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: UserApplicationId
-    12:
+    10:
       RequestApplication:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
           - application_id:
               TYPENAME: UserApplicationId
+    11:
+      Admin:
+        NEWTYPE:
+          TYPENAME: AdminOperation
 Timestamp:
   NEWTYPESTRUCT: U64
 UserApplicationDescription:

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -31,7 +31,7 @@ use linera_core::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{Recipient, SystemChannel, UserData},
+    system::{AdminOperation, Recipient, SystemChannel, UserData},
     Bytecode, Operation, Query, Response, SystemOperation, UserApplicationDescription,
     UserApplicationId,
 };
@@ -230,15 +230,11 @@ where
     /// notification as an "incoming message" in a next block).
     async fn create_committee(
         &self,
-        admin_id: ChainId,
         epoch: Epoch,
         committee: Committee,
     ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::CreateCommittee {
-            admin_id,
-            epoch,
-            committee,
-        };
+        let operation =
+            SystemOperation::Admin(AdminOperation::CreateCommittee { epoch, committee });
         self.execute_system_operation(operation).await
     }
 
@@ -265,8 +261,8 @@ where
     /// (admin chain only) Removes a committee. Once this message is accepted by a chain,
     /// blocks from the retired epoch will not be accepted until they are followed (hence
     /// re-certified) by a block certified by a recent committee.
-    async fn remove_committee(&self, admin_id: ChainId, epoch: Epoch) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::RemoveCommittee { admin_id, epoch };
+    async fn remove_committee(&self, epoch: Epoch) -> Result<CryptoHash, Error> {
+        let operation = SystemOperation::Admin(AdminOperation::RemoveCommittee { epoch });
         self.execute_system_operation(operation).await
     }
 


### PR DESCRIPTION
For voting on pricing we will soon add additional admin operations.

This deduplicates the `admin_id` check, and removes the field from the admin operations: What needs to be checked is just that the current chain is the admin chain.