### PR TITLE
Move round number to Certificate.

### DIFF
--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -34,10 +34,10 @@ fn test_signed_values() {
     };
     let value = HashedValue::new_confirmed(executed_block);
 
-    let v = LiteVote::new(value.lite(), &key1);
+    let v = LiteVote::new(value.lite(), RoundNumber(0), &key1);
     assert!(v.check().is_ok());
 
-    let mut v = LiteVote::new(value.lite(), &key2);
+    let mut v = LiteVote::new(value.lite(), RoundNumber(0), &key2);
     v.validator = name1;
     assert!(v.check().is_err());
 }
@@ -74,11 +74,11 @@ fn test_certificates() {
     };
     let value = HashedValue::new_confirmed(executed_block);
 
-    let v1 = LiteVote::new(value.lite(), &key1);
-    let v2 = LiteVote::new(value.lite(), &key2);
-    let v3 = LiteVote::new(value.lite(), &key3);
+    let v1 = LiteVote::new(value.lite(), RoundNumber(0), &key1);
+    let v2 = LiteVote::new(value.lite(), RoundNumber(0), &key2);
+    let v3 = LiteVote::new(value.lite(), RoundNumber(0), &key3);
 
-    let mut builder = SignatureAggregator::new(value.clone(), &committee);
+    let mut builder = SignatureAggregator::new(value.clone(), RoundNumber(0), &committee);
     assert!(builder
         .append(v1.validator, v1.signature)
         .unwrap()
@@ -88,7 +88,7 @@ fn test_certificates() {
     c.signatures.pop();
     assert!(c.check(&committee).is_err());
 
-    let mut builder = SignatureAggregator::new(value, &committee);
+    let mut builder = SignatureAggregator::new(value, RoundNumber(0), &committee);
     assert!(builder
         .append(v1.validator, v1.signature)
         .unwrap()

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -609,11 +609,8 @@ where
                 let block = proposal.content.block;
                 let round = proposal.content.round;
                 let (executed_block, _) = self.node_client.stage_block_execution(block).await?;
-                let value = HashedValue::from(CertificateValue::ConfirmedBlock {
-                    executed_block,
-                    round,
-                });
-                let certificate = Certificate::new(value, signatures);
+                let value = HashedValue::from(CertificateValue::ConfirmedBlock { executed_block });
+                let certificate = Certificate::new(value, round, signatures);
                 // Certificate is valid because
                 // * `communicate_with_quorum` ensured a sufficient "weight" of
                 // (non-error) answers were returned by validators.
@@ -623,13 +620,14 @@ where
             CommunicateAction::SubmitBlockForValidation(proposal) => {
                 let BlockAndRound { block, round } = proposal.content;
                 let (executed_block, _) = self.node_client.stage_block_execution(block).await?;
-                let value = HashedValue::new_validated(executed_block, round);
-                let certificate = Certificate::new(value, signatures);
+                let value = HashedValue::new_validated(executed_block);
+                let certificate = Certificate::new(value, round, signatures);
                 Ok(Some(certificate))
             }
             CommunicateAction::FinalizeBlock(validity_certificate) => {
+                let round = validity_certificate.round;
                 let conf_value = validity_certificate.value.into_confirmed();
-                Ok(Some(Certificate::new(conf_value, signatures)))
+                Ok(Some(Certificate::new(conf_value, round, signatures)))
             }
             CommunicateAction::AdvanceToNextBlockHeight(_) => Ok(None),
         }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -182,8 +182,12 @@ fn make_certificate<S>(
     worker: &WorkerState<S>,
     value: HashedValue,
 ) -> Certificate {
-    let vote = LiteVote::new(value.lite(), worker.key_pair.as_ref().unwrap());
-    let mut builder = SignatureAggregator::new(value, committee);
+    let vote = LiteVote::new(
+        value.lite(),
+        RoundNumber(0),
+        worker.key_pair.as_ref().unwrap(),
+    );
+    let mut builder = SignatureAggregator::new(value, RoundNumber(0), committee);
     builder
         .append(vote.validator, vote.signature)
         .unwrap()

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -615,11 +615,10 @@ where
         &mut self,
         certificate: Certificate,
     ) -> Result<ChainInfoResponse, WorkerError> {
-        let (block, round) = match certificate.value() {
+        let block = match certificate.value() {
             CertificateValue::ValidatedBlock {
                 executed_block: ExecutedBlock { block, .. },
-                round,
-            } => (block, *round),
+            } => block,
             CertificateValue::ConfirmedBlock { .. } => panic!("Expecting a validation certificate"),
         };
         // Check that the chain is active and ready for this confirmation.
@@ -642,7 +641,7 @@ where
             || chain
                 .manager
                 .get_mut()
-                .check_validated_block(block, round)?
+                .check_validated_block(block, certificate.round)?
                 == ChainManagerOutcome::Skip
         {
             // If we just processed the same pending block, return the chain info

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -147,12 +147,15 @@ message LiteCertificate {
   // The certified value's hash
   bytes hash = 2;
 
-  // Signatures on the value
-  bytes signatures = 3;
+  // The round in which the value was certified.
+  uint64 round = 3;
+
+  // Signatures on the value hash and round
+  bytes signatures = 4;
 
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
-  bool wait_for_outgoing_messages = 4;
+  bool wait_for_outgoing_messages = 5;
 }
 
 // A certified statement from the committee, together with other certificates
@@ -161,18 +164,21 @@ message Certificate {
   // The ID of the chain (used for routing).
   ChainId chain_id = 1;
 
-  // The certified value (BCS signable)
+  // The certified value
   bytes value = 2;
 
-  // Signatures on the value
-  bytes signatures = 3;
+  // The round in which the value was certified.
+  uint64 round = 3;
+
+  // Signatures on the value hash and round
+  bytes signatures = 4;
 
   // Other certificates containing bytecode required by the first one
-  bytes blobs = 4;
+  bytes blobs = 5;
 
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
-  bool wait_for_outgoing_messages = 5;
+  bool wait_for_outgoing_messages = 6;
 }
 
 message ChainId {

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -93,6 +93,8 @@ Certificate:
   STRUCT:
     - value:
         TYPENAME: CertificateValue
+    - round:
+        TYPENAME: RoundNumber
     - signatures:
         SEQ:
           TUPLE:
@@ -105,15 +107,11 @@ CertificateValue:
         STRUCT:
           - executed_block:
               TYPENAME: ExecutedBlock
-          - round:
-              TYPENAME: RoundNumber
     1:
       ConfirmedBlock:
         STRUCT:
           - executed_block:
               TYPENAME: ExecutedBlock
-          - round:
-              TYPENAME: RoundNumber
 ChainAndHeight:
   STRUCT:
     - chain_id:
@@ -330,6 +328,8 @@ LiteCertificate:
   STRUCT:
     - value:
         TYPENAME: LiteValue
+    - round:
+        TYPENAME: RoundNumber
     - signatures:
         SEQ:
           TUPLE:
@@ -345,6 +345,8 @@ LiteVote:
   STRUCT:
     - value:
         TYPENAME: LiteValue
+    - round:
+        TYPENAME: RoundNumber
     - validator:
         TYPENAME: ValidatorName
     - signature:

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -8,7 +8,7 @@
 use super::TestValidator;
 use crate::ToBcsBytes;
 use linera_base::{
-    data_types::Timestamp,
+    data_types::{RoundNumber, Timestamp},
     identifiers::{ApplicationId, ChainId, MessageId, Owner},
 };
 use linera_chain::data_types::{
@@ -166,8 +166,9 @@ impl BlockBuilder {
             .collect();
 
         let value = HashedValue::new_confirmed(executed_block);
-        let vote = LiteVote::new(value.lite(), self.validator.key_pair());
-        let mut builder = SignatureAggregator::new(value, self.validator.committee());
+        let vote = LiteVote::new(value.lite(), RoundNumber(0), self.validator.key_pair());
+        let mut builder =
+            SignatureAggregator::new(value, RoundNumber(0), self.validator.committee());
         let certificate = builder
             .append(vote.validator, vote.signature)
             .expect("Failed to sign block")

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -317,9 +317,9 @@ impl ClientContext {
                 chain_id,
                 vote.validator,
             );
-            let aggregator = aggregators
-                .entry(chain_id)
-                .or_insert_with(|| SignatureAggregator::new(vote.value, &committee));
+            let aggregator = aggregators.entry(chain_id).or_insert_with(|| {
+                SignatureAggregator::new(vote.value, RoundNumber(0), &committee)
+            });
             match aggregator.append(vote.validator, vote.signature) {
                 Ok(Some(certificate)) => {
                     trace!("Found certificate: {:?}", certificate);
@@ -1175,10 +1175,8 @@ where
                             WorkerState::new("staging".to_string(), None, storage.clone())
                                 .stage_block_execution(proposal.content.block.clone())
                                 .await?;
-                        let value = HashedValue::from(CertificateValue::ConfirmedBlock {
-                            executed_block,
-                            round: RoundNumber(0),
-                        });
+                        let value =
+                            HashedValue::from(CertificateValue::ConfirmedBlock { executed_block });
                         values.insert(value.hash(), value);
                     }
                 }


### PR DESCRIPTION
It's possible that two `ConfirmedBlock` certificates for the same block with different round numbers get a quorum of signatures. To make sure validators agree on the correct `previous_block_hash` for the next block, the hash must not depend on the round number.

This commit moves it from `CertificateValue` to `Certificate` (and `Vote` etc.). The signatures still apply to the value _and_ the round number.