### PR TITLE
Implement derived traits manually for ApplicationId, SessionId, BytecodeId

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -44,7 +44,7 @@ pub struct MessageId {
 }
 
 /// A unique identifier for a user application.
-#[derive(Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[derive(Hash, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 #[serde(rename = "UserApplicationId")]
 pub struct ApplicationId<A = ()> {
@@ -201,6 +201,32 @@ impl<A: PartialEq> PartialEq for ApplicationId<A> {
 }
 
 impl<A: Eq> Eq for ApplicationId<A> {}
+
+impl<A: PartialOrd> PartialOrd for ApplicationId<A> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let ApplicationId {
+            bytecode_id,
+            creation,
+        } = other;
+        match self.bytecode_id.partial_cmp(bytecode_id) {
+            Some(std::cmp::Ordering::Equal) => self.creation.partial_cmp(creation),
+            result => result,
+        }
+    }
+}
+
+impl<A: Ord> Ord for ApplicationId<A> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let ApplicationId {
+            bytecode_id,
+            creation,
+        } = other;
+        match self.bytecode_id.cmp(bytecode_id) {
+            std::cmp::Ordering::Equal => self.creation.cmp(creation),
+            result => result,
+        }
+    }
+}
 
 impl ApplicationId {
     pub fn with_abi<A>(self) -> ApplicationId<A> {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -67,7 +67,7 @@ pub struct BytecodeId<A = ()> {
 }
 
 /// The identifier of a session.
-#[derive(Debug, Ord, PartialOrd)]
+#[derive(Debug)]
 pub struct SessionId<A = ()> {
     /// The user application that runs the session.
     pub application_id: ApplicationId<A>,
@@ -293,6 +293,32 @@ impl<A: PartialEq> PartialEq for SessionId<A> {
 }
 
 impl<A: Eq> Eq for SessionId<A> {}
+
+impl<A: PartialOrd> PartialOrd for SessionId<A> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let SessionId {
+            application_id,
+            index,
+        } = other;
+        match self.application_id.partial_cmp(application_id) {
+            Some(std::cmp::Ordering::Equal) => self.index.partial_cmp(index),
+            result => result,
+        }
+    }
+}
+
+impl<A: Ord> Ord for SessionId<A> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let SessionId {
+            application_id,
+            index,
+        } = other;
+        match self.application_id.cmp(application_id) {
+            std::cmp::Ordering::Equal => self.index.cmp(index),
+            result => result,
+        }
+    }
+}
 
 impl SessionId {
     pub fn with_abi<A>(self) -> SessionId<A> {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -68,7 +68,6 @@ pub struct BytecodeId<A = ()> {
 }
 
 /// The identifier of a session.
-#[derive(Debug)]
 pub struct SessionId<A = ()> {
     /// The user application that runs the session.
     pub application_id: ApplicationId<A>,
@@ -343,6 +342,19 @@ impl<A: Ord> Ord for SessionId<A> {
             std::cmp::Ordering::Equal => self.index.cmp(index),
             result => result,
         }
+    }
+}
+
+impl<A> Debug for SessionId<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let SessionId {
+            application_id,
+            index,
+        } = self;
+        f.debug_struct("SessionId")
+            .field("application_id", application_id)
+            .field("index", index)
+            .finish()
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -44,7 +44,7 @@ pub struct MessageId {
 }
 
 /// A unique identifier for a user application.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
+#[derive(Ord, PartialOrd, Hash, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 #[serde(rename = "UserApplicationId")]
 pub struct ApplicationId<A = ()> {
@@ -157,6 +157,18 @@ impl<A> Clone for ApplicationId<A> {
 }
 
 impl<A> Copy for ApplicationId<A> {}
+
+impl<A: PartialEq> PartialEq for ApplicationId<A> {
+    fn eq(&self, other: &Self) -> bool {
+        let ApplicationId {
+            bytecode_id,
+            creation,
+        } = other;
+        self.bytecode_id == *bytecode_id && self.creation == *creation
+    }
+}
+
+impl<A: Eq> Eq for ApplicationId<A> {}
 
 impl ApplicationId {
     pub fn with_abi<A>(self) -> ApplicationId<A> {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -67,7 +67,7 @@ pub struct BytecodeId<A = ()> {
 }
 
 /// The identifier of a session.
-#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Ord, PartialOrd)]
 pub struct SessionId<A = ()> {
     /// The user application that runs the session.
     pub application_id: ApplicationId<A>,
@@ -281,6 +281,18 @@ impl<A> Clone for SessionId<A> {
 }
 
 impl<A> Copy for SessionId<A> {}
+
+impl<A: PartialEq> PartialEq for SessionId<A> {
+    fn eq(&self, other: &Self) -> bool {
+        let SessionId {
+            application_id,
+            index,
+        } = other;
+        self.application_id == *application_id && self.index == *index
+    }
+}
+
+impl<A: Eq> Eq for SessionId<A> {}
 
 impl SessionId {
     pub fn with_abi<A>(self) -> SessionId<A> {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -55,7 +55,7 @@ pub struct ApplicationId<A = ()> {
 }
 
 /// A unique identifier for an application bytecode.
-#[derive(Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Debug, Deserialize, Hash, Ord, PartialOrd, Serialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 pub struct BytecodeId<A = ()> {
     pub message_id: MessageId,
@@ -120,6 +120,18 @@ impl<A> Clone for BytecodeId<A> {
 }
 
 impl<A> Copy for BytecodeId<A> {}
+
+impl<A: PartialEq> PartialEq for BytecodeId<A> {
+    fn eq(&self, other: &Self) -> bool {
+        let BytecodeId {
+            message_id,
+            _phantom,
+        } = other;
+        self.message_id == *message_id
+    }
+}
+
+impl<A: Eq> Eq for BytecodeId<A> {}
 
 impl BytecodeId {
     pub fn new(message_id: MessageId) -> Self {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -48,7 +48,7 @@ pub struct MessageId {
 }
 
 /// A unique identifier for a user application.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 #[serde(rename = "UserApplicationId")]
 pub struct ApplicationId<A = ()> {
@@ -262,6 +262,19 @@ impl<A> Hash for ApplicationId<A> {
         } = self;
         bytecode_id.hash(state);
         creation.hash(state);
+    }
+}
+
+impl<A> Debug for ApplicationId<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ApplicationId {
+            bytecode_id,
+            creation,
+        } = self;
+        f.debug_struct("ApplicationId")
+            .field("bytecode_id", bytecode_id)
+            .field("creation", creation)
+            .finish()
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -8,7 +8,10 @@ use crate::{
     doc_scalar,
 };
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
+use std::{
+    hash::{Hash, Hasher},
+    str::FromStr,
+};
 
 #[cfg(any(test, feature = "test"))]
 use test_strategy::Arbitrary;
@@ -55,7 +58,7 @@ pub struct ApplicationId<A = ()> {
 }
 
 /// A unique identifier for an application bytecode.
-#[derive(Debug, Deserialize, Hash, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 pub struct BytecodeId<A = ()> {
     pub message_id: MessageId,
@@ -150,6 +153,16 @@ impl<A: Ord> Ord for BytecodeId<A> {
             _phantom,
         } = other;
         self.message_id.cmp(message_id)
+    }
+}
+
+impl<A> Hash for BytecodeId<A> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let BytecodeId {
+            message_id,
+            _phantom,
+        } = self;
+        message_id.hash(state);
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -47,7 +47,7 @@ pub struct MessageId {
 }
 
 /// A unique identifier for a user application.
-#[derive(Hash, Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 #[serde(rename = "UserApplicationId")]
 pub struct ApplicationId<A = ()> {
@@ -238,6 +238,17 @@ impl<A: Ord> Ord for ApplicationId<A> {
             std::cmp::Ordering::Equal => self.creation.cmp(creation),
             result => result,
         }
+    }
+}
+
+impl<A> Hash for ApplicationId<A> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let ApplicationId {
+            bytecode_id,
+            creation,
+        } = self;
+        bytecode_id.hash(state);
+        creation.hash(state);
     }
 }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -55,7 +55,7 @@ pub struct ApplicationId<A = ()> {
 }
 
 /// A unique identifier for an application bytecode.
-#[derive(Debug, Deserialize, Hash, Ord, PartialOrd, Serialize)]
+#[derive(Debug, Deserialize, Hash, Serialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 pub struct BytecodeId<A = ()> {
     pub message_id: MessageId,
@@ -132,6 +132,26 @@ impl<A: PartialEq> PartialEq for BytecodeId<A> {
 }
 
 impl<A: Eq> Eq for BytecodeId<A> {}
+
+impl<A: PartialOrd> PartialOrd for BytecodeId<A> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let BytecodeId {
+            message_id,
+            _phantom,
+        } = other;
+        self.message_id.partial_cmp(message_id)
+    }
+}
+
+impl<A: Ord> Ord for BytecodeId<A> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let BytecodeId {
+            message_id,
+            _phantom,
+        } = other;
+        self.message_id.cmp(message_id)
+    }
+}
 
 impl BytecodeId {
     pub fn new(message_id: MessageId) -> Self {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
+    fmt::Debug,
     hash::{Hash, Hasher},
     str::FromStr,
 };
@@ -58,7 +59,7 @@ pub struct ApplicationId<A = ()> {
 }
 
 /// A unique identifier for an application bytecode.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Deserialize, Serialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Default))]
 pub struct BytecodeId<A = ()> {
     pub message_id: MessageId,
@@ -163,6 +164,18 @@ impl<A> Hash for BytecodeId<A> {
             _phantom,
         } = self;
         message_id.hash(state);
+    }
+}
+
+impl<A> Debug for BytecodeId<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let BytecodeId {
+            message_id,
+            _phantom,
+        } = self;
+        f.debug_struct("BytecodeId")
+            .field("message_id", message_id)
+            .finish()
     }
 }
 
@@ -340,7 +353,7 @@ impl<A> SessionId<A> {
 
 impl std::fmt::Display for Owner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        self.0.fmt(f)
+        std::fmt::Display::fmt(&self.0, f)
     }
 }
 
@@ -366,7 +379,7 @@ impl std::str::FromStr for Owner {
 
 impl std::fmt::Display for ChainId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        std::fmt::Display::fmt(&self.0, f)
     }
 }
 


### PR DESCRIPTION
### Summary
Implemented Clone/Copy, PartialEq/Eq, PartialOrd/Ord, Debug and Hash traits for SessionId, ApplicationId and BytecodeId.
I only haven't implemented Serialize and Deserialize, because I wanted to make sure which ones exactly I should implement, or if it's really just all of them. Please let me know if I should just do all of them, and I'll update this PR with it, and set it up for review.

### Test plan
For now, just
`cargo check` and `cargo test && cargo clippy --all-targets`
Happy to learn how I could test this better though, before officially putting this up for review :)