### PR TITLE
Splitting big values and other improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2758,7 +2758,6 @@ name = "linera-storage"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-lock",
  "async-trait",
  "bcs",
  "dashmap",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1674,7 +1674,6 @@ dependencies = [
 name = "linera-storage"
 version = "0.2.0"
 dependencies = [
- "async-lock",
  "async-trait",
  "bcs",
  "dashmap",
@@ -1709,6 +1708,7 @@ dependencies = [
  "serde",
  "sha3",
  "static_assertions",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -2019,24 +2019,24 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.20.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b9b8653cec6897f73b519a43fba5ee3d50f62fe9af80b428accdcc093b4a849"
+checksum = "aa8ebbd1a9e57bbab77b9facae7f5136aea44c356943bf9a198f647da64285d6"
 dependencies = [
- "ahash 0.7.6",
+ "ahash 0.8.3",
  "metrics-macros",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-macros"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731f8ecebd9f3a4aa847dfe75455e4757a45da40a7793d2f0b1f9b6ed18b23f3"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2240,9 +2240,9 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "ppv-lite86"

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -31,6 +31,9 @@ impl KeyValueStore {
 #[async_trait]
 impl KeyValueStoreClient for KeyValueStore {
     const MAX_CONNECTIONS: usize = 1;
+    // The KeyValueStoreClient of the system_api does not have splitting limits.
+    // Those are done by the lower ranked parts of the system.
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = ViewError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -19,7 +19,6 @@ aws = ["linera-views/aws"]
 rocksdb = ["linera-views/rocksdb"]
 
 [dependencies]
-async-lock = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 dashmap = { workspace = true }

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient};
-use async_lock::{Mutex, RwLock};
 use linera_execution::WasmRuntime;
-use linera_views::memory::MemoryClient;
-use std::{collections::BTreeMap, sync::Arc};
+use linera_views::memory::{create_memory_test_client, MemoryClient};
+use std::sync::Arc;
 
 type MemoryStore = DbStore<MemoryClient>;
 
@@ -21,11 +20,7 @@ impl MemoryStoreClient {
 
 impl MemoryStore {
     pub fn new(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let state = Arc::new(Mutex::new(BTreeMap::new()));
-        let guard = state
-            .try_lock_arc()
-            .expect("We should be able to acquire what we just created");
-        let client = Arc::new(RwLock::new(guard));
+        let client = create_memory_test_client();
         Self {
             client,
             guards: ChainGuards::default(),

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -35,6 +35,7 @@ serde = { workspace = true }
 sha3 = { workspace = true }
 thiserror = { workspace = true }
 linked-hash-map = { workspace = true }
+tempfile = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt", "sync"] }
@@ -52,4 +53,4 @@ tokio-test = { workspace = true }
 
 [dev-dependencies]
 linera-views = { path = ".", features = ["test"] }
-tempfile = { workspace = true }
+

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -10,18 +10,23 @@
 //! [trait1]: common::KeyValueStoreClient
 //! [trait2]: common::Context
 
-use crate::{batch::Batch, views::ViewError};
+use crate::{
+    batch::{Batch, WriteOperation},
+    views::ViewError,
+};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use std::{
     fmt::{Debug, Display},
     future::Future,
+    mem,
     ops::{
         Bound,
         Bound::{Excluded, Included, Unbounded},
     },
     time::{Duration, Instant},
 };
+use thiserror::Error;
 
 #[cfg(test)]
 #[path = "unit_tests/common_tests.rs"]
@@ -40,6 +45,26 @@ pub(crate) enum Update<T> {
 
 /// The minimum value for the view tags. Values in 0..MIN_VIEW_TAG are used for other purposes.
 pub(crate) const MIN_VIEW_TAG: u8 = 1;
+
+/// Data type indicating that the database is not consistent
+#[derive(Error, Debug)]
+pub enum DatabaseConsistencyError {
+    /// The key is of length less than 4 so we cannot extract the first byte
+    #[error("key of length less than 4, so we cannot extract the first byte")]
+    TooShortKey,
+
+    /// In the splitting scheme a certain number of segments was specified, but some are missing
+    #[error("segment is missing from the database")]
+    MissingSegment,
+
+    /// We expect that the segments arrive sequentially
+    #[error("segment index is not what was expected")]
+    IncorrectIndexEntry,
+
+    /// In the value, we should have a count entry.
+    #[error("no count of size u32 is available in the value")]
+    NoCountAvailable,
+}
 
 /// When wanting to find the entries in a BTreeMap with a specific prefix,
 /// one option is to iterate over all keys. Another is to select an interval
@@ -60,7 +85,9 @@ pub(crate) fn get_upper_bound(key_prefix: &[u8]) -> Bound<Vec<u8>> {
     Unbounded
 }
 
-pub(crate) fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
+/// Compute an interval so that a vector has key_prefix as a prefix
+/// if and only if it belongs to the range.
+pub fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
     let upper_bound = get_upper_bound(&key_prefix);
     (Included(key_prefix), upper_bound)
 }
@@ -114,6 +141,9 @@ pub trait KeyValueStoreClient {
     /// Maximum number of simultaneous connections
     const MAX_CONNECTIONS: usize;
 
+    /// The maximal size of values that can be stored
+    const MAX_VALUE_SIZE: usize;
+
     /// The error type.
     type Error: Debug;
 
@@ -148,7 +178,7 @@ pub trait KeyValueStoreClient {
     /// The journal is located at the `base_key`.
     async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error>;
 
-    /// Reads a single `key` and deserialize the result if present.
+    /// Reads a single `key` and deserializes the result if present.
     async fn read_key<V: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<V>, Self::Error>
     where
         Self::Error: From<bcs::Error>,
@@ -169,6 +199,273 @@ pub trait KeyValueStoreClient {
             values.push(from_bytes_opt(entry)?);
         }
         Ok(values)
+    }
+}
+
+/// Implement a reader of data that splits the big values into multiple keys.
+/// Some databases have a design with relatively small size for values (like 400 kB)
+/// which forces us to split the value into several small block.
+/// Design is the following:
+/// ---We have classic key, named 'logical key" which contains the nature
+///    of the value and a part of the value.
+///    logical key are of the form [key , 0]
+///    logical value are of the form [0, value] if classic
+///                               or [0, * * * * first_segment] if segmented
+///        the [* * * *] represent the size of the block
+/// ---The remaining segment keys are of the form [key * * * * 1]
+///    with [* * * *] the index of the segment in question.
+///
+/// The effective working of the system relies on a number of design choices.
+/// ---In the retrieval by the "find_keys_by_prefix" and similar, the keys are
+///    returned in lexicographic order.
+/// ---The count and indices are serialized as u32 and the serialization is done
+///    so that the u32 ordering is the same as the lexicographic ordering. So, we
+///    get first the logical key and then the segment keys one by one in the correct
+///    order.
+/// ---Suppose that we have written a (key,value1) with several segments and then
+///    we replace by a (key,value2) which has less segment or uses just a logical key.
+///    Our choice is to leave the old segments in the database. Same with delete:
+///    we just delete the logical key.
+/// ---We avoid the overflowing of the system by the following trick: When we delete
+///    a view, we do a delete by prefix, which thus deletes the old segments if present.
+#[derive(Clone)]
+pub struct KeyValueStoreClientBigValue<K> {
+    client: K,
+}
+
+#[async_trait]
+impl<K> KeyValueStoreClient for KeyValueStoreClientBigValue<K>
+where
+    K: KeyValueStoreClient + Send + Sync,
+    K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
+{
+    const MAX_CONNECTIONS: usize = K::MAX_CONNECTIONS;
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+    type Error = K::Error;
+    type Keys = Vec<Vec<u8>>;
+    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let mut big_key = key.to_vec();
+        big_key.extend(&[0, 0, 0, 0]);
+        let value = self.client.read_key_bytes(&big_key).await?;
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        let count = Self::read_count_from_value(&value)?;
+        let mut big_value = value[4..].to_vec();
+        if count == 1 {
+            return Ok(Some(big_value));
+        }
+        let mut big_keys = Vec::new();
+        for i in 1..count {
+            let big_key_segment = Self::get_segment_key(key, i)?;
+            big_keys.push(big_key_segment);
+        }
+        let segments = self.client.read_multi_key_bytes(big_keys).await?;
+        for segment in segments {
+            match segment {
+                None => {
+                    return Err(DatabaseConsistencyError::MissingSegment.into());
+                }
+                Some(segment) => {
+                    big_value.extend(segment);
+                }
+            }
+        }
+        Ok(Some(big_value))
+    }
+
+    async fn read_multi_key_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        let mut big_keys = Vec::new();
+        for key in &keys {
+            let mut big_key = key.clone();
+            big_key.extend(&[0, 0, 0, 0]);
+            big_keys.push(big_key);
+        }
+        let values = self.client.read_multi_key_bytes(big_keys).await?;
+        let mut big_values = Vec::<Option<Vec<u8>>>::new();
+        let mut keys_add = Vec::new();
+        let mut n_blocks = Vec::new();
+        for (key, value) in keys.iter().zip(values) {
+            match value {
+                None => {
+                    n_blocks.push(0);
+                    big_values.push(None);
+                }
+                Some(value) => {
+                    let count = Self::read_count_from_value(&value)?;
+                    let big_value = value[4..].to_vec();
+                    for i in 1..count {
+                        let big_key_segment = Self::get_segment_key(key, i)?;
+                        keys_add.push(big_key_segment);
+                    }
+                    n_blocks.push(count);
+                    big_values.push(Some(big_value));
+                }
+            }
+        }
+        if !keys_add.is_empty() {
+            let segments: Vec<Option<Vec<u8>>> = self.client.read_multi_key_bytes(keys_add).await?;
+            let mut pos = 0;
+            for (idx, count) in n_blocks.iter().enumerate() {
+                if count > &1 {
+                    let value: &mut Option<Vec<u8>> = big_values.get_mut(idx).unwrap();
+                    if let Some(ref mut value) = value {
+                        for _ in 1..*count {
+                            let segment: Vec<u8> = segments.get(pos).unwrap().clone().unwrap();
+                            value.extend(segment);
+                            pos += 1;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(big_values)
+    }
+
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+        let mut keys = Vec::new();
+        for big_key in self
+            .client
+            .find_keys_by_prefix(key_prefix)
+            .await?
+            .iterator()
+        {
+            let big_key = big_key?;
+            let len = big_key.len();
+            if Self::read_index_from_key(big_key)? == 0 {
+                let key = big_key[0..len - 4].to_vec();
+                keys.push(key);
+            }
+        }
+        Ok(keys)
+    }
+
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, Self::Error> {
+        let mut key_values = Vec::new();
+        let mut key = Vec::new();
+        let mut big_value = Vec::new();
+        let mut count = 0;
+        let mut pos = 0;
+        for result in self
+            .client
+            .find_key_values_by_prefix(key_prefix)
+            .await?
+            .iterator()
+        {
+            let (big_key, value) = result?;
+            let len = big_key.len();
+            let idx = Self::read_index_from_key(big_key)?;
+            if idx == 0 {
+                count = Self::read_count_from_value(value)?;
+                key = big_key[..len - 4].to_vec();
+                big_value.extend(value[4..].to_vec());
+                pos = 1;
+            } else if big_key[..len - 4] == key {
+                if idx == pos && idx < count {
+                    big_value.extend(value);
+                    pos += 1;
+                }
+            } else {
+                pos = 0;
+            }
+            if pos == count {
+                key_values.push((mem::take(&mut key), mem::take(&mut big_value)));
+            }
+        }
+        Ok(key_values)
+    }
+
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), Self::Error> {
+        let mut batch_new = Batch::new();
+        for operation in batch.operations {
+            match operation {
+                WriteOperation::Delete { key } => {
+                    let mut big_key = key.to_vec();
+                    big_key.extend(&[0, 0, 0, 0]);
+                    batch_new.delete_key(big_key);
+                }
+                WriteOperation::Put { key, value } => {
+                    let mut big_key = key.clone();
+                    big_key.extend(&[0, 0, 0, 0]);
+                    let mut first_chunk = Vec::new();
+                    let mut pos: u32 = 0;
+                    for value_chunk in value.chunks(K::MAX_VALUE_SIZE) {
+                        let big_key_segment = Self::get_segment_key(&key, pos)?;
+                        if pos == 0 {
+                            first_chunk = value_chunk.to_vec();
+                        } else {
+                            batch_new.put_key_value_bytes(big_key_segment, value_chunk.to_vec());
+                        }
+                        pos += 1;
+                    }
+                    let value_ext = Self::get_initial_count_first_chunk(pos, &first_chunk)?;
+                    batch_new.put_key_value_bytes(big_key, value_ext);
+                }
+                WriteOperation::DeletePrefix { key_prefix } => {
+                    batch_new.delete_key_prefix(key_prefix);
+                }
+            }
+        }
+        self.client.write_batch(batch_new, base_key).await
+    }
+
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+        self.client.clear_journal(base_key).await
+    }
+}
+
+impl<K> KeyValueStoreClientBigValue<K>
+where
+    K: KeyValueStoreClient + Send + Sync,
+    K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
+{
+    /// Create a new client that deals with big values from one that does not.
+    pub fn new(client: K) -> Self {
+        KeyValueStoreClientBigValue { client }
+    }
+
+    fn read_count_from_value(value: &[u8]) -> Result<u32, K::Error> {
+        if value.len() < 4 {
+            return Err(DatabaseConsistencyError::NoCountAvailable.into());
+        }
+        let mut bytes = value[0..4].to_vec();
+        bytes.reverse();
+        Ok(bcs::from_bytes::<u32>(&bytes)?)
+    }
+
+    fn get_segment_key(key: &[u8], index: u32) -> Result<Vec<u8>, K::Error> {
+        let mut big_key_segment = key.to_vec();
+        let mut bytes = bcs::to_bytes(&index)?;
+        bytes.reverse();
+        big_key_segment.extend(bytes);
+        Ok(big_key_segment)
+    }
+
+    fn read_index_from_key(key: &[u8]) -> Result<u32, K::Error> {
+        let len = key.len();
+        if len < 4 {
+            return Err(DatabaseConsistencyError::TooShortKey.into());
+        }
+        let mut bytes = key[len - 4..len].to_vec();
+        bytes.reverse();
+        Ok(bcs::from_bytes::<u32>(&bytes)?)
+    }
+
+    fn get_initial_count_first_chunk(count: u32, first_chunk: &[u8]) -> Result<Vec<u8>, K::Error> {
+        let mut bytes = bcs::to_bytes(&count)?;
+        bytes.reverse();
+        let mut value_ext = Vec::new();
+        value_ext.extend(bytes);
+        value_ext.extend(first_chunk);
+        Ok(value_ext)
     }
 }
 
@@ -280,7 +577,7 @@ pub trait Context {
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
 
-    /// Finds keys matching the `key_prefix`. The `key_prefix` is not included in the returned keys.
+    /// Finds the keys matching the `key_prefix`. The `key_prefix` is not included in the returned keys.
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error>;
 
     /// Finds the `(key,value)` pairs matching the `key_prefix`. The `key_prefix` is not included in the returned keys.

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -215,6 +215,7 @@ pub trait KeyValueStoreClient {
 ///   and value0 the first block of the value. For the other keys [key * * * *] the
 ///   corresponding value is valueK with valueK the K-th entry in the value. The full
 ///   value is reconstructed as value = [value0 value1 .... valueN]
+///   The number of blocks is always non-zero, even if the value is empty.
 ///
 /// The effective working of the system relies on a number of design choices.
 /// * In the retrieval by the "find_keys_by_prefix" and similar, the keys are
@@ -409,7 +410,8 @@ where
                         }
                         pos += 1;
                     }
-                    let value_ext = Self::get_initial_count_first_chunk(pos, &first_chunk)?;
+                    let count = if pos == 0 { 1 } else { pos };
+                    let value_ext = Self::get_initial_count_first_chunk(count, &first_chunk)?;
                     batch_new.put_key_value_bytes(big_key, value_ext);
                 }
                 WriteOperation::DeletePrefix { key_prefix } => {

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -63,8 +63,7 @@ const _MAX_TRANSACT_WRITE_ITEM_BYTES: usize = 4194304;
 
 /// Fundamental constants in DynamoDB: The maximum size of a TransactWriteItem is 100.
 /// See <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html>
-pub const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = 25;
-//pub const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = 100;
+pub const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = 100;
 
 /// Fundamental constants in DynamoDB: The maximum size of a BatchWriteItem is 16M.
 /// See <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html>
@@ -244,11 +243,7 @@ enum KeyTag {
     Entry,
 }
 
-fn get_journaling_key(
-    base_key: &[u8],
-    tag: u8,
-    pos: u32,
-) -> Result<Vec<u8>, DynamoDbContextError> {
+fn get_journaling_key(base_key: &[u8], tag: u8, pos: u32) -> Result<Vec<u8>, DynamoDbContextError> {
     // We used the value 0 because it does not collide with other key values.
     // since other tags are starting from 1.
     let mut key = base_key.to_vec();
@@ -278,18 +273,14 @@ impl JournalHeader {
             let key = get_journaling_key(base_key, KeyTag::Entry as u8, self.block_count - 1)?;
             let value: Option<DynamoDbBatch> = db.read_key(&key).await?;
             if let Some(value) = value {
-                println!("Beginning of one resolution");
                 let mut tb = TransactionBuilder::default();
                 tb.insert_delete_request(key, db)?; // Delete the preceding journal entry
                 for delete in value.0.deletions {
-                    println!("delete={:?}", delete);
                     tb.insert_delete_request(delete, db)?;
                 }
                 for key_value in value.0.insertions {
-                    println!("put={:?} value={:?}", key_value.0, key_value.1);
                     tb.insert_put_request(key_value.0, key_value.1, db)?;
                 }
-                println!("Beginning of one resolution");
                 self.block_count -= 1;
                 DynamoDbBatch::add_journal_header_operations(&mut tb, &self, db, base_key)?;
                 tb.submit(db).await?;
@@ -322,13 +313,10 @@ impl DynamoDbBatch {
         base_key: &[u8],
     ) -> Result<(), DynamoDbContextError> {
         let key = get_journaling_key(base_key, KeyTag::Journal as u8, 0)?;
-        println!("add_journal_header_operations key={:?}", key);
         if header.block_count > 0 {
-            println!("   inserting the journal key");
             let value = bcs::to_bytes(header)?;
             transact_builder.insert_put_request(key, value, db)?;
         } else {
-            println!("   deleting the journal key");
             transact_builder.insert_delete_request(key, db)?;
         }
         Ok(())
@@ -340,11 +328,9 @@ impl DynamoDbBatch {
         db: &DynamoDbClientInternal,
         base_key: &[u8],
     ) -> Result<JournalHeader, DynamoDbContextError> {
-        println!("write_journal - Beginning base_key={:?}", base_key);
         let delete_count = self.0.deletions.len();
         let insert_count = self.0.insertions.len();
         let total_count = delete_count + insert_count;
-        println!("delete_count={} insert_count={}", delete_count, insert_count);
         let mut curr_size = 0;
         let mut curr_len = 0;
         let mut deletions = Vec::new();
@@ -355,12 +341,10 @@ impl DynamoDbBatch {
             if i < delete_count {
                 let delete = &self.0.deletions[i];
                 curr_size += delete.len();
-                println!("i={} delete key={:?}", i, delete);
                 deletions.push(delete.to_vec());
             } else {
                 let key_value = &self.0.insertions[i - delete_count];
                 curr_size += key_value.0.len() + key_value.1.len();
-                println!("i={} put key={:?} value={:?}", i, key_value.0, key_value.1);
                 insertions.push(key_value.clone());
             }
             let do_flush = if i == total_count - 1 || curr_len == MAX_TRANSACT_WRITE_ITEM_SIZE - 2 {
@@ -375,14 +359,12 @@ impl DynamoDbBatch {
                 curr_size + size_next > MAX_BATCH_WRITE_ITEM_BYTES
             };
             if do_flush {
-                println!("|deletions|={} |insertions|={}", deletions.len(), insertions.len());
                 let simple_unordered_batch = SimpleUnorderedBatch {
                     deletions: mem::take(&mut deletions),
                     insertions: mem::take(&mut insertions),
                 };
                 let entry = DynamoDbBatch(simple_unordered_batch);
                 let key = get_journaling_key(base_key, KeyTag::Entry as u8, block_count)?;
-                println!("   block_count={} key={:?}", block_count, key);
                 let value = bcs::to_bytes(&entry)?;
                 db.write_single_key_value(key, value).await?;
                 block_count += 1;
@@ -394,10 +376,8 @@ impl DynamoDbBatch {
         if block_count > 0 {
             let key = get_journaling_key(base_key, KeyTag::Journal as u8, 0)?;
             let value = bcs::to_bytes(&header)?;
-            println!("Writing the journal entry key={:?} value={:?}", key, value);
             db.write_single_key_value(key, value).await?;
         }
-        println!("write_journal - End");
         Ok(header)
     }
 
@@ -426,8 +406,6 @@ impl DynamoDbBatch {
         // Also we remove the deletes that are followed by inserts on the same key because
         // the TransactWriteItem and BatchWriteItem are not going to work that way.
         let unordered_batch = batch.simplify();
-        println!("         --------- unordered_batch -------");
-        unordered_batch.print();
         let simple_unordered_batch = unordered_batch.expand_delete_prefixes(db).await?;
         Ok(DynamoDbBatch(simple_unordered_batch))
     }
@@ -730,13 +708,11 @@ impl KeyValueStoreClient for DynamoDbClientInternal {
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), DynamoDbContextError> {
         let block_operations = DynamoDbBatch::from_batch(self, batch).await?;
         if block_operations.is_fastpath_feasible() {
-            block_operations.write_fastpath_failsafe(self).await?;
+            block_operations.write_fastpath_failsafe(self).await
         } else {
             let header = block_operations.write_journal(self, base_key).await?;
-            header.coherently_resolve_journal(self, base_key).await?;
+            header.coherently_resolve_journal(self, base_key).await
         }
-        println!("= - = - = - = - = - = - = - = - = - = - = - = - = - = - = - = - = - = - = - =");
-        Ok(())
     }
 
     async fn clear_journal(&self, base_key: &[u8]) -> Result<(), DynamoDbContextError> {

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -5,7 +5,7 @@ use crate::{
     batch::{Batch, DeletePrefixExpander, SimpleUnorderedBatch},
     common::{
         ContextFromDb, DatabaseConsistencyError, KeyIterable, KeyValueIterable,
-        KeyValueStoreClient, KeyValueStoreClientBigValue, MIN_VIEW_TAG,
+        KeyValueStoreClient, MIN_VIEW_TAG,
     },
     localstack,
     lru_caching::LruCachingKeyValueClient,
@@ -243,7 +243,11 @@ enum KeyTag {
     Entry,
 }
 
-fn get_journaling_key(base_key: &[u8], tag: u8, pos: u32) -> Result<Vec<u8>, DynamoDbContextError> {
+fn get_journaling_key(
+    base_key: &[u8],
+    tag: u8,
+    pos: usize,
+) -> Result<Vec<u8>, DynamoDbContextError> {
     // We used the value 0 because it does not collide with other key values.
     // since other tags are starting from 1.
     let mut key = base_key.to_vec();
@@ -972,6 +976,10 @@ pub enum DynamoDbContextError {
     /// The recovery failed.
     #[error("The DynamoDB database recovery failed")]
     DatabaseRecoveryFailed,
+
+    /// The database is not coherent
+    #[error(transparent)]
+    DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 
     /// The length of the value should be at most 400KB.
     #[error("The DynamoDB value should be less than 400KB")]

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -748,6 +748,9 @@ where
     ViewError: From<C::Error>,
 {
     const MAX_CONNECTIONS: usize = C::MAX_CONNECTIONS;
+    // Since the KeyValueStoreClient is based on another context
+    // the splitting is done by the lower ranked context
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = ViewError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_interval, ContextFromDb, KeyValueStoreClient},
+    common::{
+        get_interval, ContextFromDb, DatabaseConsistencyError, KeyValueStoreClient,
+        KeyValueStoreClientBigValue,
+    },
     views::ViewError,
 };
 use async_lock::{Mutex, MutexGuardArc, RwLock};
@@ -16,34 +19,18 @@ use thiserror::Error;
 pub type MemoryStoreMap = BTreeMap<Vec<u8>, Vec<u8>>;
 
 /// A virtual DB client where data are persisted in memory.
-pub type MemoryClient = Arc<RwLock<MutexGuardArc<MemoryStoreMap>>>;
-
-/// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type MemoryContext<E> = ContextFromDb<E, MemoryClient>;
-
-impl<E> MemoryContext<E> {
-    /// Creates a [`MemoryContext`].
-    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
-        Self {
-            db: Arc::new(RwLock::new(guard)),
-            base_key: Vec::new(),
-            extra,
-        }
-    }
-}
-
-/// Provides a `MemoryContext<()>` that can be used for tests.
-pub fn create_test_context() -> MemoryContext<()> {
-    let state = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = state
-        .try_lock_arc()
-        .expect("We should acquire the lock just after creating the object");
-    MemoryContext::new(guard, ())
-}
+pub type MemoryClientInternal = Arc<RwLock<MutexGuardArc<MemoryStoreMap>>>;
 
 #[async_trait]
-impl KeyValueStoreClient for MemoryClient {
+impl KeyValueStoreClient for MemoryClientInternal {
     const MAX_CONNECTIONS: usize = 1;
+    // For the memory container, memory is the limit and so usize::MAX
+    // could be used. But when memory is used for tests we want to exercise
+    // the splitting mechanism and so we set it artificially to 100.
+    #[cfg(any(test, feature = "test"))]
+    const MAX_VALUE_SIZE: usize = 100;
+    #[cfg(not(any(test, feature = "test")))]
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -121,12 +108,135 @@ impl KeyValueStoreClient for MemoryClient {
     }
 }
 
+/// Implementation of the MemoryClient from the existing one.
+#[derive(Clone)]
+pub struct MemoryClient {
+    client: KeyValueStoreClientBigValue<MemoryClientInternal>,
+}
+
+#[async_trait]
+impl KeyValueStoreClient for MemoryClient {
+    const MAX_CONNECTIONS: usize = MemoryClientInternal::MAX_CONNECTIONS;
+    const MAX_VALUE_SIZE: usize = MemoryClientInternal::MAX_VALUE_SIZE;
+    type Error = MemoryContextError;
+    type Keys = Vec<Vec<u8>>;
+    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
+        self.client.read_key_bytes(key).await
+    }
+
+    async fn read_multi_key_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {
+        self.client.read_multi_key_bytes(keys).await
+    }
+
+    async fn find_keys_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::Keys, MemoryContextError> {
+        self.client.find_keys_by_prefix(key_prefix).await
+    }
+
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, MemoryContextError> {
+        self.client.find_key_values_by_prefix(key_prefix).await
+    }
+
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
+        self.client.write_batch(batch, base_key).await
+    }
+
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+        self.client.clear_journal(base_key).await
+    }
+}
+
+impl MemoryClient {
+    /// Create a MemoryClient from the guard
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>) -> Self {
+        let client = Arc::new(RwLock::new(guard));
+        MemoryClient {
+            client: KeyValueStoreClientBigValue::new(client),
+        }
+    }
+}
+
+/// An implementation of [`crate::common::Context`] that stores all values in memory.
+pub type MemoryContext<E> = ContextFromDb<E, MemoryClient>;
+
+impl<E> MemoryContext<E> {
+    /// Creates a [`MemoryContext`].
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
+        let db = MemoryClient::new(guard);
+        let base_key = Vec::new();
+        Self {
+            db,
+            base_key,
+            extra,
+        }
+    }
+}
+
+/// Provides a `MemoryContext<()>` that can be used for tests.
+/// It is not named create_memory_test_context because it is massively
+/// used
+pub fn create_test_context() -> MemoryContext<()> {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryContext::new(guard, ())
+}
+
+/// create a test memory client for working.
+pub fn create_memory_test_client() -> MemoryClient {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryClient::new(guard)
+}
+
+/// An implementation of [`crate::common::Context`] that stores all values in memory.
+pub type MemoryContextInternal<E> = ContextFromDb<E, MemoryClientInternal>;
+
+impl<E> MemoryContextInternal<E> {
+    /// Creates a [`MemoryContext`].
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
+        let db = Arc::new(RwLock::new(guard));
+        let base_key = Vec::new();
+        Self {
+            db,
+            base_key,
+            extra,
+        }
+    }
+}
+
+/// Provides a `MemoryContext<()>` that can be used for tests.
+pub fn create_test_context_internal() -> MemoryContextInternal<()> {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryContextInternal::new(guard, ())
+}
+
 /// The error type for [`MemoryContext`].
 #[derive(Error, Debug)]
 pub enum MemoryContextError {
     /// Serialization error with BCS.
     #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
+
+    /// The database is not consistent
+    #[error(transparent)]
+    DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
 impl From<MemoryContextError> for ViewError {

--- a/linera-views/src/rocksdb.rs
+++ b/linera-views/src/rocksdb.rs
@@ -3,8 +3,11 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_upper_bound, ContextFromDb, KeyValueStoreClient},
-    lru_caching::LruCachingKeyValueClient,
+    common::{
+        get_upper_bound, ContextFromDb, DatabaseConsistencyError, KeyValueStoreClient,
+        KeyValueStoreClientBigValue,
+    },
+    lru_caching::{LruCachingKeyValueClient, TEST_CACHE_SIZE},
 };
 use async_trait::async_trait;
 use std::{
@@ -12,7 +15,12 @@ use std::{
     path::Path,
     sync::Arc,
 };
+use tempfile::TempDir;
 use thiserror::Error;
+
+// The maximum size of values in RocksDB is 3 GB
+// That is 3221225472 and so for offset reason we decrease by 400
+const MAX_VALUE_SIZE: usize = 3221225072;
 
 /// The RocksDb client in use.
 pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
@@ -20,31 +28,10 @@ pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
 /// The internal client
 pub type DbInternal = Arc<DB>;
 
-/// A shared DB client for RocksDB implementing LruCaching
-#[derive(Clone)]
-pub struct RocksdbClient {
-    client: LruCachingKeyValueClient<DbInternal>,
-}
-
-impl RocksdbClient {
-    /// Creates a rocksdb database from a specified path
-    pub fn new<P: AsRef<Path>>(path: P, cache_size: usize) -> RocksdbClient {
-        let mut options = rocksdb::Options::default();
-        options.create_if_missing(true);
-        let db = DB::open(&options, path).unwrap();
-        let client = Arc::new(db);
-        Self {
-            client: LruCachingKeyValueClient::new(client, cache_size),
-        }
-    }
-}
-
-/// An implementation of [`crate::common::Context`] based on Rocksdb
-pub type RocksdbContext<E> = ContextFromDb<E, RocksdbClient>;
-
 #[async_trait]
 impl KeyValueStoreClient for DbInternal {
     const MAX_CONNECTIONS: usize = 1;
+    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
     type Error = RocksdbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -170,9 +157,39 @@ impl KeyValueStoreClient for DbInternal {
     }
 }
 
+/// A shared DB client for RocksDB implementing LruCaching
+#[derive(Clone)]
+pub struct RocksdbClient {
+    client: LruCachingKeyValueClient<KeyValueStoreClientBigValue<DbInternal>>,
+}
+
+impl RocksdbClient {
+    /// Creates a rocksdb database from a specified path
+    pub fn new<P: AsRef<Path>>(path: P, cache_size: usize) -> RocksdbClient {
+        let mut options = rocksdb::Options::default();
+        options.create_if_missing(true);
+        let db = DB::open(&options, path).unwrap();
+        let client = Arc::new(db);
+        let client = KeyValueStoreClientBigValue::new(client);
+        Self {
+            client: LruCachingKeyValueClient::new(client, cache_size),
+        }
+    }
+}
+
+/// Create a rocksdb database client to be used for tests.
+pub fn create_rocksdb_test_client() -> RocksdbClient {
+    let dir = TempDir::new().unwrap();
+    RocksdbClient::new(dir, TEST_CACHE_SIZE)
+}
+
+/// An implementation of [`crate::common::Context`] based on Rocksdb
+pub type RocksdbContext<E> = ContextFromDb<E, RocksdbClient>;
+
 #[async_trait]
 impl KeyValueStoreClient for RocksdbClient {
     const MAX_CONNECTIONS: usize = 1;
+    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
     type Error = RocksdbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -236,6 +253,10 @@ pub enum RocksdbContextError {
     /// BCS serialization error.
     #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
+
+    /// The database is not coherent
+    #[error(transparent)]
+    DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
 impl From<RocksdbContextError> for crate::views::ViewError {

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -111,7 +111,6 @@ where
 
             tweaked_test_case.insert(commit_location + 1, CommitAndReload);
             tweaked_test_case.push(CommitAndReload);
-
             run_test_queue_operations(tweaked_test_case, contexts.new_context().await?).await?;
         }
     }
@@ -131,7 +130,6 @@ where
     let mut queue = QueueView::load(context.clone()).await?;
 
     check_queue_state(&mut queue, &expected_state).await?;
-
     for operation in operations {
         match operation {
             Operation::PushBack(new_item) => {

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -4,132 +4,183 @@
 use async_lock::{Mutex, RwLock};
 use linera_views::{
     batch::Batch,
-    common::{KeyIterable, KeyValueStoreClient},
+    common::{get_interval, KeyIterable, KeyValueIterable, KeyValueStoreClient},
     key_value_store_view::ViewContainer,
-    memory::MemoryContext,
-    test_utils::get_random_key_value_vec_prefix,
+    memory::{create_memory_test_client, create_test_context},
+    test_utils::{get_random_byte_vector, get_random_key_value_vec_prefix, get_small_key_space},
 };
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, HashSet},
     sync::Arc,
 };
 
 #[cfg(feature = "rocksdb")]
-use linera_views::rocksdb::DB;
+use linera_views::rocksdb::create_rocksdb_test_client;
 
 #[cfg(feature = "aws")]
-use linera_views::{
-    dynamo_db::DynamoDbClient, lru_caching::TEST_CACHE_SIZE, test_utils::LocalStackTestContext,
-};
+use linera_views::test_utils::create_dynamodb_test_client;
 
 #[cfg(test)]
-async fn test_ordering_keys_key_value_vec<OP: KeyValueStoreClient + Sync>(
+async fn test_readings_vec<OP: KeyValueStoreClient + Sync>(
     key_value_operation: OP,
     key_value_vec: Vec<(Vec<u8>, Vec<u8>)>,
 ) {
     // We need a nontrivial key_prefix because dynamo requires a non-trivial prefix
-    let key_prefix = vec![0];
     let mut batch = Batch::new();
-    for key_value in key_value_vec {
-        batch.put_key_value_bytes(key_value.0, key_value.1);
+    let mut keys = Vec::new();
+    let mut set_keys = HashSet::new();
+    for key_value in &key_value_vec {
+        keys.push(key_value.0.clone());
+        set_keys.insert(key_value.0.clone());
+        batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        println!(
+            "  key={:?} value={:?}",
+            key_value.0.clone(),
+            key_value.1.clone()
+        );
     }
     key_value_operation.write_batch(batch, &[]).await.unwrap();
-    let keys: Vec<Vec<u8>> = key_value_operation
-        .find_keys_by_prefix(&key_prefix)
-        .await
-        .unwrap()
-        .iterator()
-        .map(|x| {
-            let mut v = key_prefix.clone();
-            v.extend(x.unwrap());
-            v
-        })
-        .collect();
-    for i in 1..keys.len() {
-        let key1 = keys[i - 1].clone();
-        let key2 = keys[i].clone();
-        assert!(key1 < key2);
-    }
-    let mut map = HashMap::new();
+    let mut set = HashSet::new();
     for key in &keys {
         for u in 1..key.len() + 1 {
             let key_prefix = key[0..u].to_vec();
-            match map.get_mut(&key_prefix) {
-                Some(v) => {
-                    *v += 1;
-                }
-                None => {
-                    map.insert(key_prefix, 1);
-                }
-            }
+            set.insert(key_prefix);
         }
     }
-    for (key_prefix, value) in map {
-        let n_ent = key_value_operation
+    for key_prefix in set {
+        println!("key_prefix={:?}", key_prefix);
+        let len_prefix = key_prefix.len();
+        let mut keys_request = Vec::new();
+        for key in key_value_operation
             .find_keys_by_prefix(&key_prefix)
             .await
             .unwrap()
             .iterator()
-            .count();
-        assert_eq!(n_ent, value);
+        {
+            let key: Vec<u8> = key.unwrap().to_vec();
+            keys_request.push(key);
+        }
+        let mut key_values_request = Vec::new();
+        for key_value in key_value_operation
+            .find_key_values_by_prefix(&key_prefix)
+            .await
+            .unwrap()
+            .iterator()
+        {
+            let key_value = key_value.unwrap();
+            key_values_request.push((key_value.0.to_vec(), key_value.1.to_vec()));
+        }
+        // Check length coherency
+        let len = keys_request.len();
+        let len_kv = key_values_request.len();
+        assert_eq!(len, len_kv);
+        // Check find_keys / find_key_values
+        for i in 0..len {
+            let key1 = keys_request[i].clone();
+            let key2 = key_values_request[i].clone().0;
+            println!("A : key1={:?}", key1);
+            println!("    key2={:?}", key2);
+            assert_eq!(key1, key2);
+        }
+        // Check key ordering
+        for i in 1..len {
+            let key1 = keys_request[i - 1].clone();
+            let key2 = keys_request[i].clone();
+            assert!(key1 < key2);
+        }
+        // Check the obtained values
+        let mut set_key_value1 = HashSet::<(Vec<u8>, Vec<u8>)>::new();
+        for key_value in key_values_request {
+            set_key_value1.insert((key_value.0.to_vec(), key_value.1.to_vec()));
+        }
+        let mut set_key_value2 = HashSet::new();
+        for key_value in &key_value_vec {
+            if key_value.0.starts_with(&key_prefix) {
+                let key = key_value.0[len_prefix..].to_vec();
+                let value = key_value.1.clone();
+                set_key_value2.insert((key, value));
+            }
+        }
+        assert_eq!(set_key_value1, set_key_value2);
+    }
+    // Now checking the read_multi_key_bytes
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    for _ in 0..10 {
+        let mut keys = Vec::new();
+        let mut values = Vec::new();
+        for key_value in &key_value_vec {
+            let thr = rng.gen_range(0..2);
+            if thr == 0 {
+                // Put a key that is already present
+                keys.push(key_value.0.clone());
+                values.push(Some(key_value.1.clone()));
+            } else {
+                // Put a missing key
+                let len = key_value.0.len();
+                let pos = rng.gen_range(0..len);
+                let byte = *key_value.0.get(pos).unwrap();
+                let new_byte: u8 = if byte < 255 { byte + 1 } else { byte - 1 };
+                let mut new_key = key_value.0.clone();
+                *new_key.get_mut(pos).unwrap() = new_byte;
+                if !set_keys.contains(&new_key) {
+                    keys.push(new_key);
+                    values.push(None);
+                }
+            }
+        }
+        let values_read = key_value_operation
+            .read_multi_key_bytes(keys)
+            .await
+            .unwrap();
+        assert_eq!(values, values_read);
     }
 }
 
 #[cfg(test)]
-async fn test_ordering_keys<OP: KeyValueStoreClient + Sync>(key_value_operation: OP) {
+async fn test_readings_random<OP: KeyValueStoreClient + Sync>(
+    key_value_operation: OP,
+    len_value: usize,
+) {
     let key_prefix = vec![0];
     let n = 1000;
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
-    let key_value_vec = get_random_key_value_vec_prefix(&mut rng, key_prefix.clone(), n);
-    test_ordering_keys_key_value_vec(key_value_operation, key_value_vec).await;
+    let key_value_vec =
+        get_random_key_value_vec_prefix(&mut rng, key_prefix.clone(), 8, len_value, n);
+    test_readings_vec(key_value_operation, key_value_vec).await;
 }
 
 #[tokio::test]
-async fn test_ordering_memory() {
-    let map = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = map.clone().lock_arc().await;
-    let key_value_operation = Arc::new(RwLock::new(guard));
-    test_ordering_keys(key_value_operation).await;
+async fn test_readings_memory() {
+    for len_value in [50, 1000] {
+        let key_value_operation = create_memory_test_client();
+        test_readings_random(key_value_operation, len_value).await;
+    }
 }
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
-async fn test_ordering_rocksdb() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let mut options = rocksdb::Options::default();
-    options.create_if_missing(true);
-    let key_value_operation = Arc::new(DB::open(&options, &dir).unwrap());
-    //
-    test_ordering_keys(key_value_operation).await;
+async fn test_readings_rocksdb() {
+    let key_value_operation = create_rocksdb_test_client();
+    test_readings_random(key_value_operation, 8).await;
 }
 
 #[cfg(feature = "aws")]
 #[tokio::test]
-async fn test_ordering_dynamodb() {
-    let localstack = LocalStackTestContext::new().await.unwrap();
-    let (key_value_operation, _) = DynamoDbClient::from_config(
-        localstack.dynamo_db_config(),
-        "test_table".parse().expect("Invalid table name"),
-        TEST_CACHE_SIZE,
-    )
-    .await
-    .unwrap();
-    //
-    test_ordering_keys(key_value_operation).await;
+async fn test_readings_dynamodb() {
+    let key_value_operation = create_dynamodb_test_client().await;
+    test_readings_random(key_value_operation, 8).await;
 }
 
 #[tokio::test]
-async fn test_ordering_key_value_store_view_memory() {
-    let map = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = map.clone().lock_arc().await;
-    let context = MemoryContext::new(guard, ());
+async fn test_readings_key_value_store_view_memory() {
+    let context = create_test_context();
     let key_value_operation = ViewContainer::new(context).await.unwrap();
-    test_ordering_keys(key_value_operation).await;
+    test_readings_random(key_value_operation, 8).await;
 }
 
 #[tokio::test]
-async fn test_ordering_memory_specific() {
+async fn test_readings_memory_specific() {
     let map = Arc::new(Mutex::new(BTreeMap::new()));
     let guard = map.clone().lock_arc().await;
     let key_value_operation = Arc::new(RwLock::new(guard));
@@ -139,5 +190,103 @@ async fn test_ordering_memory_specific() {
         (vec![0, 2], Vec::new()),
         (vec![0, 2, 0], Vec::new()),
     ];
-    test_ordering_keys_key_value_vec(key_value_operation, key_value_vec).await;
+    test_readings_vec(key_value_operation, key_value_vec).await;
+}
+
+#[cfg(test)]
+async fn test_writings_random<OP: KeyValueStoreClient + Sync>(key_value_operation: OP) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    let mut kv_state = BTreeMap::new();
+    let n_oper = 100;
+    let siz_batch = 10;
+    // key space has size 4^4 = 256 so we necessarily encounter collisions
+    let key_prefix = vec![0];
+    for _ in 0..n_oper {
+        let mut batch = Batch::new();
+        for _ in 0..siz_batch {
+            let thr = rng.gen_range(0..8);
+            // Inserting a key
+            if thr < 5 {
+                // Insert
+                let key = get_small_key_space(&mut rng, &key_prefix, 4);
+                let len_value = rng.gen_range(0..500); // Could need to be split
+                let value = get_random_byte_vector(&mut rng, &[], len_value);
+                batch.put_key_value_bytes(key.clone(), value.clone());
+                kv_state.insert(key, value);
+            }
+            if thr == 6 {
+                // key might be missing, no matter, it has to work
+                let key = get_small_key_space(&mut rng, &key_prefix, 4);
+                kv_state.remove(&key);
+                batch.delete_key(key);
+            }
+            if thr == 7 {
+                let len = rng.gen_range(1..4); // We want a non-trivial range
+                let delete_key_prefix = get_small_key_space(&mut rng, &key_prefix, len);
+                batch.delete_key_prefix(delete_key_prefix.clone());
+                let key_list = kv_state
+                    .range(get_interval(delete_key_prefix))
+                    .map(|x| x.0.to_vec())
+                    .collect::<Vec<_>>();
+                for key in key_list {
+                    kv_state.remove(&key);
+                }
+            }
+        }
+        key_value_operation.write_batch(batch, &[]).await.unwrap();
+        // Checking the consistency
+        let mut key_values = BTreeMap::new();
+        for key_value in key_value_operation
+            .find_key_values_by_prefix(&key_prefix)
+            .await
+            .unwrap()
+            .iterator()
+        {
+            let key_value = key_value.unwrap();
+            let mut key = key_prefix.clone();
+            key.extend(key_value.0);
+            key_values.insert(key, key_value.1.to_vec());
+        }
+        assert_eq!(key_values, kv_state);
+    }
+}
+
+#[tokio::test]
+async fn test_writings_memory() {
+    let key_value_operation = create_memory_test_client();
+    test_writings_random(key_value_operation).await;
+}
+
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn test_writings_rocksdb() {
+    let key_value_operation = create_rocksdb_test_client();
+    test_writings_random(key_value_operation).await;
+}
+
+#[cfg(feature = "aws")]
+#[tokio::test]
+async fn test_writings_dynamodb() {
+    let key_value_operation = create_dynamodb_test_client().await;
+    test_writings_random(key_value_operation).await;
+}
+
+#[tokio::test]
+async fn test_big_value_read_write() {
+    use rand::{distributions::Alphanumeric, Rng};
+    let context = create_test_context();
+    for count in [50, 1024] {
+        let rng = rand::rngs::StdRng::seed_from_u64(2);
+        let test_string = rng
+            .sample_iter(&Alphanumeric)
+            .take(count)
+            .map(char::from)
+            .collect::<String>();
+        let mut batch = Batch::new();
+        let key = vec![43, 23, 56];
+        batch.put_key_value(key.clone(), &test_string).unwrap();
+        context.db.write_batch(batch, &[]).await.unwrap();
+        let read_string = context.db.read_key::<String>(&key).await.unwrap().unwrap();
+        assert_eq!(read_string, test_string);
+    }
 }


### PR DESCRIPTION
This PR is a piece of the PR https://github.com/linera-io/linera-protocol/pull/769 that causes more problems than expected.

The improvements done in this PR are:
* The `KeyValueStoreClientBigValue` allows to deal with clients that do not support large values.
* The tests have been significantly improved.
* The construction of test contexts has been simplified.
* A trait `MAX_VALUE_SIZE` has been added to the `KeyValueStoreClient` so that we know what is the maximal size supported.
* Resolve one bug in the `simplify` code for batches.
* Resolve a bug in the dynamoDb code when the journal entry was kept after write.