### PR TITLE
Minor fixes and improvements for worker and chain manager.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -95,14 +95,14 @@ impl ChainTipState {
 
     /// Returns `true` if the validated block's height is below the tip height. Returns an error if
     /// it is higher than the tip.
-    pub fn already_validated_block(&self, new_block: &Block) -> Result<bool, ChainError> {
+    pub fn already_validated_block(&self, height: BlockHeight) -> Result<bool, ChainError> {
         ensure!(
-            self.next_block_height >= new_block.height,
+            self.next_block_height >= height,
             ChainError::MissingEarlierBlocks {
                 current_block_height: self.next_block_height,
             }
         );
-        Ok(self.next_block_height > new_block.height)
+        Ok(self.next_block_height > height)
     }
 }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -235,6 +235,11 @@ impl Vote {
             signature: self.signature,
         }
     }
+
+    /// Returns the value this vote is for.
+    pub fn value(&self) -> &CertificateValue {
+        self.value.inner()
+    }
 }
 
 /// A vote on a statement from a validator, represented as a `LiteValue`.
@@ -423,12 +428,11 @@ impl CertificateValue {
         if n == 0 {
             return None;
         }
+        let message_count = self.executed_block().messages.len();
         Some(MessageId {
             chain_id: self.chain_id(),
             height: self.height(),
-            index: u32::try_from(self.executed_block().messages.len())
-                .ok()?
-                .checked_sub(n)?,
+            index: u32::try_from(message_count).ok()?.checked_sub(n)?,
         })
     }
 

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -53,10 +53,11 @@ impl SingleOwnerManager {
             ChainError::InvalidBlockProposal
         );
         if let Some(vote) = &self.pending {
-            let block = match &vote.value.inner() {
+            let block = match vote.value() {
                 CertificateValue::ConfirmedBlock { executed_block, .. } => &executed_block.block,
-                CertificateValue::ValidatedBlock { .. } => {
-                    return Err(ChainError::InvalidBlockProposal)
+                value => {
+                    let msg = format!("Unexpected value: {:?}", value);
+                    return Err(ChainError::InternalError(msg));
                 }
             };
             if block == new_block {

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -28,7 +28,7 @@ use linera_storage::Store;
 use linera_views::views::ViewError;
 use rand::prelude::SliceRandom;
 use serde::{Deserialize, Serialize};
-use std::{pin::Pin, sync::Arc};
+use std::{borrow::Cow, pin::Pin, sync::Arc};
 use thiserror::Error;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -503,7 +503,7 @@ where
         let mut node = self.node.lock().await;
         for result in results {
             if let Some(blob) = result? {
-                node.state.cache_recent_value(&blob).await;
+                node.state.cache_recent_value(Cow::Borrowed(&blob)).await;
                 blobs.push(blob);
             }
         }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -443,17 +443,21 @@ where
         .execute_operation(Operation::user(application_id, &transfer)?)
         .await?;
 
-    assert!(cert
-        .value()
-        .messages()
-        .iter()
-        .any(|OutgoingMessage { destination, message, .. }| {
+    assert!(cert.value().messages().iter().any(
+        |OutgoingMessage {
+             destination,
+             message,
+             ..
+         }| {
             matches!(
-                message,
-                Message::System(SystemMessage::RegisterApplications { applications })
-                if matches!(applications[0], UserApplicationDescription{ bytecode_id: b_id, .. } if b_id == bytecode_id.forget_abi())
+                message, Message::System(SystemMessage::RegisterApplications { applications })
+                if matches!(
+                    applications[0], UserApplicationDescription{ bytecode_id: b_id, .. }
+                    if b_id == bytecode_id.forget_abi()
+                )
             ) && *destination == Destination::Recipient(receiver.chain_id())
-        }));
+        }
+    ));
     receiver.synchronize_from_validators().await.unwrap();
     receiver.receive_certificate(cert).await.unwrap();
     let certs = receiver.process_inbox().await.unwrap();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -23,7 +23,7 @@ use linera_chain::{
         ExecutedBlock, HashedValue, IncomingMessage, LiteVote, Medium, Origin, OutgoingMessage,
         SignatureAggregator,
     },
-    ChainError,
+    ChainError, ChainManager,
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
@@ -2329,13 +2329,10 @@ where
             *recipient_chain.execution_state.system.balance.get(),
             Amount::from_tokens(4)
         );
-        assert_eq!(
-            recipient_chain
-                .manager
-                .get()
-                .verify_owner(&recipient_key_pair.public().into()),
-            Some(recipient_key_pair.public())
-        );
+        assert!(matches!(
+            recipient_chain.manager.get(),
+            ChainManager::Single(single) if single.owner == recipient_key_pair.public().into()
+        ));
         assert_eq!(recipient_chain.confirmed_log.count(), 1);
         assert_eq!(
             recipient_chain.tip_state.get().block_hash,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -629,15 +629,17 @@ where
             }
         );
         certificate.check(committee)?;
-        if chain.tip_state.get().already_validated_block(block)?
+        if chain
+            .tip_state
+            .get()
+            .already_validated_block(block.height)?
             || chain
                 .manager
                 .get_mut()
                 .check_validated_block(block, certificate.round)?
                 == ChainManagerOutcome::Skip
         {
-            // If we just processed the same pending block, return the chain info
-            // unchanged.
+            // If we just processed the same pending block, return the chain info unchanged.
             return Ok(ChainInfoResponse::new(&chain, self.key_pair()));
         }
         chain

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -308,7 +308,7 @@ impl ClientContext {
         let mut done_senders = HashSet::new();
         for vote in votes {
             // We aggregate votes indexed by sender.
-            let chain_id = vote.value.inner().chain_id();
+            let chain_id = vote.value().chain_id();
             if done_senders.contains(&chain_id) {
                 continue;
             }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -363,7 +363,7 @@ where
         certificate: &Certificate,
         batch: &mut Batch,
     ) -> Result<(), ViewError> {
-        let id = certificate.value.inner().chain_id().to_string();
+        let id = certificate.value().chain_id().to_string();
         increment_counter!(WRITE_CERTIFICATE_COUNTER, &[("chain_id", id)]);
         let hash = certificate.hash();
         let cert_key = bcs::to_bytes(&BaseKey::Certificate(hash))?;


### PR DESCRIPTION
This is in preparation for public chains, but makes sense on its own:

* `already_validated_block` only needs the height, not the whole block, and will need to be applied to leader timeouts as well, which won't contain an actual block.
* The pending block in the single owner manager is always a confirmed block. This would be an `InternalError` (should actually be unreachable), not an invalid proposal.
* `cache_recent_value` now takes a `Cow`, to avoid unnecessarily cloning a certificate that's already cached.
* Some other minor changes, like a `Vote::value` getter, a `rustfmt` fix, and a stricter `assert!`.