### PR TITLE
Better Node Service errors

### DIFF
--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -37,6 +37,7 @@ use linera_execution::{
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
+use serde_json::json;
 use std::{net::SocketAddr, num::NonZeroU16, sync::Arc};
 use thiserror::Error as ThisError;
 use tower_http::cors::CorsLayer;
@@ -106,6 +107,7 @@ impl IntoResponse for NodeServiceError {
             | NodeServiceError::UnsupportedQueryType => (StatusCode::BAD_REQUEST, self.to_string()),
             NodeServiceError::GraphQLParseError { error } => (StatusCode::BAD_REQUEST, error),
         };
+        let tuple = (tuple.0, json!({"error": tuple.1}).to_string());
         tuple.into_response()
     }
 }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -41,7 +41,7 @@ use serde_json::json;
 use std::{net::SocketAddr, num::NonZeroU16, sync::Arc};
 use thiserror::Error as ThisError;
 use tower_http::cors::CorsLayer;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 /// Our root GraphQL query type.
 struct QueryRoot<P, S> {
@@ -580,7 +580,9 @@ where
         application_id: UserApplicationId,
         request: &Request,
     ) -> Result<async_graphql::Response, NodeServiceError> {
+        debug!("Request: {:?}", &request);
         let graphql_response = self.user_application_query(application_id, request).await?;
+        debug!("Response: {:?}", &graphql_response);
         let bcs_bytes_list = bytes_from_response(graphql_response.data);
         if bcs_bytes_list.is_empty() {
             return Err(NodeServiceError::MalformedApplicationResponse);


### PR DESCRIPTION
# Motivation

Node service errors have two issues:
1. Errors returned by an application's service were not being captured (this could be a parsing error for example).
2. Errors were not correct JSON and therefore were not being parsed correctly by GraphiQL.