### PR TITLE
linera-views: Add module to support splitting large values across multiple keys

### DIFF
--- a/linera-sdk/src/test/unit/mod.rs
+++ b/linera-sdk/src/test/unit/mod.rs
@@ -78,7 +78,7 @@ pub fn mock_application_state(state: impl Into<Option<Vec<u8>>>) {
 
 /// Initializes and returns a view context for using as the mocked key-value store.
 pub fn mock_key_value_store() -> MemoryContext<()> {
-    let store = linera_views::memory::create_test_context();
+    let store = linera_views::memory::create_memory_context();
     unsafe { MOCK_KEY_VALUE_STORE = Some(store.clone()) };
     store
 }

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -31,6 +31,9 @@ impl KeyValueStore {
 #[async_trait]
 impl KeyValueStoreClient for KeyValueStore {
     const MAX_CONNECTIONS: usize = 1;
+    // The KeyValueStoreClient of the system_api does not have limits
+    // on the size of its values.
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = ViewError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -38,6 +38,7 @@ use linera_execution::{
 use linera_views::{
     batch::Batch,
     common::{Context, ContextFromDb, KeyValueStoreClient},
+    value_splitting::DatabaseConsistencyError,
     views::{CryptoHashView, RootView, View, ViewError},
 };
 use metrics::increment_counter;
@@ -260,7 +261,8 @@ impl<CL> Store for DbStoreClient<CL>
 where
     CL: KeyValueStoreClient + Clone + Send + Sync + 'static,
     ViewError: From<<CL as KeyValueStoreClient>::Error>,
-    <CL as KeyValueStoreClient>::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
+    <CL as KeyValueStoreClient>::Error:
+        From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     type Context = ContextFromDb<ChainRuntimeContext<Self>, CL>;
     type ContextError = <CL as KeyValueStoreClient>::Error;

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -3,7 +3,7 @@
 
 use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient};
 use linera_execution::WasmRuntime;
-use linera_views::memory::{create_test_memory_client, MemoryClient};
+use linera_views::memory::{create_memory_client, MemoryClient};
 use std::sync::Arc;
 
 type MemoryStore = DbStore<MemoryClient>;
@@ -20,7 +20,7 @@ impl MemoryStoreClient {
 
 impl MemoryStore {
     pub fn new(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let client = create_test_memory_client();
+        let client = create_memory_client();
         Self {
             client,
             guards: ChainGuards::default(),

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -1,0 +1,140 @@
+This document collects some design choices that were made in the `linera-views`.
+For an overview, see `README.md`.
+
+# Design
+
+## Key Value Store Clients
+
+We have designed a `KeyValueStoreClient` trait that represents the basic functionalities
+of a key-value store whose keys are `Vec<u8>` and whose values are `Vec<u8>`.
+
+We provide an implementation of the trait `KeyValueStoreClient` for the following key-value stores:
+* `MemoryClient` is using the memory (and uses internally a simple B-Tree map).
+* `RocksdbClient` is a disk-based key-value store
+* `DynamoDbClient` is the AWS-based DynamoDB service.
+
+The trait `KeyValueStoreClient` was designed so that more storage solutions can be easily added in the future.
+
+The `KeyValueStoreClient` trait is also implemented for several internal constructions of clients:
+* The `LruCachingKeyValueClient<K>` client implements the Least Recently Used (LRU)
+caching of reads into the client.
+* The `ViewContainer<C>` client implements a key-value store client from a context.
+* The `ValueSplittingKeyValueStoreClient<K>` implements a client for which the
+size of the values is unbounded, on top of another client for which it is bounded.
+(Some databases have strict limitations on the value size.)
+
+## Views
+
+A view is a container that mimics some of the properties of classic containers such
+as `VecDeque`, `BTreeMap`, etc. with the following goals:
+* The data structure can be written to the key-value store and loaded from there.
+* The changes are first done in memory and accessed there. The changes can be committed
+to the key-value store client when adequate.
+
+There are various views corresponding to several use cases. All of those are
+implemented by mapping the values in their specific types to their serializations.
+
+## Allowed keys, base key and prefixes
+
+The keys are constructed step by step from the prefix to the full key. So, whenever
+we have a view or any other object then we have a `base_key` associated with it and
+with no other objects. A view is associated to many keys, all of whom share the same
+`base_key` as prefix.
+This leads us to introduce a trait `Context` that can be implemented with a specific
+`KeyValueStoreClient` client and a `base_key`.
+
+Another issue to consider is that we do not want to just store the values, but we
+also need to accommodate other features:
+* Administrative data (like journal) need to store some data starting from the `base_key`.
+* Some of the values need to be split into several smaller values.
+
+The rules for constructing keys are the following:
+* For the construction of `struct` objects of associated base key `base_key` we do the
+following: If the corresponding type has entries `entry_0`, ..., `entry_k` then the
+base key of the object associated with the `k`-th entry is `[base_key * * * *]` with `[* * * *]`
+the serialization of the number `k` considered as a `u32`.
+* For each view type, we have some associated data. Some are the hash, others the counts
+(e.g. for `LogView` and `QueueView`) and some the index. The corresponding enum is
+named `KeyTag` for each of those containers. For the index, the values are serialized.
+* For a given base key `base_key` the keys of the form `[base_key tag]` with tags in
+`0..MIN_VIEW_TAG` are reserved for administrative data.
+
+These constructions are done in order to satisfy the following property: The set of keys
+of a view is prefix-free. That is if a key is of the form `key = [a b]` then `a` is
+not a key. This property is important for other functionalities.
+If the user is using a single view then for whatever `base_key` is chosen, the set of keys
+created will be prefix-free. If several views are created then their base keys must be
+chosen to be prefix-free so that the whole set of keys is prefix-free.
+
+## API of the `KeyValueStoreClient`
+
+The design of the key-value store client is done in the following way:
+* We can put a `(key, value)` and delete a `key`.
+* We can delete keys having a specific prefix.
+* We can retrieve the list of keys having a specific prefix. Similarly, we can
+retrieve the list of `(key, value)` whose keys have a specific prefix.
+* Also, the list of the keys are provided in the lexicographic order.
+
+## Journaling
+
+We want to make sure that all operations are done on the database in an atomic
+way. That is the operations have to be processed completely. The idea is to
+store the journal in the `[base_key 0 * * * *]` keys with `[* * * *]` the
+serialization of an `u32` entry.
+Those keys are not colliding with the other keys since their value is of the
+form `[base_key tag *]` with `tag >= MIN_VIEW_TAG` and currently, we have
+`MIN_VIEW_TAG = 1`.
+
+The journaling allows to have operations in an atomic way. It is done in the
+following way:
+* When a `Batch` of operations needs to be processed, the operations are written
+into blocks that can be processed atomically. All together the blocks for the
+"journal". When the journal has been written then the counter is written and
+only at that point is the journal considered written.
+* Each block is then processed atomically. If an interruption occurs then
+the block entries would be processed after accessing the database the next time.
+
+## Splitting large values across keys
+
+Some key-value store clients limit the size of the values (named `MAX_VALUE_SIZE`
+in the code). `ValueSplittingKeyValueStoreClient` is a wrapper that accepts values
+of any size. Internally, it splits them into smaller pieces and stores them
+using a wrapped, possibly size-limited, client.
+
+The built key-value store client has `MAX_VALUE_SIZE` set to its maximum possible
+value. This forces us to split the value into several smaller values. One key
+such example is `DynamoDb` which has a limit of 400kB on its value size.
+
+Design is the following:
+* For every `key` we build several corresponding keys `[key * * * *]` that contain
+each a piece of the full value.
+The `[* * * *]` is the serialization of the index which is `u32` so that
+the order of the serialization is the same as the order of the `u32` entries.
+* For the first key, that is `[key 0 0 0 0]` the corresponding value is `[* * * * value_0]`
+with `[* * * *]` being the serialization of the `u32` count of the number of blocks
+and `value_0` the first block of the value. For the other keys `[key * * * *]` the
+corresponding value is `value_k` with `value_k` the k-th entry in the value. The full
+value is reconstructed as `value = [value_0 value_1 .... value_N]`
+The number of blocks is always non-zero, even if the value is empty.
+
+The effective working of the system relies on several design choices.
+* In `find_keys_by_prefix` and similar, the keys are
+returned in lexicographic order.
+* The count and indices are serialized as `u32` and the serialization is done
+so that the `u32` ordering is the same as the lexicographic ordering. So, we
+get first the first key (and so the count) and then the segment keys one by
+one in the correct order.
+* Suppose that we have written a `(key, value_1)` with several segments and then
+we replace by a `(key, value_2)` which has fewer segments.
+Our choice is to leave the old segments in the database. Same with delete:
+we just delete the first key.
+* We avoid the overflowing of the system by the following trick: When we delete
+a view, we do a delete by prefix, which thus deletes the old segments if present.
+* In order to delete all the unused segments when overwriting a value, every write
+would need to have a read just before which is expensive.
+
+A key difficulty of this modelization is that we are using prefixes extensively
+and so by adding the index of the form `[* * * *]` we are potentially creating
+some collisions. That is if we delete a key of the form `[key 0 0]` we would
+also delete segments of the key of the form `key`. However, this cannot happen
+because the set of keys is prefix-free.

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -5,6 +5,50 @@ key-value store. The central notion is a [`views::View`](https://docs.rs/linera-
 be loaded from storage, modified in memory, then committed (i.e. the changes are
 atomically persisted in storage).
 
+The package provides essentially two functionalities:
+* An abstraction to access databases.
+* Several containers named views for storing data modeled on classical ones.
+
+See `DESIGN.md` for more details.
+
+## The supported databases.
+
+The databases supported are of the NoSQL variety and they are key-value stores.
+
+We provide support for the following databases:
+* `MemoryClient` is using the memory
+* `RocksdbClient` is a disk-based key-value store
+* `DynamoDbClient` is the AWS-based DynamoDB service.
+
+The corresponding type in the code is the `KeyValueStoreClient`.
+A context is the combination of a client and a path (named `base_key` which is
+of type `Vec<u8>`).
+
+## Views.
+
+A view is a container whose data lies in one of the above-mentioned databases.
+When the container is modified the modification lies first in the view before
+being committed to the database. In technical terms, a view implements the trait `View`.
+
+The specific functionalities of the trait `View` are the following:
+* `load` for loading the view from a specific context.
+* `rollback` for canceling all modifications that were not committed thus far.
+* `clear` for clearing the view, in other words for reverting it to its default state.
+* `flush` for persisting the changes to storage.
+* `delete` for deleting the changes from the database.
+
+The following views implement the `View` trait:
+* `RegisterView` implements the storing of a single data.
+* `LogView` implements a log, which is a list of entries that can be expanded.
+* `QueueView` implements a queue, which is a list of entries that can be expanded and reduced.
+* `MapView` implements a map with keys and values.
+* `SetView` implements a set with keys.
+* `CollectionView` implements a map whose values are views themselves.
+* `ReentrantCollectionView` implements a map for which different keys can be accessed independently.
+* `ViewContainer<C>` implements a `KeyValueStoreClient` and is used internally.
+
+The `LogView` can be seen as an analog of `VecDeque` while `MapView` is an analog of `BTreeMap`.
+
 <!-- cargo-rdme end -->
 
 ## Contributing

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -229,8 +229,8 @@ impl Batch {
 
     /// check the size of the values of the batch.
     pub fn check_value_size(&self, max_value_size: usize) -> bool {
-        for ent in &self.operations {
-            if let WriteOperation::Put { key: _, value } = ent {
+        for operation in &self.operations {
+            if let WriteOperation::Put { key: _, value } = operation {
                 if value.len() > max_value_size {
                     return false;
                 }

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -227,6 +227,18 @@ impl Batch {
         }
     }
 
+    /// check the size of the values of the batch.
+    pub fn check_value_size(&self, max_value_size: usize) -> bool {
+        for ent in &self.operations {
+            if let WriteOperation::Put { key: _, value } = ent {
+                if value.len() > max_value_size {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
     /// Adds the insertion of a `(key,value)` pair into the batch with a serializable value.
     /// ```rust
     /// # use linera_views::batch::Batch;
@@ -307,7 +319,7 @@ impl DeletePrefixExpander for MemoryContext<()> {
 
 #[cfg(test)]
 mod tests {
-    use linera_views::{batch::Batch, common::Context, memory::create_test_context};
+    use linera_views::{batch::Batch, common::Context, memory::create_memory_context};
 
     #[test]
     fn test_simplify_batch1() {
@@ -363,7 +375,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simplify_batch5() {
-        let context = create_test_context();
+        let context = create_memory_context();
         let mut batch = Batch::new();
         batch.put_key_value_bytes(vec![1, 2, 3], vec![]);
         batch.put_key_value_bytes(vec![1, 2, 4], vec![]);

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -162,11 +162,11 @@ where
     /// at that index was absent or had not been assigned then the default value is provided.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(vec![0, 1]).await.unwrap();
     ///   let value = subview.get();
@@ -182,11 +182,11 @@ where
     /// was removed before or it was absent then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
     ///   let subview = view.load_entry(vec![0, 1]).await.unwrap();
@@ -202,11 +202,11 @@ where
     /// already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry(vec![0, 1]).await.unwrap();
     ///   let value = subview.get();
@@ -262,11 +262,11 @@ where
     /// Resets an entry to the default value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(vec![0, 1]).await.unwrap();
     ///   let value = subview.get_mut();
@@ -287,11 +287,11 @@ where
     /// Marks the entry as removed. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(vec![0, 1]).await.unwrap();
     ///   let value = subview.get_mut();
@@ -362,11 +362,11 @@ where
     /// ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
     ///   view.load_entry_mut(vec![0, 2]).await.unwrap();
@@ -427,11 +427,11 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
     ///   view.load_entry_mut(vec![0, 2]).await.unwrap();
@@ -457,11 +457,11 @@ where
     /// Returns the list of keys in the collection. The order is lexicographic.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
     ///   view.load_entry_mut(vec![0, 2]).await.unwrap();
@@ -589,11 +589,11 @@ where
     /// was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -613,11 +613,11 @@ where
     /// was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   let subview = view.load_entry(&23).await.unwrap();
@@ -638,11 +638,11 @@ where
     /// already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry(&23).await.unwrap();
     ///   let value = subview.get();
@@ -661,11 +661,11 @@ where
     /// Resets an entry to the default value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -688,11 +688,11 @@ where
     /// Removes an entry from the CollectionView. If absent nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -729,11 +729,11 @@ where
     /// the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&25).await.unwrap();
@@ -764,11 +764,11 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&24).await.unwrap();
@@ -797,11 +797,11 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&28).await.unwrap();
@@ -901,11 +901,11 @@ where
     /// was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -925,11 +925,11 @@ where
     /// was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   let subview = view.load_entry(&23).await.unwrap();
@@ -950,11 +950,11 @@ where
     /// already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry(&23).await.unwrap();
     ///   let value = subview.get();
@@ -973,11 +973,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -1000,11 +1000,11 @@ where
     /// Removes an entry from the CollectionView. If absent nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -1040,11 +1040,11 @@ where
     /// Returns the list of indices in the collection in the order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&25).await.unwrap();
@@ -1075,11 +1075,11 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&28).await.unwrap();
     ///   view.load_entry_mut(&24).await.unwrap();
@@ -1109,11 +1109,11 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&28).await.unwrap();
     ///   view.load_entry_mut(&24).await.unwrap();

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -113,8 +113,11 @@ pub trait KeyValueIterable<Error> {
 /// Low-level, asynchronous key-value operations. Useful for storage APIs not based on views.
 #[async_trait]
 pub trait KeyValueStoreClient {
-    /// Maximum number of simultaneous connections
+    /// Maximum number of simultaneous connections.
     const MAX_CONNECTIONS: usize;
+
+    /// The maximal size of values that can be stored.
+    const MAX_VALUE_SIZE: usize;
 
     /// The error type.
     type Error: Debug;
@@ -258,6 +261,9 @@ impl<E> KeyValueIterable<E> for Vec<(Vec<u8>, Vec<u8>)> {
 pub trait Context {
     /// Maximum number of simultaneous connections
     const MAX_CONNECTIONS: usize;
+
+    /// The maximal size of values that can be stored.
+    const MAX_VALUE_SIZE: usize;
 
     /// User-provided data to be carried along.
     type Extra: Clone + Send + Sync;
@@ -445,6 +451,7 @@ where
     ViewError: From<DB::Error>,
 {
     const MAX_CONNECTIONS: usize = DB::MAX_CONNECTIONS;
+    const MAX_VALUE_SIZE: usize = DB::MAX_VALUE_SIZE;
     type Extra = E;
     type Error = DB::Error;
     type Keys = DB::Keys;

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -45,7 +45,7 @@ enum KeyTag {
     Hash,
 }
 
-/// A view that represents the function of KeyValueStoreClient (though not KeyValueStoreClient).
+/// A view that represents the functions of KeyValueStoreClient (though not KeyValueStoreClient).
 ///
 /// Comment on the data set:
 /// In order to work, the view needs to store the updates and deleted_prefixes.
@@ -158,10 +158,10 @@ where
     /// false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]);
     ///   view.insert(vec![0,2], vec![0]);
@@ -227,10 +227,10 @@ where
     /// Applies the function f over all indices.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]);
     ///   view.insert(vec![0,2], vec![0]);
@@ -258,10 +258,10 @@ where
     /// If the function f returns false then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]);
     ///   view.insert(vec![0,2], vec![0]);
@@ -326,10 +326,10 @@ where
     /// Applies the function f over all index/value pairs.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]);
     ///   view.insert(vec![0,2], vec![0]);
@@ -355,10 +355,10 @@ where
     /// Returns the list of indices in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]);
     ///   view.insert(vec![0,2], vec![0]);
@@ -379,10 +379,10 @@ where
     /// Obtains the value at the given index, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]);
     ///   assert_eq!(view.get(&[0,1]).await.unwrap(), Some(vec![42]));
@@ -408,10 +408,10 @@ where
     /// Obtains the values of a range of indices
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]);
     ///   assert_eq!(view.multi_get(vec![vec![0,1], vec![0,2]]).await.unwrap(), vec![Some(vec![42]), None]);
@@ -450,10 +450,10 @@ where
     /// Sets or inserts a value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]);
     ///   assert_eq!(view.get(&[0,1]).await.unwrap(), Some(vec![34]));
@@ -467,10 +467,10 @@ where
     /// Removes a value. If absent then the action has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]);
     ///   view.remove(vec![0,1]);
@@ -513,10 +513,10 @@ where
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]);
     ///   view.insert(vec![3,4], vec![42]);
@@ -579,10 +579,10 @@ where
     /// prefix is not included in the returned keys.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]);
     ///   view.insert(vec![3,4], vec![42]);
@@ -648,11 +648,11 @@ where
     /// Applies the given batch of `crate::common::WriteOperation`.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::batch::Batch;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]);
     ///   view.insert(vec![3,4], vec![42]);
@@ -749,6 +749,7 @@ where
     ViewError: From<C::Error>,
 {
     const MAX_CONNECTIONS: usize = C::MAX_CONNECTIONS;
+    const MAX_VALUE_SIZE: usize = C::MAX_VALUE_SIZE;
     type Error = ViewError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -120,10 +120,10 @@ where
     /// Pushes a value to the end of the log.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     /// # })
@@ -136,10 +136,10 @@ where
     /// Reads the size of the log.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   log.push(42);
@@ -169,10 +169,10 @@ where
     /// Reads the logged value with the given index (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   assert_eq!(log.get(0).await.unwrap(), Some(34));
@@ -193,10 +193,10 @@ where
     /// Reads several logged keys (including staged ones)
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   log.push(42);
@@ -252,10 +252,10 @@ where
     /// Reads the logged values in the given range (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   log.push(42);

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -95,6 +95,8 @@ where
     K: KeyValueStoreClient + Send + Sync,
 {
     const MAX_CONNECTIONS: usize = K::MAX_CONNECTIONS;
+    // The LRU cache does not change the underlying client's size limit.
+    const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
     type Error = K::Error;
     type Keys = K::Keys;
     type KeyValues = K::KeyValues;
@@ -232,7 +234,7 @@ impl<E> LruCachingMemoryContext<E> {
         extra: E,
         n: usize,
     ) -> Result<Self, ViewError> {
-        let client = MemoryClient::new(guard.into());
+        let client = MemoryClient::new(guard);
         let lru_client = LruCachingKeyValueClient::new(client, n);
         Ok(Self {
             db: lru_client,

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -126,10 +126,10 @@ where
     /// Inserts or resets the value of a key of the map.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   assert_eq!(map.keys().await.unwrap(), vec![vec![0,1]]);
@@ -143,10 +143,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], "Hello");
     ///   map.remove(vec![0,1]);
@@ -176,10 +176,10 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   assert_eq!(map.get(vec![0,1]).await.unwrap(), Some(String::from("Hello")));
@@ -215,10 +215,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   let value = map.get_mut(vec![0,1]).await.unwrap().unwrap();
@@ -251,10 +251,10 @@ where
     /// the loop exits
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -315,10 +315,10 @@ where
     /// in the lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   let mut count = 0;
@@ -343,10 +343,10 @@ where
     /// Returns the list of keys of the map in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -369,10 +369,10 @@ where
     /// ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -440,10 +440,10 @@ where
     /// in the lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   let mut count = 0;
@@ -490,10 +490,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   assert_eq!(map.get_mut_or_default(vec![7]).await.unwrap(), "");
@@ -618,10 +618,10 @@ where
     /// Inserts or resets a value at an index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_,u32,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&(24 as u32), String::from("Hello"));
     ///   assert_eq!(map.get(&(24 as u32)).await.unwrap(), Some(String::from("Hello")));
@@ -640,10 +640,10 @@ where
     /// Removes a value. If absent then the operation does nothing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = MapView::<_,u32,String>::load(context).await.unwrap();
     ///   map.remove(&(37 as u32));
     ///   assert_eq!(map.get(&(37 as u32)).await.unwrap(), None);
@@ -675,10 +675,10 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_, u32,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&(37 as u32), String::from("Hello"));
     ///   assert_eq!(map.get(&(37 as u32)).await.unwrap(), Some(String::from("Hello")));
@@ -697,10 +697,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView::<_,u32,String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(37 as u32), String::from("Hello"));
     ///   assert_eq!(map.get_mut(&(34 as u32)).await.unwrap(), None);
@@ -729,10 +729,10 @@ where
     /// Returns the list of indices in the map. The order is determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView::<_,u32,String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(37 as u32), String::from("Hello"));
     ///   assert_eq!(map.indices().await.unwrap(), vec![37 as u32]);
@@ -753,10 +753,10 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_, u128, String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Thanks"));
     ///   map.insert(&(37 as u128), String::from("Spasiba"));
@@ -786,10 +786,10 @@ where
     /// determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_, u128, String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   let mut count = 0;
@@ -818,10 +818,10 @@ where
     /// If the function returns false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_, u128, String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Thanks"));
     ///   map.insert(&(37 as u128), String::from("Spasiba"));
@@ -852,10 +852,10 @@ where
     /// visited in an order determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_,Vec<u8>,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&vec![0,1], String::from("Hello"));
     ///   let mut count = 0;
@@ -892,10 +892,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_,u32,u128> = MapView::load(context).await.unwrap();
     ///   let value = map.get_mut_or_default(&(34 as u32)).await.unwrap();
     ///   assert_eq!(*value, 0 as u128);
@@ -983,10 +983,10 @@ where
     /// Insert or resets a value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView<_,u128,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&(24 as u128), String::from("Hello"));
     ///   assert_eq!(map.get(&(24 as u128)).await.unwrap(), Some(String::from("Hello")));
@@ -1005,10 +1005,10 @@ where
     /// Removes a value. If absent then this does not do anything.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = MapView::<_,u128,String>::load(context).await.unwrap();
     ///   map.remove(&(37 as u128));
     ///   assert_eq!(map.get(&(37 as u128)).await.unwrap(), None);
@@ -1040,11 +1040,11 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::memory::MemoryContext;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : CustomMapView<MemoryContext<()>, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   assert_eq!(map.get(&(34 as u128)).await.unwrap(), Some(String::from("Hello")));
@@ -1062,10 +1062,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   let value = map.get_mut(&(34 as u128)).await.unwrap().unwrap();
@@ -1094,10 +1094,10 @@ where
     /// by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : MapView::<_,u128,String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Bonjour"));
@@ -1119,10 +1119,10 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1151,10 +1151,10 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1184,10 +1184,10 @@ where
     /// If the function returns false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map = CustomMapView::<_,u128,String>::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1217,10 +1217,10 @@ where
     /// visited in an order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1258,10 +1258,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut map : CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   assert_eq!(*map.get_mut_or_default(&(34 as u128)).await.unwrap(), String::new());
     /// # })

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -4,6 +4,7 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{get_interval, ContextFromDb, KeyValueStoreClient},
+    value_splitting::DatabaseConsistencyError,
     views::ViewError,
 };
 use async_lock::{Mutex, MutexGuardArc, RwLock};
@@ -16,49 +17,21 @@ use thiserror::Error;
 pub type MemoryStoreMap = BTreeMap<Vec<u8>, Vec<u8>>;
 
 /// A virtual DB client where data are persisted in memory.
-pub type MemoryClient = Arc<RwLock<MutexGuardArc<MemoryStoreMap>>>;
-
-/// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type MemoryContext<E> = ContextFromDb<E, MemoryClient>;
-
-impl<E> MemoryContext<E> {
-    /// Creates a [`MemoryContext`].
-    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
-        Self {
-            db: Arc::new(RwLock::new(guard)),
-            base_key: Vec::new(),
-            extra,
-        }
-    }
-}
-
-/// Provides a `MemoryContext<()>` that can be used for tests.
-pub fn create_test_context() -> MemoryContext<()> {
-    let state = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = state
-        .try_lock_arc()
-        .expect("We should acquire the lock just after creating the object");
-    MemoryContext::new(guard, ())
-}
-
-/// Creates a test memory client.
-pub fn create_test_memory_client() -> MemoryClient {
-    let state = Arc::new(Mutex::new(BTreeMap::new()));
-    let guard = state
-        .try_lock_arc()
-        .expect("We should acquire the lock just after creating the object");
-    Arc::new(RwLock::new(guard))
+#[derive(Clone)]
+pub struct MemoryClient {
+    map: Arc<RwLock<MutexGuardArc<MemoryStoreMap>>>,
 }
 
 #[async_trait]
 impl KeyValueStoreClient for MemoryClient {
     const MAX_CONNECTIONS: usize = 1;
+    const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
-        let map = self.read().await;
+        let map = self.map.read().await;
         Ok(map.get(key).cloned())
     }
 
@@ -66,7 +39,7 @@ impl KeyValueStoreClient for MemoryClient {
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {
-        let map = self.read().await;
+        let map = self.map.read().await;
         let mut result = Vec::new();
         for key in keys {
             result.push(map.get(&key).cloned());
@@ -77,8 +50,8 @@ impl KeyValueStoreClient for MemoryClient {
     async fn find_keys_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::Keys, MemoryContextError> {
-        let map = self.read().await;
+    ) -> Result<Vec<Vec<u8>>, MemoryContextError> {
+        let map = self.map.read().await;
         let mut values = Vec::new();
         let len = key_prefix.len();
         for (key, _value) in map.range(get_interval(key_prefix.to_vec())) {
@@ -90,8 +63,8 @@ impl KeyValueStoreClient for MemoryClient {
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, MemoryContextError> {
-        let map = self.read().await;
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, MemoryContextError> {
+        let map = self.map.read().await;
         let mut key_values = Vec::new();
         let len = key_prefix.len();
         for (key, value) in map.range(get_interval(key_prefix.to_vec())) {
@@ -102,7 +75,7 @@ impl KeyValueStoreClient for MemoryClient {
     }
 
     async fn write_batch(&self, batch: Batch, _base_key: &[u8]) -> Result<(), MemoryContextError> {
-        let mut map = self.write().await;
+        let mut map = self.map.write().await;
         for ent in batch.operations {
             match ent {
                 WriteOperation::Put { key, value } => {
@@ -125,9 +98,53 @@ impl KeyValueStoreClient for MemoryClient {
         Ok(())
     }
 
-    async fn clear_journal(&self, _base_key: &[u8]) -> Result<(), Self::Error> {
+    async fn clear_journal(&self, _base_key: &[u8]) -> Result<(), MemoryContextError> {
         Ok(())
     }
+}
+
+impl MemoryClient {
+    /// constructor of MemoryClient
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>) -> Self {
+        let map = Arc::new(RwLock::new(guard));
+        MemoryClient { map }
+    }
+}
+
+/// An implementation of [`crate::common::Context`] that stores all values in memory.
+pub type MemoryContext<E> = ContextFromDb<E, MemoryClient>;
+
+impl<E> MemoryContext<E> {
+    /// Creates a [`MemoryContext`].
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
+        let db = MemoryClient::new(guard);
+        let base_key = Vec::new();
+        Self {
+            db,
+            base_key,
+            extra,
+        }
+    }
+}
+
+/// Provides a `MemoryContext<()>` that can be used for tests.
+/// It is not named create_memory_test_context because it is massively
+/// used and so we want to have a short name.
+pub fn create_memory_context() -> MemoryContext<()> {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryContext::new(guard, ())
+}
+
+/// Creates a test memory client for working.
+pub fn create_memory_client() -> MemoryClient {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    MemoryClient::new(guard)
 }
 
 /// The error type for [`MemoryContext`].
@@ -136,6 +153,14 @@ pub enum MemoryContextError {
     /// Serialization error with BCS.
     #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
+
+    /// The value is too large for the MemoryClient
+    #[error("The value is too large for the MemoryClient")]
+    TooLargeValue,
+
+    /// The database is not consistent
+    #[error(transparent)]
+    DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
 impl From<MemoryContextError> for ViewError {

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -154,10 +154,10 @@ where
     /// Reads the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -177,10 +177,10 @@ where
     /// Reads the back value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -198,10 +198,10 @@ where
     /// Deletes the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34 as u128);
     ///   queue.delete_front();
@@ -220,10 +220,10 @@ where
     /// Pushes a value to the end of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(37);
@@ -238,10 +238,10 @@ where
     /// Reads the size of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   assert_eq!(queue.count(), 1);
@@ -278,10 +278,10 @@ where
     /// Reads the `count` next values in the queue (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -319,10 +319,10 @@ where
     /// Reads the `count` last values in the queue (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -356,10 +356,10 @@ where
     /// Reads all the elements
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(37);
@@ -401,10 +401,10 @@ where
     /// Gets a mutable iterator on the entries of the queue
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   let mut iter = queue.iter_mut().await.unwrap();

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -157,11 +157,11 @@ where
     /// was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry_mut(vec![0, 1]).await.unwrap();
     ///   let value = subview.get();
@@ -213,11 +213,11 @@ where
     /// If an entry was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry(vec![0, 1]).await.unwrap();
     ///   let value = subview.get();
@@ -267,11 +267,11 @@ where
     /// Removes an entry. If absent then nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   let mut subview = view.try_load_entry_mut(vec![0, 1]).await.unwrap();
     ///   let value = subview.get_mut();
@@ -293,11 +293,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(vec![0, 1]).await.unwrap();
@@ -336,11 +336,11 @@ where
     /// The entries in short_keys have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(vec![0, 1]).await.unwrap();
@@ -416,11 +416,11 @@ where
     /// The entries in short_keys have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   let short_keys = vec![vec![0, 1], vec![2, 3]];
     ///   let subviews = view.try_load_entries(short_keys).await.unwrap();
@@ -497,11 +497,11 @@ where
     /// Returns the list of indices in the collection in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(vec![0, 1]).await.unwrap();
     ///   view.try_load_entry_mut(vec![0, 2]).await.unwrap();
@@ -524,11 +524,11 @@ where
     /// ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(vec![0, 1]).await.unwrap();
     ///   view.try_load_entry_mut(vec![0, 2]).await.unwrap();
@@ -589,11 +589,11 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(vec![0, 1]).await.unwrap();
     ///   view.try_load_entry_mut(vec![0, 2]).await.unwrap();
@@ -726,11 +726,11 @@ where
     /// was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -753,11 +753,11 @@ where
     /// If an entry was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry(&23).await.unwrap();
     ///   let value = subview.get();
@@ -776,11 +776,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let mut subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -803,11 +803,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -846,11 +846,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries_mut(&indices).await.unwrap();
@@ -879,11 +879,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries(&indices).await.unwrap();
@@ -920,11 +920,11 @@ where
     /// by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&25).await.unwrap();
@@ -947,11 +947,11 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&24).await.unwrap();
@@ -980,11 +980,11 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&28).await.unwrap();
@@ -1085,11 +1085,11 @@ where
     /// was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -1112,11 +1112,11 @@ where
     /// If an entry was removed before then a default entry is put on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry(&23).await.unwrap();
     ///   let value = subview.get();
@@ -1135,11 +1135,11 @@ where
     /// Removes an entry. If absent then nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let mut subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -1162,11 +1162,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1207,11 +1207,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries_mut(indices).await.unwrap();
@@ -1240,11 +1240,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries(indices).await.unwrap();
@@ -1281,11 +1281,11 @@ where
     /// the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&25).await.unwrap();
@@ -1308,11 +1308,11 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&28).await.unwrap();
     ///   view.try_load_entry_mut(&24).await.unwrap();
@@ -1342,11 +1342,11 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_test_context, MemoryContext};
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&28).await.unwrap();
     ///   view.try_load_entry_mut(&24).await.unwrap();

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -97,10 +97,10 @@ where
     /// Access the current value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut register = RegisterView::<_,u32>::load(context).await.unwrap();
     ///   let value = register.get();
     ///   assert_eq!(*value, 0);
@@ -116,10 +116,10 @@ where
     /// Sets the value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut register = RegisterView::load(context).await.unwrap();
     ///   register.set(5);
     ///   let value = register.get();
@@ -145,10 +145,10 @@ where
     /// Obtains a mutable reference to the value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut register : RegisterView<_,u32> = RegisterView::load(context).await.unwrap();
     ///   let value = register.get_mut();
     ///   assert_eq!(*value, 0);

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -108,9 +108,9 @@ where
     /// Insert a value. If already present then it has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   assert_eq!(set.contains(vec![0,1]).await.unwrap(), true);
@@ -124,9 +124,9 @@ where
     /// Removes a value from the set. If absent then no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.remove(vec![0,1]);
     ///   assert_eq!(set.contains(vec![0,1]).await.unwrap(), false);
@@ -155,9 +155,9 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   assert_eq!(set.contains(vec![34]).await.unwrap(), false);
@@ -191,9 +191,9 @@ where
     /// Returns the list of keys in the set. The order is lexicographic.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   set.insert(vec![0,2]);
@@ -215,9 +215,9 @@ where
     /// prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   set.insert(vec![0,2]);
@@ -278,9 +278,9 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   set.insert(vec![0,2]);
@@ -404,10 +404,10 @@ where
     /// Inserts a value. If already present then no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::SetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   assert_eq!(set.indices().await.unwrap().len(), 1);
@@ -426,9 +426,9 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::SetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::SetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.remove(&(34 as u32));
     ///   assert_eq!(set.indices().await.unwrap().len(), 0);
@@ -459,9 +459,9 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::SetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::SetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set : SetView<_,u32> = SetView::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   assert_eq!(set.contains(&(34 as u32)).await.unwrap(), true);
@@ -487,9 +487,9 @@ where
     /// Returns the list of indices in the set. The order is determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_test_context, set_view::SetView};
+    /// # use linera_views::{memory::create_memory_context, set_view::SetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set : SetView<_,u32> = SetView::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   assert_eq!(set.indices().await.unwrap(), vec![34 as u32]);
@@ -510,10 +510,10 @@ where
     /// loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::SetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   set.insert(&(37 as u32));
@@ -543,10 +543,10 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::SetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   set.insert(&(37 as u32));
@@ -643,10 +643,10 @@ where
     /// Inserts a value. If present then it has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   assert_eq!(set.indices().await.unwrap().len(), 1);
@@ -665,10 +665,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.remove(&(34 as u128));
     ///   assert_eq!(set.indices().await.unwrap().len(), 0);
@@ -699,10 +699,10 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   assert_eq!(set.contains(&(34 as u128)).await.unwrap(), true);
@@ -729,10 +729,10 @@ where
     /// serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   set.insert(&(37 as u128));
@@ -754,10 +754,10 @@ where
     /// false, then the loop prematurely ends.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   set.insert(&(37 as u128));
@@ -787,10 +787,10 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_test_context;
+    /// # use linera_views::memory::create_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_test_context();
+    /// # let context = create_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   set.insert(&(37 as u128));

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -1,0 +1,565 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    batch::{Batch, WriteOperation},
+    common::{ContextFromDb, KeyIterable, KeyValueIterable, KeyValueStoreClient},
+    memory::{MemoryClient, MemoryContextError, MemoryStoreMap},
+};
+use async_lock::{Mutex, MutexGuardArc};
+use async_trait::async_trait;
+use linera_base::ensure;
+use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
+use thiserror::Error;
+
+/// Data type indicating that the database is not consistent
+#[derive(Error, Debug)]
+pub enum DatabaseConsistencyError {
+    /// The key is of length less than 4, so we cannot extract the first byte
+    #[error("the key is of length less than 4, so we cannot extract the first byte")]
+    TooShortKey,
+
+    /// value segment is missing from the database
+    #[error("value segment is missing from the database")]
+    MissingSegment,
+
+    /// no count of size u32 is available in the value
+    #[error("no count of size u32 is available in the value")]
+    NoCountAvailable,
+}
+
+/// A key-value store with no size limit for values.
+///
+/// It wraps a key-value store, potentially _with_ a size limit, and automatically
+/// splits up large values into smaller ones. A single logical key-value pair is
+/// stored as multiple smaller key-value pairs in the wrapped store.
+/// See the README.md for additional details.
+#[derive(Clone)]
+pub struct ValueSplittingKeyValueStoreClient<K> {
+    client: K,
+}
+
+#[async_trait]
+impl<K> KeyValueStoreClient for ValueSplittingKeyValueStoreClient<K>
+where
+    K: KeyValueStoreClient + Send + Sync,
+    K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
+{
+    const MAX_CONNECTIONS: usize = K::MAX_CONNECTIONS;
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+    type Error = K::Error;
+    type Keys = Vec<Vec<u8>>;
+    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let mut big_key = key.to_vec();
+        big_key.extend(&[0, 0, 0, 0]);
+        let value = self.client.read_key_bytes(&big_key).await?;
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        let count = Self::read_count_from_value(&value)?;
+        let mut big_value = value[4..].to_vec();
+        if count == 1 {
+            return Ok(Some(big_value));
+        }
+        let mut big_keys = Vec::new();
+        for i in 1..count {
+            let big_key_segment = Self::get_segment_key(key, i)?;
+            big_keys.push(big_key_segment);
+        }
+        let segments = self.client.read_multi_key_bytes(big_keys).await?;
+        for segment in segments {
+            match segment {
+                None => {
+                    return Err(DatabaseConsistencyError::MissingSegment.into());
+                }
+                Some(segment) => {
+                    big_value.extend(segment);
+                }
+            }
+        }
+        Ok(Some(big_value))
+    }
+
+    async fn read_multi_key_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        let mut big_keys = Vec::new();
+        for key in &keys {
+            let mut big_key = key.clone();
+            big_key.extend(&[0, 0, 0, 0]);
+            big_keys.push(big_key);
+        }
+        let values = self.client.read_multi_key_bytes(big_keys).await?;
+        let mut big_values = Vec::<Option<Vec<u8>>>::new();
+        let mut keys_add = Vec::new();
+        let mut n_blocks = Vec::new();
+        for (key, value) in keys.iter().zip(values) {
+            match value {
+                None => {
+                    n_blocks.push(0);
+                    big_values.push(None);
+                }
+                Some(value) => {
+                    let count = Self::read_count_from_value(&value)?;
+                    let big_value = value[4..].to_vec();
+                    for i in 1..count {
+                        let big_key_segment = Self::get_segment_key(key, i)?;
+                        keys_add.push(big_key_segment);
+                    }
+                    n_blocks.push(count);
+                    big_values.push(Some(big_value));
+                }
+            }
+        }
+        if !keys_add.is_empty() {
+            let mut segments = self
+                .client
+                .read_multi_key_bytes(keys_add)
+                .await?
+                .into_iter();
+            for (idx, count) in n_blocks.iter().enumerate() {
+                if count > &1 {
+                    let value = big_values.get_mut(idx).unwrap();
+                    if let Some(ref mut value) = value {
+                        for _ in 1..*count {
+                            let segment = segments.next().unwrap().unwrap();
+                            value.extend(segment);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(big_values)
+    }
+
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+        let mut keys = Vec::new();
+        for big_key in self
+            .client
+            .find_keys_by_prefix(key_prefix)
+            .await?
+            .iterator()
+        {
+            let big_key = big_key?;
+            let len = big_key.len();
+            if Self::read_index_from_key(big_key)? == 0 {
+                let key = big_key[0..len - 4].to_vec();
+                keys.push(key);
+            }
+        }
+        Ok(keys)
+    }
+
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, Self::Error> {
+        let small_key_values = self.client.find_key_values_by_prefix(key_prefix).await?;
+        let mut small_kv_iterator = small_key_values.into_iterator_owned();
+        let mut key_values = Vec::new();
+        while let Some(result) = small_kv_iterator.next() {
+            let (mut big_key, value) = result?;
+            if Self::read_index_from_key(&big_key)? != 0 {
+                continue; // Leftover segment from an earlier value.
+            }
+            big_key.truncate(big_key.len() - 4);
+            let key = big_key;
+            let count = Self::read_count_from_value(&value)?;
+            let mut big_value = value[4..].to_vec();
+            for idx in 1..count {
+                let (big_key, value) = small_kv_iterator
+                    .next()
+                    .ok_or(DatabaseConsistencyError::MissingSegment)??;
+                ensure!(
+                    Self::read_index_from_key(&big_key)? == idx
+                        && big_key.starts_with(&key)
+                        && big_key.len() == key.len() + 4,
+                    DatabaseConsistencyError::MissingSegment
+                );
+                big_value.extend(value);
+            }
+            key_values.push((key, big_value));
+        }
+        Ok(key_values)
+    }
+
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), Self::Error> {
+        let mut batch_new = Batch::new();
+        for operation in batch.operations {
+            match operation {
+                WriteOperation::Delete { key } => {
+                    let mut big_key = key.to_vec();
+                    big_key.extend(&[0, 0, 0, 0]);
+                    batch_new.delete_key(big_key);
+                }
+                WriteOperation::Put { key, mut value } => {
+                    let big_key = Self::get_segment_key(&key, 0)?;
+                    let mut count: u32 = 1;
+                    let value_ext = if value.len() <= K::MAX_VALUE_SIZE - 4 {
+                        Self::get_initial_count_first_chunk(count, &value)?
+                    } else {
+                        let remainder = value.split_off(K::MAX_VALUE_SIZE - 4);
+                        for value_chunk in remainder.chunks(K::MAX_VALUE_SIZE) {
+                            let big_key_segment = Self::get_segment_key(&key, count)?;
+                            batch_new.put_key_value_bytes(big_key_segment, value_chunk.to_vec());
+                            count += 1;
+                        }
+                        Self::get_initial_count_first_chunk(count, &value)?
+                    };
+                    batch_new.put_key_value_bytes(big_key, value_ext);
+                }
+                WriteOperation::DeletePrefix { key_prefix } => {
+                    batch_new.delete_key_prefix(key_prefix);
+                }
+            }
+        }
+        self.client.write_batch(batch_new, base_key).await
+    }
+
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+        self.client.clear_journal(base_key).await
+    }
+}
+
+impl<K> ValueSplittingKeyValueStoreClient<K>
+where
+    K: KeyValueStoreClient + Send + Sync,
+    K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
+{
+    /// Creates a new client that deals with big values from one that does not.
+    pub fn new(client: K) -> Self {
+        ValueSplittingKeyValueStoreClient { client }
+    }
+
+    fn read_count_from_value(value: &[u8]) -> Result<u32, K::Error> {
+        if value.len() < 4 {
+            return Err(DatabaseConsistencyError::NoCountAvailable.into());
+        }
+        let mut bytes = value[0..4].to_vec();
+        bytes.reverse();
+        Ok(bcs::from_bytes::<u32>(&bytes)?)
+    }
+
+    fn get_segment_key(key: &[u8], index: u32) -> Result<Vec<u8>, K::Error> {
+        let mut big_key_segment = key.to_vec();
+        let mut bytes = bcs::to_bytes(&index)?;
+        bytes.reverse();
+        big_key_segment.extend(bytes);
+        Ok(big_key_segment)
+    }
+
+    fn read_index_from_key(key: &[u8]) -> Result<u32, K::Error> {
+        let len = key.len();
+        if len < 4 {
+            return Err(DatabaseConsistencyError::TooShortKey.into());
+        }
+        let mut bytes = key[len - 4..len].to_vec();
+        bytes.reverse();
+        Ok(bcs::from_bytes::<u32>(&bytes)?)
+    }
+
+    fn get_initial_count_first_chunk(count: u32, first_chunk: &[u8]) -> Result<Vec<u8>, K::Error> {
+        let mut bytes = bcs::to_bytes(&count)?;
+        bytes.reverse();
+        let mut value_ext = Vec::new();
+        value_ext.extend(bytes);
+        value_ext.extend(first_chunk);
+        Ok(value_ext)
+    }
+}
+
+/// A virtual DB client where data are persisted in memory.
+#[derive(Clone)]
+pub struct TestMemoryClientInternal {
+    client: MemoryClient,
+}
+
+#[async_trait]
+impl KeyValueStoreClient for TestMemoryClientInternal {
+    const MAX_CONNECTIONS: usize = 1;
+    // We set up the MAX_VALUE_SIZE to the artificially low value of 100
+    // purely for testing purposes.
+    const MAX_VALUE_SIZE: usize = 100;
+    type Error = MemoryContextError;
+    type Keys = Vec<Vec<u8>>;
+    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
+        self.client.read_key_bytes(key).await
+    }
+
+    async fn read_multi_key_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {
+        self.client.read_multi_key_bytes(keys).await
+    }
+
+    async fn find_keys_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::Keys, MemoryContextError> {
+        self.client.find_keys_by_prefix(key_prefix).await
+    }
+
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, MemoryContextError> {
+        self.client.find_key_values_by_prefix(key_prefix).await
+    }
+
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
+        ensure!(
+            batch.check_value_size(Self::MAX_VALUE_SIZE),
+            MemoryContextError::TooLargeValue
+        );
+        self.client.write_batch(batch, base_key).await
+    }
+
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+        self.client.clear_journal(base_key).await
+    }
+}
+
+impl TestMemoryClientInternal {
+    /// Creates a `TestMemoryClient` from the guard
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>) -> Self {
+        let client = MemoryClient::new(guard);
+        TestMemoryClientInternal { client }
+    }
+}
+
+/// Supposed to be removed later
+#[derive(Clone)]
+pub struct TestMemoryClient {
+    client: ValueSplittingKeyValueStoreClient<TestMemoryClientInternal>,
+}
+
+#[async_trait]
+impl KeyValueStoreClient for TestMemoryClient {
+    const MAX_CONNECTIONS: usize = TestMemoryClientInternal::MAX_CONNECTIONS;
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+    type Error = MemoryContextError;
+    type Keys = Vec<Vec<u8>>;
+    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
+        self.client.read_key_bytes(key).await
+    }
+
+    async fn read_multi_key_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {
+        self.client.read_multi_key_bytes(keys).await
+    }
+
+    async fn find_keys_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::Keys, MemoryContextError> {
+        self.client.find_keys_by_prefix(key_prefix).await
+    }
+
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, MemoryContextError> {
+        self.client.find_key_values_by_prefix(key_prefix).await
+    }
+
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
+        self.client.write_batch(batch, base_key).await
+    }
+
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+        self.client.clear_journal(base_key).await
+    }
+}
+
+impl TestMemoryClient {
+    /// Creates a `TestMemoryClient` from the guard
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>) -> Self {
+        let client = TestMemoryClientInternal::new(guard);
+        let client = ValueSplittingKeyValueStoreClient::new(client);
+        TestMemoryClient { client }
+    }
+}
+
+/// An implementation of [`crate::common::Context`] that stores all values in memory.
+pub type TestMemoryContext<E> = ContextFromDb<E, TestMemoryClient>;
+
+impl<E> TestMemoryContext<E> {
+    /// Creates a [`TestMemoryContext`].
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
+        let db = TestMemoryClient::new(guard);
+        let base_key = Vec::new();
+        Self {
+            db,
+            base_key,
+            extra,
+        }
+    }
+}
+
+/// Provides a `TestMemoryContext<()>` that can be used for tests.
+/// It is not named create_memory_test_context because it is massively
+/// used and so we want to have a short name.
+pub fn create_test_memory_context() -> TestMemoryContext<()> {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    TestMemoryContext::new(guard, ())
+}
+
+/// Creates a `TestMemoryClient` for working.
+pub fn create_test_memory_client() -> TestMemoryClient {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    TestMemoryClient::new(guard)
+}
+
+/// An implementation of [`crate::common::Context`] that stores all values in memory.
+pub type TestMemoryContextInternal<E> = ContextFromDb<E, TestMemoryClientInternal>;
+
+impl<E> TestMemoryContextInternal<E> {
+    /// Creates a [`TestMemoryContextInternal`].
+    pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
+        let db = TestMemoryClientInternal::new(guard);
+        let base_key = Vec::new();
+        Self {
+            db,
+            base_key,
+            extra,
+        }
+    }
+}
+
+/// Provides a `TestMemoryClientInternal<()>` that can be used for tests.
+pub fn create_test_memory_client_internal() -> TestMemoryClientInternal {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    TestMemoryClientInternal::new(guard)
+}
+
+/// Provides a `TestMemoryContextInternal<()>` that can be used for tests.
+pub fn create_test_memory_context_internal() -> TestMemoryContextInternal<()> {
+    let state = Arc::new(Mutex::new(BTreeMap::new()));
+    let guard = state
+        .try_lock_arc()
+        .expect("We should acquire the lock just after creating the object");
+    TestMemoryContextInternal::new(guard, ())
+}
+
+#[cfg(test)]
+mod tests {
+    use linera_views::{
+        batch::Batch,
+        common::KeyValueStoreClient,
+        value_splitting::{
+            create_test_memory_client_internal, TestMemoryClientInternal,
+            ValueSplittingKeyValueStoreClient,
+        },
+    };
+    use rand::{Rng, SeedableRng};
+
+    // The key splitting means that when a key is overwritten
+    // some previous segments may still be present.
+    #[tokio::test]
+    #[allow(clippy::assertions_on_constants)]
+    async fn test_value_splitting1_testing_leftovers() {
+        let client = create_test_memory_client_internal();
+        const MAX_LEN: usize = TestMemoryClientInternal::MAX_VALUE_SIZE;
+        assert!(MAX_LEN > 10);
+        let big_client = ValueSplittingKeyValueStoreClient::new(client.clone());
+        let key = vec![0, 0];
+        // Write a key with a long value
+        let mut batch = Batch::new();
+        let value = Vec::from([0; MAX_LEN + 1]);
+        batch.put_key_value_bytes(key.clone(), value.clone());
+        big_client.write_batch(batch, &[]).await.unwrap();
+        let value_read = big_client.read_key_bytes(&key).await.unwrap();
+        assert_eq!(value_read, Some(value));
+        // Write a key with a smaller value
+        let mut batch = Batch::new();
+        let value = Vec::from([0, 1]);
+        batch.put_key_value_bytes(key.clone(), value.clone());
+        big_client.write_batch(batch, &[]).await.unwrap();
+        let value_read = big_client.read_key_bytes(&key).await.unwrap();
+        assert_eq!(value_read, Some(value));
+        // Two segments are present even though only one is used
+        let keys = client.find_keys_by_prefix(&[0]).await.unwrap();
+        assert_eq!(keys, vec![vec![0, 0, 0, 0, 0], vec![0, 0, 0, 0, 1]]);
+    }
+
+    #[tokio::test]
+    async fn test_value_splitting2_testing_splitting() {
+        let client = create_test_memory_client_internal();
+        const MAX_LEN: usize = TestMemoryClientInternal::MAX_VALUE_SIZE;
+        let big_client = ValueSplittingKeyValueStoreClient::new(client.clone());
+        let key = vec![0, 0];
+        // Writing a big value
+        let mut batch = Batch::new();
+        let mut value = Vec::new();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+        for _ in 0..2 * MAX_LEN - 4 {
+            value.push(rng.gen::<u8>());
+        }
+        batch.put_key_value_bytes(key.clone(), value.clone());
+        big_client.write_batch(batch, &[]).await.unwrap();
+        let value_read = big_client.read_key_bytes(&key).await.unwrap();
+        assert_eq!(value_read, Some(value.clone()));
+        // Reading the segments and checking
+        let mut value_concat = Vec::<u8>::new();
+        for index in 0..2 {
+            let mut segment_key = key.clone();
+            let mut bytes = bcs::to_bytes(&index).unwrap();
+            bytes.reverse();
+            segment_key.extend(bytes);
+            let value_read = client.read_key_bytes(&segment_key).await.unwrap();
+            let Some(value_read) = value_read else { unreachable!() };
+            if index == 0 {
+                value_concat.extend(&value_read[4..]);
+            } else {
+                value_concat.extend(&value_read);
+            }
+        }
+        assert_eq!(value, value_concat);
+    }
+
+    #[tokio::test]
+    async fn test_value_splitting3_write_and_delete() {
+        let client = create_test_memory_client_internal();
+        const MAX_LEN: usize = TestMemoryClientInternal::MAX_VALUE_SIZE;
+        let big_client = ValueSplittingKeyValueStoreClient::new(client.clone());
+        let key = vec![0, 0];
+        // writing a big key
+        let mut batch = Batch::new();
+        let mut value = Vec::new();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+        for _ in 0..3 * MAX_LEN - 4 {
+            value.push(rng.gen::<u8>());
+        }
+        batch.put_key_value_bytes(key.clone(), value.clone());
+        big_client.write_batch(batch, &[]).await.unwrap();
+        // deleting it
+        let mut batch = Batch::new();
+        batch.delete_key(key.clone());
+        big_client.write_batch(batch, &[]).await.unwrap();
+        // reading everything (there are leftover keys)
+        let key_values = big_client.find_key_values_by_prefix(&[0]).await.unwrap();
+        assert_eq!(key_values.len(), 0);
+        // Two segments remain
+        let keys = client.find_keys_by_prefix(&[0]).await.unwrap();
+        assert_eq!(keys, vec![vec![0, 0, 0, 0, 1], vec![0, 0, 0, 0, 2]]);
+    }
+}

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -74,7 +74,7 @@ pub enum ViewError {
     /// Errors within the context can occur and are presented as ViewError.
     #[error("Storage operation error in {backend}: {error}")]
     ContextError {
-        /// backend can be e.g. RocksDb / AmazonDb / Memory / etc.
+        /// backend can be e.g. RocksDB / DynamoDB / Memory / etc.
         backend: String,
         /// error is the specific problem that occurred within that context
         error: String,
@@ -95,6 +95,10 @@ pub enum ViewError {
     /// The database is corrupt: Some entries are missing
     #[error("Missing database entries")]
     MissingEntries,
+
+    /// The value is too large for the client
+    #[error("The value is too large for the client")]
+    TooLargeValue,
 }
 
 impl ViewError {

--- a/linera-views/tests/hashable_tests.rs
+++ b/linera-views/tests/hashable_tests.rs
@@ -4,7 +4,7 @@
 use linera_views::{
     common::HasherOutput,
     hashable_wrapper::WrappedHashableContainerView,
-    memory::create_test_context,
+    memory::create_memory_context,
     register_view::RegisterView,
     views::{HashableView, View},
 };
@@ -19,7 +19,7 @@ struct TestType<C> {
 // TODO(#560): Implement the same for CryptoHash
 #[tokio::test]
 async fn check_hashable_container_hash() {
-    let context = create_test_context();
+    let context = create_memory_context();
     let test = TestType::load(context).await.unwrap();
     let hash1 = test.inner.hash().await.unwrap();
     let hash2 = test.wrap.hash().await.unwrap();

--- a/linera-views/tests/queueview_tests.rs
+++ b/linera-views/tests/queueview_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::{
-    memory::create_test_context,
+    memory::create_memory_context,
     queue_view::QueueView,
     views::{CryptoHashRootView, RootView, View},
 };
@@ -15,7 +15,7 @@ pub struct StateView<C> {
 
 #[tokio::test]
 async fn queue_view_mutability_check() {
-    let context = create_test_context();
+    let context = create_memory_context();
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     let mut vector = Vec::new();
     let n = 20;

--- a/linera-views/tests/reentrant_tests.rs
+++ b/linera-views/tests/reentrant_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::{
-    memory::create_test_context,
+    memory::create_memory_context,
     reentrant_collection_view::ReentrantCollectionView,
     register_view::RegisterView,
     views::{CryptoHashRootView, RootView, View},
@@ -17,7 +17,7 @@ pub struct StateView<C> {
 
 #[tokio::test]
 async fn reentrant_collection_view_check() {
-    let context = create_test_context();
+    let context = create_memory_context();
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     let mut map = BTreeMap::<u8, u32>::new();
     let n = 20;


### PR DESCRIPTION
Following points:
* The `KeyValueStoreClientBigValue` takes a KayValueStoreClient and builds one that respects the size limitations.
* Put it in `RocksDB` and the memory containers.

I considered using the `parse_u32_from_uleb128` as initially suggested. But it is hard for me how this is an improvement since it can still return errors.