### PR TITLE
Display cause of module load error

### DIFF
--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -97,7 +97,7 @@ impl WasmApplication {
 #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
 #[derive(Debug, Error)]
 pub enum WasmExecutionError {
-    #[error("Failed to load WASM module")]
+    #[error("Failed to load WASM module: {_0}")]
     LoadModule(#[from] anyhow::Error),
     #[cfg(feature = "wasmtime")]
     #[error("Failed to create and configure Wasmtime runtime")]

--- a/linera-execution/src/wasm/module_cache.rs
+++ b/linera-execution/src/wasm/module_cache.rs
@@ -7,7 +7,7 @@
 //! estimate the total memory usage by the cache, since it's currently not possible to determine
 //! the size of a generic `Module`.
 
-use crate::{wasm::WasmExecutionError, Bytecode};
+use crate::Bytecode;
 use lru::LruCache;
 use std::sync::Arc;
 
@@ -40,10 +40,7 @@ impl<Module> ModuleCache<Module> {
         &mut self,
         bytecode: Bytecode,
         module_builder: impl FnOnce(Bytecode) -> Result<Module, E>,
-    ) -> Result<Arc<Module>, WasmExecutionError>
-    where
-        WasmExecutionError: From<E>,
-    {
+    ) -> Result<Arc<Module>, E> {
         if let Some(module) = self.get(&bytecode) {
             Ok(module)
         } else {


### PR DESCRIPTION
# Motivation

When a WebAssembly module fails to be loaded, the error reported to the user doesn't provide any details to why it failed to load. These details may be useful to quickly diagnose issues.

# Solution

Show the message generated from the internal error source.

Also, split the error variant to make it clear if the contract module failed to load or the service module failed to load.