### PR TITLE
Linera project new optimisations and git repository

### DIFF
--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -25,3 +25,9 @@ path = "src/contract.rs"
 [[bin]]
 name = "{project_name}_service"
 path = "src/service.rs"
+
+[profile.release]
+debug = true
+lto = true
+opt-level = 'z'
+strip = 'debuginfo'


### PR DESCRIPTION
# Motivation

1. Projects created by `linera project new` don't use release profile optimizations resulting in large bytecode sizes.
2. Projects created by `linera project new` do not have an associated git repository, meaning that users have to manually `git init`.

# Solution

1. Add the release profile optimisations to `Cargo.toml.template`.
2. Initialize a git repository when creating a project.