### PR TITLE
Create initial Witty crate with primitive type definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2960,6 +2960,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "linera-witty"
+version = "0.2.0"
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
         "linera-storage",
         "linera-views",
         "linera-views-derive",
+        "linera-witty",
 ]
 exclude = [
         "examples",

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "linera-witty"
+version = "0.2.0"
+description = "Generation of WIT compatible host code from Rust code"
+authors = ["Linera <contact@linera.io>"]
+readme = "README.md"
+repository = "https://github.com/linera-io/linera-protocol"
+homepage = "https://linera.io"
+documentation = "https://docs.rs/linera-witty/latest/linera_witty/"
+license = "Apache-2.0"
+edition = "2021"

--- a/linera-witty/README.md
+++ b/linera-witty/README.md
@@ -1,0 +1,19 @@
+<!-- cargo-rdme start -->
+
+Linera Witty
+
+This crate allows generating [WIT] files and host side code to interface with WebAssembly guests
+that adhere to the [WIT] interface format. The source of truth for the generated code and WIT
+files is the Rust source code.
+
+[WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+
+<!-- cargo-rdme end -->
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of the [Apache 2.0 license](../LICENSE).

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -8,3 +8,5 @@
 //! files is the Rust source code.
 //!
 //! [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
+
+mod primitive_types;

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Linera Witty
+//!
+//! This crate allows generating [WIT] files and host side code to interface with WebAssembly guests
+//! that adhere to the [WIT] interface format. The source of truth for the generated code and WIT
+//! files is the Rust source code.
+//!
+//! [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md

--- a/linera-witty/src/primitive_types/flat_type.rs
+++ b/linera-witty/src/primitive_types/flat_type.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Primitive types [supported by
+//! WebAssembly](https://webassembly.github.io/spec/core/syntax/types.html).
+//!
+//! These are types that the WebAssembly virtual machine can operate with. More importantly, these
+//! are the types that can be used in function interfaces as parameter types and return types.
+
+use super::SimpleType;
+
+/// Primitive types supported by WebAssembly.
+pub trait FlatType: SimpleType {}
+
+impl FlatType for i32 {}
+impl FlatType for i64 {}
+impl FlatType for f32 {}
+impl FlatType for f64 {}

--- a/linera-witty/src/primitive_types/flat_type.rs
+++ b/linera-witty/src/primitive_types/flat_type.rs
@@ -10,7 +10,7 @@
 use super::SimpleType;
 
 /// Primitive types supported by WebAssembly.
-pub trait FlatType: SimpleType {}
+pub trait FlatType: SimpleType<Flat = Self> {}
 
 impl FlatType for i32 {}
 impl FlatType for i64 {}

--- a/linera-witty/src/primitive_types/mod.rs
+++ b/linera-witty/src/primitive_types/mod.rs
@@ -3,6 +3,7 @@
 
 //! Primitive WebAssembly and WIT types.
 
+mod flat_type;
 mod simple_type;
 
-pub use self::simple_type::SimpleType;
+pub use self::{flat_type::FlatType, simple_type::SimpleType};

--- a/linera-witty/src/primitive_types/mod.rs
+++ b/linera-witty/src/primitive_types/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Primitive WebAssembly and WIT types.
+
+mod simple_type;
+
+pub use self::simple_type::SimpleType;

--- a/linera-witty/src/primitive_types/simple_type.rs
+++ b/linera-witty/src/primitive_types/simple_type.rs
@@ -9,6 +9,8 @@
 //! [Component Model]:
 //! https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#type-definitions
 
+use super::FlatType;
+
 /// Marker trait to prevent [`SimpleType`] to be implemented for other types.
 pub trait Sealed {}
 
@@ -18,27 +20,32 @@ pub trait SimpleType: Default + Sealed + Sized {
     ///
     /// [canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
     const ALIGNMENT: u32;
+
+    /// The underlying WebAssembly type used when flattening this type.
+    type Flat: FlatType;
 }
 
 macro_rules! simple_type {
-    ($impl_type:ident, $alignment:expr) => {
+    ($impl_type:ident -> $flat:ty, $alignment:expr) => {
         impl Sealed for $impl_type {}
 
         impl SimpleType for $impl_type {
             const ALIGNMENT: u32 = $alignment;
+
+            type Flat = $flat;
         }
     };
 }
 
-simple_type!(bool, 1);
-simple_type!(i8, 1);
-simple_type!(i16, 2);
-simple_type!(i32, 4);
-simple_type!(i64, 8);
-simple_type!(u8, 1);
-simple_type!(u16, 2);
-simple_type!(u32, 4);
-simple_type!(u64, 8);
-simple_type!(f32, 4);
-simple_type!(f64, 8);
-simple_type!(char, 4);
+simple_type!(bool -> i32, 1);
+simple_type!(i8 -> i32, 1);
+simple_type!(i16 -> i32, 2);
+simple_type!(i32 -> i32, 4);
+simple_type!(i64 -> i64, 8);
+simple_type!(u8 -> i32, 1);
+simple_type!(u16 -> i32, 2);
+simple_type!(u32 -> i32, 4);
+simple_type!(u64 -> i64, 8);
+simple_type!(f32 -> f32, 4);
+simple_type!(f64 -> f64, 8);
+simple_type!(char -> i32, 4);

--- a/linera-witty/src/primitive_types/simple_type.rs
+++ b/linera-witty/src/primitive_types/simple_type.rs
@@ -23,6 +23,9 @@ pub trait SimpleType: Default + Sealed + Sized {
 
     /// The underlying WebAssembly type used when flattening this type.
     type Flat: FlatType;
+
+    /// Flattens this type into a [`FlatType`] that's natively supported by WebAssembly.
+    fn flatten(self) -> Self::Flat;
 }
 
 macro_rules! simple_type {
@@ -33,6 +36,10 @@ macro_rules! simple_type {
             const ALIGNMENT: u32 = $alignment;
 
             type Flat = $flat;
+
+            fn flatten(self) -> Self::Flat {
+                self as $flat
+            }
         }
     };
 }

--- a/linera-witty/src/primitive_types/simple_type.rs
+++ b/linera-witty/src/primitive_types/simple_type.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Fundamental types used by WIT defined by the [Component Model] that map directly to Rust
+//! primitive types.
+//!
+//! These are primitive types that WIT defines how to store in memory.
+//!
+//! [Component Model]:
+//! https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md#type-definitions
+
+/// Marker trait to prevent [`SimpleType`] to be implemented for other types.
+pub trait Sealed {}
+
+/// Primitive fundamental WIT types.
+pub trait SimpleType: Default + Sealed + Sized {
+    /// Alignment when storing in memory, according to the [canonical ABI].
+    ///
+    /// [canonical ABI]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment
+    const ALIGNMENT: u32;
+}
+
+macro_rules! simple_type {
+    ($impl_type:ident, $alignment:expr) => {
+        impl Sealed for $impl_type {}
+
+        impl SimpleType for $impl_type {
+            const ALIGNMENT: u32 = $alignment;
+        }
+    };
+}
+
+simple_type!(bool, 1);
+simple_type!(i8, 1);
+simple_type!(i16, 2);
+simple_type!(i32, 4);
+simple_type!(i64, 8);
+simple_type!(u8, 1);
+simple_type!(u16, 2);
+simple_type!(u32, 4);
+simple_type!(u64, 8);
+simple_type!(f32, 4);
+simple_type!(f64, 8);
+simple_type!(char, 4);


### PR DESCRIPTION
# Motivation

The goal is to implement a new crate that generates host side code to interact with Wasm guest modules through a WIT interface. The first step is to represent the fundamental WebAssembly and WIT primitive types.

# Solution

Use a sub-set of the Rust types as the fundamental primitive types. There are actually two sub-sets: `SimpleType`s and `FlatType`s. A `SimpleType` is part of the set of fundamental types defined for WIT (through the Component Model). The set of `FlatType`s is a sub-set of the set of `SimpleType`s, and represent the types that are natively supported in a WebAssembly virtual machine.

The types are in separate modules because more functionality will be added to them later.