### PR TITLE
Remove log probably used for debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,6 @@ dependencies = [
  "bcs",
  "futures",
  "linera-sdk",
- "log",
  "serde",
  "serde_json",
  "thiserror",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -430,7 +430,6 @@ dependencies = [
  "bcs",
  "futures",
  "linera-sdk",
- "log",
  "serde",
  "serde_json",
  "thiserror",

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -10,7 +10,6 @@ async-trait = { workspace = true }
 bcs = { workspace = true }
 futures = { workspace = true }
 linera-sdk = { workspace = true }
-log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -58,7 +58,6 @@ impl Contract for Counter {
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult<Self::Message, Self::Response, Self::SessionState>, Self::Error>
     {
-        log::error!("incrementing by {:?}", increment);
         self.value += increment;
         Ok(ApplicationCallResult {
             value: self.value,


### PR DESCRIPTION
# Motivation

`Counter::handle_application_call` always prints an error message even though there are no errors.

# Solution

Remove the log call.