### PR TITLE
Help with diagnosing test errors

### DIFF
--- a/linera-sdk/src/bin/test-runner/mock_system_api.rs
+++ b/linera-sdk/src/bin/test-runner/mock_system_api.rs
@@ -176,7 +176,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-chain-id` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-chain-id` function");
+                    .expect(
+                        "Failed to call `mocked-chain-id` function. \
+                        Please ensure `linera_sdk::test::mock_chain_id` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 32);
             })
@@ -223,7 +226,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-application-id` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-application-id` function");
+                    .expect(
+                        "Failed to call `mocked-application-id` function. \
+                        Please ensure `linera_sdk::test::mock_application_id` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 96);
             })
@@ -248,7 +254,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-application-parameters` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-application-parameters` function");
+                    .expect(
+                        "Failed to call `mocked-application-parameters` function. \
+                        Please ensure `linera_sdk::test::mock_application_parameters` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 8);
             })
@@ -274,7 +283,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-read-system-balance` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-read-system-balance` function");
+                    .expect(
+                        "Failed to call `mocked-read-system-balance` function. \
+                        Please ensure `linera_sdk::test::mock_system_balance` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 16);
             })
@@ -297,7 +309,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-read-system-timestamp` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-read-system-timestamp` function");
+                    .expect(
+                        "Failed to call `mocked-read-system-timestamp` function. \
+                        Please ensure `linera_sdk::test::mock_system_timestamp` was called",
+                    );
 
                 timestamp
             })
@@ -366,7 +381,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-load` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-load` function");
+                    .expect(
+                        "Failed to call `mocked-load` function. \
+                        Please ensure `linera_sdk::test::mock_application_state` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 8);
             })
@@ -391,7 +409,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-load-and-lock` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-load`-and-lock function");
+                    .expect(
+                        "Failed to call `mocked-load-and-lock` function. \
+                        Please ensure `linera_sdk::test::mock_application_state` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 12);
             })
@@ -421,7 +442,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-lock` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-lock` function");
+                    .expect(
+                        "Failed to call `mocked-lock` function. \
+                        Please ensure `linera_sdk::test::mock_application_state` was called",
+                    );
 
                 match locked {
                     0 => 2,
@@ -451,7 +475,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-chain-id` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-chain-id` function");
+                    .expect(
+                        "Failed to call `mocked-chain-id` function. \
+                        Please ensure `linera_sdk::test::mock_chain_id` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 32);
             })
@@ -498,7 +525,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-application-id` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-application-id` function");
+                    .expect(
+                        "Failed to call `mocked-application-id` function. \
+                        Please ensure `linera_sdk::test::mock_application_id` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 96);
             })
@@ -523,7 +553,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-application-parameters` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-application-parameters` function");
+                    .expect(
+                        "Failed to call `mocked-application-parameters` function. \
+                        Please ensure `linera_sdk::test::mock_application_parameters` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 8);
             })
@@ -549,7 +582,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-read-system-balance` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-read-system-balance` function");
+                    .expect(
+                        "Failed to call `mocked-read-system-balance` function. \
+                        Please ensure `linera_sdk::test::mock_system_balance` was called",
+                    );
 
                 copy_memory_slices(&mut caller, result_offset, return_offset, 16);
             })
@@ -572,7 +608,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-read-system-timestamp` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-read-system-timestamp` function");
+                    .expect(
+                        "Failed to call `mocked-read-system-timestamp` function. \
+                        Please ensure `linera_sdk::test::mock_system_timestamp` was called",
+                    );
 
                 timestamp
             })
@@ -647,7 +686,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-load` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-load` function");
+                    .expect(
+                        "Failed to call `mocked-load` function. \
+                        Please ensure `linera_sdk::test::mock_application_state` was called",
+                    );
 
                 store_in_memory(&mut caller, return_offset, 1_i32);
                 store_in_memory(&mut caller, return_offset + 4, 0_i32);
@@ -676,7 +718,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-lock` function signature")
                     .call_async(&mut caller, ())
                     .await
-                    .expect("Failed to call `mocked-lock` function");
+                    .expect(
+                        "Failed to call `mocked-lock` function. \
+                        Please ensure `linera_sdk::test::mock_application_state` was called",
+                    );
 
                 match locked {
                     0 => {
@@ -878,7 +923,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                         ),
                     )
                     .await
-                    .expect("Failed to call `mocked-try-query-application` function");
+                    .expect(
+                        "Failed to call `mocked-try-query-application` function. \
+                        Please ensure `linera_sdk::test::mock_try_call_application` was called",
+                    );
 
                 store_in_memory(&mut caller, return_offset, 1_i32);
                 copy_memory_slices(&mut caller, result_offset, return_offset + 4, 12);
@@ -927,7 +975,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-read-key-bytes` function signature")
                     .call_async(&mut caller, (key_address, key_length))
                     .await
-                    .expect("Failed to call `mocked-read-key-bytes` function");
+                    .expect(
+                        "Failed to call `mocked-read-key-bytes` function. \
+                        Please ensure `linera_sdk::test::mock_key_value_store` was called",
+                    );
 
                 store_in_memory(&mut caller, return_offset, 1_i32);
                 copy_memory_slices(&mut caller, result_offset, return_offset + 4, 12);
@@ -975,7 +1026,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-find-keys` function signature")
                     .call_async(&mut caller, (prefix_address, prefix_length))
                     .await
-                    .expect("Failed to call `mocked-find-keys` function");
+                    .expect(
+                        "Failed to call `mocked-find-keys` function. \
+                        Please ensure `linera_sdk::test::mock_key_value_store` was called",
+                    );
 
                 store_in_memory(&mut caller, return_offset, 1_i32);
                 copy_memory_slices(&mut caller, result_offset, return_offset + 4, 12);
@@ -1024,7 +1078,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-find-key-values` function signature")
                     .call_async(&mut caller, (prefix_address, prefix_length))
                     .await
-                    .expect("Failed to call `mocked-find-key-values` function");
+                    .expect(
+                        "Failed to call `mocked-find-key-values` function. \
+                        Please ensure `linera_sdk::test::mock_key_value_store` was called",
+                    );
 
                 store_in_memory(&mut caller, return_offset, 1_i32);
                 copy_memory_slices(&mut caller, result_offset, return_offset + 4, 12);
@@ -1175,7 +1232,10 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                     .expect("Incorrect `mocked-write-batch` function signature")
                     .call_async(&mut caller, (operations_vector, vector_length))
                     .await
-                    .expect("Failed to call `mocked-write-batch` function");
+                    .expect(
+                        "Failed to call `mocked-write-batch` function. \
+                        Please ensure `linera_sdk::test::mock_key_value_store` was called",
+                    );
 
                 1
             })

--- a/linera-sdk/src/test/integration/mock_stubs.rs
+++ b/linera-sdk/src/test/integration/mock_stubs.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Stub functions for the API exported to unit tests.
+//!
+//! These can be used by mistake if running unit tests targeting the host architecture, and the
+//! default compiler error of missing functions isn't very helpful. Instead, these allow
+//! compilation to succeed and fails with a more helpful message *if* one of the functions is
+//! called.
+
+use linera_base::{
+    data_types::{Amount, Timestamp},
+    identifiers::{ApplicationId, ChainId},
+};
+use linera_views::memory::MemoryContext;
+
+/// A helpful error message to explain why the mock API isn't available.
+const ERROR_MESSAGE: &str =
+    "The mock API is only available for unit tests running inside a WebAssembly virtual machine. \
+    Please check that the unit tests are executed with `linera project test` or with \
+    `cargo test --target wasm32-unknown-unknown`. \
+    Also ensure that the unit tests (or the module containing them) has a \
+    `#[cfg(target_arch = \"wasm32-unknown-unknown\")]` attribute so that they don't get compiled \
+    in for the integration tests";
+
+/// Sets the mocked chain ID.
+pub fn mock_chain_id(_chain_id: impl Into<Option<ChainId>>) {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Sets the mocked application ID.
+pub fn mock_application_id(_application_id: impl Into<Option<ApplicationId>>) {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Sets the mocked application parameters.
+pub fn mock_application_parameters(_application_parameters: impl Into<Option<Vec<u8>>>) {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Sets the mocked system balance.
+pub fn mock_system_balance(_system_balance: impl Into<Option<Amount>>) {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Sets the mocked system timestamp.
+pub fn mock_system_timestamp(_system_timestamp: impl Into<Option<Timestamp>>) {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Returns all messages logged so far.
+pub fn log_messages() -> Vec<(log::Level, String)> {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Sets the mocked application state.
+pub fn mock_application_state(_state: impl Into<Option<Vec<u8>>>) {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Initializes and returns a view context for using as the mocked key-value store.
+pub fn mock_key_value_store() -> MemoryContext<()> {
+    unreachable!("{ERROR_MESSAGE}");
+}
+
+/// Mocks the `try_query_application` system API.
+pub fn mock_try_query_application<E>(
+    _handler: impl FnMut(ApplicationId, Vec<u8>) -> Result<Vec<u8>, E> + 'static,
+) where
+    E: ToString + 'static,
+{
+    unreachable!("{ERROR_MESSAGE}");
+}

--- a/linera-sdk/src/test/integration/mod.rs
+++ b/linera-sdk/src/test/integration/mod.rs
@@ -12,6 +12,7 @@
 
 mod block;
 mod chain;
+mod mock_stubs;
 mod validator;
 
-pub use self::{block::BlockBuilder, chain::ActiveChain, validator::TestValidator};
+pub use self::{block::BlockBuilder, chain::ActiveChain, mock_stubs::*, validator::TestValidator};

--- a/linera-sdk/src/test/integration/mod.rs
+++ b/linera-sdk/src/test/integration/mod.rs
@@ -8,11 +8,17 @@
 //! executed targeting the host architecture, instead of targeting `wasm32-unknown-unknown` like
 //! done for unit tests.
 
-#![cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#![cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
 
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
 mod block;
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
 mod chain;
 mod mock_stubs;
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
 mod validator;
 
-pub use self::{block::BlockBuilder, chain::ActiveChain, mock_stubs::*, validator::TestValidator};
+#[cfg(feature = "test")]
+pub use self::mock_stubs::*;
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+pub use self::{block::BlockBuilder, chain::ActiveChain, validator::TestValidator};


### PR DESCRIPTION
# Motivation

Writing tests for Linera has some small differences to writing normal Rust tests. The biggest one being that unit tests run inside a WebAssembly virtual machine while integration tests must not. Another one is that unit tests that use system APIs must have proper mocks set up.

Incorrectly running the tests leads to some confusing compile errors, which makes it hard to figure out where the root cause is.

# Solution

If the unit tests are compiled for a target other than Wasm, an explicit runtime error will appear, explaining that it should either run the unit tests with a Wasm VM or make sure they are only executed if the test target is Wasm. For this error to appear instead of other more confusing errors, the mock API for unit tests had to be stubbed in the integration tests module.

~If a Wasm runtime is not specified, a compiler error will explain that a feature flag must be enabled.~ (Removed because the `test` feature is also useful without a runtime.)

If a unit tests uses a system API without setting up the mock API, a message will now appear saying which mock API should be called. This was previously shown inside the Wasm test code (which unfortunately the `test-runner` didn't show), or if the `linera-sdk` was compiled without the `test` feature.

# Testing

This was tested by changing the `examples/reentrant-counter/service.rs` file to build the unit tests for any target (not just `target_arch = "wasm32"` and checking that `cargo test --target x86_64-unknown-linux-gnu` compiles successfully but doesn't run any tests. Without these changes, compilation would fail.