### PR TITLE
Add memory layout traits to Witty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,6 +1906,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "frunk"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a351b59e12f97b4176ee78497dff72e4276fb1ceb13e19056aca7fa0206287"
+dependencies = [
+ "frunk_core",
+ "frunk_derives",
+ "frunk_proc_macros",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2469fab0bd07e64ccf0ad57a1438f63160c69b2e57f04a439653d68eb558d6"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fa992f1656e1707946bbba340ad244f0814009ef8c0118eb7b658395f19a2e"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b54add839292b743aeda6ebedbd8b11e93404f902c56223e51b9ec18a13d2c"
+dependencies = [
+ "frunk_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "frunk_proc_macros"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71b85a1d4a9a6b300b41c05e8e13ef2feca03e0334127f29eca9506a7fe13a93"
+dependencies = [
+ "frunk_core",
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "fungible"
 version = "0.1.0"
 dependencies = [
@@ -3083,6 +3135,9 @@ dependencies = [
 [[package]]
 name = "linera-witty"
 version = "0.2.0"
+dependencies = [
+ "frunk",
+]
 
 [[package]]
 name = "link-cplusplus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ derive_more = "0.99.17"
 dirs = "5.0.0"
 ed25519 = "1.2.0"
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
+frunk = "0.4.2"
 futures = "0.3.24"
 generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -9,3 +9,6 @@ homepage = "https://linera.io"
 documentation = "https://docs.rs/linera-witty/latest/linera_witty/"
 license = "Apache-2.0"
 edition = "2021"
+
+[dependencies]
+frunk = { workspace = true }

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -9,4 +9,6 @@
 //!
 //! [WIT]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md
 
+#![deny(missing_docs)]
+
 mod primitive_types;

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -11,4 +11,5 @@
 
 #![deny(missing_docs)]
 
+mod memory_layout;
 mod primitive_types;

--- a/linera-witty/src/memory_layout/element.rs
+++ b/linera-witty/src/memory_layout/element.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of a single element in a memory layout type.
+//!
+//! This is analogous to what [`MaybeFlatType`] is to [`crate::primitive_types::FlatType`]. Empty
+//! slots (represented by the `()` unit type) make it easier to generate code for zero sized types.
+
+use crate::primitive_types::{MaybeFlatType, SimpleType};
+
+/// Marker trait to prevent [`LayoutElement`] to be implemented for other types.
+pub trait Sealed {}
+
+/// Representation of a single element in a memory layout type.
+pub trait LayoutElement: Sealed + Default + Sized {
+    /// The alignment boundary of the element type.
+    const ALIGNMENT: u32;
+    /// If the element is a zero sized type.
+    const IS_EMPTY: bool;
+
+    /// The flattened representation of this element.
+    type Flat: MaybeFlatType;
+
+    /// Converts the element into its flattened representation.
+    fn flatten(self) -> Self::Flat;
+}
+
+impl Sealed for () {}
+impl<T> Sealed for T where T: SimpleType {}
+
+impl LayoutElement for () {
+    const ALIGNMENT: u32 = 1;
+    const IS_EMPTY: bool = true;
+
+    type Flat = ();
+
+    fn flatten(self) -> Self::Flat {}
+}
+
+impl<T> LayoutElement for T
+where
+    T: SimpleType,
+{
+    const ALIGNMENT: u32 = <T as SimpleType>::ALIGNMENT;
+    const IS_EMPTY: bool = false;
+
+    type Flat = <T as SimpleType>::Flat;
+
+    fn flatten(self) -> Self::Flat {
+        <T as SimpleType>::flatten(self)
+    }
+}

--- a/linera-witty/src/memory_layout/flat_layout.rs
+++ b/linera-witty/src/memory_layout/flat_layout.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of the layout of complex types as a sequence of native WebAssembly types.
+
+use super::Layout;
+use crate::primitive_types::FlatType;
+use frunk::{HCons, HNil};
+
+/// Representation of the layout of complex types as a sequence of native WebAssembly types.
+///
+/// This allows laying out complex types as a sequence of WebAssembly types that can represent the
+/// parameters or the return list of a function. WIT uses this as an optimization to pass complex
+/// types as multiple native WebAssembly parameters.
+pub trait FlatLayout: Layout {}
+
+impl FlatLayout for HNil {}
+
+impl<Head, Tail> FlatLayout for HCons<Head, Tail>
+where
+    Head: FlatType,
+    Tail: FlatLayout,
+{
+}

--- a/linera-witty/src/memory_layout/flat_layout.rs
+++ b/linera-witty/src/memory_layout/flat_layout.rs
@@ -12,7 +12,7 @@ use frunk::{HCons, HNil};
 /// This allows laying out complex types as a sequence of WebAssembly types that can represent the
 /// parameters or the return list of a function. WIT uses this as an optimization to pass complex
 /// types as multiple native WebAssembly parameters.
-pub trait FlatLayout: Layout {}
+pub trait FlatLayout: Layout<Flat = Self> {}
 
 impl FlatLayout for HNil {}
 

--- a/linera-witty/src/memory_layout/layout.rs
+++ b/linera-witty/src/memory_layout/layout.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of the memory layout of complex types as a sequence of fundamental WIT types.
+
+use super::element::LayoutElement;
+use frunk::{hlist::HList, HCons, HNil};
+
+/// Marker trait to prevent [`LayoutElement`] to be implemented for other types.
+pub trait Sealed {}
+
+/// Representation of the memory layout of complex types as a sequence of fundamental WIT types.
+pub trait Layout: Sealed + Default + HList {
+    /// The alignment boundary required for the layout.
+    const ALIGNMENT: u32;
+}
+
+impl Sealed for HNil {}
+impl<Head, Tail> Sealed for HCons<Head, Tail>
+where
+    Head: LayoutElement,
+    Tail: Layout,
+{
+}
+
+impl Layout for HNil {
+    const ALIGNMENT: u32 = 1;
+}
+
+impl<Head, Tail> Layout for HCons<Head, Tail>
+where
+    Head: LayoutElement,
+    Tail: Layout,
+{
+    const ALIGNMENT: u32 = if Head::ALIGNMENT > Tail::ALIGNMENT {
+        Head::ALIGNMENT
+    } else {
+        Tail::ALIGNMENT
+    };
+}

--- a/linera-witty/src/memory_layout/layout.rs
+++ b/linera-witty/src/memory_layout/layout.rs
@@ -3,7 +3,8 @@
 
 //! Representation of the memory layout of complex types as a sequence of fundamental WIT types.
 
-use super::element::LayoutElement;
+use super::{element::LayoutElement, FlatLayout};
+use crate::primitive_types::MaybeFlatType;
 use frunk::{hlist::HList, HCons, HNil};
 
 /// Marker trait to prevent [`LayoutElement`] to be implemented for other types.
@@ -13,6 +14,14 @@ pub trait Sealed {}
 pub trait Layout: Sealed + Default + HList {
     /// The alignment boundary required for the layout.
     const ALIGNMENT: u32;
+
+    /// Result of flattening this layout.
+    type Flat: FlatLayout;
+
+    /// Flattens this layout into a layout consisting of native WebAssembly types.
+    ///
+    /// The resulting flat layout does not have any empty items.
+    fn flatten(self) -> Self::Flat;
 }
 
 impl Sealed for HNil {}
@@ -25,6 +34,12 @@ where
 
 impl Layout for HNil {
     const ALIGNMENT: u32 = 1;
+
+    type Flat = HNil;
+
+    fn flatten(self) -> Self::Flat {
+        HNil
+    }
 }
 
 impl<Head, Tail> Layout for HCons<Head, Tail>
@@ -37,4 +52,10 @@ where
     } else {
         Tail::ALIGNMENT
     };
+
+    type Flat = <Head::Flat as MaybeFlatType>::Flatten<Tail>;
+
+    fn flatten(self) -> Self::Flat {
+        self.head.flatten().flatten(self.tail)
+    }
 }

--- a/linera-witty/src/memory_layout/mod.rs
+++ b/linera-witty/src/memory_layout/mod.rs
@@ -8,6 +8,7 @@
 //! of fundamental types.
 
 mod element;
+mod flat_layout;
 mod layout;
 
-pub use self::layout::Layout;
+pub use self::{flat_layout::FlatLayout, layout::Layout};

--- a/linera-witty/src/memory_layout/mod.rs
+++ b/linera-witty/src/memory_layout/mod.rs
@@ -8,3 +8,6 @@
 //! of fundamental types.
 
 mod element;
+mod layout;
+
+pub use self::layout::Layout;

--- a/linera-witty/src/memory_layout/mod.rs
+++ b/linera-witty/src/memory_layout/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Memory layout of non-fundamental WIT types.
+//!
+//! Complex WIT types are stored in memory as a sequence of fundamental types. The [`Layout`] type
+//! allows representing the memory layout as a type, a heterogeneous list ([`frunk::hlist::HList`])
+//! of fundamental types.
+
+mod element;

--- a/linera-witty/src/primitive_types/maybe_flat_type.rs
+++ b/linera-witty/src/primitive_types/maybe_flat_type.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A representation of either a [`FlatType`] or nothing, represented by the unit (`()`) type.
+
+use super::flat_type::FlatType;
+
+/// A marker trait for [`FlatType`]s and the unit type, which uses no storage space.
+pub trait MaybeFlatType: Sized {}
+
+impl MaybeFlatType for () {}
+
+impl<AnyFlatType> MaybeFlatType for AnyFlatType where AnyFlatType: FlatType {}

--- a/linera-witty/src/primitive_types/mod.rs
+++ b/linera-witty/src/primitive_types/mod.rs
@@ -4,6 +4,7 @@
 //! Primitive WebAssembly and WIT types.
 
 mod flat_type;
+mod maybe_flat_type;
 mod simple_type;
 
-pub use self::{flat_type::FlatType, simple_type::SimpleType};
+pub use self::{flat_type::FlatType, maybe_flat_type::MaybeFlatType, simple_type::SimpleType};


### PR DESCRIPTION
# Motivation

With the fundamental WIT and Wasm types defined previously by #880, the next step is to prepare to handle more complex types. These types are eventually made up of fundamental types, either WIT fundamental types to store in memory or Wasm primitive types to be passed through the host/guest interface as function parameters or result lists.

# Solution

Create a `Layout` trait to allow representing the memory layout of complex types. Types that implement this trait are heterogeneous lists (thanks to the [`frunk`](https://docs.rs/frunk) crate) of (optional) fundamental WIT types.

`Layout` types can be "flattened". This means that they can be transformed into a layout suitable for using in the host/guest function interface. A `FlatLayout` trait represents a heterogeneous list made up of Wasm primitive types (a.k.a., Rust types that implement the `FlatType` trait).

Because `Layout`s can have empty positions (represented by the `()` unit type in the `LayoutElement` trait) but `FlatLayout`s can't, a `MaybeFlatType` helper trait is needed. It represents a flattened `LayoutElement` (either a `SimpleType` or the `()` empty unit type), but it's not added to a `FlatLayout`. Instead, it has a helper `flatten` method that generates a `FlatLayout` by either including itself at the head (if it's not empty) or skipping to the next element.

Both `Layout` and `FlatLayout` types can be concatenated using the `append` and `flat_append` methods, and the resulting layout types must also be reversibly splittable. This is useful for joining layouts of different types used as fields in another type to represent that outer type's layout, and also to split that outer layout into the layouts of the individual fields.