### PR TITLE
Fix liveness issue for multi owner chain manager. 

### DIFF
--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -21,10 +21,10 @@ linera-base = { workspace = true }
 linera-execution = { workspace = true }
 linera-views = { workspace = true, features = ["metrics"] }
 futures = { workspace = true }
-tracing = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 linera-chain = { path = ".", features = ["test"] }

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -114,7 +114,7 @@ impl ChainManager {
     ) -> Result<Outcome, ChainError> {
         match self {
             ChainManager::Multi(manager) => manager.check_validated_block(certificate),
-            ChainManager::None | ChainManager::Single(_)  => panic!("unexpected chain manager"),
+            ChainManager::None | ChainManager::Single(_) => panic!("unexpected chain manager"),
         }
     }
 
@@ -139,7 +139,7 @@ impl ChainManager {
     pub fn create_final_vote(&mut self, certificate: Certificate, key_pair: Option<&KeyPair>) {
         match self {
             ChainManager::Multi(manager) => manager.create_final_vote(certificate, key_pair),
-            ChainManager::None | ChainManager::Single(_)  => panic!("unexpected chain manager"),
+            ChainManager::None | ChainManager::Single(_) => panic!("unexpected chain manager"),
         }
     }
 }

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -89,11 +89,9 @@ impl MultiOwnerManager {
         Ok(Outcome::Accept)
     }
 
-    pub fn check_validated_block(
-        &self,
-        new_block: &Block,
-        new_round: RoundNumber,
-    ) -> Result<Outcome, ChainError> {
+    pub fn check_validated_block(&self, certificate: &Certificate) -> Result<Outcome, ChainError> {
+        let new_block = &certificate.value().executed_block().block;
+        let new_round = certificate.round;
         if let Some(Vote { value, round, .. }) = &self.pending {
             match value.inner() {
                 CertificateValue::ConfirmedBlock { executed_block } => {
@@ -151,6 +149,10 @@ impl MultiOwnerManager {
             // Ok to overwrite validation votes with confirmation votes at equal or higher round.
             self.pending = Some(vote);
         }
+    }
+
+    pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
+        self.owners.get(&proposal.owner).copied()
     }
 }
 

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -55,10 +55,7 @@ impl SingleOwnerManager {
         if let Some(vote) = &self.pending {
             let block = match vote.value() {
                 CertificateValue::ConfirmedBlock { executed_block, .. } => &executed_block.block,
-                value => {
-                    let msg = format!("Unexpected value: {:?}", value);
-                    return Err(ChainError::InternalError(msg));
-                }
+                _ => return Err(ChainError::InternalError("Unexpected value".to_string())),
             };
             if block == new_block {
                 return Ok(Outcome::Skip);
@@ -97,6 +94,10 @@ impl SingleOwnerManager {
             let vote = Vote::new(value, round, key_pair);
             self.pending = Some(vote);
         }
+    }
+
+    pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
+        (self.owner == proposal.owner).then_some(self.public_key)
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -645,9 +645,10 @@ where
             || chain
                 .manager
                 .get_mut()
-                .check_validated_block(block, certificate.round)?
+                .check_validated_block(&certificate)?
                 == ChainManagerOutcome::Skip
         {
+            chain.save().await?;
             // If we just processed the same pending block, return the chain info unchanged.
             return Ok(ChainInfoResponse::new(&chain, self.key_pair()));
         }
@@ -864,7 +865,7 @@ where
         let public_key = chain
             .manager
             .get()
-            .verify_owner(owner)
+            .verify_owner(&proposal)
             .ok_or(WorkerError::InvalidOwner)?;
         signature.check(&proposal.content, public_key)?;
         // Check the authentication of the operations in the block.

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -389,6 +389,9 @@ MultiOwnerManagerInfo:
     - requested_proposed:
         OPTION:
           TYPENAME: BlockProposal
+    - requested_validated:
+        OPTION:
+          TYPENAME: Certificate
     - requested_locked:
         OPTION:
           TYPENAME: Certificate


### PR DESCRIPTION
This PR contains some minor changes in preparation for BFT chains, as well as a liveness fix for the existing multi-owner chain manager:

Assume there are four equally-weighted validators, A, B, C, and D.
Then for _safety_ purposes, one faulty validator is tolerated.

This change addresses the following _liveness_ issue:

In round 0, block X is proposed, and all validators vote to validate it, so there is a `ValidatedBlock` certificate. However, it only gets sent to A at first, who votes to confirm it, so A has locked block X.
    
The other validators first see block Y proposed in round 1. Since they haven't locked any block yet, they vote to validate it. Even if they later receive the `ValidatedBlock` certificate from round 0, they now won't vote to confirm it anymore. The three of them create a certificate for a `ValidatedBlock`.

Now faulty validator D goes offline, and block X is proposed in round 2. Validator A votes to validated X in round 2, and therefore can't vote to confirm Y in 1 anymore.

That effectively blocks the chain, since A cannot vote for any proposal different from X anymore, B and C can only vote for Y, and D is gone.

The fix is to allow A to vote for Y.

In general, if there is a `ValidatedBlock` certificate from a round higher than the locked block's, voting for it is allowed.