### PR TITLE
Use packaged Cargo.lock when installing cargo tools.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,13 +100,13 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Install cargo-machete
       run: |
-        cargo install cargo-machete
+        cargo install cargo-machete --locked
     - name: Install cargo-all-features
       run: |
-        cargo install --git https://github.com/ma2bd/cargo-all-features --branch workspace_metadata
+        cargo install --git https://github.com/ma2bd/cargo-all-features --branch workspace_metadata --locked
     - name: Install cargo-rdme
       run: |
-        cargo install cargo-rdme
+        cargo install cargo-rdme --locked
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:


### PR DESCRIPTION
The cargo-machete build currently fails because grep-cli v0.1.8 doesn't compile.

Using `--locked` everywhere prevents that kind of surprise: Now the build can only fail if the tool itself publishes a broken version, not if a dependency does.