### PR TITLE
Fix liveness issue for multi owner chain manager.

### DIFF
--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -21,10 +21,10 @@ linera-base = { workspace = true }
 linera-execution = { workspace = true }
 linera-views = { workspace = true, features = ["metrics"] }
 futures = { workspace = true }
-tracing = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 linera-chain = { path = ".", features = ["test"] }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -161,6 +161,7 @@ pub struct BlockProposal {
     pub owner: Owner,
     pub signature: Signature,
     pub blobs: Vec<HashedValue>,
+    pub validated: Option<Certificate>,
 }
 
 /// A message together with routing information.
@@ -534,13 +535,19 @@ impl HashedValue {
 }
 
 impl BlockProposal {
-    pub fn new(content: BlockAndRound, secret: &KeyPair, blobs: Vec<HashedValue>) -> Self {
+    pub fn new(
+        content: BlockAndRound,
+        secret: &KeyPair,
+        blobs: Vec<HashedValue>,
+        validated: Option<Certificate>,
+    ) -> Self {
         let signature = Signature::new(&content, secret);
         Self {
             content,
             owner: secret.public().into(),
             signature,
             blobs,
+            validated,
         }
     }
 }

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -15,7 +15,6 @@ use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{BlockHeight, RoundNumber},
     doc_scalar, ensure,
-    identifiers::Owner,
 };
 use linera_execution::ChainOwnership;
 use serde::{Deserialize, Serialize};
@@ -65,16 +64,10 @@ impl ChainManager {
         !matches!(self, ChainManager::None)
     }
 
-    pub fn verify_owner(&self, owner: &Owner) -> Option<PublicKey> {
+    pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
         match self {
-            ChainManager::Single(manager) => {
-                if manager.owner == *owner {
-                    Some(manager.public_key)
-                } else {
-                    None
-                }
-            }
-            ChainManager::Multi(manager) => manager.owners.get(owner).copied(),
+            ChainManager::Single(manager) => manager.verify_owner(proposal),
+            ChainManager::Multi(manager) => manager.verify_owner(proposal),
             ChainManager::None => None,
         }
     }
@@ -85,7 +78,7 @@ impl ChainManager {
                 let round = manager.round();
                 round.try_add_one().unwrap_or(round)
             }
-            _ => RoundNumber::default(),
+            ChainManager::None | ChainManager::Single(_) => RoundNumber::default(),
         }
     }
 
@@ -93,7 +86,7 @@ impl ChainManager {
         match self {
             ChainManager::Single(manager) => manager.pending(),
             ChainManager::Multi(manager) => manager.pending(),
-            _ => None,
+            ChainManager::None => None,
         }
     }
 
@@ -111,18 +104,14 @@ impl ChainManager {
         match self {
             ChainManager::Single(manager) => manager.check_proposed_block(new_block, new_round),
             ChainManager::Multi(manager) => manager.check_proposed_block(new_block, new_round),
-            _ => panic!("unexpected chain manager"),
+            ChainManager::None => panic!("unexpected chain manager"),
         }
     }
 
-    pub fn check_validated_block(
-        &self,
-        new_block: &Block,
-        new_round: RoundNumber,
-    ) -> Result<Outcome, ChainError> {
+    pub fn check_validated_block(&self, certificate: &Certificate) -> Result<Outcome, ChainError> {
         match self {
-            ChainManager::Multi(manager) => manager.check_validated_block(new_block, new_round),
-            _ => panic!("unexpected chain manager"),
+            ChainManager::Multi(manager) => manager.check_validated_block(certificate),
+            ChainManager::None | ChainManager::Single(_) => panic!("unexpected chain manager"),
         }
     }
 
@@ -140,14 +129,14 @@ impl ChainManager {
             ChainManager::Multi(manager) => {
                 manager.create_vote(proposal, messages, state_hash, key_pair)
             }
-            _ => panic!("unexpected chain manager"),
+            ChainManager::None => panic!("unexpected chain manager"),
         }
     }
 
     pub fn create_final_vote(&mut self, certificate: Certificate, key_pair: Option<&KeyPair>) {
         match self {
             ChainManager::Multi(manager) => manager.create_final_vote(certificate, key_pair),
-            _ => panic!("unexpected chain manager"),
+            ChainManager::None | ChainManager::Single(_) => panic!("unexpected chain manager"),
         }
     }
 }

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -91,9 +91,10 @@ impl MultiOwnerManager {
 
     pub fn check_validated_block(
         &self,
-        new_block: &Block,
-        new_round: RoundNumber,
+        certificate: &Certificate,
     ) -> Result<Outcome, ChainError> {
+        let new_block = &certificate.value().executed_block().block;
+        let new_round = certificate.round;
         if let Some(Vote { value, round, .. }) = &self.pending {
             match value.inner() {
                 CertificateValue::ConfirmedBlock { executed_block } => {
@@ -151,6 +152,10 @@ impl MultiOwnerManager {
             // Ok to overwrite validation votes with confirmation votes at equal or higher round.
             self.pending = Some(vote);
         }
+    }
+
+    pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
+        self.owners.get(&proposal.owner).copied()
     }
 }
 

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -64,12 +64,6 @@ impl MultiOwnerManager {
     pub fn check_proposed_block(&self, proposal: &BlockProposal) -> Result<Outcome, ChainError> {
         let new_block = &proposal.content.block;
         let new_round = proposal.content.round;
-        if let Some(validated) = &proposal.validated {
-            ensure!(
-                validated.round < new_round,
-                ChainError::InvalidBlockProposal
-            );
-        }
         if let Some(old_proposal) = &self.proposed {
             if old_proposal.content.block == *new_block && old_proposal.content.round == new_round {
                 return Ok(Outcome::Skip);
@@ -78,21 +72,17 @@ impl MultiOwnerManager {
                 return Err(ChainError::InsufficientRound(old_proposal.content.round));
             }
         }
-        if let Some(Certificate { round, value, .. }) = &self.locked {
-            if let CertificateValue::ValidatedBlock {
-                executed_block: ExecutedBlock { block, .. },
-            } = value.inner()
-            {
-                ensure!(new_round > *round, ChainError::InsufficientRound(*round));
-                ensure!(
-                    *new_block == *block
-                        || proposal
-                            .validated
-                            .as_ref()
-                            .map_or(false, |cert| cert.round > *round),
-                    ChainError::HasLockedBlock(block.height, *round)
-                );
-            }
+        if let Some(locked) = proposal
+            .validated
+            .iter()
+            .chain(&self.locked)
+            .max_by_key(|cert| cert.round)
+        {
+            let block = &locked.value().executed_block().block;
+            ensure!(
+                locked.round < new_round && block == new_block,
+                ChainError::HasLockedBlock(block.height, locked.round)
+            );
         }
         Ok(Outcome::Accept)
     }

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -4,8 +4,8 @@
 use super::Outcome;
 use crate::{
     data_types::{
-        Block, BlockAndRound, BlockProposal, CertificateValue, ExecutedBlock, HashedValue,
-        LiteVote, OutgoingMessage, Vote,
+        BlockAndRound, BlockProposal, CertificateValue, ExecutedBlock, HashedValue, LiteVote,
+        OutgoingMessage, Vote,
     },
     ChainError,
 };
@@ -43,13 +43,11 @@ impl SingleOwnerManager {
     }
 
     /// Verifies the safety of the block w.r.t. voting rules.
-    pub fn check_proposed_block(
-        &self,
-        new_block: &Block,
-        new_round: RoundNumber,
-    ) -> Result<Outcome, ChainError> {
+    pub fn check_proposed_block(&self, proposal: &BlockProposal) -> Result<Outcome, ChainError> {
+        let new_block = &proposal.content.block;
+        let new_round = proposal.content.round;
         ensure!(
-            new_round == RoundNumber::default(),
+            new_round == RoundNumber::default() && proposal.validated.is_none(),
             ChainError::InvalidBlockProposal
         );
         if let Some(vote) = &self.pending {

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -55,10 +55,7 @@ impl SingleOwnerManager {
         if let Some(vote) = &self.pending {
             let block = match vote.value() {
                 CertificateValue::ConfirmedBlock { executed_block, .. } => &executed_block.block,
-                value => {
-                    let msg = format!("Unexpected value: {:?}", value);
-                    return Err(ChainError::InternalError(msg));
-                }
+                _ => return Err(ChainError::InternalError("Unexpected value".to_string())),
             };
             if block == new_block {
                 return Ok(Outcome::Skip);
@@ -97,6 +94,10 @@ impl SingleOwnerManager {
             let vote = Vote::new(value, round, key_pair);
             self.pending = Some(vote);
         }
+    }
+
+    pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
+        (self.owner == proposal.owner).then_some(self.public_key)
     }
 }
 

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -979,6 +979,7 @@ where
             .read_or_download_blobs(nodes, block.bytecode_locations())
             .await?;
         // Build the initial query.
+        let manager = self.chain_info().await?.manager;
         let key_pair = self.key_pair().await?;
         let proposal = BlockProposal::new(
             BlockAndRound {
@@ -987,6 +988,7 @@ where
             },
             key_pair,
             blobs,
+            manager.highest_validated().cloned(),
         );
         // Try to execute the block locally first.
         self.node_client
@@ -995,7 +997,7 @@ where
         // Remember what we are trying to do, before sending the proposal to the validators.
         self.pending_block = Some(block);
         // Send the query to validators.
-        let final_certificate = match self.chain_info().await?.manager {
+        let final_certificate = match manager {
             ChainManagerInfo::Multi(_) => {
                 // Need two round-trips.
                 let certificate = self

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -982,6 +982,7 @@ where
         let manager = self.chain_info().await?.manager;
         let key_pair = self.key_pair().await?;
         let validated = manager.highest_validated().cloned();
+        // TODO(#66): return the block that should be proposed instead
         if let Some(validated) = &validated {
             ensure!(
                 validated.value().executed_block().block == block,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -174,6 +174,7 @@ fn make_transfer_block_proposal(
         },
         key_pair,
         vec![],
+        None,
     )
 }
 
@@ -503,6 +504,7 @@ where
             },
             &key_pair,
             vec![],
+            None,
         )
     };
 
@@ -612,7 +614,7 @@ where
     let unknown_key = KeyPair::generate();
 
     let unknown_sender_block_proposal =
-        BlockProposal::new(block_proposal.content, &unknown_key, vec![]);
+        BlockProposal::new(block_proposal.content, &unknown_key, vec![], None);
     assert!(worker
         .handle_block_proposal(unknown_sender_block_proposal)
         .await

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -645,7 +645,7 @@ where
             || chain
                 .manager
                 .get_mut()
-                .check_validated_block(block, certificate.round)?
+                .check_validated_block(&certificate)?
                 == ChainManagerOutcome::Skip
         {
             // If we just processed the same pending block, return the chain info unchanged.
@@ -864,7 +864,7 @@ where
         let public_key = chain
             .manager
             .get()
-            .verify_owner(owner)
+            .verify_owner(&proposal)
             .ok_or(WorkerError::InvalidOwner)?;
         signature.check(&proposal.content, public_key)?;
         // Check the authentication of the operations in the block.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -137,6 +137,9 @@ message BlockProposal {
 
   // Required bytecode
   bytes blobs = 5;
+
+  // A certificate for a validated block that justifies the proposal in this round.
+  optional bytes validated = 6;
 }
 
 // A certified statement from the committee, without the value.

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -77,6 +77,9 @@ BlockProposal:
     - blobs:
         SEQ:
           TYPENAME: CertificateValue
+    - validated:
+        OPTION:
+          TYPENAME: Certificate
 Bytecode:
   STRUCT:
     - bytes: BYTES

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -301,6 +301,7 @@ impl ClientContext {
                 },
                 key_pair,
                 vec![],
+                None,
             );
             proposals.push(proposal.into());
             if proposals.len() >= max_proposals {


### PR DESCRIPTION
This PR contains some minor changes in preparation for BFT chains, as well as a liveness fix for the existing multi-owner chain manager:

Assume there are four equally-weighted validators, A, B, C, and D.
Then for _safety_ purposes, one faulty validator is tolerated.

This change addresses the following _liveness_ issue:

In round 0, block X is proposed, and all validators vote to validate it, so there is a `ValidatedBlock` certificate. However, it only gets sent to A at first, who votes to confirm it, so A has locked block X.
    
The other validators first see block Y proposed in round 1. Since they haven't locked any block yet, they vote to validate it. Even if they later receive the `ValidatedBlock` certificate from round 0, they now won't vote to confirm it anymore. The three of them create a certificate for a `ValidatedBlock`.

Now faulty validator D goes offline, and block X is proposed in round 2. Validator A votes to validated X in round 2, and therefore can't vote to confirm Y in 1 anymore.

That effectively blocks the chain, since A cannot vote for any proposal different from X anymore, B and C can only vote for Y, and D is gone.

The fix is to allow A to vote for Y.

In general, if there is a `ValidatedBlock` certificate from a round higher than the locked block's, voting for it is allowed. The block proposer has to include it in the proposal.