### PR TITLE
Add abstraction to access guest Wasm module memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,7 @@ dependencies = [
  "frunk",
  "linera-witty",
  "linera-witty-macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -17,6 +17,7 @@ macros = ["linera-witty-macros"]
 [dependencies]
 frunk = { workspace = true }
 linera-witty-macros = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 linera-witty = { workspace = true, features = ["macros"] }

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -19,7 +19,7 @@ mod primitive_types;
 mod runtime;
 mod type_traits;
 
-pub use self::{memory_layout::Layout, type_traits::WitType};
+pub use self::{memory_layout::Layout, runtime::Memory, type_traits::WitType};
 pub use frunk::{hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::WitType;

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -16,6 +16,7 @@ mod macro_utils;
 
 mod memory_layout;
 mod primitive_types;
+mod runtime;
 mod type_traits;
 
 pub use self::{memory_layout::Layout, type_traits::WitType};

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -8,6 +8,18 @@ use thiserror::Error;
 /// Errors that can occur when using a Wasm runtime.
 #[derive(Debug, Error)]
 pub enum RuntimeError {
+    /// Attempt to allocate a buffer larger than `i32::MAX`.
+    #[error("Requested allocation size is too large")]
+    AllocationTooLarge,
+
+    /// Call to `cabi_realloc` returned a negative value instead of a valid address.
+    #[error("Memory allocation failed")]
+    AllocationFailed,
+
+    /// Attempt to deallocate an address that's after `i32::MAX`.
+    #[error("Attempt to deallocate an invalid address")]
+    DeallocateInvalidAddress,
+
     /// Attempt to load a function not exported from a module.
     #[error("Function `{_0}` could not be found in the module's exports")]
     FunctionNotFound(String),

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -7,4 +7,12 @@ use thiserror::Error;
 
 /// Errors that can occur when using a Wasm runtime.
 #[derive(Debug, Error)]
-pub enum RuntimeError {}
+pub enum RuntimeError {
+    /// Attempt to load a function not exported from a module.
+    #[error("Function `{_0}` could not be found in the module's exports")]
+    FunctionNotFound(String),
+
+    /// Attempt to load a function with a name that's used for a different import in the module.
+    #[error("Export `{_0}` is not a function")]
+    NotAFunction(String),
+}

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Common error type for usage of different Wasm runtimes.
+
+use thiserror::Error;
+
+/// Errors that can occur when using a Wasm runtime.
+#[derive(Debug, Error)]
+pub enum RuntimeError {}

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -3,8 +3,9 @@
 
 //! Abstraction over how different runtimes manipulate the guest WebAssembly module's memory.
 
-use super::RuntimeError;
+use super::{InstanceWithFunction, Runtime, RuntimeError};
 use crate::{Layout, WitType};
+use frunk::{hlist, hlist_pat, HList};
 use std::borrow::Cow;
 
 /// An address for a location in a guest WebAssembly module's memory.
@@ -50,4 +51,107 @@ pub trait RuntimeMemory<Instance> {
         location: GuestPointer,
         bytes: &[u8],
     ) -> Result<(), RuntimeError>;
+}
+
+/// Trait alias for a Wasm module instance with the WIT Canonical ABI `cabi_realloc` function.
+pub trait CabiReallocAlias: InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]> {}
+
+impl<AnyInstance> CabiReallocAlias for AnyInstance where
+    AnyInstance: InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]>
+{
+}
+
+/// Trait alias for a Wasm module instance with the WIT Canonical ABI `cabi_free` function.
+pub trait CabiFreeAlias: InstanceWithFunction<HList![i32], HList![]> {}
+
+impl<AnyInstance> CabiFreeAlias for AnyInstance where
+    AnyInstance: InstanceWithFunction<HList![i32], HList![]>
+{
+}
+
+/// A handle to interface with a guest Wasm module instance's memory.
+#[allow(clippy::type_complexity)]
+pub struct Memory<'runtime, Instance>
+where
+    Instance: CabiReallocAlias + CabiFreeAlias,
+{
+    instance: &'runtime mut Instance,
+    memory: <Instance::Runtime as Runtime>::Memory,
+    cabi_realloc: Option<
+        <Instance as InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]>>::Function,
+    >,
+    cabi_free: Option<<Instance as InstanceWithFunction<HList![i32], HList![]>>::Function>,
+}
+
+impl<Instance> Memory<'_, Instance>
+where
+    Instance: CabiReallocAlias + CabiFreeAlias,
+    <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+{
+    /// Reads `length` bytes from `location`.
+    ///
+    /// The underlying runtime may return either a memory slice or an owned buffer.
+    pub fn read(&self, location: GuestPointer, length: u32) -> Result<Cow<'_, [u8]>, RuntimeError> {
+        self.memory.read(&*self.instance, location, length)
+    }
+
+    /// Writes `bytes` to `location`.
+    pub fn write(&mut self, location: GuestPointer, bytes: &[u8]) -> Result<(), RuntimeError> {
+        self.memory.write(&mut *self.instance, location, bytes)
+    }
+
+    /// Returns a newly allocated buffer of `size` bytes in the guest module's memory.
+    ///
+    /// Calls the guest module to allocate the memory, so the resulting allocation is managed by
+    /// the guest.
+    pub fn allocate(&mut self, size: u32) -> Result<GuestPointer, RuntimeError> {
+        if self.cabi_realloc.is_none() {
+            self.cabi_realloc = Some(<Instance as InstanceWithFunction<
+                HList![i32, i32, i32, i32],
+                HList![i32],
+            >>::load_function(self.instance, "cabi_realloc")?);
+        }
+
+        let size = i32::try_from(size).map_err(|_| RuntimeError::AllocationTooLarge)?;
+
+        let cabi_realloc = self
+            .cabi_realloc
+            .as_ref()
+            .expect("`cabi_realloc` function was not loaded before it was called");
+
+        let hlist_pat![allocation_address] =
+            self.instance.call(cabi_realloc, hlist![0, 0, 1, size])?;
+
+        Ok(GuestPointer(
+            allocation_address
+                .try_into()
+                .map_err(|_| RuntimeError::AllocationFailed)?,
+        ))
+    }
+
+    /// Deallocates the `allocation` managed by the guest.
+    pub fn deallocate(&mut self, allocation: GuestPointer) -> Result<(), RuntimeError> {
+        if self.cabi_free.is_none() {
+            self.cabi_free = Some(
+                <Instance as InstanceWithFunction<HList![i32], HList![]>>::load_function(
+                    self.instance,
+                    "cabi_free",
+                )?,
+            );
+        }
+
+        let address = allocation
+            .0
+            .try_into()
+            .map_err(|_| RuntimeError::DeallocateInvalidAddress)?;
+
+        let cabi_free = self
+            .cabi_free
+            .as_ref()
+            .expect("`cabi_free` function was not loaded before it was called");
+
+        self.instance.call(cabi_free, hlist![address])?;
+
+        Ok(())
+    }
 }

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Abstraction over how different runtimes manipulate the guest WebAssembly module's memory.
+
+use crate::{Layout, WitType};
+
+/// An address for a location in a guest WebAssembly module's memory.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GuestPointer(u32);
+
+impl GuestPointer {
+    /// Returns a new address that's the current address advanced to after the size of `T`.
+    pub fn after<T: WitType>(&self) -> Self {
+        GuestPointer(self.0 + T::SIZE)
+    }
+
+    /// Returns a new address that's the current address advanced to add padding to ensure it's
+    /// aligned properly for `T`.
+    pub fn after_padding_for<T: WitType>(&self) -> Self {
+        let padding = (-(self.0 as i32) & (<T::Layout as Layout>::ALIGNMENT as i32 - 1)) as u32;
+
+        GuestPointer(self.0 + padding)
+    }
+
+    /// Returns the address of an element in a contiguous list of properly aligned `T` types.
+    pub fn index<T: WitType>(&self, index: u32) -> Self {
+        let element_size = GuestPointer(T::SIZE).after_padding_for::<T>();
+
+        GuestPointer(self.0 + index * element_size.0)
+    }
+}

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -3,7 +3,9 @@
 
 //! Abstraction over how different runtimes manipulate the guest WebAssembly module's memory.
 
+use super::RuntimeError;
 use crate::{Layout, WitType};
+use std::borrow::Cow;
 
 /// An address for a location in a guest WebAssembly module's memory.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -29,4 +31,23 @@ impl GuestPointer {
 
         GuestPointer(self.0 + index * element_size.0)
     }
+}
+
+/// Interface for accessing a runtime specific memory.
+pub trait RuntimeMemory<Instance> {
+    /// Reads `length` bytes from memory from the provided `location`.
+    fn read<'instance>(
+        &self,
+        instance: &'instance Instance,
+        location: GuestPointer,
+        length: u32,
+    ) -> Result<Cow<'instance, [u8]>, RuntimeError>;
+
+    /// Writes the `bytes` to memory at the provided `location`.
+    fn write(
+        &mut self,
+        instance: &mut Instance,
+        location: GuestPointer,
+        bytes: &[u8],
+    ) -> Result<(), RuntimeError>;
 }

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Code to interface with different runtimes.
+
+mod traits;

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 //! Code to interface with different runtimes.
 
 mod error;
+mod memory;
 mod traits;
 
 pub use self::error::RuntimeError;

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -7,4 +7,8 @@ mod error;
 mod memory;
 mod traits;
 
-pub use self::error::RuntimeError;
+pub use self::{
+    error::RuntimeError,
+    memory::Memory,
+    traits::{Instance, InstanceWithFunction, Runtime},
+};

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -3,4 +3,7 @@
 
 //! Code to interface with different runtimes.
 
+mod error;
 mod traits;
+
+pub use self::error::RuntimeError;

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -6,10 +6,16 @@
 /// A Wasm runtime.
 ///
 /// Shared types between different guest instances that use the same runtime.
-pub trait Runtime: Sized {}
+pub trait Runtime: Sized {
+    /// A handle to something exported from a guest Wasm module.
+    type Export;
+}
 
 /// An active guest Wasm module.
 pub trait Instance: Sized {
     /// The runtime this instance is running in.
     type Runtime: Runtime;
+
+    /// Loads an export from the guest module.
+    fn load_export(&mut self, name: &str) -> Option<<Self::Runtime as Runtime>::Export>;
 }

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Abstractions over different Wasm runtime implementations.
+
+/// A Wasm runtime.
+///
+/// Shared types between different guest instances that use the same runtime.
+pub trait Runtime: Sized {}

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -7,3 +7,9 @@
 ///
 /// Shared types between different guest instances that use the same runtime.
 pub trait Runtime: Sized {}
+
+/// An active guest Wasm module.
+pub trait Instance: Sized {
+    /// The runtime this instance is running in.
+    type Runtime: Runtime;
+}

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -3,6 +3,9 @@
 
 //! Abstractions over different Wasm runtime implementations.
 
+use super::RuntimeError;
+use crate::memory_layout::FlatLayout;
+
 /// A Wasm runtime.
 ///
 /// Shared types between different guest instances that use the same runtime.
@@ -18,4 +21,37 @@ pub trait Instance: Sized {
 
     /// Loads an export from the guest module.
     fn load_export(&mut self, name: &str) -> Option<<Self::Runtime as Runtime>::Export>;
+}
+
+/// How a runtime supports a function signature.
+pub trait InstanceWithFunction<Parameters, Results>: Instance
+where
+    Parameters: FlatLayout,
+    Results: FlatLayout,
+{
+    /// The runtime-specific type to represent the function.
+    type Function;
+
+    /// Converts an export into a function, if it is one.
+    fn function_from_export(
+        &mut self,
+        export: <Self::Runtime as Runtime>::Export,
+    ) -> Result<Option<Self::Function>, RuntimeError>;
+
+    /// Calls the `function` from this instance using the specified `parameters`.
+    fn call(
+        &mut self,
+        function: &Self::Function,
+        parameters: Parameters,
+    ) -> Result<Results, RuntimeError>;
+
+    /// Loads a function from the guest Wasm instance.
+    fn load_function(&mut self, name: &str) -> Result<Self::Function, RuntimeError> {
+        let export = self
+            .load_export(name)
+            .ok_or_else(|| RuntimeError::FunctionNotFound(name.to_string()))?;
+
+        self.function_from_export(export)?
+            .ok_or_else(|| RuntimeError::NotAFunction(name.to_string()))
+    }
 }

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -12,6 +12,9 @@ use crate::memory_layout::FlatLayout;
 pub trait Runtime: Sized {
     /// A handle to something exported from a guest Wasm module.
     type Export;
+
+    /// A handle to the guest Wasm module's memory.
+    type Memory;
 }
 
 /// An active guest Wasm module.


### PR DESCRIPTION
# Motivation

Some types require dynamic memory to be allocated so that they can be sent between the host and the guest Wasm module instance. Wasmer and Wasmtime have slightly different ways to access the guest memory, so an abstraction over them is needed.

# Solution

Create a `Runtime` trait to represent the runtime implementation (initially the plan is to support Wasmer and Wasmtime), and have an `Instance` trait to represent a guest Wasm module instanced for a specific runtime. Because runtimes have different ways to call guest functions, and because the allocations must be handled by the guest according to WIT's canonical ABI, an `InstanceWithFunction` generic trait is defined. The trait is parameterized with an heterogeneous list of parameters and another list of results. The trait provides the runtime-specific function type for that pair of parameters and results, as well as functions to load that function from the guest and call it.

Accessing the memory in a runtime specific way is then abstracted away by a new `RuntimeMemory` trait (parameterized over the `Instance`). Finally, a `Memory` type is created to allow allocating, deallocating, reading and writing to an instance's memory.