### PR TITLE
Make node service process all owned chains.

### DIFF
--- a/examples/counter/web-frontend/src/App.js
+++ b/examples/counter/web-frontend/src/App.js
@@ -20,17 +20,18 @@ const INCREMENT_COUNTER = gql`
 `;
 
 const NOTIFICATION_SUBSCRIPTION = gql`
-  subscription {
-    notifications
+  subscription Notifications($chainId: ID!) {
+    notifications(chainId: $chainId)
   }
 `;
 
-function App() {
+function App({ chainId }) {
   let [valueQuery, { data, called }] = useLazyQuery(GET_COUNTER_VALUE, {
     fetchPolicy: "network-only",
   });
   useSubscription(NOTIFICATION_SUBSCRIPTION, {
-    onData: () => valueQuery(),
+    variables: { chainId: chainId },
+    onData: () => valueQuery()
   });
   if (!called) {
     void valueQuery();

--- a/examples/counter/web-frontend/src/GraphQLProvider.js
+++ b/examples/counter/web-frontend/src/GraphQLProvider.js
@@ -10,20 +10,20 @@ import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";
 
-function GraphQLProvider({ applicationId, children }) {
-  let client = apolloClient(applicationId);
+function GraphQLProvider({ chainId, applicationId, port, children }) {
+  let client = apolloClient(chainId, applicationId, port);
   return <ApolloProvider client={client}>{children}</ApolloProvider>;
 }
 
-function apolloClient(applicationId) {
+function apolloClient(chainId, applicationId, port) {
   const wsLink = new GraphQLWsLink(
     createClient({
-      url: "ws://localhost:8080/ws",
+      url: `ws://localhost:${port}/ws`,
     })
   );
 
   const httpLink = new HttpLink({
-    uri: "http://localhost:8080/applications/" + applicationId,
+    uri: `http://localhost:${port}/chains/${chainId}/applications/${applicationId}`,
   });
 
   const splitLink = split(

--- a/examples/counter/web-frontend/src/index.js
+++ b/examples/counter/web-frontend/src/index.js
@@ -2,7 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
-import { BrowserRouter, Route, Routes, useParams } from "react-router-dom";
+import {
+  BrowserRouter,
+  Route,
+  Routes,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import GraphQLProvider from "./GraphQLProvider";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
@@ -19,9 +25,18 @@ root.render(
 
 function GraphQLApp() {
   const { id } = useParams();
+  const [searchParams] = useSearchParams();
+  let app = searchParams.get("app");
+  let port = searchParams.get("port");
+  if (app == null) {
+    throw Error("missing app query param");
+  }
+  if (port == null) {
+    port = 8080;
+  }
   return (
-    <GraphQLProvider applicationId={id}>
-      <App />
+    <GraphQLProvider chainId={id} applicationId={app} port={port}>
+      <App chainId={id} />
     </GraphQLProvider>
   );
 }

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -49,15 +49,15 @@ application, and publish them as an application bytecode:
 
 ```bash
 alias linera="$PWD/target/debug/linera"
-export LINERA_WALLET1="$PWD/target/debug/wallet.json"
-export LINERA_STORAGE1="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
+export LINERA_WALLET="$PWD/target/debug/wallet.json"
+export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
 export LINERA_WALLET2="$PWD/target/debug/wallet_2.json"
 export LINERA_STORAGE2="rocksdb:$(dirname "$LINERA_WALLET2")/linera_2.db"
 
 (cargo build && cd examples && cargo build --release)
-linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" publish-bytecode \
+linera publish-bytecode \
   examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm
-linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" publish-bytecode \
+linera publish-bytecode \
   examples/target/wasm32-unknown-unknown/release/crowd_funding_{contract,service}.wasm
 ```
 
@@ -81,7 +81,7 @@ In order to select the accounts to have initial tokens, the command below can be
 the chains created for the test as known by each wallet:
 
 ```bash
-linera --storage "$LINERA_STORAGE1" --wallet "$LINERA_WALLET1" wallet show
+linera wallet show
 linera --storage "$LINERA_STORAGE2" --wallet "$LINERA_WALLET2" wallet show
 ```
 
@@ -109,7 +109,7 @@ Create a fungible token application where two accounts start with the minted tok
 one with 100 of them and another with 200 of them:
 
 ```bash
-linera --storage "$LINERA_STORAGE1" --wallet "$LINERA_WALLET1" create-application $BYTECODE_ID1 \
+linera create-application $BYTECODE_ID1 \
     --json-argument '{ "accounts": { "User:'$OWNER1'": "100", "User:'$OWNER2'": "200" } }'
 ```
 
@@ -127,7 +127,7 @@ Similarly, we're going to create a crowd-funding campaign on the default chain.
 We have to specify our fungible application as a dependency and a parameter:
 
 ```bash
-linera --storage "$LINERA_STORAGE1" --wallet "$LINERA_WALLET1" create-application $BYTECODE_ID2 \
+linera create-application $BYTECODE_ID2 \
    --json-argument '{ "owner": "User:'$OWNER1'", "deadline": 4102473600000000, "target": "100." }'  --required-application-ids=$APP_ID1  --json-parameters='"'$APP_ID1'"'
 ```
 
@@ -135,35 +135,37 @@ Let's remember the application ID as `$APP_ID2`.
 
 ## Interacting with the campaign
 
-First, a node service has to be started for each wallet, using two different ports. The
-`$SOURCE_CHAIN_ID` and `$TARGET_CHAIN_ID` can be left blank to use the default chains from each
-wallet:
+First, a node service has to be started for each wallet, using two different ports:
 
 ```bash
-linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" service --port 8080 $SOURCE_CHAIN_ID &
-linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" service --port 8081 $TARGET_CHAIN_ID &
+linera service --port 8080 &
+linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" service --port 8081 &
 ```
 
 Point your browser to http://localhost:8080, and enter the query:
 
 ```gql,ignore
-query { applications { id link } }
+query { applications(
+    chainId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
+) { id link } }
 ```
 
 The response will have two entries, one for each application.
 
-If you do the same in http://localhost:8081, the node service for the other wallet,
-it will have no entries at all, because the applications haven't been registered
-there yet. Request `crowd-funding` from the other chain. As an application ID, use
-`$APP_ID2`:
+If you do the same with the other chain ID in http://localhost:8081, the node service for the
+other wallet, it will have no entries at all, because the applications haven't been registered
+there yet. Request `crowd-funding` from the other chain. As an application ID, use `$APP_ID2`:
 
 ```gql,ignore
-mutation { requestApplication(applicationId:"e476187…") }
+mutation { requestApplication(
+    chainId: "1db1936dad0717597a7743a8353c9c0191c14c3a129b258e9743aec2b4f05d03"
+    applicationId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65030000000000000000000000e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65070000000000000000000000"
+) }
 ```
 
-If you enter `query { applications { id link } }` again, both entries will
-appear in the second wallet as well now. `$APP_ID1` has been registered,
-too, because it is a dependency of the other application.
+If you enter the `applications` query again, both entries will appear in the second wallet as
+well now. `$APP_ID1` has been registered, too, because it is a dependency of the other
+application.
 
 On both http://localhost:8080 and http://localhost:8081, you recognize the crowd-funding
 application by its ID. The entry also has a field `link`. If you open that in a new tab, you
@@ -231,7 +233,9 @@ In the fungible application on 8080, check that we have received 110 tokens, in 
 70 that we had left after pledging 30:
 
 ```gql,ignore
-query {accounts(accountOwner:"User:445991f46ae490fe207e60c95d0ed95bf4e7ed9c270d4fd4fa555587c2604fe1")}
+query { accounts(
+    accountOwner:"User:445991f46ae490fe207e60c95d0ed95bf4e7ed9c270d4fd4fa555587c2604fe1"
+)}
 ```
 
 <!-- cargo-rdme end -->

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -44,13 +44,14 @@ Compile the `fungible` application WebAssembly binaries, and publish them as an 
 bytecode:
 
 ```bash
+alias linera="$PWD/target/debug/linera"
 export LINERA_WALLET="$(realpath target/debug/wallet.json)"
 export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
 export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
 export LINERA_STORAGE_2="rocksdb:$(dirname "$LINERA_WALLET_2")/linera_2.db"
 
 cd examples/fungible && cargo build --release && cd ../..
-linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" publish-bytecode \
+linera publish-bytecode \
 examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm
 ```
 
@@ -71,7 +72,7 @@ In order to select the accounts to have initial tokens, the command below can be
 the chains created for the test:
 
 ```bash
-linera --storage "$LINERA_STORAGE" --wallet "$LINERA_WALLET" wallet show
+linera wallet show
 ```
 
 A table will be shown with the chains registered in the wallet and their meta-data. The default
@@ -82,7 +83,7 @@ The example below creates a token application where two accounts start with the 
 one with 100 of them and another with 200 of them:
 
 ```bash
-linera --storage "$LINERA_STORAGE" --wallet "$LINERA_WALLET" create-application $BYTECODE_ID \
+linera create-application e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65010000000000000001000000 \
     --json-argument '{ "accounts": {
         "User:445991f46ae490fe207e60c95d0ed95bf4e7ed9c270d4fd4fa555587c2604fe1": "100.",
         "User:c2f98d76c332bf809d7f91671eb76e5839c02d5896209881368da5838d85c83f": "200."
@@ -108,13 +109,11 @@ secondary wallet, use:
 linera --storage "$LINERA_STORAGE_2" --wallet "$LINERA_WALLET_2" wallet show
 ```
 
-First, a node service has to be started for each wallet, using two different ports. The
-`$SOURCE_CHAIN_ID` and `$TARGET_CHAIN_ID` can be left blank to use the default chains from each
-wallet:
+First, a node service has to be started for each wallet, using two different ports:
 
 ```bash
-linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" service --port 8080 $SOURCE_CHAIN_ID &
-linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 $TARGET_CHAIN_ID &
+linera service --port 8080 &
+linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
 ```
 
 Then the web frontend has to be started

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -47,8 +47,6 @@ bytecode:
 alias linera="$PWD/target/debug/linera"
 export LINERA_WALLET="$(realpath target/debug/wallet.json)"
 export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
-export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
-export LINERA_STORAGE_2="rocksdb:$(dirname "$LINERA_WALLET_2")/linera_2.db"
 
 cd examples/fungible && cargo build --release && cd ../..
 linera publish-bytecode \
@@ -100,23 +98,15 @@ e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a650100000000000000
 
 Before using the token, a source and target address should be selected. The source address
 should ideally be on the default chain (used to create the token) and one of the accounts chosen
-for the initial state, because it will already have some initial tokens to send. The target
-address should be from a separate wallet due to current technical limitations (`linera service`
-can only handle one chain per wallet at the same time). To see the available chains in the
-secondary wallet, use:
+for the initial state, because it will already have some initial tokens to send.
 
-```bash
-linera --storage "$LINERA_STORAGE_2" --wallet "$LINERA_WALLET_2" wallet show
-```
-
-First, a node service has to be started for each wallet, using two different ports:
+First, a node service has to be started:
 
 ```bash
 linera service --port 8080 &
-linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
 ```
 
-Then the web frontend has to be started
+Then the web frontend:
 
 ```bash
 cd examples/fungible/web-frontend
@@ -125,12 +115,12 @@ npm start
 ```
 
 The web UI can then be opened by navigating to
-`http://localhost:3000/$APPLICATION_ID?owner=$SOURCE_ACCOUNT&port=$PORT`, where:
+`http://localhost:3000/$CHAIN_ID?app=$APPLICATION_ID&owner=$SOURCE_ACCOUNT&port=$PORT`, where:
 
-- `$APPLICATION_ID` is the token application ID obtained when creating the token
-- `$SOURCE_ACCOUNT` is the owner of the chosen sender account
-- `$PORT` is the port the sender wallet service is listening to (`8080` for the sender wallet
-  and `8081` for the receiver wallet as per the previous commands)
+- `$CHAIN_ID` is the ID of the chain where we registered the application.
+- `$APPLICATION_ID` is the token application ID obtained when creating the token.
+- `$SOURCE_ACCOUNT` is the owner of the chosen sender account.
+- `$PORT` is the port the sender wallet service is listening to.
 
 Two browser instances can be opened, one for the sender account and one for the receiver
 account. In the sender account browser, the target chain ID and account can be specified, as

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -45,13 +45,14 @@
 //! bytecode:
 //!
 //! ```bash
+//! alias linera="$PWD/target/debug/linera"
 //! export LINERA_WALLET="$(realpath target/debug/wallet.json)"
 //! export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
 //! export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
 //! export LINERA_STORAGE_2="rocksdb:$(dirname "$LINERA_WALLET_2")/linera_2.db"
 //!
 //! cd examples/fungible && cargo build --release && cd ../..
-//! linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" publish-bytecode \
+//! linera publish-bytecode \
 //! examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm
 //! ```
 //!
@@ -72,7 +73,7 @@
 //! the chains created for the test:
 //!
 //! ```bash
-//! linera --storage "$LINERA_STORAGE" --wallet "$LINERA_WALLET" wallet show
+//! linera wallet show
 //! ```
 //!
 //! A table will be shown with the chains registered in the wallet and their meta-data. The default
@@ -83,7 +84,7 @@
 //! one with 100 of them and another with 200 of them:
 //!
 //! ```bash
-//! linera --storage "$LINERA_STORAGE" --wallet "$LINERA_WALLET" create-application $BYTECODE_ID \
+//! linera create-application e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65010000000000000001000000 \
 //!     --json-argument '{ "accounts": {
 //!         "User:445991f46ae490fe207e60c95d0ed95bf4e7ed9c270d4fd4fa555587c2604fe1": "100.",
 //!         "User:c2f98d76c332bf809d7f91671eb76e5839c02d5896209881368da5838d85c83f": "200."
@@ -109,13 +110,11 @@
 //! linera --storage "$LINERA_STORAGE_2" --wallet "$LINERA_WALLET_2" wallet show
 //! ```
 //!
-//! First, a node service has to be started for each wallet, using two different ports. The
-//! `$SOURCE_CHAIN_ID` and `$TARGET_CHAIN_ID` can be left blank to use the default chains from each
-//! wallet:
+//! First, a node service has to be started for each wallet, using two different ports:
 //!
 //! ```bash
-//! linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" service --port 8080 $SOURCE_CHAIN_ID &
-//! linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 $TARGET_CHAIN_ID &
+//! linera service --port 8080 &
+//! linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
 //! ```
 //!
 //! Then the web frontend has to be started

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -48,8 +48,6 @@
 //! alias linera="$PWD/target/debug/linera"
 //! export LINERA_WALLET="$(realpath target/debug/wallet.json)"
 //! export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
-//! export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
-//! export LINERA_STORAGE_2="rocksdb:$(dirname "$LINERA_WALLET_2")/linera_2.db"
 //!
 //! cd examples/fungible && cargo build --release && cd ../..
 //! linera publish-bytecode \
@@ -101,23 +99,15 @@
 //!
 //! Before using the token, a source and target address should be selected. The source address
 //! should ideally be on the default chain (used to create the token) and one of the accounts chosen
-//! for the initial state, because it will already have some initial tokens to send. The target
-//! address should be from a separate wallet due to current technical limitations (`linera service`
-//! can only handle one chain per wallet at the same time). To see the available chains in the
-//! secondary wallet, use:
+//! for the initial state, because it will already have some initial tokens to send.
 //!
-//! ```bash
-//! linera --storage "$LINERA_STORAGE_2" --wallet "$LINERA_WALLET_2" wallet show
-//! ```
-//!
-//! First, a node service has to be started for each wallet, using two different ports:
+//! First, a node service has to be started:
 //!
 //! ```bash
 //! linera service --port 8080 &
-//! linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
 //! ```
 //!
-//! Then the web frontend has to be started
+//! Then the web frontend:
 //!
 //! ```bash
 //! cd examples/fungible/web-frontend
@@ -126,12 +116,12 @@
 //! ```
 //!
 //! The web UI can then be opened by navigating to
-//! `http://localhost:3000/$APPLICATION_ID?owner=$SOURCE_ACCOUNT&port=$PORT`, where:
+//! `http://localhost:3000/$CHAIN_ID?app=$APPLICATION_ID&owner=$SOURCE_ACCOUNT&port=$PORT`, where:
 //!
-//! - `$APPLICATION_ID` is the token application ID obtained when creating the token
-//! - `$SOURCE_ACCOUNT` is the owner of the chosen sender account
-//! - `$PORT` is the port the sender wallet service is listening to (`8080` for the sender wallet
-//!   and `8081` for the receiver wallet as per the previous commands)
+//! - `$CHAIN_ID` is the ID of the chain where we registered the application.
+//! - `$APPLICATION_ID` is the token application ID obtained when creating the token.
+//! - `$SOURCE_ACCOUNT` is the owner of the chosen sender account.
+//! - `$PORT` is the port the sender wallet service is listening to.
 //!
 //! Two browser instances can be opened, one for the sender account and one for the receiver
 //! account. In the sender account browser, the target chain ID and account can be specified, as

--- a/examples/fungible/web-frontend/src/App.js
+++ b/examples/fungible/web-frontend/src/App.js
@@ -20,8 +20,8 @@ const MAKE_PAYMENT = gql`
 `;
 
 const NOTIFICATION_SUBSCRIPTION = gql`
-  subscription {
-    notifications
+  subscription Notifications($chainId: ID!) {
+    notifications(chainId: $chainId)
   }
 `;
 
@@ -51,7 +51,7 @@ const ErrorMessage = tw.div`
 `;
 
 // App component
-function App({ owner }) {
+function App({ chainId, owner }) {
   const [recipient, setRecipient] = useState("");
   const [targetChain, setTargetChain] = useState("");
   const [amount, setAmount] = useState("");
@@ -76,6 +76,7 @@ function App({ owner }) {
   }
 
   useSubscription(NOTIFICATION_SUBSCRIPTION, {
+    variables: { chainId: chainId },
     onData: () => balanceQuery(),
   });
 
@@ -95,14 +96,14 @@ function App({ owner }) {
   const handleSubmit = (event) => {
     event.preventDefault();
     makePayment({
-        variables: {
-            owner: `User:${owner}`,
-            amount,
-            targetAccount: {
-                chainId: targetChain,
-                owner: `User:${recipient}`,
-            },
+      variables: {
+        owner: `User:${owner}`,
+        amount,
+        targetAccount: {
+          chainId: targetChain,
+          owner: `User:${recipient}`,
         },
+      },
     }).then(r => console.log("payment made: " + r));
   };
 

--- a/examples/fungible/web-frontend/src/GraphQLProvider.js
+++ b/examples/fungible/web-frontend/src/GraphQLProvider.js
@@ -10,12 +10,12 @@ import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { createClient } from "graphql-ws";
 import { getMainDefinition } from "@apollo/client/utilities";
 
-function GraphQLProvider({ applicationId, port, children }) {
-  let client = apolloClient(applicationId, port);
+function GraphQLProvider({ chainId, applicationId, port, children }) {
+  let client = apolloClient(chainId, applicationId, port);
   return <ApolloProvider client={client}>{children}</ApolloProvider>;
 }
 
-function apolloClient(applicationId, port) {
+function apolloClient(chainId, applicationId, port) {
   const wsLink = new GraphQLWsLink(
     createClient({
       url: `ws://localhost:${port}/ws`,
@@ -23,7 +23,7 @@ function apolloClient(applicationId, port) {
   );
 
   const httpLink = new HttpLink({
-    uri: `http://localhost:${port}/applications/` + applicationId,
+    uri: `http://localhost:${port}/chains/${chainId}/applications/${applicationId}`,
   });
 
   const splitLink = split(

--- a/examples/fungible/web-frontend/src/index.js
+++ b/examples/fungible/web-frontend/src/index.js
@@ -26,8 +26,12 @@ root.render(
 function GraphQLApp() {
   const { id } = useParams();
   const [searchParams] = useSearchParams();
+  let app = searchParams.get("app");
   let owner = searchParams.get("owner");
   let port = searchParams.get("port");
+  if (app == null) {
+    throw Error("missing app query param");
+  }
   if (owner == null) {
     throw Error("missing owner query param");
   }
@@ -35,8 +39,8 @@ function GraphQLApp() {
     port = 8080;
   }
   return (
-    <GraphQLProvider applicationId={id} port={port}>
-      <App owner={owner} />
+    <GraphQLProvider chainId={id} applicationId={app} port={port}>
+      <App chainId={id} owner={owner} />
     </GraphQLProvider>
   );
 }

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -36,6 +36,7 @@ separate terminal:
 Compile the `social` example and create an application with it:
 
 ```bash
+alias linera="$PWD/target/debug/linera"
 export LINERA_WALLET="$(realpath target/debug/wallet.json)"
 export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
 export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
@@ -43,7 +44,7 @@ export LINERA_STORAGE_2="rocksdb:$(dirname "$LINERA_WALLET_2")/linera_2.db"
 
 cd examples/social && cargo build --release && cd ../..
 
-linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
+linera publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
 ```
 
 This will output the new application ID, e.g.:
@@ -55,7 +56,7 @@ e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a650100000000000000
 With the `wallet show` command you can find the ID of the application creator's chain:
 
 ```bash
-linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" wallet show
+linera wallet show
 ```
 
 ```rust
@@ -66,26 +67,30 @@ e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65
 Now start a node service for each wallet, using two different ports:
 
 ```bash
-linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" service --port 8080 &
+linera service --port 8080 &
 linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
 ```
 
 Point your browser to http://localhost:8081. This is the wallet that didn't create the
-application, so we have to request it from the creator chain:
+application, so we have to request it from the creator chain. As the chain ID specify the
+one of the chain where it isn't registered yet:
 
 ```json
 mutation {
     requestApplication(
+        chainId: "1db1936dad0717597a7743a8353c9c0191c14c3a129b258e9743aec2b4f05d03",
         applicationId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65010000000000000001000000e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65030000000000000000000000"
     )
 }
 ```
 
 Now in both http://localhost:8080 and http://localhost:8081, this should list the
-application and provide a link to its GraphQL API:
+application and provide a link to its GraphQL API. Remember to use each wallet's chain ID:
 
 ```json
-query { applications { id description link } }
+query { applications(
+    chainId:"1db1936dad0717597a7743a8353c9c0191c14c3a129b258e9743aec2b4f05d03"
+) { id link } }
 ```
 
 Open both URLs under the entry `link`. Now you can use the application on each chain.

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -37,6 +37,7 @@
 //! Compile the `social` example and create an application with it:
 //!
 //! ```bash
+//! alias linera="$PWD/target/debug/linera"
 //! export LINERA_WALLET="$(realpath target/debug/wallet.json)"
 //! export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
 //! export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
@@ -44,7 +45,7 @@
 //!
 //! cd examples/social && cargo build --release && cd ../..
 //!
-//! linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
+//! linera publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
 //! ```
 //!
 //! This will output the new application ID, e.g.:
@@ -56,7 +57,7 @@
 //! With the `wallet show` command you can find the ID of the application creator's chain:
 //!
 //! ```bash
-//! linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" wallet show
+//! linera wallet show
 //! ```
 //!
 //! ```ignore
@@ -67,26 +68,30 @@
 //! Now start a node service for each wallet, using two different ports:
 //!
 //! ```bash
-//! linera --wallet "$LINERA_WALLET" --storage "$LINERA_STORAGE" service --port 8080 &
+//! linera service --port 8080 &
 //! linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
 //! ```
 //!
 //! Point your browser to http://localhost:8081. This is the wallet that didn't create the
-//! application, so we have to request it from the creator chain:
+//! application, so we have to request it from the creator chain. As the chain ID specify the
+//! one of the chain where it isn't registered yet:
 //!
 //! ```json
 //! mutation {
 //!     requestApplication(
+//!         chainId: "1db1936dad0717597a7743a8353c9c0191c14c3a129b258e9743aec2b4f05d03",
 //!         applicationId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65010000000000000001000000e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65030000000000000000000000"
 //!     )
 //! }
 //! ```
 //!
 //! Now in both http://localhost:8080 and http://localhost:8081, this should list the
-//! application and provide a link to its GraphQL API:
+//! application and provide a link to its GraphQL API. Remember to use each wallet's chain ID:
 //!
 //! ```json
-//! query { applications { id description link } }
+//! query { applications(
+//!     chainId:"1db1936dad0717597a7743a8353c9c0191c14c3a129b258e9743aec2b4f05d03"
+//! ) { id link } }
 //! ```
 //!
 //! Open both URLs under the entry `link`. Now you can use the application on each chain.

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -760,7 +760,7 @@ where
         Ok((name, new_tracker, certificates))
     }
 
-    /// Process the result of [`synchronize_received_certificates_from_validator`].
+    /// Processes the result of [`synchronize_received_certificates_from_validator`].
     async fn receive_certificates_from_validator(
         &mut self,
         name: ValidatorName,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1125,7 +1125,7 @@ where
     }
 
     /// Queries an application.
-    pub async fn query_application(&mut self, query: &Query) -> Result<Response> {
+    pub async fn query_application(&self, query: &Query) -> Result<Response> {
         let response = self
             .node_client
             .query_application(self.chain_id, query)

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -166,6 +166,8 @@ pub enum NodeError {
     CannotResolveValidatorAddress { address: String },
     #[error("Subscription error due to incorrect transport. Was expecting gRPC, instead found: {transport}")]
     SubscriptionError { transport: String },
+    #[error("Failed to subscribe; tonic status: {status}")]
+    SubscriptionFailed { status: String },
     #[error("We don't have the value for the certificate.")]
     MissingCertificateValue,
 }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -412,7 +412,7 @@ where
     }
 
     pub async fn query_application(
-        &mut self,
+        &self,
         chain_id: ChainId,
         query: &Query,
     ) -> Result<Response, NodeError> {

--- a/linera-explorer/graphql/schema.graphql
+++ b/linera-explorer/graphql/schema.graphql
@@ -438,7 +438,7 @@ scalar Recipient
 
 type SubscriptionRoot {
 	"""
-	Subscribes to notifications from the current chain.
+	Subscribes to notifications from the specified chain.
 	"""
 	notifications(chainId: ChainId!): Notification!
 }

--- a/linera-explorer/graphql/schema.graphql
+++ b/linera-explorer/graphql/schema.graphql
@@ -156,7 +156,7 @@ type ChainTipState {
 
 type Chains {
 	list: [ChainId!]!
-	default: ChainId!
+	default: ChainId
 }
 
 """
@@ -296,68 +296,68 @@ type MutationRoot {
 	"""
 	Processes the inbox and returns the lists of certificate hashes that were created, if any.
 	"""
-	processInbox: [CryptoHash!]!
+	processInbox(chainId: ChainId!): [CryptoHash!]!
 	"""
 	Transfers `amount` units of value from the given owner's account to the recipient.
 	If no owner is given, try to take the units out of the unattributed account.
 	"""
-	transfer(owner: Owner, recipient: Recipient!, amount: Amount!, userData: UserData): CryptoHash!
+	transfer(chainId: ChainId!, owner: Owner, recipient: Recipient!, amount: Amount!, userData: UserData): CryptoHash!
 	"""
 	Claims `amount` units of value from the given owner's account in
 	the remote `target` chain. Depending on its configuration (see also #464), the
 	`target` chain may refuse to process the message.
 	"""
-	claim(owner: Owner!, target: ChainId!, recipient: Recipient!, amount: Amount!, userData: UserData): CryptoHash!
+	claim(chainId: ChainId!, owner: Owner!, target: ChainId!, recipient: Recipient!, amount: Amount!, userData: UserData): CryptoHash!
 	"""
 	Creates (or activates) a new chain by installing the given authentication key.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openChain(publicKey: PublicKey!): ChainId!
+	openChain(chainId: ChainId!, publicKey: PublicKey!): ChainId!
 	"""
 	Closes the chain.
 	"""
-	closeChain: CryptoHash!
+	closeChain(chainId: ChainId!): CryptoHash!
 	"""
 	Changes the authentication key of the chain.
 	"""
-	changeOwner(newPublicKey: PublicKey!): CryptoHash!
+	changeOwner(chainId: ChainId!, newPublicKey: PublicKey!): CryptoHash!
 	"""
 	Changes the authentication key of the chain.
 	"""
-	changeMultipleOwners(newPublicKeys: [PublicKey!]!): CryptoHash!
+	changeMultipleOwners(chainId: ChainId!, newPublicKeys: [PublicKey!]!): CryptoHash!
 	"""
 	(admin chain only) Registers a new committee. This will notify the subscribers of
 	the admin chain so that they can migrate to the new epoch (by accepting the
 	notification as an "incoming message" in a next block).
 	"""
-	createCommittee(epoch: Epoch!, committee: Committee!): CryptoHash!
+	createCommittee(chainId: ChainId!, epoch: Epoch!, committee: Committee!): CryptoHash!
 	"""
 	Subscribes to a system channel.
 	"""
-	subscribe(chainId: ChainId!, channel: SystemChannel!): CryptoHash!
+	subscribe(subscriberChainId: ChainId!, publisherChainId: ChainId!, channel: SystemChannel!): CryptoHash!
 	"""
 	Unsubscribes from a system channel.
 	"""
-	unsubscribe(chainId: ChainId!, channel: SystemChannel!): CryptoHash!
+	unsubscribe(subscriberChainId: ChainId!, publisherChainId: ChainId!, channel: SystemChannel!): CryptoHash!
 	"""
 	(admin chain only) Removes a committee. Once this message is accepted by a chain,
 	blocks from the retired epoch will not be accepted until they are followed (hence
 	re-certified) by a block certified by a recent committee.
 	"""
-	removeCommittee(epoch: Epoch!): CryptoHash!
+	removeCommittee(chainId: ChainId!, epoch: Epoch!): CryptoHash!
 	"""
 	Publishes a new application bytecode.
 	"""
-	publishBytecode(contract: Bytecode!, service: Bytecode!): BytecodeId!
+	publishBytecode(chainId: ChainId!, contract: Bytecode!, service: Bytecode!): BytecodeId!
 	"""
 	Creates a new application.
 	"""
-	createApplication(bytecodeId: BytecodeId!, parameters: String!, initializationArgument: String!, requiredApplicationIds: [ApplicationId!]!): ApplicationId!
+	createApplication(chainId: ChainId!, bytecodeId: BytecodeId!, parameters: String!, initializationArgument: String!, requiredApplicationIds: [ApplicationId!]!): ApplicationId!
 	"""
 	Requests a `RegisterApplications` message from another chain so the application can be used
 	on this one.
 	"""
-	requestApplication(applicationId: ApplicationId!, targetChainId: ChainId): CryptoHash!
+	requestApplication(chainId: ChainId!, applicationId: ApplicationId!, targetChainId: ChainId): CryptoHash!
 }
 
 """
@@ -423,11 +423,11 @@ A signature public key
 scalar PublicKey
 
 type QueryRoot {
-	chain(chainId: ChainId): ChainStateExtendedView!
-	applications(chainId: ChainId): [ApplicationOverview!]!
+	chain(chainId: ChainId!): ChainStateExtendedView!
+	applications(chainId: ChainId!): [ApplicationOverview!]!
 	chains: Chains!
-	block(hash: CryptoHash, chainId: ChainId): HashedValue
-	blocks(from: CryptoHash, chainId: ChainId, limit: Int): [HashedValue!]!
+	block(hash: CryptoHash, chainId: ChainId!): HashedValue
+	blocks(from: CryptoHash, chainId: ChainId!, limit: Int): [HashedValue!]!
 }
 
 """
@@ -440,7 +440,7 @@ type SubscriptionRoot {
 	"""
 	Subscribes to notifications from the current chain.
 	"""
-	notifications: Notification!
+	notifications(chainId: ChainId!): Notification!
 }
 
 """

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -32,6 +32,8 @@ use graphql::{
 };
 use js_utils::{getf, log_str, parse, setf, stringify, SER};
 
+static mut WEBSOCKET: Option<WsMeta> = None;
+
 /// Page enum containing info for each page.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -86,7 +88,7 @@ impl Config {
 pub struct Data {
     config: Config,
     page: Page,
-    chains: Vec<Value>,
+    chains: Vec<ChainId>,
     chain: ChainId,
 }
 
@@ -127,35 +129,35 @@ fn node_service_address(config: &Config, protocol: Protocol) -> String {
 
 async fn get_blocks(
     node: &str,
-    chain_id: &ChainId,
+    chain_id: ChainId,
     from: Option<CryptoHash>,
     limit: Option<u32>,
 ) -> Result<Vec<Blocks>, String> {
     let client = reqwest::Client::new();
     let variables = graphql::blocks::Variables {
         from,
-        chain_id: Some(*chain_id),
+        chain_id: Some(chain_id),
         limit: limit.map(|x| x.into()),
     };
     let res = post_graphql::<crate::graphql::Blocks, _>(&client, node, variables)
         .await
         .map_err(|e| e.to_string())?;
     match res.data {
-        None => Err("null blocks data".to_string()),
+        None => Err(format!("null blocks data: {:?}", res.errors)),
         Some(data) => Ok(data.blocks),
     }
 }
 
-async fn get_applications(node: &str, chain_id: &ChainId) -> Result<Vec<Application>, String> {
+async fn get_applications(node: &str, chain_id: ChainId) -> Result<Vec<Application>, String> {
     let client = reqwest::Client::new();
     let variables = graphql::applications::Variables {
-        chain_id: Some(*chain_id),
+        chain_id: Some(chain_id),
     };
     let result = post_graphql::<crate::graphql::Applications, _>(&client, node, variables)
         .await
         .map_err(|e| e.to_string())?;
     match result.data {
-        None => Err("null applications data".to_string()),
+        None => Err(format!("null applications data: {:?}", result.errors)),
         Some(data) => Ok(data.applications),
     }
 }
@@ -166,7 +168,7 @@ fn error(msg: &str) -> (Page, String) {
 }
 
 /// Returns the home page.
-async fn home(node: &str, chain_id: &ChainId) -> Result<(Page, String), String> {
+async fn home(node: &str, chain_id: ChainId) -> Result<(Page, String), String> {
     let blocks = get_blocks(node, chain_id, None, None).await?;
     let apps = get_applications(node, chain_id).await?;
     Ok((Page::Home { blocks, apps }, format!("/?chain={}", chain_id)))
@@ -175,7 +177,7 @@ async fn home(node: &str, chain_id: &ChainId) -> Result<(Page, String), String> 
 /// Returns the blocks page.
 async fn blocks(
     node: &str,
-    chain_id: &ChainId,
+    chain_id: ChainId,
     from: Option<CryptoHash>,
     limit: Option<u32>,
 ) -> Result<(Page, String), String> {
@@ -187,13 +189,13 @@ async fn blocks(
 /// Returns the block page.
 async fn block(
     node: &str,
-    chain_id: &ChainId,
+    chain_id: ChainId,
     hash: Option<CryptoHash>,
 ) -> Result<(Page, String), String> {
     let client = reqwest::Client::new();
     let variables = graphql::block::Variables {
         hash,
-        chain_id: Some(*chain_id),
+        chain_id: Some(chain_id),
     };
     let result = post_graphql::<crate::graphql::Block, _>(&client, node, variables)
         .await
@@ -220,11 +222,14 @@ async fn chains(app: &JsValue, node: &str) -> Result<ChainId, String> {
         .serialize(&SER)
         .expect("failed to serialize ChainIds");
     setf(app, "chains", &chains_js);
-    Ok(chains.default)
+    Ok(chains.default.unwrap_or_else(|| match chains.list.get(0) {
+        None => ChainId::from(ChainDescription::Root(0)),
+        Some(chain_id) => *chain_id,
+    }))
 }
 
 /// Returns the applications page.
-async fn applications(node: &str, chain_id: &ChainId) -> Result<(Page, String), String> {
+async fn applications(node: &str, chain_id: ChainId) -> Result<(Page, String), String> {
     let applications = get_applications(node, chain_id).await?;
     Ok((
         Page::Applications(applications),
@@ -408,55 +413,69 @@ fn chain_id_from_args(
     app: &JsValue,
     data: &Data,
     args: &[(String, String)],
-) -> Result<ChainId, String> {
+) -> Result<(ChainId, bool), String> {
     match find_arg(args, "chain") {
-        None => Ok(data.chain),
+        None => Ok((data.chain, false)),
         Some(chain_id) => {
             let chain_js: JsValue = chain_id
                 .serialize(&SER)
                 .expect("failed to serialize ChainId");
             setf(app, "chain", &chain_js);
-            ChainId::from_str(&chain_id).map_err(|e| e.to_string())
+            ChainId::from_str(&chain_id)
+                .map_err(|e| e.to_string())
+                .map(|id| (id, id == data.chain))
         }
     }
 }
 
-/// Main function to switch between vue.js pages.
+/// Main function to switch between Vue pages.
 async fn route_aux(app: &JsValue, data: &Data, path: &Option<String>, args: &[(String, String)]) {
-    let chain_id = chain_id_from_args(app, data, args);
+    let chain_info = chain_id_from_args(app, data, args);
     let (page_name, args): (&str, Vec<(String, String)>) = match (path, &data.page) {
         (Some(p), _) => (p, args.to_vec()),
         (_, p) => page_name_and_args(p),
     };
     let address = node_service_address(&data.config, Protocol::Http);
-    let result = match chain_id {
+    let result = match chain_info {
         Err(e) => Err(e),
-        Ok(chain_id) => match page_name {
-            "" => home(&address, &chain_id).await,
-            "block" => {
-                let hash = find_arg(&args, "block")
-                    .map(|hash| CryptoHash::from_str(&hash).map_err(|e| e.to_string()));
-                match hash {
-                    Some(Err(e)) => Err(e),
-                    None => block(&address, &chain_id, None).await,
-                    Some(Ok(hash)) => block(&address, &chain_id, Some(hash)).await,
+        Ok((chain_id, chain_changed)) => {
+            let page_result = match page_name {
+                "" => home(&address, chain_id).await,
+                "block" => {
+                    let hash = find_arg(&args, "block")
+                        .map(|hash| CryptoHash::from_str(&hash).map_err(|e| e.to_string()));
+                    match hash {
+                        Some(Err(e)) => Err(e),
+                        None => block(&address, chain_id, None).await,
+                        Some(Ok(hash)) => block(&address, chain_id, Some(hash)).await,
+                    }
                 }
-            }
-            "blocks" => blocks(&address, &chain_id, None, Some(20)).await,
-            "applications" => applications(&address, &chain_id).await,
-            "application" => match find_arg(&args, "app").map(|v| parse(&v)) {
-                None => Err("unknown application".to_string()),
-                Some(app_js) => {
-                    let app = from_value::<Application>(app_js).unwrap();
-                    application(app).await
+                "blocks" => blocks(&address, chain_id, None, Some(20)).await,
+                "applications" => applications(&address, chain_id).await,
+                "application" => match find_arg(&args, "app").map(|v| parse(&v)) {
+                    None => Err("unknown application".to_string()),
+                    Some(app_js) => {
+                        let app = from_value::<Application>(app_js).unwrap();
+                        application(app).await
+                    }
+                },
+                "error" => {
+                    let msg = find_arg(&args, "msg").unwrap_or("unknown error".to_string());
+                    Err(msg)
                 }
-            },
-            "error" => {
-                let msg = find_arg(&args, "msg").unwrap_or("unknown error".to_string());
-                Err(msg)
-            }
-            _ => Err("unknown page".to_string()),
-        },
+                _ => Err("unknown page".to_string()),
+            };
+            if chain_changed {
+                unsafe {
+                    if let Some(ws) = &WEBSOCKET {
+                        let _ = ws.close().await;
+                    }
+                }
+                let address = node_service_address(&data.config, Protocol::Websocket);
+                subscribe_chain(app, &address, chain_id).await;
+            };
+            page_result
+        }
     };
     let (page, new_path) = result.unwrap_or_else(|e| error(&e));
     let page_js = format_bytes(&page.serialize(&SER).unwrap());
@@ -500,28 +519,27 @@ fn set_onpopstate(app: JsValue) {
     callback.forget()
 }
 
-/// Subscribes to new block notifications.
-async fn subscribe(app: JsValue) {
-    spawn_local(async move {
-        let data = from_value::<Data>(app.clone()).expect("cannot parse vue data");
-        let address = node_service_address(&data.config, Protocol::Websocket);
-        let (_ws, mut wsio) = WsMeta::connect(
-            &format!("{}/ws", address),
-            Some(vec!["graphql-transport-ws"]),
-        )
-        .await
-        .expect("cannot connect to websocket");
-        wsio.send(WsMessage::Text(
-            "{\"type\": \"connection_init\", \"payload\": {}}".to_string(),
-        ))
+/// Subscribes to notifications for one chain
+async fn subscribe_chain(app: &JsValue, address: &str, chain: ChainId) {
+    let (ws, mut wsio) = WsMeta::connect(
+        &format!("{}/ws", address),
+        Some(vec!["graphql-transport-ws"]),
+    )
+    .await
+    .expect("cannot connect to websocket");
+    wsio.send(WsMessage::Text(
+        "{\"type\": \"connection_init\", \"payload\": {}}".to_string(),
+    ))
+    .await
+    .expect("cannot send to websocket");
+    wsio.next().await;
+    let uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, b"linera.dev");
+    let query = format!("{{\"id\": \"{}\", \"type\": \"subscribe\", \"payload\": {{\"query\": \"subscription {{ notifications(chainId: {}) }}\"}}}}", uuid, chain);
+    wsio.send(WsMessage::Text(query))
         .await
         .expect("cannot send to websocket");
-        wsio.next().await;
-        let uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, b"linera.dev");
-        let query = format!("{{\"id\": \"{}\", \"type\": \"subscribe\", \"payload\": {{\"query\": \"subscription {{ notifications }}\"}}}}", uuid);
-        wsio.send(WsMessage::Text(query))
-            .await
-            .expect("cannot send to websocket");
+    let app = app.clone();
+    spawn_local(async move {
         while let Some(evt) = wsio.next().await {
             match evt {
                 WsMessage::Text(s) => {
@@ -533,19 +551,25 @@ async fn subscribe(app: JsValue) {
                         if let Some(d) = p.data {
                             let data =
                                 from_value::<Data>(app.clone()).expect("cannot parse vue data");
-                            if let (true, graphql::Reason::NewBlock { hash: _hash, .. }) = (
-                                d.notifications.chain_id == data.chain,
-                                d.notifications.reason,
-                            ) {
-                                route_aux(&app, &data, &None, &Vec::new()).await
-                            };
+                            if let graphql::Reason::NewBlock { hash: _hash, .. } =
+                                d.notifications.reason
+                            {
+                                if d.notifications.chain_id == chain {
+                                    route_aux(&app, &data, &None, &Vec::new()).await
+                                }
+                            }
+                        }
+                        if let Some(errors) = p.errors {
+                            errors.iter().for_each(|e| log_str(&e.to_string()));
+                            break;
                         }
                     };
                 }
                 WsMessage::Binary(_) => (),
             }
         }
-    })
+    });
+    unsafe { WEBSOCKET = Some(ws) }
 }
 
 /// Initializes pages and subscribes to notifications.
@@ -594,7 +618,6 @@ pub async fn init(app: JsValue, uri: String) {
                 },
             };
             route_aux(&app, &data, &path, &args).await;
-            subscribe(app).await;
         }
     }
 }

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -499,6 +499,10 @@ NodeError:
         STRUCT:
           - transport: STR
     22:
+      SubscriptionFailed:
+        STRUCT:
+          - status: STR
+    23:
       MissingCertificateValue: UNIT
 Operation:
   ENUM:

--- a/linera-sdk/src/contract/system_api.rs
+++ b/linera-sdk/src/contract/system_api.rs
@@ -94,7 +94,7 @@ pub fn current_system_balance() -> Amount {
     wit::read_system_balance().into()
 }
 
-/// Retrieves the current system time.
+/// Retrieves the current system time, i.e. the timestamp of the block in which this is called.
 pub fn current_system_time() -> Timestamp {
     wit::read_system_timestamp().into()
 }

--- a/linera-sdk/src/service/system_api.rs
+++ b/linera-sdk/src/service/system_api.rs
@@ -79,7 +79,7 @@ pub fn current_system_balance() -> Amount {
     wit::read_system_balance().into()
 }
 
-/// Retrieves the current system time.
+/// Retrieves the current system time, i.e. the timestamp of the latest block in this chain.
 pub fn current_system_time() -> Timestamp {
     wit::read_system_timestamp().into()
 }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -102,9 +102,8 @@ where
                         ..
                     } = out_msg
                     {
-                        if let Some(key_pair) = context.wallet_state().key_pair_for_pk(public_key) {
-                            context.update_wallet_for_new_chain(*new_id, Some(key_pair), timestamp);
-                        }
+                        let key_pair = context.wallet_state().key_pair_for_pk(public_key);
+                        context.update_wallet_for_new_chain(*new_id, key_pair, timestamp);
                     }
                 }
             }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -102,8 +102,7 @@ where
                         ..
                     } = out_msg
                     {
-                        if let Some(key_pair) = context.wallet_state().key_pair_for_pk(&public_key)
-                        {
+                        if let Some(key_pair) = context.wallet_state().key_pair_for_pk(public_key) {
                             context.update_wallet_for_new_chain(*new_id, Some(key_pair), timestamp);
                         }
                     }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -108,7 +108,7 @@ where
                 }
             }
             context.update_wallet(&mut *client.lock().await).await;
-            // TODO(#901)
+            // TODO(#901): Node service should track newly opened chains
             // self.update_streams(&mut streams, &mut context, &storage)
             //     .await?;
         }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -2,17 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use futures::{lock::Mutex, StreamExt};
+use futures::{future, lock::Mutex, StreamExt};
+use linera_base::{crypto::KeyPair, data_types::Timestamp, identifiers::ChainId};
 use linera_core::{
     client::{ChainClient, ValidatorNodeProvider},
     tracker::NotificationTracker,
-    worker::Reason,
+    worker::{Notification, Reason},
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
-use std::{ops::DerefMut, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use structopt::StructOpt;
+use tokio_stream::Stream;
 use tracing::{info, warn};
+
+use crate::{config::WalletState, node_service::ClientMap};
+
+type ClientNotificationStream<P, S> =
+    Box<dyn Stream<Item = (Notification, Arc<Mutex<ChainClient<P, S>>>)> + Send + Unpin>;
 
 #[derive(Debug, Clone, StructOpt)]
 pub struct ChainListenerConfig {
@@ -27,6 +34,21 @@ pub struct ChainListenerConfig {
 
 #[async_trait]
 pub trait ClientContext<P: ValidatorNodeProvider> {
+    fn wallet_state(&self) -> &WalletState;
+
+    fn make_chain_client<S>(
+        &self,
+        storage: S,
+        chain_id: impl Into<Option<ChainId>>,
+    ) -> ChainClient<P, S>;
+
+    fn update_wallet_for_new_chain(
+        &mut self,
+        chain_id: ChainId,
+        key_pair: Option<KeyPair>,
+        timestamp: Timestamp,
+    );
+
     async fn update_wallet<'a, S>(&'a mut self, client: &'a mut ChainClient<P, S>)
     where
         S: Store + Clone + Send + Sync + 'static,
@@ -37,7 +59,7 @@ pub trait ClientContext<P: ValidatorNodeProvider> {
 /// appropriately.
 pub struct ChainListener<P, S> {
     config: ChainListenerConfig,
-    client: Arc<Mutex<ChainClient<P, S>>>,
+    clients: ClientMap<P, S>,
 }
 
 impl<P, S> ChainListener<P, S>
@@ -46,55 +68,114 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
-    /// Creates a new chain listener given a client chain.
-    pub fn new(config: ChainListenerConfig, client: Arc<Mutex<ChainClient<P, S>>>) -> Self {
-        Self { config, client }
+    /// Creates a new chain listener given client chains.
+    pub(crate) fn new(config: ChainListenerConfig, clients: ClientMap<P, S>) -> Self {
+        Self { config, clients }
     }
 
     /// Runs the chain listener.
-    pub async fn run<C>(self, mut context: C) -> Result<(), anyhow::Error>
+    pub async fn run<C>(self, mut context: C, storage: S) -> Result<(), anyhow::Error>
     where
         C: ClientContext<P>,
     {
-        let mut notification_stream = ChainClient::listen(self.client.clone()).await?;
-        let mut tracker = NotificationTracker::default();
-        while let Some(notification) = notification_stream.next().await {
-            if tracker.insert(notification.clone()) {
-                info!("Received new notification: {:?}", notification);
-                if self.config.delay_before_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(self.config.delay_before_ms)).await;
-                }
-                {
-                    let mut client = self.client.lock().await;
-                    match &notification.reason {
-                        Reason::NewBlock { .. } => {
-                            if let Err(e) = client.update_validators().await {
-                                warn!(
-                                    "Failed to update validators about the local chain after \
-                                    receiving notification {:?} with error: {:?}",
-                                    notification, e
-                                );
-                            }
-                        }
-                        Reason::NewIncomingMessage { .. } => {
-                            if let Err(e) = client.process_inbox().await {
-                                warn!(
-                                    "Failed to process inbox after receiving new message: {:?} \
-                                    with error: {:?}",
-                                    notification, e
-                                );
-                            }
-                        }
-                    }
-                    context.update_wallet(client.deref_mut()).await;
-                }
+        let mut streams = HashMap::new();
+        self.update_streams(&mut streams, &mut context, &storage)
+            .await?;
 
-                if self.config.delay_after_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(self.config.delay_after_ms)).await;
+        while let (Some((_notification, _client)), _, _) =
+            future::select_all(streams.values_mut().map(StreamExt::next)).await
+        {}
+
+        Ok(())
+    }
+
+    async fn handle_notification(client: &mut ChainClient<P, S>, notification: Notification) {
+        match &notification.reason {
+            Reason::NewBlock { .. } => {
+                if let Err(e) = client.update_validators().await {
+                    warn!(
+                        "Failed to update validators about the local chain after \
+                        receiving notification {:?} with error: {:?}",
+                        notification, e
+                    );
+                }
+            }
+            Reason::NewIncomingMessage { .. } => {
+                if let Err(e) = client.process_inbox().await {
+                    warn!(
+                        "Failed to process inbox after receiving new message: {:?} \
+                        with error: {:?}",
+                        notification, e
+                    );
                 }
             }
         }
+    }
 
+    async fn update_streams<C>(
+        &self,
+        streams: &mut HashMap<ChainId, ClientNotificationStream<P, S>>,
+        context: &mut C,
+        storage: &S,
+    ) -> Result<(), anyhow::Error>
+    where
+        C: ClientContext<P>,
+    {
+        let new_clients: Vec<_> = {
+            let mut map_guard = self.clients.map_lock().await;
+            for chain_id in context.wallet_state().own_chain_ids() {
+                map_guard.entry(chain_id).or_insert_with(|| {
+                    let client = context.make_chain_client(storage.clone(), chain_id);
+                    Arc::new(Mutex::new(client))
+                });
+            }
+            map_guard
+                .iter()
+                .filter(|(chain_id, _)| !streams.contains_key(chain_id))
+                .map(|(chain_id, client)| (*chain_id, client.clone()))
+                .collect()
+        };
+        let delay_before_ms = self.config.delay_before_ms;
+        let delay_after_ms = self.config.delay_after_ms;
+        let new_streams = future::join_all(new_clients.into_iter().map(
+            |(chain_id, client)| async move {
+                {
+                    // Process the inbox: For messages that are already there we won't receive a
+                    // notification.
+                    let mut guard = client.lock().await;
+                    guard.synchronize_from_validators().await?;
+                    guard.process_inbox().await?;
+                }
+                let notification_stream = ChainClient::listen(client.clone()).await?;
+                let mut tracker = NotificationTracker::default();
+                let stream = notification_stream
+                    .filter(move |notification| future::ready(tracker.insert(notification.clone())))
+                    .then(move |notification| {
+                        info!("Received new notification: {:?}", notification);
+                        let client = client.clone();
+                        Box::pin(async move {
+                            if delay_before_ms > 0 {
+                                tokio::time::sleep(Duration::from_millis(delay_before_ms)).await;
+                            }
+                            {
+                                let mut client = client.lock().await;
+                                Self::handle_notification(&mut *client, notification.clone()).await;
+                            }
+                            if delay_after_ms > 0 {
+                                tokio::time::sleep(Duration::from_millis(delay_after_ms)).await;
+                            }
+                            (notification, client.clone())
+                        })
+                    });
+                Ok((chain_id, stream))
+            },
+        ))
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, anyhow::Error>>()?;
+        for (chain_id, stream) in new_streams {
+            streams.insert(chain_id, Box::new(stream));
+        }
         Ok(())
     }
 }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -22,7 +22,7 @@ use structopt::StructOpt;
 use tokio_stream::Stream;
 use tracing::{info, warn};
 
-use crate::{config::WalletState, node_service::ClientMap};
+use crate::{config::WalletState, node_service::ChainClients};
 
 type ClientNotificationStream<P, S> =
     Box<dyn Stream<Item = (Notification, Arc<Mutex<ChainClient<P, S>>>)> + Send + Unpin>;
@@ -65,7 +65,7 @@ pub trait ClientContext<P: ValidatorNodeProvider> {
 /// appropriately.
 pub struct ChainListener<P, S> {
     config: ChainListenerConfig,
-    clients: ClientMap<P, S>,
+    clients: ChainClients<P, S>,
 }
 
 impl<P, S> ChainListener<P, S>
@@ -75,7 +75,7 @@ where
     ViewError: From<S::ContextError>,
 {
     /// Creates a new chain listener given client chains.
-    pub(crate) fn new(config: ChainListenerConfig, clients: ClientMap<P, S>) -> Self {
+    pub(crate) fn new(config: ChainListenerConfig, clients: ChainClients<P, S>) -> Self {
         Self { config, clients }
     }
 

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -109,8 +109,9 @@ where
                 }
             }
             context.update_wallet(&mut *client.lock().await).await;
-            self.update_streams(&mut streams, &mut context, &storage)
-                .await?;
+            // TODO(#901)
+            // self.update_streams(&mut streams, &mut context, &storage)
+            //     .await?;
         }
 
         Ok(())

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -181,9 +181,19 @@ impl WalletState {
     }
 
     pub fn key_pair_for_pk(&self, key: &PublicKey) -> Option<KeyPair> {
-        self.inner
+        if let Some(key_pair) = self
+            .inner
             .unassigned_key_pairs
             .get(key)
+            .map(|key_pair| key_pair.copy())
+        {
+            return Some(key_pair);
+        }
+        self.inner
+            .chains
+            .values()
+            .filter_map(|user_chain| user_chain.key_pair.as_ref())
+            .find(|key_pair| key_pair.public() == *key)
             .map(|key_pair| key_pair.copy())
     }
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -30,7 +30,7 @@ use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_service::{
     chain_listener::{self, ChainListenerConfig},
     config::{CommitteeConfig, Export, GenesisConfig, Import, UserChain, WalletState},
-    node_service::{Chains, NodeService},
+    node_service::NodeService,
     project::{self, Project},
     storage::{Runnable, StorageConfig},
 };
@@ -1331,10 +1331,8 @@ where
             }
 
             Service { config, port } => {
-                let default = context.wallet_state.default_chain();
-                let list = context.wallet_state.chain_ids();
-                let chains = Chains { list, default };
-                let service = NodeService::new(config, port, chains, storage);
+                let default_chain = context.wallet_state.default_chain();
+                let service = NodeService::new(config, port, default_chain, storage);
                 service.run(context).await?;
             }
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -700,9 +700,7 @@ where
 
         info!("GraphiQL IDE: http://localhost:{}", port);
 
-        ChainListener::new(self.config, self.clients.clone())
-            .run(context, self.storage.clone())
-            .await?;
+        ChainListener::new(self.config, self.clients.clone()).run(context, self.storage.clone());
         let serve_fut =
             Server::bind(&SocketAddr::from(([127, 0, 0, 1], port))).serve(app.into_make_service());
         serve_fut.await?;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -17,9 +17,12 @@ use axum::{
     response::IntoResponse,
     Extension, Router, Server,
 };
-use futures::{future, lock::Mutex};
+use futures::{
+    future,
+    lock::{Mutex, MutexGuard, OwnedMutexGuard},
+};
 use linera_base::{
-    crypto::{CryptoHash, PublicKey},
+    crypto::{CryptoError, CryptoHash, PublicKey},
     data_types::Amount,
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner},
     BcsHexParseError,
@@ -39,7 +42,7 @@ use linera_storage::Store;
 use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::{net::SocketAddr, num::NonZeroU16, sync::Arc};
+use std::{collections::BTreeMap, net::SocketAddr, num::NonZeroU16, sync::Arc};
 use thiserror::Error as ThisError;
 use tower_http::cors::CorsLayer;
 use tracing::{debug, error, info};
@@ -47,24 +50,56 @@ use tracing::{debug, error, info};
 #[derive(SimpleObject, Serialize, Deserialize, Clone)]
 pub struct Chains {
     pub list: Vec<ChainId>,
-    pub default: ChainId,
+    pub default: Option<ChainId>,
+}
+
+pub(crate) type ClientMapInner<P, S> = BTreeMap<ChainId, Arc<Mutex<ChainClient<P, S>>>>;
+pub(crate) struct ClientMap<P, S>(Arc<Mutex<ClientMapInner<P, S>>>);
+
+impl<P, S> Clone for ClientMap<P, S> {
+    fn clone(&self) -> Self {
+        ClientMap(self.0.clone())
+    }
+}
+
+impl<P, S> Default for ClientMap<P, S> {
+    fn default() -> Self {
+        Self(Arc::new(Mutex::new(BTreeMap::new())))
+    }
+}
+
+impl<P, S> ClientMap<P, S> {
+    async fn client(&self, chain_id: &ChainId) -> Option<Arc<Mutex<ChainClient<P, S>>>> {
+        Some(self.0.lock().await.get(chain_id)?.clone())
+    }
+
+    pub(crate) async fn client_lock(
+        &self,
+        chain_id: &ChainId,
+    ) -> Option<OwnedMutexGuard<ChainClient<P, S>>> {
+        Some(self.client(chain_id).await?.lock_owned().await)
+    }
+
+    pub(crate) async fn map_lock(&self) -> MutexGuard<ClientMapInner<P, S>> {
+        self.0.lock().await
+    }
 }
 
 /// Our root GraphQL query type.
 pub struct QueryRoot<P, S> {
-    client: Arc<Mutex<ChainClient<P, S>>>,
+    clients: ClientMap<P, S>,
     port: NonZeroU16,
     chains: Chains,
 }
 
 /// Our root GraphQL subscription type.
 pub struct SubscriptionRoot<P, S> {
-    client: Arc<Mutex<ChainClient<P, S>>>,
+    clients: ClientMap<P, S>,
 }
 
 /// Our root GraphQL mutation type.
 pub struct MutationRoot<P, S> {
-    client: Arc<Mutex<ChainClient<P, S>>>,
+    clients: ClientMap<P, S>,
 }
 
 #[derive(Debug, ThisError)]
@@ -91,6 +126,10 @@ enum NodeServiceError {
     MalformedApplicationResponse,
     #[error("application service error")]
     ApplicationServiceError { errors: Vec<String> },
+    #[error("chain ID not found")]
+    UnknownChainId,
+    #[error("malformed chain ID")]
+    InvalidChainId(CryptoError),
 }
 
 impl From<ServerError> for NodeServiceError {
@@ -127,6 +166,14 @@ impl IntoResponse for NodeServiceError {
             NodeServiceError::ApplicationServiceError { errors } => {
                 (StatusCode::BAD_REQUEST, errors)
             }
+            NodeServiceError::UnknownChainId => (
+                StatusCode::BAD_REQUEST,
+                vec!["unknown chain ID".to_string()],
+            ),
+            NodeServiceError::InvalidChainId(_) => (
+                StatusCode::BAD_REQUEST,
+                vec!["invalid chain ID".to_string()],
+            ),
         };
         let tuple = (tuple.0, json!({"error": tuple.1}).to_string());
         tuple.into_response()
@@ -141,8 +188,14 @@ where
     ViewError: From<S::ContextError>,
 {
     /// Subscribes to notifications from the current chain.
-    async fn notifications(&self) -> Result<impl Stream<Item = Notification>, Error> {
-        Ok(ChainClient::listen(self.client.clone()).await?)
+    async fn notifications(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<impl Stream<Item = Notification>, Error> {
+        let Some(client) = self.clients.client(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
+        Ok(ChainClient::listen(client).await?)
     }
 }
 
@@ -155,9 +208,12 @@ where
     async fn execute_system_operation(
         &self,
         system_operation: SystemOperation,
+        chain_id: ChainId,
     ) -> Result<CryptoHash, Error> {
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let operation = Operation::System(system_operation);
-        let mut client = self.client.lock().await;
         Ok(client.execute_operation(operation).await?.value.hash())
     }
 }
@@ -170,8 +226,10 @@ where
     ViewError: From<S::ContextError>,
 {
     /// Processes the inbox and returns the lists of certificate hashes that were created, if any.
-    async fn process_inbox(&self) -> Result<Vec<CryptoHash>, Error> {
-        let mut client = self.client.lock().await;
+    async fn process_inbox(&self, chain_id: ChainId) -> Result<Vec<CryptoHash>, Error> {
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         client.synchronize_from_validators().await?;
         let certificates = client.process_inbox().await?;
         let hashes = certificates.into_iter().map(|cert| cert.hash()).collect();
@@ -182,12 +240,15 @@ where
     /// If no owner is given, try to take the units out of the unattributed account.
     async fn transfer(
         &self,
+        chain_id: ChainId,
         owner: Option<Owner>,
         recipient: Recipient,
         amount: Amount,
         user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
-        let mut client = self.client.lock().await;
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let certificate = client
             .transfer(owner, amount, recipient, user_data.unwrap_or_default())
             .await?;
@@ -197,15 +258,19 @@ where
     /// Claims `amount` units of value from the given owner's account in
     /// the remote `target` chain. Depending on its configuration (see also #464), the
     /// `target` chain may refuse to process the message.
+    #[allow(clippy::too_many_arguments)]
     async fn claim(
         &self,
+        chain_id: ChainId,
         owner: Owner,
         target: ChainId,
         recipient: Recipient,
         amount: Amount,
         user_data: Option<UserData>,
     ) -> Result<CryptoHash, Error> {
-        let mut client = self.client.lock().await;
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let certificate = client
             .claim(
                 owner,
@@ -220,32 +285,41 @@ where
 
     /// Creates (or activates) a new chain by installing the given authentication key.
     /// This will automatically subscribe to the future committees created by `admin_id`.
-    async fn open_chain(&self, public_key: PublicKey) -> Result<ChainId, Error> {
-        let mut client = self.client.lock().await;
+    async fn open_chain(&self, chain_id: ChainId, public_key: PublicKey) -> Result<ChainId, Error> {
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let (message_id, _) = client.open_chain(public_key).await?;
         Ok(ChainId::child(message_id))
     }
 
     /// Closes the chain.
-    async fn close_chain(&self) -> Result<CryptoHash, Error> {
-        let mut client = self.client.lock().await;
+    async fn close_chain(&self, chain_id: ChainId) -> Result<CryptoHash, Error> {
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let certificate = client.close_chain().await?;
         Ok(certificate.hash())
     }
 
     /// Changes the authentication key of the chain.
-    async fn change_owner(&self, new_public_key: PublicKey) -> Result<CryptoHash, Error> {
+    async fn change_owner(
+        &self,
+        chain_id: ChainId,
+        new_public_key: PublicKey,
+    ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeOwner { new_public_key };
-        self.execute_system_operation(operation).await
+        self.execute_system_operation(operation, chain_id).await
     }
 
     /// Changes the authentication key of the chain.
     async fn change_multiple_owners(
         &self,
+        chain_id: ChainId,
         new_public_keys: Vec<PublicKey>,
     ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeMultipleOwners { new_public_keys };
-        self.execute_system_operation(operation).await
+        self.execute_system_operation(operation, chain_id).await
     }
 
     /// (admin chain only) Registers a new committee. This will notify the subscribers of
@@ -253,49 +327,63 @@ where
     /// notification as an "incoming message" in a next block).
     async fn create_committee(
         &self,
+        chain_id: ChainId,
         epoch: Epoch,
         committee: Committee,
     ) -> Result<CryptoHash, Error> {
         let operation =
             SystemOperation::Admin(AdminOperation::CreateCommittee { epoch, committee });
-        self.execute_system_operation(operation).await
+        self.execute_system_operation(operation, chain_id).await
     }
 
     /// Subscribes to a system channel.
     async fn subscribe(
         &self,
-        chain_id: ChainId,
+        subscriber_chain_id: ChainId,
+        publisher_chain_id: ChainId,
         channel: SystemChannel,
     ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::Subscribe { chain_id, channel };
-        self.execute_system_operation(operation).await
+        let operation = SystemOperation::Subscribe {
+            chain_id: publisher_chain_id,
+            channel,
+        };
+        self.execute_system_operation(operation, subscriber_chain_id)
+            .await
     }
 
     /// Unsubscribes from a system channel.
     async fn unsubscribe(
         &self,
-        chain_id: ChainId,
+        subscriber_chain_id: ChainId,
+        publisher_chain_id: ChainId,
         channel: SystemChannel,
     ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::Unsubscribe { chain_id, channel };
-        self.execute_system_operation(operation).await
+        let operation = SystemOperation::Unsubscribe {
+            chain_id: publisher_chain_id,
+            channel,
+        };
+        self.execute_system_operation(operation, subscriber_chain_id)
+            .await
     }
 
     /// (admin chain only) Removes a committee. Once this message is accepted by a chain,
     /// blocks from the retired epoch will not be accepted until they are followed (hence
     /// re-certified) by a block certified by a recent committee.
-    async fn remove_committee(&self, epoch: Epoch) -> Result<CryptoHash, Error> {
+    async fn remove_committee(&self, chain_id: ChainId, epoch: Epoch) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::Admin(AdminOperation::RemoveCommittee { epoch });
-        self.execute_system_operation(operation).await
+        self.execute_system_operation(operation, chain_id).await
     }
 
     /// Publishes a new application bytecode.
     async fn publish_bytecode(
         &self,
+        chain_id: ChainId,
         contract: Bytecode,
         service: Bytecode,
     ) -> Result<BytecodeId, Error> {
-        let mut client = self.client.lock().await;
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let (bytecode_id, _) = client.publish_bytecode(contract, service).await?;
         Ok(bytecode_id)
     }
@@ -303,12 +391,15 @@ where
     /// Creates a new application.
     async fn create_application(
         &self,
+        chain_id: ChainId,
         bytecode_id: BytecodeId,
         parameters: String,
         initialization_argument: String,
         required_application_ids: Vec<UserApplicationId>,
     ) -> Result<ApplicationId, Error> {
-        let mut client = self.client.lock().await;
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let (application_id, _) = client
             .create_application_untyped(
                 bytecode_id,
@@ -324,10 +415,13 @@ where
     /// on this one.
     async fn request_application(
         &self,
+        chain_id: ChainId,
         application_id: UserApplicationId,
         target_chain_id: Option<ChainId>,
     ) -> Result<CryptoHash, Error> {
-        let mut client = self.client.lock().await;
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
         let certificate = client
             .request_application(application_id, target_chain_id)
             .await?;
@@ -342,23 +436,20 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
-    async fn chain(
-        &self,
-        chain_id: Option<ChainId>,
-    ) -> Result<ChainStateExtendedView<S::Context>, Error> {
-        let view = self.client.lock().await.chain_state_view(chain_id).await?;
+    async fn chain(&self, chain_id: ChainId) -> Result<ChainStateExtendedView<S::Context>, Error> {
+        let Some(client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
+        let view = client.chain_state_view(Some(chain_id)).await?;
         Ok(ChainStateExtendedView::new(view))
     }
 
-    async fn applications(
-        &self,
-        chain_id: Option<ChainId>,
-    ) -> Result<Vec<ApplicationOverview>, Error> {
-        let applications = self
-            .client
-            .lock()
-            .await
-            .chain_state_view(chain_id)
+    async fn applications(&self, chain_id: ChainId) -> Result<Vec<ApplicationOverview>, Error> {
+        let Some(client) = self.clients.client_lock(&chain_id).await else {
+            return Err(Error::new("Unknown chain ID"));
+        };
+        let applications = client
+            .chain_state_view(Some(chain_id))
             .await?
             .execution_state
             .list_applications()
@@ -366,7 +457,7 @@ where
 
         let overviews = applications
             .into_iter()
-            .map(|(id, description)| ApplicationOverview::new(id, description, self.port))
+            .map(|(id, description)| ApplicationOverview::new(id, description, self.port, chain_id))
             .collect();
 
         Ok(overviews)
@@ -379,17 +470,20 @@ where
     async fn block(
         &self,
         hash: Option<CryptoHash>,
-        chain_id: Option<ChainId>,
+        chain_id: ChainId,
     ) -> Result<Option<HashedValue>, Error> {
+        let Some(client) = self.clients.client_lock(&chain_id).await else {
+            return Ok(None);
+        };
         let hash = match hash {
             Some(hash) => Some(hash),
             None => {
-                let view = self.client.lock().await.chain_state_view(chain_id).await?;
+                let view = client.chain_state_view(Some(chain_id)).await?;
                 view.tip_state.get().block_hash
             }
         };
         if let Some(hash) = hash {
-            let block = self.client.lock().await.read_value(hash).await?;
+            let block = client.read_value(hash).await?;
             Ok(Some(block))
         } else {
             Ok(None)
@@ -399,24 +493,22 @@ where
     async fn blocks(
         &self,
         from: Option<CryptoHash>,
-        chain_id: Option<ChainId>,
+        chain_id: ChainId,
         limit: Option<u32>,
     ) -> Result<Vec<HashedValue>, Error> {
+        let Some(client) = self.clients.client_lock(&chain_id).await else {
+            return Ok(vec![]);
+        };
         let limit = limit.unwrap_or(10);
         let from = match from {
             Some(from) => Some(from),
             None => {
-                let view = self.client.lock().await.chain_state_view(chain_id).await?;
+                let view = client.chain_state_view(Some(chain_id)).await?;
                 view.tip_state.get().block_hash
             }
         };
         if let Some(from) = from {
-            let values = self
-                .client
-                .lock()
-                .await
-                .read_values_downward(from, limit)
-                .await?;
+            let values = client.read_values_downward(from, limit).await?;
             Ok(values)
         } else {
             Ok(vec![])
@@ -466,11 +558,17 @@ impl ApplicationOverview {
         id: UserApplicationId,
         description: UserApplicationDescription,
         port: NonZeroU16,
+        chain_id: ChainId,
     ) -> Self {
         Self {
             id,
             description,
-            link: format!("http://localhost:{}/applications/{}", port.get(), id),
+            link: format!(
+                "http://localhost:{}/chains/{}/applications/{}",
+                port.get(),
+                chain_id,
+                id
+            ),
         }
     }
 }
@@ -538,19 +636,21 @@ async fn graphiql(uri: Uri) -> impl IntoResponse {
 /// The `NodeService` is a server that exposes a web-server to the client.
 /// The node service is primarily used to explore the state of a chain in GraphQL.
 pub struct NodeService<P, S> {
-    client: Arc<Mutex<ChainClient<P, S>>>,
+    clients: ClientMap<P, S>,
     config: ChainListenerConfig,
     port: NonZeroU16,
     chains: Chains,
+    storage: S,
 }
 
-impl<P, S> Clone for NodeService<P, S> {
+impl<P, S: Clone> Clone for NodeService<P, S> {
     fn clone(&self) -> Self {
         Self {
-            client: self.client.clone(),
+            clients: self.clients.clone(),
             config: self.config.clone(),
             port: self.port,
             chains: self.chains.clone(),
+            storage: self.storage.clone(),
         }
     }
 }
@@ -562,33 +662,28 @@ where
     ViewError: From<S::ContextError>,
 {
     /// Creates a new instance of the node service given a client chain and a port.
-    pub fn new(
-        client: ChainClient<P, S>,
-        config: ChainListenerConfig,
-        port: NonZeroU16,
-        chains: Chains,
-    ) -> Self {
-        let client = Arc::new(Mutex::new(client));
+    pub fn new(config: ChainListenerConfig, port: NonZeroU16, chains: Chains, storage: S) -> Self {
         Self {
-            client,
+            clients: ClientMap::default(),
             config,
             port,
             chains,
+            storage,
         }
     }
 
     pub fn schema(&self) -> Schema<QueryRoot<P, S>, MutationRoot<P, S>, SubscriptionRoot<P, S>> {
         Schema::build(
             QueryRoot {
-                client: self.client.clone(),
+                clients: self.clients.clone(),
                 port: self.port,
                 chains: self.chains.clone(),
             },
             MutationRoot {
-                client: self.client.clone(),
+                clients: self.clients.clone(),
             },
             SubscriptionRoot {
-                client: self.client.clone(),
+                clients: self.clients.clone(),
             },
         )
         .finish()
@@ -599,19 +694,16 @@ where
     where
         C: ClientContext<P>,
     {
-        // Process the inbox: For messages that are already there we won't receive a notification.
-        let mut client = self.client.lock().await;
-        client.synchronize_from_validators().await?;
-        client.process_inbox().await?;
-        drop(client);
-
         let port = self.port.get();
         let index_handler = axum::routing::get(graphiql).post(Self::index_handler);
         let applications_handler = axum::routing::get(graphiql).post(Self::application_handler);
 
         let app = Router::new()
             .route("/", index_handler)
-            .route("/applications/:id", applications_handler)
+            .route(
+                "/chains/:chain_id/applications/:application_id",
+                applications_handler,
+            )
             .route("/ready", axum::routing::get(|| async { "ready!" }))
             .route_service("/ws", GraphQLSubscription::new(self.schema()))
             .layer(Extension(self.clone()))
@@ -620,7 +712,10 @@ where
 
         info!("GraphiQL IDE: http://localhost:{}", port);
 
-        let sync_fut = Box::pin(ChainListener::new(self.config, self.client.clone()).run(context));
+        let sync_fut = Box::pin(
+            ChainListener::new(self.config, self.clients.clone())
+                .run(context, self.storage.clone()),
+        );
         let serve_fut =
             Server::bind(&SocketAddr::from(([127, 0, 0, 1], port))).serve(app.into_make_service());
 
@@ -643,13 +738,17 @@ where
         &self,
         application_id: UserApplicationId,
         request: &Request,
+        chain_id: ChainId,
     ) -> Result<async_graphql::Response, NodeServiceError> {
         let bytes = serde_json::to_vec(&request)?;
         let query = Query::User {
             application_id,
             bytes,
         };
-        let response = self.client.lock().await.query_application(&query).await?;
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(NodeServiceError::UnknownChainId);
+        };
+        let response = client.query_application(&query).await?;
         let user_response_bytes = match response {
             Response::System(_) => unreachable!("cannot get a system response for a user query"),
             Response::User(user) => user,
@@ -662,9 +761,12 @@ where
         &self,
         application_id: UserApplicationId,
         request: &Request,
+        chain_id: ChainId,
     ) -> Result<async_graphql::Response, NodeServiceError> {
         debug!("Request: {:?}", &request);
-        let graphql_response = self.user_application_query(application_id, request).await?;
+        let graphql_response = self
+            .user_application_query(application_id, request, chain_id)
+            .await?;
         if graphql_response.is_err() {
             let errors = graphql_response
                 .errors
@@ -686,7 +788,9 @@ where
             })
             .collect();
 
-        let mut client = self.client.lock().await;
+        let Some(mut client) = self.clients.client_lock(&chain_id).await else {
+            return Err(NodeServiceError::UnknownChainId);
+        };
         let hash = client.execute_operations(operations).await?.value.hash();
         Ok(async_graphql::Response::new(hash.to_value()))
     }
@@ -705,7 +809,7 @@ where
     /// Pattern matches on the `OperationType` of the query and routes the query
     /// accordingly.
     async fn application_handler(
-        Path(application_id): Path<String>,
+        Path((chain_id, application_id)): Path<(String, String)>,
         service: Extension<Self>,
         request: GraphQLRequest,
     ) -> Result<GraphQLResponse, NodeServiceError> {
@@ -714,19 +818,20 @@ where
         let parsed_query = request.parsed_query()?;
         let operation_type = operation_type(parsed_query)?;
 
+        let chain_id: ChainId = chain_id.parse().map_err(NodeServiceError::InvalidChainId)?;
         let application_id: UserApplicationId = application_id.parse()?;
 
         let response = match operation_type {
             OperationType::Query => {
                 service
                     .0
-                    .user_application_query(application_id, &request)
+                    .user_application_query(application_id, &request, chain_id)
                     .await?
             }
             OperationType::Mutation => {
                 service
                     .0
-                    .user_application_mutation(application_id, &request)
+                    .user_application_mutation(application_id, &request, chain_id)
                     .await?
             }
             OperationType::Subscription => return Err(NodeServiceError::UnsupportedQueryType),

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -53,7 +53,7 @@ pub struct Chains {
     pub default: Option<ChainId>,
 }
 
-pub(crate) type ClientMapInner<P, S> = BTreeMap<ChainId, Arc<Mutex<ChainClient<P, S>>>>;
+pub type ClientMapInner<P, S> = BTreeMap<ChainId, Arc<Mutex<ChainClient<P, S>>>>;
 pub(crate) struct ChainClients<P, S>(Arc<Mutex<ClientMapInner<P, S>>>);
 
 impl<P, S> Clone for ChainClients<P, S> {
@@ -236,6 +236,7 @@ where
         let mut client = self.clients.try_client_lock(&chain_id).await?;
         client.synchronize_from_validators().await?;
         let certificates = client.process_inbox().await?;
+        drop(client);
         let hashes = certificates.into_iter().map(|cert| cert.hash()).collect();
         Ok(hashes)
     }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::identifiers::{ChainDescription, ChainId};
+use linera_base::identifiers::ChainId;
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 
 use async_trait::async_trait;
@@ -11,10 +11,7 @@ use linera_core::{
     node::{NodeError, NotificationStream, ValidatorNode},
 };
 use linera_execution::committee::Committee;
-use linera_service::{
-    chain_listener::ChainListenerConfig,
-    node_service::{Chains, NodeService},
-};
+use linera_service::{chain_listener::ChainListenerConfig, node_service::NodeService};
 use linera_storage::MemoryStoreClient;
 
 #[derive(Clone)]
@@ -71,12 +68,7 @@ impl ValidatorNodeProvider for DummyValidatorNodeProvider {
 }
 
 fn main() -> std::io::Result<()> {
-    let chain_id = ChainId::from(ChainDescription::Root(0));
     let store = MemoryStoreClient::new(None);
-    let chains = Chains {
-        list: Vec::new(),
-        default: Some(chain_id),
-    };
     let config = ChainListenerConfig {
         delay_before_ms: 0,
         delay_after_ms: 0,
@@ -84,7 +76,7 @@ fn main() -> std::io::Result<()> {
     let service = NodeService::<DummyValidatorNodeProvider, _>::new(
         config,
         std::num::NonZeroU16::new(8080).unwrap(),
-        chains,
+        None,
         store,
     );
     let schema = service.schema().sdl();

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -1,15 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{
-    data_types::{BlockHeight, Timestamp},
-    identifiers::{ChainDescription, ChainId},
-};
+use linera_base::identifiers::{ChainDescription, ChainId};
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 
 use async_trait::async_trait;
 use linera_core::{
-    client::{ChainClient, ValidatorNodeProvider},
+    client::ValidatorNodeProvider,
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{NodeError, NotificationStream, ValidatorNode},
 };
@@ -76,32 +73,19 @@ impl ValidatorNodeProvider for DummyValidatorNodeProvider {
 fn main() -> std::io::Result<()> {
     let chain_id = ChainId::from(ChainDescription::Root(0));
     let store = MemoryStoreClient::new(None);
-    let chain_client = ChainClient::new(
-        chain_id,
-        Vec::new(),
-        DummyValidatorNodeProvider,
-        store,
-        chain_id,
-        0,
-        None,
-        Timestamp::now(),
-        BlockHeight(0),
-        std::time::Duration::from_micros(0),
-        0,
-    );
     let chains = Chains {
         list: Vec::new(),
-        default: chain_id,
+        default: Some(chain_id),
     };
     let config = ChainListenerConfig {
         delay_before_ms: 0,
         delay_after_ms: 0,
     };
-    let service = NodeService::new(
-        chain_client,
+    let service = NodeService::<DummyValidatorNodeProvider, _>::new(
         config,
         std::num::NonZeroU16::new(8080).unwrap(),
         chains,
+        store,
     );
     let schema = service.schema().sdl();
     print!("{}", schema);

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1498,7 +1498,8 @@ async fn test_reconfiguration(network: Network) {
 }
 
 #[test_log::test(tokio::test)]
-#[ignore] // TODO(#901)
+// TODO(#901): Node service should track newly opened chains
+#[ignore]
 async fn test_open_chain_node_service() {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1498,6 +1498,7 @@ async fn test_reconfiguration(network: Network) {
 }
 
 #[test_log::test(tokio::test)]
+#[ignore] // TODO(#901)
 async fn test_open_chain_node_service() {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1522,6 +1522,18 @@ async fn test_open_chain_node_service() {
 
     // Open a new chain with the same public key.
     // The node service should automatically create a client for it internally.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    let query = format!(
+        "mutation {{ openChain(\
+            chainId:\"{default_chain}\", \
+            publicKey:\"{public_key}\"\
+        ) }}"
+    );
+    node_service.query_node(&query).await;
+
+    // Open another new chain.
+    // This is a regression test; a PR had to be reverted because this was hanging:
+    // https://github.com/linera-io/linera-protocol/pull/899
     let query = format!(
         "mutation {{ openChain(\
             chainId:\"{default_chain}\", \

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1523,7 +1523,6 @@ async fn test_open_chain_node_service() {
 
     // Open a new chain with the same public key.
     // The node service should automatically create a client for it internally.
-    tokio::time::sleep(Duration::from_secs(5)).await;
     let query = format!(
         "mutation {{ openChain(\
             chainId:\"{default_chain}\", \


### PR DESCRIPTION
# Motivation

If `linera service` is started for one chain, due to the file lock on the wallet, it's not possible to also start a service for any other chain. So e.g. sending tokens to another local chain will not update its balance.

# Solution

Make `linera service` listen for and update all owned chains, not just the default chain. All mutations should specify the chain they are applied to explicitly. If a new chain is opened and the wallet contains the secret key for it, it should also be tracked.

This PR is most of the reverted https://github.com/linera-io/linera-protocol/pull/878, with a few changes:

* I didn't add `new_chains` to the `NewBlock` notification. Instead, I'm reading the block itself and check its outgoing messages. This means we're reading every block from disk again; we could later add a flag to `NewBlock` that just indicates whether there were any newly opened chains. It also means that the explorer can't update its set of chains based on the notification.

* I disabled the line that makes the node service start tracking and processing newly opened chains, because this is causing the service to hang if you open two chains. (See below.) I created https://github.com/linera-io/linera-protocol/issues/901 to fix this later.

* I partly fixed the chains query, so that it would read the chain IDs from the current notification stream map. Once https://github.com/linera-io/linera-protocol/issues/901 is addressed, that should add newly opened chains to the list.

Closes #865
Closes #901