### PR TITLE
Correct a bug in the construction of views for struct views

### DIFF
--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -105,8 +105,8 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
         let idx_lit = syn::LitInt::new(&idx.to_string(), Span::call_site());
         let type_ident = get_type_field(e).expect("Failed to find the type");
         load_future_quotes.push(quote! {
-            let index = #idx_lit + linera_views::common::MIN_VIEW_TAG;
-            let base_key = context.derive_key(&index)?;
+            let index = #idx_lit;
+            let base_key = context.derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
             let #fut = #type_ident::load(context.clone_with_base_key(base_key));
         });
         load_ident_quotes.push(quote! {
@@ -742,12 +742,12 @@ pub mod tests {
                             stringify!(TestView),
                             &context.base_key(),
                         );
-                        let index = 0 + linera_views::common::MIN_VIEW_TAG;
-                        let base_key = context.derive_key(&index)?;
+                        let index = 0;
+                        let base_key = context.derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
                         let register_fut =
                             RegisterView::load(context.clone_with_base_key(base_key));
-                        let index = 1 + linera_views::common::MIN_VIEW_TAG;
-                        let base_key = context.derive_key(&index)?;
+                        let index = 1;
+                        let base_key = context.derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
                         let collection_fut =
                             CollectionView::load(context.clone_with_base_key(base_key));
                         let result = join!(register_fut, collection_fut);

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -105,7 +105,7 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
         let idx_lit = syn::LitInt::new(&idx.to_string(), Span::call_site());
         let type_ident = get_type_field(e).expect("Failed to find the type");
         load_future_quotes.push(quote! {
-            let index = #idx_lit;
+            let index = #idx_lit + linera_views::common::MIN_VIEW_TAG;
             let base_key = context.derive_key(&index)?;
             let #fut = #type_ident::load(context.clone_with_base_key(base_key));
         });
@@ -742,11 +742,11 @@ pub mod tests {
                             stringify!(TestView),
                             &context.base_key(),
                         );
-                        let index = 0;
+                        let index = 0 + linera_views::common::MIN_VIEW_TAG;
                         let base_key = context.derive_key(&index)?;
                         let register_fut =
                             RegisterView::load(context.clone_with_base_key(base_key));
-                        let index = 1;
+                        let index = 1 + linera_views::common::MIN_VIEW_TAG;
                         let base_key = context.derive_key(&index)?;
                         let collection_fut =
                             CollectionView::load(context.clone_with_base_key(base_key));

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -39,7 +39,7 @@ pub(crate) enum Update<T> {
 }
 
 /// The minimum value for the view tags. Values in 0..MIN_VIEW_TAG are used for other purposes.
-pub(crate) const MIN_VIEW_TAG: u8 = 1;
+pub const MIN_VIEW_TAG: u8 = 1;
 
 /// When wanting to find the entries in a BTreeMap with a specific prefix,
 /// one option is to iterate over all keys. Another is to select an interval


### PR DESCRIPTION
# Problem
In order to handle the journal (and possibly other management structures), we need to have a way to store administrative data in the key-value store.
This leads to the use of the `MIN_VIEW_TAG` which allows this administrative work to be done. This is done for `MapView`, `SetView`, etc. but not for the struct views.

# Solution
Implement the `MIN_VIEW_TAG` for the struct views. This allows the use of the journaling for the struct views.