### PR TITLE
Create a `WitLoad` trait

### DIFF
--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -18,3 +18,6 @@ proc-macro-error = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
 syn = { workspace = true }
+
+[dev-dependencies]
+syn = { workspace = true, features = ["full"] }

--- a/linera-witty-macros/src/unit_tests/wit_load.rs
+++ b/linera-witty-macros/src/unit_tests/wit_load.rs
@@ -1,0 +1,157 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the `WitLoad` derive macro.
+
+#![cfg(test)]
+
+use super::derive_for_struct;
+use quote::quote;
+use syn::{parse_quote, Fields, ItemStruct};
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a unit struct.
+#[test]
+fn zero_sized_type() {
+    let input = Fields::Unit;
+    let output = derive_for_struct(&input);
+
+    let expected = quote! {
+        fn load<Instance>(
+            memory: &linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            Ok(Self)
+        }
+
+        fn lift_from<Instance>(
+            flat_layout: <Self::Layout as linera_witty::Layout>::Flat,
+            memory: &linera_witty::Memory<'_, Instance>,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            Ok(Self)
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a named struct.
+#[test]
+fn named_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type {
+            first: u8,
+            second: CustomType,
+        }
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        fn load<Instance>(
+            memory: &linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            location = location.after_padding_for::<u8>();
+            let first = <u8 as linera_witty::WitLoad>::load(memory, location)?;
+            location = location.after::<u8>();
+
+            location = location.after_padding_for::<CustomType>();
+            let second = <CustomType as linera_witty::WitLoad>::load(memory, location)?;
+            location = location.after::<CustomType>();
+
+            Ok(Self { first, second })
+        }
+
+        fn lift_from<Instance>(
+            flat_layout: <Self::Layout as linera_witty::Layout>::Flat,
+            memory: &linera_witty::Memory<'_, Instance>,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
+            let first = <u8 as WitLoad>::lift_from(field_layout, memory)?;
+
+            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
+            let second = <CustomType as WitLoad>::lift_from(field_layout, memory)?;
+
+            Ok(Self { first, second })
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a tuple struct.
+#[test]
+fn tuple_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type(String, Vec<CustomType>, i64);
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        fn load<Instance>(
+            memory: &linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            location = location.after_padding_for::<String>();
+            let field0 = <String as linera_witty::WitLoad>::load(memory, location)?;
+            location = location.after::<String>();
+
+            location = location.after_padding_for::<Vec<CustomType> >();
+            let field1 = <Vec<CustomType> as linera_witty::WitLoad>::load(memory, location)?;
+            location = location.after::<Vec<CustomType> >();
+
+            location = location.after_padding_for::<i64>();
+            let field2 = <i64 as linera_witty::WitLoad>::load(memory, location)?;
+            location = location.after::<i64>();
+
+            Ok(Self(field0, field1, field2))
+        }
+
+        fn lift_from<Instance>(
+            flat_layout: <Self::Layout as linera_witty::Layout>::Flat,
+            memory: &linera_witty::Memory<'_, Instance>,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
+            let field0 = <String as WitLoad>::lift_from(field_layout, memory)?;
+
+            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
+            let field1 = <Vec<CustomType> as WitLoad>::lift_from(field_layout, memory)?;
+
+            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
+            let field2 = <i64 as WitLoad>::lift_from(field_layout, memory)?;
+
+            Ok(Self(field0, field1, field2))
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}

--- a/linera-witty-macros/src/wit_load.rs
+++ b/linera-witty-macros/src/wit_load.rs
@@ -3,6 +3,9 @@
 
 //! Derivation of the `WitLoad` trait.
 
+#[path = "unit_tests/wit_load.rs"]
+mod tests;
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{Fields, Ident};

--- a/linera-witty-macros/src/wit_load.rs
+++ b/linera-witty-macros/src/wit_load.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Derivation of the `WitLoad` trait.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::{Fields, Ident};
+
+/// Returns the body of the `WitLoad` implementation for the Rust `struct` with the specified
+/// `fields`.
+pub fn derive_for_struct(fields: &Fields) -> TokenStream {
+    let field_pairs: Vec<_> = field_names_and_types(fields).collect();
+
+    let load_fields = loads_for_fields(field_pairs.iter().cloned());
+    let construction = construction_for_fields(field_pairs.iter().cloned(), fields);
+
+    let lift_fields = field_pairs.iter().map(|(field_name, field_type)| {
+        quote! {
+            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
+            let #field_name = <#field_type as WitLoad>::lift_from(field_layout, memory)?;
+        }
+    });
+
+    quote! {
+        fn load<Instance>(
+            memory: &linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            #( #load_fields )*
+
+            Ok(Self #construction)
+        }
+
+        fn lift_from<Instance>(
+            flat_layout: <Self::Layout as linera_witty::Layout>::Flat,
+            memory: &linera_witty::Memory<'_, Instance>,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            #( #lift_fields )*
+
+            Ok(Self #construction)
+        }
+    }
+}
+
+/// Returns an iterator over the names and types of the provided `fields`.
+fn field_names_and_types(
+    fields: &Fields,
+) -> impl Iterator<Item = (Ident, TokenStream)> + Clone + '_ {
+    let field_names = fields.iter().enumerate().map(|(index, field)| {
+        field
+            .ident
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| format_ident!("field{index}"))
+    });
+
+    let field_types = fields.iter().map(|field| field.ty.to_token_stream());
+
+    field_names.zip(field_types)
+}
+
+/// Returns the code generated to load a single field.
+///
+/// Assumes that `location` points to where the field starts in memory, and advances it to the end
+/// of the field. A binding with the field name is created in the generated code.
+fn loads_for_fields(
+    field_names_and_types: impl Iterator<Item = (Ident, TokenStream)> + Clone,
+) -> impl Iterator<Item = TokenStream> {
+    field_names_and_types.map(|(field_name, field_type)| {
+        quote! {
+            location = location.after_padding_for::<#field_type>();
+            let #field_name = <#field_type as linera_witty::WitLoad>::load(memory, location)?;
+            location = location.after::<#field_type>();
+        }
+    })
+}
+
+/// Returns the code to construct an instance of the field type.
+///
+/// Assumes that bindings were created with the field names.
+fn construction_for_fields(
+    field_names_and_types: impl Iterator<Item = (Ident, TokenStream)>,
+    fields: &Fields,
+) -> TokenStream {
+    let field_names = field_names_and_types.map(|(name, _)| name);
+
+    match fields {
+        Fields::Unit => quote! {},
+        Fields::Named(_) => quote! { { #( #field_names ),* } },
+        Fields::Unnamed(_) => quote! {( #( #field_names ),* ) },
+    }
+}

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [features]
 default = ["macros"]
 macros = ["linera-witty-macros"]
+test = []
 
 [dependencies]
 frunk = { workspace = true }
@@ -20,4 +21,4 @@ linera-witty-macros = { workspace = true, optional = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-linera-witty = { workspace = true, features = ["macros"] }
+linera-witty = { workspace = true, features = ["macros", "test"] }

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -28,4 +28,4 @@ pub use self::{
 };
 pub use frunk::{hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]
-pub use linera_witty_macros::WitType;
+pub use linera_witty_macros::{WitLoad, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -28,6 +28,6 @@ pub use self::{
     type_traits::{WitLoad, WitType},
     util::Split,
 };
-pub use frunk::{hlist::HList, HList, HNil};
+pub use frunk::{hlist, hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::{WitLoad, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -21,7 +21,7 @@ mod type_traits;
 
 pub use self::{
     memory_layout::Layout,
-    runtime::{InstanceWithMemory, Memory},
+    runtime::{GuestPointer, InstanceWithMemory, Memory},
     type_traits::WitType,
 };
 pub use frunk::{hlist::HList, HList, HNil};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -19,7 +19,11 @@ mod primitive_types;
 mod runtime;
 mod type_traits;
 
-pub use self::{memory_layout::Layout, runtime::Memory, type_traits::WitType};
+pub use self::{
+    memory_layout::Layout,
+    runtime::{InstanceWithMemory, Memory},
+    type_traits::WitType,
+};
 pub use frunk::{hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::WitType;

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -21,8 +21,8 @@ mod type_traits;
 
 pub use self::{
     memory_layout::Layout,
-    runtime::{GuestPointer, InstanceWithMemory, Memory},
-    type_traits::WitType,
+    runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},
+    type_traits::{WitLoad, WitType},
 };
 pub use frunk::{hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -21,7 +21,7 @@ mod type_traits;
 mod util;
 
 #[cfg(any(test, feature = "test"))]
-pub use self::runtime::FakeRuntime;
+pub use self::runtime::{FakeInstance, FakeRuntime};
 pub use self::{
     memory_layout::Layout,
     runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -20,6 +20,8 @@ mod runtime;
 mod type_traits;
 mod util;
 
+#[cfg(any(test, feature = "test"))]
+pub use self::runtime::FakeRuntime;
 pub use self::{
     memory_layout::Layout,
     runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -18,11 +18,13 @@ mod memory_layout;
 mod primitive_types;
 mod runtime;
 mod type_traits;
+mod util;
 
 pub use self::{
     memory_layout::Layout,
     runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},
     type_traits::{WitLoad, WitType},
+    util::Split,
 };
 pub use frunk::{hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -29,6 +29,14 @@ pub enum RuntimeError {
     #[error("Export `{_0}` is not a function")]
     NotAFunction(String),
 
+    /// Attempt to load the memory export from a module that doesn't export it.
+    #[error("Failed to load `memory` export")]
+    MissingMemory,
+
+    /// Attempt to load the memory export from a module that exports it as something else.
+    #[error("Unexpected type for `memory` export")]
+    NotMemory,
+
     /// Attempt to load a string from a sequence of bytes that doesn't contain a UTF-8 string.
     #[error("Failed to load string from non-UTF-8 bytes")]
     InvalidString(#[from] FromUtf8Error),

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -3,6 +3,7 @@
 
 //! Common error type for usage of different Wasm runtimes.
 
+use std::{num::TryFromIntError, string::FromUtf8Error};
 use thiserror::Error;
 
 /// Errors that can occur when using a Wasm runtime.
@@ -27,4 +28,12 @@ pub enum RuntimeError {
     /// Attempt to load a function with a name that's used for a different import in the module.
     #[error("Export `{_0}` is not a function")]
     NotAFunction(String),
+
+    /// Attempt to load a string from a sequence of bytes that doesn't contain a UTF-8 string.
+    #[error("Failed to load string from non-UTF-8 bytes")]
+    InvalidString(#[from] FromUtf8Error),
+
+    /// Attempt to create a `GuestPointer` from an invalid address representation.
+    #[error("Invalid address read")]
+    InvalidNumber(#[from] TryFromIntError),
 }

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -70,6 +70,24 @@ where
     cabi_free: Option<<Instance as InstanceWithFunction<HList![i32], HList![]>>::Function>,
 }
 
+impl<'runtime, Instance> Memory<'runtime, Instance>
+where
+    Instance: CabiReallocAlias + CabiFreeAlias,
+{
+    /// Creates a new [`Memory`] instance using a Wasm module `instance` and its `memory` export.
+    pub(super) fn new(
+        instance: &'runtime mut Instance,
+        memory: <Instance::Runtime as Runtime>::Memory,
+    ) -> Self {
+        Memory {
+            instance,
+            memory,
+            cabi_realloc: None,
+            cabi_free: None,
+        }
+    }
+}
+
 impl<Instance> Memory<'_, Instance>
 where
     Instance: CabiReallocAlias + CabiFreeAlias,

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -3,7 +3,10 @@
 
 //! Abstraction over how different runtimes manipulate the guest WebAssembly module's memory.
 
-use super::{InstanceWithFunction, Runtime, RuntimeError};
+use super::{
+    traits::{CabiFreeAlias, CabiReallocAlias},
+    InstanceWithFunction, Runtime, RuntimeError,
+};
 use crate::{Layout, WitType};
 use frunk::{hlist, hlist_pat, HList};
 use std::borrow::Cow;
@@ -51,22 +54,6 @@ pub trait RuntimeMemory<Instance> {
         location: GuestPointer,
         bytes: &[u8],
     ) -> Result<(), RuntimeError>;
-}
-
-/// Trait alias for a Wasm module instance with the WIT Canonical ABI `cabi_realloc` function.
-pub trait CabiReallocAlias: InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]> {}
-
-impl<AnyInstance> CabiReallocAlias for AnyInstance where
-    AnyInstance: InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]>
-{
-}
-
-/// Trait alias for a Wasm module instance with the WIT Canonical ABI `cabi_free` function.
-pub trait CabiFreeAlias: InstanceWithFunction<HList![i32], HList![]> {}
-
-impl<AnyInstance> CabiFreeAlias for AnyInstance where
-    AnyInstance: InstanceWithFunction<HList![i32], HList![]>
-{
 }
 
 /// A handle to interface with a guest Wasm module instance's memory.

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 
 /// An address for a location in a guest WebAssembly module's memory.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GuestPointer(u32);
+pub struct GuestPointer(pub(crate) u32);
 
 impl GuestPointer {
     /// Returns a new address that's the current address advanced to after the size of `T`.

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -16,6 +16,14 @@ use std::borrow::Cow;
 pub struct GuestPointer(pub(crate) u32);
 
 impl GuestPointer {
+    /// Returns a new address that's the current address advanced to add padding to ensure it's
+    /// aligned to the `alignment` byte boundary.
+    pub fn aligned_at(&self, alignment: u32) -> Self {
+        let padding = (-(self.0 as i32) & (alignment as i32 - 1)) as u32;
+
+        GuestPointer(self.0 + padding)
+    }
+
     /// Returns a new address that's the current address advanced to after the size of `T`.
     pub fn after<T: WitType>(&self) -> Self {
         GuestPointer(self.0 + T::SIZE)
@@ -24,9 +32,7 @@ impl GuestPointer {
     /// Returns a new address that's the current address advanced to add padding to ensure it's
     /// aligned properly for `T`.
     pub fn after_padding_for<T: WitType>(&self) -> Self {
-        let padding = (-(self.0 as i32) & (<T::Layout as Layout>::ALIGNMENT as i32 - 1)) as u32;
-
-        GuestPointer(self.0 + padding)
+        self.aligned_at(<T::Layout as Layout>::ALIGNMENT)
     }
 
     /// Returns the address of an element in a contiguous list of properly aligned `T` types.

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -9,6 +9,6 @@ mod traits;
 
 pub use self::{
     error::RuntimeError,
-    memory::Memory,
+    memory::{GuestPointer, Memory},
     traits::{Instance, InstanceWithFunction, InstanceWithMemory, Runtime},
 };

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -10,5 +10,5 @@ mod traits;
 pub use self::{
     error::RuntimeError,
     memory::Memory,
-    traits::{Instance, InstanceWithFunction, Runtime},
+    traits::{Instance, InstanceWithFunction, InstanceWithMemory, Runtime},
 };

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -10,7 +10,7 @@ mod test;
 mod traits;
 
 #[cfg(any(test, feature = "test"))]
-pub use self::test::FakeRuntime;
+pub use self::test::{FakeInstance, FakeRuntime};
 pub use self::{
     error::RuntimeError,
     memory::{GuestPointer, Memory, RuntimeMemory},

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -5,8 +5,12 @@
 
 mod error;
 mod memory;
+#[cfg(any(test, feature = "test"))]
+mod test;
 mod traits;
 
+#[cfg(any(test, feature = "test"))]
+pub use self::test::FakeRuntime;
 pub use self::{
     error::RuntimeError,
     memory::{GuestPointer, Memory, RuntimeMemory},

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -9,6 +9,6 @@ mod traits;
 
 pub use self::{
     error::RuntimeError,
-    memory::{GuestPointer, Memory},
+    memory::{GuestPointer, Memory, RuntimeMemory},
     traits::{Instance, InstanceWithFunction, InstanceWithMemory, Runtime},
 };

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -6,7 +6,8 @@
 //! No WebAssembly bytecode can be executed, but it allows calling the canonical ABI functions
 //! related to memory allocation.
 
-use super::{Instance, Runtime};
+use super::{GuestPointer, Instance, InstanceWithFunction, Runtime, RuntimeError};
+use frunk::{hlist, hlist_pat, HList};
 use std::sync::{Arc, Mutex};
 
 /// A fake Wasm runtime.
@@ -33,5 +34,62 @@ impl Instance for FakeInstance {
             "memory" | "cabi_realloc" | "cabi_free" => Some(()),
             _ => None,
         }
+    }
+}
+
+// Support for `cabi_free`.
+impl InstanceWithFunction<HList![i32], HList![]> for FakeInstance {
+    type Function = ();
+
+    fn function_from_export(
+        &mut self,
+        (): <Self::Runtime as Runtime>::Export,
+    ) -> Result<Option<Self::Function>, RuntimeError> {
+        Ok(Some(()))
+    }
+
+    fn call(
+        &mut self,
+        _function: &Self::Function,
+        _: HList![i32],
+    ) -> Result<HList![], RuntimeError> {
+        Ok(hlist![])
+    }
+}
+
+// Support for `cabi_realloc`.
+impl InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]> for FakeInstance {
+    type Function = ();
+
+    fn function_from_export(
+        &mut self,
+        (): <Self::Runtime as Runtime>::Export,
+    ) -> Result<Option<Self::Function>, RuntimeError> {
+        Ok(Some(()))
+    }
+
+    fn call(
+        &mut self,
+        _function: &Self::Function,
+        hlist_pat![_old_address, _old_size, alignment, new_size]: HList![i32, i32, i32, i32],
+    ) -> Result<HList![i32], RuntimeError> {
+        let allocation_size =
+            usize::try_from(new_size).expect("Failed to allocate a negative amount of memory");
+
+        let mut memory = self
+            .memory
+            .lock()
+            .expect("Panic while holding a lock to a `FakeInstance`'s memory");
+
+        let address = GuestPointer(memory.len().try_into()?).aligned_at(alignment as u32);
+
+        memory.resize(address.0 as usize + allocation_size, 0);
+
+        assert!(
+            memory.len() <= i32::MAX as usize,
+            "No more memory for allocations"
+        );
+
+        Ok(hlist![address.0 as i32])
     }
 }

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -6,7 +6,7 @@
 //! No WebAssembly bytecode can be executed, but it allows calling the canonical ABI functions
 //! related to memory allocation.
 
-use super::Runtime;
+use super::{Instance, Runtime};
 use std::sync::{Arc, Mutex};
 
 /// A fake Wasm runtime.
@@ -15,4 +15,23 @@ pub struct FakeRuntime;
 impl Runtime for FakeRuntime {
     type Export = ();
     type Memory = Arc<Mutex<Vec<u8>>>;
+}
+
+/// A fake Wasm instance.
+///
+/// Only contains exports for the memory and the canonical ABI allocation functions.
+#[derive(Default)]
+pub struct FakeInstance {
+    memory: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Instance for FakeInstance {
+    type Runtime = FakeRuntime;
+
+    fn load_export(&mut self, name: &str) -> Option<()> {
+        match name {
+            "memory" | "cabi_realloc" | "cabi_free" => Some(()),
+            _ => None,
+        }
+    }
 }

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A dummy runtime implementation useful for tests.
+//!
+//! No WebAssembly bytecode can be executed, but it allows calling the canonical ABI functions
+//! related to memory allocation.
+
+use super::Runtime;
+use std::sync::{Arc, Mutex};
+
+/// A fake Wasm runtime.
+pub struct FakeRuntime;
+
+impl Runtime for FakeRuntime {
+    type Export = ();
+    type Memory = Arc<Mutex<Vec<u8>>>;
+}

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -3,7 +3,7 @@
 
 //! Abstractions over different Wasm runtime implementations.
 
-use super::RuntimeError;
+use super::{memory::RuntimeMemory, RuntimeError};
 use crate::memory_layout::FlatLayout;
 use frunk::HList;
 
@@ -73,5 +73,15 @@ pub trait CabiFreeAlias: InstanceWithFunction<HList![i32], HList![]> {}
 
 impl<AnyInstance> CabiFreeAlias for AnyInstance where
     AnyInstance: InstanceWithFunction<HList![i32], HList![]>
+{
+}
+
+/// Trait alias for a Wasm module instance with the WIT Canonical ABI functions.
+pub trait InstanceWithMemory: CabiReallocAlias + CabiFreeAlias {}
+
+impl<AnyInstance> InstanceWithMemory for AnyInstance
+where
+    AnyInstance: CabiReallocAlias + CabiFreeAlias,
+    <AnyInstance::Runtime as Runtime>::Memory: RuntimeMemory<AnyInstance>,
 {
 }

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -5,6 +5,7 @@
 
 use super::RuntimeError;
 use crate::memory_layout::FlatLayout;
+use frunk::HList;
 
 /// A Wasm runtime.
 ///
@@ -57,4 +58,20 @@ where
         self.function_from_export(export)?
             .ok_or_else(|| RuntimeError::NotAFunction(name.to_string()))
     }
+}
+
+/// Trait alias for a Wasm module instance with the WIT Canonical ABI `cabi_realloc` function.
+pub trait CabiReallocAlias: InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]> {}
+
+impl<AnyInstance> CabiReallocAlias for AnyInstance where
+    AnyInstance: InstanceWithFunction<HList![i32, i32, i32, i32], HList![i32]>
+{
+}
+
+/// Trait alias for a Wasm module instance with the WIT Canonical ABI `cabi_free` function.
+pub trait CabiFreeAlias: InstanceWithFunction<HList![i32], HList![]> {}
+
+impl<AnyInstance> CabiFreeAlias for AnyInstance where
+    AnyInstance: InstanceWithFunction<HList![i32], HList![]>
+{
 }

--- a/linera-witty/src/type_traits/implementations/custom_types.rs
+++ b/linera-witty/src/type_traits/implementations/custom_types.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for types declared in this crate.
+
+use crate::{GuestPointer, WitType};
+use frunk::HList;
+
+impl WitType for GuestPointer {
+    const SIZE: u32 = u32::SIZE;
+
+    type Layout = HList![i32];
+}

--- a/linera-witty/src/type_traits/implementations/custom_types.rs
+++ b/linera-witty/src/type_traits/implementations/custom_types.rs
@@ -3,11 +3,38 @@
 
 //! Implementations of the custom traits for types declared in this crate.
 
-use crate::{GuestPointer, WitType};
-use frunk::HList;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitType,
+};
+use frunk::{hlist_pat, HList};
 
 impl WitType for GuestPointer {
     const SIZE: u32 = u32::SIZE;
 
     type Layout = HList![i32];
+}
+
+impl WitLoad for GuestPointer {
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(GuestPointer(u32::load(memory, location)?))
+    }
+
+    fn lift_from<Instance>(
+        hlist_pat![value]: <Self::Layout as Layout>::Flat,
+        _memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(GuestPointer(value.try_into()?))
+    }
 }

--- a/linera-witty/src/type_traits/implementations/frunk.rs
+++ b/linera-witty/src/type_traits/implementations/frunk.rs
@@ -3,7 +3,10 @@
 
 //! Implementations of the custom traits for types from the standard library.
 
-use crate::{Layout, WitType};
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory, Split,
+    WitLoad, WitType,
+};
 use frunk::{HCons, HNil};
 use std::ops::Add;
 
@@ -11,6 +14,28 @@ impl WitType for HNil {
     const SIZE: u32 = 0;
 
     type Layout = HNil;
+}
+
+impl WitLoad for HNil {
+    fn load<Instance>(
+        _memory: &Memory<'_, Instance>,
+        _location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+    {
+        Ok(HNil)
+    }
+
+    fn lift_from<Instance>(
+        HNil: <Self::Layout as Layout>::Flat,
+        _memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+    {
+        Ok(HNil)
+    }
 }
 
 impl<Head, Tail> WitType for HCons<Head, Tail>
@@ -23,4 +48,44 @@ where
     const SIZE: u32 = Head::SIZE + Tail::SIZE;
 
     type Layout = <Head::Layout as Add<Tail::Layout>>::Output;
+}
+
+impl<Head, Tail> WitLoad for HCons<Head, Tail>
+where
+    Head: WitLoad,
+    Tail: WitLoad,
+    Head::Layout: Add<Tail::Layout>,
+    <Head::Layout as Add<Tail::Layout>>::Output: Layout,
+    <Self::Layout as Layout>::Flat:
+        Split<<Head::Layout as Layout>::Flat, Remainder = <Tail::Layout as Layout>::Flat>,
+{
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(HCons {
+            head: Head::load(memory, location)?,
+            tail: Tail::load(memory, location.after::<Head>())?,
+        })
+    }
+
+    fn lift_from<Instance>(
+        layout: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let (head_layout, tail_layout) = layout.split();
+
+        Ok(HCons {
+            head: Head::lift_from(head_layout, memory)?,
+            tail: Tail::lift_from(tail_layout, memory)?,
+        })
+    }
 }

--- a/linera-witty/src/type_traits/implementations/mod.rs
+++ b/linera-witty/src/type_traits/implementations/mod.rs
@@ -3,5 +3,6 @@
 
 //! Implementations of the custom traits for existing types.
 
+mod custom_types;
 mod frunk;
 mod std;

--- a/linera-witty/src/type_traits/implementations/std/floats.rs
+++ b/linera-witty/src/type_traits/implementations/std/floats.rs
@@ -3,8 +3,11 @@
 
 //! Implementations of the custom traits for float primitives.
 
-use crate::WitType;
-use frunk::HList;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitType,
+};
+use frunk::{hlist_pat, HList};
 
 macro_rules! impl_wit_traits {
     ($float:ty, $size:expr) => {
@@ -12,6 +15,33 @@ macro_rules! impl_wit_traits {
             const SIZE: u32 = $size;
 
             type Layout = HList![$float];
+        }
+
+        impl WitLoad for $float {
+            fn load<Instance>(
+                memory: &Memory<'_, Instance>,
+                location: GuestPointer,
+            ) -> Result<Self, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let slice = memory.read(location, Self::SIZE)?;
+                let bytes = (*slice).try_into().expect("Incorrect number of bytes read");
+
+                Ok(Self::from_le_bytes(bytes))
+            }
+
+            fn lift_from<Instance>(
+                hlist_pat![value]: <Self::Layout as Layout>::Flat,
+                _memory: &Memory<'_, Instance>,
+            ) -> Result<Self, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                Ok(value)
+            }
         }
     };
 }

--- a/linera-witty/src/type_traits/implementations/std/integers.rs
+++ b/linera-witty/src/type_traits/implementations/std/integers.rs
@@ -3,8 +3,11 @@
 
 //! Implementations of the custom traits for integer primitives.
 
-use crate::WitType;
-use frunk::HList;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitType,
+};
+use frunk::{hlist_pat, HList};
 
 macro_rules! impl_wit_traits {
     ($integer:ty, 1) => {
@@ -13,21 +16,79 @@ macro_rules! impl_wit_traits {
 
             type Layout = HList![$integer];
         }
+
+        impl WitLoad for $integer {
+            fn load<Instance>(
+                memory: &Memory<'_, Instance>,
+                location: GuestPointer,
+            ) -> Result<Self, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let slice = memory.read(location, 1)?;
+                Ok(slice[0] as $integer)
+            }
+
+            fn lift_from<Instance>(
+                hlist_pat![value]: <Self::Layout as Layout>::Flat,
+                _memory: &Memory<'_, Instance>,
+            ) -> Result<Self, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                Ok(value as $integer)
+            }
+        }
     };
 
     ($integer:ty, $size:expr) => {
-        impl_wit_traits!($integer, $size, ($integer));
+        impl_wit_traits!(
+            $integer,
+            $size,
+            ($integer),
+            hlist_pat![value] => value as Self
+        );
     };
 
     (
         $integer:ty,
         $size:expr,
-        ($( $simple_types:ty ),*)
+        ($( $simple_types:ty ),*),
+        $lift_pattern:pat => $lift:expr
     ) => {
         impl WitType for $integer {
             const SIZE: u32 = $size;
 
             type Layout = HList![$( $simple_types ),*];
+        }
+
+        impl WitLoad for $integer {
+            fn load<Instance>(
+                memory: &Memory<'_, Instance>,
+                location: GuestPointer,
+            ) -> Result<Self, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let slice = memory.read(location, Self::SIZE)?;
+                let bytes = (*slice).try_into().expect("Incorrect number of bytes read");
+
+                Ok(Self::from_le_bytes(bytes))
+            }
+
+            fn lift_from<Instance>(
+                $lift_pattern: <Self::Layout as Layout>::Flat,
+                _memory: &Memory<'_, Instance>,
+            ) -> Result<Self, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                Ok($lift)
+            }
         }
     };
 }
@@ -40,5 +101,23 @@ impl_wit_traits!(u32, 4);
 impl_wit_traits!(i32, 4);
 impl_wit_traits!(u64, 8);
 impl_wit_traits!(i64, 8);
-impl_wit_traits!(u128, 16, (u64, u64));
-impl_wit_traits!(i128, 16, (i64, i64));
+
+impl_wit_traits!(
+    u128,
+    16,
+    (u64, u64),
+    hlist_pat![least_significant_bytes, most_significant_bytes] => {
+        ((most_significant_bytes as Self) << 64)
+        | (least_significant_bytes as Self & ((1 << 64) - 1))
+    }
+);
+
+impl_wit_traits!(
+    i128,
+    16,
+    (i64, i64),
+    hlist_pat![least_significant_bytes, most_significant_bytes] => {
+        ((most_significant_bytes as Self) << 64)
+        | (least_significant_bytes as Self & ((1 << 64) - 1))
+    }
+);

--- a/linera-witty/src/type_traits/implementations/std/phantom_data.rs
+++ b/linera-witty/src/type_traits/implementations/std/phantom_data.rs
@@ -3,7 +3,10 @@
 
 //! Implementations of the custom traits for the [`PhantomData`] type.
 
-use crate::WitType;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitType,
+};
 use frunk::HList;
 use std::marker::PhantomData;
 
@@ -11,4 +14,28 @@ impl<T> WitType for PhantomData<T> {
     const SIZE: u32 = 0;
 
     type Layout = HList![];
+}
+
+impl<T> WitLoad for PhantomData<T> {
+    fn load<Instance>(
+        _memory: &Memory<'_, Instance>,
+        _location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(PhantomData)
+    }
+
+    fn lift_from<Instance>(
+        _flat_layout: <Self::Layout as Layout>::Flat,
+        _memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(PhantomData)
+    }
 }

--- a/linera-witty/src/type_traits/implementations/std/primitives.rs
+++ b/linera-witty/src/type_traits/implementations/std/primitives.rs
@@ -3,13 +3,40 @@
 
 //! Implementations of the custom traits for other standard primitive types.
 
-use crate::WitType;
-use frunk::HList;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitType,
+};
+use frunk::{hlist_pat, HList};
 
 impl WitType for bool {
     const SIZE: u32 = 1;
 
     type Layout = HList![i8];
+}
+
+impl WitLoad for bool {
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(u8::load(memory, location)? != 0)
+    }
+
+    fn lift_from<Instance>(
+        hlist_pat![value]: <Self::Layout as Layout>::Flat,
+        _memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(value != 0)
+    }
 }
 
 impl<'t, T> WitType for &'t T

--- a/linera-witty/src/type_traits/implementations/std/string.rs
+++ b/linera-witty/src/type_traits/implementations/std/string.rs
@@ -3,11 +3,48 @@
 
 //! Implementations of the custom traits for the [`String`] type.
 
-use crate::WitType;
-use frunk::HList;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitType,
+};
+use frunk::{hlist_pat, HList};
 
 impl WitType for String {
     const SIZE: u32 = 8;
 
     type Layout = HList![i32, i32];
+}
+
+impl WitLoad for String {
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let address = GuestPointer::load(memory, location)?;
+        let length = u32::load(memory, location.after::<GuestPointer>())?;
+
+        let bytes = memory.read(address, length)?.to_vec();
+
+        Ok(String::from_utf8(bytes)?)
+    }
+
+    fn lift_from<Instance>(
+        hlist_pat![address, length]: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let address = GuestPointer(address.try_into()?);
+        let length = length as u32;
+
+        let bytes = memory.read(address, length)?.to_vec();
+
+        Ok(String::from_utf8(bytes)?)
+    }
 }

--- a/linera-witty/src/type_traits/implementations/std/vec.rs
+++ b/linera-witty/src/type_traits/implementations/std/vec.rs
@@ -3,8 +3,11 @@
 
 //! Implementations of the custom traits for the [`Vec`] type.
 
-use crate::WitType;
-use frunk::HList;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitType,
+};
+use frunk::{hlist_pat, HList};
 
 impl<T> WitType for Vec<T>
 where
@@ -13,4 +16,41 @@ where
     const SIZE: u32 = 8;
 
     type Layout = HList![i32, i32];
+}
+
+impl<T> WitLoad for Vec<T>
+where
+    T: WitLoad,
+{
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let address = GuestPointer::load(memory, location)?;
+        let length = u32::load(memory, location.after::<GuestPointer>())?;
+
+        (0..length)
+            .map(|index| T::load(memory, address.index::<T>(index)))
+            .collect()
+    }
+
+    fn lift_from<Instance>(
+        hlist_pat![address, length]: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let address = GuestPointer(address.try_into()?);
+        let length = length as u32;
+
+        (0..length)
+            .map(|index| T::load(memory, address.index::<T>(index)))
+            .collect()
+    }
 }

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -8,7 +8,7 @@ mod implementations;
 use crate::memory_layout::Layout;
 
 /// A type that is representable by fundamental WIT types.
-pub trait WitType {
+pub trait WitType: Sized {
     /// The size of the type when laid out in memory.
     const SIZE: u32;
 

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -5,7 +5,9 @@
 
 mod implementations;
 
-use crate::memory_layout::Layout;
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+};
 
 /// A type that is representable by fundamental WIT types.
 pub trait WitType: Sized {
@@ -14,4 +16,27 @@ pub trait WitType: Sized {
 
     /// The layout of the type as fundamental types.
     type Layout: Layout;
+}
+
+/// A type that can be loaded from a guest Wasm module.
+pub trait WitLoad: WitType {
+    /// Loads an instance of the type from the `location` in the guest's `memory`.
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
+
+    /// Lifts an instance of the type from the `flat_layout` representation.
+    ///
+    /// May read from the `memory` if the type has references to heap data.
+    fn lift_from<Instance>(
+        flat_layout: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
 }

--- a/linera-witty/src/util/mod.rs
+++ b/linera-witty/src/util/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper types and functions that aren't specific to WIT or WebAssembly.
+
+mod split;
+
+pub use self::split::Split;

--- a/linera-witty/src/util/split.rs
+++ b/linera-witty/src/util/split.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compile time splitting of heterogeneous lists.
+
+use frunk::{hlist, HCons, HNil};
+
+/// Compile time splitting of heterogeneous lists.
+///
+/// Allows splitting a heterogeneous list at a certain point, determined by the `Target` type,
+/// which should match this list type until a certain element. The list after that point is
+/// returned as the `Remainder` type.
+pub trait Split<Target> {
+    /// The tail of remaining elements after splitting up the list.
+    type Remainder;
+
+    /// Splits the current heterogeneous list in two.
+    fn split(self) -> (Target, Self::Remainder);
+}
+
+impl<AnyTail> Split<HNil> for AnyTail {
+    type Remainder = AnyTail;
+
+    fn split(self) -> (HNil, Self::Remainder) {
+        (hlist![], self)
+    }
+}
+
+impl<Head, SourceTail, TargetTail> Split<HCons<Head, TargetTail>> for HCons<Head, SourceTail>
+where
+    SourceTail: Split<TargetTail>,
+{
+    type Remainder = <SourceTail as Split<TargetTail>>::Remainder;
+
+    fn split(self) -> (HCons<Head, TargetTail>, Self::Remainder) {
+        let (tail, remainder) = self.tail.split();
+
+        (
+            HCons {
+                head: self.head,
+                tail,
+            },
+            remainder,
+        )
+    }
+}

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dummy types used in tests.
+
+use linera_witty::WitType;
+
+/// A type that wraps a simple type.
+#[derive(WitType)]
+pub struct SimpleWrapper(bool);
+
+/// A tuple struct that doesn't need any internal padding in its memory layout.
+#[derive(WitType)]
+pub struct TupleWithoutPadding(u64, i32, i16);
+
+/// A tuple struct that requires internal padding in its memory layout between all of its fields.
+#[derive(WitType)]
+pub struct TupleWithPadding(u16, u32, i64);
+
+/// A struct with named fields that requires padding in two locations in its memory layout.
+#[allow(dead_code)]
+#[derive(WitType)]
+pub struct RecordWithDoublePadding {
+    first: u16,
+    second: u32,
+    third: i8,
+    fourth: i64,
+}
+
+/// A simple struct with named fields to be used inside a more complex struct.
+#[allow(dead_code)]
+#[derive(WitType)]
+pub struct Leaf {
+    first: bool,
+    second: u128,
+}
+
+/// A struct that contains fields with custom types that also have derived trait implementations.
+#[allow(dead_code)]
+#[derive(WitType)]
+pub struct Branch {
+    tag: u16,
+    first_leaf: Leaf,
+    second_leaf: Leaf,
+}

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -3,43 +3,43 @@
 
 //! Dummy types used in tests.
 
-use linera_witty::WitType;
+use linera_witty::{WitLoad, WitType};
 
 /// A type that wraps a simple type.
-#[derive(WitType)]
-pub struct SimpleWrapper(bool);
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+pub struct SimpleWrapper(pub bool);
 
 /// A tuple struct that doesn't need any internal padding in its memory layout.
-#[derive(WitType)]
-pub struct TupleWithoutPadding(u64, i32, i16);
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+pub struct TupleWithoutPadding(pub u64, pub i32, pub i16);
 
 /// A tuple struct that requires internal padding in its memory layout between all of its fields.
-#[derive(WitType)]
-pub struct TupleWithPadding(u16, u32, i64);
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+pub struct TupleWithPadding(pub u16, pub u32, pub i64);
 
 /// A struct with named fields that requires padding in two locations in its memory layout.
 #[allow(dead_code)]
-#[derive(WitType)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
 pub struct RecordWithDoublePadding {
-    first: u16,
-    second: u32,
-    third: i8,
-    fourth: i64,
+    pub first: u16,
+    pub second: u32,
+    pub third: i8,
+    pub fourth: i64,
 }
 
 /// A simple struct with named fields to be used inside a more complex struct.
 #[allow(dead_code)]
-#[derive(WitType)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
 pub struct Leaf {
-    first: bool,
-    second: u128,
+    pub first: bool,
+    pub second: u128,
 }
 
 /// A struct that contains fields with custom types that also have derived trait implementations.
 #[allow(dead_code)]
-#[derive(WitType)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
 pub struct Branch {
-    tag: u16,
-    first_leaf: Leaf,
-    second_leaf: Leaf,
+    pub tag: u16,
+    pub first_leaf: Leaf,
+    pub second_leaf: Leaf,
 }

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -3,26 +3,26 @@
 
 //! Tests for the `WitType` derive macro.
 
+#[path = "common/types.rs"]
+mod types;
+
+use self::types::{
+    Branch, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding, TupleWithoutPadding,
+};
 use linera_witty::{HList, Layout, WitType};
 
 /// Check the memory size and layout derived for a wrapper type.
 #[test]
 fn simple_bool_wrapper() {
-    #[derive(WitType)]
-    struct MyWrapper(bool);
-
-    assert_eq!(MyWrapper::SIZE, 1);
-    assert_eq!(<MyWrapper as WitType>::Layout::ALIGNMENT, 1);
-    assert_eq!(<<MyWrapper as WitType>::Layout as Layout>::Flat::LEN, 1);
+    assert_eq!(SimpleWrapper::SIZE, 1);
+    assert_eq!(<SimpleWrapper as WitType>::Layout::ALIGNMENT, 1);
+    assert_eq!(<<SimpleWrapper as WitType>::Layout as Layout>::Flat::LEN, 1);
 }
 
 /// Check the memory size and layout derived for a type with multiple fields ordered in a way that
 /// doesn't require any padding.
 #[test]
 fn tuple_struct_without_padding() {
-    #[derive(WitType)]
-    struct TupleWithoutPadding(u64, i32, i16);
-
     assert_eq!(TupleWithoutPadding::SIZE, 14);
     assert_eq!(<TupleWithoutPadding as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(
@@ -35,9 +35,6 @@ fn tuple_struct_without_padding() {
 /// requires padding between all fields.
 #[test]
 fn tuple_struct_with_padding() {
-    #[derive(WitType)]
-    struct TupleWithPadding(u16, u32, i64);
-
     assert_eq!(TupleWithPadding::SIZE, 16);
     assert_eq!(<TupleWithPadding as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(
@@ -50,15 +47,6 @@ fn tuple_struct_with_padding() {
 /// that requires padding before two fields.
 #[test]
 fn named_struct_with_double_padding() {
-    #[allow(dead_code)]
-    #[derive(WitType)]
-    struct RecordWithDoublePadding {
-        first: u16,
-        second: u32,
-        third: i8,
-        fourth: i64,
-    }
-
     assert_eq!(RecordWithDoublePadding::SIZE, 24);
     assert_eq!(<RecordWithDoublePadding as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(
@@ -71,24 +59,9 @@ fn named_struct_with_double_padding() {
 /// has `WitType` derived for it.
 #[test]
 fn nested_types() {
-    #[allow(dead_code)]
-    #[derive(WitType)]
-    struct Leaf {
-        first: bool,
-        second: u128,
-    }
-
     assert_eq!(Leaf::SIZE, 24);
     assert_eq!(<Leaf as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Leaf as WitType>::Layout as Layout>::Flat::LEN, 3);
-
-    #[allow(dead_code)]
-    #[derive(WitType)]
-    struct Branch {
-        tag: u16,
-        first_leaf: Leaf,
-        second_leaf: Leaf,
-    }
 
     assert_eq!(Branch::SIZE, 56);
     assert_eq!(<Branch as WitType>::Layout::ALIGNMENT, 8);


### PR DESCRIPTION
# Motivation

Complex types should be able to be loaded from guest Wasm modules into host types.

# Solution

Create a `WitLoad` type that represents types that can be loaded from a guest Wasm module's memory or from a flat layout sent by the guest, both following WIT conventions.

Include a derive macro for the new trait, that currently only supports `struct`s. The generated code loads each field in sequence.

The new macro is tested with the help of a `FakeInstance` that simulates a Wasm guest instance for a `FakeRuntime`.

# Related Issues

Part of #906 