### PR TITLE
Create a `WitStore` trait

### DIFF
--- a/linera-witty-macros/src/unit_tests/wit_store.rs
+++ b/linera-witty-macros/src/unit_tests/wit_store.rs
@@ -1,0 +1,170 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the `WitStore` derive macro.
+
+#![cfg(test)]
+
+use super::derive_for_struct;
+use quote::quote;
+use syn::{parse_quote, Fields, ItemStruct};
+
+/// Check the generated code for the body of the implementation of `WitStore` for a unit struct.
+#[test]
+fn zero_sized_type() {
+    let input = Fields::Unit;
+    let output = derive_for_struct(&input);
+
+    let expected = quote! {
+        fn store<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<(), linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let Self = self;
+            Ok(())
+        }
+
+        fn lower<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+        ) -> Result<<Self::Layout as linera_witty::Layout>::Flat, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let flat_layout = linera_witty::HList![];
+            Ok(flat_layout)
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitStore` for a named struct.
+#[test]
+fn named_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type {
+            first: u8,
+            second: CustomType,
+        }
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        fn store<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<(), linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let Self { first, second } = self;
+
+            location = location.after_padding_for::<u8>();
+            WitStore::store(first, memory, location)?;
+            location = location.after::<u8>();
+
+            location = location.after_padding_for::<CustomType>();
+            WitStore::store(second, memory, location)?;
+            location = location.after::<CustomType>();
+
+            Ok(())
+        }
+
+        fn lower<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+        ) -> Result<<Self::Layout as linera_witty::Layout>::Flat, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let flat_layout = linera_witty::HList![];
+
+            let field_layout = WitStore::lower(&self.first, memory)?;
+            let flat_layout = flat_layout + field_layout;
+
+            let field_layout = WitStore::lower(&self.second, memory)?;
+            let flat_layout = flat_layout + field_layout;
+
+            Ok(flat_layout)
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitStore` for a tuple struct.
+#[test]
+fn tuple_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type(String, Vec<CustomType>, i64);
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        fn store<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<(), linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let Self(field0, field1, field2) = self;
+
+            location = location.after_padding_for::<String>();
+            WitStore::store(field0, memory, location)?;
+            location = location.after::<String>();
+
+            location = location.after_padding_for::<Vec<CustomType> >();
+            WitStore::store(field1, memory, location)?;
+            location = location.after::<Vec<CustomType> >();
+
+            location = location.after_padding_for::<i64>();
+            WitStore::store(field2, memory, location)?;
+            location = location.after::<i64>();
+
+            Ok(())
+        }
+
+        fn lower<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+        ) -> Result<<Self::Layout as linera_witty::Layout>::Flat, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let flat_layout = linera_witty::HList![];
+
+            let field_layout = WitStore::lower(&self.0, memory)?;
+            let flat_layout = flat_layout + field_layout;
+
+            let field_layout = WitStore::lower(&self.1, memory)?;
+            let flat_layout = flat_layout + field_layout;
+
+            let field_layout = WitStore::lower(&self.2, memory)?;
+            let flat_layout = flat_layout + field_layout;
+
+            Ok(flat_layout)
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}

--- a/linera-witty-macros/src/wit_store.rs
+++ b/linera-witty-macros/src/wit_store.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Derivation of the `WitStore` trait.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::{Fields, Ident, Index, Type};
+
+/// Returns the body of the `WitStore` implementation for the Rust `struct` with the specified
+/// `fields`.
+pub fn derive_for_struct(fields: &Fields) -> TokenStream {
+    let field_names = field_names(fields);
+    let field_bindings = field_bindings(fields);
+    let field_types = fields.iter().map(|field| &field.ty);
+    let field_pairs = field_bindings.clone().zip(field_types);
+
+    let store_fields = field_pairs.map(store_field);
+
+    let lower_fields = field_names.clone().map(|field_name| {
+        quote! {
+            let field_layout = WitStore::lower(&self.#field_name, memory)?;
+            let flat_layout = flat_layout + field_layout;
+        }
+    });
+
+    let construction = match fields {
+        Fields::Unit => quote! {},
+        Fields::Named(_) => quote! { { #( #field_bindings ),* } },
+        Fields::Unnamed(_) => quote! { ( #( #field_bindings ),* ) },
+    };
+
+    quote! {
+        fn store<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<(), linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let Self #construction = self;
+
+            #( #store_fields )*
+
+            Ok(())
+        }
+
+        fn lower<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+        ) -> Result<<Self::Layout as linera_witty::Layout>::Flat, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let flat_layout = linera_witty::HList![];
+
+            #( #lower_fields )*
+
+            Ok(flat_layout)
+        }
+    }
+}
+
+/// Returns an iterator over the names of the provided `fields`.
+fn field_names(fields: &Fields) -> impl Iterator<Item = TokenStream> + Clone + '_ {
+    fields.iter().enumerate().map(|(index, field)| {
+        field
+            .ident
+            .as_ref()
+            .map(ToTokens::to_token_stream)
+            .unwrap_or_else(|| Index::from(index).to_token_stream())
+    })
+}
+
+/// Returns an iterator over names for bindings used to deconstruct the provided `fields`.
+fn field_bindings(fields: &Fields) -> impl Iterator<Item = Ident> + Clone + '_ {
+    fields.iter().enumerate().map(|(index, field)| {
+        field
+            .ident
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(|| format_ident!("field{index}"))
+    })
+}
+
+/// Returns the code to store a field.
+fn store_field((field_name, field_type): (Ident, &Type)) -> TokenStream {
+    quote! {
+        location = location.after_padding_for::<#field_type>();
+        WitStore::store(#field_name, memory, location)?;
+        location = location.after::<#field_type>();
+    }
+}

--- a/linera-witty-macros/src/wit_store.rs
+++ b/linera-witty-macros/src/wit_store.rs
@@ -7,6 +7,9 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::{Fields, Ident, Index, Type};
 
+#[path = "unit_tests/wit_store.rs"]
+mod tests;
+
 /// Returns the body of the `WitStore` implementation for the Rust `struct` with the specified
 /// `fields`.
 pub fn derive_for_struct(fields: &Fields) -> TokenStream {

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -30,4 +30,4 @@ pub use self::{
 };
 pub use frunk::{hlist, hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]
-pub use linera_witty_macros::{WitLoad, WitType};
+pub use linera_witty_macros::{WitLoad, WitStore, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -25,7 +25,7 @@ pub use self::runtime::{FakeInstance, FakeRuntime};
 pub use self::{
     memory_layout::Layout,
     runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},
-    type_traits::{WitLoad, WitType},
+    type_traits::{WitLoad, WitStore, WitType},
     util::Split,
 };
 pub use frunk::{hlist, hlist::HList, HList, HNil};

--- a/linera-witty/src/type_traits/implementations/custom_types.rs
+++ b/linera-witty/src/type_traits/implementations/custom_types.rs
@@ -5,9 +5,9 @@
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
-    WitLoad, WitType,
+    WitLoad, WitStore, WitType,
 };
-use frunk::{hlist_pat, HList};
+use frunk::{hlist, hlist_pat, HList};
 
 impl WitType for GuestPointer {
     const SIZE: u32 = u32::SIZE;
@@ -36,5 +36,30 @@ impl WitLoad for GuestPointer {
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
         Ok(GuestPointer(value.try_into()?))
+    }
+}
+
+impl WitStore for GuestPointer {
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        self.0.store(memory, location)
+    }
+
+    fn lower<Instance>(
+        &self,
+        _memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::Layout, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(hlist![self.0 as i32])
     }
 }

--- a/linera-witty/src/type_traits/implementations/std/floats.rs
+++ b/linera-witty/src/type_traits/implementations/std/floats.rs
@@ -5,9 +5,9 @@
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
-    WitLoad, WitType,
+    WitLoad, WitStore, WitType,
 };
-use frunk::{hlist_pat, HList};
+use frunk::{hlist, hlist_pat, HList};
 
 macro_rules! impl_wit_traits {
     ($float:ty, $size:expr) => {
@@ -41,6 +41,31 @@ macro_rules! impl_wit_traits {
                 <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
             {
                 Ok(value)
+            }
+        }
+
+        impl WitStore for $float {
+            fn store<Instance>(
+                &self,
+                memory: &mut Memory<'_, Instance>,
+                location: GuestPointer,
+            ) -> Result<(), RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                memory.write(location, &self.to_le_bytes())
+            }
+
+            fn lower<Instance>(
+                &self,
+                _memory: &mut Memory<'_, Instance>,
+            ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                Ok(hlist![*self])
             }
         }
     };

--- a/linera-witty/src/type_traits/implementations/std/integers.rs
+++ b/linera-witty/src/type_traits/implementations/std/integers.rs
@@ -5,9 +5,9 @@
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
-    WitLoad, WitType,
+    WitLoad, WitStore, WitType,
 };
-use frunk::{hlist_pat, HList};
+use frunk::{hlist, hlist_pat, HList};
 
 macro_rules! impl_wit_traits {
     ($integer:ty, 1) => {
@@ -41,13 +41,40 @@ macro_rules! impl_wit_traits {
                 Ok(value as $integer)
             }
         }
+
+        impl WitStore for $integer {
+            fn store<Instance>(
+                &self,
+                memory: &mut Memory<'_, Instance>,
+                location: GuestPointer,
+            ) -> Result<(), RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                memory.write(location, &[*self as u8])
+            }
+
+            fn lower<Instance>(
+                &self,
+                _memory: &mut Memory<'_, Instance>,
+            ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                Ok(hlist![*self as i32])
+            }
+        }
     };
 
-    ($integer:ty, $size:expr) => {
+    ($integer:ty, $size:expr, $flat_type:ty) => {
         impl_wit_traits!(
             $integer,
             $size,
             ($integer),
+            ($flat_type),
+            self -> hlist![*self as $flat_type],
             hlist_pat![value] => value as Self
         );
     };
@@ -56,6 +83,8 @@ macro_rules! impl_wit_traits {
         $integer:ty,
         $size:expr,
         ($( $simple_types:ty ),*),
+        ($( $flat_types:ty ),*),
+        $this:ident -> $lower:expr,
         $lift_pattern:pat => $lift:expr
     ) => {
         impl WitType for $integer {
@@ -90,22 +119,58 @@ macro_rules! impl_wit_traits {
                 Ok($lift)
             }
         }
+
+        impl WitStore for $integer {
+            fn store<Instance>(
+                &self,
+                memory: &mut Memory<'_, Instance>,
+                location: GuestPointer,
+            ) -> Result<(), RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                memory.write(location, &self.to_le_bytes())
+            }
+
+            fn lower<Instance>(
+                &$this,
+                _memory: &mut Memory<'_, Instance>,
+            ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                Ok($lower)
+            }
+        }
     };
 }
 
 impl_wit_traits!(u8, 1);
 impl_wit_traits!(i8, 1);
-impl_wit_traits!(u16, 2);
-impl_wit_traits!(i16, 2);
-impl_wit_traits!(u32, 4);
-impl_wit_traits!(i32, 4);
-impl_wit_traits!(u64, 8);
-impl_wit_traits!(i64, 8);
+impl_wit_traits!(u16, 2, i32);
+impl_wit_traits!(i16, 2, i32);
+impl_wit_traits!(u32, 4, i32);
+impl_wit_traits!(i32, 4, i32);
+impl_wit_traits!(u64, 8, i64);
+impl_wit_traits!(i64, 8, i64);
+
+macro_rules! x128_lower {
+    ($this:ident) => {
+        hlist![
+            ($this & ((1 << 64) - 1)) as i64,
+            (($this >> 64) & ((1 << 64) - 1)) as i64,
+        ]
+    };
+}
 
 impl_wit_traits!(
     u128,
     16,
     (u64, u64),
+    (i64, i64),
+    self -> x128_lower!(self),
     hlist_pat![least_significant_bytes, most_significant_bytes] => {
         ((most_significant_bytes as Self) << 64)
         | (least_significant_bytes as Self & ((1 << 64) - 1))
@@ -116,6 +181,8 @@ impl_wit_traits!(
     i128,
     16,
     (i64, i64),
+    (i64, i64),
+    self -> x128_lower!(self),
     hlist_pat![least_significant_bytes, most_significant_bytes] => {
         ((most_significant_bytes as Self) << 64)
         | (least_significant_bytes as Self & ((1 << 64) - 1))

--- a/linera-witty/src/type_traits/implementations/std/phantom_data.rs
+++ b/linera-witty/src/type_traits/implementations/std/phantom_data.rs
@@ -5,9 +5,9 @@
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
-    WitLoad, WitType,
+    WitLoad, WitStore, WitType,
 };
-use frunk::HList;
+use frunk::{hlist, HList};
 use std::marker::PhantomData;
 
 impl<T> WitType for PhantomData<T> {
@@ -37,5 +37,30 @@ impl<T> WitLoad for PhantomData<T> {
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
     {
         Ok(PhantomData)
+    }
+}
+
+impl<T> WitStore for PhantomData<T> {
+    fn store<Instance>(
+        &self,
+        _memory: &mut Memory<'_, Instance>,
+        _location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(())
+    }
+
+    fn lower<Instance>(
+        &self,
+        _memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::Layout, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Ok(hlist![])
     }
 }

--- a/linera-witty/src/type_traits/implementations/std/tuples.rs
+++ b/linera-witty/src/type_traits/implementations/std/tuples.rs
@@ -5,12 +5,41 @@
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
-    WitLoad, WitType,
+    WitLoad, WitStore, WitType,
 };
-use frunk::{hlist_pat, HList};
+use frunk::{hlist, hlist_pat, HList};
 
+/// Implement [`WitType`], [`WitLoad`] and [`WitStore`].
+///
+/// When implementing [`WitStore`] for tuples, it's necessary to deconstruct the tuple and rebuild
+/// it as an heterogeneous list. However, because the methods receive `&self`, the deconstruction
+/// leads to references to the elements. Therefore an extra constraint is necessary, which is that
+/// the reference also implements [`WitStore`] and that the layout is the same as the referenced
+/// type.
+///
+/// Using this clause for the unit type leads to a compiler error, because it tries to match the
+/// layout type to itself, which the compiler doesn't handle correctly. The solution to this is to
+/// only add the clause for the implementations that have elements.
 macro_rules! impl_wit_traits {
+    () => {
+        impl_wit_traits_with_borrow_store_clause!(;);
+    };
+
     ($( $names:ident : $types:ident ),*) => {
+        impl_wit_traits_with_borrow_store_clause!(
+            $( $names: $types ),* ;
+            for<'a> HList![$( &'a $types ),*]:
+                WitType<Layout = <HList![$( $types ),*] as WitType>::Layout> + WitStore,
+        );
+    };
+}
+
+/// Implement [`WitType`], [`WitLoad`] and [`WitStore`], using the optional extra where clause.
+///
+/// See [`impl_wit_traits`] above for why the extra clause is optional and can't be used with the
+/// implementation for the unit type.
+macro_rules! impl_wit_traits_with_borrow_store_clause {
+    ($( $names:ident : $types:ident ),* ; $( $borrow_store_clause:tt )*) => {
         impl<$( $types ),*> WitType for ($( $types, )*)
         where
             $( $types: WitType, )*
@@ -52,6 +81,42 @@ macro_rules! impl_wit_traits {
                     <HList![$( $types, )*] as WitLoad>::lift_from(layout, memory)?;
 
                 Ok(($( $names, )*))
+            }
+        }
+
+        impl<$( $types ),*> WitStore for ($( $types, )*)
+        where
+            $( $types: WitStore, )*
+            HList![$( $types ),*]: WitStore,
+            $( $borrow_store_clause )*
+        {
+            fn store<Instance>(
+                &self,
+                memory: &mut Memory<'_, Instance>,
+                location: GuestPointer,
+            ) -> Result<(), RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let ($( $names, )*) = self;
+
+                hlist![$( $names ),*].store(memory, location)?;
+
+                Ok(())
+            }
+
+            fn lower<Instance>(
+                &self,
+                memory: &mut Memory<'_, Instance>,
+            ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+            where
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let ($( $names, )*) = self;
+
+                hlist![$( $names ),*].lower(memory)
             }
         }
     };

--- a/linera-witty/src/type_traits/implementations/std/vec.rs
+++ b/linera-witty/src/type_traits/implementations/std/vec.rs
@@ -5,9 +5,9 @@
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
-    WitLoad, WitType,
+    WitLoad, WitStore, WitType,
 };
-use frunk::{hlist_pat, HList};
+use frunk::{hlist, hlist_pat, HList};
 
 impl<T> WitType for Vec<T>
 where
@@ -52,5 +52,52 @@ where
         (0..length)
             .map(|index| T::load(memory, address.index::<T>(index)))
             .collect()
+    }
+}
+
+impl<T> WitStore for Vec<T>
+where
+    T: WitStore,
+{
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let length = u32::try_from(self.len())?;
+        let size = length * T::SIZE;
+
+        let destination = memory.allocate(size)?;
+
+        destination.store(memory, location)?;
+        length.store(memory, location.after::<GuestPointer>())?;
+
+        self.iter()
+            .zip(0..)
+            .try_for_each(|(element, index)| element.store(memory, destination.index::<T>(index)))
+    }
+
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::Layout, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let length = u32::try_from(self.len())?;
+        let size = length * T::SIZE;
+
+        let destination = memory.allocate(size)?;
+
+        self.iter().zip(0..).try_for_each(|(element, index)| {
+            element.store(memory, destination.index::<T>(index))
+        })?;
+
+        Ok(destination.lower(memory)? + hlist![length as i32])
     }
 }

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -40,3 +40,28 @@ pub trait WitLoad: WitType {
         Instance: InstanceWithMemory,
         <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
 }
+
+/// A type that can be stored in a guest Wasm module.
+pub trait WitStore: WitType {
+    /// Stores the type at the `location` in the guest's `memory`.
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
+
+    /// Lowers the type into its flat layout representation.
+    ///
+    /// May write to the `memory` if the type has references to heap data or if it doesn't fix in
+    /// the maximum flat layout size.
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
+}

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -3,22 +3,22 @@
 
 //! Dummy types used in tests.
 
-use linera_witty::{WitLoad, WitType};
+use linera_witty::{WitLoad, WitStore, WitType};
 
 /// A type that wraps a simple type.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct SimpleWrapper(pub bool);
 
 /// A tuple struct that doesn't need any internal padding in its memory layout.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct TupleWithoutPadding(pub u64, pub i32, pub i16);
 
 /// A tuple struct that requires internal padding in its memory layout between all of its fields.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct TupleWithPadding(pub u16, pub u32, pub i64);
 
 /// A struct with named fields that requires padding in two locations in its memory layout.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct RecordWithDoublePadding {
     pub first: u16,
     pub second: u32,
@@ -27,14 +27,14 @@ pub struct RecordWithDoublePadding {
 }
 
 /// A simple struct with named fields to be used inside a more complex struct.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct Leaf {
     pub first: bool,
     pub second: u128,
 }
 
 /// A struct that contains fields with custom types that also have derived trait implementations.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct Branch {
     pub tag: u16,
     pub first_leaf: Leaf,

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -18,7 +18,6 @@ pub struct TupleWithoutPadding(pub u64, pub i32, pub i16);
 pub struct TupleWithPadding(pub u16, pub u32, pub i64);
 
 /// A struct with named fields that requires padding in two locations in its memory layout.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
 pub struct RecordWithDoublePadding {
     pub first: u16,
@@ -28,7 +27,6 @@ pub struct RecordWithDoublePadding {
 }
 
 /// A simple struct with named fields to be used inside a more complex struct.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
 pub struct Leaf {
     pub first: bool,
@@ -36,7 +34,6 @@ pub struct Leaf {
 }
 
 /// A struct that contains fields with custom types that also have derived trait implementations.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
 pub struct Branch {
     pub tag: u16,

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -1,0 +1,158 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the `WitStore` derive macro.
+
+#[path = "common/types.rs"]
+mod types;
+
+use self::types::{
+    Branch, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding, TupleWithoutPadding,
+};
+use linera_witty::{hlist, FakeInstance, InstanceWithMemory, Layout, WitStore};
+use std::fmt::Debug;
+
+/// Check that a wrapper type is properly stored in memory and lowered into its flat layout.
+#[test]
+fn simple_bool_wrapper() {
+    test_store_in_memory(&SimpleWrapper(true), &[1]);
+    test_store_in_memory(&SimpleWrapper(false), &[0]);
+
+    test_lower_to_flat_layout(&SimpleWrapper(true), hlist![1]);
+    test_lower_to_flat_layout(&SimpleWrapper(false), hlist![0]);
+}
+
+/// Check that a type with multiple fields ordered in a way that doesn't require any padding is
+/// properly stored in memory and lowered into its flat layout.
+#[test]
+fn tuple_struct_without_padding() {
+    let data = TupleWithoutPadding(0x0123_4567_89ab_cdef_u64, 0x0011_2233_i32, 0x4455_i16);
+
+    test_store_in_memory(
+        &data,
+        &[
+            0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, 0x33, 0x22, 0x11, 0x00, 0x55, 0x44,
+        ],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0123_4567_89ab_cdef_i64, 0x0011_2233_i32, 0x0000_4455_i32],
+    );
+}
+
+/// Check that a type with multiple fields ordered in a way that requires padding between two of its
+/// fields is properly stored in memory and lowered into its flat layout.
+#[test]
+fn tuple_struct_with_padding() {
+    let data = TupleWithPadding(0x0123_u16, 0x4567_89ab_u32, 0x0011_2233_4455_6677_i64);
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x23, 0x01, 0, 0, 0xab, 0x89, 0x67, 0x45, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
+            0x00,
+        ],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0000_0123_i32, 0x4567_89ab_i32, 0x0011_2233_4455_6677_i64],
+    );
+}
+
+/// Check that a type with multiple named fields ordered in a way that requires padding before two
+/// fields is properly stored in memory and lowered into its flat layout.
+#[test]
+fn named_struct_with_double_padding() {
+    let data = RecordWithDoublePadding {
+        first: 0x0123_u16,
+        second: 0x0011_2233_u32,
+        third: 0x45_i8,
+        fourth: 0x6789_abcd_ef44_5566_i64,
+    };
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x23, 0x01, 0, 0, 0x33, 0x22, 0x11, 0x00, 0x45, 0, 0, 0, 0, 0, 0, 0, 0x66, 0x55, 0x44,
+            0xef, 0xcd, 0xab, 0x89, 0x67,
+        ],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![
+            0x0000_0123_i32,
+            0x0011_2233_i32,
+            0x0000_0045_i32,
+            0x6789_abcd_ef44_5566_i64,
+        ],
+    );
+}
+
+/// Check that a type that contains a field with a type that also has `WitStore` derived for it is
+/// properly stored in memory and lowered into its flat layout.
+#[test]
+fn nested_types() {
+    let data = Branch {
+        tag: 0x0123_u16,
+        first_leaf: Leaf {
+            first: false,
+            second: 0x4567_89ab_cdef_0011_2233_4455_6677_8899_u128,
+        },
+        second_leaf: Leaf {
+            first: true,
+            second: 0xaabb_ccdd_eeff_0f1e_2d3c_4b5a_6978_8796_u128,
+        },
+    };
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x23, 0x01, 0, 0, 0, 0, 0, 0, 0x00, 0, 0, 0, 0, 0, 0, 0, 0x99, 0x88, 0x77, 0x66, 0x55,
+            0x44, 0x33, 0x22, 0x11, 0x00, 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x01, 0, 0, 0, 0, 0,
+            0, 0, 0x96, 0x87, 0x78, 0x69, 0x5a, 0x4b, 0x3c, 0x2d, 0x1e, 0x0f, 0xff, 0xee, 0xdd,
+            0xcc, 0xbb, 0xaa,
+        ],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![
+            0x0000_0123_i32,
+            0x0000_0000_i32,
+            0x2233_4455_6677_8899_i64,
+            0x4567_89ab_cdef_0011_i64,
+            0x0000_0001_i32,
+            0x2d3c_4b5a_6978_8796_i64,
+            0xaabb_ccdd_eeff_0f1e_u64 as i64,
+        ],
+    );
+}
+
+/// Tests that the `data` of type `T` can be stored as a sequence of bytes in memory and that it
+/// matches the `expected` bytes.
+fn test_store_in_memory<T>(data: &T, expected: &[u8])
+where
+    T: WitStore,
+{
+    let mut instance = FakeInstance::default();
+    let mut memory = instance.memory().unwrap();
+
+    let length = expected.len() as u32;
+    let address = memory.allocate(length).unwrap();
+
+    data.store(&mut memory, address).unwrap();
+
+    assert_eq!(memory.read(address, length).unwrap(), expected);
+}
+
+/// Tests that the `data` of type `T` can be lowered to its flat layout and that it matches the
+/// `expected` value.
+fn test_lower_to_flat_layout<T>(data: &T, expected: <T::Layout as Layout>::Flat)
+where
+    T: WitStore,
+    <T::Layout as Layout>::Flat: Debug + Eq,
+{
+    let mut instance = FakeInstance::default();
+    let mut memory = instance.memory().unwrap();
+
+    assert_eq!(data.lower(&mut memory).unwrap(), expected);
+}


### PR DESCRIPTION
# Motivation

Complex types should be able to be sent to guest Wasm modules from the host.

# Solution

Create a `WitStore` trait that represents types that can be stored in a guest Wasm module's memory or lowered into its flat layout so that it can be sent to the guest, both following WIT conventions.

Include a derive macro for the new trait, that currently only supports `struct`s. The generated code stores each field in sequence.

# Related Issues

Part of #906 