### PR TITLE
Add support for WIT variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encode_unicode"
@@ -3137,6 +3137,7 @@ dependencies = [
 name = "linera-witty"
 version = "0.3.0"
 dependencies = [
+ "either",
  "frunk",
  "linera-witty",
  "linera-witty-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2491,6 +2491,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "int-conv"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0249b28817672371aa3a25e0420548646663592c0442d71ac67c9cb4fe1f94c"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,6 +3148,7 @@ version = "0.3.0"
 dependencies = [
  "either",
  "frunk",
+ "int-conv",
  "linera-witty",
  "linera-witty-macros",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ futures = "0.3.24"
 generic-array = { version = "0.14.4", features = ["serde"] }
 hex = "0.4.3"
 http = "0.2.7"
+int-conv = "0.1.4"
 log = "0.4.17"
 lru = "0.9.0"
 metrics = "0.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ derive_more = "0.99.17"
 dirs = "5.0.0"
 ed25519 = "1.2.0"
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
+either = "1.9.0"
 frunk = "0.4.2"
 futures = "0.3.24"
 generic-array = { version = "0.14.4", features = ["serde"] }

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -65,7 +65,9 @@ pub fn derive_wit_store(input: TokenStream) -> TokenStream {
 
     let body = match &input.data {
         Data::Struct(struct_item) => wit_store::derive_for_struct(&struct_item.fields),
-        Data::Enum(_enum_item) => todo!("Enums require joining and splitting flat types"),
+        Data::Enum(enum_item) => {
+            wit_store::derive_for_enum(&input.ident, enum_item.variants.iter())
+        }
         Data::Union(_union_item) => {
             abort!(input.ident, "Can't derive `WitStore` for `union`s")
         }

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -46,7 +46,7 @@ pub fn derive_wit_load(input: TokenStream) -> TokenStream {
 
     let body = match &input.data {
         Data::Struct(struct_item) => wit_load::derive_for_struct(&struct_item.fields),
-        Data::Enum(_enum_item) => todo!("Enums require joining and splitting flat types"),
+        Data::Enum(enum_item) => wit_load::derive_for_enum(&input.ident, enum_item.variants.iter()),
         Data::Union(_union_item) => {
             abort!(input.ident, "Can't derive `WitLoad` for `union`s")
         }

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -27,7 +27,7 @@ pub fn derive_wit_type(input: TokenStream) -> TokenStream {
 
     let body = match &input.data {
         Data::Struct(struct_item) => wit_type::derive_for_struct(&struct_item.fields),
-        Data::Enum(_enum_item) => todo!("Enums require joining and splitting flat types"),
+        Data::Enum(enum_item) => wit_type::derive_for_enum(&input.ident, enum_item.variants.iter()),
         Data::Union(_union_item) => {
             abort!(input.ident, "Can't derive `WitType` for `union`s")
         }

--- a/linera-witty-macros/src/unit_tests/wit_load.rs
+++ b/linera-witty-macros/src/unit_tests/wit_load.rs
@@ -5,9 +5,9 @@
 
 #![cfg(test)]
 
-use super::derive_for_struct;
+use super::{derive_for_enum, derive_for_struct};
 use quote::quote;
-use syn::{parse_quote, Fields, ItemStruct};
+use syn::{parse_quote, Fields, ItemEnum, ItemStruct};
 
 /// Check the generated code for the body of the implementation of `WitLoad` for a unit struct.
 #[test]
@@ -150,6 +150,115 @@ fn tuple_struct() {
             let field2 = <i64 as WitLoad>::lift_from(field_layout, memory)?;
 
             Ok(Self(field0, field1, field2))
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitType` for an enum.
+#[test]
+fn enum_type() {
+    let input: ItemEnum = parse_quote! {
+        enum Enum {
+            Empty,
+            Tuple(i8, CustomType),
+            Struct {
+                first: (),
+                second: String,
+            },
+        }
+    };
+    let output = derive_for_enum(&input.ident, input.variants.iter());
+
+    let expected = quote! {
+        fn load<Instance>(
+            memory: &linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            location = location.after_padding_for::<u8>();
+            let discriminant = <u8 as linera_witty::WitLoad>::load(memory, location,)?;
+            location = location.after::<u8>();
+
+            match discriminant {
+                0 => {
+                    Ok(Enum::Empty)
+                }
+                1 => {
+                    location = location.after_padding_for::<i8>();
+                    let field0 = <i8 as linera_witty::WitLoad>::load(memory, location)?;
+                    location = location.after::<i8>();
+
+                    location = location.after_padding_for::<CustomType>();
+                    let field1 = <CustomType as linera_witty::WitLoad>::load(memory, location)?;
+                    location = location.after::<CustomType>();
+
+                    Ok(Enum::Tuple(field0, field1))
+                }
+                2 => {
+                    location = location.after_padding_for::<()>();
+                    let first = <() as linera_witty::WitLoad>::load(memory, location)?;
+                    location = location.after::<()>();
+
+                    location = location.after_padding_for::<String>();
+                    let second = <String as linera_witty::WitLoad>::load(memory, location)?;
+                    location = location.after::<String>();
+
+                    Ok(Enum::Struct { first, second })
+                }
+                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+            }
+        }
+
+        fn lift_from<Instance>(
+            linera_witty::hlist_pat![discriminant_flat_type, ...flat_layout]:
+                <Self::Layout as linera_witty::Layout>::Flat,
+            memory: &linera_witty::Memory<'_, Instance>,
+        ) -> Result<Self, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            let discriminant = <u8 as linera_witty::WitLoad>::lift_from(
+                linera_witty::hlist![discriminant_flat_type],
+                memory,
+            )?;
+
+            match discriminant {
+                0 => {
+                    let linera_witty::hlist_pat![] = <linera_witty::HList![] as WitLoad>::lift_from(
+                        linera_witty::SplitFlatLayouts::split(flat_layout),
+                        memory,
+                    )?;
+
+                    Ok(Enum::Empty)
+                }
+                1 => {
+                    let linera_witty::hlist_pat![field0, field1,] =
+                        <linera_witty::HList![i8, CustomType] as WitLoad>::lift_from(
+                            linera_witty::SplitFlatLayouts::split(flat_layout),
+                            memory,
+                        )?;
+
+                    Ok(Enum::Tuple(field0, field1))
+                }
+                2 => {
+                    let linera_witty::hlist_pat![first, second,] =
+                        <linera_witty::HList![(), String] as WitLoad>::lift_from(
+                            linera_witty::SplitFlatLayouts::split(flat_layout),
+                            memory,
+                        )?;
+
+                    Ok(Enum::Struct { first, second })
+                }
+                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+            }
         }
     };
 

--- a/linera-witty-macros/src/unit_tests/wit_store.rs
+++ b/linera-witty-macros/src/unit_tests/wit_store.rs
@@ -5,9 +5,9 @@
 
 #![cfg(test)]
 
-use super::derive_for_struct;
+use super::{derive_for_enum, derive_for_struct};
 use quote::quote;
-use syn::{parse_quote, Fields, ItemStruct};
+use syn::{parse_quote, Fields, ItemEnum, ItemStruct};
 
 /// Check the generated code for the body of the implementation of `WitStore` for a unit struct.
 #[test]
@@ -163,6 +163,117 @@ fn tuple_struct() {
             let flat_layout = flat_layout + field_layout;
 
             Ok(flat_layout)
+        }
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitStore` for a enum.
+#[test]
+fn enum_type() {
+    let input: ItemEnum = parse_quote! {
+        enum Enum {
+            Empty,
+            Tuple(i8, CustomType),
+            Struct {
+                first: (),
+                second: String,
+            },
+        }
+    };
+    let output = derive_for_enum(&input.ident, input.variants.iter());
+
+    let expected = quote! {
+        fn store<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+            mut location: linera_witty::GuestPointer,
+        ) -> Result<(), linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            match self {
+                Enum::Empty => {
+                    location = location.after_padding_for::<u8>();
+                    0_u8.store(memory, location)?;
+                    location = location.after::<u8>();
+
+                    Ok(())
+                }
+                Enum::Tuple(field0, field1) => {
+                    location = location.after_padding_for::<u8>();
+                    1_u8.store(memory, location)?;
+                    location = location.after::<u8>();
+
+                    location = location.after_padding_for::<i8>();
+                    WitStore::store(field0, memory, location)?;
+                    location = location.after::<i8>();
+
+                    location = location.after_padding_for::<CustomType>();
+                    WitStore::store(field1, memory, location)?;
+                    location = location.after::<CustomType>();
+
+                    Ok(())
+                }
+                Enum::Struct { first, second } => {
+                    location = location.after_padding_for::<u8>();
+                    2_u8.store(memory, location)?;
+                    location = location.after::<u8>();
+
+                    location = location.after_padding_for::<()>();
+                    WitStore::store(first, memory, location)?;
+                    location = location.after::<()>();
+
+                    location = location.after_padding_for::<String>();
+                    WitStore::store(second, memory, location)?;
+                    location = location.after::<String>();
+
+                    Ok(())
+                }
+            }
+        }
+
+        fn lower<Instance>(
+            &self,
+            memory: &mut linera_witty::Memory<'_, Instance>,
+        ) -> Result<<Self::Layout as linera_witty::Layout>::Flat, linera_witty::RuntimeError>
+        where
+            Instance: linera_witty::InstanceWithMemory,
+            <Instance::Runtime as linera_witty::Runtime>::Memory:
+                linera_witty::RuntimeMemory<Instance>,
+        {
+            match self {
+                Enum::Empty => {
+                    let variant_flat_layout = linera_witty::hlist![].lower(memory)?;
+                    let flat_layout: <Self::Layout as linera_witty::Layout>::Flat =
+                        linera_witty::JoinFlatLayouts::join(
+                            0_u8.lower(memory)? + variant_flat_layout,
+                        );
+
+                    Ok(flat_layout)
+                }
+                Enum::Tuple(field0, field1) => {
+                    let variant_flat_layout = linera_witty::hlist![field0, field1].lower(memory)?;
+                    let flat_layout: <Self::Layout as linera_witty::Layout>::Flat =
+                        linera_witty::JoinFlatLayouts::join(
+                            1_u8.lower(memory)? + variant_flat_layout,
+                        );
+
+                    Ok(flat_layout)
+                }
+                Enum::Struct { first, second } => {
+                    let variant_flat_layout = linera_witty::hlist![first, second].lower(memory)?;
+                    let flat_layout: <Self::Layout as linera_witty::Layout>::Flat =
+                        linera_witty::JoinFlatLayouts::join(
+                            2_u8.lower(memory)? + variant_flat_layout,
+                        );
+
+                    Ok(flat_layout)
+                }
+            }
         }
     };
 

--- a/linera-witty-macros/src/unit_tests/wit_type.rs
+++ b/linera-witty-macros/src/unit_tests/wit_type.rs
@@ -1,0 +1,116 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the `WitLoad` derive macro.
+
+#![cfg(test)]
+
+use super::derive_for_struct;
+use quote::quote;
+use syn::{parse_quote, Fields, ItemStruct};
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a unit struct.
+#[test]
+fn zero_sized_type() {
+    let input = Fields::Unit;
+    let output = derive_for_struct(&input);
+
+    let expected = quote! {
+        const SIZE: u32 = {
+            let mut size = 0;
+            size
+        };
+
+        type Layout = linera_witty::HNil;
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a named struct.
+#[test]
+fn named_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type {
+            first: u8,
+            second: CustomType,
+        }
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        const SIZE: u32 = {
+            let mut size = 0;
+
+            let field_alignment =
+                <<u8 as linera_witty::WitType>::Layout as linera_witty::Layout>::ALIGNMENT;
+            let field_size = <u8 as linera_witty::WitType>::SIZE;
+            let padding = (-(size as i32) & (field_alignment as i32 - 1)) as u32;
+            size += padding;
+            size += field_size;
+
+            let field_alignment =
+                <<CustomType as linera_witty::WitType>::Layout as linera_witty::Layout>::ALIGNMENT;
+            let field_size = <CustomType as linera_witty::WitType>::SIZE;
+            let padding = (-(size as i32) & (field_alignment as i32 - 1)) as u32;
+            size += padding;
+            size += field_size;
+
+            size
+        };
+
+        type Layout = <
+            <linera_witty::HNil
+            as std::ops::Add<<u8 as linera_witty::WitType>::Layout>>::Output
+            as std::ops::Add<<CustomType as linera_witty::WitType>::Layout>>::Output;
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a tuple struct.
+#[test]
+fn tuple_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type(String, Vec<CustomType>, i64);
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        const SIZE: u32 = {
+            let mut size = 0;
+
+            let field_alignment =
+                <<String as linera_witty::WitType>::Layout as linera_witty::Layout>::ALIGNMENT;
+            let field_size = <String as linera_witty::WitType>::SIZE;
+            let padding = (-(size as i32) & (field_alignment as i32 - 1)) as u32;
+            size += padding;
+            size += field_size;
+
+            let field_alignment =
+                <<Vec<CustomType> as linera_witty::WitType>::Layout
+                    as linera_witty::Layout>::ALIGNMENT;
+            let field_size = <Vec<CustomType> as linera_witty::WitType>::SIZE;
+            let padding = (-(size as i32) & (field_alignment as i32 - 1)) as u32;
+            size += padding;
+            size += field_size;
+
+            let field_alignment =
+                <<i64 as linera_witty::WitType>::Layout as linera_witty::Layout>::ALIGNMENT;
+            let field_size = <i64 as linera_witty::WitType>::SIZE;
+            let padding = (-(size as i32) & (field_alignment as i32 - 1)) as u32;
+            size += padding;
+            size += field_size;
+
+            size
+        };
+
+        type Layout = < <
+            <linera_witty::HNil
+            as std::ops::Add<<String as linera_witty::WitType>::Layout>>::Output
+            as std::ops::Add<<Vec<CustomType> as linera_witty::WitType>::Layout>>::Output
+            as std::ops::Add<<i64 as linera_witty::WitType>::Layout>>::Output;
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}

--- a/linera-witty-macros/src/wit_type.rs
+++ b/linera-witty-macros/src/wit_type.rs
@@ -7,6 +7,9 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Fields, Type};
 
+#[path = "unit_tests/wit_type.rs"]
+mod tests;
+
 /// Returns the body of the `WitType` implementation for the Rust `struct` with the specified
 /// `fields`.
 pub fn derive_for_struct(fields: &Fields) -> TokenStream {

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -16,6 +16,7 @@ macros = ["linera-witty-macros"]
 test = []
 
 [dependencies]
+either = { workspace = true }
 frunk = { workspace = true }
 linera-witty-macros = { workspace = true, optional = true }
 thiserror = { workspace = true }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -18,6 +18,7 @@ test = []
 [dependencies]
 either = { workspace = true }
 frunk = { workspace = true }
+int-conv = { workspace = true }
 linera-witty-macros = { workspace = true, optional = true }
 thiserror = { workspace = true }
 

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -23,7 +23,7 @@ mod util;
 #[cfg(any(test, feature = "test"))]
 pub use self::runtime::{FakeInstance, FakeRuntime};
 pub use self::{
-    memory_layout::Layout,
+    memory_layout::{JoinFlatLayouts, Layout},
     runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},
     type_traits::{WitLoad, WitStore, WitType},
     util::{Merge, Split},

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -26,7 +26,7 @@ pub use self::{
     memory_layout::Layout,
     runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},
     type_traits::{WitLoad, WitStore, WitType},
-    util::Split,
+    util::{Merge, Split},
 };
 pub use frunk::{hlist, hlist::HList, HList, HNil};
 #[cfg(feature = "macros")]

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -28,6 +28,6 @@ pub use self::{
     type_traits::{WitLoad, WitStore, WitType},
     util::{Merge, Split},
 };
-pub use frunk::{hlist, hlist::HList, HCons, HList, HNil};
+pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::{WitLoad, WitStore, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -23,7 +23,7 @@ mod util;
 #[cfg(any(test, feature = "test"))]
 pub use self::runtime::{FakeInstance, FakeRuntime};
 pub use self::{
-    memory_layout::{JoinFlatLayouts, Layout},
+    memory_layout::{JoinFlatLayouts, Layout, SplitFlatLayouts},
     runtime::{GuestPointer, InstanceWithMemory, Memory, Runtime, RuntimeError, RuntimeMemory},
     type_traits::{WitLoad, WitStore, WitType},
     util::{Merge, Split},

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -28,6 +28,6 @@ pub use self::{
     type_traits::{WitLoad, WitStore, WitType},
     util::{Merge, Split},
 };
-pub use frunk::{hlist, hlist::HList, HList, HNil};
+pub use frunk::{hlist, hlist::HList, HCons, HList, HNil};
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::{WitLoad, WitStore, WitType};

--- a/linera-witty/src/memory_layout/element.rs
+++ b/linera-witty/src/memory_layout/element.rs
@@ -12,7 +12,7 @@ use crate::primitive_types::{MaybeFlatType, SimpleType};
 pub trait Sealed {}
 
 /// Representation of a single element in a memory layout type.
-pub trait LayoutElement: Sealed + Default + Sized {
+pub trait LayoutElement: Sealed + Sized {
     /// The alignment boundary of the element type.
     const ALIGNMENT: u32;
     /// If the element is a zero sized type.

--- a/linera-witty/src/memory_layout/element.rs
+++ b/linera-witty/src/memory_layout/element.rs
@@ -6,7 +6,8 @@
 //! This is analogous to what [`MaybeFlatType`] is to [`crate::primitive_types::FlatType`]. Empty
 //! slots (represented by the `()` unit type) make it easier to generate code for zero sized types.
 
-use crate::primitive_types::{MaybeFlatType, SimpleType};
+use crate::primitive_types::{JoinFlatTypes, MaybeFlatType, SimpleType};
+use either::Either;
 
 /// Marker trait to prevent [`LayoutElement`] to be implemented for other types.
 pub trait Sealed {}
@@ -48,5 +49,52 @@ where
 
     fn flatten(self) -> Self::Flat {
         <T as SimpleType>::flatten(self)
+    }
+}
+
+impl<L, R> Sealed for Either<L, R>
+where
+    L: LayoutElement,
+    R: LayoutElement,
+{
+}
+
+impl<R> LayoutElement for Either<(), R>
+where
+    R: LayoutElement,
+{
+    const ALIGNMENT: u32 = R::ALIGNMENT;
+    const IS_EMPTY: bool = R::IS_EMPTY;
+
+    type Flat = R::Flat;
+
+    fn flatten(self) -> Self::Flat {
+        match self {
+            Either::Left(()) => <R::Flat as Default>::default(),
+            Either::Right(value) => value.flatten(),
+        }
+    }
+}
+
+impl<L, R> LayoutElement for Either<L, R>
+where
+    L: SimpleType,
+    R: LayoutElement,
+    Either<L::Flat, R::Flat>: JoinFlatTypes,
+{
+    const ALIGNMENT: u32 = if L::ALIGNMENT > R::ALIGNMENT {
+        L::ALIGNMENT
+    } else {
+        R::ALIGNMENT
+    };
+    const IS_EMPTY: bool = L::IS_EMPTY && R::IS_EMPTY;
+
+    type Flat = <Either<L::Flat, R::Flat> as JoinFlatTypes>::Flat;
+
+    fn flatten(self) -> Self::Flat {
+        match self {
+            Either::Left(left) => Either::Left(left.flatten()).join(),
+            Either::Right(right) => Either::Right(right.flatten()).join(),
+        }
     }
 }

--- a/linera-witty/src/memory_layout/flat_layout.rs
+++ b/linera-witty/src/memory_layout/flat_layout.rs
@@ -12,7 +12,7 @@ use frunk::{HCons, HNil};
 /// This allows laying out complex types as a sequence of WebAssembly types that can represent the
 /// parameters or the return list of a function. WIT uses this as an optimization to pass complex
 /// types as multiple native WebAssembly parameters.
-pub trait FlatLayout: Layout<Flat = Self> {}
+pub trait FlatLayout: Default + Layout<Flat = Self> {}
 
 impl FlatLayout for HNil {}
 

--- a/linera-witty/src/memory_layout/join_flat_layouts.rs
+++ b/linera-witty/src/memory_layout/join_flat_layouts.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Joining of flat layouts of different variants of a `variant` type.
+//!
+//! When flattening `variant` types, a single flat layout must be obtained for the type by joining
+//! the flat layout of each variant. This means finding a flat type for each layout element to
+//! represent the flat type of any of the variants. See [`crate::JoinFlatTypes`] for more
+//! information on how flat types are joined.
+
+use crate::primitive_types::JoinFlatTypes;
+use either::Either;
+use frunk::{HCons, HNil};
+
+/// Converts the current flat layout into the join `Target` flat layout, which may be longer or have
+/// some elements wider than the current elements.
+pub trait JoinFlatLayouts<Target> {
+    /// Converts the current flat layout into a the join `Target` flat layout.
+    fn join(self) -> Target;
+}
+
+impl JoinFlatLayouts<HNil> for HNil {
+    fn join(self) -> HNil {
+        HNil
+    }
+}
+
+impl<TargetHead, TargetTail> JoinFlatLayouts<HCons<TargetHead, TargetTail>> for HNil
+where
+    TargetHead: Default,
+    HNil: JoinFlatLayouts<TargetTail>,
+{
+    fn join(self) -> HCons<TargetHead, TargetTail> {
+        HCons {
+            head: TargetHead::default(),
+            tail: HNil.join(),
+        }
+    }
+}
+
+impl<SourceHead, SourceTail, TargetHead, TargetTail> JoinFlatLayouts<HCons<TargetHead, TargetTail>>
+    for HCons<SourceHead, SourceTail>
+where
+    Either<SourceHead, TargetHead>: JoinFlatTypes<Flat = TargetHead>,
+    SourceTail: JoinFlatLayouts<TargetTail>,
+{
+    fn join(self) -> HCons<TargetHead, TargetTail> {
+        HCons {
+            head: Either::Left(self.head).join(),
+            tail: self.tail.join(),
+        }
+    }
+}

--- a/linera-witty/src/memory_layout/layout.rs
+++ b/linera-witty/src/memory_layout/layout.rs
@@ -11,7 +11,7 @@ use frunk::{hlist::HList, HCons, HNil};
 pub trait Sealed {}
 
 /// Representation of the memory layout of complex types as a sequence of fundamental WIT types.
-pub trait Layout: Sealed + Default + HList {
+pub trait Layout: Sealed + HList {
     /// The alignment boundary required for the layout.
     const ALIGNMENT: u32;
 

--- a/linera-witty/src/memory_layout/mod.rs
+++ b/linera-witty/src/memory_layout/mod.rs
@@ -9,6 +9,7 @@
 
 mod element;
 mod flat_layout;
+mod join_flat_layouts;
 mod layout;
 
-pub use self::{flat_layout::FlatLayout, layout::Layout};
+pub use self::{flat_layout::FlatLayout, join_flat_layouts::JoinFlatLayouts, layout::Layout};

--- a/linera-witty/src/memory_layout/mod.rs
+++ b/linera-witty/src/memory_layout/mod.rs
@@ -11,5 +11,9 @@ mod element;
 mod flat_layout;
 mod join_flat_layouts;
 mod layout;
+mod split_flat_layouts;
 
-pub use self::{flat_layout::FlatLayout, join_flat_layouts::JoinFlatLayouts, layout::Layout};
+pub use self::{
+    flat_layout::FlatLayout, join_flat_layouts::JoinFlatLayouts, layout::Layout,
+    split_flat_layouts::SplitFlatLayouts,
+};

--- a/linera-witty/src/memory_layout/split_flat_layouts.rs
+++ b/linera-witty/src/memory_layout/split_flat_layouts.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Splitting of the flat layout of a `variant` type into the flat layout of one of its variants.
+//!
+//! When flattening `variant` types, a single flat layout must be obtained for the type by joining
+//! the flat layout of each variant. This means finding a flat type for each layout element to
+//! represent the flat type of any of the variants. See [`crate::JoinFlatTypes`] for more
+//! information on how flat types are joined.
+
+use crate::primitive_types::FlatType;
+use frunk::{HCons, HNil};
+
+/// Converts the current joined flat layout into the `Target` flat layout, which may be shorter or
+/// have elements that are narrower than the current elements.
+pub trait SplitFlatLayouts<Target> {
+    /// Converts the current joined flat layout into the `Target` flat layout.
+    fn split(self) -> Target;
+}
+
+impl<AllFlatLayouts> SplitFlatLayouts<HNil> for AllFlatLayouts {
+    fn split(self) -> HNil {
+        HNil
+    }
+}
+
+impl<Source, TargetTail> SplitFlatLayouts<HCons<(), TargetTail>> for Source
+where
+    Source: SplitFlatLayouts<TargetTail>,
+{
+    fn split(self) -> HCons<(), TargetTail> {
+        HCons {
+            head: (),
+            tail: self.split(),
+        }
+    }
+}
+
+impl<SourceHead, SourceTail, TargetHead, TargetTail> SplitFlatLayouts<HCons<TargetHead, TargetTail>>
+    for HCons<SourceHead, SourceTail>
+where
+    TargetHead: FlatType,
+    SourceHead: FlatType,
+    SourceTail: SplitFlatLayouts<TargetTail>,
+{
+    fn split(self) -> HCons<TargetHead, TargetTail> {
+        HCons {
+            head: self.head.split_into(),
+            tail: self.tail.split(),
+        }
+    }
+}

--- a/linera-witty/src/primitive_types/flat_type.rs
+++ b/linera-witty/src/primitive_types/flat_type.rs
@@ -6,13 +6,140 @@
 //!
 //! These are types that the WebAssembly virtual machine can operate with. More importantly, these
 //! are the types that can be used in function interfaces as parameter types and return types.
+//!
+//! The [Component Model canonical ABI used by WIT][flattening] specifies that when flattening
+//! `variant` types, a "joined" flat type must be found for each element in its flat layout (see
+//! [`JoinFlatTypes`][`super::JoinFlatTypes`] for more information). The [`FlatType`] trait
+//! includes support for the reverse "split" operation.
+//!
+//! [flattening]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
 
 use super::SimpleType;
 
 /// Primitive types supported by WebAssembly.
-pub trait FlatType: SimpleType<Flat = Self> {}
+pub trait FlatType: SimpleType<Flat = Self> {
+    /// Splits itself from a joined `i32` flat value.
+    ///
+    /// # Panics
+    ///
+    /// If this flat type can't be joined into an `i32`.
+    fn split_from_i32(joined_i32: i32) -> Self;
 
-impl FlatType for i32 {}
-impl FlatType for i64 {}
-impl FlatType for f32 {}
-impl FlatType for f64 {}
+    /// Splits itself from a joined `i64` flat value.
+    ///
+    /// # Panics
+    ///
+    /// If this flat type can't be joined into an `i64`.
+    fn split_from_i64(joined_i64: i64) -> Self;
+
+    /// Splits itself from a joined `f32` flat value.
+    ///
+    /// # Panics
+    ///
+    /// If this flat type can't be joined into an `f32`.
+    fn split_from_f32(joined_f32: f32) -> Self;
+
+    /// Splits itself from a joined `f64` flat value.
+    ///
+    /// # Panics
+    ///
+    /// If this flat type can't be joined into an `f64`.
+    fn split_from_f64(joined_f64: f64) -> Self;
+
+    /// Splits off the `Target` flat type from this flat type.
+    ///
+    /// # Panics
+    ///
+    /// If the `Target` type can't be joined into this flat type.
+    fn split_into<Target: FlatType>(self) -> Target;
+}
+
+impl FlatType for i32 {
+    fn split_from_i32(joined_i32: i32) -> Self {
+        joined_i32
+    }
+
+    fn split_from_i64(joined_i64: i64) -> Self {
+        joined_i64
+            .try_into()
+            .expect("Invalid `i32` stored in `i64`")
+    }
+
+    fn split_from_f32(_joined_f32: f32) -> Self {
+        unreachable!("`i32` is never joined into `f32`");
+    }
+
+    fn split_from_f64(_joined_f64: f64) -> Self {
+        unreachable!("`i32` is never joined into `f64`");
+    }
+
+    fn split_into<Target: FlatType>(self) -> Target {
+        Target::split_from_i32(self)
+    }
+}
+
+impl FlatType for i64 {
+    fn split_from_i32(_joined_i32: i32) -> Self {
+        unreachable!("`i64` is never joined into `i32`");
+    }
+
+    fn split_from_i64(joined_i64: i64) -> Self {
+        joined_i64
+    }
+
+    fn split_from_f32(_joined_f32: f32) -> Self {
+        unreachable!("`i64` is never joined into `f32`");
+    }
+
+    fn split_from_f64(_joined_f64: f64) -> Self {
+        unreachable!("`i64` is never joined into `f64`");
+    }
+
+    fn split_into<Target: FlatType>(self) -> Target {
+        Target::split_from_i64(self)
+    }
+}
+
+impl FlatType for f32 {
+    fn split_from_i32(joined_i32: i32) -> Self {
+        joined_i32 as f32
+    }
+
+    fn split_from_i64(joined_i64: i64) -> Self {
+        (joined_i64 as i32) as f32
+    }
+
+    fn split_from_f32(joined_f32: f32) -> Self {
+        joined_f32
+    }
+
+    fn split_from_f64(_joined_f64: f64) -> Self {
+        unreachable!("`f32` is never joined into `f64`");
+    }
+
+    fn split_into<Target: FlatType>(self) -> Target {
+        Target::split_from_f32(self)
+    }
+}
+
+impl FlatType for f64 {
+    fn split_from_i32(_joined_i32: i32) -> Self {
+        unreachable!("`f64` is never joined into `i32`");
+    }
+
+    fn split_from_i64(joined_i64: i64) -> Self {
+        joined_i64 as f64
+    }
+
+    fn split_from_f32(_joined_f32: f32) -> Self {
+        unreachable!("`f64` is never joined into `f32`");
+    }
+
+    fn split_from_f64(joined_f64: f64) -> Self {
+        joined_f64
+    }
+
+    fn split_into<Target: FlatType>(self) -> Target {
+        Target::split_from_f64(self)
+    }
+}

--- a/linera-witty/src/primitive_types/join_flat_types.rs
+++ b/linera-witty/src/primitive_types/join_flat_types.rs
@@ -116,3 +116,31 @@ join_flat_types!(
         { |value| value },
     ),
 );
+
+impl<AnyFlatType> JoinFlatTypes for Either<(), AnyFlatType>
+where
+    AnyFlatType: FlatType,
+{
+    type Flat = AnyFlatType;
+
+    fn join(self) -> Self::Flat {
+        match self {
+            Either::Left(()) => AnyFlatType::default(),
+            Either::Right(value) => value,
+        }
+    }
+}
+
+impl<AnyFlatType> JoinFlatTypes for Either<AnyFlatType, ()>
+where
+    AnyFlatType: FlatType,
+{
+    type Flat = AnyFlatType;
+
+    fn join(self) -> Self::Flat {
+        match self {
+            Either::Left(value) => value,
+            Either::Right(()) => AnyFlatType::default(),
+        }
+    }
+}

--- a/linera-witty/src/primitive_types/join_flat_types.rs
+++ b/linera-witty/src/primitive_types/join_flat_types.rs
@@ -1,0 +1,118 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementation of the `join` operator for flattening WIT `variant` types.
+//!
+//! The [Component Model canonical ABI][flattening] used by WIT specifies that in order to flatten
+//! a `variant` type, it is necessary to find common flat types to represent individual elements of
+//! the flattened variants. This is called the `join` operator, and is basically finding the
+//! widest bit-representation for the two types.
+
+use super::FlatType;
+use either::Either;
+use int_conv::ZeroExtend;
+
+/// Trait that allows joining one of two possible flat type values into a common flat type.
+pub trait JoinFlatTypes {
+    /// The resulting flat type.
+    type Flat: FlatType;
+
+    /// Joins a value that's one of two flat types into a single flat type.
+    fn join(self) -> Self::Flat;
+}
+
+/// Implement [`JoinFlatTypes`] for an [`Either`] type of two flat types.
+macro_rules! join_flat_types {
+    (
+        $( ($left:ty, $right:ty) -> $joined:ty => ($join_left:tt, $join_right:tt $(,)?) ),* $(,)?
+    ) => {
+        $(
+            impl JoinFlatTypes for Either<$left, $right> {
+                type Flat = $joined;
+
+                fn join(self) -> Self::Flat {
+                    match self {
+                        Either::Left(left) => {
+                            let join_left = $join_left;
+                            join_left(left)
+                        }
+                        Either::Right(right) => {
+                            let join_right = $join_right;
+                            join_right(right)
+                        }
+                    }
+                }
+            }
+        )*
+    }
+}
+
+join_flat_types!(
+    (i32, i32) -> i32 => (
+        { |value| value },
+        { |value| value },
+    ),
+    (i32, i64) -> i64 => (
+        { |value: i32| value.zero_extend() },
+        { |value| value },
+    ),
+    (i32, f32) -> i32 => (
+        { |value| value },
+        { |value| value as i32 },
+    ),
+    (i32, f64) -> i64 => (
+        { |value: i32| value.zero_extend() },
+        { |value| value as i64 },
+    ),
+
+    (i64, i32) -> i64 => (
+        { |value| value },
+        { |value: i32| value.zero_extend() },
+    ),
+    (i64, i64) -> i64 => (
+        { |value| value },
+        { |value| value },
+    ),
+    (i64, f32) -> i64 => (
+        { |value| value },
+        { |value| (value as i32).zero_extend() },
+    ),
+    (i64, f64) -> i64 => (
+        { |value| value },
+        { |value| value as i64 },
+    ),
+
+    (f32, i32) -> i32 => (
+        { |value| value as i32 },
+        { |value| value },
+    ),
+    (f32, i64) -> i64 => (
+        { |value| (value as i32).zero_extend() },
+        { |value| value },
+    ),
+    (f32, f32) -> f32 => (
+        { |value| value },
+        { |value| value },
+    ),
+    (f32, f64) -> i64 => (
+        { |value| (value as i32).zero_extend() },
+        { |value| value as i64 },
+    ),
+
+    (f64, i32) -> i64 => (
+        { |value| value as i64 },
+        { |value: i32| value.zero_extend() },
+    ),
+    (f64, i64) -> i64 => (
+        { |value| value as i64 },
+        { |value| value },
+    ),
+    (f64, f32) -> i64 => (
+        { |value| value as i64 },
+        { |value| (value as i32).zero_extend() },
+    ),
+    (f64, f64) -> f64 => (
+        { |value| value },
+        { |value| value },
+    ),
+);

--- a/linera-witty/src/primitive_types/maybe_flat_type.rs
+++ b/linera-witty/src/primitive_types/maybe_flat_type.rs
@@ -8,7 +8,7 @@ use crate::{memory_layout::FlatLayout, Layout};
 use frunk::HCons;
 
 /// A marker trait for [`FlatType`]s and the unit type, which uses no storage space.
-pub trait MaybeFlatType: Sized {
+pub trait MaybeFlatType: Default + Sized {
     /// Result of flattening the layout made up of the current element followed by `Tail`.
     type Flatten<Tail: Layout>: FlatLayout;
 

--- a/linera-witty/src/primitive_types/mod.rs
+++ b/linera-witty/src/primitive_types/mod.rs
@@ -4,7 +4,11 @@
 //! Primitive WebAssembly and WIT types.
 
 mod flat_type;
+mod join_flat_types;
 mod maybe_flat_type;
 mod simple_type;
 
-pub use self::{flat_type::FlatType, maybe_flat_type::MaybeFlatType, simple_type::SimpleType};
+pub use self::{
+    flat_type::FlatType, join_flat_types::JoinFlatTypes, maybe_flat_type::MaybeFlatType,
+    simple_type::SimpleType,
+};

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -44,4 +44,8 @@ pub enum RuntimeError {
     /// Attempt to create a `GuestPointer` from an invalid address representation.
     #[error("Invalid address read")]
     InvalidNumber(#[from] TryFromIntError),
+
+    /// Attempt to load an `enum` type but the discriminant doesn't match any of the variants.
+    #[error("Unexpected variant discriminant")]
+    InvalidVariant,
 }

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -5,6 +5,7 @@
 
 mod floats;
 mod integers;
+mod option;
 mod phantom_data;
 mod primitives;
 mod string;

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -8,6 +8,7 @@ mod integers;
 mod option;
 mod phantom_data;
 mod primitives;
+mod result;
 mod string;
 mod tuples;
 mod vec;

--- a/linera-witty/src/type_traits/implementations/std/option.rs
+++ b/linera-witty/src/type_traits/implementations/std/option.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for the [`Option`] type.
+
+use crate::{Layout, Merge, WitType};
+use frunk::{HCons, HNil};
+
+impl<T> WitType for Option<T>
+where
+    T: WitType,
+    HNil: Merge<T::Layout>,
+    <HNil as Merge<T::Layout>>::Output: Layout,
+{
+    const SIZE: u32 = {
+        let padding = <T::Layout as Layout>::ALIGNMENT - 1;
+
+        1 + padding + T::SIZE
+    };
+
+    type Layout = HCons<i8, <HNil as Merge<T::Layout>>::Output>;
+}

--- a/linera-witty/src/type_traits/implementations/std/option.rs
+++ b/linera-witty/src/type_traits/implementations/std/option.rs
@@ -3,8 +3,11 @@
 
 //! Implementations of the custom traits for the [`Option`] type.
 
-use crate::{Layout, Merge, WitType};
-use frunk::{HCons, HNil};
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Merge, Runtime, RuntimeError, RuntimeMemory,
+    SplitFlatLayouts, WitLoad, WitType,
+};
+use frunk::{hlist, hlist_pat, HCons, HNil};
 
 impl<T> WitType for Option<T>
 where
@@ -19,4 +22,49 @@ where
     };
 
     type Layout = HCons<i8, <HNil as Merge<T::Layout>>::Output>;
+}
+
+impl<T> WitLoad for Option<T>
+where
+    T: WitLoad,
+    HNil: Merge<T::Layout>,
+    <HNil as Merge<T::Layout>>::Output: Layout,
+    <<HNil as Merge<T::Layout>>::Output as Layout>::Flat:
+        SplitFlatLayouts<<T::Layout as Layout>::Flat>,
+{
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let is_some = bool::load(memory, location)?;
+
+        match is_some {
+            true => Ok(Some(T::load(
+                memory,
+                location.after::<bool>().after_padding_for::<T>(),
+            )?)),
+            false => Ok(None),
+        }
+    }
+
+    fn lift_from<Instance>(
+        hlist_pat![is_some, ...value_layout]: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let is_some = bool::lift_from(hlist![is_some], memory)?;
+
+        if is_some {
+            Ok(Some(T::lift_from(value_layout.split(), memory)?))
+        } else {
+            Ok(None)
+        }
+    }
 }

--- a/linera-witty/src/type_traits/implementations/std/result.rs
+++ b/linera-witty/src/type_traits/implementations/std/result.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for the [`Result`] type.
+
+use crate::{Layout, Merge, WitType};
+use frunk::HCons;
+
+impl<T, E> WitType for Result<T, E>
+where
+    T: WitType,
+    E: WitType,
+    T::Layout: Merge<E::Layout>,
+    <T::Layout as Merge<E::Layout>>::Output: Layout,
+{
+    const SIZE: u32 = {
+        let ok_alignment = <T::Layout as Layout>::ALIGNMENT;
+        let err_alignment = <E::Layout as Layout>::ALIGNMENT;
+
+        let padding = if ok_alignment > err_alignment {
+            ok_alignment - 1
+        } else {
+            err_alignment - 1
+        };
+
+        if T::SIZE > E::SIZE {
+            1 + padding + T::SIZE
+        } else {
+            1 + padding + E::SIZE
+        }
+    };
+
+    type Layout = HCons<i8, <T::Layout as Merge<E::Layout>>::Output>;
+}

--- a/linera-witty/src/util/merge.rs
+++ b/linera-witty/src/util/merge.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper types and functions that aren't specific to WIT or WebAssembly.
+
+use either::Either;
+use frunk::{HCons, HNil};
+
+/// Merging of two heterogeneous lists, resulting in a new heterogenous list where every element is
+/// of type `Either<Left, Right>`, where `Left` is an element from the current list and `Right` is
+/// an element from the `Other` list.
+pub trait Merge<Other>: Sized {
+    /// The resulting heterogeneous list with elements of both input lists.
+    type Output;
+}
+
+impl Merge<HNil> for HNil {
+    type Output = HNil;
+}
+
+impl<Head, Tail> Merge<HNil> for HCons<Head, Tail>
+where
+    Tail: Merge<HNil>,
+{
+    type Output = HCons<Either<Head, ()>, <Tail as Merge<HNil>>::Output>;
+}
+
+impl<Head, Tail> Merge<HCons<Head, Tail>> for HNil
+where
+    HNil: Merge<Tail>,
+{
+    type Output = HCons<Either<(), Head>, <HNil as Merge<Tail>>::Output>;
+}
+
+impl<LeftHead, LeftTail, RightHead, RightTail> Merge<HCons<RightHead, RightTail>>
+    for HCons<LeftHead, LeftTail>
+where
+    LeftTail: Merge<RightTail>,
+{
+    type Output = HCons<Either<LeftHead, RightHead>, <LeftTail as Merge<RightTail>>::Output>;
+}

--- a/linera-witty/src/util/mod.rs
+++ b/linera-witty/src/util/mod.rs
@@ -3,6 +3,7 @@
 
 //! Helper types and functions that aren't specific to WIT or WebAssembly.
 
+mod merge;
 mod split;
 
-pub use self::split::Split;
+pub use self::{merge::Merge, split::Split};

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -40,3 +40,12 @@ pub struct Branch {
     pub first_leaf: Leaf,
     pub second_leaf: Leaf,
 }
+
+/// An enum that has its alignment obtained from one variant and its size from another.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType)]
+pub enum Enum {
+    Empty,
+    LargeVariantWithLooseAlignment(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8),
+    SmallerVariantWithStrictAlignment { inner: u64 },
+}

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -43,7 +43,7 @@ pub struct Branch {
 
 /// An enum that has its alignment obtained from one variant and its size from another.
 #[allow(dead_code)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub enum Enum {
     Empty,
     LargeVariantWithLooseAlignment(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8),

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -43,7 +43,7 @@ pub struct Branch {
 
 /// An enum that has its alignment obtained from one variant and its size from another.
 #[allow(dead_code)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad)]
 pub enum Enum {
     Empty,
     LargeVariantWithLooseAlignment(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8),

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -7,7 +7,8 @@
 mod types;
 
 use self::types::{
-    Branch, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding, TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding,
+    TupleWithoutPadding,
 };
 use linera_witty::{hlist, FakeInstance, InstanceWithMemory, Layout, WitLoad};
 use std::fmt::Debug;
@@ -112,6 +113,58 @@ fn nested_types() {
             0x0000_0021_i32,
             0x302f_2e2d_2c2b_2a29_i64,
             0x3837_3635_3433_3231_i64,
+        ],
+        expected,
+    );
+}
+
+/// Check that an enum type's variants are properly loaded from memory and lifted from its flat
+/// layout.
+#[test]
+fn enum_type() {
+    let expected = Enum::Empty;
+
+    test_load_from_memory(
+        &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15],
+        expected,
+    );
+    test_lift_from_flat_layout(
+        hlist![0_i32, 0_i64, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32],
+        expected,
+    );
+
+    let expected = Enum::LargeVariantWithLooseAlignment(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    test_load_from_memory(
+        &[1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+        expected,
+    );
+    test_lift_from_flat_layout(
+        hlist![1_i32, 0_i64, 1_i32, 2_i32, 3_i32, 4_i32, 5_i32, 6_i32, 7_i32, 8_i32, 9_i32],
+        expected,
+    );
+
+    let expected = Enum::SmallerVariantWithStrictAlignment {
+        inner: 0x0e0d_0c0b_0a09_0807_u64,
+    };
+
+    test_load_from_memory(
+        &[2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14],
+        expected,
+    );
+    test_lift_from_flat_layout(
+        hlist![
+            2_i32,
+            0x0e0d_0c0b_0a09_0807_i64,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32,
+            0_i32
         ],
         expected,
     );

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -7,7 +7,8 @@
 mod types;
 
 use self::types::{
-    Branch, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding, TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding,
+    TupleWithoutPadding,
 };
 use linera_witty::{hlist, FakeInstance, InstanceWithMemory, Layout, WitStore};
 use std::fmt::Debug;
@@ -123,6 +124,90 @@ fn nested_types() {
             0x0000_0001_i32,
             0x2d3c_4b5a_6978_8796_i64,
             0xaabb_ccdd_eeff_0f1e_u64 as i64,
+        ],
+    );
+}
+
+/// Check that an enum type's variants are properly stored in memory and lowered into its flat
+/// layout.
+#[test]
+fn enum_type() {
+    let data = Enum::Empty;
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![
+            0x0000_0000_i32,
+            0x0000_0000_0000_0000_i64,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+        ],
+    );
+
+    let data = Enum::LargeVariantWithLooseAlignment(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x01, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x00, 0x00, 0x00,
+            0x00, 0x00,
+        ],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![
+            0x0000_0001_i32,
+            0x0000_0000_0000_0000_i64,
+            0x0000_0001_i32,
+            0x0000_0002_i32,
+            0x0000_0003_i32,
+            0x0000_0004_i32,
+            0x0000_0005_i32,
+            0x0000_0006_i32,
+            0x0000_0007_i32,
+            0x0000_0008_i32,
+            0x0000_0009_i32,
+        ],
+    );
+
+    let data = Enum::SmallerVariantWithStrictAlignment {
+        inner: 0x0102_0304_0506_0708_u64,
+    };
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x02, 0, 0, 0, 0, 0, 0, 0, 0x08, 0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01,
+        ],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![
+            0x0000_0002_i32,
+            0x0102_0304_0506_0708_i64,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
+            0x0000_0000_i32,
         ],
     );
 }

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -7,7 +7,8 @@
 mod types;
 
 use self::types::{
-    Branch, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding, TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding,
+    TupleWithoutPadding,
 };
 use linera_witty::{HList, Layout, WitType};
 
@@ -66,4 +67,12 @@ fn nested_types() {
     assert_eq!(Branch::SIZE, 56);
     assert_eq!(<Branch as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Branch as WitType>::Layout as Layout>::Flat::LEN, 7);
+}
+
+/// Check the memory size and layout derived for an `enum` type.
+#[test]
+fn enum_type() {
+    assert_eq!(Enum::SIZE, 16);
+    assert_eq!(<Enum as WitType>::Layout::ALIGNMENT, 8);
+    assert_eq!(<<Enum as WitType>::Layout as Layout>::Flat::LEN, 11);
 }


### PR DESCRIPTION
# Motivation

The `WitType`, `WitLoad` and `WitStore` derive macros should support Rust `enum`s (called `variant` types in WIT).

# Solution

Since each of an `enum`'s variants can have a different layout by itself, there's a need to build a layout that combines them all for the final type. The [canonical ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening) specifies a `join` operator for combining flat types from different variants into a common flat type. The logic is to basically select the widest representation and zero-extend it if needed, falling back to integers if joining a floating point type with a different type.

A new `JoinFlatType`s trait was creating for joining pairs of flat types (represented using the `Either` type). Splitting the type back into one of the original flat types is done with methods inside the `FlatType` trait. For layouts, two new traits are available: `JoinFlatLayouts` and `SplitFlatLayouts`.

With the new `join` operation implemented, the `WitType`, `WitLoad` and `WitStore` derive macros could be updated to support `enum`s, and the `Option<T>` and `Result<T, E>` could also have implementations of the traits.

# Related Issues

Part of #906 