### PR TITLE
Fault-tolerant multi-owner chain manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,8 @@ dependencies = [
  "linera-chain",
  "linera-execution",
  "linera-views",
+ "rand_chacha 0.3.1",
+ "rand_distr",
  "serde",
  "thiserror",
  "tokio",
@@ -4346,6 +4348,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -4384,6 +4387,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.10",
+ "serde",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ prost = "0.11"
 quote = "1.0"
 rand = "0.8.5"
 rand07 = { package = "rand", version = "0.7.3" }
+rand_chacha = "0.3.1"
+rand_distr = "0.4.3"
 reqwest = "0.11.14"
 rocksdb = "0.19.0"
 serde = { version = "1.0.152", features = ["derive"] }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1595,6 +1595,8 @@ dependencies = [
  "linera-base",
  "linera-execution",
  "linera-views",
+ "rand_chacha 0.3.1",
+ "rand_distr",
  "serde",
  "thiserror",
  "tokio",
@@ -2433,6 +2435,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+ "serde",
 ]
 
 [[package]]
@@ -2471,6 +2474,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.9",
+ "serde",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+ "serde",
 ]
 
 [[package]]

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::{fmt, time::SystemTime};
+use std::{
+    fmt,
+    time::{Duration, SystemTime},
+};
 use thiserror::Error;
 
 use crate::doc_scalar;
@@ -85,6 +88,12 @@ impl Timestamp {
     /// earlier than `self`.
     pub fn saturating_diff_micros(&self, other: Timestamp) -> u64 {
         self.0.saturating_sub(other.0)
+    }
+
+    /// Returns the timestamp that is `duration` later than `self`.
+    pub fn saturating_add(&self, duration: Duration) -> Timestamp {
+        let micros = u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
+        Timestamp(self.0.saturating_add(micros))
     }
 
     /// Returns a timestamp `micros` microseconds later than `self`, or the highest possible value

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -21,6 +21,8 @@ linera-base = { workspace = true }
 linera-execution = { workspace = true }
 linera-views = { workspace = true, features = ["metrics"] }
 futures = { workspace = true }
+rand_distr = { workspace = true, features = ["serde1"] }
+rand_chacha = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -260,6 +260,7 @@ where
         timestamp: Timestamp,
         messages: Vec<OutgoingMessage>,
         certificate_hash: CryptoHash,
+        now: Timestamp,
     ) -> Result<(), ChainError> {
         let chain_id = self.chain_id();
         ensure!(
@@ -307,7 +308,7 @@ where
                     height,
                     index,
                 };
-                self.execute_immediate_message(message_id, &message, timestamp)
+                self.execute_immediate_message(message_id, &message, timestamp, now)
                     .await?;
             }
             // Record the inbox event to process it below.
@@ -354,6 +355,7 @@ where
         message_id: MessageId,
         message: &Message,
         timestamp: Timestamp,
+        now: Timestamp,
     ) -> Result<(), ChainError> {
         if let Message::System(SystemMessage::OpenChain {
             ownership,
@@ -375,9 +377,11 @@ where
             let hash = self.execution_state.crypto_hash().await?;
             self.execution_state_hash.set(Some(hash));
             // Last, reset the consensus state based on the current ownership.
-            self.manager
-                .get_mut()
-                .reset(self.execution_state.system.ownership.get(), BlockHeight(0))?;
+            self.manager.get_mut().reset(
+                self.execution_state.system.ownership.get(),
+                BlockHeight(0),
+                now,
+            )?;
         }
         Ok(())
     }
@@ -421,6 +425,7 @@ where
     pub async fn execute_block(
         &mut self,
         block: &Block,
+        now: Timestamp,
     ) -> Result<(Vec<OutgoingMessage>, CryptoHash), ChainError> {
         assert_eq!(block.chain_id, self.chain_id());
         let chain_id = self.chain_id();
@@ -509,6 +514,7 @@ where
         self.manager.get_mut().reset(
             self.execution_state.system.ownership.get(),
             block.height.try_add_one()?,
+            now,
         )?;
         Ok((messages, state_hash))
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -377,7 +377,7 @@ where
             // Last, reset the consensus state based on the current ownership.
             self.manager
                 .get_mut()
-                .reset(self.execution_state.system.ownership.get());
+                .reset(self.execution_state.system.ownership.get(), BlockHeight(0))?;
         }
         Ok(())
     }
@@ -506,9 +506,10 @@ where
         let state_hash = self.execution_state.crypto_hash().await?;
         self.execution_state_hash.set(Some(state_hash));
         // Last, reset the consensus state based on the current ownership.
-        self.manager
-            .get_mut()
-            .reset(self.execution_state.system.ownership.get());
+        self.manager.get_mut().reset(
+            self.execution_state.system.ownership.get(),
+            block.height.try_add_one()?,
+        )?;
         Ok((messages, state_hash))
     }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -252,6 +252,7 @@ struct ValueHashAndRound(CryptoHash, RoundNumber);
 
 /// A vote on a statement from a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(any(test, feature = "test"), derive(Eq, PartialEq))]
 pub struct Vote {
     pub value: HashedValue,
     pub round: RoundNumber,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -21,6 +21,7 @@ use linera_base::{
 use linera_execution::{pricing::PricingError, ExecutionError};
 use linera_views::views::ViewError;
 pub use manager::{ChainManager, ChainManagerInfo, Outcome as ChainManagerOutcome};
+use rand_distr::WeightedError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -119,4 +120,6 @@ pub enum ChainError {
     InternalError(String),
     #[error("Insufficient balance to pay the fees")]
     InsufficientBalance,
+    #[error("Invalid owner weights: {0}")]
+    OwnerWeightError(#[from] WeightedError),
 }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -20,7 +20,10 @@ use linera_base::{
 };
 use linera_execution::{pricing::PricingError, ExecutionError};
 use linera_views::views::ViewError;
-pub use manager::{ChainManager, ChainManagerInfo, Outcome as ChainManagerOutcome};
+pub use manager::{
+    ChainManager, ChainManagerInfo, MultiOwnerManagerInfo, Outcome as ChainManagerOutcome,
+    SingleOwnerManagerInfo,
+};
 use rand_distr::WeightedError;
 use thiserror::Error;
 

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -104,8 +104,10 @@ pub enum ChainError {
     PreviousBlockMustBeConfirmedFirst,
     #[error("Invalid block proposal")]
     InvalidBlockProposal,
-    #[error("Round number should be greater than {0:?}")]
+    #[error("Round number should be at least {0:?}")]
     InsufficientRound(RoundNumber),
+    #[error("Round number should be {0:?}")]
+    WrongRound(RoundNumber),
     #[error("A different block for height {0:?} was already locked at round number {1:?}")]
     HasLockedBlock(BlockHeight, RoundNumber),
     #[error("Cannot confirm a block before its predecessors: {current_block_height:?}")]

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -60,10 +60,14 @@ impl ChainManager {
                     ChainManager::Single(Box::new(SingleOwnerManager::new(*owner, *public_key)));
             }
             ChainOwnership::Multi {
-                public_keys: owners,
+                public_keys,
+                multi_leader_rounds,
             } => {
-                let owners = owners.clone();
-                *self = ChainManager::Multi(Box::new(MultiOwnerManager::new(owners, height.0)?));
+                *self = ChainManager::Multi(Box::new(MultiOwnerManager::new(
+                    public_keys.clone(),
+                    *multi_leader_rounds,
+                    height.0,
+                )?));
             }
         }
         Ok(())

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -46,7 +46,11 @@ pub enum Outcome {
 }
 
 impl ChainManager {
-    pub fn reset(&mut self, ownership: &ChainOwnership) {
+    pub fn reset(
+        &mut self,
+        ownership: &ChainOwnership,
+        height: BlockHeight,
+    ) -> Result<(), ChainError> {
         match ownership {
             ChainOwnership::None => {
                 *self = ChainManager::None;
@@ -58,13 +62,11 @@ impl ChainManager {
             ChainOwnership::Multi {
                 public_keys: owners,
             } => {
-                let owners = owners
-                    .iter()
-                    .map(|(owner, public_key)| (*owner, *public_key))
-                    .collect();
-                *self = ChainManager::Multi(Box::new(MultiOwnerManager::new(owners)));
+                let owners = owners.clone();
+                *self = ChainManager::Multi(Box::new(MultiOwnerManager::new(owners, height.0)?));
             }
         }
+        Ok(())
     }
 
     pub fn is_active(&self) -> bool {

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -15,7 +15,7 @@ use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{BlockHeight, RoundNumber},
     doc_scalar, ensure,
-    identifiers::ChainId,
+    identifiers::{ChainId, Owner},
 };
 use linera_execution::{committee::Epoch, ChainOwnership};
 use serde::{Deserialize, Serialize};
@@ -77,10 +77,14 @@ impl ChainManager {
         !matches!(self, ChainManager::None)
     }
 
-    pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
+    pub fn verify_owner(
+        &self,
+        owner: &Owner,
+        round: impl Into<Option<RoundNumber>>,
+    ) -> Option<PublicKey> {
         match self {
-            ChainManager::Single(manager) => manager.verify_owner(proposal),
-            ChainManager::Multi(manager) => manager.verify_owner(proposal),
+            ChainManager::Single(manager) => manager.verify_owner(owner, round.into()),
+            ChainManager::Multi(manager) => manager.verify_owner(owner, round.into()),
             ChainManager::None => None,
         }
     }

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -81,12 +81,9 @@ impl ChainManager {
         }
     }
 
-    pub fn next_round(&self) -> RoundNumber {
+    pub fn current_round(&self) -> RoundNumber {
         match self {
-            ChainManager::Multi(manager) => {
-                let round = manager.round();
-                round.try_add_one().unwrap_or(round)
-            }
+            ChainManager::Multi(manager) => manager.current_round(),
             ChainManager::None | ChainManager::Single(_) => RoundNumber::default(),
         }
     }
@@ -225,10 +222,17 @@ impl ChainManagerInfo {
         }
     }
 
-    pub fn next_round(&self) -> RoundNumber {
+    pub fn current_round(&self) -> RoundNumber {
         match self {
-            ChainManagerInfo::Multi(multi) => multi.next_round(),
+            ChainManagerInfo::Multi(multi) => multi.current_round,
             ChainManagerInfo::None | ChainManagerInfo::Single(_) => RoundNumber::default(),
+        }
+    }
+
+    pub fn next_round(&self) -> Option<RoundNumber> {
+        match self {
+            ChainManagerInfo::Multi(multi) => multi.next_round,
+            ChainManagerInfo::None | ChainManagerInfo::Single(_) => Some(RoundNumber::default()),
         }
     }
 }

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -240,7 +240,8 @@ impl ChainManagerInfo {
     pub fn next_round(&self) -> Option<RoundNumber> {
         match self {
             ChainManagerInfo::Multi(multi) => multi.next_round,
-            ChainManagerInfo::None | ChainManagerInfo::Single(_) => Some(RoundNumber::default()),
+            ChainManagerInfo::Single(_) => Some(RoundNumber::default()),
+            ChainManagerInfo::None => None,
         }
     }
 }

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -1,6 +1,55 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! # Manager for Multi-Owner Chains
+//!
+//! This module contains the consensus mechanism for multi-owner chains. Whenever a block is
+//! confirmed, a new chain manager is created for the next block height. It manages the consensus
+//! state until a new block is confirmed. As long as less than a third of the validators are faulty,
+//! it guarantees that at most one `ConfirmedBlock` certificate will be created for this height.
+//! There are two modes of operation:
+//!
+//! * In cooperative mode, all chain owners can propose blocks at any time. The protocol is
+//!   guaranteed to eventually confirm a block as long as no chain owner continuously actively
+//!   prevents progress.
+//! * In leader rotation mode, chain owners take turns at proposing blocks. It can make progress
+//!   as long as at least one owner is honest, even if other owners try to prevent it.
+//!
+//! ## Safety, i.e. at most one block will be confirmed
+//!
+//! In both modes is guaranteed as follows:
+//!
+//! * Validators (honest ones) never cast a vote if they have already cast any vote in a later
+//!   round.
+//! * Validators never vote for a `ValidatedBlock` **A** in round **r** if they have voted for a
+//!   _different_ `ConfirmedBlock` **B** in an earlier round **s** ≤ **r**, unless there is a
+//!   `ValidatedBlock` certificate (with a quorum of validator signatures) for **A** in some round
+//!   between **s** and **r**.
+//! * Validators only vote for a `ConfirmedBlock` if there is a `ValidatedBlock` certificate for the
+//!   same block in the same round.
+//!
+//! This guarantees that once a quroum votes for some `ConfirmedBlock`, there can never be a
+//! `ValidatedBlock` certificate (and thuse also no `ConfirmedBlock` certificate) for a different
+//! block in a later round. So if there are two different `ConfirmedBlock` certificates, they may
+//! be from different rounds, but they are guaranteed to contain the same block.
+//!
+//!
+//! ## Liveness, i.e. some block will eventually be confirmed
+//!
+//! In cooperative mode, if there is contention, the owners need to agree on a single owner as the
+//! next proposer. That owner should then download all highest-round certificates and block
+//! proposals known to the honest validators. They can then make a proposal in a round higher than
+//! all previous proposals. If there is any `ValidatedBlock` certificate they must include the
+//! highest one in their proposal, and propose that block. Otherwise they can propose a new block.
+//! Now all honest validators are allowed to vote for that proposal, and eventually confirm it.
+//!
+//! In leader-based mode, an honest owner should subscribe to notifications from all validators,
+//! and follow the chain. Whenever another leader's round takes too long, they should request
+//! timeout votes from the validators to make the next round begin. Once the honest owner becomes
+//! the round leader, they should update all validators, so that they all agree on the current
+//! round. Then they download the highest `ValidatedBlock` certificate known to any honest validator
+//! and include that in their block proposal, just like in the cooperative case.
+
 use super::Outcome;
 use crate::{
     data_types::{
@@ -11,7 +60,7 @@ use crate::{
 };
 use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
-    data_types::{BlockHeight, RoundNumber},
+    data_types::{BlockHeight, RoundNumber, Timestamp},
     ensure,
     identifiers::{ChainId, Owner},
 };
@@ -19,10 +68,15 @@ use linera_execution::committee::Epoch;
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
 use rand_distr::{Distribution, WeightedAliasIndex};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    time::Duration,
+};
 use tracing::error;
 
-/// The specific state of a chain managed by multiple owners.
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The specific state of a chain with multiple owners some of which are potentially faulty.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MultiOwnerManager {
     /// The public keys of the chain's co-owners, with their weights. If all weights are zero, every owner can
@@ -32,12 +86,19 @@ pub struct MultiOwnerManager {
     pub seed: u64,
     /// The probability distribution for choosing a round leader.
     pub distribution: Option<WeightedAliasIndex<u128>>,
-    /// Latest authenticated block that we have received.
+    /// Latest authenticated block that we have received and checked.
     pub proposed: Option<BlockProposal>,
-    /// Latest validated proposal that we have seen (and voted to confirm).
+    /// Latest validated proposal that we have voted to confirm (or would have, if we are not a
+    /// validator).
     pub locked: Option<Certificate>,
-    /// Latest proposal that we have voted on (either to validate or to confirm it).
+    /// Latest leader timeout certificate we have received.
+    pub leader_timeout: Option<Certificate>,
+    /// Latest vote we have cast, to validate or confirm.
     pub pending: Option<Vote>,
+    /// Latest timeout vote we cast.
+    pub timeout_vote: Option<Vote>,
+    /// The time after which we are ready to sign a timeout certificate for the current round.
+    pub round_timeout: Timestamp,
 }
 
 impl MultiOwnerManager {
@@ -52,6 +113,7 @@ impl MultiOwnerManager {
             let weights = public_keys.values().map(|(_, weight)| *weight).collect();
             Some(WeightedAliasIndex::new(weights)?)
         };
+        let round_timeout = Timestamp::now().saturating_add(TIMEOUT);
 
         Ok(MultiOwnerManager {
             public_keys,
@@ -59,23 +121,29 @@ impl MultiOwnerManager {
             distribution,
             proposed: None,
             locked: None,
+            leader_timeout: None,
             pending: None,
+            timeout_vote: None,
+            round_timeout,
         })
     }
 
-    pub fn round(&self) -> RoundNumber {
-        let mut current_round = RoundNumber::default();
-        if let Some(proposal) = &self.proposed {
-            if current_round < proposal.content.round {
-                current_round = proposal.content.round;
-            }
-        }
-        if let Some(Certificate { round, .. }) = &self.locked {
-            if current_round < *round {
-                current_round = *round;
-            }
-        }
-        current_round
+    /// Returns the lowest round where we can still vote to validate a block.
+    ///
+    /// Both having a leader timeout or a validated block certificate in any given round causes the
+    /// next one to become current.
+    pub fn current_round(&self) -> RoundNumber {
+        let leader_timeout = self.leader_timeout.as_ref().into_iter();
+        let validated = self
+            .proposed
+            .as_ref()
+            .and_then(|proposal| proposal.validated.as_ref());
+        let locked = self.locked.as_ref();
+        let certificates = leader_timeout.chain(locked).chain(validated);
+        certificates
+            .map(|certificate| certificate.round.try_add_one().unwrap_or(RoundNumber::MAX))
+            .max()
+            .unwrap_or_default()
     }
 
     /// Returns the most recent vote we cast.
@@ -83,10 +151,33 @@ impl MultiOwnerManager {
         self.pending.as_ref()
     }
 
-    /// Verifies the safety of the block w.r.t. voting rules.
+    /// Verifies the safety of the block with respect to voting rules.
     pub fn check_proposed_block(&self, proposal: &BlockProposal) -> Result<Outcome, ChainError> {
-        let new_block = &proposal.content.block;
         let new_round = proposal.content.round;
+        let new_block = &proposal.content.block;
+        let validated = proposal.validated.as_ref();
+        if let Some(validated) = validated {
+            ensure!(
+                validated.value().is_validated(),
+                ChainError::InvalidBlockProposal
+            );
+        }
+        let expected_round = match validated {
+            None => self.current_round(),
+            Some(cert) => cert.round.try_add_one()?,
+        };
+        // In leader rotation mode, the round must equal the expected one exactly.
+        if self.distribution.is_some() {
+            ensure!(
+                expected_round == new_round,
+                ChainError::WrongRound(expected_round)
+            );
+        } else {
+            ensure!(
+                expected_round <= new_round,
+                ChainError::InsufficientRound(expected_round)
+            );
+        }
         if let Some(old_proposal) = &self.proposed {
             if old_proposal.content.block == *new_block && old_proposal.content.round == new_round {
                 return Ok(Outcome::Skip); // We already voted for this proposal; nothing to do.
@@ -120,12 +211,31 @@ impl MultiOwnerManager {
     /// Checks if the current round has timed out, and signs a `LeaderTimeout`.
     pub fn vote_leader_timeout(
         &mut self,
-        _chain_id: ChainId,
-        _height: BlockHeight,
-        _epoch: Epoch,
-        _key_pair: Option<&KeyPair>,
+        chain_id: ChainId,
+        height: BlockHeight,
+        epoch: Epoch,
+        key_pair: Option<&KeyPair>,
     ) -> bool {
-        false // TODO(#464)
+        let Some(key_pair) = key_pair else {
+            return false; // We are not a chain owner.
+        };
+        if Timestamp::now() < self.round_timeout {
+            return false; // Round has not timed out yet.
+        }
+        let current_round = self.current_round();
+        if let Some(vote) = &self.timeout_vote {
+            if vote.round == current_round {
+                return false; // We already signed this timeout.
+            }
+        }
+        let value = CertificateValue::LeaderTimeout {
+            chain_id,
+            height,
+            epoch,
+        };
+        let vote = Vote::new(HashedValue::from(value), current_round, key_pair);
+        self.timeout_vote = Some(vote);
+        true
     }
 
     /// Verifies that we can vote to confirm a validated block.
@@ -139,10 +249,9 @@ impl MultiOwnerManager {
                         return Ok(Outcome::Skip); // We already voted to confirm this block.
                     }
                 }
-                CertificateValue::ValidatedBlock { .. } => ensure!(
-                    new_round >= *round,
-                    ChainError::InsufficientRound(round.try_sub_one().unwrap())
-                ),
+                CertificateValue::ValidatedBlock { .. } => {
+                    ensure!(new_round >= *round, ChainError::InsufficientRound(*round))
+                }
                 CertificateValue::LeaderTimeout { .. } => {
                     // Unreachable: We only put validated or confirmed blocks in pending.
                     return Err(ChainError::InternalError(
@@ -151,12 +260,11 @@ impl MultiOwnerManager {
                 }
             }
         }
-        if let Some(Certificate { round, .. }) = &self.locked {
-            ensure!(
-                new_round >= *round,
-                ChainError::InsufficientRound(round.try_sub_one().unwrap())
-            );
-        }
+        let current_round = self.current_round();
+        ensure!(
+            new_round >= current_round,
+            ChainError::InsufficientRound(current_round)
+        );
         Ok(Outcome::Accept)
     }
 
@@ -168,6 +276,9 @@ impl MultiOwnerManager {
         state_hash: CryptoHash,
         key_pair: Option<&KeyPair>,
     ) {
+        if let Some(validated) = &proposal.validated {
+            self.update_timeout(validated.round);
+        }
         // Record the proposed block, so it can be supplied to clients that request it.
         self.proposed = Some(proposal.clone());
         if let Some(key_pair) = key_pair {
@@ -191,6 +302,7 @@ impl MultiOwnerManager {
             return;
         };
         let round = certificate.round;
+        self.update_timeout(round);
         self.locked = Some(certificate);
         if let Some(key_pair) = key_pair {
             // Vote to confirm.
@@ -200,10 +312,31 @@ impl MultiOwnerManager {
         }
     }
 
+    /// Resets the timer if `round` has just ended.
+    fn update_timeout(&mut self, round: RoundNumber) {
+        if self.current_round() <= round {
+            let factor = round.0.saturating_add(2);
+            let timeout = TIMEOUT.saturating_mul(factor);
+            self.round_timeout = Timestamp::now().saturating_add(timeout);
+        }
+    }
+
     /// Updates the round number and timer if the timeout certificate is from a higher round than
     /// any known certificate.
-    pub fn handle_timeout_certificate(&mut self, _certificate: Certificate) {
-        // TODO(#464)
+    pub fn handle_timeout_certificate(&mut self, certificate: Certificate) {
+        if !certificate.value().is_timeout() {
+            // Unreachable: This is only called with timeout certificates.
+            error!("Unexpected certificate; expected leader timeout");
+            return;
+        }
+        let round = certificate.round;
+        if let Some(known_certificate) = &self.leader_timeout {
+            if known_certificate.round >= round {
+                return;
+            }
+        }
+        self.update_timeout(round);
+        self.leader_timeout = Some(certificate);
     }
 
     /// Returns the public key of the block proposal's signer, if they are a valid owner and allowed
@@ -211,7 +344,7 @@ impl MultiOwnerManager {
     pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
         let Some(distribution) = &self.distribution else {
             let (key, _) = self.public_keys.get(&proposal.owner)?;
-            return Some(*key);
+            return Some(*key); // Not in leader rotation mode; any owner is allowed to propose.
         };
         let round = proposal.content.round.0;
         let seed = u64::from(round).rotate_left(32).wrapping_add(self.seed);
@@ -219,6 +352,18 @@ impl MultiOwnerManager {
         let index = distribution.sample(&mut rng);
         let (owner, (key, _)) = self.public_keys.iter().nth(index)?;
         (*owner == proposal.owner).then_some(*key)
+    }
+
+    /// The leader who is allowed to propose a block in the given round, or `None` if every owner
+    /// is allowed to propose.
+    fn round_leader(&self, round: RoundNumber) -> Option<&Owner> {
+        let Some(distribution) = &self.distribution else {
+            return None;
+        };
+        let seed = u64::from(round.0).rotate_left(32).wrapping_add(self.seed);
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let index = distribution.sample(&mut rng);
+        self.public_keys.keys().nth(index)
     }
 }
 
@@ -232,28 +377,53 @@ pub struct MultiOwnerManagerInfo {
     pub public_keys: HashMap<Owner, (PublicKey, u128)>,
     /// Latest authenticated block that we have received, if requested.
     pub requested_proposed: Option<BlockProposal>,
-    /// Latest validated proposal that we have seen (and voted to confirm), if requested.
+    /// Latest validated proposal that we have voted to confirm (or would have, if we are not a
+    /// validator).
     pub requested_locked: Option<Certificate>,
+    /// Latest timeout certificate we have seen.
+    pub leader_timeout: Option<Certificate>,
     /// Latest vote we cast (either to validate or to confirm a block).
     pub pending: Option<LiteVote>,
     /// Latest timeout vote we cast.
     pub timeout_vote: Option<LiteVote>,
     /// The value we voted for, if requested.
     pub requested_pending_value: Option<HashedValue>,
-    /// The current round.
-    pub round: RoundNumber,
+    /// The current round, i.e. the round number for the next block proposal.
+    pub current_round: RoundNumber,
+    /// The lowest round in which a new block can be proposed.
+    pub next_round: Option<RoundNumber>,
+    /// The current leader, who is allowed to propose the next block.
+    /// `None` if everyone is allowed to propose.
+    pub leader: Option<Owner>,
+    /// The timestamp when the current round times out.
+    pub round_timeout: Timestamp,
 }
 
 impl From<&MultiOwnerManager> for MultiOwnerManagerInfo {
     fn from(manager: &MultiOwnerManager) -> Self {
+        let current_round = manager.current_round();
+        let next_round = match &manager.proposed {
+            Some(proposal) if proposal.content.round == current_round => {
+                if manager.distribution.is_some() {
+                    None // There's already a proposal in the current round.
+                } else {
+                    current_round.try_add_one().ok()
+                }
+            }
+            _ => Some(current_round),
+        };
         MultiOwnerManagerInfo {
             public_keys: manager.public_keys.clone().into_iter().collect(),
             requested_proposed: None,
             requested_locked: None,
+            leader_timeout: manager.leader_timeout.clone(),
             pending: manager.pending.as_ref().map(|vote| vote.lite()),
-            timeout_vote: None,
+            timeout_vote: manager.timeout_vote.as_ref().map(Vote::lite),
             requested_pending_value: None,
-            round: manager.round(),
+            current_round,
+            next_round,
+            leader: manager.round_leader(current_round).cloned(),
+            round_timeout: manager.round_timeout,
         }
     }
 }
@@ -263,10 +433,6 @@ impl MultiOwnerManagerInfo {
         self.requested_proposed = manager.proposed.clone();
         self.requested_locked = manager.locked.clone();
         self.requested_pending_value = manager.pending.as_ref().map(|vote| vote.value.clone());
-    }
-
-    pub fn next_round(&self) -> RoundNumber {
-        self.round.try_add_one().unwrap_or(self.round)
     }
 
     pub fn highest_validated(&self) -> Option<&Certificate> {

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -100,7 +100,7 @@ impl SingleOwnerManager {
 
     pub fn verify_owner(&self, owner: &Owner, round: Option<RoundNumber>) -> Option<PublicKey> {
         if let Some(round) = round {
-            if round != RoundNumber::zero() {
+            if round != RoundNumber::ZERO {
                 return None;
             }
         }

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -98,8 +98,13 @@ impl SingleOwnerManager {
         }
     }
 
-    pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
-        (self.owner == proposal.owner).then_some(self.public_key)
+    pub fn verify_owner(&self, owner: &Owner, round: Option<RoundNumber>) -> Option<PublicKey> {
+        if let Some(round) = round {
+            if round != RoundNumber::zero() {
+                return None;
+            }
+        }
+        (self.owner == *owner).then_some(self.public_key)
     }
 }
 

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::KeyPair,
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, RoundNumber, Timestamp},
     identifiers::ChainId,
 };
 use linera_execution::{committee::Epoch, system::Recipient, Operation, SystemOperation};
@@ -59,8 +59,12 @@ pub trait BlockTestExt: Sized {
     /// Returns the block with the specified epoch.
     fn with_epoch(self, epoch: impl Into<Epoch>) -> Self;
 
-    /// Returns a block proposal with round 0, without any blobs or validated block.
-    fn into_simple_proposal(self, key_pair: &KeyPair) -> BlockProposal;
+    /// Returns a block proposal without any blobs or validated block.
+    fn into_simple_proposal(
+        self,
+        key_pair: &KeyPair,
+        round: impl Into<RoundNumber>,
+    ) -> BlockProposal;
 }
 
 impl BlockTestExt for Block {
@@ -93,15 +97,15 @@ impl BlockTestExt for Block {
         self
     }
 
-    fn into_simple_proposal(self, key_pair: &KeyPair) -> BlockProposal {
-        BlockProposal::new(
-            BlockAndRound {
-                block: self,
-                round: Default::default(),
-            },
-            key_pair,
-            vec![],
-            None,
-        )
+    fn into_simple_proposal(
+        self,
+        key_pair: &KeyPair,
+        round: impl Into<RoundNumber>,
+    ) -> BlockProposal {
+        let content = BlockAndRound {
+            block: self,
+            round: round.into(),
+        };
+        BlockProposal::new(content, key_pair, vec![], None)
     }
 }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1420,7 +1420,7 @@ where
             ChainManagerInfo::Multi(manager) => manager
                 .public_keys
                 .values()
-                .cloned()
+                .map(|(public_key, _)| *public_key)
                 .chain(iter::once(new_public_key))
                 .collect(),
         };

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -397,7 +397,10 @@ where
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let new_key_pair = KeyPair::generate();
-    let certificate = sender.share_ownership(new_key_pair.public()).await.unwrap();
+    let certificate = sender
+        .share_ownership(new_key_pair.public(), 100)
+        .await
+        .unwrap();
     assert_eq!(sender.next_block_height, BlockHeight::from(1));
     assert!(sender.pending_block.is_none());
     assert!(sender.key_pair().await.is_ok());

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -13,7 +13,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{BlockProposal, Certificate, CertificateValue, LiteVote},
-    ChainManagerInfo,
+    ChainManager,
 };
 use linera_execution::committee::{Committee, Epoch, ValidatorName};
 use linera_storage::Store;
@@ -390,10 +390,9 @@ where
                 }
             }
         }
-        let query = ChainInfoQuery::new(chain_id).with_manager_values();
-        let info = self.client.handle_chain_info_query(query).await?.info;
-        if let ChainManagerInfo::Multi(manager) = info.manager {
-            if let Some(cert) = manager.requested_locked {
+        let manager = self.store.load_chain(chain_id).await?.manager.get().clone();
+        if let ChainManager::Multi(manager) = manager {
+            if let Some(cert) = manager.locked {
                 if cert.value().is_validated() && cert.value().chain_id() == chain_id {
                     self.send_certificate(cert, false).await?;
                 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -11,7 +11,10 @@ use linera_base::{
     data_types::BlockHeight,
     identifiers::{ChainDescription, ChainId, MessageId},
 };
-use linera_chain::data_types::{BlockProposal, Certificate, CertificateValue, LiteVote};
+use linera_chain::{
+    data_types::{BlockProposal, Certificate, CertificateValue, LiteVote},
+    ChainManagerInfo,
+};
 use linera_execution::committee::{Committee, ValidatorName};
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -379,6 +382,20 @@ where
                 let certs = self.store.read_certificates(keys.into_iter()).await?;
                 for cert in certs {
                     self.send_certificate(cert, retryable).await?;
+                }
+            }
+        }
+        let query = ChainInfoQuery::new(chain_id).with_manager_values();
+        let info = self.client.handle_chain_info_query(query).await?.info;
+        if let ChainManagerInfo::Multi(manager) = info.manager {
+            if let Some(cert) = manager.requested_locked {
+                if cert.value().is_validated() && cert.value().chain_id() == chain_id {
+                    self.send_certificate(cert, false).await?;
+                }
+            }
+            if let Some(cert) = manager.leader_timeout {
+                if cert.value().is_timeout() && cert.value().chain_id() == chain_id {
+                    self.send_certificate(cert, false).await?;
                 }
             }
         }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -8,14 +8,14 @@ use crate::{
 };
 use futures::{future, StreamExt};
 use linera_base::{
-    data_types::BlockHeight,
+    data_types::{BlockHeight, RoundNumber},
     identifiers::{ChainDescription, ChainId, MessageId},
 };
 use linera_chain::{
     data_types::{BlockProposal, Certificate, CertificateValue, LiteVote},
     ChainManagerInfo,
 };
-use linera_execution::committee::{Committee, ValidatorName};
+use linera_execution::committee::{Committee, Epoch, ValidatorName};
 use linera_storage::Store;
 use linera_views::views::ViewError;
 use std::{
@@ -42,6 +42,11 @@ pub enum CommunicateAction {
     SubmitBlockForValidation(BlockProposal),
     FinalizeBlock(Certificate),
     AdvanceToNextBlockHeight(BlockHeight),
+    RequestLeaderTimeout {
+        height: BlockHeight,
+        round: RoundNumber,
+        epoch: Epoch,
+    },
 }
 
 pub struct ValidatorUpdater<A, S> {
@@ -436,7 +441,8 @@ where
                 proposal.content.block.height
             }
             CommunicateAction::FinalizeBlock(certificate) => certificate.value().height(),
-            CommunicateAction::AdvanceToNextBlockHeight(seq) => *seq,
+            CommunicateAction::AdvanceToNextBlockHeight(height) => *height,
+            CommunicateAction::RequestLeaderTimeout { height, .. } => *height,
         };
         // Update the validator with missing information, if needed.
         self.send_chain_information(chain_id, target_block_height)
@@ -461,6 +467,19 @@ where
                 let retryable = target_block_height == BlockHeight::ZERO;
                 let info = self.send_certificate(certificate, retryable).await?;
                 match info.manager.pending() {
+                    Some(vote) if vote.validator == self.name => {
+                        vote.check()?;
+                        return Ok(Some(vote.clone()));
+                    }
+                    Some(_) | None => {
+                        return Err(NodeError::MissingVoteInValidatorResponse);
+                    }
+                }
+            }
+            CommunicateAction::RequestLeaderTimeout { .. } => {
+                let query = ChainInfoQuery::new(chain_id).with_leader_timeout();
+                let info = self.client.handle_chain_info_query(query).await?.info;
+                match info.manager.timeout_vote() {
                     Some(vote) if vote.validator == self.name => {
                         vote.check()?;
                         return Ok(Some(vote.clone()));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -944,7 +944,7 @@ where
         let public_key = chain
             .manager
             .get()
-            .verify_owner(&proposal)
+            .verify_owner(&proposal.owner, proposal.content.round)
             .ok_or(WorkerError::InvalidOwner)?;
         signature.check(&proposal.content, public_key)?;
         // Check the authentication of the operations in the block.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -338,7 +338,8 @@ where
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         let mut chain = self.storage.load_active_chain(block.chain_id).await?;
-        let (messages, state_hash) = chain.execute_block(&block).await?;
+        let now = self.storage.current_time();
+        let (messages, state_hash) = chain.execute_block(&block, now).await?;
         let response = ChainInfoResponse::new(&chain, None);
         let executed_block = ExecutedBlock {
             block,
@@ -532,7 +533,8 @@ where
         // Execute the block and update inboxes.
         chain.remove_events_from_inboxes(block).await?;
         // We should always agree on the messages and state hash.
-        let (verified_messages, verified_state_hash) = chain.execute_block(block).await?;
+        let now = self.storage.current_time();
+        let (verified_messages, verified_state_hash) = chain.execute_block(block, now).await?;
         ensure!(
             *messages == verified_messages,
             WorkerError::IncorrectMessages
@@ -660,10 +662,11 @@ where
         }
         self.cache_validated(&certificate.value).await;
         let current_round = chain.manager.get().current_round();
-        chain
-            .manager
-            .get_mut()
-            .create_final_vote(certificate.clone(), self.key_pair());
+        chain.manager.get_mut().create_final_vote(
+            certificate.clone(),
+            self.key_pair(),
+            self.storage.current_time(),
+        );
         let info = ChainInfoResponse::new(&chain, self.key_pair());
         chain.save().await?;
         if chain.manager.get().current_round() > current_round {
@@ -714,7 +717,7 @@ where
         chain
             .manager
             .get_mut()
-            .handle_timeout_certificate(certificate.clone());
+            .handle_timeout_certificate(certificate.clone(), self.storage.current_time());
         if chain.manager.get().current_round() > current_round {
             actions.notifications.push(Notification {
                 chain_id,
@@ -768,9 +771,10 @@ where
                         },
                     ..
                 } => {
+                    let now = self.storage.current_time();
                     // Update the staged chain state with the received block.
                     chain
-                        .receive_block(origin, block.height, block.timestamp, messages, hash)
+                        .receive_block(origin, block.height, block.timestamp, messages, hash, now)
                         .await?
                 }
                 value => {
@@ -977,8 +981,9 @@ where
         if time_till_block > 0 {
             tokio::time::sleep(Duration::from_micros(time_till_block)).await;
         }
+        let now = self.storage.current_time();
         let (messages, state_hash) = {
-            let (messages, state_hash) = chain.execute_block(block).await?;
+            let (messages, state_hash) = chain.execute_block(block, now).await?;
             // Verify that the resulting chain would have no unconfirmed incoming messages.
             chain.validate_incoming_messages().await?;
             // Reset all the staged changes as we were only validating things.
@@ -987,7 +992,7 @@ where
         };
         // Create the vote and store it in the chain state.
         let manager = chain.manager.get_mut();
-        manager.create_vote(proposal, messages, state_hash, self.key_pair());
+        manager.create_vote(proposal, messages, state_hash, self.key_pair(), now);
         // Cache the value we voted on, so the client doesn't have to send it again.
         if let Some(vote) = manager.pending() {
             self.cache_recent_value(Cow::Borrowed(&vote.value)).await;
@@ -1070,6 +1075,7 @@ where
                     chain.tip_state.get().next_block_height,
                     *epoch,
                     self.key_pair(),
+                    self.storage.current_time(),
                 ) {
                     chain.save().await?;
                 }

--- a/linera-execution/src/ownership.rs
+++ b/linera-execution/src/ownership.rs
@@ -15,7 +15,7 @@ pub enum ChainOwnership {
     Single { owner: Owner, public_key: PublicKey },
     /// The chain is managed by multiple owners.
     Multi {
-        public_keys: BTreeMap<Owner, PublicKey>,
+        public_keys: BTreeMap<Owner, (PublicKey, u128)>,
     },
 }
 
@@ -27,11 +27,11 @@ impl ChainOwnership {
         }
     }
 
-    pub fn multiple(public_keys: impl IntoIterator<Item = PublicKey>) -> Self {
+    pub fn multiple(keys_and_weights: impl IntoIterator<Item = (PublicKey, u128)>) -> Self {
         ChainOwnership::Multi {
-            public_keys: public_keys
+            public_keys: keys_and_weights
                 .into_iter()
-                .map(|key| (Owner::from(key), key))
+                .map(|(key, weight)| (Owner::from(key), (key, weight)))
                 .collect(),
         }
     }
@@ -54,7 +54,7 @@ impl ChainOwnership {
             }
             ChainOwnership::Multi {
                 public_keys: owners,
-            } => owners.get(owner).copied(),
+            } => owners.get(owner).map(|(key, _)| *key),
             ChainOwnership::None => None,
         }
     }

--- a/linera-execution/src/ownership.rs
+++ b/linera-execution/src/ownership.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::{crypto::PublicKey, identifiers::Owner};
+use linera_base::{crypto::PublicKey, data_types::RoundNumber, identifiers::Owner};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -15,7 +15,11 @@ pub enum ChainOwnership {
     Single { owner: Owner, public_key: PublicKey },
     /// The chain is managed by multiple owners.
     Multi {
+        /// The owners, with their weights that determine how often they are round leader.
         public_keys: BTreeMap<Owner, (PublicKey, u128)>,
+        /// The number of initial rounds in which all owners are allowed to propose blocks,
+        /// i.e. the first round with only a single leader.
+        multi_leader_rounds: RoundNumber,
     },
 }
 
@@ -27,12 +31,16 @@ impl ChainOwnership {
         }
     }
 
-    pub fn multiple(keys_and_weights: impl IntoIterator<Item = (PublicKey, u128)>) -> Self {
+    pub fn multiple(
+        keys_and_weights: impl IntoIterator<Item = (PublicKey, u128)>,
+        multi_leader_rounds: RoundNumber,
+    ) -> Self {
         ChainOwnership::Multi {
             public_keys: keys_and_weights
                 .into_iter()
                 .map(|(key, weight)| (Owner::from(key), (key, weight)))
                 .collect(),
+            multi_leader_rounds,
         }
     }
 
@@ -52,9 +60,9 @@ impl ChainOwnership {
                     None
                 }
             }
-            ChainOwnership::Multi {
-                public_keys: owners,
-            } => owners.get(owner).map(|(key, _)| *key),
+            ChainOwnership::Multi { public_keys, .. } => {
+                public_keys.get(owner).map(|(key, _)| *key)
+            }
             ChainOwnership::None => None,
         }
     }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -12,7 +12,7 @@ use async_graphql::Enum;
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, ArithmeticError, Timestamp},
+    data_types::{Amount, ArithmeticError, RoundNumber, Timestamp},
     ensure, hex_debug,
     identifiers::{BytecodeId, ChainDescription, ChainId, MessageId, Owner},
 };
@@ -113,7 +113,10 @@ pub enum SystemOperation {
     /// Changes the authentication key of the chain.
     ChangeOwner { new_public_key: PublicKey },
     /// Changes the authentication key of the chain.
-    ChangeMultipleOwners { new_public_keys: Vec<PublicKey> },
+    ChangeMultipleOwners {
+        new_public_keys: Vec<(PublicKey, u128)>,
+        multi_leader_rounds: RoundNumber,
+    },
     /// Subscribes to a system channel.
     Subscribe {
         chain_id: ChainId,
@@ -520,9 +523,13 @@ where
             ChangeOwner { new_public_key } => {
                 self.ownership.set(ChainOwnership::single(*new_public_key));
             }
-            ChangeMultipleOwners { new_public_keys } => {
+            ChangeMultipleOwners {
+                new_public_keys,
+                multi_leader_rounds,
+            } => {
                 self.ownership.set(ChainOwnership::multiple(
-                    new_public_keys.iter().map(|pub_key| (*pub_key, 0)),
+                    new_public_keys.iter().map(|(key, weight)| (*key, *weight)),
+                    *multi_leader_rounds,
                 ));
             }
             CloseChain => {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -521,8 +521,9 @@ where
                 self.ownership.set(ChainOwnership::single(*new_public_key));
             }
             ChangeMultipleOwners { new_public_keys } => {
-                self.ownership
-                    .set(ChainOwnership::multiple(new_public_keys.iter().cloned()));
+                self.ownership.set(ChainOwnership::multiple(
+                    new_public_keys.iter().map(|pub_key| (*pub_key, 0)),
+                ));
             }
             CloseChain => {
                 self.ownership.set(ChainOwnership::default());

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -244,6 +244,8 @@ ChainOwnership:
                   TUPLE:
                     - TYPENAME: PublicKey
                     - U128
+          - multi_leader_rounds:
+              TYPENAME: RoundNumber
 ChannelFullName:
   STRUCT:
     - application_id:
@@ -430,6 +432,8 @@ MultiOwnerManagerInfo:
             TUPLE:
               - TYPENAME: PublicKey
               - U128
+    - multi_leader_rounds:
+        TYPENAME: RoundNumber
     - requested_proposed:
         OPTION:
           TYPENAME: BlockProposal
@@ -806,7 +810,11 @@ SystemOperation:
         STRUCT:
           - new_public_keys:
               SEQ:
-                TYPENAME: PublicKey
+                TUPLE:
+                  - TYPENAME: PublicKey
+                  - U128
+          - multi_leader_rounds:
+              TYPENAME: RoundNumber
     6:
       Subscribe:
         STRUCT:

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -241,7 +241,9 @@ ChainOwnership:
                 KEY:
                   TYPENAME: Owner
                 VALUE:
-                  TYPENAME: PublicKey
+                  TUPLE:
+                    - TYPENAME: PublicKey
+                    - U128
 ChannelFullName:
   STRUCT:
     - application_id:
@@ -425,7 +427,9 @@ MultiOwnerManagerInfo:
           KEY:
             TYPENAME: Owner
           VALUE:
-            TYPENAME: PublicKey
+            TUPLE:
+              - TYPENAME: PublicKey
+              - U128
     - requested_proposed:
         OPTION:
           TYPENAME: BlockProposal

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -436,6 +436,9 @@ MultiOwnerManagerInfo:
     - requested_locked:
         OPTION:
           TYPENAME: Certificate
+    - leader_timeout:
+        OPTION:
+          TYPENAME: Certificate
     - pending:
         OPTION:
           TYPENAME: LiteVote
@@ -445,8 +448,16 @@ MultiOwnerManagerInfo:
     - requested_pending_value:
         OPTION:
           TYPENAME: CertificateValue
-    - round:
+    - current_round:
         TYPENAME: RoundNumber
+    - next_round:
+        OPTION:
+          TYPENAME: RoundNumber
+    - leader:
+        OPTION:
+          TYPENAME: Owner
+    - round_timeout:
+        TYPENAME: Timestamp
 NodeError:
   ENUM:
     0:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -317,7 +317,7 @@ type MutationRoot {
 	Creates (or activates) a new chain by installing the given authentication keys.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openMultiOwnerChain(chainId: ChainId!, publicKeys: [PublicKey!]!): ChainId!
+	openMultiOwnerChain(chainId: ChainId!, owners: [PublicKey!]!, weights: [Int!]!): ChainId!
 	"""
 	Closes the chain.
 	"""

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -317,7 +317,7 @@ type MutationRoot {
 	Creates (or activates) a new chain by installing the given authentication keys.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openMultiOwnerChain(chainId: ChainId!, owners: [PublicKey!]!, weights: [Int!]!): ChainId!
+	openMultiOwnerChain(chainId: ChainId!, publicKeys: [PublicKey!]!, weights: [Int!], multiLeaderRounds: RoundNumber): ChainId!
 	"""
 	Closes the chain.
 	"""
@@ -329,7 +329,7 @@ type MutationRoot {
 	"""
 	Changes the authentication key of the chain.
 	"""
-	changeMultipleOwners(chainId: ChainId!, newPublicKeys: [PublicKey!]!): CryptoHash!
+	changeMultipleOwners(chainId: ChainId!, newPublicKeys: [PublicKey!]!, newWeights: [Int!]!, multiLeaderRounds: RoundNumber!): CryptoHash!
 	"""
 	(admin chain only) Registers a new committee. This will notify the subscribers of
 	the admin chain so that they can migrate to the new epoch (by accepting the
@@ -452,6 +452,11 @@ type QueryRoot {
 The recipient of a transfer
 """
 scalar Recipient
+
+"""
+A number to identify successive attempts to decide a value in a consensus protocol.
+"""
+scalar RoundNumber
 
 
 type SubscriptionRoot {

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -151,7 +151,7 @@ where
         loop {
             let notification = match tokio::time::timeout(
                 round_timeout.map_or(MAX_TIMEOUT, |t| {
-                    Duration::from_micros(t.saturating_diff_micros(Timestamp::now()))
+                    Duration::from_micros(t.saturating_diff_micros(storage.current_time()))
                 }),
                 stream.next(),
             )

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1106,7 +1106,8 @@ impl Runnable for Job {
                 let mut chain_client = context.make_chain_client(storage, chain_id);
                 info!("Starting operation to open a new chain");
                 let time_start = Instant::now();
-                let ownership = ChainOwnership::multiple(public_keys);
+                let owners = public_keys.into_iter().map(|pk| (pk, 100));
+                let ownership = ChainOwnership::multiple(owners);
                 let (message_id, certificate) = chain_client.open_chain(ownership).await.unwrap();
                 let time_total = time_start.elapsed().as_micros();
                 info!("Operation confirmed after {} us", time_total);

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -37,6 +37,7 @@ use serde_json::Value;
 use std::{
     env, fs,
     io::Read,
+    iter,
     num::NonZeroU16,
     path::PathBuf,
     sync::Arc,
@@ -683,6 +684,13 @@ enum ClientCommand {
         /// Public keys of the new owners
         #[structopt(long = "to-public-keys")]
         public_keys: Vec<PublicKey>,
+
+        /// Weights for the new owners
+        #[structopt(long = "weights")]
+        weights: Vec<u128>,
+
+        #[structopt(long = "multi-leader-rounds")]
+        multi_leader_rounds: Option<RoundNumber>,
     },
 
     /// Close (i.e. deactivate) an existing chain.
@@ -1102,12 +1110,26 @@ impl Runnable for Job {
             OpenMultiOwnerChain {
                 chain_id,
                 public_keys,
+                weights,
+                multi_leader_rounds,
             } => {
                 let mut chain_client = context.make_chain_client(storage, chain_id);
                 info!("Starting operation to open a new chain");
                 let time_start = Instant::now();
-                let owners = public_keys.into_iter().map(|pk| (pk, 100));
-                let ownership = ChainOwnership::multiple(owners);
+                let owners: Vec<_> = if weights.is_empty() {
+                    public_keys.into_iter().zip(iter::repeat(100)).collect()
+                } else if weights.len() != public_keys.len() {
+                    bail!(
+                        "There are {} public keys but {} weights.",
+                        public_keys.len(),
+                        weights.len()
+                    );
+                } else {
+                    let weights = weights.into_iter().map(u128::from);
+                    public_keys.into_iter().zip(weights).collect()
+                };
+                let multi_leader_rounds = multi_leader_rounds.unwrap_or(RoundNumber::MAX);
+                let ownership = ChainOwnership::multiple(owners, multi_leader_rounds);
                 let (message_id, certificate) = chain_client.open_chain(ownership).await.unwrap();
                 let time_total = time_start.elapsed().as_micros();
                 info!("Operation confirmed after {} us", time_total);

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -9,7 +9,7 @@ use colored::Colorize;
 use futures::{lock::Mutex, StreamExt};
 use linera_base::{
     crypto::{KeyPair, PublicKey},
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, RoundNumber, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, MessageId},
 };
 use linera_chain::data_types::{Certificate, CertificateValue, ExecutedBlock};
@@ -49,7 +49,6 @@ use tracing::{debug, info, warn};
 use linera_service::client::{LocalNetwork, Network};
 #[cfg(feature = "benchmark")]
 use {
-    linera_base::data_types::RoundNumber,
     linera_chain::data_types::{
         Block, BlockAndRound, BlockProposal, HashedValue, SignatureAggregator, Vote,
     },

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -20,7 +20,7 @@ use axum::{
 use futures::lock::{Mutex, MutexGuard, OwnedMutexGuard};
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
-    data_types::Amount,
+    data_types::{Amount, RoundNumber},
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner},
     BcsHexParseError,
 };
@@ -40,7 +40,7 @@ use linera_storage::Store;
 use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use std::{collections::BTreeMap, net::SocketAddr, num::NonZeroU16, sync::Arc};
+use std::{collections::BTreeMap, iter, net::SocketAddr, num::NonZeroU16, sync::Arc};
 use thiserror::Error as ThisError;
 use tower_http::cors::CorsLayer;
 use tracing::{debug, error, info};
@@ -296,14 +296,28 @@ where
     async fn open_multi_owner_chain(
         &self,
         chain_id: ChainId,
-        owners: Vec<PublicKey>,
-        weights: Vec<u64>,
+        public_keys: Vec<PublicKey>,
+        weights: Option<Vec<u64>>,
+        multi_leader_rounds: Option<RoundNumber>,
     ) -> Result<ChainId, Error> {
+        let owners: Vec<_> = if let Some(weights) = weights {
+            if weights.len() != public_keys.len() {
+                return Err(Error::new(format!(
+                    "There are {} public keys but {} weights.",
+                    public_keys.len(),
+                    weights.len()
+                )));
+            }
+            let weights = weights.into_iter().map(u128::from);
+            public_keys.into_iter().zip(weights).collect()
+        } else {
+            public_keys.into_iter().zip(iter::repeat(100)).collect()
+        };
+        let multi_leader_rounds = multi_leader_rounds.unwrap_or(RoundNumber::MAX);
+        let ownership = ChainOwnership::multiple(owners, multi_leader_rounds);
         let Some(mut client) = self.clients.client_lock(&chain_id).await else {
             return Err(Error::new("Unknown chain ID"));
         };
-        let weights = weights.into_iter().map(u128::from);
-        let ownership = ChainOwnership::multiple(owners.into_iter().zip(weights));
         let (message_id, _) = client.open_chain(ownership).await?;
         Ok(ChainId::child(message_id))
     }
@@ -330,8 +344,14 @@ where
         &self,
         chain_id: ChainId,
         new_public_keys: Vec<PublicKey>,
+        new_weights: Vec<u64>,
+        multi_leader_rounds: RoundNumber,
     ) -> Result<CryptoHash, Error> {
-        let operation = SystemOperation::ChangeMultipleOwners { new_public_keys };
+        let new_weights = new_weights.into_iter().map(u128::from);
+        let operation = SystemOperation::ChangeMultipleOwners {
+            new_public_keys: new_public_keys.into_iter().zip(new_weights).collect(),
+            multi_leader_rounds,
+        };
         self.execute_system_operation(operation, chain_id).await
     }
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -296,12 +296,14 @@ where
     async fn open_multi_owner_chain(
         &self,
         chain_id: ChainId,
-        public_keys: Vec<PublicKey>,
+        owners: Vec<PublicKey>,
+        weights: Vec<u64>,
     ) -> Result<ChainId, Error> {
         let Some(mut client) = self.clients.client_lock(&chain_id).await else {
             return Err(Error::new("Unknown chain ID"));
         };
-        let ownership = ChainOwnership::multiple(public_keys);
+        let weights = weights.into_iter().map(u128::from);
+        let ownership = ChainOwnership::multiple(owners.into_iter().zip(weights));
         let (message_id, _) = client.open_chain(ownership).await?;
         Ok(ChainId::child(message_id))
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -27,7 +27,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
 use linera_chain::{
@@ -178,7 +178,7 @@ pub trait Store: Sized {
         chain
             .manager
             .get_mut()
-            .reset(&ChainOwnership::single(public_key));
+            .reset(&ChainOwnership::single(public_key), BlockHeight(0))?;
         chain.save().await?;
         Ok(())
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -175,10 +175,11 @@ pub trait Store: Sized {
         system_state.timestamp.set(timestamp);
         let state_hash = chain.execution_state.crypto_hash().await?;
         chain.execution_state_hash.set(Some(state_hash));
-        chain
-            .manager
-            .get_mut()
-            .reset(&ChainOwnership::single(public_key), BlockHeight(0))?;
+        chain.manager.get_mut().reset(
+            &ChainOwnership::single(public_key),
+            BlockHeight(0),
+            self.current_time(),
+        )?;
         chain.save().await?;
         Ok(())
     }


### PR DESCRIPTION
## Motivation

Public chains will need to be live even if some chain owners are faulty.

## Proposal

Extend the multi-owner chain manager with a leader-based consensus protocol that tolerates faults of owners, and will eventually confirm a block even if some owners are actively malicious.

Before the single-leader rounds that guarantee liveness even in case of malicious owners, there is a configurable number of multi-leader rounds where everyone can propose blocks, just like in the current multi-owner chains.

## Test Plan

TBD: This is why it's still a draft.

## Links

Part of #464.

## Release Plan

- [ ] All good!
- [x] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
