### PR TITLE
Fix internal alignment in `frunk` heterogeneous lists

### DIFF
--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -18,25 +18,25 @@ pub struct GuestPointer(pub(crate) u32);
 impl GuestPointer {
     /// Returns a new address that's the current address advanced to add padding to ensure it's
     /// aligned to the `alignment` byte boundary.
-    pub fn aligned_at(&self, alignment: u32) -> Self {
+    pub const fn aligned_at(&self, alignment: u32) -> Self {
         let padding = (-(self.0 as i32) & (alignment as i32 - 1)) as u32;
 
         GuestPointer(self.0 + padding)
     }
 
     /// Returns a new address that's the current address advanced to after the size of `T`.
-    pub fn after<T: WitType>(&self) -> Self {
+    pub const fn after<T: WitType>(&self) -> Self {
         GuestPointer(self.0 + T::SIZE)
     }
 
     /// Returns a new address that's the current address advanced to add padding to ensure it's
     /// aligned properly for `T`.
-    pub fn after_padding_for<T: WitType>(&self) -> Self {
+    pub const fn after_padding_for<T: WitType>(&self) -> Self {
         self.aligned_at(<T::Layout as Layout>::ALIGNMENT)
     }
 
     /// Returns the address of an element in a contiguous list of properly aligned `T` types.
-    pub fn index<T: WitType>(&self, index: u32) -> Self {
+    pub const fn index<T: WitType>(&self, index: u32) -> Self {
         let element_size = GuestPointer(T::SIZE).after_padding_for::<T>();
 
         GuestPointer(self.0 + index * element_size.0)

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -19,6 +19,9 @@ impl GuestPointer {
     /// Returns a new address that's the current address advanced to add padding to ensure it's
     /// aligned to the `alignment` byte boundary.
     pub const fn aligned_at(&self, alignment: u32) -> Self {
+        // The following computation is equivalent to:
+        // `(alignment - (self.0 % alignment)) % alignment`.
+        // Source: https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
         let padding = (-(self.0 as i32) & (alignment as i32 - 1)) as u32;
 
         GuestPointer(self.0 + padding)

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -11,6 +11,10 @@ use crate::{Layout, WitType};
 use frunk::{hlist, hlist_pat, HList};
 use std::borrow::Cow;
 
+#[cfg(test)]
+#[path = "unit_tests/memory.rs"]
+mod tests;
+
 /// An address for a location in a guest WebAssembly module's memory.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GuestPointer(pub(crate) u32);

--- a/linera-witty/src/runtime/unit_tests/memory.rs
+++ b/linera-witty/src/runtime/unit_tests/memory.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for guest Wasm module memory manipulation.
+
+use super::GuestPointer;
+
+/// Test aligning memory addresses.
+///
+/// Check that the resulting address is aligned and that it never advances more than the alignment
+/// amount.
+#[test]
+fn align_guest_pointer() {
+    for alignment_bits in 0..3 {
+        let alignment = 1 << alignment_bits;
+        let alignment_mask = alignment - 1;
+
+        for start_offset in 0..32 {
+            let address = GuestPointer(start_offset).aligned_at(alignment);
+
+            assert_eq!(address.0 & alignment_mask, 0);
+            assert!(address.0 - start_offset < alignment);
+        }
+    }
+}

--- a/linera-witty/src/type_traits/implementations/mod.rs
+++ b/linera-witty/src/type_traits/implementations/mod.rs
@@ -6,3 +6,5 @@
 mod custom_types;
 mod frunk;
 mod std;
+#[cfg(test)]
+mod tests;

--- a/linera-witty/src/type_traits/implementations/tests.rs
+++ b/linera-witty/src/type_traits/implementations/tests.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for implementations of the custom traits for existing types.
+
+use crate::{FakeInstance, InstanceWithMemory, Layout, WitLoad, WitStore};
+use frunk::hlist;
+use std::fmt::Debug;
+
+/// Test roundtrip of a heterogeneous list that doesn't need any internal padding.
+#[test]
+fn hlist_without_padding() {
+    let input = hlist![
+        0x1011_1213_1415_1617_1819_1a1b_1c1d_1e1f_u128,
+        0x2021_2223_2425_2627_i64,
+        0x3031_3233_u32,
+        0x4041_i16,
+        true,
+    ];
+
+    test_memory_roundtrip(
+        input,
+        &[
+            0x1f, 0x1e, 0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12,
+            0x11, 0x10, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0x20, 0x33, 0x32, 0x31, 0x30,
+            0x41, 0x40, 0x01,
+        ],
+    );
+    test_flattening_roundtrip(
+        input,
+        hlist![
+            0x1819_1a1b_1c1d_1e1f_i64,
+            0x1011_1213_1415_1617_i64,
+            0x2021_2223_2425_2627_i64,
+            0x3031_3233_i32,
+            0x0000_4041_i32,
+            0x0000_0001_i32,
+        ],
+    );
+}
+
+/// Test roundtrip of a heterogeneous list that needs internal padding between some of its elements.
+#[test]
+fn hlist_with_padding() {
+    let input = hlist![
+        true,
+        0x1011_i16,
+        0x2021_u16,
+        0x3031_3233_u32,
+        0x4041_4243_4445_4647_i64,
+    ];
+
+    test_memory_roundtrip(
+        input,
+        &[
+            0x01, 0, 0x11, 0x10, 0x21, 0x20, 0, 0, 0x33, 0x32, 0x31, 0x30, 0, 0, 0, 0, 0x47, 0x46,
+            0x45, 0x44, 0x43, 0x42, 0x41, 0x40,
+        ],
+    );
+    test_flattening_roundtrip(
+        input,
+        hlist![
+            0x0000_0001_i32,
+            0x0000_1011_i32,
+            0x0000_2021_i32,
+            0x3031_3233_i32,
+            0x4041_4243_4445_4647_i64,
+        ],
+    );
+}
+
+/// Test storing an instance of `T` to memory, checking that the `memory_data` bytes are correctly
+/// written, and check that the instance can be loaded from those bytes.
+fn test_memory_roundtrip<T>(input: T, memory_data: &[u8])
+where
+    T: Debug + Eq + WitLoad + WitStore,
+{
+    let mut instance = FakeInstance::default();
+    let mut memory = instance.memory().unwrap();
+    let length = memory_data.len() as u32;
+
+    assert_eq!(length, T::SIZE);
+
+    let address = memory.allocate(length).unwrap();
+
+    input.store(&mut memory, address).unwrap();
+
+    assert_eq!(memory.read(address, length).unwrap(), memory_data);
+    assert_eq!(T::load(&memory, address).unwrap(), input);
+}
+
+/// Test lowering an instance of `T`, checking that the resulting flat layout matches the expected
+/// `flat_layout`, and check that the instance can be lifted from that flat layout.
+fn test_flattening_roundtrip<T>(input: T, flat_layout: <T::Layout as Layout>::Flat)
+where
+    T: Debug + Eq + WitLoad + WitStore,
+    <T::Layout as Layout>::Flat: Debug + Eq,
+{
+    let mut instance = FakeInstance::default();
+    let mut memory = instance.memory().unwrap();
+
+    let lowered_layout = input.lower(&mut memory).unwrap();
+
+    assert_eq!(lowered_layout, flat_layout);
+    assert_eq!(T::lift_from(lowered_layout, &memory).unwrap(), input);
+}

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -13,7 +13,7 @@ pub struct SimpleWrapper(pub bool);
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct TupleWithoutPadding(pub u64, pub i32, pub i16);
 
-/// A tuple struct that requires internal padding in its memory layout between all of its fields.
+/// A tuple struct that requires internal padding in its memory layout between two of its fields.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub struct TupleWithPadding(pub u16, pub u32, pub i64);
 


### PR DESCRIPTION
## Motivation

The `WitType`, `WitLoad` and `WitStore` implementations for `frunk` heterogeneous lists (`HCons` and `HNil` types) weren't respecting the alignment of its elements when reading and writing to memory. This meant that they didn't correctly implement WIT's [canonical ABI specification](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#alignment).

## Proposal

Respecting the alignment for its elements is not simple because the lists are represented by recursive types. The `HCons` type for example can check the alignment of its element (the "head") or of the rest of the list (the "tail"). However, the alignment of a list is defined as the largest alignment of its elements. So using the tail's alignment is not the correct solution. Instead, the alignment of the first element of the tail must be obtained.

Also, in order to calculate the size of the list, internal padding must be included. The padding is calculated based on the alignment of each element. The solution is to calculate the padding using the size up until the current element, and the alignment of the next element. Unfortunately, it's not possible to write a `const fn` to calculate the size this way, so instead a workaround must be used. Since the maximum alignment is expected to be 8 bytes (for the largest flat types, `i64` and `f64`), we can enumerate the size's offset inside that 8-byte window, and implement the size calculation considering each case.

A helper `SizeCalculation` trait was added that is used internally to calculate the size and to obtain the first element of the tail.

## Test Plan

Two unit tests were written to check the roundtrip to memory and to a flat layout of heterogeneous lists that require internal padding and that don't. The test with the list that requires padding would fail before the fix.

## Links

This is unexpected work part of #906 

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
