### PR TITLE
Add a parameter `max_concurrent_queries` for controlling the number of concurrent queries

### DIFF
--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -19,7 +19,9 @@ use thiserror::Error;
 
 #[cfg(any(test, feature = "test"))]
 use {
-    async_lock::Mutex, linera_views::memory::MemoryContext, std::collections::BTreeMap,
+    async_lock::Mutex,
+    linera_views::memory::{MemoryContext, MEMORY_MAX_STREAM_QUERIES},
+    std::collections::BTreeMap,
     std::sync::Arc,
 };
 
@@ -246,7 +248,7 @@ where
         let guard = Arc::new(Mutex::new(BTreeMap::new()))
             .try_lock_arc()
             .expect("a guard");
-        let context = MemoryContext::new(guard, ());
+        let context = MemoryContext::new(guard, MEMORY_MAX_STREAM_QUERIES, ());
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -11,7 +11,9 @@ use linera_views::{
 
 #[cfg(any(test, feature = "test"))]
 use {
-    async_lock::Mutex, linera_views::memory::MemoryContext, std::collections::BTreeMap,
+    async_lock::Mutex,
+    linera_views::memory::{MemoryContext, MEMORY_MAX_STREAM_QUERIES},
+    std::collections::BTreeMap,
     std::sync::Arc,
 };
 
@@ -82,7 +84,7 @@ where
         let guard = Arc::new(Mutex::new(BTreeMap::new()))
             .try_lock_arc()
             .expect("a guard");
-        let context = MemoryContext::new(guard, ());
+        let context = MemoryContext::new(guard, MEMORY_MAX_STREAM_QUERIES, ());
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -20,22 +20,32 @@ use linera_execution::{
     WasmRuntime,
 };
 use linera_storage::Store;
-use linera_views::views::ViewError;
+use linera_views::{memory::MEMORY_MAX_STREAM_QUERIES, views::ViewError};
 use serde_json::json;
 use std::collections::BTreeMap;
 use test_case::test_case;
 
 #[cfg(feature = "rocksdb")]
-use crate::client::client_tests::{MakeRocksDbStoreClient, ROCKS_DB_SEMAPHORE};
+use {
+    crate::client::client_tests::{MakeRocksDbStoreClient, ROCKS_DB_SEMAPHORE},
+    linera_views::rocks_db::ROCKS_DB_MAX_STREAM_QUERIES,
+};
 
 #[cfg(feature = "aws")]
-use crate::client::client_tests::MakeDynamoDbStoreClient;
+use {
+    crate::client::client_tests::MakeDynamoDbStoreClient,
+    linera_views::dynamo_db::DYNAMO_DB_MAX_STREAM_QUERIES,
+};
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    run_test_create_application(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_create_application(MakeMemoryStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        MEMORY_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "rocksdb")]
@@ -44,7 +54,11 @@ async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(),
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_create_application(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_create_application(MakeRocksDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        ROCKS_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "aws")]
@@ -52,7 +66,11 @@ async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    run_test_create_application(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_create_application(MakeDynamoDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        DYNAMO_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 async fn run_test_create_application<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -134,8 +152,11 @@ where
 async fn test_memory_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_run_application_with_dependency(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime))
-        .await
+    run_test_run_application_with_dependency(MakeMemoryStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        MEMORY_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "rocksdb")]
@@ -148,6 +169,7 @@ async fn test_rocks_db_run_application_with_dependency(
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
     run_test_run_application_with_dependency(MakeRocksDbStoreClient::with_wasm_runtime(
         wasm_runtime,
+        ROCKS_DB_MAX_STREAM_QUERIES,
     ))
     .await
 }
@@ -161,6 +183,7 @@ async fn test_dynamo_db_run_application_with_dependency(
 ) -> Result<(), anyhow::Error> {
     run_test_run_application_with_dependency(MakeDynamoDbStoreClient::with_wasm_runtime(
         wasm_runtime,
+        DYNAMO_DB_MAX_STREAM_QUERIES,
     ))
     .await
 }
@@ -269,7 +292,11 @@ where
 async fn test_memory_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_run_reentrant_application(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_run_reentrant_application(MakeMemoryStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        MEMORY_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "rocksdb")]
@@ -280,8 +307,11 @@ async fn test_rocks_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_run_reentrant_application(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime))
-        .await
+    run_test_run_reentrant_application(MakeRocksDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        ROCKS_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "aws")]
@@ -291,8 +321,11 @@ async fn test_rocks_db_run_reentrant_application(
 async fn test_dynamo_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_run_reentrant_application(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime))
-        .await
+    run_test_run_reentrant_application(MakeDynamoDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        DYNAMO_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 async fn run_test_run_reentrant_application<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -366,7 +399,11 @@ where
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    run_test_cross_chain_message(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_cross_chain_message(MakeMemoryStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        MEMORY_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "rocksdb")]
@@ -375,7 +412,11 @@ async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<()
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_cross_chain_message(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_cross_chain_message(MakeRocksDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        ROCKS_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "aws")]
@@ -385,7 +426,11 @@ async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<
 async fn test_dynamo_db_cross_chain_message(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_cross_chain_message(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_cross_chain_message(MakeDynamoDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        DYNAMO_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 async fn run_test_cross_chain_message<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -546,7 +591,11 @@ where
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_memory_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    run_test_user_pub_sub_channels(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_user_pub_sub_channels(MakeMemoryStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        MEMORY_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "rocksdb")]
@@ -557,7 +606,11 @@ async fn test_rocks_db_user_pub_sub_channels(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_user_pub_sub_channels(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_user_pub_sub_channels(MakeRocksDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        ROCKS_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 #[cfg(feature = "aws")]
@@ -567,7 +620,11 @@ async fn test_rocks_db_user_pub_sub_channels(
 async fn test_dynamo_db_user_pub_sub_channels(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_user_pub_sub_channels(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_user_pub_sub_channels(MakeDynamoDbStoreClient::with_wasm_runtime(
+        wasm_runtime,
+        DYNAMO_DB_MAX_STREAM_QUERIES,
+    ))
+    .await
 }
 
 async fn run_test_user_pub_sub_channels<B>(store_builder: B) -> Result<(), anyhow::Error>

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -18,8 +18,11 @@ use std::collections::{HashMap, HashSet};
 
 #[cfg(any(test, feature = "test"))]
 use {
-    async_lock::Mutex, linera_views::memory::MemoryContext, linera_views::views::View,
-    std::collections::BTreeMap, std::sync::Arc,
+    async_lock::Mutex,
+    linera_views::memory::{MemoryContext, MEMORY_MAX_STREAM_QUERIES},
+    linera_views::views::View,
+    std::collections::BTreeMap,
+    std::sync::Arc,
 };
 
 #[cfg(test)]
@@ -287,7 +290,7 @@ where
 {
     pub async fn new() -> Self {
         let guard = Arc::new(Mutex::new(BTreeMap::new())).lock_arc().await;
-        let context = MemoryContext::new(guard, ());
+        let context = MemoryContext::new(guard, MEMORY_MAX_STREAM_QUERIES, ());
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -25,7 +25,7 @@ use linera_views_derive::CryptoHashView;
 use {
     crate::{system::SystemExecutionState, TestExecutionRuntimeContext, UserApplicationCode},
     async_lock::Mutex,
-    linera_views::memory::MemoryContext,
+    linera_views::memory::{MemoryContext, MEMORY_MAX_STREAM_QUERIES},
     std::collections::BTreeMap,
     std::sync::Arc,
 };
@@ -68,7 +68,7 @@ where
         let extra = TestExecutionRuntimeContext::new(
             description.expect("Chain description should be set").into(),
         );
-        let context = MemoryContext::new(guard, extra);
+        let context = MemoryContext::new(guard, MEMORY_MAX_STREAM_QUERIES, extra);
         let mut view = Self::load(context)
             .await
             .expect("Loading from memory should work");

--- a/linera-sdk/src/test/integration/validator.rs
+++ b/linera-sdk/src/test/integration/validator.rs
@@ -20,6 +20,7 @@ use linera_execution::{
     WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, Store};
+use linera_views::memory::MEMORY_MAX_STREAM_QUERIES;
 use std::sync::{
     atomic::{AtomicU32, Ordering},
     Arc,
@@ -48,7 +49,8 @@ impl Default for TestValidator {
     fn default() -> Self {
         let key_pair = KeyPair::generate();
         let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
-        let client = MemoryStoreClient::new(Some(WasmRuntime::default()));
+        let client =
+            MemoryStoreClient::new(Some(WasmRuntime::default()), MEMORY_MAX_STREAM_QUERIES);
 
         let worker = WorkerState::new(
             "Single validator node".to_string(),

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -30,13 +30,16 @@ impl KeyValueStore {
 
 #[async_trait]
 impl KeyValueStoreClient for KeyValueStore {
-    const MAX_CONNECTIONS: usize = 1;
     // The KeyValueStoreClient of the system_api does not have limits
     // on the size of its values.
     const MAX_VALUE_SIZE: usize = usize::MAX;
     type Error = ViewError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    fn max_stream_queries(&self) -> usize {
+        1
+    }
 
     async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let future = wit::ReadKeyBytes::new(key);

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -599,6 +599,14 @@ struct ClientOptions {
     #[structopt(long)]
     wasm_runtime: Option<WasmRuntime>,
 
+    /// The maximal number of simultaneous queries to the database
+    #[structopt(long)]
+    max_concurrent_queries: Option<usize>,
+
+    /// The maximal number of simultaneous stream queries to the database
+    #[structopt(long, default_value = "10")]
+    max_stream_queries: usize,
+
     /// The maximal number of entries in the storage cache.
     #[structopt(long, default_value = "1000")]
     cache_size: usize,
@@ -1676,12 +1684,16 @@ async fn run_command_with_storage(options: ClientOptions) -> Result<(), Error> {
     let genesis_config = context.wallet_state.genesis_config().clone();
     let wasm_runtime = options.wasm_runtime.with_wasm_default();
     let cache_size = options.cache_size;
+    let max_concurrent_queries = options.max_concurrent_queries;
+    let max_stream_queries = options.max_stream_queries;
     let storage_config = ClientContext::storage_config(&options)?;
 
     storage_config
         .run_with_storage(
             &genesis_config,
             wasm_runtime,
+            max_concurrent_queries,
+            max_stream_queries,
             cache_size,
             Job(context, options.command),
         )

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -3,6 +3,7 @@
 
 use linera_base::identifiers::ChainId;
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
+use linera_views::memory::MEMORY_MAX_STREAM_QUERIES;
 
 use async_trait::async_trait;
 use linera_core::{
@@ -68,7 +69,7 @@ impl ValidatorNodeProvider for DummyValidatorNodeProvider {
 }
 
 fn main() -> std::io::Result<()> {
-    let store = MemoryStoreClient::new(None);
+    let store = MemoryStoreClient::new(None, MEMORY_MAX_STREAM_QUERIES);
     let config = ChainListenerConfig {
         delay_before_ms: 0,
         delay_after_ms: 0,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -306,6 +306,14 @@ enum ServerCommand {
         #[structopt(long)]
         wasm_runtime: Option<WasmRuntime>,
 
+        /// The maximal number of simultaneous queries to the database
+        #[structopt(long)]
+        max_concurrent_queries: Option<usize>,
+
+        /// The maximal number of stream queries to the database
+        #[structopt(long, default_value = "10")]
+        max_stream_queries: usize,
+
         /// The maximal number of entries in the storage cache.
         #[structopt(long, default_value = "1000")]
         cache_size: usize,
@@ -353,6 +361,8 @@ async fn main() {
             shard,
             grace_period,
             wasm_runtime,
+            max_concurrent_queries,
+            max_stream_queries,
             cache_size,
         } => {
             let genesis_config = GenesisConfig::read(&genesis_config_path)
@@ -368,7 +378,14 @@ async fn main() {
             };
             let wasm_runtime = wasm_runtime.with_wasm_default();
             storage_config
-                .run_with_storage(&genesis_config, wasm_runtime, cache_size, job)
+                .run_with_storage(
+                    &genesis_config,
+                    wasm_runtime,
+                    max_concurrent_queries,
+                    max_stream_queries,
+                    cache_size,
+                    job,
+                )
                 .await
                 .unwrap();
         }

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -21,21 +21,34 @@ pub type DynamoDbStoreClient = DbStoreClient<DynamoDbClient>;
 impl DynamoDbStoreClient {
     pub async fn new(
         table: TableName,
+        max_concurrent_queries: Option<usize>,
+        max_stream_queries: usize,
         cache_size: usize,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        Self::with_store(DynamoDbStore::new(table, cache_size, wasm_runtime)).await
+        Self::with_store(DynamoDbStore::new(
+            table,
+            max_concurrent_queries,
+            max_stream_queries,
+            cache_size,
+            wasm_runtime,
+        ))
+        .await
     }
 
     pub async fn from_config(
         config: impl Into<Config>,
         table: TableName,
+        max_concurrent_queries: Option<usize>,
+        max_stream_queries: usize,
         cache_size: usize,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         Self::with_store(DynamoDbStore::from_config(
             config.into(),
             table,
+            max_concurrent_queries,
+            max_stream_queries,
             cache_size,
             wasm_runtime,
         ))
@@ -44,11 +57,15 @@ impl DynamoDbStoreClient {
 
     pub async fn with_localstack(
         table: TableName,
+        max_concurrent_queries: Option<usize>,
+        max_stream_queries: usize,
         cache_size: usize,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         Self::with_store(DynamoDbStore::with_localstack(
             table,
+            max_concurrent_queries,
+            max_stream_queries,
             cache_size,
             wasm_runtime,
         ))
@@ -69,20 +86,43 @@ impl DynamoDbStoreClient {
 impl DynamoDbStore {
     pub async fn new(
         table: TableName,
+        max_concurrent_queries: Option<usize>,
+        max_stream_queries: usize,
         cache_size: usize,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        Self::with_client(|| DynamoDbClient::new(table, cache_size), wasm_runtime).await
+        Self::with_client(
+            || {
+                DynamoDbClient::new(
+                    table,
+                    max_concurrent_queries,
+                    max_stream_queries,
+                    cache_size,
+                )
+            },
+            wasm_runtime,
+        )
+        .await
     }
 
     pub async fn from_config(
         config: Config,
         table: TableName,
+        max_concurrent_queries: Option<usize>,
+        max_stream_queries: usize,
         cache_size: usize,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         Self::with_client(
-            || DynamoDbClient::from_config(config, table, cache_size),
+            || {
+                DynamoDbClient::from_config(
+                    config,
+                    table,
+                    max_concurrent_queries,
+                    max_stream_queries,
+                    cache_size,
+                )
+            },
             wasm_runtime,
         )
         .await
@@ -90,11 +130,20 @@ impl DynamoDbStore {
 
     pub async fn with_localstack(
         table: TableName,
+        max_concurrent_queries: Option<usize>,
+        max_stream_queries: usize,
         cache_size: usize,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         Self::with_client(
-            || DynamoDbClient::with_localstack(table, cache_size),
+            || {
+                DynamoDbClient::with_localstack(
+                    table,
+                    max_concurrent_queries,
+                    max_stream_queries,
+                    cache_size,
+                )
+            },
             wasm_runtime,
         )
         .await

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -3,7 +3,7 @@
 
 use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient};
 use linera_execution::WasmRuntime;
-use linera_views::memory::{create_memory_client, MemoryClient};
+use linera_views::memory::{create_memory_client_stream_queries, MemoryClient};
 use std::sync::Arc;
 
 type MemoryStore = DbStore<MemoryClient>;
@@ -11,16 +11,16 @@ type MemoryStore = DbStore<MemoryClient>;
 pub type MemoryStoreClient = DbStoreClient<MemoryClient>;
 
 impl MemoryStoreClient {
-    pub fn new(wasm_runtime: Option<WasmRuntime>) -> Self {
+    pub fn new(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize) -> Self {
         Self {
-            client: Arc::new(MemoryStore::new(wasm_runtime)),
+            client: Arc::new(MemoryStore::new(wasm_runtime, max_stream_queries)),
         }
     }
 }
 
 impl MemoryStore {
-    pub fn new(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let client = create_memory_client();
+    pub fn new(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize) -> Self {
+        let client = create_memory_client_stream_queries(max_stream_queries);
         Self {
             client,
             guards: ChainGuards::default(),

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -15,16 +15,31 @@ type RocksDbStore = DbStore<RocksDbClient>;
 pub type RocksDbStoreClient = DbStoreClient<RocksDbClient>;
 
 impl RocksDbStoreClient {
-    pub fn new(path: PathBuf, wasm_runtime: Option<WasmRuntime>, cache_size: usize) -> Self {
+    pub fn new(
+        path: PathBuf,
+        wasm_runtime: Option<WasmRuntime>,
+        max_stream_queries: usize,
+        cache_size: usize,
+    ) -> Self {
         RocksDbStoreClient {
-            client: Arc::new(RocksDbStore::new(path, wasm_runtime, cache_size)),
+            client: Arc::new(RocksDbStore::new(
+                path,
+                wasm_runtime,
+                max_stream_queries,
+                cache_size,
+            )),
         }
     }
 }
 
 impl RocksDbStore {
-    pub fn new(dir: PathBuf, wasm_runtime: Option<WasmRuntime>, cache_size: usize) -> Self {
-        let client = RocksDbClient::new(dir, cache_size);
+    pub fn new(
+        dir: PathBuf,
+        wasm_runtime: Option<WasmRuntime>,
+        max_stream_queries: usize,
+        cache_size: usize,
+    ) -> Self {
+        let client = RocksDbClient::new(dir, max_stream_queries, cache_size);
         Self {
             client,
             guards: ChainGuards::default(),

--- a/linera-storage/src/unit_tests/dynamo_db.rs
+++ b/linera-storage/src/unit_tests/dynamo_db.rs
@@ -4,7 +4,11 @@
 use super::DynamoDbStoreClient;
 use crate::Store;
 use linera_base::identifiers::ChainId;
-use linera_views::{lru_caching::TEST_CACHE_SIZE, test_utils::LocalStackTestContext};
+use linera_views::{
+    dynamo_db::{DYNAMO_DB_MAX_CONCURRENT_QUERIES, DYNAMO_DB_MAX_STREAM_QUERIES},
+    lru_caching::TEST_CACHE_SIZE,
+    test_utils::LocalStackTestContext,
+};
 use std::mem;
 
 /// Tests if released guards don't use memory.
@@ -15,6 +19,8 @@ async fn guards_dont_leak() -> Result<(), anyhow::Error> {
     let (store, _) = DynamoDbStoreClient::from_config(
         localstack.dynamo_db_config(),
         table,
+        Some(DYNAMO_DB_MAX_CONCURRENT_QUERIES),
+        DYNAMO_DB_MAX_STREAM_QUERIES,
         TEST_CACHE_SIZE,
         None,
     )

--- a/linera-storage/src/unit_tests/rocks_db.rs
+++ b/linera-storage/src/unit_tests/rocks_db.rs
@@ -4,7 +4,7 @@
 use super::RocksDbStoreClient;
 use crate::Store;
 use linera_base::identifiers::ChainId;
-use linera_views::lru_caching::TEST_CACHE_SIZE;
+use linera_views::{lru_caching::TEST_CACHE_SIZE, rocks_db::ROCKS_DB_MAX_STREAM_QUERIES};
 use std::mem;
 use tempfile::TempDir;
 
@@ -12,7 +12,12 @@ use tempfile::TempDir;
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
     let directory = TempDir::new()?;
-    let store = RocksDbStoreClient::new(directory.path().to_owned(), None, TEST_CACHE_SIZE);
+    let store = RocksDbStoreClient::new(
+        directory.path().to_owned(),
+        None,
+        ROCKS_DB_MAX_STREAM_QUERIES,
+        TEST_CACHE_SIZE,
+    );
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(store.client.guards.active_guards(), 0);

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -12,6 +12,7 @@ use std::collections::HashSet;
 #[cfg(feature = "aws")]
 use {
     crate::dynamo_db::DynamoDbClient,
+    crate::dynamo_db::{DYNAMO_DB_MAX_CONCURRENT_QUERIES, DYNAMO_DB_MAX_STREAM_QUERIES},
     crate::lru_caching::TEST_CACHE_SIZE,
     anyhow::{Context, Error},
     aws_sdk_s3::Endpoint,
@@ -144,6 +145,8 @@ pub async fn create_dynamodb_test_client() -> DynamoDbClient {
     let (key_value_operation, _) = DynamoDbClient::from_config(
         localstack.dynamo_db_config(),
         "test_table".parse().expect("Invalid table name"),
+        Some(DYNAMO_DB_MAX_CONCURRENT_QUERIES),
+        DYNAMO_DB_MAX_STREAM_QUERIES,
         TEST_CACHE_SIZE,
     )
     .await

--- a/linera-views/src/unit_tests/dynamo_db_context_tests.rs
+++ b/linera-views/src/unit_tests/dynamo_db_context_tests.rs
@@ -3,6 +3,7 @@
 
 use super::{DynamoDbContext, TableName, TableStatus};
 use crate::{
+    dynamo_db::{DYNAMO_DB_MAX_CONCURRENT_QUERIES, DYNAMO_DB_MAX_STREAM_QUERIES},
     lru_caching::TEST_CACHE_SIZE,
     test_utils::{list_tables, LocalStackTestContext},
 };
@@ -21,6 +22,8 @@ async fn table_is_created() -> Result<(), Error> {
     let (_storage, table_status) = DynamoDbContext::from_config(
         localstack.dynamo_db_config(),
         table.clone(),
+        Some(DYNAMO_DB_MAX_CONCURRENT_QUERIES),
+        DYNAMO_DB_MAX_STREAM_QUERIES,
         TEST_CACHE_SIZE,
         vec![],
         (),
@@ -49,6 +52,8 @@ async fn separate_tables_are_created() -> Result<(), Error> {
     let (_storage, first_table_status) = DynamoDbContext::from_config(
         localstack.dynamo_db_config(),
         first_table.clone(),
+        Some(DYNAMO_DB_MAX_CONCURRENT_QUERIES),
+        DYNAMO_DB_MAX_STREAM_QUERIES,
         TEST_CACHE_SIZE,
         vec![],
         (),
@@ -57,6 +62,8 @@ async fn separate_tables_are_created() -> Result<(), Error> {
     let (_storage, second_table_status) = DynamoDbContext::from_config(
         localstack.dynamo_db_config(),
         second_table.clone(),
+        Some(DYNAMO_DB_MAX_CONCURRENT_QUERIES),
+        DYNAMO_DB_MAX_STREAM_QUERIES,
         TEST_CACHE_SIZE,
         vec![],
         (),


### PR DESCRIPTION
## Motivation

The number of connections that can be achieved is a limit to some systems. For example, when testing some DynamoDb on MacOS I reach the error "too many open files". But the question is beyond MacOS and would apply to other systems. We should have a way to limit the number of simultaneous connections to the database.
That number `max_concurrent_queries` is available as a parameter for the binaries and is set to a constant value for the tests.

## Proposal

Add an entry `count: Arc<Semaphore>` to the `DynamoDbClientInternal`. The lock is acquired by a `lock()`that is left unused. By setting up the semaphore, we can limit the number of connections. There is thus an unused variable for `_guard` in the same way that we have for the RocksDB tests.

## Test Plan

The feature can be tested by doing the following:
* Removing `--no-default-features` to the `Dynamodb.yml`.
* Adding `target: wasm32-unknown-unknown` to the `actions-rs/toolchain`

Without that correction and running `cargo test client::client_tests::wasm::test_dynamo_db_run_application_with_dependency::wasmer --features aws` 
we have the error `too many open files`. By having the correction and setting up `MAX_CONNECTION` to `10` we remove that error (and get another one, though that is another story).

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!