### PR TITLE
Use heterogeneous lists in code generated by Witty derive macros

### DIFF
--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![deny(missing_docs)]
 
+mod util;
 mod wit_load;
 mod wit_store;
 mod wit_type;

--- a/linera-witty-macros/src/unit_tests/wit_load.rs
+++ b/linera-witty-macros/src/unit_tests/wit_load.rs
@@ -25,6 +25,9 @@ fn zero_sized_type() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
+            let linera_witty::hlist_pat![] =
+                <linera_witty::HList![] as linera_witty::WitLoad>::load(memory, location)?;
+
             Ok(Self)
         }
 
@@ -37,6 +40,9 @@ fn zero_sized_type() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
+            let linera_witty::hlist_pat![] =
+                <linera_witty::HList![] as linera_witty::WitLoad>::lift_from(flat_layout, memory)?;
+
             Ok(Self)
         }
     };
@@ -65,13 +71,11 @@ fn named_struct() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            location = location.after_padding_for::<u8>();
-            let first = <u8 as linera_witty::WitLoad>::load(memory, location)?;
-            location = location.after::<u8>();
-
-            location = location.after_padding_for::<CustomType>();
-            let second = <CustomType as linera_witty::WitLoad>::load(memory, location)?;
-            location = location.after::<CustomType>();
+            let linera_witty::hlist_pat![first, second] =
+                <linera_witty::HList![u8, CustomType] as linera_witty::WitLoad>::load(
+                    memory,
+                    location
+                )?;
 
             Ok(Self { first, second })
         }
@@ -85,11 +89,11 @@ fn named_struct() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
-            let first = <u8 as WitLoad>::lift_from(field_layout, memory)?;
-
-            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
-            let second = <CustomType as WitLoad>::lift_from(field_layout, memory)?;
+            let linera_witty::hlist_pat![first, second] =
+                <linera_witty::HList![u8, CustomType] as linera_witty::WitLoad>::lift_from(
+                    flat_layout,
+                    memory
+                )?;
 
             Ok(Self { first, second })
         }
@@ -116,17 +120,11 @@ fn tuple_struct() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            location = location.after_padding_for::<String>();
-            let field0 = <String as linera_witty::WitLoad>::load(memory, location)?;
-            location = location.after::<String>();
-
-            location = location.after_padding_for::<Vec<CustomType> >();
-            let field1 = <Vec<CustomType> as linera_witty::WitLoad>::load(memory, location)?;
-            location = location.after::<Vec<CustomType> >();
-
-            location = location.after_padding_for::<i64>();
-            let field2 = <i64 as linera_witty::WitLoad>::load(memory, location)?;
-            location = location.after::<i64>();
+            let linera_witty::hlist_pat![field0, field1, field2] = <linera_witty::HList![
+                String,
+                Vec<CustomType>,
+                i64
+            ] as linera_witty::WitLoad>::load(memory, location)?;
 
             Ok(Self(field0, field1, field2))
         }
@@ -140,14 +138,11 @@ fn tuple_struct() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
-            let field0 = <String as WitLoad>::lift_from(field_layout, memory)?;
-
-            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
-            let field1 = <Vec<CustomType> as WitLoad>::lift_from(field_layout, memory)?;
-
-            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
-            let field2 = <i64 as WitLoad>::lift_from(field_layout, memory)?;
+            let linera_witty::hlist_pat![field0, field1, field2] = <linera_witty::HList![
+                String,
+                Vec<CustomType>,
+                i64
+            ] as linera_witty::WitLoad>::lift_from(flat_layout, memory)?;
 
             Ok(Self(field0, field1, field2))
         }

--- a/linera-witty-macros/src/unit_tests/wit_store.rs
+++ b/linera-witty-macros/src/unit_tests/wit_store.rs
@@ -27,7 +27,7 @@ fn zero_sized_type() {
                 linera_witty::RuntimeMemory<Instance>,
         {
             let Self = self;
-            Ok(())
+            linera_witty::hlist![].store(memory, location)
         }
 
         fn lower<Instance>(
@@ -39,8 +39,8 @@ fn zero_sized_type() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let flat_layout = linera_witty::HList![];
-            Ok(flat_layout)
+            let Self = self;
+            linera_witty::hlist![].lower(memory)
         }
     };
 
@@ -70,16 +70,7 @@ fn named_struct() {
                 linera_witty::RuntimeMemory<Instance>,
         {
             let Self { first, second } = self;
-
-            location = location.after_padding_for::<u8>();
-            WitStore::store(first, memory, location)?;
-            location = location.after::<u8>();
-
-            location = location.after_padding_for::<CustomType>();
-            WitStore::store(second, memory, location)?;
-            location = location.after::<CustomType>();
-
-            Ok(())
+            linera_witty::hlist![first, second].store(memory, location)
         }
 
         fn lower<Instance>(
@@ -91,15 +82,8 @@ fn named_struct() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let flat_layout = linera_witty::HList![];
-
-            let field_layout = WitStore::lower(&self.first, memory)?;
-            let flat_layout = flat_layout + field_layout;
-
-            let field_layout = WitStore::lower(&self.second, memory)?;
-            let flat_layout = flat_layout + field_layout;
-
-            Ok(flat_layout)
+            let Self { first, second } = self;
+            linera_witty::hlist![first, second].lower(memory)
         }
     };
 
@@ -126,20 +110,7 @@ fn tuple_struct() {
                 linera_witty::RuntimeMemory<Instance>,
         {
             let Self(field0, field1, field2) = self;
-
-            location = location.after_padding_for::<String>();
-            WitStore::store(field0, memory, location)?;
-            location = location.after::<String>();
-
-            location = location.after_padding_for::<Vec<CustomType> >();
-            WitStore::store(field1, memory, location)?;
-            location = location.after::<Vec<CustomType> >();
-
-            location = location.after_padding_for::<i64>();
-            WitStore::store(field2, memory, location)?;
-            location = location.after::<i64>();
-
-            Ok(())
+            linera_witty::hlist![field0, field1, field2].store(memory, location)
         }
 
         fn lower<Instance>(
@@ -151,18 +122,8 @@ fn tuple_struct() {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            let flat_layout = linera_witty::HList![];
-
-            let field_layout = WitStore::lower(&self.0, memory)?;
-            let flat_layout = flat_layout + field_layout;
-
-            let field_layout = WitStore::lower(&self.1, memory)?;
-            let flat_layout = flat_layout + field_layout;
-
-            let field_layout = WitStore::lower(&self.2, memory)?;
-            let flat_layout = flat_layout + field_layout;
-
-            Ok(flat_layout)
+            let Self(field0, field1, field2) = self;
+            linera_witty::hlist![field0, field1, field2].lower(memory)
         }
     };
 

--- a/linera-witty-macros/src/unit_tests/wit_type.rs
+++ b/linera-witty-macros/src/unit_tests/wit_type.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Unit tests for the `WitLoad` derive macro.
+
+#![cfg(test)]
+
+use super::derive_for_struct;
+use quote::quote;
+use syn::{parse_quote, Fields, ItemStruct};
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a unit struct.
+#[test]
+fn zero_sized_type() {
+    let input = Fields::Unit;
+    let output = derive_for_struct(&input);
+
+    let expected = quote! {
+        const SIZE: u32 = <linera_witty::HList![] as linera_witty::WitType>::SIZE;
+
+        type Layout = <linera_witty::HList![] as linera_witty::WitType>::Layout;
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a named struct.
+#[test]
+fn named_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type {
+            first: u8,
+            second: CustomType,
+        }
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        const SIZE: u32 = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::SIZE;
+
+        type Layout = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::Layout;
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}
+
+/// Check the generated code for the body of the implementation of `WitLoad` for a tuple struct.
+#[test]
+fn tuple_struct() {
+    let input: ItemStruct = parse_quote! {
+        struct Type(String, Vec<CustomType>, i64);
+    };
+    let output = derive_for_struct(&input.fields);
+
+    let expected = quote! {
+        const SIZE: u32 =
+            <linera_witty::HList![String, Vec<CustomType>, i64] as linera_witty::WitType>::SIZE;
+
+        type Layout =
+            <linera_witty::HList![String, Vec<CustomType>, i64] as linera_witty::WitType>::Layout;
+    };
+
+    assert_eq!(output.to_string(), expected.to_string());
+}

--- a/linera-witty-macros/src/util.rs
+++ b/linera-witty-macros/src/util.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper functions shared between different macro implementations.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Fields, Ident};
+
+/// Returns the code with a pattern to match a heterogenous list using the `field_names` as
+/// bindings.
+///
+/// This function receives `field_names` instead of a `Fields` instance because some fields might
+/// not have names, so binding names must be created for them.
+pub fn hlist_bindings_for(field_names: impl Iterator<Item = Ident>) -> TokenStream {
+    quote! { linera_witty::hlist_pat![#( #field_names ),*] }
+}
+
+/// Returns the code with a pattern to match a heterogenous list using the `field_names` as
+/// bindings.
+pub fn hlist_type_for(fields: &Fields) -> TokenStream {
+    let field_types = fields.iter().map(|field| &field.ty);
+    quote! { linera_witty::HList![#( #field_types ),*] }
+}

--- a/linera-witty-macros/src/wit_load.rs
+++ b/linera-witty-macros/src/wit_load.rs
@@ -6,24 +6,18 @@
 #[path = "unit_tests/wit_load.rs"]
 mod tests;
 
+use crate::util::{hlist_bindings_for, hlist_type_for};
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{format_ident, quote};
 use syn::{Fields, Ident};
 
 /// Returns the body of the `WitLoad` implementation for the Rust `struct` with the specified
 /// `fields`.
 pub fn derive_for_struct(fields: &Fields) -> TokenStream {
-    let field_pairs: Vec<_> = field_names_and_types(fields).collect();
-
-    let load_fields = loads_for_fields(field_pairs.iter().cloned());
-    let construction = construction_for_fields(field_pairs.iter().cloned(), fields);
-
-    let lift_fields = field_pairs.iter().map(|(field_name, field_type)| {
-        quote! {
-            let (field_layout, flat_layout) = linera_witty::Split::split(flat_layout);
-            let #field_name = <#field_type as WitLoad>::lift_from(field_layout, memory)?;
-        }
-    });
+    let field_names = field_names(fields);
+    let fields_hlist_binding = hlist_bindings_for(field_names.clone());
+    let fields_hlist_type = hlist_type_for(fields);
+    let construction = construction_for_fields(field_names, fields);
 
     quote! {
         fn load<Instance>(
@@ -35,7 +29,8 @@ pub fn derive_for_struct(fields: &Fields) -> TokenStream {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            #( #load_fields )*
+            let #fields_hlist_binding =
+                <#fields_hlist_type as linera_witty::WitLoad>::load(memory, location)?;
 
             Ok(Self #construction)
         }
@@ -49,43 +44,22 @@ pub fn derive_for_struct(fields: &Fields) -> TokenStream {
             <Instance::Runtime as linera_witty::Runtime>::Memory:
                 linera_witty::RuntimeMemory<Instance>,
         {
-            #( #lift_fields )*
+            let #fields_hlist_binding =
+                <#fields_hlist_type as linera_witty::WitLoad>::lift_from(flat_layout, memory)?;
 
             Ok(Self #construction)
         }
     }
 }
 
-/// Returns an iterator over the names and types of the provided `fields`.
-fn field_names_and_types(
-    fields: &Fields,
-) -> impl Iterator<Item = (Ident, TokenStream)> + Clone + '_ {
-    let field_names = fields.iter().enumerate().map(|(index, field)| {
+/// Returns an iterator over the names of the provided `fields`.
+fn field_names(fields: &Fields) -> impl Iterator<Item = Ident> + Clone + '_ {
+    fields.iter().enumerate().map(|(index, field)| {
         field
             .ident
             .as_ref()
             .cloned()
             .unwrap_or_else(|| format_ident!("field{index}"))
-    });
-
-    let field_types = fields.iter().map(|field| field.ty.to_token_stream());
-
-    field_names.zip(field_types)
-}
-
-/// Returns the code generated to load a single field.
-///
-/// Assumes that `location` points to where the field starts in memory, and advances it to the end
-/// of the field. A binding with the field name is created in the generated code.
-fn loads_for_fields(
-    field_names_and_types: impl Iterator<Item = (Ident, TokenStream)> + Clone,
-) -> impl Iterator<Item = TokenStream> {
-    field_names_and_types.map(|(field_name, field_type)| {
-        quote! {
-            location = location.after_padding_for::<#field_type>();
-            let #field_name = <#field_type as linera_witty::WitLoad>::load(memory, location)?;
-            location = location.after::<#field_type>();
-        }
     })
 }
 
@@ -93,11 +67,9 @@ fn loads_for_fields(
 ///
 /// Assumes that bindings were created with the field names.
 fn construction_for_fields(
-    field_names_and_types: impl Iterator<Item = (Ident, TokenStream)>,
+    field_names: impl Iterator<Item = Ident>,
     fields: &Fields,
 ) -> TokenStream {
-    let field_names = field_names_and_types.map(|(name, _)| name);
-
     match fields {
         Fields::Unit => quote! {},
         Fields::Named(_) => quote! { { #( #field_names ),* } },

--- a/linera-witty-macros/src/wit_type.rs
+++ b/linera-witty-macros/src/wit_type.rs
@@ -3,53 +3,22 @@
 
 //! Derivation of the `WitType` trait.
 
+use crate::util::hlist_type_for;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Fields, Type};
+use syn::Fields;
+
+#[path = "unit_tests/wit_type.rs"]
+mod tests;
 
 /// Returns the body of the `WitType` implementation for the Rust `struct` with the specified
 /// `fields`.
 pub fn derive_for_struct(fields: &Fields) -> TokenStream {
-    let field_types = fields.iter().map(|field| &field.ty);
-    let size = struct_size_calculation(field_types.clone(), &quote! { 0 });
-    let layout = struct_layout_type(field_types);
+    let fields_hlist = hlist_type_for(fields);
 
     quote! {
-        const SIZE: u32 = #size;
+        const SIZE: u32 = <#fields_hlist as linera_witty::WitType>::SIZE;
 
-        type Layout = #layout;
+        type Layout = <#fields_hlist as linera_witty::WitType>::Layout;
     }
-}
-
-/// Returns an expression that calculates the size in memory of the sequence of `field_types`.
-fn struct_size_calculation<'fields>(
-    field_types: impl Iterator<Item = &'fields Type>,
-    prefix_size: &TokenStream,
-) -> TokenStream {
-    let field_size_calculations = field_types.map(|field_type| {
-        quote! {
-            let field_alignment =
-                <<#field_type as linera_witty::WitType>::Layout as linera_witty::Layout>::ALIGNMENT;
-            let field_size = <#field_type as linera_witty::WitType>::SIZE;
-            let padding = (-(size as i32) & (field_alignment as i32 - 1)) as u32;
-
-            size += padding;
-            size += field_size;
-        }
-    });
-
-    quote! {{
-        let mut size = #prefix_size;
-        #(#field_size_calculations)*
-        size
-    }}
-}
-
-/// Returns the layout type for the sequence of `field_types`.
-fn struct_layout_type<'fields>(field_types: impl Iterator<Item = &'fields Type>) -> TokenStream {
-    field_types.fold(quote! { linera_witty::HNil }, |current, field_type| {
-        quote! {
-            <#current as std::ops::Add<<#field_type as linera_witty::WitType>::Layout>>::Output
-        }
-    })
 }

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -28,6 +28,6 @@ pub use self::{
     type_traits::{WitLoad, WitStore, WitType},
     util::Split,
 };
-pub use frunk::{hlist, hlist::HList, HList, HNil};
+pub use frunk::{hlist, hlist::HList, hlist_pat, HList, HNil};
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::{WitLoad, WitStore, WitType};


### PR DESCRIPTION
## Motivation

The code generated by Witty derive macros is non-trivial and is mostly equivalent to the implementation for `frunk`'s heterogeneous lists.

## Proposal

Refactor the Witty derive macros to generate code that use heterogeneous lists instead of code to manually handle each field in a type. This reduces the amount of code generated, centralizes the more complex code in the implementations for `frunk` types and hopefully improves readability of the generated code.

## Test Plan

The unit and integration tests that already exist cover the behavior which the refactoring must not change.

## Links

This is an unexpected extra work related to of #906.
<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
