### PR TITLE
Make round number a u32.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -61,7 +61,7 @@ pub struct BlockHeight(pub u64);
 #[derive(
     Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
 )]
-pub struct RoundNumber(pub u64);
+pub struct RoundNumber(pub u32);
 
 /// A timestamp, in microseconds since the Unix epoch.
 #[derive(
@@ -258,7 +258,7 @@ macro_rules! impl_wrapped_number {
 
 impl_wrapped_number!(Amount, u128);
 impl_wrapped_number!(BlockHeight, u64);
-impl_strictly_wrapped_number!(RoundNumber, u64);
+impl_strictly_wrapped_number!(RoundNumber, u32);
 
 impl fmt::Display for Amount {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -362,7 +362,7 @@ impl std::str::FromStr for RoundNumber {
     type Err = std::num::ParseIntError;
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        Ok(Self(u64::from_str(src)?))
+        Ok(Self(u32::from_str(src)?))
     }
 }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -151,7 +151,7 @@ message LiteCertificate {
   bytes hash = 2;
 
   // The round in which the value was certified.
-  uint64 round = 3;
+  uint32 round = 3;
 
   // Signatures on the value hash and round
   bytes signatures = 4;
@@ -171,7 +171,7 @@ message Certificate {
   bytes value = 2;
 
   // The round in which the value was certified.
-  uint64 round = 3;
+  uint32 round = 3;
 
   // Signatures on the value hash and round
   bytes signatures = 4;

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -558,7 +558,7 @@ Recipient:
         NEWTYPE:
           TYPENAME: Account
 RoundNumber:
-  NEWTYPESTRUCT: U64
+  NEWTYPESTRUCT: U32
 RpcMessage:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

In practice, the upper 32 bits of a 64-bit round number will always be zero. Even with one round per second, 2<sup>32</sup> rounds would be 136 years. Since round lengths are increasing, `u32::MAX` should be unreachable in practice.

## Proposal

Make round numbers `u32` instead of `u64`.

## Test Plan

Current tests use round numbers up to 2.
In the future, tests for the BFT protocols will probably exercise higher round numbers. It's not feasible to have a test that goes through 2<sup>32</sup> rounds, though.

## Release Plan

It changes the protocol format. But at this stage of development, I'm not sure if that requires a version bump?

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
