### PR TITLE
Ignore invalid notifications.

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -306,7 +306,7 @@ where
         &mut self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let mut node = self.node.lock().await;
+        let node = self.node.lock().await;
         // In local nodes, we can trust fully_handle_certificate to carry all actions eventually.
         let (response, _actions) = node.state.handle_chain_info_query(query).await?;
         Ok(response)

--- a/linera-core/src/tracker.rs
+++ b/linera-core/src/tracker.rs
@@ -14,6 +14,21 @@ pub struct NotificationTracker {
 }
 
 impl NotificationTracker {
+    /// Returns whether the `Notification` has a higher `BlockHeight` than any previously
+    /// seen `Notification`.
+    pub fn is_new(&mut self, notification: &Notification) -> bool {
+        match &notification.reason {
+            Reason::NewBlock { height, .. } => self
+                .new_block
+                .get(&notification.chain_id)
+                .map_or(true, |prev_height| height > prev_height),
+            Reason::NewIncomingMessage { height, origin } => self
+                .new_message
+                .get(&(notification.chain_id, origin.clone()))
+                .map_or(true, |prev_height| height > prev_height),
+        }
+    }
+
     /// Adds a `Notification` to the `Tracker`.
     ///
     /// If the `Notification` has a higher `BlockHeight` than any previously seen `Notification`

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -214,7 +214,7 @@ where
         query: ChainInfoQuery,
         sender: oneshot::Sender<Result<ChainInfoResponse, NodeError>>,
     ) -> Result<(), Result<ChainInfoResponse, NodeError>> {
-        let mut validator = self.client.lock().await;
+        let validator = self.client.lock().await;
         let result = validator.state.handle_chain_info_query(query).await;
         // In a local node cross-chain messages can't get lost, so we can ignore the actions here.
         sender.send(result.map_err(Into::into).map(|(info, _actions)| info))

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -82,7 +82,7 @@ pub trait ValidatorWorker {
 
     /// Handles information queries on chains.
     async fn handle_chain_info_query(
-        &mut self,
+        &self,
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError>;
 
@@ -398,7 +398,7 @@ where
     }
 
     async fn create_cross_chain_request(
-        &mut self,
+        &self,
         confirmed_log: &mut LogView<Client::Context, CryptoHash>,
         height_map: Vec<(Medium, Vec<BlockHeight>)>,
         sender: ChainId,
@@ -423,7 +423,7 @@ where
 
     /// Loads pending cross-chain requests.
     async fn create_network_actions(
-        &mut self,
+        &self,
         chain: &mut ChainStateView<Client::Context>,
     ) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
@@ -984,7 +984,7 @@ where
         chain_id = format!("{:.8}", query.chain_id)
     ))]
     async fn handle_chain_info_query(
-        &mut self,
+        &self,
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);


### PR DESCRIPTION
## Motivation

If an invalid notification with a high block number gets added to the tracker, other, valid, notifications get ignored, and the client fails to update its chains.

`NewBlock` notifications with a correct height but a wrong block hash.

## Proposal

Don't add invalid notifications to the tracker, and filter out `NewBlock` notifications with a wrong hash.

## Test Plan

Notifications are already tested and this doesn't break the tests. However, testing invalid notifications would require implementing malicious test validators, which we also don't do for other (more complex) scenarios yet.

## Release Plan


- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
