### PR TITLE
Add support for Wasmer in Witty

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,6 +72,10 @@ jobs:
         cd examples
         CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=../target/debug/test-runner cargo test --target wasm32-unknown-unknown
         cargo test --locked --target x86_64-unknown-linux-gnu
+    - name: Run Witty integration tests
+      run: |
+        cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
+        cargo test -p linera-witty --features wasmer
 
   lint:
     runs-on: ubuntu-latest-4-cores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
  "async-trait",
  "axum-core",
  "base64 0.21.0",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "headers",
@@ -727,7 +727,7 @@ version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -761,6 +761,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -956,7 +962,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -969,7 +975,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "textwrap 0.16.0",
@@ -1388,7 +1394,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",
@@ -1677,7 +1683,7 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "proc-macro-error",
@@ -2266,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -2298,6 +2304,9 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3077,7 +3086,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f8f5fb82f0ee75fc78652787ac487ff788020236538ec6b04351e647c52067"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "linera-wit-bindgen-guest-rust-macro",
 ]
 
@@ -3100,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b21ae41a07f0b8ec5aaa1edd8d3fdb49e7207d5fe356ebebc2f73cbf2175be2f"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "linera-wit-bindgen-host-wasmer-rust-macro",
  "once_cell",
  "thiserror",
@@ -3126,7 +3135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd05705632cc00e6407a260bb40d4ae338bacdb9d3b227b7a3ca1faddccea09d"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "linera-wit-bindgen-host-wasmtime-rust-macro",
  "thiserror",
  "wasmtime",
@@ -3180,6 +3189,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "linera-witty-test-modules"
+version = "0.1.0"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3694,7 +3710,7 @@ version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4007,7 +4023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -4110,7 +4126,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -4257,7 +4273,7 @@ version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4288,7 +4304,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4297,7 +4313,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -4375,7 +4391,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "mach",
  "winapi",
@@ -4505,7 +4521,7 @@ version = "0.35.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.2.8",
  "io-lifetimes 0.7.5",
  "libc",
@@ -4519,7 +4535,7 @@ version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno 0.3.1",
  "io-lifetimes 1.0.10",
  "libc",
@@ -4694,7 +4710,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5651,7 +5667,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6061,6 +6077,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e5156581ff4a302405c44ca7c85347563ca431d15f1a773f12c9c7b9a6cdc9"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "wasm-encoder 0.29.0",
+ "wasmparser 0.107.0",
+]
+
+[[package]]
 name = "wasmer"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6234,6 +6272,16 @@ checksum = "bf2f22ef84ac5666544afa52f326f13e16f3d019d2e61e704fd8091c9358b130"
 dependencies = [
  "indexmap",
  "url",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
+dependencies = [
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -6775,6 +6823,96 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a628591b3905328e886462f75de3b2af1e546b19af5f4c359086b26bec29c4bd"
+dependencies = [
+ "bitflags 2.3.3",
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a19aa69c4f33cb5ac10e55880a899f4d52ec85d4cde4d593b575e7a97e2b08"
+dependencies = [
+ "anyhow",
+ "wit-component",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a50274c0cf2f8e33fc967825cef0114cdfe222d474c1d78aa77a6a801abaadf"
+dependencies = [
+ "heck 0.4.1",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-bindgen-rust-lib",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-lib"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3d58b5ced269f1a1cdcecfe0317c059fe158da9b670fff9907903b244bb89a"
+dependencies = [
+ "heck 0.4.1",
+ "wit-bindgen-core",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cce32dd08007af45dbaa00e225eb73d05524096f93933d7ecba852d50d8af3"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "syn 2.0.15",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cbd4c7f8f400327c482c88571f373844b7889e61460650d650fc5881bb3575c"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "indexmap",
+ "log",
+ "wasm-encoder 0.29.0",
+ "wasm-metadata",
+ "wasmparser 0.107.0",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6daec9f093dbaea0e94043eeb92ece327bbbe70c86b1f41aca9bbfefd7f050f0"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "pulldown-cmark",
+ "semver",
+ "unicode-xid",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "wasmer",
+ "wasmer-vm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3167,6 +3167,7 @@ dependencies = [
  "linera-witty-macros",
  "test-case",
  "thiserror",
+ "wasmer",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
         "linera-views",
         "linera-views-derive",
         "linera-witty",
+        "linera-witty/test-modules",
         "linera-witty-macros",
         "linera-explorer",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
 wasm-encoder = "0.24.1"
 wasmer = { version = "=3.1.1", features = ["singlepass"] }
 wasmer-middlewares = "3.1.1"
+wasmer-vm = { version = "=3.1.1" }
 wasmparser = "0.101.1"
 wasmtime = "1.0"
 wit-bindgen-guest-rust = { version = "0.2.0", package = "linera-wit-bindgen-guest-rust" }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -14,13 +14,14 @@ edition = "2021"
 default = ["macros"]
 macros = ["linera-witty-macros"]
 test = []
-wasmer = []
+wasmer = ["dep:wasmer"]
 
 [dependencies]
 either = { workspace = true }
 frunk = { workspace = true }
 linera-witty-macros = { workspace = true, optional = true }
 thiserror = { workspace = true }
+wasmer = { workspace = true, optional = true }
 
 [dev-dependencies]
 linera-witty = { workspace = true, features = ["macros", "test"] }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 default = ["macros"]
 macros = ["linera-witty-macros"]
 test = []
+wasmer = []
 
 [dependencies]
 either = { workspace = true }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 default = ["macros"]
 macros = ["linera-witty-macros"]
 test = []
-wasmer = ["dep:wasmer"]
+wasmer = ["dep:wasmer", "wasmer-vm"]
 
 [dependencies]
 either = { workspace = true }
@@ -22,6 +22,7 @@ frunk = { workspace = true }
 linera-witty-macros = { workspace = true, optional = true }
 thiserror = { workspace = true }
 wasmer = { workspace = true, optional = true }
+wasmer-vm = { workspace = true, optional = true }
 
 [dev-dependencies]
 linera-witty = { workspace = true, features = ["macros", "test"] }

--- a/linera-witty/src/imported_function_interface/parameters.rs
+++ b/linera-witty/src/imported_function_interface/parameters.rs
@@ -3,14 +3,17 @@
 
 //! Representation of the parameters of an imported function.
 //!
-//! The host parameters type is flattened and if it's made up of 16 or less flat types, they are
-//! sent directly as the guest's function parameters. If there are more than 16 flat types, then
-//! the host type is instead stored in a heap allocated region of memory, and the address to that
-//! region is sent as a parameter instead.
+//! The maximum number of parameters that can be used in a WIT function is defined by the
+//! [canonical ABI][flattening] as the `MAX_FLAT_PARAMS` constant (16). There is no equivalent
+//! constant defined in Witty. Instead, any attempt to use more than the limit should lead to a
+//! compiler error.
 //!
-//! See the [canonical ABI's section on
-//! flattening](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening)
-//! for more details.
+//! The host parameters type is flattened and if it's made up of `MAX_FLAT_PARAMS` or less flat
+//! types, they are sent directly as the guest's function parameters. If there are more than
+//! `MAX_FLAT_PARAMS` flat types, then the host type is instead stored in a heap allocated region
+//! of memory, and the address to that region is sent as a parameter instead.
+//!
+//! [flattening]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
 
 use crate::{
     memory_layout::FlatLayout, primitive_types::FlatType, InstanceWithMemory, Layout, Memory,
@@ -72,9 +75,11 @@ repeat_macro!(direct_parameters => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, 
 /// Implementation of [`FlatHostParameters`] for parameters that are sent to the guest through the
 /// heap.
 ///
-/// When more than 16 function parameters are needed, they are spilled over into a heap memory
-/// allocation and the only parameter sent as a function parameter is the address to that
-/// allocation.
+/// The maximum number of parameters is defined by the [canonical
+/// ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening)
+/// as the `MAX_FLAT_PARAMS` constant. When more than `MAX_FLAT_PARAMS` (16) function parameters
+/// are needed, they are spilled over into a heap memory allocation and the only parameter sent as
+/// a function parameter is the address to that allocation.
 impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Tail> FlatHostParameters for HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...Tail]
 where
     A: FlatType,

--- a/linera-witty/src/imported_function_interface/results.rs
+++ b/linera-witty/src/imported_function_interface/results.rs
@@ -11,9 +11,11 @@
 //! then the results type is stored in a heap allocated memory region instead, and the address to
 //! that region is returned as a value from the function.
 //!
-//! See the [canonical ABI's section on
+//! This is determined by the `MAX_FLAT_RESULTS` in the [canonical ABI's section on
 //! flattening](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening)
-//! for more details.
+//! and has the value of `1`. There is no equivalent constant in Witty. Instead, the
+//! [`FlatHostResults`] implementations automatically handle flat layouts with more or less
+//! elements than the limit.
 
 use crate::{
     memory_layout::FlatLayout, primitive_types::FlatType, GuestPointer, InstanceWithMemory, Layout,

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -21,6 +21,8 @@ mod runtime;
 mod type_traits;
 mod util;
 
+#[cfg(feature = "wasmer")]
+pub use self::runtime::wasmer;
 #[cfg(any(test, feature = "test"))]
 pub use self::runtime::{MockExportedFunction, MockInstance, MockRuntime};
 pub use self::{

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -53,4 +53,9 @@ pub enum RuntimeError {
     #[cfg(feature = "wasmer")]
     #[error(transparent)]
     Wasmer(#[from] wasmer::RuntimeError),
+
+    /// Attempt to access an invalid memory address using Wasmer.
+    #[cfg(feature = "wasmer")]
+    #[error(transparent)]
+    WasmerMemory(#[from] wasmer::MemoryAccessError),
 }

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -48,4 +48,9 @@ pub enum RuntimeError {
     /// Attempt to load an `enum` type but the discriminant doesn't match any of the variants.
     #[error("Unexpected variant discriminant")]
     InvalidVariant,
+
+    /// Wasmer runtime error.
+    #[cfg(feature = "wasmer")]
+    #[error(transparent)]
+    Wasmer(#[from] wasmer::RuntimeError),
 }

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -8,6 +8,8 @@ mod memory;
 #[cfg(any(test, feature = "test"))]
 mod test;
 mod traits;
+#[cfg(feature = "wasmer")]
+pub mod wasmer;
 
 #[cfg(any(test, feature = "test"))]
 pub use self::test::{MockExportedFunction, MockInstance, MockRuntime};

--- a/linera-witty/src/runtime/wasmer/function.rs
+++ b/linera-witty/src/runtime/wasmer/function.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of [`InstanceWithFunction`] for Wasmer instances.
+
+use super::{parameters::WasmerParameters, results::WasmerResults, EntrypointInstance};
+use crate::{
+    memory_layout::FlatLayout, primitive_types::FlatType, InstanceWithFunction, Runtime,
+    RuntimeError,
+};
+use frunk::{hlist_pat, HList};
+use wasmer::{AsStoreRef, Extern, FromToNativeWasmType, TypedFunction};
+
+/// Implements [`InstanceWithFunction`] for functions with the provided amount of parameters.
+macro_rules! impl_instance_with_function {
+    ($( $names:ident : $types:ident ),*) => {
+        impl<$( $types, )* Results> InstanceWithFunction<HList![$( $types ),*], Results>
+            for EntrypointInstance
+        where
+            $( $types: FlatType + FromToNativeWasmType, )*
+            Results: FlatLayout + WasmerResults,
+        {
+            type Function = TypedFunction<
+                <HList![$( $types ),*] as WasmerParameters>::ImportParameters,
+                <Results as WasmerResults>::Results,
+            >;
+
+            fn function_from_export(
+                &mut self,
+                export: <Self::Runtime as Runtime>::Export,
+            ) -> Result<Option<Self::Function>, RuntimeError> {
+                Ok(match export {
+                    Extern::Function(function) => Some(function.typed(&self.as_store_ref())?),
+                    _ => None,
+                })
+            }
+
+            fn call(
+                &mut self,
+                function: &Self::Function,
+                hlist_pat![$( $names ),*]: HList![$( $types ),*],
+            ) -> Result<Results, RuntimeError> {
+                let results = function.call(&mut *self, $( $names ),*)?;
+
+                Ok(Results::from_wasmer(results))
+            }
+        }
+    };
+}
+
+repeat_macro!(impl_instance_with_function =>
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P
+);

--- a/linera-witty/src/runtime/wasmer/memory.rs
+++ b/linera-witty/src/runtime/wasmer/memory.rs
@@ -3,45 +3,52 @@
 
 //! How to access the memory of a Wasmer guest instance.
 
-use super::{super::traits::InstanceWithMemory, EntrypointInstance};
+use super::{super::traits::InstanceWithMemory, EntrypointInstance, ReentrantInstance};
 use crate::{GuestPointer, RuntimeError, RuntimeMemory};
 use std::borrow::Cow;
 use wasmer::{Extern, Memory};
 
-impl InstanceWithMemory for EntrypointInstance {
-    fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
-        Ok(match export {
-            Extern::Memory(memory) => Some(memory),
-            _ => None,
-        })
-    }
+macro_rules! impl_memory_traits {
+    ($instance:ty) => {
+        impl InstanceWithMemory for $instance {
+            fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
+                Ok(match export {
+                    Extern::Memory(memory) => Some(memory),
+                    _ => None,
+                })
+            }
+        }
+
+        impl RuntimeMemory<$instance> for Memory {
+            fn read<'instance>(
+                &self,
+                instance: &'instance $instance,
+                location: GuestPointer,
+                length: u32,
+            ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
+                let mut buffer = vec![0u8; length as usize];
+                let start = location.0 as u64;
+
+                self.view(instance).read(start, &mut buffer)?;
+
+                Ok(Cow::Owned(buffer))
+            }
+
+            fn write(
+                &mut self,
+                instance: &mut $instance,
+                location: GuestPointer,
+                bytes: &[u8],
+            ) -> Result<(), RuntimeError> {
+                let start = location.0 as u64;
+
+                self.view(&*instance).write(start, bytes)?;
+
+                Ok(())
+            }
+        }
+    };
 }
 
-impl RuntimeMemory<EntrypointInstance> for Memory {
-    fn read<'instance>(
-        &self,
-        instance: &'instance EntrypointInstance,
-        location: GuestPointer,
-        length: u32,
-    ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
-        let mut buffer = vec![0u8; length as usize];
-        let start = location.0 as u64;
-
-        self.view(instance).read(start, &mut buffer)?;
-
-        Ok(Cow::Owned(buffer))
-    }
-
-    fn write(
-        &mut self,
-        instance: &mut EntrypointInstance,
-        location: GuestPointer,
-        bytes: &[u8],
-    ) -> Result<(), RuntimeError> {
-        let start = location.0 as u64;
-
-        self.view(&*instance).write(start, bytes)?;
-
-        Ok(())
-    }
-}
+impl_memory_traits!(EntrypointInstance);
+impl_memory_traits!(ReentrantInstance<'_>);

--- a/linera-witty/src/runtime/wasmer/memory.rs
+++ b/linera-witty/src/runtime/wasmer/memory.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! How to access the memory of a Wasmer guest instance.
+
+use super::{super::traits::InstanceWithMemory, EntrypointInstance};
+use crate::{GuestPointer, RuntimeError, RuntimeMemory};
+use std::borrow::Cow;
+use wasmer::{Extern, Memory};
+
+impl InstanceWithMemory for EntrypointInstance {
+    fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
+        Ok(match export {
+            Extern::Memory(memory) => Some(memory),
+            _ => None,
+        })
+    }
+}
+
+impl RuntimeMemory<EntrypointInstance> for Memory {
+    fn read<'instance>(
+        &self,
+        instance: &'instance EntrypointInstance,
+        location: GuestPointer,
+        length: u32,
+    ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
+        let mut buffer = vec![0u8; length as usize];
+        let start = location.0 as u64;
+
+        self.view(instance).read(start, &mut buffer)?;
+
+        Ok(Cow::Owned(buffer))
+    }
+
+    fn write(
+        &mut self,
+        instance: &mut EntrypointInstance,
+        location: GuestPointer,
+        bytes: &[u8],
+    ) -> Result<(), RuntimeError> {
+        let start = location.0 as u64;
+
+        self.view(&*instance).write(start, bytes)?;
+
+        Ok(())
+    }
+}

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -4,6 +4,7 @@
 //! Support for the [Wasmer](https://wasmer.io) runtime.
 
 use super::traits::Runtime;
+use std::sync::{Arc, Mutex};
 use wasmer::{Extern, Memory};
 
 /// Representation of the [Wasmer](https://wasmer.io) runtime.
@@ -12,4 +13,35 @@ pub struct Wasmer;
 impl Runtime for Wasmer {
     type Export = Extern;
     type Memory = Memory;
+}
+
+/// A slot to store a [`wasmer::Instance`] in a way that can be shared with reentrant calls.
+#[derive(Clone)]
+pub struct InstanceSlot {
+    instance: Arc<Mutex<Option<wasmer::Instance>>>,
+}
+
+impl InstanceSlot {
+    /// Creates a new [`InstanceSlot`] using the optionally provided `instance`.
+    fn new(instance: impl Into<Option<wasmer::Instance>>) -> Self {
+        InstanceSlot {
+            instance: Arc::new(Mutex::new(instance.into())),
+        }
+    }
+
+    /// Loads an export from the current instance.
+    ///
+    /// # Panics
+    ///
+    /// If the underlying instance is accessed concurrently or if the slot is empty.
+    fn load_export(&mut self, name: &str) -> Option<Extern> {
+        self.instance
+            .try_lock()
+            .expect("Unexpected reentrant access to data")
+            .as_mut()
+            .expect("Unexpected attempt to load an export before instance is created")
+            .exports
+            .get_extern(name)
+            .cloned()
+    }
 }

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -3,6 +3,7 @@
 
 //! Support for the [Wasmer](https://wasmer.io) runtime.
 
+mod parameters;
 mod results;
 
 use super::traits::{Instance, Runtime};

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -3,6 +3,7 @@
 
 //! Support for the [Wasmer](https://wasmer.io) runtime.
 
+mod function;
 mod parameters;
 mod results;
 

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -4,6 +4,7 @@
 //! Support for the [Wasmer](https://wasmer.io) runtime.
 
 mod function;
+mod memory;
 mod parameters;
 mod results;
 

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -3,6 +3,8 @@
 
 //! Support for the [Wasmer](https://wasmer.io) runtime.
 
+mod results;
+
 use super::traits::{Instance, Runtime};
 use std::sync::{Arc, Mutex};
 use wasmer::{

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Support for the [Wasmer](https://wasmer.io) runtime.
+
+use super::traits::Runtime;
+use wasmer::{Extern, Memory};
+
+/// Representation of the [Wasmer](https://wasmer.io) runtime.
+pub struct Wasmer;
+
+impl Runtime for Wasmer {
+    type Export = Extern;
+    type Memory = Memory;
+}

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -11,8 +11,8 @@ mod results;
 use super::traits::{Instance, Runtime};
 use std::sync::{Arc, Mutex};
 use wasmer::{
-    AsStoreMut, AsStoreRef, Engine, Extern, FunctionEnv, Imports, InstantiationError, Memory,
-    Module, Store, StoreMut, StoreRef,
+    AsStoreMut, AsStoreRef, Engine, Extern, FunctionEnv, FunctionEnvMut, Imports,
+    InstantiationError, Memory, Module, Store, StoreMut, StoreRef,
 };
 use wasmer_vm::StoreObjects;
 
@@ -106,6 +106,18 @@ impl Instance for EntrypointInstance {
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         self.instance.load_export(name)
+    }
+}
+
+/// Alias for the [`Instance`] implementation made available inside host functions called by the
+/// guest.
+pub type ReentrantInstance<'a> = FunctionEnvMut<'a, InstanceSlot>;
+
+impl Instance for ReentrantInstance<'_> {
+    type Runtime = Wasmer;
+
+    fn load_export(&mut self, name: &str) -> Option<Extern> {
+        self.data_mut().load_export(name)
     }
 }
 

--- a/linera-witty/src/runtime/wasmer/parameters.rs
+++ b/linera-witty/src/runtime/wasmer/parameters.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of Wasmer function parameter types.
+
+use crate::{memory_layout::FlatLayout, primitive_types::FlatType};
+use frunk::{hlist, hlist_pat, HList};
+use wasmer::FromToNativeWasmType;
+
+/// Conversions between flat layouts and Wasmer parameter types.
+pub trait WasmerParameters: FlatLayout {
+    /// The type Wasmer uses to represent the parameters in a function imported from a guest.
+    type ImportParameters;
+
+    /// The type Wasmer uses to represent the parameters in a function exported from a host.
+    type ExportParameters;
+
+    /// Converts from this flat layout into Wasmer's representation for functions imported from a
+    /// guest.
+    fn into_wasmer(self) -> Self::ImportParameters;
+
+    /// Converts from Wasmer's representation for functions exported from the host into this flat
+    /// layout.
+    fn from_wasmer(parameters: Self::ExportParameters) -> Self;
+}
+
+impl WasmerParameters for HList![] {
+    type ImportParameters = ();
+    type ExportParameters = ();
+
+    fn into_wasmer(self) -> Self::ImportParameters {}
+
+    fn from_wasmer((): Self::ExportParameters) -> Self {
+        hlist![]
+    }
+}
+
+impl<Parameter> WasmerParameters for HList![Parameter]
+where
+    Parameter: FlatType + FromToNativeWasmType,
+{
+    type ImportParameters = Parameter;
+    type ExportParameters = (Parameter,);
+
+    #[allow(clippy::unused_unit)]
+    fn into_wasmer(self) -> Self::ImportParameters {
+        let hlist_pat![parameter] = self;
+
+        parameter
+    }
+
+    fn from_wasmer((parameter,): Self::ExportParameters) -> Self {
+        hlist![parameter]
+    }
+}
+
+/// Helper macro to implement [`WasmerParameters`] for flat layouts up to the maximum limit.
+///
+/// The maximum number of parameters is defined by the [canonical
+/// ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening)
+/// as the `MAX_FLAT_PARAMS` constant.
+macro_rules! parameters {
+    ($( $names:ident : $types:ident ),*) => {
+        impl<$( $types ),*> WasmerParameters for HList![$( $types ),*]
+        where
+            $( $types: FlatType + FromToNativeWasmType, )*
+        {
+            type ImportParameters = ($( $types, )*);
+            type ExportParameters = ($( $types, )*);
+
+            #[allow(clippy::unused_unit)]
+            fn into_wasmer(self) -> Self::ImportParameters {
+                let hlist_pat![$( $names ),*] = self;
+
+                ($( $names, )*)
+            }
+
+            fn from_wasmer(($( $names, )*): Self::ExportParameters) -> Self {
+                hlist![$( $names ),*]
+            }
+        }
+    };
+}
+
+repeat_macro!(parameters =>
+    a: A,
+    b: B |
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P
+);

--- a/linera-witty/src/runtime/wasmer/parameters.rs
+++ b/linera-witty/src/runtime/wasmer/parameters.rs
@@ -58,7 +58,11 @@ where
 ///
 /// The maximum number of parameters is defined by the [canonical
 /// ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening)
-/// as the `MAX_FLAT_PARAMS` constant.
+/// as the `MAX_FLAT_PARAMS` constant. There is no equivalent constant defined in Witty. Instead,
+/// any attempt to use more than the limit should lead to a compiler error. Therefore, this macro
+/// only implements the trait up to the limit. The same is done in other parts of the code, like
+/// for example in
+/// [`FlatHostParameters`][`crate::imported_function_interface::FlatHostParameters`].
 macro_rules! parameters {
     ($( $names:ident : $types:ident ),*) => {
         impl<$( $types ),*> WasmerParameters for HList![$( $types ),*]

--- a/linera-witty/src/runtime/wasmer/results.rs
+++ b/linera-witty/src/runtime/wasmer/results.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of Wasmer function result types.
+
+use crate::{memory_layout::FlatLayout, primitive_types::FlatType};
+use frunk::{hlist, hlist_pat, HList};
+use wasmer::{FromToNativeWasmType, WasmTypeList};
+
+/// Conversions between flat layouts and Wasmer function result types.
+pub trait WasmerResults: FlatLayout {
+    /// The type Wasmer uses to represent the results.
+    type Results: WasmTypeList;
+
+    /// Converts from Wasmer's representation into a flat layout.
+    fn from_wasmer(results: Self::Results) -> Self;
+
+    /// Converts from this flat layout into Wasmer's representation.
+    fn into_wasmer(self) -> Self::Results;
+}
+
+impl WasmerResults for HList![] {
+    type Results = ();
+
+    fn from_wasmer((): Self::Results) -> Self::Flat {
+        hlist![]
+    }
+
+    fn into_wasmer(self) -> Self::Results {}
+}
+
+impl<T> WasmerResults for HList![T]
+where
+    T: FlatType + FromToNativeWasmType,
+{
+    type Results = T;
+
+    fn from_wasmer(value: Self::Results) -> Self {
+        hlist![value]
+    }
+
+    fn into_wasmer(self) -> Self::Results {
+        let hlist_pat![value] = self;
+        value
+    }
+}

--- a/linera-witty/test-modules/Cargo.toml
+++ b/linera-witty/test-modules/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "linera-witty-test-modules"
+description = "Generation of WIT compatible host code from Rust code"
+authors = ["Linera <contact@linera.io>"]
+repository = "https://github.com/linera-io/linera-protocol"
+homepage = "https://linera.io"
+license = "Apache-2.0"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "export-simple-function"
+path = "src/export/simple_function.rs"
+
+[[bin]]
+name = "export-getters"
+path = "src/export/getters.rs"
+
+[[bin]]
+name = "export-setters"
+path = "src/export/setters.rs"
+
+[[bin]]
+name = "export-operations"
+path = "src/export/operations.rs"
+
+[dependencies]
+wit-bindgen = { version = "0.7.0", features = ["macros"] }

--- a/linera-witty/test-modules/src/export/getters.rs
+++ b/linera-witty/test-modules/src/export/getters.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module with some functions that have no parameters but return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("export-getters");
+
+export_export_getters!(Implementation);
+
+use self::exports::witty_macros::test_modules::getters::Getters;
+
+struct Implementation;
+
+impl Getters for Implementation {
+    fn get_true() -> bool {
+        true
+    }
+
+    fn get_false() -> bool {
+        false
+    }
+
+    fn get_s8() -> i8 {
+        -125
+    }
+
+    fn get_u8() -> u8 {
+        200
+    }
+
+    fn get_s16() -> i16 {
+        -410
+    }
+
+    fn get_u16() -> u16 {
+        60_000
+    }
+
+    fn get_s32() -> i32 {
+        -100_000
+    }
+
+    fn get_u32() -> u32 {
+        3_000_111
+    }
+
+    fn get_s64() -> i64 {
+        -5_000_000
+    }
+
+    fn get_u64() -> u64 {
+        10_000_000_000
+    }
+
+    fn get_float32() -> f32 {
+        -0.125
+    }
+
+    fn get_float64() -> f64 {
+        128.25
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/export/operations.rs
+++ b/linera-witty/test-modules/src/export/operations.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module with some functions that have two parameters and one return value.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("export-operations");
+
+export_export_operations!(Implementation);
+
+use self::exports::witty_macros::test_modules::operations::Operations;
+
+struct Implementation;
+
+impl Operations for Implementation {
+    fn and_bool(first: bool, second: bool) -> bool {
+        first && second
+    }
+
+    fn add_s8(first: i8, second: i8) -> i8 {
+        first + second
+    }
+
+    fn add_u8(first: u8, second: u8) -> u8 {
+        first + second
+    }
+
+    fn add_s16(first: i16, second: i16) -> i16 {
+        first + second
+    }
+
+    fn add_u16(first: u16, second: u16) -> u16 {
+        first + second
+    }
+
+    fn add_s32(first: i32, second: i32) -> i32 {
+        first + second
+    }
+
+    fn add_u32(first: u32, second: u32) -> u32 {
+        first + second
+    }
+
+    fn add_s64(first: i64, second: i64) -> i64 {
+        first + second
+    }
+
+    fn add_u64(first: u64, second: u64) -> u64 {
+        first + second
+    }
+
+    fn add_float32(first: f32, second: f32) -> f32 {
+        first + second
+    }
+
+    fn add_float64(first: f64, second: f64) -> f64 {
+        first + second
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/export/setters.rs
+++ b/linera-witty/test-modules/src/export/setters.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module with some functions that have one parameter and no return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("export-setters");
+
+export_export_setters!(Implementation);
+
+use self::exports::witty_macros::test_modules::setters::Setters;
+
+struct Implementation;
+
+impl Setters for Implementation {
+    fn set_bool(_value: bool) {}
+
+    fn set_s8(_value: i8) {}
+
+    fn set_u8(_value: u8) {}
+
+    fn set_s16(_value: i16) {}
+
+    fn set_u16(_value: u16) {}
+
+    fn set_s32(_value: i32) {}
+
+    fn set_u32(_value: u32) {}
+
+    fn set_s64(_value: i64) {}
+
+    fn set_u64(_value: u64) {}
+
+    fn set_float32(_value: f32) {}
+
+    fn set_float64(_value: f64) {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/export/simple_function.rs
+++ b/linera-witty/test-modules/src/export/simple_function.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module with a minimal function without parameters or return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("export-simple-function");
+
+export_export_simple_function!(Implementation);
+
+use self::exports::witty_macros::test_modules::simple_function::SimpleFunction;
+
+struct Implementation;
+
+impl SimpleFunction for Implementation {
+    fn simple() {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/wit/export.wit
+++ b/linera-witty/test-modules/wit/export.wit
@@ -1,0 +1,17 @@
+package witty-macros:test-modules
+
+world export-simple-function {
+    export simple-function
+}
+
+world export-getters {
+    export getters
+}
+
+world export-setters {
+    export setters
+}
+
+world export-operations {
+    export operations
+}

--- a/linera-witty/test-modules/wit/getters.wit
+++ b/linera-witty/test-modules/wit/getters.wit
@@ -1,0 +1,16 @@
+package witty-macros:test-modules
+
+interface getters {
+    get-true: func() -> bool
+    get-false: func() -> bool
+    get-s8: func() -> s8
+    get-u8: func() -> u8
+    get-s16: func() -> s16
+    get-u16: func() -> u16
+    get-s32: func() -> s32
+    get-u32: func() -> u32
+    get-s64: func() -> s64
+    get-u64: func() -> u64
+    get-float32: func() -> float32
+    get-float64: func() -> float64
+}

--- a/linera-witty/test-modules/wit/operations.wit
+++ b/linera-witty/test-modules/wit/operations.wit
@@ -1,0 +1,15 @@
+package witty-macros:test-modules
+
+interface operations {
+    and-bool: func(first: bool, second: bool) -> bool
+    add-s8: func(first: s8, second: s8) -> s8
+    add-u8: func(first: u8, second: u8) -> u8
+    add-s16: func(first: s16, second: s16) -> s16
+    add-u16: func(first: u16, second: u16) -> u16
+    add-s32: func(first: s32, second: s32) -> s32
+    add-u32: func(first: u32, second: u32) -> u32
+    add-s64: func(first: s64, second: s64) -> s64
+    add-u64: func(first: u64, second: u64) -> u64
+    add-float32: func(first: float32, second: float32) -> float32
+    add-float64: func(first: float64, second: float64) -> float64
+}

--- a/linera-witty/test-modules/wit/setters.wit
+++ b/linera-witty/test-modules/wit/setters.wit
@@ -1,0 +1,15 @@
+package witty-macros:test-modules
+
+interface setters {
+    set-bool: func(value: bool)
+    set-s8: func(value: s8)
+    set-u8: func(value: u8)
+    set-s16: func(value: s16)
+    set-u16: func(value: u16)
+    set-s32: func(value: s32)
+    set-u32: func(value: u32)
+    set-s64: func(value: s64)
+    set-u64: func(value: u64)
+    set-float32: func(value: float32)
+    set-float64: func(value: float64)
+}

--- a/linera-witty/test-modules/wit/simple-function.wit
+++ b/linera-witty/test-modules/wit/simple-function.wit
@@ -1,0 +1,5 @@
+package witty-macros:test-modules
+
+interface simple-function {
+    simple: func()
+}

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -8,6 +8,8 @@
 #[path = "common/test_instance.rs"]
 mod test_instance;
 
+#[cfg(feature = "wasmer")]
+use self::test_instance::WasmerInstanceFactory;
 use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
 use linera_witty::{Instance, Runtime, RuntimeMemory};
 use linera_witty_macros::wit_import;
@@ -21,6 +23,7 @@ trait SimpleFunction {
 
 /// Test importing a simple function without parameters or return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -54,6 +57,7 @@ trait Getters {
 
 /// Test importing functions with return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 fn getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -157,6 +161,7 @@ trait Setters {
 
 /// Test importing functions with parameters.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 fn setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -221,6 +226,7 @@ trait Operations {
 
 /// Test importing functions with multiple parameters and return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 fn operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,


### PR DESCRIPTION
## Motivation

The new Witty crate should generate host code that's compatible with the [Wasmer](https://wasmer.io) runtime.

## Proposal

Create a feature gated `wasmer` module in `linera_witty::runtime`, with implementations for the Witty traits. There are two `Instance` implementations, one for newly created instances (`EntrypointInstance`) and one for instances made available inside host functions called by the guest module (`ReentrantInstance`).

## Test Plan

Reuse the integration tests for `wit_import`.

## Links

Part of #906 

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
