### PR TITLE
Add support for Wasmtime in Witty

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Run Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
-        cargo test -p linera-witty --features wasmer
+        cargo test -p linera-witty --features wasmer,wasmtime
 
   lint:
     runs-on: ubuntu-latest-4-cores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,6 +3170,7 @@ dependencies = [
 name = "linera-witty"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "either",
  "frunk",
  "linera-witty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,6 +3178,7 @@ dependencies = [
  "thiserror",
  "wasmer",
  "wasmer-vm",
+ "wasmtime",
 ]
 
 [[package]]

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -15,6 +15,7 @@ default = ["macros"]
 macros = ["linera-witty-macros"]
 test = []
 wasmer = ["dep:wasmer", "wasmer-vm"]
+wasmtime = ["dep:wasmtime"]
 
 [dependencies]
 either = { workspace = true }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -15,9 +15,10 @@ default = ["macros"]
 macros = ["linera-witty-macros"]
 test = []
 wasmer = ["dep:wasmer", "wasmer-vm"]
-wasmtime = ["dep:wasmtime"]
+wasmtime = ["dep:wasmtime", "anyhow"]
 
 [dependencies]
+anyhow = { workspace = true, optional = true }
 either = { workspace = true }
 frunk = { workspace = true }
 linera-witty-macros = { workspace = true, optional = true }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -24,6 +24,7 @@ linera-witty-macros = { workspace = true, optional = true }
 thiserror = { workspace = true }
 wasmer = { workspace = true, optional = true }
 wasmer-vm = { workspace = true, optional = true }
+wasmtime = { workspace = true, optional = true }
 
 [dev-dependencies]
 linera-witty = { workspace = true, features = ["macros", "test"] }

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -23,6 +23,8 @@ mod util;
 
 #[cfg(feature = "wasmer")]
 pub use self::runtime::wasmer;
+#[cfg(feature = "wasmtime")]
+pub use self::runtime::wasmtime;
 #[cfg(any(test, feature = "test"))]
 pub use self::runtime::{MockExportedFunction, MockInstance, MockRuntime};
 pub use self::{

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -58,4 +58,14 @@ pub enum RuntimeError {
     #[cfg(feature = "wasmer")]
     #[error(transparent)]
     WasmerMemory(#[from] wasmer::MemoryAccessError),
+
+    /// Wasmtime error.
+    #[cfg(feature = "wasmtime")]
+    #[error(transparent)]
+    Wasmtime(#[from] anyhow::Error),
+
+    /// Wasmtime trap during execution.
+    #[cfg(feature = "wasmtime")]
+    #[error(transparent)]
+    WasmtimeTrap(#[from] wasmtime::Trap),
 }

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -10,6 +10,8 @@ mod test;
 mod traits;
 #[cfg(feature = "wasmer")]
 pub mod wasmer;
+#[cfg(feature = "wasmtime")]
+pub mod wasmtime;
 
 #[cfg(any(test, feature = "test"))]
 pub use self::test::{MockExportedFunction, MockInstance, MockRuntime};

--- a/linera-witty/src/runtime/wasmtime/function.rs
+++ b/linera-witty/src/runtime/wasmtime/function.rs
@@ -3,37 +3,47 @@
 
 //! Implementations of [`InstanceWithFunction`] for Wasmtime instances.
 
-use super::{parameters::WasmtimeParameters, results::WasmtimeResults, EntrypointInstance};
+use super::{
+    parameters::WasmtimeParameters, results::WasmtimeResults, EntrypointInstance, ReentrantInstance,
+};
 use crate::{memory_layout::FlatLayout, InstanceWithFunction, Runtime, RuntimeError};
 use wasmtime::{AsContext, AsContextMut, Extern, TypedFunc};
 
-impl<Parameters, Results> InstanceWithFunction<Parameters, Results> for EntrypointInstance
-where
-    Parameters: FlatLayout + WasmtimeParameters,
-    Results: FlatLayout + WasmtimeResults,
-{
-    type Function = TypedFunc<
-        <Parameters as WasmtimeParameters>::Parameters,
-        <Results as WasmtimeResults>::Results,
-    >;
+/// Implements [`InstanceWithFunction`] for the Wasmtime [`Instance`] implementations.
+macro_rules! impl_instance_with_function {
+    ($instance:ty) => {
+        impl<Parameters, Results> InstanceWithFunction<Parameters, Results> for $instance
+        where
+            Parameters: FlatLayout + WasmtimeParameters,
+            Results: FlatLayout + WasmtimeResults,
+        {
+            type Function = TypedFunc<
+                <Parameters as WasmtimeParameters>::Parameters,
+                <Results as WasmtimeResults>::Results,
+            >;
 
-    fn function_from_export(
-        &mut self,
-        export: <Self::Runtime as Runtime>::Export,
-    ) -> Result<Option<Self::Function>, RuntimeError> {
-        Ok(match export {
-            Extern::Func(function) => Some(function.typed(self.as_context())?),
-            _ => None,
-        })
-    }
+            fn function_from_export(
+                &mut self,
+                export: <Self::Runtime as Runtime>::Export,
+            ) -> Result<Option<Self::Function>, RuntimeError> {
+                Ok(match export {
+                    Extern::Func(function) => Some(function.typed(self.as_context())?),
+                    _ => None,
+                })
+            }
 
-    fn call(
-        &mut self,
-        function: &Self::Function,
-        parameters: Parameters,
-    ) -> Result<Results, RuntimeError> {
-        let results = function.call(self.as_context_mut(), parameters.into_wasmtime())?;
+            fn call(
+                &mut self,
+                function: &Self::Function,
+                parameters: Parameters,
+            ) -> Result<Results, RuntimeError> {
+                let results = function.call(self.as_context_mut(), parameters.into_wasmtime())?;
 
-        Ok(Results::from_wasmtime(results))
-    }
+                Ok(Results::from_wasmtime(results))
+            }
+        }
+    };
 }
+
+impl_instance_with_function!(EntrypointInstance);
+impl_instance_with_function!(ReentrantInstance<'_>);

--- a/linera-witty/src/runtime/wasmtime/function.rs
+++ b/linera-witty/src/runtime/wasmtime/function.rs
@@ -1,0 +1,39 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of [`InstanceWithFunction`] for Wasmtime instances.
+
+use super::{parameters::WasmtimeParameters, results::WasmtimeResults, EntrypointInstance};
+use crate::{memory_layout::FlatLayout, InstanceWithFunction, Runtime, RuntimeError};
+use wasmtime::{AsContext, AsContextMut, Extern, TypedFunc};
+
+impl<Parameters, Results> InstanceWithFunction<Parameters, Results> for EntrypointInstance
+where
+    Parameters: FlatLayout + WasmtimeParameters,
+    Results: FlatLayout + WasmtimeResults,
+{
+    type Function = TypedFunc<
+        <Parameters as WasmtimeParameters>::Parameters,
+        <Results as WasmtimeResults>::Results,
+    >;
+
+    fn function_from_export(
+        &mut self,
+        export: <Self::Runtime as Runtime>::Export,
+    ) -> Result<Option<Self::Function>, RuntimeError> {
+        Ok(match export {
+            Extern::Func(function) => Some(function.typed(self.as_context())?),
+            _ => None,
+        })
+    }
+
+    fn call(
+        &mut self,
+        function: &Self::Function,
+        parameters: Parameters,
+    ) -> Result<Results, RuntimeError> {
+        let results = function.call(self.as_context_mut(), parameters.into_wasmtime())?;
+
+        Ok(Results::from_wasmtime(results))
+    }
+}

--- a/linera-witty/src/runtime/wasmtime/memory.rs
+++ b/linera-witty/src/runtime/wasmtime/memory.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! How to access the memory of a Wasmtime guest instance.
+
+use super::{super::traits::InstanceWithMemory, EntrypointInstance};
+use crate::{GuestPointer, RuntimeError, RuntimeMemory};
+use std::borrow::Cow;
+use wasmtime::{Extern, Memory};
+
+impl InstanceWithMemory for EntrypointInstance {
+    fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
+        Ok(match export {
+            Extern::Memory(memory) => Some(memory),
+            _ => None,
+        })
+    }
+}
+
+impl RuntimeMemory<EntrypointInstance> for Memory {
+    fn read<'instance>(
+        &self,
+        instance: &'instance EntrypointInstance,
+        location: GuestPointer,
+        length: u32,
+    ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
+        let start = location.0 as usize;
+        let end = start + length as usize;
+
+        Ok(Cow::Borrowed(&self.data(instance)[start..end]))
+    }
+
+    fn write(
+        &mut self,
+        instance: &mut EntrypointInstance,
+        location: GuestPointer,
+        bytes: &[u8],
+    ) -> Result<(), RuntimeError> {
+        let start = location.0 as usize;
+        let end = start + bytes.len();
+
+        self.data_mut(instance)[start..end].copy_from_slice(bytes);
+
+        Ok(())
+    }
+}

--- a/linera-witty/src/runtime/wasmtime/memory.rs
+++ b/linera-witty/src/runtime/wasmtime/memory.rs
@@ -3,44 +3,51 @@
 
 //! How to access the memory of a Wasmtime guest instance.
 
-use super::{super::traits::InstanceWithMemory, EntrypointInstance};
+use super::{super::traits::InstanceWithMemory, EntrypointInstance, ReentrantInstance};
 use crate::{GuestPointer, RuntimeError, RuntimeMemory};
 use std::borrow::Cow;
 use wasmtime::{Extern, Memory};
 
-impl InstanceWithMemory for EntrypointInstance {
-    fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
-        Ok(match export {
-            Extern::Memory(memory) => Some(memory),
-            _ => None,
-        })
-    }
+macro_rules! impl_memory_traits {
+    ($instance:ty) => {
+        impl InstanceWithMemory for $instance {
+            fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
+                Ok(match export {
+                    Extern::Memory(memory) => Some(memory),
+                    _ => None,
+                })
+            }
+        }
+
+        impl RuntimeMemory<$instance> for Memory {
+            fn read<'instance>(
+                &self,
+                instance: &'instance $instance,
+                location: GuestPointer,
+                length: u32,
+            ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
+                let start = location.0 as usize;
+                let end = start + length as usize;
+
+                Ok(Cow::Borrowed(&self.data(instance)[start..end]))
+            }
+
+            fn write(
+                &mut self,
+                instance: &mut $instance,
+                location: GuestPointer,
+                bytes: &[u8],
+            ) -> Result<(), RuntimeError> {
+                let start = location.0 as usize;
+                let end = start + bytes.len();
+
+                self.data_mut(instance)[start..end].copy_from_slice(bytes);
+
+                Ok(())
+            }
+        }
+    };
 }
 
-impl RuntimeMemory<EntrypointInstance> for Memory {
-    fn read<'instance>(
-        &self,
-        instance: &'instance EntrypointInstance,
-        location: GuestPointer,
-        length: u32,
-    ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
-        let start = location.0 as usize;
-        let end = start + length as usize;
-
-        Ok(Cow::Borrowed(&self.data(instance)[start..end]))
-    }
-
-    fn write(
-        &mut self,
-        instance: &mut EntrypointInstance,
-        location: GuestPointer,
-        bytes: &[u8],
-    ) -> Result<(), RuntimeError> {
-        let start = location.0 as usize;
-        let end = start + bytes.len();
-
-        self.data_mut(instance)[start..end].copy_from_slice(bytes);
-
-        Ok(())
-    }
-}
+impl_memory_traits!(EntrypointInstance);
+impl_memory_traits!(ReentrantInstance<'_>);

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -3,6 +3,7 @@
 
 //! Support for the [Wasmtime](https://wasmtime.dev) runtime.
 
+mod parameters;
 mod results;
 
 use super::traits::{Instance, Runtime};

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Support for the [Wasmtime](https://wasmtime.dev) runtime.
+
+use super::traits::Runtime;
+use wasmtime::{Extern, Memory};
+
+/// Representation of the [Wasmtime](https://wasmtime.dev) runtime.
+pub struct Wasmtime;
+
+impl Runtime for Wasmtime {
+    type Export = Extern;
+    type Memory = Memory;
+}

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -4,6 +4,7 @@
 //! Support for the [Wasmtime](https://wasmtime.dev) runtime.
 
 mod function;
+mod memory;
 mod parameters;
 mod results;
 

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -9,7 +9,9 @@ mod parameters;
 mod results;
 
 use super::traits::{Instance, Runtime};
-use wasmtime::{AsContext, AsContextMut, Extern, Memory, Store, StoreContext, StoreContextMut};
+use wasmtime::{
+    AsContext, AsContextMut, Caller, Extern, Memory, Store, StoreContext, StoreContextMut,
+};
 
 /// Representation of the [Wasmtime](https://wasmtime.dev) runtime.
 pub struct Wasmtime;
@@ -52,5 +54,17 @@ impl Instance for EntrypointInstance {
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         self.instance.get_export(&mut self.store, name)
+    }
+}
+
+/// Alias for the [`Instance`] implementation made available inside host functions called by the
+/// guest.
+pub type ReentrantInstance<'a> = Caller<'a, ()>;
+
+impl Instance for Caller<'_, ()> {
+    type Runtime = Wasmtime;
+
+    fn load_export(&mut self, name: &str) -> Option<Extern> {
+        Caller::get_export(self, name)
     }
 }

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -3,6 +3,7 @@
 
 //! Support for the [Wasmtime](https://wasmtime.dev) runtime.
 
+mod function;
 mod parameters;
 mod results;
 

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -3,8 +3,8 @@
 
 //! Support for the [Wasmtime](https://wasmtime.dev) runtime.
 
-use super::traits::Runtime;
-use wasmtime::{Extern, Memory};
+use super::traits::{Instance, Runtime};
+use wasmtime::{AsContext, AsContextMut, Extern, Memory, Store, StoreContext, StoreContextMut};
 
 /// Representation of the [Wasmtime](https://wasmtime.dev) runtime.
 pub struct Wasmtime;
@@ -12,4 +12,40 @@ pub struct Wasmtime;
 impl Runtime for Wasmtime {
     type Export = Extern;
     type Memory = Memory;
+}
+
+/// Necessary data for implementing an entrypoint [`Instance`].
+pub struct EntrypointInstance {
+    instance: wasmtime::Instance,
+    store: Store<()>,
+}
+
+impl EntrypointInstance {
+    /// Creates a new [`EntrypointInstance`] with the guest module
+    /// [`Instance`][`wasmtime::Instance`] and [`Store`].
+    pub fn new(instance: wasmtime::Instance, store: Store<()>) -> Self {
+        EntrypointInstance { instance, store }
+    }
+}
+
+impl AsContext for EntrypointInstance {
+    type Data = ();
+
+    fn as_context(&self) -> StoreContext<()> {
+        self.store.as_context()
+    }
+}
+
+impl AsContextMut for EntrypointInstance {
+    fn as_context_mut(&mut self) -> StoreContextMut<()> {
+        self.store.as_context_mut()
+    }
+}
+
+impl Instance for EntrypointInstance {
+    type Runtime = Wasmtime;
+
+    fn load_export(&mut self, name: &str) -> Option<Extern> {
+        self.instance.get_export(&mut self.store, name)
+    }
 }

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -3,6 +3,8 @@
 
 //! Support for the [Wasmtime](https://wasmtime.dev) runtime.
 
+mod results;
+
 use super::traits::{Instance, Runtime};
 use wasmtime::{AsContext, AsContextMut, Extern, Memory, Store, StoreContext, StoreContextMut};
 

--- a/linera-witty/src/runtime/wasmtime/parameters.rs
+++ b/linera-witty/src/runtime/wasmtime/parameters.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of Wasmtime function parameter types.
+
+use crate::{primitive_types::FlatType, Layout};
+use frunk::{hlist, hlist_pat, HCons, HList};
+use wasmtime::{WasmParams, WasmTy};
+
+/// Conversions between flat layouts and Wasmtime parameter types.
+pub trait WasmtimeParameters {
+    /// The type Wasmtime uses to represent the parameters.
+    type Parameters: WasmParams;
+
+    /// Converts from this flat layout into Wasmtime's representation.
+    fn into_wasmtime(self) -> Self::Parameters;
+
+    /// Converts from Wasmtime's representation into a flat layout.
+    fn from_wasmtime(parameters: Self::Parameters) -> Self;
+}
+
+/// Helper macro to implement [`WasmtimeParameters`] for flat layouts up to the maximum limit.
+///
+/// The maximum number of parameters is defined by the [canonical
+/// ABI](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening)
+/// as the `MAX_FLAT_PARAMS` constant. There is no equivalent constant defined in Witty. Instead,
+/// any attempt to use more than the limit should lead to a compiler error. Therefore, this macro
+/// only implements the trait up to the limit. The same is done in other parts of the code, like
+/// for example in
+/// [`FlatHostParameters`][`crate::imported_function_interface::FlatHostParameters`].
+macro_rules! parameters {
+    ($( $names:ident : $types:ident ),*) => {
+        parameters!(| $( $names: $types ),*);
+    };
+
+    ($( $names:ident : $types:ident ),* |) => {
+        parameters!(@generate $( $names: $types ),*);
+    };
+
+    (
+        $( $names_to_generate:ident : $types_to_generate:ident ),* |
+        $next_name:ident : $next_type:ident $( , $queued_names:ident : $queued_types:ident )*
+    ) => {
+        parameters!(@generate $( $names_to_generate: $types_to_generate ),*);
+        parameters!(
+            $( $names_to_generate: $types_to_generate, )*
+            $next_name: $next_type | $( $queued_names: $queued_types ),*);
+    };
+
+    (@generate $( $names:ident : $types:ident ),*) => {
+        impl<$( $types ),*> WasmtimeParameters for HList![$( $types ),*]
+        where
+            $( $types: FlatType + WasmTy, )*
+        {
+            type Parameters = ($( $types, )*);
+
+            #[allow(clippy::unused_unit)]
+            fn into_wasmtime(self) -> Self::Parameters {
+                let hlist_pat![$( $names ),*] = self;
+
+                ($( $names, )*)
+            }
+
+            fn from_wasmtime(($( $names, )*): Self::Parameters) -> Self {
+                hlist![$( $names ),*]
+            }
+        }
+    };
+}
+
+parameters!(
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P
+);
+
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Rest> WasmtimeParameters
+    for HCons<
+        A,
+        HCons<
+            B,
+            HCons<
+                C,
+                HCons<
+                    D,
+                    HCons<
+                        E,
+                        HCons<
+                            F,
+                            HCons<
+                                G,
+                                HCons<
+                                    H,
+                                    HCons<
+                                        I,
+                                        HCons<
+                                            J,
+                                            HCons<
+                                                K,
+                                                HCons<
+                                                    L,
+                                                    HCons<
+                                                        M,
+                                                        HCons<
+                                                            N,
+                                                            HCons<O, HCons<P, HCons<Q, Rest>>>,
+                                                        >,
+                                                    >,
+                                                >,
+                                            >,
+                                        >,
+                                    >,
+                                >,
+                            >,
+                        >,
+                    >,
+                >,
+            >,
+        >,
+    >
+where
+    A: FlatType,
+    B: FlatType,
+    C: FlatType,
+    D: FlatType,
+    E: FlatType,
+    F: FlatType,
+    G: FlatType,
+    H: FlatType,
+    I: FlatType,
+    J: FlatType,
+    K: FlatType,
+    L: FlatType,
+    M: FlatType,
+    N: FlatType,
+    O: FlatType,
+    P: FlatType,
+    Q: FlatType,
+    Rest: Layout,
+{
+    type Parameters = (i32,);
+
+    fn into_wasmtime(self) -> Self::Parameters {
+        unreachable!("Attempt to convert a list of flat parameters larger than the maximum limit");
+    }
+
+    fn from_wasmtime(_: Self::Parameters) -> Self {
+        unreachable!(
+            "Attempt to convert into a list of flat parameters larger than the maximum limit"
+        );
+    }
+}

--- a/linera-witty/src/runtime/wasmtime/results.rs
+++ b/linera-witty/src/runtime/wasmtime/results.rs
@@ -1,0 +1,46 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of Wasmtime function result types.
+
+use crate::{memory_layout::FlatLayout, primitive_types::FlatType};
+use frunk::{hlist, hlist_pat, HList};
+use wasmtime::{WasmResults, WasmTy};
+
+/// Conversions between flat layouts and Wasmtime function result types.
+pub trait WasmtimeResults: FlatLayout {
+    /// The type Wasmtime uses to represent the results.
+    type Results: WasmResults;
+
+    /// Converts from Wasmtime's representation into a flat layout.
+    fn from_wasmtime(results: Self::Results) -> Self;
+
+    /// Converts from this flat layout into Wasmtime's representation.
+    fn into_wasmtime(self) -> Self::Results;
+}
+
+impl WasmtimeResults for HList![] {
+    type Results = ();
+
+    fn from_wasmtime((): Self::Results) -> Self::Flat {
+        hlist![]
+    }
+
+    fn into_wasmtime(self) -> Self::Results {}
+}
+
+impl<T> WasmtimeResults for HList![T]
+where
+    T: FlatType + WasmTy,
+{
+    type Results = T;
+
+    fn from_wasmtime(value: Self::Results) -> Self {
+        hlist![value]
+    }
+
+    fn into_wasmtime(self) -> Self::Results {
+        let hlist_pat![value] = self;
+        value
+    }
+}

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -10,6 +10,8 @@ mod test_instance;
 
 #[cfg(feature = "wasmer")]
 use self::test_instance::WasmerInstanceFactory;
+#[cfg(feature = "wasmtime")]
+use self::test_instance::WasmtimeInstanceFactory;
 use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
 use linera_witty::{Instance, Runtime, RuntimeMemory};
 use linera_witty_macros::wit_import;
@@ -24,6 +26,7 @@ trait SimpleFunction {
 /// Test importing a simple function without parameters or return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -58,6 +61,7 @@ trait Getters {
 /// Test importing functions with return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -162,6 +166,7 @@ trait Setters {
 /// Test importing functions with parameters.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -227,6 +232,7 @@ trait Operations {
 /// Test importing functions with multiple parameters and return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,


### PR DESCRIPTION
## Motivation

The new Witty crate should generate host code that's compatible with the [Wasmtime](https://wasmtime.dev) runtime.

## Proposal

Create a feature gated `wasmtime` module in `linera_witty::runtime`, with implementations for the Witty traits. There are two `Instance` implementations, one for newly created instances (`EntrypointInstance`) and one for instances made available inside host functions called by the guest module (`ReentrantInstance`).

## Test Plan

Reuse the integration tests for `wit_import` and Wasmer.

## Links

Part of #906 

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [ ] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!