### PR TITLE
Allow creating multi-owner chains.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -354,7 +354,7 @@ where
         timestamp: Timestamp,
     ) -> Result<(), ChainError> {
         if let Message::System(SystemMessage::OpenChain {
-            public_key,
+            ownership,
             epoch,
             committees,
             admin_id,
@@ -363,7 +363,7 @@ where
             // Initialize ourself.
             self.execution_state.system.open_chain(
                 message_id,
-                *public_key,
+                ownership.clone(),
                 *epoch,
                 committees.clone(),
                 *admin_id,

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -55,7 +55,11 @@ impl ChainManager {
                     ChainManager::Single(Box::new(SingleOwnerManager::new(*owner, *public_key)));
             }
             ChainOwnership::Multi { owners } => {
-                *self = ChainManager::Multi(Box::new(MultiOwnerManager::new(owners.clone())));
+                let owners = owners
+                    .iter()
+                    .map(|(owner, public_key)| (*owner, *public_key))
+                    .collect();
+                *self = ChainManager::Multi(Box::new(MultiOwnerManager::new(owners)));
             }
         }
     }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -30,8 +30,8 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
     system::{Account, AdminOperation, Recipient, SystemChannel, SystemOperation, UserData},
-    Bytecode, Message, Operation, Query, Response, SystemMessage, SystemQuery, SystemResponse,
-    UserApplicationId,
+    Bytecode, ChainOwnership, Message, Operation, Query, Response, SystemMessage, SystemQuery,
+    SystemResponse, UserApplicationId,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -1313,7 +1313,10 @@ where
     }
 
     /// Opens a new chain with a derived UID.
-    pub async fn open_chain(&mut self, public_key: PublicKey) -> Result<(MessageId, Certificate)> {
+    pub async fn open_chain(
+        &mut self,
+        ownership: ChainOwnership,
+    ) -> Result<(MessageId, Certificate)> {
         self.prepare_chain().await?;
         let (epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
         let epoch = epoch.ok_or(NodeError::InactiveLocalChain(self.chain_id))?;
@@ -1322,7 +1325,7 @@ where
             .execute_block(
                 messages,
                 vec![Operation::System(SystemOperation::OpenChain {
-                    public_key,
+                    ownership,
                     committees,
                     admin_id: self.admin_id,
                     epoch,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -19,7 +19,7 @@ use linera_execution::{
     committee::{Committee, Epoch},
     pricing::Pricing,
     system::{Account, Recipient, SystemOperation, UserData},
-    Operation, SystemQuery, SystemResponse,
+    ChainOwnership, Operation, SystemQuery, SystemResponse,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -481,7 +481,10 @@ where
         .await?;
     let new_key_pair = KeyPair::generate();
     // Open the new chain.
-    let (message_id, certificate) = sender.open_chain(new_key_pair.public()).await.unwrap();
+    let (message_id, certificate) = sender
+        .open_chain(ChainOwnership::single(new_key_pair.public()))
+        .await
+        .unwrap();
     assert_eq!(sender.next_block_height, BlockHeight::from(1));
     assert!(sender.pending_block.is_none());
     assert!(sender.key_pair().await.is_ok());
@@ -548,8 +551,10 @@ where
         .await
         .unwrap();
     // Open the new chain.
-    let (open_chain_message_id, certificate) =
-        sender.open_chain(new_key_pair.public()).await.unwrap();
+    let (open_chain_message_id, certificate) = sender
+        .open_chain(ChainOwnership::single(new_key_pair.public()))
+        .await
+        .unwrap();
     let new_id2 = ChainId::child(open_chain_message_id);
     assert_eq!(new_id, new_id2);
     assert_eq!(sender.next_block_height, BlockHeight::from(2));
@@ -624,8 +629,10 @@ where
         .await?;
     let new_key_pair = KeyPair::generate();
     // Open the new chain.
-    let (message_id, creation_certificate) =
-        sender.open_chain(new_key_pair.public()).await.unwrap();
+    let (message_id, creation_certificate) = sender
+        .open_chain(ChainOwnership::single(new_key_pair.public()))
+        .await
+        .unwrap();
     let new_id = ChainId::child(message_id);
     // Transfer after creating the chain.
     let transfer_certificate = sender

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2647,7 +2647,7 @@ where
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
                 operations: vec![Operation::System(SystemOperation::OpenChain {
-                    public_key: key_pair.public(),
+                    ownership: ChainOwnership::single(key_pair.public()),
                     epoch: Epoch::from(0),
                     committees: committees.clone(),
                     admin_id,
@@ -2661,7 +2661,7 @@ where
                 direct_outgoing_message(
                     user_id,
                     SystemMessage::OpenChain {
-                        public_key: key_pair.public(),
+                        ownership: ChainOwnership::single(key_pair.public()),
                         epoch: Epoch::from(0),
                         committees: committees.clone(),
                         admin_id,

--- a/linera-execution/src/ownership.rs
+++ b/linera-execution/src/ownership.rs
@@ -3,11 +3,10 @@
 
 use linera_base::{crypto::PublicKey, identifiers::Owner};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Represents the owner(s) of a chain.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "test"), derive(Eq, PartialEq))]
+#[derive(PartialEq, Eq, Clone, Hash, Debug, Default, Serialize, Deserialize)]
 pub enum ChainOwnership {
     /// The chain is not active. (No blocks can be created)
     #[default]
@@ -15,7 +14,7 @@ pub enum ChainOwnership {
     /// The chain is managed by a single owner.
     Single { owner: Owner, public_key: PublicKey },
     /// The chain is managed by multiple owners.
-    Multi { owners: HashMap<Owner, PublicKey> },
+    Multi { owners: BTreeMap<Owner, PublicKey> },
 }
 
 impl ChainOwnership {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -100,10 +100,10 @@ pub enum SystemOperation {
         amount: Amount,
         user_data: UserData,
     },
-    /// Creates (or activates) a new chain by installing the given authentication key.
+    /// Creates (or activates) a new chain.
     /// This will automatically subscribe to the future committees created by `admin_id`.
     OpenChain {
-        public_key: PublicKey,
+        ownership: ChainOwnership,
         admin_id: ChainId,
         epoch: Epoch,
         committees: BTreeMap<Epoch, Committee>,
@@ -176,9 +176,9 @@ pub enum SystemMessage {
         recipient: Recipient,
         user_data: UserData,
     },
-    /// Creates (or activates) a new chain by installing the given authentication key.
+    /// Creates (or activates) a new chain.
     OpenChain {
-        public_key: PublicKey,
+        ownership: ChainOwnership,
         admin_id: ChainId,
         epoch: Epoch,
         committees: BTreeMap<Epoch, Committee>,
@@ -457,7 +457,7 @@ where
         let mut new_application = None;
         match operation {
             OpenChain {
-                public_key,
+                ownership,
                 committees,
                 admin_id,
                 epoch,
@@ -482,7 +482,7 @@ where
                     Destination::Recipient(child_id),
                     false,
                     SystemMessage::OpenChain {
-                        public_key: *public_key,
+                        ownership: ownership.clone(),
                         committees: committees.clone(),
                         admin_id: *admin_id,
                         epoch: *epoch,
@@ -882,7 +882,7 @@ where
     pub fn open_chain(
         &mut self,
         message_id: MessageId,
-        public_key: PublicKey,
+        ownership: ChainOwnership,
         epoch: Epoch,
         committees: BTreeMap<Epoch, Committee>,
         admin_id: ChainId,
@@ -903,7 +903,7 @@ where
                 name: SystemChannel::Admin.name(),
             })
             .expect("serialization failed");
-        self.ownership.set(ChainOwnership::single(public_key));
+        self.ownership.set(ownership);
         self.timestamp.set(timestamp);
     }
 

--- a/linera-explorer/graphql/schema.graphql
+++ b/linera-explorer/graphql/schema.graphql
@@ -314,6 +314,11 @@ type MutationRoot {
 	"""
 	openChain(chainId: ChainId!, publicKey: PublicKey!): ChainId!
 	"""
+	Creates (or activates) a new chain by installing the given authentication keys.
+	This will automatically subscribe to the future committees created by `admin_id`.
+	"""
+	openMultiOwnerChain(chainId: ChainId!, publicKeys: [PublicKey!]!): ChainId!
+	"""
 	Closes the chain.
 	"""
 	closeChain(chainId: ChainId!): CryptoHash!

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -10,7 +10,7 @@ use linera_chain::{
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
     system::{AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
-    ApplicationId, Message, Operation,
+    ApplicationId, ChainOwnership, Message, Operation,
 };
 use linera_rpc::RpcMessage;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
@@ -38,6 +38,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Medium>(&samples)?;
     tracer.trace_type::<Destination>(&samples)?;
     tracer.trace_type::<ChainDescription>(&samples)?;
+    tracer.trace_type::<ChainOwnership>(&samples)?;
     tracer.trace_type::<ApplicationId>(&samples)?;
     tracer.trace_type::<ChainManagerInfo>(&samples)?;
     tracer.trace_type::<CrossChainRequest>(&samples)?;

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -214,6 +214,26 @@ ChainManagerInfo:
       Multi:
         NEWTYPE:
           TYPENAME: MultiOwnerManagerInfo
+ChainOwnership:
+  ENUM:
+    0:
+      None: UNIT
+    1:
+      Single:
+        STRUCT:
+          - owner:
+              TYPENAME: Owner
+          - public_key:
+              TYPENAME: PublicKey
+    2:
+      Multi:
+        STRUCT:
+          - owners:
+              MAP:
+                KEY:
+                  TYPENAME: Owner
+                VALUE:
+                  TYPENAME: PublicKey
 ChannelFullName:
   STRUCT:
     - application_id:
@@ -637,8 +657,8 @@ SystemMessage:
     2:
       OpenChain:
         STRUCT:
-          - public_key:
-              TYPENAME: PublicKey
+          - ownership:
+              TYPENAME: ChainOwnership
           - admin_id:
               TYPENAME: ChainId
           - epoch:
@@ -733,8 +753,8 @@ SystemOperation:
     2:
       OpenChain:
         STRUCT:
-          - public_key:
-              TYPENAME: PublicKey
+          - ownership:
+              TYPENAME: ChainOwnership
           - admin_id:
               TYPENAME: ChainId
           - epoch:

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -15,7 +15,7 @@ use linera_core::{
     tracker::NotificationTracker,
     worker::{Notification, Reason},
 };
-use linera_execution::{Message, SystemMessage};
+use linera_execution::{ChainOwnership, Message, SystemMessage};
 use linera_storage::Store;
 use linera_views::views::ViewError;
 use std::{sync::Arc, time::Duration};
@@ -162,7 +162,11 @@ where
                 for outgoing_message in &executed_block.messages {
                     if let OutgoingMessage {
                         destination: Destination::Recipient(new_id),
-                        message: Message::System(SystemMessage::OpenChain { public_key, .. }),
+                        message:
+                            Message::System(SystemMessage::OpenChain {
+                                ownership: ChainOwnership::Single { public_key, .. },
+                                ..
+                            }),
                         ..
                     } = outgoing_message
                     {


### PR DESCRIPTION
## Motivation

Currently a new chain is always single-owner, with 1.5 round trips. There needs to be a way to open a new multi-owner chain, e.g. for future public chains.

## Proposal

This generalizes the `OpenChain` operation and message, and adds a new `open-multi-owner-chain` command and mutation, so that multi-owner 2.5 round-trip chains can be created.

The node service only tracks newly created single-owner chains for now: To what extent it should automatically select keys for new chains still needs discussion.

## Test Plan

A new end-to-end test creates a chain with two owners and asserts that both can create blocks.

## Links

Closes https://github.com/linera-io/linera-protocol/issues/896.

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
