### PR TITLE
Code generate mutation root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,6 +2880,7 @@ dependencies = [
  "linera-chain",
  "linera-core",
  "linera-execution",
+ "linera-sdk-derive",
  "linera-storage",
  "linera-views",
  "linera-wit-bindgen-guest-rust",
@@ -2894,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,6 +2893,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "linera-sdk-derive"
+version = "0.1.0"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "linera-sdk-wasm-tests"
 version = "0.1.0"
 dependencies = [
@@ -3018,12 +3027,10 @@ dependencies = [
 name = "linera-views-derive"
 version = "0.3.0"
 dependencies = [
- "async-graphql",
  "convert_case 0.6.0",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "serde",
  "syn 1.0.109",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,7 @@ linera-views = { version = "0.3.0", path = "./linera-views", default-features = 
 linera-views-derive = { version = "0.3.0", path = "./linera-views-derive" }
 linera-witty = { version = "0.3.0", path = "./linera-witty" }
 linera-witty-macros = { version = "0.3.0", path = "./linera-witty-macros" }
+linera-sdk-derive = { version = "0.3.0", path = "./linera-sdk-derive" }
 linera-service = { version = "0.3.0", path = "./linera-service" }
 
 counter = { path = "./examples/counter" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
         "linera-rpc",
         "linera-sdk",
         "linera-sdk/wasm-tests",
+        "linera-sdk-derive",
         "linera-service",
         "linera-storage",
         "linera-views",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1658,6 +1658,7 @@ dependencies = [
  "linera-chain",
  "linera-core",
  "linera-execution",
+ "linera-sdk-derive",
  "linera-storage",
  "linera-views",
  "linera-wit-bindgen-guest-rust",
@@ -1667,6 +1668,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "wasmtime",
+]
+
+[[package]]
+name = "linera-sdk-derive"
+version = "0.3.0"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1718,12 +1728,10 @@ dependencies = [
 name = "linera-views-derive"
 version = "0.3.0"
 dependencies = [
- "async-graphql",
  "convert_case 0.6.0",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "serde",
  "syn 1.0.109",
 ]
 

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -241,7 +241,10 @@
 
 use async_graphql::{Request, Response, SimpleObject};
 use fungible::AccountOwner;
-use linera_sdk::base::{Amount, ApplicationId, ContractAbi, ServiceAbi, Timestamp};
+use linera_sdk::{
+    base::{Amount, ApplicationId, ContractAbi, ServiceAbi, Timestamp},
+    MutationRoot,
+};
 use serde::{Deserialize, Serialize};
 
 pub struct CrowdFundingAbi;
@@ -285,7 +288,7 @@ impl std::fmt::Display for InitializationArgument {
 }
 
 /// Operations that can be executed by the application.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, MutationRoot)]
 #[allow(clippy::large_enum_variant)]
 pub enum Operation {
     /// Pledge some tokens to the campaign (from an account on the current chain to the campaign chain).

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -243,7 +243,7 @@ use async_graphql::{Request, Response, SimpleObject};
 use fungible::AccountOwner;
 use linera_sdk::{
     base::{Amount, ApplicationId, ContractAbi, ServiceAbi, Timestamp},
-    MutationRoot,
+    graphql::MutationRoot,
 };
 use serde::{Deserialize, Serialize};
 

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -5,14 +5,11 @@
 
 mod state;
 
-use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use async_graphql::{EmptySubscription, Request, Response, Schema};
 use async_trait::async_trait;
 use crowd_funding::Operation;
-use fungible::AccountOwner;
-use linera_sdk::{
-    base::{Amount, WithServiceAbi},
-    QueryContext, Service, ViewStateStorage,
-};
+
+use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
 use state::CrowdFunding;
 use std::sync::Arc;
 use thiserror::Error;
@@ -33,26 +30,10 @@ impl Service for CrowdFunding {
         _context: &QueryContext,
         request: Request,
     ) -> Result<Response, Self::Error> {
-        let schema = Schema::build(self.clone(), MutationRoot {}, EmptySubscription).finish();
+        let schema =
+            Schema::build(self.clone(), Operation::mutation_root(), EmptySubscription).finish();
         let response = schema.execute(request).await;
         Ok(response)
-    }
-}
-
-struct MutationRoot;
-
-#[Object]
-impl MutationRoot {
-    async fn pledge_with_transfer(&self, owner: AccountOwner, amount: Amount) -> Vec<u8> {
-        bcs::to_bytes(&Operation::PledgeWithTransfer { owner, amount }).unwrap()
-    }
-
-    async fn collect(&self) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Collect {}).unwrap()
-    }
-
-    async fn cancel(&self) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Cancel {}).unwrap()
     }
 }
 

--- a/examples/crowd-funding/src/service.rs
+++ b/examples/crowd-funding/src/service.rs
@@ -9,7 +9,9 @@ use async_graphql::{EmptySubscription, Request, Response, Schema};
 use async_trait::async_trait;
 use crowd_funding::Operation;
 
-use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
+use linera_sdk::{
+    base::WithServiceAbi, graphql::GraphQLMutationRoot, QueryContext, Service, ViewStateStorage,
+};
 use state::CrowdFunding;
 use std::sync::Arc;
 use thiserror::Error;

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -131,7 +131,7 @@
 use async_graphql::{scalar, InputObject, Request, Response};
 use linera_sdk::{
     base::{Amount, ApplicationId, ChainId, ContractAbi, Owner, ServiceAbi},
-    MutationRoot,
+    graphql::MutationRoot,
 };
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeMap, str::FromStr};

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -129,7 +129,10 @@
 //! automatically update.
 
 use async_graphql::{scalar, InputObject, Request, Response};
-use linera_sdk::base::{Amount, ApplicationId, ChainId, ContractAbi, Owner, ServiceAbi};
+use linera_sdk::{
+    base::{Amount, ApplicationId, ChainId, ContractAbi, Owner, ServiceAbi},
+    MutationRoot,
+};
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::{collections::BTreeMap, str::FromStr};
 #[cfg(all(any(test, feature = "test"), not(target_arch = "wasm32")))]
@@ -162,7 +165,7 @@ impl ServiceAbi for FungibleTokenAbi {
 }
 
 /// An operation.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, MutationRoot)]
 pub enum Operation {
     /// A transfer from a (locally owned) account to a (possibly remote) account.
     Transfer {

--- a/examples/fungible/src/service.rs
+++ b/examples/fungible/src/service.rs
@@ -9,7 +9,9 @@ use self::state::FungibleToken;
 use async_graphql::{EmptySubscription, Request, Response, Schema};
 use async_trait::async_trait;
 use fungible::Operation;
-use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
+use linera_sdk::{
+    base::WithServiceAbi, graphql::GraphQLMutationRoot, QueryContext, Service, ViewStateStorage,
+};
 use std::sync::Arc;
 use thiserror::Error;
 

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -3,7 +3,10 @@
 
 use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use fungible::{AccountOwner, FungibleTokenAbi};
-use linera_sdk::base::{Amount, ApplicationId, ContractAbi, ServiceAbi};
+use linera_sdk::{
+    base::{Amount, ApplicationId, ContractAbi, ServiceAbi},
+    MutationRoot,
+};
 use linera_views::{common::CustomSerialize, views::ViewError};
 use serde::{Deserialize, Serialize};
 
@@ -132,7 +135,7 @@ pub struct Parameters {
 scalar!(Parameters);
 
 /// Operations that can be sent to the application.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, MutationRoot)]
 pub enum Operation {
     /// The order that is going to be executed on the chain of the order book.
     ExecuteOrder { order: Order },

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -5,7 +5,7 @@ use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use fungible::{AccountOwner, FungibleTokenAbi};
 use linera_sdk::{
     base::{Amount, ApplicationId, ContractAbi, ServiceAbi},
-    MutationRoot,
+    graphql::MutationRoot,
 };
 use linera_views::{common::CustomSerialize, views::ViewError};
 use serde::{Deserialize, Serialize};

--- a/examples/matching-engine/src/service.rs
+++ b/examples/matching-engine/src/service.rs
@@ -6,10 +6,10 @@
 mod state;
 
 use crate::state::{MatchingEngine, MatchingEngineError};
-use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use async_graphql::{EmptySubscription, Request, Response, Schema};
 use async_trait::async_trait;
 use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
-use matching_engine::{Operation, Order};
+use matching_engine::Operation;
 use std::sync::Arc;
 
 linera_sdk::service!(MatchingEngine);
@@ -28,17 +28,9 @@ impl Service for MatchingEngine {
         _context: &QueryContext,
         request: Request,
     ) -> Result<Response, Self::Error> {
-        let schema = Schema::build(self.clone(), MutationRoot, EmptySubscription).finish();
+        let schema =
+            Schema::build(self.clone(), Operation::mutation_root(), EmptySubscription).finish();
         let response = schema.execute(request).await;
         Ok(response)
-    }
-}
-
-struct MutationRoot;
-
-#[Object]
-impl MutationRoot {
-    async fn order(&self, order: Order) -> Vec<u8> {
-        bcs::to_bytes(&Operation::ExecuteOrder { order }).unwrap()
     }
 }

--- a/examples/matching-engine/src/service.rs
+++ b/examples/matching-engine/src/service.rs
@@ -8,7 +8,9 @@ mod state;
 use crate::state::{MatchingEngine, MatchingEngineError};
 use async_graphql::{EmptySubscription, Request, Response, Schema};
 use async_trait::async_trait;
-use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
+use linera_sdk::{
+    base::WithServiceAbi, graphql::GraphQLMutationRoot, QueryContext, Service, ViewStateStorage,
+};
 use matching_engine::Operation;
 use std::sync::Arc;
 

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -145,7 +145,10 @@
 //! ```
 
 use async_graphql::{InputObject, Request, Response, SimpleObject};
-use linera_sdk::base::{ChainId, ContractAbi, ServiceAbi, Timestamp};
+use linera_sdk::{
+    base::{ChainId, ContractAbi, ServiceAbi, Timestamp},
+    MutationRoot,
+};
 use linera_views::{common::CustomSerialize, views};
 use serde::{Deserialize, Serialize};
 
@@ -169,7 +172,7 @@ impl ServiceAbi for SocialAbi {
 }
 
 /// An operation that can be executed by the application.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, MutationRoot)]
 pub enum Operation {
     /// Request to be subscribed to another chain.
     RequestSubscribe(ChainId),

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -147,7 +147,7 @@
 use async_graphql::{InputObject, Request, Response, SimpleObject};
 use linera_sdk::{
     base::{ChainId, ContractAbi, ServiceAbi, Timestamp},
-    MutationRoot,
+    graphql::MutationRoot,
 };
 use linera_views::{common::CustomSerialize, views};
 use serde::{Deserialize, Serialize};

--- a/examples/social/src/service.rs
+++ b/examples/social/src/service.rs
@@ -7,7 +7,9 @@ mod state;
 
 use async_graphql::{EmptySubscription, Request, Response, Schema};
 use async_trait::async_trait;
-use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
+use linera_sdk::{
+    base::WithServiceAbi, graphql::GraphQLMutationRoot, QueryContext, Service, ViewStateStorage,
+};
 use linera_views::views::ViewError;
 use social::Operation;
 use state::Social;

--- a/examples/social/src/service.rs
+++ b/examples/social/src/service.rs
@@ -5,12 +5,9 @@
 
 mod state;
 
-use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use async_graphql::{EmptySubscription, Request, Response, Schema};
 use async_trait::async_trait;
-use linera_sdk::{
-    base::{ChainId, WithServiceAbi},
-    QueryContext, Service, ViewStateStorage,
-};
+use linera_sdk::{base::WithServiceAbi, QueryContext, Service, ViewStateStorage};
 use linera_views::views::ViewError;
 use social::Operation;
 use state::Social;
@@ -33,26 +30,10 @@ impl Service for Social {
         _context: &QueryContext,
         request: Request,
     ) -> Result<Response, Self::Error> {
-        let schema = Schema::build(self.clone(), MutationRoot, EmptySubscription).finish();
+        let schema =
+            Schema::build(self.clone(), Operation::mutation_root(), EmptySubscription).finish();
         let response = schema.execute(request).await;
         Ok(response)
-    }
-}
-
-struct MutationRoot;
-
-#[Object]
-impl MutationRoot {
-    async fn subscribe(&self, chain_id: ChainId) -> Vec<u8> {
-        bcs::to_bytes(&Operation::RequestSubscribe(chain_id)).unwrap()
-    }
-
-    async fn unsubscribe(&self, chain_id: ChainId) -> Vec<u8> {
-        bcs::to_bytes(&Operation::RequestUnsubscribe(chain_id)).unwrap()
-    }
-
-    async fn post(&self, text: String) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Post(text)).unwrap()
     }
 }
 

--- a/linera-sdk-derive/Cargo.toml
+++ b/linera-sdk-derive/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "linera-views-derive"
-version = "0.3.0"
-description = "The procedural macros for the crate `linera-views`"
+name = "linera-sdk-derive"
+version = "0.1.0"
+description = "The procedural macros for the crate `linera-sdk`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"
 homepage = "https://linera.io"
 license = "Apache-2.0"
 edition = "2021"
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
 [lib]
 proc-macro = true
 
 [dependencies]
 syn = { workspace = true, features = ["full", "extra-traits"] }
-heck = { workspace = true }
-quote = { workspace = true }
 proc-macro2 = { workspace = true }
-convert_case = { workspace = true }
+convert_case = "0.6.0"

--- a/linera-sdk-derive/Cargo.toml
+++ b/linera-sdk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk-derive"
-version = "0.1.0"
+version = "0.3.0"
 description = "The procedural macros for the crate `linera-sdk`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-sdk-derive/README.md
+++ b/linera-sdk-derive/README.md
@@ -1,0 +1,13 @@
+<!-- cargo-rdme start -->
+
+The procedural macros for the crate `linera-sdk`.
+
+<!-- cargo-rdme end -->
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of the [Apache 2.0 license](../LICENSE).

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -78,8 +78,10 @@ fn generate_mutation_root_code(input: ItemEnum) -> TokenStream2 {
             *
         }
 
-        impl #enum_name {
-            pub fn mutation_root() -> #mutation_root_name {
+        impl linera_sdk::graphql::GraphQLMutationRoot for #enum_name {
+            type MutationRoot = #mutation_root_name;
+
+            fn mutation_root() -> Self::MutationRoot {
                 #mutation_root_name
             }
         }
@@ -132,8 +134,10 @@ pub mod tests {
                 }
             }
 
-            impl SomeOperation {
-                pub fn mutation_root() -> SomeOperationMutationRoot {
+            impl linera_sdk::graphql::GraphQLMutationRoot for SomeOperation {
+                type MutationRoot = SomeOperationMutationRoot;
+
+                fn mutation_root() -> Self::MutationRoot {
                     SomeOperationMutationRoot
                 }
             }

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -45,7 +45,7 @@ fn generate_mutation_root_code(input: ItemEnum) -> TokenStream2 {
                 let mut fields = vec![];
                 let mut field_names = vec![];
                 for (i, field) in unnamed.unnamed.iter().enumerate() {
-                    let name = concat(&syn::parse_str::<Ident>("field_").unwrap(), &i.to_string());
+                    let name = concat(&syn::parse_str::<Ident>("field").unwrap(), &i.to_string());
                     let ty = &field.ty;
                     fields.push(quote! {#name: #ty});
                     field_names.push(name);
@@ -121,8 +121,8 @@ pub mod tests {
 
             #[async_graphql::Object]
             impl SomeOperationMutationRoot {
-                async fn tuple_variant(&self, field_0: String,) -> Vec<u8> {
-                    bcs::to_bytes(&SomeOperation::TupleVariant(field_0,)).unwrap()
+                async fn tuple_variant(&self, field0: String,) -> Vec<u8> {
+                    bcs::to_bytes(&SomeOperation::TupleVariant(field0,)).unwrap()
                 }
                 async fn struct_variant(&self, a: u32, b: u64,) -> Vec<u8> {
                     bcs::to_bytes(&SomeOperation::StructVariant { a, b, }).unwrap()

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+//! The procedural macros for the crate `linera-sdk`.
+
 mod utils;
 
 use crate::utils::{concat, snakify};

--- a/linera-sdk-derive/src/lib.rs
+++ b/linera-sdk-derive/src/lib.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod utils;
+
+use crate::utils::{concat, snakify};
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use syn::{
+    parse_macro_input, Fields, ItemEnum,
+    __private::{quote::quote, TokenStream2},
+};
+
+#[proc_macro_derive(MutationRoot)]
+pub fn derive_mutation_root(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemEnum);
+    generate_mutation_root_code(input).into()
+}
+
+fn generate_mutation_root_code(input: ItemEnum) -> TokenStream2 {
+    let enum_name = input.ident;
+    let mut methods = vec![];
+
+    for variant in input.variants {
+        let variant_name = &variant.ident;
+        let function_name = snakify(variant_name);
+        match variant.fields {
+            Fields::Named(named) => {
+                let mut fields = vec![];
+                let mut field_names = vec![];
+                for field in named.named {
+                    let name = field.ident.expect("named fields always have names");
+                    let ty = field.ty;
+                    fields.push(quote! {#name: #ty});
+                    field_names.push(name);
+                }
+                methods.push(quote! {
+                    async fn #function_name(&self, #(#fields,)*) -> Vec<u8> {
+                        bcs::to_bytes(&#enum_name::#variant_name { #(#field_names,)* }).unwrap()
+                    }
+                });
+            }
+            Fields::Unnamed(unnamed) => {
+                let mut fields = vec![];
+                let mut field_names = vec![];
+                for (i, field) in unnamed.unnamed.iter().enumerate() {
+                    let name = concat(&syn::parse_str::<Ident>("field_").unwrap(), &i.to_string());
+                    let ty = &field.ty;
+                    fields.push(quote! {#name: #ty});
+                    field_names.push(name);
+                }
+                methods.push(quote! {
+                    async fn #function_name(&self, #(#fields,)*) -> Vec<u8> {
+                        bcs::to_bytes(&#enum_name::#variant_name ( #(#field_names,)* )).unwrap()
+                    }
+                });
+            }
+            Fields::Unit => {
+                methods.push(quote! {
+                    async fn #function_name(&self) -> Vec<u8> {
+                        bcs::to_bytes(&#enum_name::#variant_name).unwrap()
+                    }
+                });
+            }
+        };
+    }
+
+    quote! {
+        #[async_graphql::Object]
+        impl #enum_name {
+            #
+
+            (#methods)
+
+            *
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::generate_mutation_root_code;
+    use syn::{parse_quote, ItemEnum, __private::quote::quote};
+
+    fn assert_eq_no_whitespace(mut actual: String, mut expected: String) {
+        // Intentionally left here for debugging purposes
+        println!("{}", actual);
+
+        actual.retain(|c| !c.is_whitespace());
+        expected.retain(|c| !c.is_whitespace());
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_derive_mutation_root() {
+        let operation: ItemEnum = parse_quote! {
+            enum SomeOperation {
+                TupleVariant(String),
+                StructVariant {
+                    a: u32,
+                    b: u64
+                },
+                EmptyVariant
+            }
+        };
+
+        let output = generate_mutation_root_code(operation);
+
+        let expected = quote! {
+            #[async_graphql::Object]
+            impl SomeOperation {
+                async fn tuple_variant(&self, field_0: String,) -> Vec<u8> {
+                    bcs::to_bytes(&SomeOperation::TupleVariant(field_0,)).unwrap()
+                }
+                async fn struct_variant(&self, a: u32, b: u64,) -> Vec<u8> {
+                    bcs::to_bytes(&SomeOperation::StructVariant { a, b, }).unwrap()
+                }
+                async fn empty_variant(&self) -> Vec<u8> {
+                    bcs::to_bytes(&SomeOperation::EmptyVariant).unwrap()
+                }
+            }
+        };
+
+        assert_eq_no_whitespace(output.to_string(), expected.to_string());
+    }
+}

--- a/linera-sdk-derive/src/utils.rs
+++ b/linera-sdk-derive/src/utils.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use convert_case::{Case, Casing};
+use proc_macro2::{Ident, Span};
+
+/// Extracts the first `Ident` in a type and convert to snake case.
+pub fn snakify(ident: &Ident) -> Ident {
+    transform_non_keyword_ident(ident, |s: String| s.to_case(Case::Snake))
+}
+
+/// Extends an identifier with a suffix.
+pub fn concat(ident: &Ident, suffix: &str) -> Ident {
+    transform_non_keyword_ident(ident, |s: String| format!("{}{}", s, suffix))
+}
+
+/// Applies a string transformation (`transform`) to the input `Ident`-
+/// However, it will not apply the transform to rust keywords.
+fn transform_non_keyword_ident<Transform>(ident: &Ident, transform: Transform) -> Ident
+where
+    Transform: FnOnce(String) -> String,
+{
+    let is_keyword = syn::parse_str::<Ident>(&ident.to_string()).is_err();
+    if is_keyword {
+        ident.clone()
+    } else {
+        Ident::new(&transform(ident.to_string()), Span::call_site())
+    }
+}

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -30,6 +30,7 @@ log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 linera-base = { workspace = true }
+linera-sdk-derive = { workspace = true }
 linera-views = { workspace = true }
 wit-bindgen-guest-rust = { workspace = true }
 

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -24,6 +24,7 @@ test = []
 
 [dependencies]
 async-trait = { workspace = true }
+async-graphql = { workspace = true }
 bcs = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }

--- a/linera-sdk/src/graphql.rs
+++ b/linera-sdk/src/graphql.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! GraphQL traits for generating interfaces into applications.
+
+/// A trait which is derived by the `MutationRoot` proc macro.
+pub trait GraphQLMutationRoot {
+    /// The associated `MutationRoot` type which is code-generated.
+    type MutationRoot: async_graphql::ObjectType;
+
+    /// Returns the `MutationRoot` for a given operation.
+    fn mutation_root() -> Self::MutationRoot;
+}

--- a/linera-sdk/src/graphql.rs
+++ b/linera-sdk/src/graphql.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! GraphQL traits for generating interfaces into applications.
-
+pub use linera_sdk_derive::MutationRoot;
 /// A trait which is derived by the `MutationRoot` proc macro.
 pub trait GraphQLMutationRoot {
     /// The associated `MutationRoot` type which is code-generated.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -41,6 +41,7 @@ pub mod base;
 pub mod contract;
 mod exported_future;
 mod extensions;
+pub mod graphql;
 mod log;
 pub mod service;
 #[cfg(feature = "test")]

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -69,7 +69,6 @@ pub use self::{
     log::{ContractLogger, ServiceLogger},
 };
 pub use linera_base::ensure;
-pub use linera_sdk_derive::MutationRoot;
 #[doc(hidden)]
 pub use wit_bindgen_guest_rust;
 

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -68,6 +68,7 @@ pub use self::{
     log::{ContractLogger, ServiceLogger},
 };
 pub use linera_base::ensure;
+pub use linera_sdk_derive::MutationRoot;
 #[doc(hidden)]
 pub use wit_bindgen_guest_rust;
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -685,7 +685,7 @@ async fn test_end_to_end_social_user_pub_sub() {
         .make_application(&chain2, &application_id)
         .await
         .into();
-    let subscribe = format!("mutation {{ subscribe(chainId: \"{chain1}\") }}");
+    let subscribe = format!("mutation {{ requestSubscribe(field0: \"{chain1}\") }}");
     let hash = app2.query_application(&subscribe).await;
 
     // The returned hash should now be the latest one.
@@ -697,7 +697,7 @@ async fn test_end_to_end_social_user_pub_sub() {
         .make_application(&chain1, &application_id)
         .await
         .into();
-    let post = "mutation { post(text: \"Linera Social is the new Mastodon!\") }";
+    let post = "mutation { post(field0: \"Linera Social is the new Mastodon!\") }";
     app1.query_application(post).await;
 
     // Instead of retrying, we could call `node_service1.process_inbox(chain1).await` here.
@@ -1302,7 +1302,7 @@ async fn test_end_to_end_matching_engine() {
             nature: OrderNature::Bid,
             price,
         };
-        let query_string = format!("mutation {{ order(order: {}) }}", insert2.to_value());
+        let query_string = format!("mutation {{ executeOrder(order: {}) }}", insert2.to_value());
         app_matching_a.query_application(&query_string).await;
     }
     for price in [4, 2] {
@@ -1314,7 +1314,7 @@ async fn test_end_to_end_matching_engine() {
             nature: OrderNature::Ask,
             price,
         };
-        let query_string = format!("mutation {{ order(order: {}) }}", insert3.to_value());
+        let query_string = format!("mutation {{ executeOrder(order: {}) }}", insert3.to_value());
         app_matching_b.query_application(&query_string).await;
     }
     node_service_admin.process_inbox(&chain_admin).await;
@@ -1336,7 +1336,7 @@ async fn test_end_to_end_matching_engine() {
     for (owner, order_ids) in [(owner_a, order_ids_a), (owner_b, order_ids_b)] {
         for order_id in order_ids {
             let cancel = matching_engine::Order::Cancel { owner, order_id };
-            let query_string = format!("mutation {{ order(order: {}) }}", cancel.to_value());
+            let query_string = format!("mutation {{ executeOrder(order: {}) }}", cancel.to_value());
             app_matching_admin.query_application(&query_string).await;
         }
     }


### PR DESCRIPTION
## Motivation

The MutationRoot used for the GraphQL flavour of Linera services was boilerplate and can be code generated.

## Proposal

A derive macro is used on top of operations which are the only mutations that are made to state. 

## Test Plan

Tested by unit tests and integration tests in the form of it being used by example applications.

## Links

Closes #876.

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [x] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
