### PR TITLE
Add `wit_export` attribute macro to export host functions to Wasm modules

### DIFF
--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2021"
 [lib]
 proc-macro = true
 
+[features]
+wasmer = []
+
 [dependencies]
 heck = { workspace = true }
 proc-macro-error = { workspace = true }

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 proc-macro = true
 
 [features]
+mock-instance = []
 wasmer = []
 wasmtime = []
 

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 
 [features]
 wasmer = []
+wasmtime = []
 
 [dependencies]
 heck = { workspace = true }

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -19,7 +19,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
 use syn::ItemImpl;
 use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
 
@@ -115,7 +115,7 @@ pub fn wit_import(attribute: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// The code generated depends on the enabled feature flags to determine which Wasm runtimes will
 /// be supported.
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn wit_export(attribute: TokenStream, input: TokenStream) -> TokenStream {

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -19,7 +19,9 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemImpl, ItemTrait};
+#[cfg(feature = "wasmer")]
+use syn::ItemImpl;
+use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
 
 /// Derives `WitType` for a Rust type.
 ///
@@ -113,6 +115,7 @@ pub fn wit_import(attribute: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// The code generated depends on the enabled feature flags to determine which Wasm runtimes will
 /// be supported.
+#[cfg(feature = "wasmer")]
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn wit_export(attribute: TokenStream, input: TokenStream) -> TokenStream {

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -19,7 +19,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
+use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemImpl, ItemTrait};
 
 /// Derives `WitType` for a Rust type.
 ///
@@ -106,4 +106,18 @@ pub fn wit_import(attribute: TokenStream, input: TokenStream) -> TokenStream {
     let namespace = extract_namespace(attribute, &input.ident);
 
     wit_import::generate(input, &namespace).into()
+}
+
+/// Registers an `impl` block's functions as callable host functions exported to guest Wasm
+/// modules.
+///
+/// The code generated depends on the enabled feature flags to determine which Wasm runtimes will
+/// be supported.
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn wit_export(attribute: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemImpl);
+    let namespace = extract_namespace(attribute, wit_export::type_name(&input));
+
+    wit_export::generate(&input, &namespace).into()
 }

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -8,6 +8,7 @@
 #![deny(missing_docs)]
 
 mod util;
+mod wit_export;
 mod wit_import;
 mod wit_load;
 mod wit_store;

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -19,7 +19,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
-#[cfg(feature = "wasmer")]
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
 use syn::ItemImpl;
 use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
 
@@ -115,7 +115,7 @@ pub fn wit_import(attribute: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// The code generated depends on the enabled feature flags to determine which Wasm runtimes will
 /// be supported.
-#[cfg(feature = "wasmer")]
+#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn wit_export(attribute: TokenStream, input: TokenStream) -> TokenStream {

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -118,6 +118,27 @@ impl<'input> FunctionInformation<'input> {
         )
     }
 
+    /// Generates the code to export a host function using the Wasmtime runtime.
+    #[cfg(feature = "wasmtime")]
+    pub fn generate_for_wasmtime(&self, namespace: &LitStr) -> TokenStream {
+        let caller = quote! { linera_witty::wasmtime::Caller<'_, ()> };
+        let input_to_guest_parameters = quote! {
+            linera_witty::wasmtime::WasmtimeParameters::from_wasmtime(input)
+        };
+        let guest_results_to_output = quote! {
+            linera_witty::wasmtime::WasmtimeResults::into_wasmtime(guest_results)
+        };
+        let output_results_trait = quote! { linera_witty::wasmtime::WasmtimeResults };
+
+        self.generate(
+            namespace,
+            caller,
+            input_to_guest_parameters,
+            guest_results_to_output,
+            output_results_trait,
+        )
+    }
+
     /// Generates the code to export using a host function.
     fn generate(
         &self,

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -139,6 +139,23 @@ impl<'input> FunctionInformation<'input> {
         )
     }
 
+    /// Generates the code to export a host function using a mock Wasm instance for testing.
+    #[cfg(feature = "mock-instance")]
+    pub fn generate_for_mock_instance(&self, namespace: &LitStr) -> TokenStream {
+        let caller = quote! { linera_witty::MockInstance };
+        let input_to_guest_parameters = quote! { input };
+        let guest_results_to_output = quote! { guest_results };
+        let output_results_trait = quote! { linera_witty::MockResults };
+
+        self.generate(
+            namespace,
+            caller,
+            input_to_guest_parameters,
+            guest_results_to_output,
+            output_results_trait,
+        )
+    }
+
     /// Generates the code to export using a host function.
     fn generate(
         &self,

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -1,0 +1,191 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Extraction of information and generation of code related to a single exported host function.
+
+use heck::ToKebabCase;
+use proc_macro2::{Span, TokenStream};
+use proc_macro_error::abort;
+use quote::{quote, quote_spanned, ToTokens};
+use syn::{
+    spanned::Spanned, FnArg, GenericArgument, ImplItem, ImplItemMethod, Path, PathArguments,
+    PathSegment, ReturnType, Token, Type, TypePath,
+};
+
+/// Pieces of information extracted from a function's definition.
+pub struct FunctionInformation<'input> {
+    function: &'input ImplItemMethod,
+    wit_name: String,
+    parameter_bindings: TokenStream,
+    call_early_return: Option<Token![?]>,
+    interface_type: TokenStream,
+}
+
+impl<'input> From<&'input ImplItem> for FunctionInformation<'input> {
+    fn from(item: &'input ImplItem) -> Self {
+        match item {
+            ImplItem::Method(function) => FunctionInformation::new(function),
+            ImplItem::Const(const_item) => abort!(
+                const_item.ident,
+                "Const items are not supported in exported types"
+            ),
+            ImplItem::Type(type_item) => abort!(
+                type_item.ident,
+                "Type items are not supported in exported types"
+            ),
+            ImplItem::Macro(macro_item) => abort!(
+                macro_item.mac.path,
+                "Macro items are not supported in exported types"
+            ),
+            _ => abort!(item, "Only function items are supported in exported types"),
+        }
+    }
+}
+
+impl<'input> FunctionInformation<'input> {
+    /// Parses a function definition and collects pieces of information into a
+    /// [`FunctionInformation`] instance.
+    pub fn new(function: &'input ImplItemMethod) -> Self {
+        let wit_name = function.sig.ident.to_string().to_kebab_case();
+        let (parameter_bindings, parameter_types) =
+            Self::parse_parameters(function.sig.inputs.iter());
+        let (results, is_fallible) = Self::parse_output(&function.sig.output);
+
+        let interface_type = quote_spanned! { function.sig.span() =>
+            (linera_witty::HList![#parameter_types], #results)
+        };
+
+        FunctionInformation {
+            function,
+            wit_name,
+            parameter_bindings,
+            call_early_return: is_fallible.then(|| Token![?](Span::call_site())),
+            interface_type,
+        }
+    }
+
+    /// Parses a function's parameters and returns the generated code with a list ofbindings to the
+    /// parameters and a list of the parameters types.
+    fn parse_parameters(
+        inputs: impl Iterator<Item = &'input FnArg> + Clone,
+    ) -> (TokenStream, TokenStream) {
+        let parameters = inputs.map(|input| match input {
+            FnArg::Typed(parameter) => parameter,
+            FnArg::Receiver(receiver) => abort!(
+                receiver.self_token,
+                "Exported interfaces can not have `self` parameters"
+            ),
+        });
+
+        let bindings = parameters.clone().map(|parameter| &parameter.pat);
+        let types = parameters.map(|parameter| &parameter.ty);
+
+        (quote! { #( #bindings ),* }, quote! { #( #types ),* })
+    }
+
+    /// Parses a function's return type, returning the type to use as the WIT result and whether
+    /// the function is fallible.
+    fn parse_output(output: &ReturnType) -> (TokenStream, bool) {
+        match output {
+            ReturnType::Default => (quote_spanned! { output.span() => () }, false),
+            ReturnType::Type(_, return_type) => match ok_type_inside_result(return_type) {
+                Some(inner_type) => (inner_type.to_token_stream(), true),
+                None => (return_type.to_token_stream(), false),
+            },
+        }
+    }
+}
+
+/// Returns the type inside the `Ok` variant of the `maybe_result_type`.
+///
+/// The type is only considered if it's a [`Result`] type with `RuntimeError` as its error variant.
+fn ok_type_inside_result(maybe_result_type: &Type) -> Option<&Type> {
+    let Type::Path(TypePath { qself: None, path }) = maybe_result_type else {
+        return None;
+    };
+
+    let (ok_type, error_type) = result_type_arguments(path)?;
+
+    if let Type::Path(TypePath { qself: None, path }) = error_type {
+        if !path.is_ident("RuntimeError") {
+            return None;
+        }
+    } else {
+        return None;
+    }
+
+    Some(ok_type)
+}
+
+/// Returns the generic type arguments of the [`Result`] type in `result_path`.
+fn result_type_arguments(result_path: &Path) -> Option<(&Type, &Type)> {
+    if !type_is_result(result_path) {
+        return None;
+    }
+
+    let PathArguments::AngleBracketed(type_arguments) = &result_path.segments.last()?.arguments
+    else {
+        return None;
+    };
+
+    if type_arguments.args.len() != 2 {
+        return None;
+    }
+
+    let mut arguments = type_arguments.args.iter();
+
+    let GenericArgument::Type(ok_type) = arguments.next()? else {
+        return None;
+    };
+
+    let GenericArgument::Type(error_type) = arguments.next()? else {
+        return None;
+    };
+
+    Some((ok_type, error_type))
+}
+
+/// Checks if `result_path` is a [`Result`] type.
+fn type_is_result(result_path: &Path) -> bool {
+    let segment_count = result_path.segments.len();
+
+    if segment_count == 1 {
+        result_path.leading_colon.is_none() && path_matches_segments(result_path, &["Result"])
+    } else if result_path.segments.len() == 3 {
+        path_matches_segments(result_path, &["std", "result", "Result"])
+    } else {
+        false
+    }
+}
+
+/// Checks if `path` matches the provided path `segments`.
+fn path_matches_segments(path: &Path, segments: &[&str]) -> bool {
+    if path.segments.len() != segments.len() {
+        return false;
+    }
+
+    for (index, (segment, expected)) in path.segments.iter().zip(segments).enumerate() {
+        let with_type_parameters = index == segments.len();
+
+        if !is_path_segment(segment, expected, with_type_parameters) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Checks if `segment` is the `expected_identifier` and if it should have generic type parameters.
+fn is_path_segment(
+    segment: &PathSegment,
+    expected_identifier: &str,
+    with_type_parameters: bool,
+) -> bool {
+    let arguments_are_correct = if with_type_parameters {
+        matches!(segment.arguments, PathArguments::AngleBracketed(_))
+    } else {
+        matches!(segment.arguments, PathArguments::None)
+    };
+
+    segment.ident == expected_identifier && arguments_are_correct
+}

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -4,3 +4,78 @@
 //! Generation of code to export host functions to a Wasm guest instance.
 
 mod function_information;
+
+use self::function_information::FunctionInformation;
+use proc_macro2::TokenStream;
+use proc_macro_error::abort;
+use quote::quote;
+use syn::{Ident, ItemImpl, LitStr, Type, TypePath};
+
+/// Returns the code generated for exporting host functions to guest Wasm instances.
+///
+/// The generated code implements the `linera_witty::ExportTo` trait for the Wasm runtimes enabled
+/// through feature flags. The trait implementation exports the host functions in the input `impl`
+/// block to a provided Wasm guest instance.
+pub fn generate(implementation: &ItemImpl, namespace: &LitStr) -> TokenStream {
+    WitExportGenerator::new(implementation, namespace).generate()
+}
+
+/// A helper type for generation of the code to export host functions to Wasm guest instances.
+///
+/// Code generating is done in two phases. First the necessary pieces are collected and stored in
+/// this type. Then, they are used to generate the final code.
+pub struct WitExportGenerator<'input> {
+    type_name: &'input Ident,
+    implementation: &'input ItemImpl,
+    functions: Vec<FunctionInformation<'input>>,
+    namespace: &'input LitStr,
+}
+
+impl<'input> WitExportGenerator<'input> {
+    /// Collects the pieces necessary for code generation from the inputs.
+    pub fn new(implementation: &'input ItemImpl, namespace: &'input LitStr) -> Self {
+        let type_name = type_name(implementation);
+        let functions = implementation
+            .items
+            .iter()
+            .map(FunctionInformation::from)
+            .collect();
+
+        WitExportGenerator {
+            type_name,
+            implementation,
+            functions,
+            namespace,
+        }
+    }
+
+    /// Consumes the collected pieces to generate the final code.
+    pub fn generate(mut self) -> TokenStream {
+        let implementation = self.implementation;
+
+        quote! {
+            #implementation
+        }
+    }
+}
+
+/// Returns the type name of the type the `impl` block is for.
+pub fn type_name(implementation: &ItemImpl) -> &Ident {
+    let Type::Path(TypePath {
+        qself: None,
+        path: path_name,
+    }) = &*implementation.self_ty
+    else {
+        abort!(
+            implementation.self_ty,
+            "`#[wit_export]` must be used on `impl` blocks of non-generic types",
+        );
+    };
+
+    path_name.get_ident().unwrap_or_else(|| {
+        abort!(
+            implementation.self_ty,
+            "`#[wit_export]` must be used on `impl` blocks of non-generic types",
+        );
+    })
+}

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generation of code to export host functions to a Wasm guest instance.
+
+mod function_information;

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 default = ["macros"]
 macros = ["linera-witty-macros"]
 test = []
-wasmer = ["dep:wasmer", "wasmer-vm"]
+wasmer = ["dep:wasmer", "linera-witty-macros?/wasmer", "wasmer-vm"]
 wasmtime = ["dep:wasmtime", "anyhow"]
 
 [dependencies]

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [features]
 default = ["macros"]
 macros = ["linera-witty-macros"]
-test = []
+test = ["linera-witty-macros?/mock-instance"]
 wasmer = ["dep:wasmer", "linera-witty-macros?/wasmer", "wasmer-vm"]
 wasmtime = ["dep:wasmtime", "anyhow", "linera-witty-macros?/wasmtime"]
 

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -15,7 +15,7 @@ default = ["macros"]
 macros = ["linera-witty-macros"]
 test = []
 wasmer = ["dep:wasmer", "linera-witty-macros?/wasmer", "wasmer-vm"]
-wasmtime = ["dep:wasmtime", "anyhow"]
+wasmtime = ["dep:wasmtime", "anyhow", "linera-witty-macros?/wasmtime"]
 
 [dependencies]
 anyhow = { workspace = true, optional = true }

--- a/linera-witty/src/exported_function_interface/guest_interface.rs
+++ b/linera-witty/src/exported_function_interface/guest_interface.rs
@@ -1,0 +1,224 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of the interface a guest Wasm instance uses for a host function.
+//!
+//! The [`GuestInterface`] trait is implemented for the tuple pair of the flattened representation
+//! of the host function's parameters type and results type. The trait then maps the flattened host
+//! function signature into the interface guest Wasm instances expect. This involves selecting
+//! where the host function's parameters and results are stored and if the guest Wasm instance
+//! needs to provide additional parameters to the function with the addresses to store the
+//! parameters and/or results in memory.
+//!
+//! The [canonical ABI][flattening] describes a `MAX_FLAT_PARAMS` limit on the number of flat types
+//! that can be sent to the function through Wasm parameters. If more flat parameters are needed,
+//! then all of them are stored in memory instead, and the guest Wasm instance must provide a
+//! single parameter with the address in memory of where the parameters are stored. The same must
+//! be done if more flat result types than the `MAX_FLAT_RESULTS` limit defined by the [canonical
+//! ABI][flattening] need to be returned from the function. In that case, the guest Wasm instance
+//! is responsible for sending an additional parameter with an address in memory where the results
+//! can be stored. See [`ResultStorage`] for more information.
+//!
+//! [flattening]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
+
+use super::result_storage::ResultStorage;
+use crate::{
+    memory_layout::FlatLayout, primitive_types::FlatType, util::Split, GuestPointer,
+    InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory, WitLoad,
+};
+use frunk::HList;
+use std::ops::Add;
+
+/// Representation of the interface a guest Wasm instance uses for a host function.
+///
+/// See the module level documentation for more information.
+pub trait GuestInterface {
+    /// The flattened layout of the host function's parameters type.
+    ///
+    /// This is used as a generic input type in all implementations, but is needed here so it can
+    /// be used in the constraints of the [`Self::lift_parameters`] method.
+    type FlatHostParameters: FlatLayout;
+
+    /// The flat types the guest Wasm instances use as parameters for the host function.
+    type FlatGuestParameters: FlatLayout;
+
+    /// How the host function's results type is sent back to the guest Wasm instance.
+    type ResultStorage: ResultStorage;
+
+    /// Lifts the parameters received from the guest Wasm instance into the parameters type the
+    /// host function expects.
+    ///
+    /// Returns the lifted host function's parameters together with a [`ResultStorage`]
+    /// implementation which is later used to lower the host function's results to where the guest
+    /// Wasm instance expects them to be. The [`ResultStorage`] is either the unit type `()`
+    /// indicating that the results should just be lowered and sent to the guest as the function's
+    /// return value, or a [`GuestPointer`] with the address of where the results should be stored
+    /// in memory.
+    fn lift_parameters<Instance, HostParameters>(
+        guest_parameters: Self::FlatGuestParameters,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<(HostParameters, Self::ResultStorage), RuntimeError>
+    where
+        HostParameters: WitLoad,
+        HostParameters::Layout: Layout<Flat = Self::FlatHostParameters>,
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
+}
+
+/// Implements [`GuestInterface`] for the cases where the parameters and the results are sent
+/// directly as the function's parameters and results, without requiring any of them to be moved to
+/// memory.
+macro_rules! direct_interface {
+    ($( $types:ident ),* $(,)*) => {
+        direct_interface_with_result!($( $types ),* =>);
+        direct_interface_with_result!($( $types ),* => FlatResult);
+    };
+}
+
+/// Helper macro to [`direct_interface`] so that it can handle the two possible return signatures
+/// with all parameter combinations.
+macro_rules! direct_interface_with_result {
+    ($( $types:ident ),* => $( $flat_result:ident )?) => {
+        impl<$( $types, )* $( $flat_result )*> GuestInterface
+            for (HList![$( $types, )*], HList![$( $flat_result )*])
+        where
+            HList![$( $types, )*]: FlatLayout,
+            $( $flat_result: FlatType, )*
+        {
+            type FlatHostParameters = HList![$( $types, )*];
+            type FlatGuestParameters = HList![$( $types, )*];
+            type ResultStorage = ();
+
+            fn lift_parameters<Instance, HostParameters>(
+                guest_parameters: Self::FlatGuestParameters,
+                memory: &Memory<'_, Instance>,
+            ) -> Result<(HostParameters, Self::ResultStorage), RuntimeError>
+            where
+                HostParameters: WitLoad,
+                HostParameters::Layout: Layout<Flat = Self::FlatHostParameters>,
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let parameters = HostParameters::lift_from(guest_parameters, memory)?;
+
+                Ok((parameters, ()))
+            }
+        }
+    };
+}
+
+repeat_macro!(direct_interface => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+
+/// Implements [`GuestInterface`] for the cases where the parameters are sent directly as the
+/// function's parameters but the results are stored in memory instead.
+macro_rules! indirect_results {
+    ($( $types:ident ),*) => {
+        impl<$( $types, )* Y, Z, Tail> GuestInterface
+            for (HList![$( $types, )*], HList![Y, Z, ...Tail])
+        where
+            HList![$( $types, )*]: FlatLayout + Add<HList![i32]>,
+            <HList![$( $types, )*] as Add<HList![i32]>>::Output:
+                FlatLayout + Split<HList![$( $types, )*], Remainder = HList![i32]>,
+        {
+            type FlatHostParameters = HList![$( $types, )*];
+            type FlatGuestParameters = <Self::FlatHostParameters as Add<HList![i32]>>::Output;
+            type ResultStorage = GuestPointer;
+
+            fn lift_parameters<Instance, Parameters>(
+                guest_parameters: Self::FlatGuestParameters,
+                memory: &Memory<'_, Instance>,
+            ) -> Result<(Parameters, Self::ResultStorage), RuntimeError>
+            where
+                Parameters: WitLoad,
+                Parameters::Layout: Layout<Flat = Self::FlatHostParameters>,
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let (parameters_layout, result_storage_layout) = guest_parameters.split();
+                let parameters = Parameters::lift_from(parameters_layout, memory)?;
+                let result_storage = Self::ResultStorage::lift_from(result_storage_layout, memory)?;
+
+                Ok((parameters, result_storage))
+            }
+        }
+    };
+}
+
+repeat_macro!(indirect_results => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+
+/// Implements [`GuestInterface`] for the cases where the results are sent directly as the
+/// function's return value but the parameters are stored in memory instead.
+macro_rules! indirect_parameters {
+    (=> $( $flat_result:ident )? ) => {
+        impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Tail $(, $flat_result )*>
+            GuestInterface
+            for (
+                HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...Tail],
+                HList![$( $flat_result )*],
+            )
+        where
+            HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...Tail]: FlatLayout,
+            $( $flat_result: FlatType, )*
+        {
+            type FlatHostParameters =
+                HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...Tail];
+            type FlatGuestParameters = HList![i32];
+            type ResultStorage = ();
+
+            fn lift_parameters<Instance, Parameters>(
+                guest_parameters: Self::FlatGuestParameters,
+                memory: &Memory<'_, Instance>,
+            ) -> Result<(Parameters, Self::ResultStorage), RuntimeError>
+            where
+                Parameters: WitLoad,
+                Parameters::Layout: Layout<Flat = Self::FlatHostParameters>,
+                Instance: InstanceWithMemory,
+                <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+            {
+                let parameters_location = GuestPointer::lift_from(guest_parameters, memory)?;
+                let parameters = Parameters::load(memory, parameters_location)?;
+
+                Ok((parameters, ()))
+            }
+        }
+    };
+}
+
+indirect_parameters!(=>);
+indirect_parameters!(=> Z);
+
+/// Implements [`GuestInterface`] for the cases where the parameters and the results need to be
+/// stored in memory.
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, OtherParameters, Y, Z, OtherResults>
+    GuestInterface
+    for (
+        HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, ...OtherParameters],
+        HList![Y, Z, ...OtherResults],
+    )
+where
+    HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, ...OtherParameters]: FlatLayout,
+    HList![Y, Z, ...OtherResults]: FlatLayout,
+{
+    type FlatHostParameters =
+        HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, ...OtherParameters];
+    type FlatGuestParameters = HList![i32, i32];
+    type ResultStorage = GuestPointer;
+
+    fn lift_parameters<Instance, Parameters>(
+        guest_parameters: Self::FlatGuestParameters,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<(Parameters, Self::ResultStorage), RuntimeError>
+    where
+        Parameters: WitLoad,
+        Parameters::Layout: Layout<Flat = Self::FlatHostParameters>,
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let (parameters_layout, result_storage_layout) = guest_parameters.split();
+        let parameters_location = GuestPointer::lift_from(parameters_layout, memory)?;
+        let parameters = Parameters::load(memory, parameters_location)?;
+        let result_storage = Self::ResultStorage::lift_from(result_storage_layout, memory)?;
+
+        Ok((parameters, result_storage))
+    }
+}

--- a/linera-witty/src/exported_function_interface/mod.rs
+++ b/linera-witty/src/exported_function_interface/mod.rs
@@ -6,9 +6,10 @@
 //! These help determining the function signature the guest expects based on the host function
 //! signature.
 
+mod guest_interface;
 mod result_storage;
 
-use self::result_storage::ResultStorage;
+use self::{guest_interface::GuestInterface, result_storage::ResultStorage};
 use crate::RuntimeError;
 
 /// A type that can register some functions as exports for the target `Instance`.

--- a/linera-witty/src/exported_function_interface/mod.rs
+++ b/linera-witty/src/exported_function_interface/mod.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper traits for exporting host functions to guest Wasm instances.
+//!
+//! These help determining the function signature the guest expects based on the host function
+//! signature.
+
+use crate::RuntimeError;
+
+/// A type that can register some functions as exports for the target `Instance`.
+pub trait ExportTo<Instance> {
+    /// Registers some host functions as exports to the provided guest Wasm `instance`.
+    fn export_to(instance: &mut Instance) -> Result<(), RuntimeError>;
+}

--- a/linera-witty/src/exported_function_interface/mod.rs
+++ b/linera-witty/src/exported_function_interface/mod.rs
@@ -10,7 +10,10 @@ mod guest_interface;
 mod result_storage;
 
 use self::{guest_interface::GuestInterface, result_storage::ResultStorage};
-use crate::RuntimeError;
+use crate::{
+    InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory, WitLoad, WitStore,
+    WitType,
+};
 
 /// A type that can register some functions as exports for the target `Instance`.
 pub trait ExportTo<Instance> {
@@ -31,4 +34,97 @@ pub trait ExportFunction<Handler, Parameters, Results> {
         function_name: &str,
         handler: Handler,
     ) -> Result<(), RuntimeError>;
+}
+
+/// Representation of an exported host function's interface.
+///
+/// Implemented for a tuple pair of the host parameters type and the host results type, and allows
+/// converting to the signature the guest Wasm instance uses for that host function.
+pub trait ExportedFunctionInterface {
+    /// The type representing the host-side parameters.
+    type HostParameters: WitType;
+
+    /// The type representing the host-side results.
+    type HostResults: WitStore;
+
+    /// The representation of the guest-side function interface.
+    type GuestInterface: GuestInterface<
+        FlatHostParameters = <<Self::HostParameters as WitType>::Layout as Layout>::Flat,
+        ResultStorage = Self::ResultStorage,
+    >;
+
+    /// The type representing the guest-side parameters.
+    type GuestParameters;
+
+    /// The type representing the guest-side results.
+    type GuestResults;
+
+    /// How the results from the exported host function should be sent back to the guest.
+    type ResultStorage: ResultStorage<OutputFor<Self::HostResults> = Self::GuestResults>;
+
+    /// Converts the guest-side parameters into the host-side parameters.
+    fn lift_parameters<Instance>(
+        guest_parameters: Self::GuestParameters,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<(Self::HostParameters, Self::ResultStorage), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
+
+    /// Converts the host-side results into the guest-side results.
+    fn lower_results<Instance>(
+        results: Self::HostResults,
+        result_storage: Self::ResultStorage,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::GuestResults, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
+}
+
+impl<Parameters, Results> ExportedFunctionInterface for (Parameters, Results)
+where
+    Parameters: WitLoad,
+    Results: WitStore,
+    (
+        <Parameters::Layout as Layout>::Flat,
+        <Results::Layout as Layout>::Flat,
+    ): GuestInterface<FlatHostParameters = <Parameters::Layout as Layout>::Flat>,
+    <() as WitType>::Layout: Layout<Flat = frunk::HNil>,
+{
+    type HostParameters = Parameters;
+    type HostResults = Results;
+    type GuestInterface = (
+        <Parameters::Layout as Layout>::Flat,
+        <Results::Layout as Layout>::Flat,
+    );
+    type GuestParameters = <Self::GuestInterface as GuestInterface>::FlatGuestParameters;
+    type GuestResults =
+        <<Self::GuestInterface as GuestInterface>::ResultStorage as ResultStorage>::OutputFor<
+            Self::HostResults,
+        >;
+    type ResultStorage = <Self::GuestInterface as GuestInterface>::ResultStorage;
+
+    fn lift_parameters<Instance>(
+        guest_parameters: Self::GuestParameters,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<(Self::HostParameters, Self::ResultStorage), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        Self::GuestInterface::lift_parameters(guest_parameters, memory)
+    }
+
+    fn lower_results<Instance>(
+        results: Self::HostResults,
+        result_storage: Self::ResultStorage,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::GuestResults, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        result_storage.lower_result(results, memory)
+    }
 }

--- a/linera-witty/src/exported_function_interface/mod.rs
+++ b/linera-witty/src/exported_function_interface/mod.rs
@@ -13,3 +13,18 @@ pub trait ExportTo<Instance> {
     /// Registers some host functions as exports to the provided guest Wasm `instance`.
     fn export_to(instance: &mut Instance) -> Result<(), RuntimeError>;
 }
+
+/// A type that accepts registering a host function as an export for a guest Wasm instance.
+///
+/// The `Handler` represents the closure type required for the host function, and `Parameters` and
+/// `Results` are the input and output types of the closure, respectively.
+pub trait ExportFunction<Handler, Parameters, Results> {
+    /// Registers a host function executed by the `handler` with the provided `module_name` and
+    /// `function_name` as an export for a guest Wasm instance.
+    fn export(
+        &mut self,
+        module_name: &str,
+        function_name: &str,
+        handler: Handler,
+    ) -> Result<(), RuntimeError>;
+}

--- a/linera-witty/src/exported_function_interface/mod.rs
+++ b/linera-witty/src/exported_function_interface/mod.rs
@@ -6,6 +6,9 @@
 //! These help determining the function signature the guest expects based on the host function
 //! signature.
 
+mod result_storage;
+
+use self::result_storage::ResultStorage;
 use crate::RuntimeError;
 
 /// A type that can register some functions as exports for the target `Instance`.

--- a/linera-witty/src/exported_function_interface/result_storage.rs
+++ b/linera-witty/src/exported_function_interface/result_storage.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of where a function's results should be stored.
+//!
+//! The [canonical ABI][flattening] describes a `MAX_FLAT_RESULTS` limit on the number of flat
+//! types that are returned from a function. The limit is currently one. That means that any type
+//! returned from a host function that needs more than one flat type to represent it after lowering
+//! needs to be placed in memory.
+//!
+//! The [`ResultStorage`] trait below allows representing in compile time if the results should be
+//! returned as a single flat value (scenario represented by the `()` unit type) or placed in
+//! memory and not have any return value (scenario represented by a [`GuestPointer`] instance with
+//! the address where the results should be stored).
+//!
+//! [flattening]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening
+
+use crate::{
+    memory_layout::FlatLayout, GuestPointer, InstanceWithMemory, Layout, Memory, Runtime,
+    RuntimeError, RuntimeMemory, WitStore,
+};
+use frunk::HNil;
+
+/// Representation of where a function's results should be stored.
+///
+/// See the module level documentation for details.
+pub trait ResultStorage {
+    /// A helper associated type that maps the flat layout of a `HostResults` type into the flat
+    /// layout of the returned value.
+    ///
+    /// This is either an empty layout representing a function that has no return values or a
+    /// layout with a single flat type representing a function that returns one flat value.
+    type OutputFor<HostResults>: FlatLayout
+    where
+        HostResults: WitStore;
+
+    /// Lowers the `HostResults` and prepares the output for the function, storing it in memory if
+    /// needed.
+    fn lower_result<HostResults, Instance>(
+        self,
+        result: HostResults,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::OutputFor<HostResults>, RuntimeError>
+    where
+        HostResults: WitStore,
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>;
+}
+
+impl ResultStorage for () {
+    type OutputFor<HostResults> = <HostResults::Layout as Layout>::Flat
+    where
+        HostResults: WitStore;
+
+    fn lower_result<HostResults, Instance>(
+        self,
+        result: HostResults,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::OutputFor<HostResults>, RuntimeError>
+    where
+        HostResults: WitStore,
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        result.lower(memory)
+    }
+}
+
+impl ResultStorage for GuestPointer {
+    type OutputFor<HostResults> = HNil
+    where
+        HostResults: WitStore;
+
+    fn lower_result<HostResults, Instance>(
+        self,
+        result: HostResults,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::OutputFor<HostResults>, RuntimeError>
+    where
+        HostResults: WitStore,
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        result.store(memory, self)?;
+
+        Ok(HNil)
+    }
+}

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -40,5 +40,7 @@ pub use self::{
     util::{Merge, Split},
 };
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
+#[cfg(all(feature = "macros", feature = "wasmer"))]
+pub use linera_witty_macros::wit_export;
 #[cfg(feature = "macros")]
-pub use linera_witty_macros::{wit_export, wit_import, WitLoad, WitStore, WitType};
+pub use linera_witty_macros::{wit_import, WitLoad, WitStore, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::runtime::wasmtime;
 #[cfg(any(test, feature = "test"))]
 pub use self::runtime::{MockExportedFunction, MockInstance, MockRuntime};
 pub use self::{
-    exported_function_interface::ExportTo,
+    exported_function_interface::{ExportFunction, ExportTo},
     imported_function_interface::ImportedFunctionInterface,
     memory_layout::{JoinFlatLayouts, Layout},
     runtime::{

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -39,4 +39,4 @@ pub use self::{
 };
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
 #[cfg(feature = "macros")]
-pub use linera_witty_macros::{WitLoad, WitStore, WitType};
+pub use linera_witty_macros::{wit_import, WitLoad, WitStore, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::runtime::wasmtime;
 #[cfg(any(test, feature = "test"))]
 pub use self::runtime::{MockExportedFunction, MockInstance, MockRuntime};
 pub use self::{
-    exported_function_interface::{ExportFunction, ExportTo},
+    exported_function_interface::{ExportFunction, ExportTo, ExportedFunctionInterface},
     imported_function_interface::ImportedFunctionInterface,
     memory_layout::{JoinFlatLayouts, Layout},
     runtime::{

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -27,7 +27,7 @@ pub use self::runtime::wasmer;
 #[cfg(feature = "wasmtime")]
 pub use self::runtime::wasmtime;
 #[cfg(any(test, feature = "test"))]
-pub use self::runtime::{MockExportedFunction, MockInstance, MockRuntime};
+pub use self::runtime::{MockExportedFunction, MockInstance, MockResults, MockRuntime};
 pub use self::{
     exported_function_interface::{ExportFunction, ExportTo, ExportedFunctionInterface},
     imported_function_interface::ImportedFunctionInterface,

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -40,7 +40,7 @@ pub use self::{
     util::{Merge, Split},
 };
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
-#[cfg(all(feature = "macros", feature = "wasmer"))]
+#[cfg(all(feature = "macros", any(feature = "wasmer", feature = "wasmtime")))]
 pub use linera_witty_macros::wit_export;
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::{wit_import, WitLoad, WitStore, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -14,6 +14,7 @@
 #[macro_use]
 mod macro_utils;
 
+mod exported_function_interface;
 mod imported_function_interface;
 mod memory_layout;
 mod primitive_types;
@@ -28,6 +29,7 @@ pub use self::runtime::wasmtime;
 #[cfg(any(test, feature = "test"))]
 pub use self::runtime::{MockExportedFunction, MockInstance, MockRuntime};
 pub use self::{
+    exported_function_interface::ExportTo,
     imported_function_interface::ImportedFunctionInterface,
     memory_layout::{JoinFlatLayouts, Layout},
     runtime::{

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -40,7 +40,10 @@ pub use self::{
     util::{Merge, Split},
 };
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
-#[cfg(all(feature = "macros", any(feature = "wasmer", feature = "wasmtime")))]
+#[cfg(all(
+    feature = "macros",
+    any(feature = "test", feature = "wasmer", feature = "wasmtime")
+))]
 pub use linera_witty_macros::wit_export;
 #[cfg(feature = "macros")]
 pub use linera_witty_macros::{wit_import, WitLoad, WitStore, WitType};

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -41,4 +41,4 @@ pub use self::{
 };
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
 #[cfg(feature = "macros")]
-pub use linera_witty_macros::{wit_import, WitLoad, WitStore, WitType};
+pub use linera_witty_macros::{wit_export, wit_import, WitLoad, WitStore, WitType};

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -14,7 +14,7 @@ pub mod wasmer;
 pub mod wasmtime;
 
 #[cfg(any(test, feature = "test"))]
-pub use self::test::{MockExportedFunction, MockInstance, MockRuntime};
+pub use self::test::{MockExportedFunction, MockInstance, MockResults, MockRuntime};
 pub use self::{
     error::RuntimeError,
     memory::{GuestPointer, Memory, RuntimeMemory},

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -279,6 +279,19 @@ where
     }
 }
 
+/// A helper trait to serve as an equivalent to [`crate::wasmer::WasmerResults`] and
+/// [`crate::wasmtime::WasmtimeResults`] for the [`MockInstance`].
+///
+/// This is in order to help with writing tests generic over the Wasm guest instance type.
+pub trait MockResults {
+    /// The mock native type of the results for the [`MockInstance`].
+    type Results;
+}
+
+impl<T> MockResults for T {
+    type Results = T;
+}
+
 /// A helper type to verify how many times an exported function is called.
 pub struct MockExportedFunction<Parameters, Results> {
     name: String,

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -10,7 +10,7 @@ use super::{
     GuestPointer, Instance, InstanceWithFunction, InstanceWithMemory, Runtime, RuntimeError,
     RuntimeMemory,
 };
-use crate::memory_layout::FlatLayout;
+use crate::{memory_layout::FlatLayout, ExportFunction, WitLoad, WitStore};
 use frunk::{hlist, hlist_pat, HList};
 use std::{
     any::Any,
@@ -30,15 +30,18 @@ impl Runtime for MockRuntime {
     type Memory = Arc<Mutex<Vec<u8>>>;
 }
 
-/// A closure for handling calls to mocked exported guest functions.
-pub type ExportedFunctionHandler = Box<dyn Fn(Box<dyn Any>) -> Result<Box<dyn Any>, RuntimeError>>;
+/// A closure for handling calls to mocked functions.
+pub type FunctionHandler =
+    Arc<dyn Fn(MockInstance, Box<dyn Any>) -> Result<Box<dyn Any>, RuntimeError>>;
 
 /// A fake Wasm instance.
 ///
 /// Only contains exports for the memory and the canonical ABI allocation functions.
+#[derive(Clone)]
 pub struct MockInstance {
     memory: Arc<Mutex<Vec<u8>>>,
-    exported_functions: HashMap<String, ExportedFunctionHandler>,
+    exported_functions: HashMap<String, FunctionHandler>,
+    imported_functions: HashMap<String, FunctionHandler>,
 }
 
 impl Default for MockInstance {
@@ -48,11 +51,13 @@ impl Default for MockInstance {
         MockInstance {
             memory: memory.clone(),
             exported_functions: HashMap::new(),
+            imported_functions: HashMap::new(),
         }
-        .with_exported_function("cabi_free", |_: HList![i32]| Ok(hlist![]))
+        .with_exported_function("cabi_free", |_, _: HList![i32]| Ok(hlist![]))
         .with_exported_function(
             "cabi_realloc",
-            move |hlist_pat![_old_address, _old_size, alignment, new_size]: HList![
+            move |_,
+                  hlist_pat![_old_address, _old_size, alignment, new_size]: HList![
                 i32, i32, i32, i32
             ]| {
                 let allocation_size = usize::try_from(new_size)
@@ -89,7 +94,7 @@ impl MockInstance {
     where
         Parameters: 'static,
         Results: 'static,
-        Handler: Fn(Parameters) -> Result<Results, RuntimeError> + 'static,
+        Handler: Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
     {
         self.add_exported_function(name, handler);
         self
@@ -106,19 +111,43 @@ impl MockInstance {
     where
         Parameters: 'static,
         Results: 'static,
-        Handler: Fn(Parameters) -> Result<Results, RuntimeError> + 'static,
+        Handler: Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
     {
         self.exported_functions.insert(
             name.into(),
-            Box::new(move |boxed_parameters| {
+            Arc::new(move |caller, boxed_parameters| {
                 let parameters = boxed_parameters
                     .downcast()
                     .expect("Incorrect parameters used to call handler for exported function");
 
-                handler(*parameters).map(|results| Box::new(results) as Box<dyn Any>)
+                handler(caller, *parameters).map(|results| Box::new(results) as Box<dyn Any>)
             }),
         );
         self
+    }
+
+    /// Calls a function that the mock instance imported from the host.
+    pub fn call_imported_function<Parameters, Results>(
+        &self,
+        function: &str,
+        parameters: Parameters,
+    ) -> Result<Results, RuntimeError>
+    where
+        Parameters: WitStore + 'static,
+        Results: WitLoad + 'static,
+    {
+        let handler = self
+            .imported_functions
+            .get(function)
+            .unwrap_or_else(|| panic!("Missing function imported from host: {function:?}"));
+
+        let flat_parameters = parameters.lower(&mut self.clone().memory()?)?;
+        let boxed_flat_results = handler(self.clone(), Box::new(flat_parameters))?;
+        let flat_results = *boxed_flat_results
+            .downcast()
+            .expect("Expected an incorrect results type from imported host function");
+
+        Results::lift_from(flat_results, &self.clone().memory()?)
     }
 }
 
@@ -158,7 +187,7 @@ where
             .get(function)
             .ok_or_else(|| RuntimeError::FunctionNotFound(function.clone()))?;
 
-        let results = handler(Box::new(parameters))?;
+        let results = handler(self.clone(), Box::new(parameters))?;
 
         Ok(*results
             .downcast()
@@ -217,12 +246,45 @@ impl InstanceWithMemory for MockInstance {
     }
 }
 
+impl<Handler, Parameters, Results> ExportFunction<Handler, Parameters, Results> for MockInstance
+where
+    Handler: Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
+    Parameters: 'static,
+    Results: 'static,
+{
+    fn export(
+        &mut self,
+        module_name: &str,
+        function_name: &str,
+        handler: Handler,
+    ) -> Result<(), RuntimeError> {
+        let name = format!("{module_name}#{function_name}");
+
+        self.imported_functions.insert(
+            name.clone(),
+            Arc::new(move |instance, boxed_parameters| {
+                let parameters = boxed_parameters.downcast().unwrap_or_else(|_| {
+                    panic!(
+                        "Incorrect parameters used to call handler for exported function {name:?}"
+                    )
+                });
+
+                let results = handler(instance, *parameters)?;
+
+                Ok(Box::new(results))
+            }),
+        );
+
+        Ok(())
+    }
+}
+
 /// A helper type to verify how many times an exported function is called.
 pub struct MockExportedFunction<Parameters, Results> {
     name: String,
     call_counter: Arc<AtomicUsize>,
     expected_calls: usize,
-    handler: fn(Parameters) -> Result<Results, RuntimeError>,
+    handler: fn(MockInstance, Parameters) -> Result<Results, RuntimeError>,
 }
 
 impl<Parameters, Results> MockExportedFunction<Parameters, Results>
@@ -238,7 +300,7 @@ where
     /// times.
     pub fn new(
         name: impl Into<String>,
-        handler: fn(Parameters) -> Result<Results, RuntimeError>,
+        handler: fn(MockInstance, Parameters) -> Result<Results, RuntimeError>,
         expected_calls: usize,
     ) -> Self {
         MockExportedFunction {
@@ -254,9 +316,9 @@ where
         let call_counter = self.call_counter.clone();
         let handler = self.handler;
 
-        instance.add_exported_function(self.name.clone(), move |parameters: Parameters| {
+        instance.add_exported_function(self.name.clone(), move |caller, parameters: Parameters| {
             call_counter.fetch_add(1, Ordering::AcqRel);
-            handler(parameters)
+            handler(caller, parameters)
         });
     }
 }

--- a/linera-witty/src/runtime/wasmer/export_function.rs
+++ b/linera-witty/src/runtime/wasmer/export_function.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wasmer support for host functions exported to guests Wasm instances.
+
+#![allow(clippy::let_unit_value)]
+
+use super::{InstanceBuilder, InstanceSlot};
+use crate::{primitive_types::MaybeFlatType, ExportFunction, RuntimeError};
+use std::error::Error;
+use wasmer::{FromToNativeWasmType, Function, FunctionEnvMut, WasmTypeList};
+
+/// Implements [`ExportFunction`] for [`InstanceBuilder`] using the supported function signatures.
+macro_rules! export_function {
+    ($( $names:ident: $types:ident ),*) => {
+        impl<Handler, HandlerError, $( $types, )* FlatResult>
+            ExportFunction<Handler, ($( $types, )*), FlatResult> for InstanceBuilder
+        where
+            $( $types: FromToNativeWasmType, )*
+            FlatResult: MaybeFlatType + WasmTypeList,
+            HandlerError: Error + Send + Sync + 'static,
+            Handler:
+                Fn(
+                    FunctionEnvMut<'_, InstanceSlot>,
+                    ($( $types, )*),
+                ) -> Result<FlatResult, HandlerError>
+                + Send
+                + Sync
+                + 'static,
+        {
+            fn export(
+                &mut self,
+                module_name: &str,
+                function_name: &str,
+                handler: Handler,
+            ) -> Result<(), RuntimeError> {
+                let environment = self.environment();
+
+                let function = Function::new_typed_with_env(
+                    self,
+                    &environment,
+                    move |
+                        environment: FunctionEnvMut<'_, InstanceSlot>,
+                        $( $names: $types ),*
+                    | -> Result<FlatResult, wasmer::RuntimeError> {
+                        handler(environment, ($( $names, )*))
+                            .map_err(|error| -> Box<dyn std::error::Error + Send + Sync> {
+                                Box::new(error)
+                            })
+                            .map_err(wasmer::RuntimeError::user)
+                    },
+                );
+
+                self.define(
+                    module_name,
+                    function_name,
+                    function,
+                );
+
+                Ok(())
+            }
+        }
+    };
+}
+
+repeat_macro!(export_function =>
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+);

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -9,11 +9,13 @@ mod memory;
 mod parameters;
 mod results;
 
+pub use self::{parameters::WasmerParameters, results::WasmerResults};
 use super::traits::{Instance, Runtime};
 use std::sync::{Arc, Mutex};
+pub use wasmer::FunctionEnvMut;
 use wasmer::{
-    AsStoreMut, AsStoreRef, Engine, Extern, FunctionEnv, FunctionEnvMut, Imports,
-    InstantiationError, Memory, Module, Store, StoreMut, StoreRef,
+    AsStoreMut, AsStoreRef, Engine, Extern, FunctionEnv, Imports, InstantiationError, Memory,
+    Module, Store, StoreMut, StoreRef,
 };
 use wasmer_vm::StoreObjects;
 

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -3,6 +3,7 @@
 
 //! Support for the [Wasmer](https://wasmer.io) runtime.
 
+mod export_function;
 mod function;
 mod memory;
 mod parameters;
@@ -76,6 +77,22 @@ impl InstanceBuilder {
             store: self.store,
             instance: self.environment,
         })
+    }
+}
+
+impl AsStoreRef for InstanceBuilder {
+    fn as_store_ref(&self) -> StoreRef<'_> {
+        self.store.as_store_ref()
+    }
+}
+
+impl AsStoreMut for InstanceBuilder {
+    fn as_store_mut(&mut self) -> StoreMut<'_> {
+        self.store.as_store_mut()
+    }
+
+    fn objects_mut(&mut self) -> &mut StoreObjects {
+        self.store.objects_mut()
     }
 }
 

--- a/linera-witty/src/runtime/wasmtime/export_function.rs
+++ b/linera-witty/src/runtime/wasmtime/export_function.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wasmtime support for host functions exported to guests Wasm instances.
+
+#![allow(clippy::let_unit_value)]
+
+use crate::{primitive_types::MaybeFlatType, ExportFunction, RuntimeError};
+use wasmtime::{Caller, Linker, Trap, WasmRet, WasmTy};
+
+/// Implements [`ExportFunction`] for Wasmtime's [`Linker`] using the supported function
+/// signatures.
+macro_rules! export_function {
+    ($( $names:ident: $types:ident ),*) => {
+        impl<Handler, $( $types, )* FlatResult, Data>
+            ExportFunction<Handler, ($( $types, )*), FlatResult> for Linker<Data>
+        where
+            $( $types: WasmTy, )*
+            FlatResult: MaybeFlatType + WasmRet,
+            Handler:
+                Fn(Caller<'_, Data>, ($( $types, )*)) -> Result<FlatResult, RuntimeError>
+                + Send
+                + Sync
+                + 'static,
+        {
+            fn export(
+                &mut self,
+                module_name: &str,
+                function_name: &str,
+                handler: Handler,
+            ) -> Result<(), RuntimeError> {
+                self.func_wrap(
+                    module_name,
+                    function_name,
+                    move |
+                        caller: Caller<'_, Data>,
+                        $( $names: $types ),*
+                    | -> Result<FlatResult, Trap> {
+                        let response = handler(caller, ($( $names, )*))
+                            .map_err(|error| Trap::new(error.to_string()))?;
+                        Ok(response)
+                    },
+                )?;
+                Ok(())
+            }
+        }
+    };
+}
+
+repeat_macro!(export_function =>
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J,
+    k: K,
+    l: L,
+    m: M,
+    n: N,
+    o: O,
+    p: P,
+);

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -3,6 +3,7 @@
 
 //! Support for the [Wasmtime](https://wasmtime.dev) runtime.
 
+mod export_function;
 mod function;
 mod memory;
 mod parameters;

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -9,10 +9,11 @@ mod memory;
 mod parameters;
 mod results;
 
+pub use self::{parameters::WasmtimeParameters, results::WasmtimeResults};
 use super::traits::{Instance, Runtime};
-use wasmtime::{
-    AsContext, AsContextMut, Caller, Extern, Memory, Store, StoreContext, StoreContextMut,
-};
+pub use anyhow;
+use wasmtime::{AsContext, AsContextMut, Extern, Memory, Store, StoreContext, StoreContextMut};
+pub use wasmtime::{Caller, Linker};
 
 /// Representation of the [Wasmtime](https://wasmtime.dev) runtime.
 pub struct Wasmtime;

--- a/linera-witty/test-modules/Cargo.toml
+++ b/linera-witty/test-modules/Cargo.toml
@@ -24,5 +24,21 @@ path = "src/export/setters.rs"
 name = "export-operations"
 path = "src/export/operations.rs"
 
+[[bin]]
+name = "import-simple-function"
+path = "src/import/simple_function.rs"
+
+[[bin]]
+name = "import-getters"
+path = "src/import/getters.rs"
+
+[[bin]]
+name = "import-setters"
+path = "src/import/setters.rs"
+
+[[bin]]
+name = "import-operations"
+path = "src/import/operations.rs"
+
 [dependencies]
 wit-bindgen = { version = "0.7.0", features = ["macros"] }

--- a/linera-witty/test-modules/src/import/getters.rs
+++ b/linera-witty/test-modules/src/import/getters.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module that calls some functions that have no parameters but return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("import-getters");
+
+export_import_getters!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::entrypoint::Entrypoint,
+    witty_macros::test_modules::getters::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    #[allow(clippy::bool_assert_comparison)]
+    fn entrypoint() {
+        assert_eq!(get_true(), true);
+        assert_eq!(get_false(), false);
+        assert_eq!(get_s8(), -125);
+        assert_eq!(get_u8(), 200);
+        assert_eq!(get_s16(), -410);
+        assert_eq!(get_u16(), 60_000);
+        assert_eq!(get_s32(), -100_000);
+        assert_eq!(get_u32(), 3_000_111);
+        assert_eq!(get_float32(), -0.125);
+        assert_eq!(get_float64(), 128.25);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/import/operations.rs
+++ b/linera-witty/test-modules/src/import/operations.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module that calls some functions that have two parameters and one return value.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("import-operations");
+
+export_import_operations!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::entrypoint::Entrypoint,
+    witty_macros::test_modules::operations::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    #[allow(clippy::bool_assert_comparison)]
+    fn entrypoint() {
+        assert_eq!(and_bool(true, true), true);
+        assert_eq!(and_bool(true, false), false);
+        assert_eq!(add_s8(-100, 40), -60);
+        assert_eq!(add_u8(201, 32), 233);
+        assert_eq!(add_s16(-20_000, 30_000), 10_000);
+        assert_eq!(add_u16(50_000, 256), 50_256);
+        assert_eq!(add_s32(-2_000_000, -1), -2_000_001);
+        assert_eq!(add_u32(4_000_000, 1), 4_000_001);
+        assert_eq!(add_s64(-16_000_000, 32_000_000), 16_000_000);
+        assert_eq!(add_u64(3_000_000_000, 9_345_678_999), 12_345_678_999);
+        assert_eq!(add_float32(10.5, 120.25), 130.75);
+        assert_eq!(add_float64(-0.000_08, 1.0), 0.999_92);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/import/setters.rs
+++ b/linera-witty/test-modules/src/import/setters.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module that calls some functions that have one parameter and no return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("import-setters");
+
+export_import_setters!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::entrypoint::Entrypoint,
+    witty_macros::test_modules::setters::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    fn entrypoint() {
+        set_bool(false);
+        set_s8(-100);
+        set_u8(201);
+        set_s16(-20_000);
+        set_u16(50_000);
+        set_s32(-2_000_000);
+        set_u32(4_000_000);
+        set_float32(10.4);
+        set_float64(-0.000_08);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/import/simple_function.rs
+++ b/linera-witty/test-modules/src/import/simple_function.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module that calls a minimal function without parameters or return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("import-simple-function");
+
+export_import_simple_function!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::entrypoint::Entrypoint,
+    witty_macros::test_modules::simple_function::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    fn entrypoint() {
+        simple();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/wit/entrypoint.wit
+++ b/linera-witty/test-modules/wit/entrypoint.wit
@@ -1,0 +1,5 @@
+package witty-macros:test-modules
+
+interface entrypoint {
+    entrypoint: func()
+}

--- a/linera-witty/test-modules/wit/import.wit
+++ b/linera-witty/test-modules/wit/import.wit
@@ -1,0 +1,21 @@
+package witty-macros:test-modules
+
+world import-simple-function {
+    import simple-function
+    export entrypoint
+}
+
+world import-getters {
+    import getters
+    export entrypoint
+}
+
+world import-setters {
+    import setters
+    export entrypoint
+}
+
+world import-operations {
+    import operations
+    export entrypoint
+}

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -135,7 +135,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/simple-function#simple",
-            |_: HList![]| Ok(hlist![]),
+            |_, _: HList![]| Ok(hlist![]),
             1,
         );
     }
@@ -145,73 +145,73 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-true",
-            |_: HList![]| Ok(hlist![1_i32]),
+            |_, _: HList![]| Ok(hlist![1_i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-false",
-            |_: HList![]| Ok(hlist![0_i32]),
+            |_, _: HList![]| Ok(hlist![0_i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-s8",
-            |_: HList![]| Ok(hlist![-125_i8 as u8 as i32]),
+            |_, _: HList![]| Ok(hlist![-125_i8 as u8 as i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-u8",
-            |_: HList![]| Ok(hlist![200_u8 as i32]),
+            |_, _: HList![]| Ok(hlist![200_u8 as i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-s16",
-            |_: HList![]| Ok(hlist![-410_i16 as u16 as i32]),
+            |_, _: HList![]| Ok(hlist![-410_i16 as u16 as i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-u16",
-            |_: HList![]| Ok(hlist![60_000_u16 as i32]),
+            |_, _: HList![]| Ok(hlist![60_000_u16 as i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-s32",
-            |_: HList![]| Ok(hlist![-100_000_i32]),
+            |_, _: HList![]| Ok(hlist![-100_000_i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-u32",
-            |_: HList![]| Ok(hlist![3_000_111_i32]),
+            |_, _: HList![]| Ok(hlist![3_000_111_i32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-s64",
-            |_: HList![]| Ok(hlist![-5_000_000_i64]),
+            |_, _: HList![]| Ok(hlist![-5_000_000_i64]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-u64",
-            |_: HList![]| Ok(hlist![10_000_000_000_i64]),
+            |_, _: HList![]| Ok(hlist![10_000_000_000_i64]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-float32",
-            |_: HList![]| Ok(hlist![-0.125_f32]),
+            |_, _: HList![]| Ok(hlist![-0.125_f32]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-float64",
-            |_: HList![]| Ok(hlist![128.25_f64]),
+            |_, _: HList![]| Ok(hlist![128.25_f64]),
             1,
         );
     }
@@ -221,7 +221,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-bool",
-            |hlist_pat![parameter]: HList![i32]| {
+            |_, hlist_pat![parameter]: HList![i32]| {
                 assert_eq!(parameter, 0);
                 Ok(hlist![])
             },
@@ -230,7 +230,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-s8",
-            |hlist_pat![parameter]: HList![i32]| {
+            |_, hlist_pat![parameter]: HList![i32]| {
                 assert_eq!(parameter, -100_i8 as i32);
                 Ok(hlist![])
             },
@@ -239,7 +239,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-u8",
-            |hlist_pat![parameter]: HList![i32]| {
+            |_, hlist_pat![parameter]: HList![i32]| {
                 assert_eq!(parameter, 201);
                 Ok(hlist![])
             },
@@ -248,7 +248,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-s16",
-            |hlist_pat![parameter]: HList![i32]| {
+            |_, hlist_pat![parameter]: HList![i32]| {
                 assert_eq!(parameter, -20_000_i16 as i32);
                 Ok(hlist![])
             },
@@ -257,7 +257,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-u16",
-            |hlist_pat![parameter]: HList![i32]| {
+            |_, hlist_pat![parameter]: HList![i32]| {
                 assert_eq!(parameter, 50_000);
                 Ok(hlist![])
             },
@@ -266,7 +266,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-s32",
-            |hlist_pat![parameter]: HList![i32]| {
+            |_, hlist_pat![parameter]: HList![i32]| {
                 assert_eq!(parameter, -2_000_000);
                 Ok(hlist![])
             },
@@ -275,7 +275,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-u32",
-            |hlist_pat![parameter]: HList![i32]| {
+            |_, hlist_pat![parameter]: HList![i32]| {
                 assert_eq!(parameter, 4_000_000_u32 as i32);
                 Ok(hlist![])
             },
@@ -284,7 +284,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-s64",
-            |hlist_pat![parameter]: HList![i64]| {
+            |_, hlist_pat![parameter]: HList![i64]| {
                 assert_eq!(parameter, -25_000_000_000);
                 Ok(hlist![])
             },
@@ -293,7 +293,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-u64",
-            |hlist_pat![parameter]: HList![i64]| {
+            |_, hlist_pat![parameter]: HList![i64]| {
                 assert_eq!(parameter, 7_000_000_000);
                 Ok(hlist![])
             },
@@ -302,7 +302,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-float32",
-            |hlist_pat![parameter]: HList![f32]| {
+            |_, hlist_pat![parameter]: HList![f32]| {
                 assert_eq!(parameter, 10.5);
                 Ok(hlist![])
             },
@@ -311,7 +311,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-float64",
-            |hlist_pat![parameter]: HList![f64]| {
+            |_, hlist_pat![parameter]: HList![f64]| {
                 assert_eq!(parameter, -0.000_08);
                 Ok(hlist![])
             },
@@ -324,7 +324,7 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#and-bool",
-            |hlist_pat![first, second]: HList![i32, i32]| {
+            |_, hlist_pat![first, second]: HList![i32, i32]| {
                 Ok(hlist![if first != 0 && second != 0 { 1 } else { 0 }])
             },
             2,
@@ -332,61 +332,61 @@ impl MockInstanceFactory {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-s8",
-            |hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-u8",
-            |hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-s16",
-            |hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-u16",
-            |hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-s32",
-            |hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-u32",
-            |hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i32, i32]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-s64",
-            |hlist_pat![first, second]: HList![i64, i64]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i64, i64]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-u64",
-            |hlist_pat![first, second]: HList![i64, i64]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![i64, i64]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-float32",
-            |hlist_pat![first, second]: HList![f32, f32]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![f32, f32]| Ok(hlist![first + second]),
             1,
         );
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#add-float64",
-            |hlist_pat![first, second]: HList![f64, f64]| Ok(hlist![first + second]),
+            |_, hlist_pat![first, second]: HList![f64, f64]| Ok(hlist![first + second]),
             1,
         );
     }
@@ -402,7 +402,7 @@ impl MockInstanceFactory {
         &mut self,
         instance: &mut MockInstance,
         name: &str,
-        handler: fn(Parameters) -> Result<Results, RuntimeError>,
+        handler: fn(MockInstance, Parameters) -> Result<Results, RuntimeError>,
         expected_calls: usize,
     ) where
         Parameters: 'static,

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -120,6 +120,10 @@ impl TestInstanceFactory for MockInstanceFactory {
             ("export", "getters") => self.export_getters(&mut instance),
             ("export", "setters") => self.export_setters(&mut instance),
             ("export", "operations") => self.export_operations(&mut instance),
+            ("import", "simple-function") => self.import_simple_function(&mut instance),
+            ("import", "getters") => self.import_getters(&mut instance),
+            ("import", "setters") => self.import_setters(&mut instance),
+            ("import", "operations") => self.import_operations(&mut instance),
             _ => panic!(
                 "Attempt to load module \"{group}-{module}\" which has no mock configuration"
             ),

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -1,0 +1,250 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the `wit_export` attribute macro.
+
+#[path = "common/test_instance.rs"]
+mod test_instance;
+
+#[cfg(feature = "wasmer")]
+use self::test_instance::WasmerInstanceFactory;
+#[cfg(feature = "wasmtime")]
+use self::test_instance::WasmtimeInstanceFactory;
+use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
+use linera_witty::{wit_export, wit_import, ExportTo, Instance, Runtime, RuntimeMemory};
+use test_case::test_case;
+
+/// An interface to call into the test modules.
+#[wit_import(package = "witty-macros:test-modules")]
+pub trait Entrypoint {
+    fn entrypoint();
+}
+
+/// Type to export a simple function without parameters or return values.
+pub struct SimpleFunction;
+
+#[wit_export(package = "witty-macros:test-modules")]
+impl SimpleFunction {
+    fn simple() {
+        println!("In simple");
+    }
+}
+
+/// Test exporting a simple function without parameters or return values.
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    SimpleFunction: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("import", "simple-function", |linker| {
+        SimpleFunction::export_to(linker).expect("Failed to export simple function WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to call guest's `simple` function");
+}
+
+/// Type to export functions with return values.
+pub struct Getters;
+
+#[wit_export(package = "witty-macros:test-modules")]
+impl Getters {
+    fn get_true() -> bool {
+        true
+    }
+
+    fn get_false() -> bool {
+        false
+    }
+
+    fn get_s8() -> i8 {
+        -125
+    }
+
+    fn get_u8() -> u8 {
+        200
+    }
+
+    fn get_s16() -> i16 {
+        -410
+    }
+
+    fn get_u16() -> u16 {
+        60_000
+    }
+
+    fn get_s32() -> i32 {
+        -100_000
+    }
+
+    fn get_u32() -> u32 {
+        3_000_111
+    }
+
+    fn get_float32() -> f32 {
+        -0.125
+    }
+
+    fn get_float64() -> f64 {
+        128.25
+    }
+}
+
+/// Test exporting functions with return values.
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+fn getters<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    Getters: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("import", "getters", |instance| {
+        Getters::export_to(instance).expect("Failed to export getters WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to execute test of imported getters");
+}
+
+/// Type to export functions with parameters.
+pub struct Setters;
+
+#[wit_export(package = "witty-macros:test-modules")]
+impl Setters {
+    #[allow(clippy::bool_assert_comparison)]
+    fn set_bool(value: bool) {
+        assert_eq!(value, false);
+    }
+
+    fn set_s8(value: i8) {
+        assert_eq!(value, -100);
+    }
+
+    fn set_u8(value: u8) {
+        assert_eq!(value, 201);
+    }
+
+    fn set_s16(value: i16) {
+        assert_eq!(value, -20_000);
+    }
+
+    fn set_u16(value: u16) {
+        assert_eq!(value, 50_000);
+    }
+
+    fn set_s32(value: i32) {
+        assert_eq!(value, -2_000_000);
+    }
+
+    fn set_u32(value: u32) {
+        assert_eq!(value, 4_000_000);
+    }
+
+    fn set_float32(value: f32) {
+        assert_eq!(value, 10.4);
+    }
+
+    fn set_float64(value: f64) {
+        assert_eq!(value, -0.000_08);
+    }
+}
+
+/// Test exporting functions with parameters.
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+fn setters<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    Setters: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("import", "setters", |instance| {
+        Setters::export_to(instance).expect("Failed to export setters WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to execute test of imported setters");
+}
+
+/// Type to export functions with multiple parameters and return values.
+pub struct Operations;
+
+#[wit_export(package = "witty-macros:test-modules")]
+impl Operations {
+    fn and_bool(first: bool, second: bool) -> bool {
+        first && second
+    }
+
+    fn add_s8(first: i8, second: i8) -> i8 {
+        first + second
+    }
+
+    fn add_u8(first: u8, second: u8) -> u8 {
+        first + second
+    }
+
+    fn add_s16(first: i16, second: i16) -> i16 {
+        first + second
+    }
+
+    fn add_u16(first: u16, second: u16) -> u16 {
+        first + second
+    }
+
+    fn add_s32(first: i32, second: i32) -> i32 {
+        first + second
+    }
+
+    fn add_u32(first: u32, second: u32) -> u32 {
+        first + second
+    }
+
+    fn add_s64(first: i64, second: i64) -> i64 {
+        first + second
+    }
+
+    fn add_u64(first: u64, second: u64) -> u64 {
+        first + second
+    }
+
+    fn add_float32(first: f32, second: f32) -> f32 {
+        first + second
+    }
+
+    fn add_float64(first: f64, second: f64) -> f64 {
+        first + second
+    }
+}
+
+/// Test exporting functions with multiple parameters and return values.
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+fn operations<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    Operations: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("import", "operations", |instance| {
+        Operations::export_to(instance).expect("Failed to export operations WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to execute test of imported operations");
+}

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -31,6 +31,7 @@ impl SimpleFunction {
 }
 
 /// Test exporting a simple function without parameters or return values.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
@@ -97,6 +98,7 @@ impl Getters {
 }
 
 /// Test exporting functions with return values.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn getters<InstanceFactory>(mut factory: InstanceFactory)
@@ -160,6 +162,7 @@ impl Setters {
 }
 
 /// Test exporting functions with parameters.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn setters<InstanceFactory>(mut factory: InstanceFactory)
@@ -230,6 +233,7 @@ impl Operations {
 }
 
 /// Test exporting functions with multiple parameters and return values.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn operations<InstanceFactory>(mut factory: InstanceFactory)

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -33,7 +33,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("simple-function");
+    let instance = factory.load_test_module("export", "simple-function");
 
     SimpleFunction::new(instance)
         .simple()
@@ -68,7 +68,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("getters");
+    let instance = factory.load_test_module("export", "getters");
 
     let mut getters = Getters::new(instance);
 
@@ -173,7 +173,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("setters");
+    let instance = factory.load_test_module("export", "setters");
 
     let mut setters = Setters::new(instance);
 
@@ -239,7 +239,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("operations");
+    let instance = factory.load_test_module("export", "operations");
 
     let mut operations = Operations::new(instance);
 

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -13,8 +13,7 @@ use self::test_instance::WasmerInstanceFactory;
 #[cfg(feature = "wasmtime")]
 use self::test_instance::WasmtimeInstanceFactory;
 use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
-use linera_witty::{Instance, Runtime, RuntimeMemory};
-use linera_witty_macros::wit_import;
+use linera_witty::{wit_import, Instance, Runtime, RuntimeMemory};
 use test_case::test_case;
 
 /// An interface to import a single function without parameters or return values.

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -33,7 +33,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "simple-function");
+    let instance = factory.load_test_module("export", "simple-function", |_| {});
 
     SimpleFunction::new(instance)
         .simple()
@@ -68,7 +68,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "getters");
+    let instance = factory.load_test_module("export", "getters", |_| {});
 
     let mut getters = Getters::new(instance);
 
@@ -173,7 +173,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "setters");
+    let instance = factory.load_test_module("export", "setters", |_| {});
 
     let mut setters = Setters::new(instance);
 
@@ -239,7 +239,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "operations");
+    let instance = factory.load_test_module("export", "operations", |_| {});
 
     let mut operations = Operations::new(instance);
 


### PR DESCRIPTION
## Motivation

The new Witty crate should allow the host to export functions to guest Wasm modules.

## Proposal

Add an `ExportTo<Target>` helper trait and implement a `wit_export` attribute macro that should be used in `impl` blocks. The macro implements `ExportTo` to different Wasm runtime targets, depending on the enabled feature flags. The implementations export the host functions in the `impl` block to guest Wasm instances.

## Test Plan

Some generic integration tests were written to check that some different types of host functions can be exported to Wasm guest instances using Wasmtime and Wasmer, and check that the host functions are properly called. The same tests can also run with a `MockInstance` when no Wasm runtimes are enabled to allow some testing without compiling in a Wasm runtime and without having to compile the Wasm test modules.

## Links

Part of #906

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
