### PR TITLE
`linera project new` version derived from binary version

### DIFF
--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -276,31 +276,16 @@ impl Project {
     }
 
     /// Adds ['linera-sdk'] dependencies in `release` mode.
-    ///
-    /// Includes the contents of `linera-sdk`'s `Cargo.toml` at compile time
-    /// to figure out the latest version.
     #[cfg(not(debug_assertions))]
     fn linera_sdk_dependencies() -> (String, String, String) {
-        let sdk_toml_contents = include_str!("../../linera-sdk/Cargo.toml");
-        let views_toml_contents = include_str!("../../linera-views/Cargo.toml");
-        let sdk_version = Self::crate_version(sdk_toml_contents);
-        let views_version = Self::crate_version(views_toml_contents);
-        let linera_sdk_dep = format!("linera-sdk = \"{}\"", sdk_version);
+        let version = env!("CARGO_PKG_VERSION");
+        let linera_sdk_dep = format!("linera-sdk = \"{}\"", version);
         let linera_sdk_dev_dep = format!(
             "linera-sdk = {{ version = \"{}\", features = [\"test\"] }}",
-            sdk_version
+            version
         );
-        let linera_views_dep = format!("linera-views = \"{}\"", views_version);
+        let linera_views_dep = format!("linera-views = \"{}\"", version);
         (linera_sdk_dep, linera_sdk_dev_dep, linera_views_dep)
-    }
-
-    #[cfg(not(debug_assertions))]
-    fn crate_version(toml_contents: &'static str) -> String {
-        let cargo_toml: toml::Value = toml::from_str(toml_contents)
-            .expect("there was an error parsing a TOML file included at compile-time - this should never happen.");
-        let sdk_version = cargo_toml["package"]["version"].as_str()
-            .expect("there was an error finding the version in a TOML file included at compile-time - this should never happen.");
-        sdk_version.to_string()
     }
 
     pub fn build(&self, name: Option<String>) -> Result<(PathBuf, PathBuf), anyhow::Error> {


### PR DESCRIPTION
## Motivation

`cargo install linera` was broken because relative paths were used to determine the version of `linera-sdk` and `linera-views`.

## Proposal

Use the `linera` binary version.

## Test Plan

There is no practical way to test this. `cargo install --bin linera --path .` works however it also worked last time.

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
