### PR TITLE
Fix detection of fallible functions in Witty

### DIFF
--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -281,7 +281,7 @@ fn path_matches_segments(path: &Path, segments: &[&str]) -> bool {
     }
 
     for (index, (segment, expected)) in path.segments.iter().zip(segments).enumerate() {
-        let with_type_parameters = index == segments.len();
+        let with_type_parameters = index == segments.len() - 1;
 
         if !is_path_segment(segment, expected, with_type_parameters) {
             return false;

--- a/linera-witty/test-modules/src/export/setters.rs
+++ b/linera-witty/test-modules/src/export/setters.rs
@@ -14,27 +14,50 @@ use self::exports::witty_macros::test_modules::setters::Setters;
 struct Implementation;
 
 impl Setters for Implementation {
-    fn set_bool(_value: bool) {}
+    #[allow(clippy::bool_assert_comparison)]
+    fn set_bool(value: bool) {
+        assert_eq!(value, false);
+    }
 
-    fn set_s8(_value: i8) {}
+    fn set_s8(value: i8) {
+        assert_eq!(value, -100);
+    }
 
-    fn set_u8(_value: u8) {}
+    fn set_u8(value: u8) {
+        assert_eq!(value, 201);
+    }
 
-    fn set_s16(_value: i16) {}
+    fn set_s16(value: i16) {
+        assert_eq!(value, -20_000);
+    }
 
-    fn set_u16(_value: u16) {}
+    fn set_u16(value: u16) {
+        assert_eq!(value, 50_000);
+    }
 
-    fn set_s32(_value: i32) {}
+    fn set_s32(value: i32) {
+        assert_eq!(value, -2_000_000);
+    }
 
-    fn set_u32(_value: u32) {}
+    fn set_u32(value: u32) {
+        assert_eq!(value, 4_000_000);
+    }
 
-    fn set_s64(_value: i64) {}
+    fn set_s64(value: i64) {
+        assert_eq!(value, -25_000_000_000);
+    }
 
-    fn set_u64(_value: u64) {}
+    fn set_u64(value: u64) {
+        assert_eq!(value, 7_000_000_000);
+    }
 
-    fn set_float32(_value: f32) {}
+    fn set_float32(value: f32) {
+        assert_eq!(value, 10.4);
+    }
 
-    fn set_float64(_value: f64) {}
+    fn set_float64(value: f64) {
+        assert_eq!(value, -0.000_08);
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -136,7 +136,7 @@ impl TestInstanceFactory for MockInstanceFactory {
 }
 
 impl MockInstanceFactory {
-    /// Mock the exported functions for the "simple-function" module.
+    /// Mock the exported functions from the "export-simple-function" module.
     fn export_simple_function(&mut self, instance: &mut MockInstance) {
         self.mock_exported_function(
             instance,
@@ -146,7 +146,7 @@ impl MockInstanceFactory {
         );
     }
 
-    /// Mock the exported functions for the "getters" module.
+    /// Mock the exported functions from the "export-getters" module.
     fn export_getters(&mut self, instance: &mut MockInstance) {
         self.mock_exported_function(
             instance,
@@ -222,7 +222,7 @@ impl MockInstanceFactory {
         );
     }
 
-    /// Mock the exported functions for the "setters" module.
+    /// Mock the exported functions from the "export-setters" module.
     fn export_setters(&mut self, instance: &mut MockInstance) {
         self.mock_exported_function(
             instance,
@@ -325,7 +325,7 @@ impl MockInstanceFactory {
         );
     }
 
-    /// Mock the exported functions for the "operations" module.
+    /// Mock the exported functions from the "operations" module.
     fn export_operations(&mut self, instance: &mut MockInstance) {
         self.mock_exported_function(
             instance,
@@ -397,7 +397,7 @@ impl MockInstanceFactory {
         );
     }
 
-    /// Mock the exported functions for the "simple-function" module.
+    /// Mock calling the imported function in the "import-simple-function" module.
     fn import_simple_function(&mut self, instance: &mut MockInstance) {
         self.mock_exported_function(
             instance,
@@ -413,7 +413,7 @@ impl MockInstanceFactory {
         );
     }
 
-    /// Mock the exported functions for the "import-getters" module.
+    /// Mock calling the imported functions in the "import-getters" module.
     fn import_getters(&mut self, instance: &mut MockInstance) {
         fn check_getter<Value>(caller: &MockInstance, name: &str, expected_value: Value)
         where
@@ -453,7 +453,7 @@ impl MockInstanceFactory {
         );
     }
 
-    /// Mocks the exported functions for the "import-setters" module.
+    /// Mock calling the imported functions in the "import-setters" module.
     fn import_setters(&mut self, instance: &mut MockInstance) {
         fn send_to_setter<Value>(caller: &MockInstance, name: &str, value: Value)
         where
@@ -494,7 +494,7 @@ impl MockInstanceFactory {
         );
     }
 
-    /// Mocks the exported functions for the "import-operations" module.
+    /// Mock calling the imported functions in the "import-operations".
     fn import_operations(&mut self, instance: &mut MockInstance) {
         fn check_operation<Value>(
             caller: &MockInstance,

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -442,6 +442,8 @@ impl MockInstanceFactory {
                 check_getter(&caller, "get-u16", 60_000_u16);
                 check_getter(&caller, "get-s32", -100_000_i32);
                 check_getter(&caller, "get-u32", 3_000_111_u32);
+                check_getter(&caller, "get-s64", -5_000_000_i64);
+                check_getter(&caller, "get-u64", 10_000_000_000_u64);
                 check_getter(&caller, "get-float32", -0.125_f32);
                 check_getter(&caller, "get-float64", 128.25_f64);
 
@@ -481,6 +483,8 @@ impl MockInstanceFactory {
                 send_to_setter(&caller, "set-u16", 50_000_u16);
                 send_to_setter(&caller, "set-s32", -2_000_000_i32);
                 send_to_setter(&caller, "set-u32", 4_000_000_u32);
+                send_to_setter(&caller, "set-s64", -25_000_000_000_i64);
+                send_to_setter(&caller, "set-u64", 7_000_000_000_u64);
                 send_to_setter(&caller, "set-float32", 10.4_f32);
                 send_to_setter(&caller, "set-float64", -0.000_08_f64);
 

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -309,7 +309,7 @@ impl MockInstanceFactory {
             instance,
             "witty-macros:test-modules/setters#set-float32",
             |_, hlist_pat![parameter]: HList![f32]| {
-                assert_eq!(parameter, 10.5);
+                assert_eq!(parameter, 10.4);
                 Ok(hlist![])
             },
             1,

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -88,6 +88,14 @@ impl Getters {
         3_000_111
     }
 
+    fn get_s64() -> i64 {
+        -5_000_000
+    }
+
+    fn get_u64() -> u64 {
+        10_000_000_000
+    }
+
     fn get_float32() -> f32 {
         -0.125
     }
@@ -150,6 +158,14 @@ impl Setters {
 
     fn set_u32(value: u32) {
         assert_eq!(value, 4_000_000);
+    }
+
+    fn set_s64(value: i64) {
+        assert_eq!(value, -25_000_000_000);
+    }
+
+    fn set_u64(value: u64) {
+        assert_eq!(value, 7_000_000_000);
     }
 
     fn set_float32(value: f32) {

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -42,8 +42,8 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     SimpleFunction: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("import", "simple-function", |linker| {
-        SimpleFunction::export_to(linker).expect("Failed to export simple function WIT interface")
+    let instance = factory.load_test_module("import", "simple-function", |instance| {
+        SimpleFunction::export_to(instance).expect("Failed to export simple function WIT interface")
     });
 
     Entrypoint::new(instance)

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -205,7 +205,7 @@ where
         .set_u64(7_000_000_000)
         .expect("Failed to run guest's `set-u64` function");
     setters
-        .set_float32(10.5)
+        .set_float32(10.4)
         .expect("Failed to run guest's `set-f32` function");
     setters
         .set_float64(-0.000_08)


### PR DESCRIPTION
## Motivation

Some bits and pieces of technical debt accumulated while the `linera-witty` crate was being merged, which includes one serious bug: exported host functions that were fallible weren't correctly detected and couldn't be used.

## Proposal

Fix the off-by-one bug that prevented fallible functions from being detected by the `wit_export` macro.

Apply some minor fixes that aren't related to any of Witty's specific features. These include:

- Improving documentation
- Increasing test coverage
- Renaming a parameter for consistency

## Test Plan

Fallible functions are required for reentrancy, so the next PR will include integration tests that cover it.

## Links

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->
Unexpected work related to #906.

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
