### PR TITLE
Add reentrancy support to Witty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3177,6 +3177,7 @@ dependencies = [
  "linera-witty-macros",
  "test-case",
  "thiserror",
+ "tracing",
  "wasmer",
  "wasmer-vm",
  "wasmtime",

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -14,9 +14,9 @@ edition = "2021"
 proc-macro = true
 
 [features]
-mock-instance = []
-wasmer = []
-wasmtime = []
+mock-instance = ["syn/extra-traits"]
+wasmer = ["syn/extra-traits"]
+wasmtime = ["syn/extra-traits"]
 
 [dependencies]
 heck = { workspace = true }

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -200,6 +200,7 @@ impl<'input> FunctionInformation<'input> {
         let host_parameters = &self.parameter_bindings;
         let call_early_return = &self.call_early_return;
         let function_name = &self.function.sig.ident;
+        let caller_parameter = self.is_reentrant.then(|| quote! { &mut caller, });
 
         let output_type = quote_spanned! { self.function.sig.output.span() =>
             <
@@ -226,7 +227,10 @@ impl<'input> FunctionInformation<'input> {
                         )?;
 
                     #[allow(clippy::let_unit_value)]
-                    let host_results = Self::#function_name(#host_parameters) #call_early_return;
+                    let host_results = Self::#function_name(
+                        #caller_parameter
+                        #host_parameters
+                    ) #call_early_return;
                     let guest_results =
                         <Interface as linera_witty::ExportedFunctionInterface>::lower_results(
                             host_results,

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -30,3 +30,4 @@ wasmtime = { workspace = true, optional = true }
 [dev-dependencies]
 linera-witty = { workspace = true, features = ["macros", "test"] }
 test-case = { workspace = true }
+tracing = { workspace = true }

--- a/linera-witty/src/runtime/borrowed_instance.rs
+++ b/linera-witty/src/runtime/borrowed_instance.rs
@@ -1,0 +1,87 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of Wasm instance related traits to mutable borrows of instances.
+//!
+//! This allows using the same traits without having to move the type implementation around, for
+//! example as parameters in reentrant functions.
+
+use super::{
+    traits::{CabiFreeAlias, CabiReallocAlias},
+    Instance, InstanceWithFunction, InstanceWithMemory, Runtime, RuntimeError, RuntimeMemory,
+};
+use crate::{memory_layout::FlatLayout, GuestPointer};
+use std::borrow::Cow;
+
+impl<I> Instance for &mut I
+where
+    I: Instance,
+{
+    type Runtime = I::Runtime;
+
+    fn load_export(&mut self, name: &str) -> Option<<Self::Runtime as Runtime>::Export> {
+        I::load_export(*self, name)
+    }
+}
+
+impl<Parameters, Results, I> InstanceWithFunction<Parameters, Results> for &mut I
+where
+    I: InstanceWithFunction<Parameters, Results>,
+    Parameters: FlatLayout,
+    Results: FlatLayout,
+{
+    type Function = I::Function;
+
+    fn function_from_export(
+        &mut self,
+        export: <Self::Runtime as Runtime>::Export,
+    ) -> Result<Option<Self::Function>, RuntimeError> {
+        I::function_from_export(*self, export)
+    }
+
+    fn call(
+        &mut self,
+        function: &Self::Function,
+        parameters: Parameters,
+    ) -> Result<Results, RuntimeError> {
+        I::call(*self, function, parameters)
+    }
+}
+
+impl<'a, I> InstanceWithMemory for &'a mut I
+where
+    I: InstanceWithMemory,
+    &'a mut I: Instance<Runtime = I::Runtime> + CabiReallocAlias + CabiFreeAlias,
+{
+    fn memory_from_export(
+        &self,
+        export: <Self::Runtime as Runtime>::Export,
+    ) -> Result<Option<<Self::Runtime as Runtime>::Memory>, RuntimeError> {
+        I::memory_from_export(&**self, export)
+    }
+}
+
+impl<M, I> RuntimeMemory<&mut I> for M
+where
+    M: RuntimeMemory<I>,
+{
+    /// Reads `length` bytes from memory from the provided `location`.
+    fn read<'instance>(
+        &self,
+        instance: &'instance &mut I,
+        location: GuestPointer,
+        length: u32,
+    ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
+        self.read(&**instance, location, length)
+    }
+
+    /// Writes the `bytes` to memory at the provided `location`.
+    fn write(
+        &mut self,
+        instance: &mut &mut I,
+        location: GuestPointer,
+        bytes: &[u8],
+    ) -> Result<(), RuntimeError> {
+        self.write(&mut **instance, location, bytes)
+    }
+}

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -3,6 +3,7 @@
 
 //! Code to interface with different runtimes.
 
+mod borrowed_instance;
 mod error;
 mod memory;
 #[cfg(any(test, feature = "test"))]

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -189,9 +189,9 @@ where
 
         let results = handler(self.clone(), Box::new(parameters))?;
 
-        Ok(*results
-            .downcast()
-            .expect("Incorrect results type expected from handler of expected function"))
+        Ok(*results.downcast().unwrap_or_else(|_| {
+            panic!("Incorrect results type expected from handler of expected function: {function}")
+        }))
     }
 }
 

--- a/linera-witty/test-modules/Cargo.toml
+++ b/linera-witty/test-modules/Cargo.toml
@@ -56,5 +56,9 @@ path = "src/reentrancy/setters.rs"
 name = "reentrancy-operations"
 path = "src/reentrancy/operations.rs"
 
+[[bin]]
+name = "reentrancy-global-state"
+path = "src/reentrancy/global_state.rs"
+
 [dependencies]
 wit-bindgen = { version = "0.7.0", features = ["macros"] }

--- a/linera-witty/test-modules/Cargo.toml
+++ b/linera-witty/test-modules/Cargo.toml
@@ -40,5 +40,21 @@ path = "src/import/setters.rs"
 name = "import-operations"
 path = "src/import/operations.rs"
 
+[[bin]]
+name = "reentrancy-simple-function"
+path = "src/reentrancy/simple_function.rs"
+
+[[bin]]
+name = "reentrancy-getters"
+path = "src/reentrancy/getters.rs"
+
+[[bin]]
+name = "reentrancy-setters"
+path = "src/reentrancy/setters.rs"
+
+[[bin]]
+name = "reentrancy-operations"
+path = "src/reentrancy/operations.rs"
+
 [dependencies]
 wit-bindgen = { version = "0.7.0", features = ["macros"] }

--- a/linera-witty/test-modules/src/reentrancy/getters.rs
+++ b/linera-witty/test-modules/src/reentrancy/getters.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module for reentrancy tests with some functions that return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("reentrant-getters");
+
+export_reentrant_getters!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::{entrypoint::Entrypoint, getters::Getters},
+    witty_macros::test_modules::getters::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    #[allow(clippy::bool_assert_comparison)]
+    fn entrypoint() {
+        assert_eq!(get_true(), true);
+        assert_eq!(get_false(), false);
+        assert_eq!(get_s8(), -125);
+        assert_eq!(get_u8(), 200);
+        assert_eq!(get_s16(), -410);
+        assert_eq!(get_u16(), 60_000);
+        assert_eq!(get_s32(), -100_000);
+        assert_eq!(get_u32(), 3_000_111);
+        assert_eq!(get_s64(), -5_000_000);
+        assert_eq!(get_u64(), 10_000_000_000);
+        assert_eq!(get_float32(), -0.125);
+        assert_eq!(get_float64(), 128.25);
+    }
+}
+
+impl Getters for Implementation {
+    fn get_true() -> bool {
+        true
+    }
+
+    fn get_false() -> bool {
+        false
+    }
+
+    fn get_s8() -> i8 {
+        -125
+    }
+
+    fn get_u8() -> u8 {
+        200
+    }
+
+    fn get_s16() -> i16 {
+        -410
+    }
+
+    fn get_u16() -> u16 {
+        60_000
+    }
+
+    fn get_s32() -> i32 {
+        -100_000
+    }
+
+    fn get_u32() -> u32 {
+        3_000_111
+    }
+
+    fn get_s64() -> i64 {
+        -5_000_000
+    }
+
+    fn get_u64() -> u64 {
+        10_000_000_000
+    }
+
+    fn get_float32() -> f32 {
+        -0.125
+    }
+
+    fn get_float64() -> f64 {
+        128.25
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/reentrancy/global_state.rs
+++ b/linera-witty/test-modules/src/reentrancy/global_state.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module for reentrancy tests with a global state, to check that it is persisted
+//! across reentrant calls.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("reentrant-global-state");
+
+export_reentrant_global_state!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::global_state::GlobalState,
+    witty_macros::test_modules::get_host_value::*,
+};
+
+static mut GLOBAL_STATE: u32 = 0;
+
+struct Implementation;
+
+impl GlobalState for Implementation {
+    fn entrypoint(value: u32) -> u32 {
+        unsafe { GLOBAL_STATE = value };
+        get_host_value()
+    }
+
+    fn get_global_state() -> u32 {
+        unsafe { GLOBAL_STATE }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/reentrancy/operations.rs
+++ b/linera-witty/test-modules/src/reentrancy/operations.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module for reentrancy tests with some functions that have multiple parameters and
+//! return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("reentrant-operations");
+
+export_reentrant_operations!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::{entrypoint::Entrypoint, operations::Operations},
+    witty_macros::test_modules::operations::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    #[allow(clippy::bool_assert_comparison)]
+    fn entrypoint() {
+        assert_eq!(and_bool(true, true), true);
+        assert_eq!(and_bool(true, false), false);
+        assert_eq!(add_s8(-100, 40), -60);
+        assert_eq!(add_u8(201, 32), 233);
+        assert_eq!(add_s16(-20_000, 30_000), 10_000);
+        assert_eq!(add_u16(50_000, 256), 50_256);
+        assert_eq!(add_s32(-2_000_000, -1), -2_000_001);
+        assert_eq!(add_u32(4_000_000, 1), 4_000_001);
+        assert_eq!(add_s64(-16_000_000, 32_000_000), 16_000_000);
+        assert_eq!(add_u64(3_000_000_000, 9_345_678_999), 12_345_678_999);
+        assert_eq!(add_float32(10.5, 120.25), 130.75);
+        assert_eq!(add_float64(-0.000_08, 1.0), 0.999_92);
+    }
+}
+
+impl Operations for Implementation {
+    fn and_bool(first: bool, second: bool) -> bool {
+        first && second
+    }
+
+    fn add_s8(first: i8, second: i8) -> i8 {
+        first + second
+    }
+
+    fn add_u8(first: u8, second: u8) -> u8 {
+        first + second
+    }
+
+    fn add_s16(first: i16, second: i16) -> i16 {
+        first + second
+    }
+
+    fn add_u16(first: u16, second: u16) -> u16 {
+        first + second
+    }
+
+    fn add_s32(first: i32, second: i32) -> i32 {
+        first + second
+    }
+
+    fn add_u32(first: u32, second: u32) -> u32 {
+        first + second
+    }
+
+    fn add_s64(first: i64, second: i64) -> i64 {
+        first + second
+    }
+
+    fn add_u64(first: u64, second: u64) -> u64 {
+        first + second
+    }
+
+    fn add_float32(first: f32, second: f32) -> f32 {
+        first + second
+    }
+
+    fn add_float64(first: f64, second: f64) -> f64 {
+        first + second
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/reentrancy/setters.rs
+++ b/linera-witty/test-modules/src/reentrancy/setters.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module for reentrancy tests with some functions that have one parameter and no
+//! return values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("reentrant-setters");
+
+export_reentrant_setters!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::{entrypoint::Entrypoint, setters::Setters},
+    witty_macros::test_modules::setters::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    fn entrypoint() {
+        set_bool(false);
+        set_s8(-100);
+        set_u8(201);
+        set_s16(-20_000);
+        set_u16(50_000);
+        set_s32(-2_000_000);
+        set_u32(4_000_000);
+        set_float32(10.4);
+        set_float64(-0.000_08);
+    }
+}
+
+impl Setters for Implementation {
+    #[allow(clippy::bool_assert_comparison)]
+    fn set_bool(value: bool) {
+        assert_eq!(value, false);
+    }
+
+    fn set_s8(value: i8) {
+        assert_eq!(value, -100);
+    }
+
+    fn set_u8(value: u8) {
+        assert_eq!(value, 201);
+    }
+
+    fn set_s16(value: i16) {
+        assert_eq!(value, -20_000);
+    }
+
+    fn set_u16(value: u16) {
+        assert_eq!(value, 50_000);
+    }
+
+    fn set_s32(value: i32) {
+        assert_eq!(value, -2_000_000);
+    }
+
+    fn set_u32(value: u32) {
+        assert_eq!(value, 4_000_000);
+    }
+
+    fn set_s64(value: i64) {
+        assert_eq!(value, -25_000_000_000);
+    }
+
+    fn set_u64(value: u64) {
+        assert_eq!(value, 7_000_000_000);
+    }
+
+    fn set_float32(value: f32) {
+        assert_eq!(value, 10.4);
+    }
+
+    fn set_float64(value: f64) {
+        assert_eq!(value, -0.000_08);
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/src/reentrancy/simple_function.rs
+++ b/linera-witty/test-modules/src/reentrancy/simple_function.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper Wasm module for reentrancy tests with a simple function that has no parameters nor
+//! returns values.
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+wit_bindgen::generate!("reentrant-simple-function");
+
+export_reentrant_simple_function!(Implementation);
+
+use self::{
+    exports::witty_macros::test_modules::{
+        entrypoint::Entrypoint, simple_function::SimpleFunction,
+    },
+    witty_macros::test_modules::simple_function::*,
+};
+
+struct Implementation;
+
+impl Entrypoint for Implementation {
+    fn entrypoint() {
+        simple();
+    }
+}
+
+impl SimpleFunction for Implementation {
+    fn simple() {}
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() {}

--- a/linera-witty/test-modules/wit/global-state.wit
+++ b/linera-witty/test-modules/wit/global-state.wit
@@ -1,0 +1,10 @@
+package witty-macros:test-modules
+
+interface global-state {
+    entrypoint: func(value: u32) -> u32
+    get-global-state: func() -> u32
+}
+
+interface get-host-value {
+    get-host-value: func() -> u32
+}

--- a/linera-witty/test-modules/wit/reentrancy.wit
+++ b/linera-witty/test-modules/wit/reentrancy.wit
@@ -1,0 +1,25 @@
+package witty-macros:test-modules
+
+world reentrant-simple-function {
+    import simple-function
+    export simple-function
+    export entrypoint
+}
+
+world reentrant-getters {
+    import getters
+    export getters
+    export entrypoint
+}
+
+world reentrant-setters {
+    import setters
+    export setters
+    export entrypoint
+}
+
+world reentrant-operations {
+    import operations
+    export operations
+    export entrypoint
+}

--- a/linera-witty/test-modules/wit/reentrancy.wit
+++ b/linera-witty/test-modules/wit/reentrancy.wit
@@ -23,3 +23,8 @@ world reentrant-operations {
     export operations
     export entrypoint
 }
+
+world reentrant-global-state {
+    import get-host-value
+    export global-state
+}

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -124,6 +124,10 @@ impl TestInstanceFactory for MockInstanceFactory {
             ("import", "getters") => self.import_getters(&mut instance),
             ("import", "setters") => self.import_setters(&mut instance),
             ("import", "operations") => self.import_operations(&mut instance),
+            ("reentrancy", "simple-function") => self.reentrancy_simple_function(&mut instance),
+            ("reentrancy", "getters") => self.reentrancy_getters(&mut instance),
+            ("reentrancy", "setters") => self.reentrancy_setters(&mut instance),
+            ("reentrancy", "operations") => self.reentrancy_operations(&mut instance),
             _ => panic!(
                 "Attempt to load module \"{group}-{module}\" which has no mock configuration"
             ),
@@ -551,6 +555,30 @@ impl MockInstanceFactory {
             },
             1,
         );
+    }
+
+    /// Mock the behavior of the "reentrancy-simple-function" module.
+    fn reentrancy_simple_function(&mut self, instance: &mut MockInstance) {
+        self.import_simple_function(instance);
+        self.export_simple_function(instance);
+    }
+
+    /// Mock the behavior of the "reentrancy-getters" module.
+    fn reentrancy_getters(&mut self, instance: &mut MockInstance) {
+        self.import_getters(instance);
+        self.export_getters(instance);
+    }
+
+    /// Mock the behavior of the "reentrancy-setters" module.
+    fn reentrancy_setters(&mut self, instance: &mut MockInstance) {
+        self.import_setters(instance);
+        self.export_setters(instance);
+    }
+
+    /// Mock the behavior of the "reentrancy-operations" module.
+    fn reentrancy_operations(&mut self, instance: &mut MockInstance) {
+        self.import_operations(instance);
+        self.export_operations(instance);
     }
 
     /// Mocks an exported function with the provided `name`.

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -592,7 +592,7 @@ impl MockInstanceFactory {
         &mut self,
         instance: &mut MockInstance,
         name: &str,
-        handler: fn(MockInstance, Parameters) -> Result<Results, RuntimeError>,
+        handler: impl Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
         expected_calls: usize,
     ) where
         Parameters: 'static,

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -6,6 +6,10 @@
 #[path = "common/test_instance.rs"]
 mod test_instance;
 
+#[cfg(feature = "wasmer")]
+use self::test_instance::WasmerInstanceFactory;
+#[cfg(feature = "wasmtime")]
+use self::test_instance::WasmtimeInstanceFactory;
 use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
 use linera_witty::{
     wit_export, wit_import, ExportTo, Instance, Runtime, RuntimeError, RuntimeMemory,
@@ -46,6 +50,8 @@ impl ExportedSimpleFunction {
 /// The host function is called from the guest, and calls the guest back through a function with
 /// the same name.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -188,6 +194,8 @@ impl ExportedGetters {
 /// The host functions are called from the guest, and they return values obtained by calling back
 /// the guest through functions with the same names.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -321,6 +329,8 @@ impl ExportedSetters {
 /// The host functions are called from the guest, and they forward the arguments back to the guest
 /// by calling guest functions with the same names.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -454,6 +464,8 @@ impl ExportedOperations {
 /// The host functions are called from the guest, and they call the guest back through functions
 /// with the same names, forwarding the arguments and retrieving the final results.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
 fn operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -52,7 +52,7 @@ impl ExportedSimpleFunction {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
+fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,
@@ -196,7 +196,7 @@ impl ExportedGetters {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn getters<InstanceFactory>(mut factory: InstanceFactory)
+fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,
@@ -331,7 +331,7 @@ impl ExportedSetters {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn setters<InstanceFactory>(mut factory: InstanceFactory)
+fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,
@@ -466,7 +466,7 @@ impl ExportedOperations {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn operations<InstanceFactory>(mut factory: InstanceFactory)
+fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -1,0 +1,473 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests for the `wit_import` and `wit_export` attribute macro using reentrant host functions.
+
+#[path = "common/test_instance.rs"]
+mod test_instance;
+
+use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
+use linera_witty::{
+    wit_export, wit_import, ExportTo, Instance, Runtime, RuntimeError, RuntimeMemory,
+};
+use test_case::test_case;
+
+/// An interface to call into the test modules.
+#[wit_import(package = "witty-macros:test-modules")]
+pub trait Entrypoint {
+    fn entrypoint();
+}
+
+/// An interface to import a single function without parameters or return values.
+#[wit_import(package = "witty-macros:test-modules", interface = "simple-function")]
+trait ImportedSimpleFunction {
+    fn simple();
+}
+
+/// Type to export a simple reentrant function without parameters or return values.
+pub struct ExportedSimpleFunction;
+
+#[wit_export(package = "witty-macros:test-modules", interface = "simple-function")]
+impl ExportedSimpleFunction {
+    fn simple<Caller>(caller: Caller) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSimpleFunction,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        tracing::debug!("Before reentrant call");
+        ImportedSimpleFunction::new(caller).simple()?;
+        tracing::debug!("After reentrant call");
+        Ok(())
+    }
+}
+
+/// Test a simple reentrant function without parameters or return values.
+///
+/// The host function is called from the guest, and calls the guest back through a function with
+/// the same name.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
+fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    ExportedSimpleFunction: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("reentrancy", "simple-function", |linker| {
+        ExportedSimpleFunction::export_to(linker)
+            .expect("Failed to export reentrant simple function WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to call guest's `entrypoint` function");
+}
+
+/// An interface to import functions with return values.
+#[wit_import(package = "witty-macros:test-modules", interface = "getters")]
+trait ImportedGetters {
+    fn get_true() -> bool;
+    fn get_false() -> bool;
+    fn get_s8() -> i8;
+    fn get_u8() -> u8;
+    fn get_s16() -> i16;
+    fn get_u16() -> u16;
+    fn get_s32() -> i32;
+    fn get_u32() -> u32;
+    fn get_s64() -> i64;
+    fn get_u64() -> u64;
+    fn get_float32() -> f32;
+    fn get_float64() -> f64;
+}
+
+/// Type to export reentrant functions with return values.
+pub struct ExportedGetters;
+
+#[wit_export(package = "witty-macros:test-modules", interface = "getters")]
+impl ExportedGetters {
+    fn get_true<Caller>(caller: Caller) -> Result<bool, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_true()
+    }
+
+    fn get_false<Caller>(caller: Caller) -> Result<bool, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_false()
+    }
+
+    fn get_s8<Caller>(caller: Caller) -> Result<i8, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_s8()
+    }
+
+    fn get_u8<Caller>(caller: Caller) -> Result<u8, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_u8()
+    }
+
+    fn get_s16<Caller>(caller: Caller) -> Result<i16, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_s16()
+    }
+
+    fn get_u16<Caller>(caller: Caller) -> Result<u16, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_u16()
+    }
+
+    fn get_s32<Caller>(caller: Caller) -> Result<i32, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_s32()
+    }
+
+    fn get_u32<Caller>(caller: Caller) -> Result<u32, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_u32()
+    }
+
+    fn get_s64<Caller>(caller: Caller) -> Result<i64, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_s64()
+    }
+
+    fn get_u64<Caller>(caller: Caller) -> Result<u64, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_u64()
+    }
+
+    fn get_float32<Caller>(caller: Caller) -> Result<f32, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_float32()
+    }
+
+    fn get_float64<Caller>(caller: Caller) -> Result<f64, RuntimeError>
+    where
+        Caller: InstanceForImportedGetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedGetters::new(caller).get_float64()
+    }
+}
+
+/// Test reentrant functions with return values.
+///
+/// The host functions are called from the guest, and they return values obtained by calling back
+/// the guest through functions with the same names.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
+fn getters<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    ExportedGetters: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("reentrancy", "getters", |instance| {
+        ExportedGetters::export_to(instance)
+            .expect("Failed to export reentrant getters WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to call guest's `entrypoint` function");
+}
+
+/// An interface to import functions with parameters.
+#[wit_import(package = "witty-macros:test-modules", interface = "setters")]
+trait ImportedSetters {
+    fn set_bool(value: bool);
+    fn set_s8(value: i8);
+    fn set_u8(value: u8);
+    fn set_s16(value: i16);
+    fn set_u16(value: u16);
+    fn set_s32(value: i32);
+    fn set_u32(value: u32);
+    fn set_s64(value: i64);
+    fn set_u64(value: u64);
+    fn set_float32(value: f32);
+    fn set_float64(value: f64);
+}
+
+/// Type to export reentrant functions with parameters.
+pub struct ExportedSetters;
+
+#[wit_export(package = "witty-macros:test-modules", interface = "setters")]
+impl ExportedSetters {
+    fn set_bool<Caller>(caller: Caller, value: bool) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_bool(value)
+    }
+
+    fn set_s8<Caller>(caller: Caller, value: i8) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_s8(value)
+    }
+
+    fn set_u8<Caller>(caller: Caller, value: u8) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_u8(value)
+    }
+
+    fn set_s16<Caller>(caller: Caller, value: i16) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_s16(value)
+    }
+
+    fn set_u16<Caller>(caller: Caller, value: u16) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_u16(value)
+    }
+
+    fn set_s32<Caller>(caller: Caller, value: i32) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_s32(value)
+    }
+
+    fn set_u32<Caller>(caller: Caller, value: u32) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_u32(value)
+    }
+
+    fn set_s64<Caller>(caller: Caller, value: i64) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_s64(value)
+    }
+
+    fn set_u64<Caller>(caller: Caller, value: u64) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_u64(value)
+    }
+
+    fn set_float32<Caller>(caller: Caller, value: f32) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_float32(value)
+    }
+
+    fn set_float64<Caller>(caller: Caller, value: f64) -> Result<(), RuntimeError>
+    where
+        Caller: InstanceForImportedSetters,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedSetters::new(caller).set_float64(value)
+    }
+}
+
+/// Test reentrant functions with parameters.
+///
+/// The host functions are called from the guest, and they forward the arguments back to the guest
+/// by calling guest functions with the same names.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
+fn setters<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    ExportedSetters: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("reentrancy", "setters", |instance| {
+        ExportedSetters::export_to(instance)
+            .expect("Failed to export reentrant setters WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to call guest's `entrypoint` function");
+}
+
+/// An interface to import functions with multiple parameters and return values.
+#[wit_import(package = "witty-macros:test-modules", interface = "operations")]
+trait ImportedOperations {
+    fn and_bool(first: bool, second: bool) -> bool;
+    fn add_s8(first: i8, second: i8) -> i8;
+    fn add_u8(first: u8, second: u8) -> u8;
+    fn add_s16(first: i16, second: i16) -> i16;
+    fn add_u16(first: u16, second: u16) -> u16;
+    fn add_s32(first: i32, second: i32) -> i32;
+    fn add_u32(first: u32, second: u32) -> u32;
+    fn add_s64(first: i64, second: i64) -> i64;
+    fn add_u64(first: u64, second: u64) -> u64;
+    fn add_float32(first: f32, second: f32) -> f32;
+    fn add_float64(first: f64, second: f64) -> f64;
+}
+
+/// Type to export reentrant functions with multiple parameters and return values.
+pub struct ExportedOperations;
+
+#[wit_export(package = "witty-macros:test-modules", interface = "operations")]
+impl ExportedOperations {
+    fn and_bool<Caller>(caller: Caller, first: bool, second: bool) -> Result<bool, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).and_bool(first, second)
+    }
+
+    fn add_s8<Caller>(caller: Caller, first: i8, second: i8) -> Result<i8, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_s8(first, second)
+    }
+
+    fn add_u8<Caller>(caller: Caller, first: u8, second: u8) -> Result<u8, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_u8(first, second)
+    }
+
+    fn add_s16<Caller>(caller: Caller, first: i16, second: i16) -> Result<i16, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_s16(first, second)
+    }
+
+    fn add_u16<Caller>(caller: Caller, first: u16, second: u16) -> Result<u16, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_u16(first, second)
+    }
+
+    fn add_s32<Caller>(caller: Caller, first: i32, second: i32) -> Result<i32, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_s32(first, second)
+    }
+
+    fn add_u32<Caller>(caller: Caller, first: u32, second: u32) -> Result<u32, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_u32(first, second)
+    }
+
+    fn add_s64<Caller>(caller: Caller, first: i64, second: i64) -> Result<i64, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_s64(first, second)
+    }
+
+    fn add_u64<Caller>(caller: Caller, first: u64, second: u64) -> Result<u64, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_u64(first, second)
+    }
+
+    fn add_float32<Caller>(caller: Caller, first: f32, second: f32) -> Result<f32, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_float32(first, second)
+    }
+
+    fn add_float64<Caller>(caller: Caller, first: f64, second: f64) -> Result<f64, RuntimeError>
+    where
+        Caller: InstanceForImportedOperations,
+        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+    {
+        ImportedOperations::new(caller).add_float64(first, second)
+    }
+}
+
+/// Test reentrant functions with multiple parameters and with return values.
+///
+/// The host functions are called from the guest, and they call the guest back through functions
+/// with the same names, forwarding the arguments and retrieving the final results.
+#[test_case(MockInstanceFactory::default(); "with a mock instance")]
+fn operations<InstanceFactory>(mut factory: InstanceFactory)
+where
+    InstanceFactory: TestInstanceFactory,
+    InstanceFactory::Instance: InstanceForEntrypoint,
+    <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
+        RuntimeMemory<InstanceFactory::Instance>,
+    ExportedOperations: ExportTo<InstanceFactory::Builder>,
+{
+    let instance = factory.load_test_module("reentrancy", "operations", |instance| {
+        ExportedOperations::export_to(instance)
+            .expect("Failed to export reentrant operations WIT interface")
+    });
+
+    Entrypoint::new(instance)
+        .entrypoint()
+        .expect("Failed to call guest's `entrypoint` function");
+}

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -60,10 +60,8 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     ExportedSimpleFunction: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("reentrancy", "simple-function", |linker| {
-        ExportedSimpleFunction::export_to(linker)
-            .expect("Failed to export reentrant simple function WIT interface")
-    });
+    let instance =
+        factory.load_test_module::<ExportedSimpleFunction>("reentrancy", "simple-function");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -204,10 +202,7 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     ExportedGetters: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("reentrancy", "getters", |instance| {
-        ExportedGetters::export_to(instance)
-            .expect("Failed to export reentrant getters WIT interface")
-    });
+    let instance = factory.load_test_module::<ExportedGetters>("reentrancy", "getters");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -339,10 +334,7 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     ExportedSetters: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("reentrancy", "setters", |instance| {
-        ExportedSetters::export_to(instance)
-            .expect("Failed to export reentrant setters WIT interface")
-    });
+    let instance = factory.load_test_module::<ExportedSetters>("reentrancy", "setters");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -474,10 +466,7 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     ExportedOperations: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("reentrancy", "operations", |instance| {
-        ExportedOperations::export_to(instance)
-            .expect("Failed to export reentrant operations WIT interface")
-    });
+    let instance = factory.load_test_module::<ExportedOperations>("reentrancy", "operations");
 
     Entrypoint::new(instance)
         .entrypoint()

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -34,7 +34,7 @@ impl SimpleFunction {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
+fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,
@@ -109,7 +109,7 @@ impl Getters {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn getters<InstanceFactory>(mut factory: InstanceFactory)
+fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,
@@ -181,7 +181,7 @@ impl Setters {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn setters<InstanceFactory>(mut factory: InstanceFactory)
+fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,
@@ -252,7 +252,7 @@ impl Operations {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn operations<InstanceFactory>(mut factory: InstanceFactory)
+fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForEntrypoint,

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -42,9 +42,7 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     SimpleFunction: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("import", "simple-function", |instance| {
-        SimpleFunction::export_to(instance).expect("Failed to export simple function WIT interface")
-    });
+    let instance = factory.load_test_module::<SimpleFunction>("import", "simple-function");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -117,9 +115,7 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     Getters: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("import", "getters", |instance| {
-        Getters::export_to(instance).expect("Failed to export getters WIT interface")
-    });
+    let instance = factory.load_test_module::<Getters>("import", "getters");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -189,9 +185,7 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     Setters: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("import", "setters", |instance| {
-        Setters::export_to(instance).expect("Failed to export setters WIT interface")
-    });
+    let instance = factory.load_test_module::<Setters>("import", "setters");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -260,9 +254,7 @@ where
         RuntimeMemory<InstanceFactory::Instance>,
     Operations: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module("import", "operations", |instance| {
-        Operations::export_to(instance).expect("Failed to export operations WIT interface")
-    });
+    let instance = factory.load_test_module::<Operations>("import", "operations");
 
     Entrypoint::new(instance)
         .entrypoint()

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -26,7 +26,7 @@ trait SimpleFunction {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn simple_function<InstanceFactory>(mut factory: InstanceFactory)
+fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForSimpleFunction,
@@ -61,7 +61,7 @@ trait Getters {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn getters<InstanceFactory>(mut factory: InstanceFactory)
+fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForGetters,
@@ -166,7 +166,7 @@ trait Setters {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn setters<InstanceFactory>(mut factory: InstanceFactory)
+fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForSetters,
@@ -232,7 +232,7 @@ trait Operations {
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
 #[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
-fn operations<InstanceFactory>(mut factory: InstanceFactory)
+fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
     InstanceFactory::Instance: InstanceForOperations,

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -12,7 +12,7 @@ mod test_instance;
 use self::test_instance::WasmerInstanceFactory;
 #[cfg(feature = "wasmtime")]
 use self::test_instance::WasmtimeInstanceFactory;
-use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
+use self::test_instance::{MockInstanceFactory, TestInstanceFactory, WithoutExports};
 use linera_witty::{wit_import, Instance, Runtime, RuntimeMemory};
 use test_case::test_case;
 
@@ -33,7 +33,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "simple-function", |_| {});
+    let instance = factory.load_test_module::<WithoutExports>("export", "simple-function");
 
     SimpleFunction::new(instance)
         .simple()
@@ -68,7 +68,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "getters", |_| {});
+    let instance = factory.load_test_module::<WithoutExports>("export", "getters");
 
     let mut getters = Getters::new(instance);
 
@@ -173,7 +173,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "setters", |_| {});
+    let instance = factory.load_test_module::<WithoutExports>("export", "setters");
 
     let mut setters = Setters::new(instance);
 
@@ -239,7 +239,7 @@ where
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
 {
-    let instance = factory.load_test_module("export", "operations", |_| {});
+    let instance = factory.load_test_module::<WithoutExports>("export", "operations");
 
     let mut operations = Operations::new(instance);
 

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 
 /// Check that a wrapper type is properly loaded from memory and lifted from its flat layout.
 #[test]
-fn simple_bool_wrapper() {
+fn test_simple_bool_wrapper() {
     test_load_from_memory(&[1], SimpleWrapper(true));
     test_load_from_memory(&[0], SimpleWrapper(false));
 
@@ -26,7 +26,7 @@ fn simple_bool_wrapper() {
 /// Check that a type with multiple fields ordered in a way that doesn't require any padding is
 /// properly loaded from memory and lifted from its flat layout.
 #[test]
-fn tuple_struct_without_padding() {
+fn test_tuple_struct_without_padding() {
     let expected = TupleWithoutPadding(0x0807_0605_0403_0201_u64, 0x0c0b_0a09_i32, 0x0e0d_i16);
 
     test_load_from_memory(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], expected);
@@ -39,7 +39,7 @@ fn tuple_struct_without_padding() {
 /// Check that a type with multiple fields ordered in a way that requires padding between two of its
 /// fields is properly loaded from memory and lifted from its flat layout.
 #[test]
-fn tuple_struct_with_padding() {
+fn test_tuple_struct_with_padding() {
     let expected = TupleWithPadding(0x0201_u16, 0x0807_0605_u32, 0x100f_0e0d_0c0b_0a09_i64);
 
     test_load_from_memory(
@@ -55,7 +55,7 @@ fn tuple_struct_with_padding() {
 /// Check that a type with multiple named fields ordered in a way that requires padding before two
 /// fields is properly loaded from memory and lifted from its flat layout.
 #[test]
-fn named_struct_with_double_padding() {
+fn test_named_struct_with_double_padding() {
     let expected = RecordWithDoublePadding {
         first: 0x0201_u16,
         second: 0x0807_0605_u32,
@@ -83,7 +83,7 @@ fn named_struct_with_double_padding() {
 /// Check that a type that contains a field with a type that also has `WitStore` derived for it is
 /// properly loaded from memory and lifted from its flat layout.
 #[test]
-fn nested_types() {
+fn test_nested_types() {
     let expected = Branch {
         tag: 0x0201_u16,
         first_leaf: Leaf {
@@ -121,7 +121,7 @@ fn nested_types() {
 /// Check that an enum type's variants are properly loaded from memory and lifted from its flat
 /// layout.
 #[test]
-fn enum_type() {
+fn test_enum_type() {
     let expected = Enum::Empty;
 
     test_load_from_memory(

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 
 /// Check that a wrapper type is properly stored in memory and lowered into its flat layout.
 #[test]
-fn simple_bool_wrapper() {
+fn test_simple_bool_wrapper() {
     test_store_in_memory(&SimpleWrapper(true), &[1]);
     test_store_in_memory(&SimpleWrapper(false), &[0]);
 
@@ -26,7 +26,7 @@ fn simple_bool_wrapper() {
 /// Check that a type with multiple fields ordered in a way that doesn't require any padding is
 /// properly stored in memory and lowered into its flat layout.
 #[test]
-fn tuple_struct_without_padding() {
+fn test_tuple_struct_without_padding() {
     let data = TupleWithoutPadding(0x0123_4567_89ab_cdef_u64, 0x0011_2233_i32, 0x4455_i16);
 
     test_store_in_memory(
@@ -44,7 +44,7 @@ fn tuple_struct_without_padding() {
 /// Check that a type with multiple fields ordered in a way that requires padding between two of its
 /// fields is properly stored in memory and lowered into its flat layout.
 #[test]
-fn tuple_struct_with_padding() {
+fn test_tuple_struct_with_padding() {
     let data = TupleWithPadding(0x0123_u16, 0x4567_89ab_u32, 0x0011_2233_4455_6677_i64);
 
     test_store_in_memory(
@@ -63,7 +63,7 @@ fn tuple_struct_with_padding() {
 /// Check that a type with multiple named fields ordered in a way that requires padding before two
 /// fields is properly stored in memory and lowered into its flat layout.
 #[test]
-fn named_struct_with_double_padding() {
+fn test_named_struct_with_double_padding() {
     let data = RecordWithDoublePadding {
         first: 0x0123_u16,
         second: 0x0011_2233_u32,
@@ -92,7 +92,7 @@ fn named_struct_with_double_padding() {
 /// Check that a type that contains a field with a type that also has `WitStore` derived for it is
 /// properly stored in memory and lowered into its flat layout.
 #[test]
-fn nested_types() {
+fn test_nested_types() {
     let data = Branch {
         tag: 0x0123_u16,
         first_leaf: Leaf {
@@ -131,7 +131,7 @@ fn nested_types() {
 /// Check that an enum type's variants are properly stored in memory and lowered into its flat
 /// layout.
 #[test]
-fn enum_type() {
+fn test_enum_type() {
     let data = Enum::Empty;
 
     test_store_in_memory(

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -14,7 +14,7 @@ use linera_witty::{HList, Layout, WitType};
 
 /// Check the memory size and layout derived for a wrapper type.
 #[test]
-fn simple_bool_wrapper() {
+fn test_simple_bool_wrapper() {
     assert_eq!(SimpleWrapper::SIZE, 1);
     assert_eq!(<SimpleWrapper as WitType>::Layout::ALIGNMENT, 1);
     assert_eq!(<<SimpleWrapper as WitType>::Layout as Layout>::Flat::LEN, 1);
@@ -23,7 +23,7 @@ fn simple_bool_wrapper() {
 /// Check the memory size and layout derived for a type with multiple fields ordered in a way that
 /// doesn't require any padding.
 #[test]
-fn tuple_struct_without_padding() {
+fn test_tuple_struct_without_padding() {
     assert_eq!(TupleWithoutPadding::SIZE, 14);
     assert_eq!(<TupleWithoutPadding as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(
@@ -35,7 +35,7 @@ fn tuple_struct_without_padding() {
 /// Check the memory size and layout derived for a type with multiple fields ordered in a way that
 /// requires padding between all fields.
 #[test]
-fn tuple_struct_with_padding() {
+fn test_tuple_struct_with_padding() {
     assert_eq!(TupleWithPadding::SIZE, 16);
     assert_eq!(<TupleWithPadding as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(
@@ -47,7 +47,7 @@ fn tuple_struct_with_padding() {
 /// Check the memory size and layout derived for a type with multiple named fields ordered in a way
 /// that requires padding before two fields.
 #[test]
-fn named_struct_with_double_padding() {
+fn test_named_struct_with_double_padding() {
     assert_eq!(RecordWithDoublePadding::SIZE, 24);
     assert_eq!(<RecordWithDoublePadding as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(
@@ -59,7 +59,7 @@ fn named_struct_with_double_padding() {
 /// Check the memory size and layout derived for a type that contains a field with a type that also
 /// has `WitType` derived for it.
 #[test]
-fn nested_types() {
+fn test_nested_types() {
     assert_eq!(Leaf::SIZE, 24);
     assert_eq!(<Leaf as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Leaf as WitType>::Layout as Layout>::Flat::LEN, 3);
@@ -71,7 +71,7 @@ fn nested_types() {
 
 /// Check the memory size and layout derived for an `enum` type.
 #[test]
-fn enum_type() {
+fn test_enum_type() {
     assert_eq!(Enum::SIZE, 18);
     assert_eq!(<Enum as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Enum as WitType>::Layout as Layout>::Flat::LEN, 11);


### PR DESCRIPTION
## Motivation

One of the main goals of the Witty crate is to make it easy to export host functions to guest Wasm modules in a reentrant manner, i.e., allowing the host functions to call back to the guest before returning.

## Proposal

Allow reentrant functions to be defined in `impl` blocks that use the `#[wit_export]` attribute procedural macro by having the functions have a generic type parameter representing the Wasm runtime-specific caller instance. The macro automatically detects this and generates code that will handle the parameter in a special manner.

Since the caller type has to be borrowed by the handler closure, the runtime instance traits must also be implemented for `&mut T`, not just `T` anymore.

## Test Plan

Some new integration tests are included which have reentrant functions. These functions are called by the guest and act as proxies, calling back to the guest to complete the test.

The tests also cover fallible functions, covering the bug fixed by #959.

## Links

Part of #906 

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
