### PR TITLE
Make wallet and storage explicit in READMEs with multiple wallets.

### DIFF
--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -49,15 +49,15 @@ application, and publish them as an application bytecode:
 
 ```bash
 alias linera="$PWD/target/debug/linera"
-export LINERA_WALLET="$PWD/target/debug/wallet.json"
-export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
+export LINERA_WALLET1="$PWD/target/debug/wallet.json"
+export LINERA_STORAGE1="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
 export LINERA_WALLET2="$PWD/target/debug/wallet_2.json"
 export LINERA_STORAGE2="rocksdb:$(dirname "$LINERA_WALLET2")/linera_2.db"
 
 (cargo build && cd examples && cargo build --release)
-linera publish-bytecode \
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" publish-bytecode \
   examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm
-linera publish-bytecode \
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" publish-bytecode \
   examples/target/wasm32-unknown-unknown/release/crowd_funding_{contract,service}.wasm
 ```
 
@@ -81,8 +81,8 @@ In order to select the accounts to have initial tokens, the command below can be
 the chains created for the test as known by each wallet:
 
 ```bash
-linera wallet show
-linera --storage "$LINERA_STORAGE2" --wallet "$LINERA_WALLET2" wallet show
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" wallet show
+linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" wallet show
 ```
 
 A table will be shown with the chains registered in the wallet and their meta-data:
@@ -109,7 +109,8 @@ Create a fungible token application where two accounts start with the minted tok
 one with 100 of them and another with 200 of them:
 
 ```bash
-linera create-application $BYTECODE_ID1 \
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" \
+    create-application $BYTECODE_ID1 \
     --json-argument '{ "accounts": { "User:'$OWNER1'": "100", "User:'$OWNER2'": "200" } }'
 ```
 
@@ -127,7 +128,8 @@ Similarly, we're going to create a crowd-funding campaign on the default chain.
 We have to specify our fungible application as a dependency and a parameter:
 
 ```bash
-linera create-application $BYTECODE_ID2 \
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" \
+   create-application $BYTECODE_ID2 \
    --json-argument '{ "owner": "User:'$OWNER1'", "deadline": 4102473600000000, "target": "100." }'  --required-application-ids=$APP_ID1  --json-parameters='"'$APP_ID1'"'
 ```
 
@@ -138,7 +140,7 @@ Let's remember the application ID as `$APP_ID2`.
 First, a node service has to be started for each wallet, using two different ports:
 
 ```bash
-linera service --port 8080 &
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" service --port 8080 &
 linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" service --port 8081 &
 ```
 

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -50,15 +50,15 @@
 //!
 //! ```bash
 //! alias linera="$PWD/target/debug/linera"
-//! export LINERA_WALLET="$PWD/target/debug/wallet.json"
-//! export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
+//! export LINERA_WALLET1="$PWD/target/debug/wallet.json"
+//! export LINERA_STORAGE1="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
 //! export LINERA_WALLET2="$PWD/target/debug/wallet_2.json"
 //! export LINERA_STORAGE2="rocksdb:$(dirname "$LINERA_WALLET2")/linera_2.db"
 //!
 //! (cargo build && cd examples && cargo build --release)
-//! linera publish-bytecode \
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" publish-bytecode \
 //!   examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm
-//! linera publish-bytecode \
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" publish-bytecode \
 //!   examples/target/wasm32-unknown-unknown/release/crowd_funding_{contract,service}.wasm
 //! ```
 //!
@@ -82,8 +82,8 @@
 //! the chains created for the test as known by each wallet:
 //!
 //! ```bash
-//! linera wallet show
-//! linera --storage "$LINERA_STORAGE2" --wallet "$LINERA_WALLET2" wallet show
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" wallet show
+//! linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" wallet show
 //! ```
 //!
 //! A table will be shown with the chains registered in the wallet and their meta-data:
@@ -110,7 +110,8 @@
 //! one with 100 of them and another with 200 of them:
 //!
 //! ```bash
-//! linera create-application $BYTECODE_ID1 \
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" \
+//!     create-application $BYTECODE_ID1 \
 //!     --json-argument '{ "accounts": { "User:'$OWNER1'": "100", "User:'$OWNER2'": "200" } }'
 //! ```
 //!
@@ -128,7 +129,8 @@
 //! We have to specify our fungible application as a dependency and a parameter:
 //!
 //! ```bash
-//! linera create-application $BYTECODE_ID2 \
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" \
+//!    create-application $BYTECODE_ID2 \
 //!    --json-argument '{ "owner": "User:'$OWNER1'", "deadline": 4102473600000000, "target": "100." }'  --required-application-ids=$APP_ID1  --json-parameters='"'$APP_ID1'"'
 //! ```
 //!
@@ -139,7 +141,7 @@
 //! First, a node service has to be started for each wallet, using two different ports:
 //!
 //! ```bash
-//! linera service --port 8080 &
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" service --port 8080 &
 //! linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" service --port 8081 &
 //! ```
 //!

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -37,14 +37,15 @@ Compile the `social` example and create an application with it:
 
 ```bash
 alias linera="$PWD/target/debug/linera"
-export LINERA_WALLET="$(realpath target/debug/wallet.json)"
-export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
-export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
-export LINERA_STORAGE_2="rocksdb:$(dirname "$LINERA_WALLET_2")/linera_2.db"
+export LINERA_WALLET1="$(realpath target/debug/wallet.json)"
+export LINERA_STORAGE1="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
+export LINERA_WALLET2="$(realpath target/debug/wallet_2.json)"
+export LINERA_STORAGE2="rocksdb:$(dirname "$LINERA_WALLET2")/linera_2.db"
 
 cd examples/social && cargo build --release && cd ../..
 
-linera publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" \
+  publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
 ```
 
 This will output the new application ID, e.g.:
@@ -56,7 +57,7 @@ e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a650100000000000000
 With the `wallet show` command you can find the ID of the application creator's chain:
 
 ```bash
-linera wallet show
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" wallet show
 ```
 
 ```rust
@@ -67,8 +68,8 @@ e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65
 Now start a node service for each wallet, using two different ports:
 
 ```bash
-linera service --port 8080 &
-linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
+linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" service --port 8080 &
+linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" service --port 8081 &
 ```
 
 Point your browser to http://localhost:8081. This is the wallet that didn't create the

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -38,14 +38,15 @@
 //!
 //! ```bash
 //! alias linera="$PWD/target/debug/linera"
-//! export LINERA_WALLET="$(realpath target/debug/wallet.json)"
-//! export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
-//! export LINERA_WALLET_2="$(realpath target/debug/wallet_2.json)"
-//! export LINERA_STORAGE_2="rocksdb:$(dirname "$LINERA_WALLET_2")/linera_2.db"
+//! export LINERA_WALLET1="$(realpath target/debug/wallet.json)"
+//! export LINERA_STORAGE1="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
+//! export LINERA_WALLET2="$(realpath target/debug/wallet_2.json)"
+//! export LINERA_STORAGE2="rocksdb:$(dirname "$LINERA_WALLET2")/linera_2.db"
 //!
 //! cd examples/social && cargo build --release && cd ../..
 //!
-//! linera publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" \
+//!   publish-and-create examples/target/wasm32-unknown-unknown/release/social_{contract,service}.wasm
 //! ```
 //!
 //! This will output the new application ID, e.g.:
@@ -57,7 +58,7 @@
 //! With the `wallet show` command you can find the ID of the application creator's chain:
 //!
 //! ```bash
-//! linera wallet show
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" wallet show
 //! ```
 //!
 //! ```ignore
@@ -68,8 +69,8 @@
 //! Now start a node service for each wallet, using two different ports:
 //!
 //! ```bash
-//! linera service --port 8080 &
-//! linera --wallet "$LINERA_WALLET_2" --storage "$LINERA_STORAGE_2" service --port 8081 &
+//! linera --wallet "$LINERA_WALLET1" --storage "$LINERA_STORAGE1" service --port 8080 &
+//! linera --wallet "$LINERA_WALLET2" --storage "$LINERA_STORAGE2" service --port 8081 &
 //! ```
 //!
 //! Point your browser to http://localhost:8081. This is the wallet that didn't create the


### PR DESCRIPTION
## Motivation

If no `--wallet` and `--storage` is specified, `linera` uses the `LINERA_WALLET` and `LINERA_STORAGE` environment variables, so we set these in the example `README.md` files.

The `crowd_funding` and `social` examples use two wallets, though, so it is confusing if one of them is implicit.

Also, a `LINERA_WALLET1` was missed in the `crowd_funding` README.

## Proposal

In the `crowd_funding` and `social` examples, use `LINERA_WALLET1` and `LINERA_STORAGE1` or `2` and specify them on the command line everywhere.

## Test Plan

No code was changed, and we currently don't have tests for the README file commands.

## Release Plan


- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
