### PR TITLE
New round notification, leader timeout value

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -183,21 +183,31 @@ pub struct ExecutedBlock {
 /// A statement to be certified by the validators.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Deserialize, Serialize)]
 pub enum CertificateValue {
-    ValidatedBlock { executed_block: ExecutedBlock },
-    ConfirmedBlock { executed_block: ExecutedBlock },
+    ValidatedBlock {
+        executed_block: ExecutedBlock,
+    },
+    ConfirmedBlock {
+        executed_block: ExecutedBlock,
+    },
+    LeaderTimeout {
+        chain_id: ChainId,
+        height: BlockHeight,
+        epoch: Epoch,
+    },
 }
 
 #[Object]
 impl CertificateValue {
     #[graphql(derived(name = "executed_block"))]
-    async fn _executed_block(&self) -> ExecutedBlock {
-        self.executed_block().clone()
+    async fn _executed_block(&self) -> Option<ExecutedBlock> {
+        self.executed_block().cloned()
     }
 
     async fn status(&self) -> String {
         match self {
             CertificateValue::ValidatedBlock { .. } => "validated".to_string(),
             CertificateValue::ConfirmedBlock { .. } => "confirmed".to_string(),
+            CertificateValue::LeaderTimeout { .. } => "timeout".to_string(),
         }
     }
 }
@@ -454,15 +464,31 @@ impl From<HashedValue> for CertificateValue {
 
 impl CertificateValue {
     pub fn chain_id(&self) -> ChainId {
-        self.executed_block().block.chain_id
+        match self {
+            CertificateValue::ConfirmedBlock { executed_block, .. }
+            | CertificateValue::ValidatedBlock { executed_block, .. } => {
+                executed_block.block.chain_id
+            }
+            CertificateValue::LeaderTimeout { chain_id, .. } => *chain_id,
+        }
     }
 
     pub fn height(&self) -> BlockHeight {
-        self.executed_block().block.height
+        match self {
+            CertificateValue::ConfirmedBlock { executed_block, .. }
+            | CertificateValue::ValidatedBlock { executed_block, .. } => {
+                executed_block.block.height
+            }
+            CertificateValue::LeaderTimeout { height, .. } => *height,
+        }
     }
 
     pub fn epoch(&self) -> Epoch {
-        self.executed_block().block.epoch
+        match self {
+            CertificateValue::ConfirmedBlock { executed_block, .. }
+            | CertificateValue::ValidatedBlock { executed_block, .. } => executed_block.block.epoch,
+            CertificateValue::LeaderTimeout { epoch, .. } => *epoch,
+        }
     }
 
     /// Creates a `HashedValue` without checking that this is the correct hash!
@@ -472,10 +498,15 @@ impl CertificateValue {
 
     /// Returns whether this value contains the message with the specified ID.
     pub fn has_message(&self, message_id: &MessageId) -> bool {
+        let Some(executed_block) = self.executed_block() else {
+            return false;
+        };
+        let Ok(index) = usize::try_from(message_id.index) else {
+            return false;
+        };
         self.height() == message_id.height
             && self.chain_id() == message_id.chain_id
-            && self.executed_block().messages.len()
-                > usize::try_from(message_id.index).unwrap_or(usize::MAX)
+            && executed_block.messages.len() > index
     }
 
     /// Skip `n-1` messages from the end of the block and return the message ID, if any.
@@ -483,7 +514,7 @@ impl CertificateValue {
         if n == 0 {
             return None;
         }
-        let message_count = self.executed_block().messages.len();
+        let message_count = self.executed_block()?.messages.len();
         Some(MessageId {
             chain_id: self.chain_id(),
             height: self.height(),
@@ -499,16 +530,26 @@ impl CertificateValue {
         matches!(self, CertificateValue::ValidatedBlock { .. })
     }
 
-    #[cfg(any(test, feature = "test"))]
-    pub fn messages(&self) -> &Vec<OutgoingMessage> {
-        &self.executed_block().messages
+    pub fn is_timeout(&self) -> bool {
+        matches!(self, CertificateValue::LeaderTimeout { .. })
     }
 
-    pub fn executed_block(&self) -> &ExecutedBlock {
+    #[cfg(any(test, feature = "test"))]
+    pub fn messages(&self) -> Option<&Vec<OutgoingMessage>> {
+        Some(&self.executed_block()?.messages)
+    }
+
+    pub fn executed_block(&self) -> Option<&ExecutedBlock> {
         match self {
             CertificateValue::ConfirmedBlock { executed_block, .. }
-            | CertificateValue::ValidatedBlock { executed_block, .. } => executed_block,
+            | CertificateValue::ValidatedBlock { executed_block, .. } => Some(executed_block),
+            CertificateValue::LeaderTimeout { .. } => None,
         }
+    }
+
+    pub fn block(&self) -> Option<&Block> {
+        self.executed_block()
+            .map(|executed_block| &executed_block.block)
     }
 }
 
@@ -534,15 +575,16 @@ impl HashedValue {
         }
     }
 
-    pub fn into_confirmed(self) -> HashedValue {
+    pub fn into_confirmed(self) -> Option<HashedValue> {
         match self.value {
-            value @ CertificateValue::ConfirmedBlock { .. } => HashedValue {
+            value @ CertificateValue::ConfirmedBlock { .. } => Some(HashedValue {
                 hash: self.hash,
                 value,
-            },
+            }),
             CertificateValue::ValidatedBlock { executed_block } => {
-                CertificateValue::ConfirmedBlock { executed_block }.into()
+                Some(CertificateValue::ConfirmedBlock { executed_block }.into())
             }
+            CertificateValue::LeaderTimeout { .. } => None,
         }
     }
 

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -136,6 +136,13 @@ impl ChainManager {
     pub fn create_final_vote(&mut self, certificate: Certificate, key_pair: Option<&KeyPair>) {
         match self {
             ChainManager::Multi(manager) => manager.create_final_vote(certificate, key_pair),
+            _ => panic!("unexpected chain manager"),
+        }
+    }
+
+    pub fn handle_timeout_certificate(&mut self, _: Certificate) {
+        match self {
+            ChainManager::Multi(_) => {}
             ChainManager::None | ChainManager::Single(_) => panic!("unexpected chain manager"),
         }
     }

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -136,7 +136,7 @@ impl ChainManager {
     pub fn create_final_vote(&mut self, certificate: Certificate, key_pair: Option<&KeyPair>) {
         match self {
             ChainManager::Multi(manager) => manager.create_final_vote(certificate, key_pair),
-            _ => panic!("unexpected chain manager"),
+            ChainManager::None | ChainManager::Single(_) => panic!("unexpected chain manager"),
         }
     }
 
@@ -187,7 +187,7 @@ impl ChainManagerInfo {
         match self {
             ChainManagerInfo::Single(single) => single.pending.as_ref(),
             ChainManagerInfo::Multi(multi) => multi.pending.as_ref(),
-            _ => None,
+            ChainManagerInfo::None => None,
         }
     }
 
@@ -201,7 +201,7 @@ impl ChainManagerInfo {
     pub fn next_round(&self) -> RoundNumber {
         match self {
             ChainManagerInfo::Multi(multi) => multi.next_round(),
-            _ => RoundNumber::default(),
+            ChainManagerInfo::None | ChainManagerInfo::Single(_) => RoundNumber::default(),
         }
     }
 }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -653,7 +653,10 @@ where
             }
             CommunicateAction::FinalizeBlock(validity_certificate) => {
                 let round = validity_certificate.round;
-                (validity_certificate.value.into_confirmed(), round)
+                let Some(conf_value) = validity_certificate.value.into_confirmed() else {
+                    bail!("Unexpected certificate value for finalized block");
+                };
+                (conf_value, round)
             }
             CommunicateAction::AdvanceToNextBlockHeight(_) => {
                 return match result {
@@ -1039,7 +1042,7 @@ where
         // TODO(#66): return the block that should be proposed instead
         if let Some(validated) = &validated {
             ensure!(
-                validated.value().executed_block().block == block,
+                validated.value().block() == Some(&block),
                 "A different block has already been validated at this height"
             );
         }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -490,7 +490,8 @@ where
         .execute_operation(Operation::user(application_id, &transfer)?)
         .await?;
 
-    assert!(cert.value().messages().iter().any(
+    let messages = cert.value().messages().unwrap();
+    assert!(messages.iter().any(
         |OutgoingMessage {
              destination,
              message,
@@ -513,7 +514,7 @@ where
         CertificateValue::ConfirmedBlock { executed_block, .. } => {
             &executed_block.block.incoming_messages
         }
-        CertificateValue::ValidatedBlock { .. } => panic!("Unexpected value"),
+        _ => panic!("Unexpected value"),
     };
     assert!(messages.iter().any(|msg| matches!(
         &msg.event.message,
@@ -544,7 +545,7 @@ where
         CertificateValue::ConfirmedBlock { executed_block, .. } => {
             &executed_block.block.incoming_messages
         }
-        CertificateValue::ValidatedBlock { .. } => panic!("Unexpected value"),
+        _ => panic!("Unexpected value"),
     };
     // The new block should _not_ contain another `RegisterApplications` message, because the
     // application is already registered.
@@ -692,7 +693,7 @@ where
         CertificateValue::ConfirmedBlock { executed_block, .. } => {
             &executed_block.block.incoming_messages
         }
-        CertificateValue::ValidatedBlock { .. } => panic!("Unexpected value"),
+        _ => panic!("Unexpected value"),
     };
     assert!(messages
         .iter()

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -190,6 +190,7 @@ where
                     | CertificateValue::ValidatedBlock { executed_block, .. } => {
                         executed_block.block.bytecode_locations()
                     }
+                    CertificateValue::LeaderTimeout { .. } => HashMap::new(),
                 };
                 for location in locations {
                     if !required.contains_key(location) {

--- a/linera-explorer/graphql/schema.graphql
+++ b/linera-explorer/graphql/schema.graphql
@@ -79,7 +79,7 @@ A unique identifier for an application bytecode
 scalar BytecodeId
 
 type CertificateValue {
-	executedBlock: ExecutedBlock!
+	executedBlock: ExecutedBlock
 	status: String!
 }
 

--- a/linera-explorer/src/graphql.rs
+++ b/linera-explorer/src/graphql.rs
@@ -4,7 +4,7 @@
 use graphql_client::GraphQLQuery;
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, Timestamp},
+    data_types::{BlockHeight, RoundNumber, Timestamp},
     identifiers::{ChainId, Destination, Owner},
 };
 use serde::{Deserialize, Serialize};
@@ -25,6 +25,7 @@ pub struct Notification {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum Reason {
     NewBlock {
         height: BlockHeight,
@@ -33,6 +34,10 @@ pub enum Reason {
     NewIncomingMessage {
         origin: Origin,
         height: BlockHeight,
+    },
+    NewRound {
+        height: BlockHeight,
+        round: RoundNumber,
     },
 }
 

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -115,6 +115,15 @@ CertificateValue:
         STRUCT:
           - executed_block:
               TYPENAME: ExecutedBlock
+    2:
+      LeaderTimeout:
+        STRUCT:
+          - chain_id:
+              TYPENAME: ChainId
+          - height:
+              TYPENAME: BlockHeight
+          - epoch:
+              TYPENAME: Epoch
 ChainAndHeight:
   STRUCT:
     - chain_id:

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -375,7 +375,11 @@ impl ActiveChain {
                 .expect("Failed to load certificate to search for bytecode location")
                 .expect("Bytecode location not found");
 
-            let message_index = certificate.value().messages().iter().position(|message| {
+            let messages = certificate
+                .value()
+                .messages()
+                .expect("Unexpected certificate value");
+            let message_index = messages.iter().position(|message| {
                 matches!(
                     &message.message,
                     Message::System(SystemMessage::BytecodeLocations { locations })

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -157,7 +157,9 @@ where
             }
             if let Reason::NewBlock { hash, .. } = notification.reason {
                 let value = storage.read_value(hash).await?;
-                let executed_block = value.inner().executed_block();
+                let Some(executed_block) = value.inner().executed_block() else {
+                    continue;
+                };
                 let timestamp = executed_block.block.timestamp;
                 for outgoing_message in &executed_block.messages {
                     if let OutgoingMessage {

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -212,6 +212,15 @@ where
                     );
                 }
             }
+            Reason::NewRound { .. } => {
+                if let Err(e) = client.update_validators().await {
+                    warn!(
+                        "Failed to update validators about the local chain after \
+                        receiving notification {:?} with error: {:?}",
+                        notification, e
+                    );
+                }
+            }
         }
     }
 }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1195,12 +1195,7 @@ where
                     .await
                     .unwrap()
                     .into_iter()
-                    .map(|c| match c.value() {
-                        CertificateValue::ConfirmedBlock { executed_block, .. } => {
-                            executed_block.messages.len()
-                        }
-                        CertificateValue::ValidatedBlock { .. } => 0,
-                    })
+                    .filter_map(|c| c.value().executed_block().map(|e| e.messages.len()))
                     .sum::<usize>();
                 info!("Subscribed {} chains to new committees", n);
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -313,7 +313,10 @@ where
                 break;
             };
             let value = self.read_value(next_hash).await?;
-            hash = value.inner().executed_block().block.previous_block_hash;
+            let Some(executed_block) = value.inner().executed_block() else {
+                break;
+            };
+            hash = executed_block.block.previous_block_hash;
             result.push(value);
         }
         Ok(result)


### PR DESCRIPTION
## Motivation

For the BFT consensus protocol, validators will need to notify clients when a new consensus round starts, and sign to skip a round if it times out.

## Proposal

Add a `NewRound` notification reason, and a `LeaderTimeout` certificate value.

## Test Plan

These values aren't used yet, so there is nothing to test. This PR is in preparation for the BFT consensus, to keep the diff with the main branch small.

## Links

Public chains issue: https://github.com/linera-io/linera-protocol/issues/464
BFT consensus draft: https://github.com/linera-io/linera-protocol/pull/928

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
