### PR TITLE
Simplify generics for exporting reentrant functions with Witty

### DIFF
--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -8,9 +8,9 @@ use proc_macro2::{Span, TokenStream};
 use proc_macro_error::abort;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
-    spanned::Spanned, FnArg, GenericArgument, GenericParam, ImplItem, ImplItemMethod, LitStr,
-    PatType, Path, PathArguments, PathSegment, ReturnType, Signature, Token, Type, TypePath,
-    TypeReference,
+    spanned::Spanned, FnArg, GenericArgument, GenericParam, Ident, ImplItem, ImplItemMethod,
+    LitStr, PatType, Path, PathArguments, PathSegment, ReturnType, Signature, Token, Type,
+    TypePath, TypeReference,
 };
 
 /// Pieces of information extracted from a function's definition.
@@ -148,7 +148,7 @@ impl<'input> FunctionInformation<'input> {
 
     /// Generates the code to export a host function using the Wasmer runtime.
     #[cfg(feature = "wasmer")]
-    pub fn generate_for_wasmer(&self, namespace: &LitStr) -> TokenStream {
+    pub fn generate_for_wasmer(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
         let caller = quote! {
             linera_witty::wasmer::FunctionEnvMut<'_, linera_witty::wasmer::InstanceSlot>
         };
@@ -162,6 +162,7 @@ impl<'input> FunctionInformation<'input> {
 
         self.generate(
             namespace,
+            type_name,
             caller,
             input_to_guest_parameters,
             guest_results_to_output,
@@ -171,7 +172,7 @@ impl<'input> FunctionInformation<'input> {
 
     /// Generates the code to export a host function using the Wasmtime runtime.
     #[cfg(feature = "wasmtime")]
-    pub fn generate_for_wasmtime(&self, namespace: &LitStr) -> TokenStream {
+    pub fn generate_for_wasmtime(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
         let caller = quote! { linera_witty::wasmtime::Caller<'_, ()> };
         let input_to_guest_parameters = quote! {
             linera_witty::wasmtime::WasmtimeParameters::from_wasmtime(input)
@@ -183,6 +184,7 @@ impl<'input> FunctionInformation<'input> {
 
         self.generate(
             namespace,
+            type_name,
             caller,
             input_to_guest_parameters,
             guest_results_to_output,
@@ -192,7 +194,7 @@ impl<'input> FunctionInformation<'input> {
 
     /// Generates the code to export a host function using a mock Wasm instance for testing.
     #[cfg(feature = "mock-instance")]
-    pub fn generate_for_mock_instance(&self, namespace: &LitStr) -> TokenStream {
+    pub fn generate_for_mock_instance(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
         let caller = quote! { linera_witty::MockInstance };
         let input_to_guest_parameters = quote! { input };
         let guest_results_to_output = quote! { guest_results };
@@ -200,6 +202,7 @@ impl<'input> FunctionInformation<'input> {
 
         self.generate(
             namespace,
+            type_name,
             caller,
             input_to_guest_parameters,
             guest_results_to_output,
@@ -211,6 +214,7 @@ impl<'input> FunctionInformation<'input> {
     fn generate(
         &self,
         namespace: &LitStr,
+        type_name: &Ident,
         caller: TokenStream,
         input_to_guest_parameters: TokenStream,
         guest_results_to_output: TokenStream,
@@ -248,7 +252,7 @@ impl<'input> FunctionInformation<'input> {
                         )?;
 
                     #[allow(clippy::let_unit_value)]
-                    let host_results = Self::#function_name(
+                    let host_results = #type_name::#function_name(
                         #caller_parameter
                         #host_parameters
                     ) #call_early_return;

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -23,8 +23,10 @@ pub struct FunctionInformation<'input> {
     interface_type: TokenStream,
 }
 
-impl<'input> From<&'input ImplItem> for FunctionInformation<'input> {
-    fn from(item: &'input ImplItem) -> Self {
+impl<'input> FunctionInformation<'input> {
+    /// Parses a function definition from an [`ImplItem`] and collects pieces of information into a
+    /// [`FunctionInformation`] instance.
+    pub fn from_item(item: &'input ImplItem) -> Self {
         match item {
             ImplItem::Method(function) => FunctionInformation::new(function),
             ImplItem::Const(const_item) => abort!(
@@ -42,9 +44,7 @@ impl<'input> From<&'input ImplItem> for FunctionInformation<'input> {
             _ => abort!(item, "Only function items are supported in exported types"),
         }
     }
-}
 
-impl<'input> FunctionInformation<'input> {
     /// Parses a function definition and collects pieces of information into a
     /// [`FunctionInformation`] instance.
     pub fn new(function: &'input ImplItemMethod) -> Self {

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -74,7 +74,7 @@ impl<'input> WitExportGenerator<'input> {
             let exported_functions = self
                 .functions
                 .iter()
-                .map(|function| function.generate_for_wasmer(self.namespace));
+                .map(|function| function.generate_for_wasmer(self.namespace, self.type_name));
 
             Some(self.generate_for(export_target, exported_functions))
         }
@@ -92,7 +92,7 @@ impl<'input> WitExportGenerator<'input> {
             let exported_functions = self
                 .functions
                 .iter()
-                .map(|function| function.generate_for_wasmtime(self.namespace));
+                .map(|function| function.generate_for_wasmtime(self.namespace, self.type_name));
 
             Some(self.generate_for(export_target, exported_functions))
         }
@@ -107,10 +107,9 @@ impl<'input> WitExportGenerator<'input> {
         #[cfg(feature = "mock-instance")]
         {
             let export_target = quote! { linera_witty::MockInstance };
-            let exported_functions = self
-                .functions
-                .iter()
-                .map(|function| function.generate_for_mock_instance(self.namespace));
+            let exported_functions = self.functions.iter().map(|function| {
+                function.generate_for_mock_instance(self.namespace, self.type_name)
+            });
 
             Some(self.generate_for(export_target, exported_functions))
         }

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -151,14 +151,15 @@ pub fn type_name(implementation: &ItemImpl) -> &Ident {
     else {
         abort!(
             implementation.self_ty,
-            "`#[wit_export]` must be used on `impl` blocks of non-generic types",
+            "`#[wit_export]` must be used on `impl` blocks",
         );
     };
 
-    path_name.get_ident().unwrap_or_else(|| {
-        abort!(
-            implementation.self_ty,
-            "`#[wit_export]` must be used on `impl` blocks of non-generic types",
-        );
-    })
+    &path_name
+        .segments
+        .last()
+        .unwrap_or_else(|| {
+            abort!(implementation.self_ty, "Missing type name identifier",);
+        })
+        .ident
 }

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -40,7 +40,7 @@ impl<'input> WitExportGenerator<'input> {
         let functions = implementation
             .items
             .iter()
-            .map(FunctionInformation::from)
+            .map(FunctionInformation::from_item)
             .collect();
 
         WitExportGenerator {

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -42,7 +42,7 @@ impl<'input> WitExportGenerator<'input> {
         let functions = implementation
             .items
             .iter()
-            .map(FunctionInformation::from_item)
+            .map(|item| FunctionInformation::from_item(item, caller_type_parameter))
             .collect();
 
         WitExportGenerator {

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -31,6 +31,9 @@ pub trait TestInstanceFactory {
     /// The type representing a guest Wasm instance.
     type Instance: InstanceWithMemory;
 
+    /// The type received by host functions to use for reentrant calls.
+    type Caller<'caller>;
+
     /// Loads a test module with the provided `module_name` from the named `group`_
     fn load_test_module<ExportedFunctions>(
         &mut self,
@@ -49,6 +52,7 @@ pub struct WasmtimeInstanceFactory;
 impl TestInstanceFactory for WasmtimeInstanceFactory {
     type Builder = ::wasmtime::Linker<()>;
     type Instance = wasmtime::EntrypointInstance;
+    type Caller<'caller> = ::wasmtime::Caller<'caller, ()>;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance
     where
@@ -83,6 +87,7 @@ pub struct WasmerInstanceFactory;
 impl TestInstanceFactory for WasmerInstanceFactory {
     type Builder = wasmer::InstanceBuilder;
     type Instance = wasmer::EntrypointInstance;
+    type Caller<'caller> = ::wasmer::FunctionEnvMut<'caller, wasmer::InstanceSlot>;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance
     where
@@ -115,6 +120,7 @@ pub struct MockInstanceFactory {
 impl TestInstanceFactory for MockInstanceFactory {
     type Builder = MockInstance;
     type Instance = MockInstance;
+    type Caller<'caller> = MockInstance;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance
     where

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -14,6 +14,7 @@ use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
 use linera_witty::{
     wit_export, wit_import, ExportTo, Instance, Runtime, RuntimeError, RuntimeMemory,
 };
+use std::marker::PhantomData;
 use test_case::test_case;
 
 /// An interface to call into the test modules.
@@ -86,103 +87,59 @@ trait ImportedGetters {
 }
 
 /// Type to export reentrant functions with return values.
-pub struct ExportedGetters;
+pub struct ExportedGetters<Caller>(PhantomData<Caller>);
 
 #[wit_export(package = "witty-macros:test-modules", interface = "getters")]
-impl ExportedGetters {
-    fn get_true<Caller>(caller: &mut Caller) -> Result<bool, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+impl<Caller> ExportedGetters<Caller>
+where
+    Caller: InstanceForImportedGetters,
+    <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+{
+    fn get_true(caller: &mut Caller) -> Result<bool, RuntimeError> {
         ImportedGetters::new(caller).get_true()
     }
 
-    fn get_false<Caller>(caller: &mut Caller) -> Result<bool, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_false(caller: &mut Caller) -> Result<bool, RuntimeError> {
         ImportedGetters::new(caller).get_false()
     }
 
-    fn get_s8<Caller>(caller: &mut Caller) -> Result<i8, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_s8(caller: &mut Caller) -> Result<i8, RuntimeError> {
         ImportedGetters::new(caller).get_s8()
     }
 
-    fn get_u8<Caller>(caller: &mut Caller) -> Result<u8, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_u8(caller: &mut Caller) -> Result<u8, RuntimeError> {
         ImportedGetters::new(caller).get_u8()
     }
 
-    fn get_s16<Caller>(caller: &mut Caller) -> Result<i16, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_s16(caller: &mut Caller) -> Result<i16, RuntimeError> {
         ImportedGetters::new(caller).get_s16()
     }
 
-    fn get_u16<Caller>(caller: &mut Caller) -> Result<u16, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_u16(caller: &mut Caller) -> Result<u16, RuntimeError> {
         ImportedGetters::new(caller).get_u16()
     }
 
-    fn get_s32<Caller>(caller: &mut Caller) -> Result<i32, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_s32(caller: &mut Caller) -> Result<i32, RuntimeError> {
         ImportedGetters::new(caller).get_s32()
     }
 
-    fn get_u32<Caller>(caller: &mut Caller) -> Result<u32, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_u32(caller: &mut Caller) -> Result<u32, RuntimeError> {
         ImportedGetters::new(caller).get_u32()
     }
 
-    fn get_s64<Caller>(caller: &mut Caller) -> Result<i64, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_s64(caller: &mut Caller) -> Result<i64, RuntimeError> {
         ImportedGetters::new(caller).get_s64()
     }
 
-    fn get_u64<Caller>(caller: &mut Caller) -> Result<u64, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_u64(caller: &mut Caller) -> Result<u64, RuntimeError> {
         ImportedGetters::new(caller).get_u64()
     }
 
-    fn get_float32<Caller>(caller: &mut Caller) -> Result<f32, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_float32(caller: &mut Caller) -> Result<f32, RuntimeError> {
         ImportedGetters::new(caller).get_float32()
     }
 
-    fn get_float64<Caller>(caller: &mut Caller) -> Result<f64, RuntimeError>
-    where
-        Caller: InstanceForImportedGetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn get_float64(caller: &mut Caller) -> Result<f64, RuntimeError> {
         ImportedGetters::new(caller).get_float64()
     }
 }
@@ -200,9 +157,9 @@ where
     InstanceFactory::Instance: InstanceForEntrypoint,
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
-    ExportedGetters: ExportTo<InstanceFactory::Builder>,
+    ExportedGetters<InstanceFactory::Caller<'static>>: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module::<ExportedGetters>("reentrancy", "getters");
+    let instance = factory.load_test_module::<ExportedGetters<_>>("reentrancy", "getters");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -226,95 +183,55 @@ trait ImportedSetters {
 }
 
 /// Type to export reentrant functions with parameters.
-pub struct ExportedSetters;
+pub struct ExportedSetters<Caller>(PhantomData<Caller>);
 
 #[wit_export(package = "witty-macros:test-modules", interface = "setters")]
-impl ExportedSetters {
-    fn set_bool<Caller>(caller: &mut Caller, value: bool) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+impl<Caller> ExportedSetters<Caller>
+where
+    Caller: InstanceForImportedSetters,
+    <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+{
+    fn set_bool(caller: &mut Caller, value: bool) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_bool(value)
     }
 
-    fn set_s8<Caller>(caller: &mut Caller, value: i8) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_s8(caller: &mut Caller, value: i8) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_s8(value)
     }
 
-    fn set_u8<Caller>(caller: &mut Caller, value: u8) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_u8(caller: &mut Caller, value: u8) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_u8(value)
     }
 
-    fn set_s16<Caller>(caller: &mut Caller, value: i16) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_s16(caller: &mut Caller, value: i16) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_s16(value)
     }
 
-    fn set_u16<Caller>(caller: &mut Caller, value: u16) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_u16(caller: &mut Caller, value: u16) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_u16(value)
     }
 
-    fn set_s32<Caller>(caller: &mut Caller, value: i32) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_s32(caller: &mut Caller, value: i32) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_s32(value)
     }
 
-    fn set_u32<Caller>(caller: &mut Caller, value: u32) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_u32(caller: &mut Caller, value: u32) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_u32(value)
     }
 
-    fn set_s64<Caller>(caller: &mut Caller, value: i64) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_s64(caller: &mut Caller, value: i64) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_s64(value)
     }
 
-    fn set_u64<Caller>(caller: &mut Caller, value: u64) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_u64(caller: &mut Caller, value: u64) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_u64(value)
     }
 
-    fn set_float32<Caller>(caller: &mut Caller, value: f32) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_float32(caller: &mut Caller, value: f32) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_float32(value)
     }
 
-    fn set_float64<Caller>(caller: &mut Caller, value: f64) -> Result<(), RuntimeError>
-    where
-        Caller: InstanceForImportedSetters,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn set_float64(caller: &mut Caller, value: f64) -> Result<(), RuntimeError> {
         ImportedSetters::new(caller).set_float64(value)
     }
 }
@@ -332,9 +249,9 @@ where
     InstanceFactory::Instance: InstanceForEntrypoint,
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
-    ExportedSetters: ExportTo<InstanceFactory::Builder>,
+    ExportedSetters<InstanceFactory::Caller<'static>>: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module::<ExportedSetters>("reentrancy", "setters");
+    let instance = factory.load_test_module::<ExportedSetters<_>>("reentrancy", "setters");
 
     Entrypoint::new(instance)
         .entrypoint()
@@ -358,95 +275,55 @@ trait ImportedOperations {
 }
 
 /// Type to export reentrant functions with multiple parameters and return values.
-pub struct ExportedOperations;
+pub struct ExportedOperations<Caller>(PhantomData<Caller>);
 
 #[wit_export(package = "witty-macros:test-modules", interface = "operations")]
-impl ExportedOperations {
-    fn and_bool<Caller>(caller: &mut Caller, first: bool, second: bool) -> Result<bool, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+impl<Caller> ExportedOperations<Caller>
+where
+    Caller: InstanceForImportedOperations,
+    <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+{
+    fn and_bool(caller: &mut Caller, first: bool, second: bool) -> Result<bool, RuntimeError> {
         ImportedOperations::new(caller).and_bool(first, second)
     }
 
-    fn add_s8<Caller>(caller: &mut Caller, first: i8, second: i8) -> Result<i8, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_s8(caller: &mut Caller, first: i8, second: i8) -> Result<i8, RuntimeError> {
         ImportedOperations::new(caller).add_s8(first, second)
     }
 
-    fn add_u8<Caller>(caller: &mut Caller, first: u8, second: u8) -> Result<u8, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_u8(caller: &mut Caller, first: u8, second: u8) -> Result<u8, RuntimeError> {
         ImportedOperations::new(caller).add_u8(first, second)
     }
 
-    fn add_s16<Caller>(caller: &mut Caller, first: i16, second: i16) -> Result<i16, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_s16(caller: &mut Caller, first: i16, second: i16) -> Result<i16, RuntimeError> {
         ImportedOperations::new(caller).add_s16(first, second)
     }
 
-    fn add_u16<Caller>(caller: &mut Caller, first: u16, second: u16) -> Result<u16, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_u16(caller: &mut Caller, first: u16, second: u16) -> Result<u16, RuntimeError> {
         ImportedOperations::new(caller).add_u16(first, second)
     }
 
-    fn add_s32<Caller>(caller: &mut Caller, first: i32, second: i32) -> Result<i32, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_s32(caller: &mut Caller, first: i32, second: i32) -> Result<i32, RuntimeError> {
         ImportedOperations::new(caller).add_s32(first, second)
     }
 
-    fn add_u32<Caller>(caller: &mut Caller, first: u32, second: u32) -> Result<u32, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_u32(caller: &mut Caller, first: u32, second: u32) -> Result<u32, RuntimeError> {
         ImportedOperations::new(caller).add_u32(first, second)
     }
 
-    fn add_s64<Caller>(caller: &mut Caller, first: i64, second: i64) -> Result<i64, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_s64(caller: &mut Caller, first: i64, second: i64) -> Result<i64, RuntimeError> {
         ImportedOperations::new(caller).add_s64(first, second)
     }
 
-    fn add_u64<Caller>(caller: &mut Caller, first: u64, second: u64) -> Result<u64, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_u64(caller: &mut Caller, first: u64, second: u64) -> Result<u64, RuntimeError> {
         ImportedOperations::new(caller).add_u64(first, second)
     }
 
-    fn add_float32<Caller>(caller: &mut Caller, first: f32, second: f32) -> Result<f32, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_float32(caller: &mut Caller, first: f32, second: f32) -> Result<f32, RuntimeError> {
         ImportedOperations::new(caller).add_float32(first, second)
     }
 
-    fn add_float64<Caller>(caller: &mut Caller, first: f64, second: f64) -> Result<f64, RuntimeError>
-    where
-        Caller: InstanceForImportedOperations,
-        <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
-    {
+    fn add_float64(caller: &mut Caller, first: f64, second: f64) -> Result<f64, RuntimeError> {
         ImportedOperations::new(caller).add_float64(first, second)
     }
 }
@@ -464,9 +341,9 @@ where
     InstanceFactory::Instance: InstanceForEntrypoint,
     <<InstanceFactory::Instance as Instance>::Runtime as Runtime>::Memory:
         RuntimeMemory<InstanceFactory::Instance>,
-    ExportedOperations: ExportTo<InstanceFactory::Builder>,
+    ExportedOperations<InstanceFactory::Caller<'static>>: ExportTo<InstanceFactory::Builder>,
 {
-    let instance = factory.load_test_module::<ExportedOperations>("reentrancy", "operations");
+    let instance = factory.load_test_module::<ExportedOperations<_>>("reentrancy", "operations");
 
     Entrypoint::new(instance)
         .entrypoint()

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -33,7 +33,7 @@ pub struct ExportedSimpleFunction;
 
 #[wit_export(package = "witty-macros:test-modules", interface = "simple-function")]
 impl ExportedSimpleFunction {
-    fn simple<Caller>(caller: Caller) -> Result<(), RuntimeError>
+    fn simple<Caller>(caller: &mut Caller) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSimpleFunction,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -90,7 +90,7 @@ pub struct ExportedGetters;
 
 #[wit_export(package = "witty-macros:test-modules", interface = "getters")]
 impl ExportedGetters {
-    fn get_true<Caller>(caller: Caller) -> Result<bool, RuntimeError>
+    fn get_true<Caller>(caller: &mut Caller) -> Result<bool, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -98,7 +98,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_true()
     }
 
-    fn get_false<Caller>(caller: Caller) -> Result<bool, RuntimeError>
+    fn get_false<Caller>(caller: &mut Caller) -> Result<bool, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -106,7 +106,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_false()
     }
 
-    fn get_s8<Caller>(caller: Caller) -> Result<i8, RuntimeError>
+    fn get_s8<Caller>(caller: &mut Caller) -> Result<i8, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -114,7 +114,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_s8()
     }
 
-    fn get_u8<Caller>(caller: Caller) -> Result<u8, RuntimeError>
+    fn get_u8<Caller>(caller: &mut Caller) -> Result<u8, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -122,7 +122,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_u8()
     }
 
-    fn get_s16<Caller>(caller: Caller) -> Result<i16, RuntimeError>
+    fn get_s16<Caller>(caller: &mut Caller) -> Result<i16, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -130,7 +130,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_s16()
     }
 
-    fn get_u16<Caller>(caller: Caller) -> Result<u16, RuntimeError>
+    fn get_u16<Caller>(caller: &mut Caller) -> Result<u16, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -138,7 +138,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_u16()
     }
 
-    fn get_s32<Caller>(caller: Caller) -> Result<i32, RuntimeError>
+    fn get_s32<Caller>(caller: &mut Caller) -> Result<i32, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -146,7 +146,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_s32()
     }
 
-    fn get_u32<Caller>(caller: Caller) -> Result<u32, RuntimeError>
+    fn get_u32<Caller>(caller: &mut Caller) -> Result<u32, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -154,7 +154,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_u32()
     }
 
-    fn get_s64<Caller>(caller: Caller) -> Result<i64, RuntimeError>
+    fn get_s64<Caller>(caller: &mut Caller) -> Result<i64, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -162,7 +162,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_s64()
     }
 
-    fn get_u64<Caller>(caller: Caller) -> Result<u64, RuntimeError>
+    fn get_u64<Caller>(caller: &mut Caller) -> Result<u64, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -170,7 +170,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_u64()
     }
 
-    fn get_float32<Caller>(caller: Caller) -> Result<f32, RuntimeError>
+    fn get_float32<Caller>(caller: &mut Caller) -> Result<f32, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -178,7 +178,7 @@ impl ExportedGetters {
         ImportedGetters::new(caller).get_float32()
     }
 
-    fn get_float64<Caller>(caller: Caller) -> Result<f64, RuntimeError>
+    fn get_float64<Caller>(caller: &mut Caller) -> Result<f64, RuntimeError>
     where
         Caller: InstanceForImportedGetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -230,7 +230,7 @@ pub struct ExportedSetters;
 
 #[wit_export(package = "witty-macros:test-modules", interface = "setters")]
 impl ExportedSetters {
-    fn set_bool<Caller>(caller: Caller, value: bool) -> Result<(), RuntimeError>
+    fn set_bool<Caller>(caller: &mut Caller, value: bool) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -238,7 +238,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_bool(value)
     }
 
-    fn set_s8<Caller>(caller: Caller, value: i8) -> Result<(), RuntimeError>
+    fn set_s8<Caller>(caller: &mut Caller, value: i8) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -246,7 +246,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_s8(value)
     }
 
-    fn set_u8<Caller>(caller: Caller, value: u8) -> Result<(), RuntimeError>
+    fn set_u8<Caller>(caller: &mut Caller, value: u8) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -254,7 +254,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_u8(value)
     }
 
-    fn set_s16<Caller>(caller: Caller, value: i16) -> Result<(), RuntimeError>
+    fn set_s16<Caller>(caller: &mut Caller, value: i16) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -262,7 +262,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_s16(value)
     }
 
-    fn set_u16<Caller>(caller: Caller, value: u16) -> Result<(), RuntimeError>
+    fn set_u16<Caller>(caller: &mut Caller, value: u16) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -270,7 +270,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_u16(value)
     }
 
-    fn set_s32<Caller>(caller: Caller, value: i32) -> Result<(), RuntimeError>
+    fn set_s32<Caller>(caller: &mut Caller, value: i32) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -278,7 +278,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_s32(value)
     }
 
-    fn set_u32<Caller>(caller: Caller, value: u32) -> Result<(), RuntimeError>
+    fn set_u32<Caller>(caller: &mut Caller, value: u32) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -286,7 +286,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_u32(value)
     }
 
-    fn set_s64<Caller>(caller: Caller, value: i64) -> Result<(), RuntimeError>
+    fn set_s64<Caller>(caller: &mut Caller, value: i64) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -294,7 +294,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_s64(value)
     }
 
-    fn set_u64<Caller>(caller: Caller, value: u64) -> Result<(), RuntimeError>
+    fn set_u64<Caller>(caller: &mut Caller, value: u64) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -302,7 +302,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_u64(value)
     }
 
-    fn set_float32<Caller>(caller: Caller, value: f32) -> Result<(), RuntimeError>
+    fn set_float32<Caller>(caller: &mut Caller, value: f32) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -310,7 +310,7 @@ impl ExportedSetters {
         ImportedSetters::new(caller).set_float32(value)
     }
 
-    fn set_float64<Caller>(caller: Caller, value: f64) -> Result<(), RuntimeError>
+    fn set_float64<Caller>(caller: &mut Caller, value: f64) -> Result<(), RuntimeError>
     where
         Caller: InstanceForImportedSetters,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -362,7 +362,7 @@ pub struct ExportedOperations;
 
 #[wit_export(package = "witty-macros:test-modules", interface = "operations")]
 impl ExportedOperations {
-    fn and_bool<Caller>(caller: Caller, first: bool, second: bool) -> Result<bool, RuntimeError>
+    fn and_bool<Caller>(caller: &mut Caller, first: bool, second: bool) -> Result<bool, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -370,7 +370,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).and_bool(first, second)
     }
 
-    fn add_s8<Caller>(caller: Caller, first: i8, second: i8) -> Result<i8, RuntimeError>
+    fn add_s8<Caller>(caller: &mut Caller, first: i8, second: i8) -> Result<i8, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -378,7 +378,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_s8(first, second)
     }
 
-    fn add_u8<Caller>(caller: Caller, first: u8, second: u8) -> Result<u8, RuntimeError>
+    fn add_u8<Caller>(caller: &mut Caller, first: u8, second: u8) -> Result<u8, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -386,7 +386,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_u8(first, second)
     }
 
-    fn add_s16<Caller>(caller: Caller, first: i16, second: i16) -> Result<i16, RuntimeError>
+    fn add_s16<Caller>(caller: &mut Caller, first: i16, second: i16) -> Result<i16, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -394,7 +394,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_s16(first, second)
     }
 
-    fn add_u16<Caller>(caller: Caller, first: u16, second: u16) -> Result<u16, RuntimeError>
+    fn add_u16<Caller>(caller: &mut Caller, first: u16, second: u16) -> Result<u16, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -402,7 +402,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_u16(first, second)
     }
 
-    fn add_s32<Caller>(caller: Caller, first: i32, second: i32) -> Result<i32, RuntimeError>
+    fn add_s32<Caller>(caller: &mut Caller, first: i32, second: i32) -> Result<i32, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -410,7 +410,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_s32(first, second)
     }
 
-    fn add_u32<Caller>(caller: Caller, first: u32, second: u32) -> Result<u32, RuntimeError>
+    fn add_u32<Caller>(caller: &mut Caller, first: u32, second: u32) -> Result<u32, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -418,7 +418,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_u32(first, second)
     }
 
-    fn add_s64<Caller>(caller: Caller, first: i64, second: i64) -> Result<i64, RuntimeError>
+    fn add_s64<Caller>(caller: &mut Caller, first: i64, second: i64) -> Result<i64, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -426,7 +426,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_s64(first, second)
     }
 
-    fn add_u64<Caller>(caller: Caller, first: u64, second: u64) -> Result<u64, RuntimeError>
+    fn add_u64<Caller>(caller: &mut Caller, first: u64, second: u64) -> Result<u64, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -434,7 +434,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_u64(first, second)
     }
 
-    fn add_float32<Caller>(caller: Caller, first: f32, second: f32) -> Result<f32, RuntimeError>
+    fn add_float32<Caller>(caller: &mut Caller, first: f32, second: f32) -> Result<f32, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -442,7 +442,7 @@ impl ExportedOperations {
         ImportedOperations::new(caller).add_float32(first, second)
     }
 
-    fn add_float64<Caller>(caller: Caller, first: f64, second: f64) -> Result<f64, RuntimeError>
+    fn add_float64<Caller>(caller: &mut Caller, first: f64, second: f64) -> Result<f64, RuntimeError>
     where
         Caller: InstanceForImportedOperations,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
@@ -485,7 +485,7 @@ pub struct ExportedGlobalState;
 
 #[wit_export(package = "witty-macros:test-modules", interface = "get-host-value")]
 impl ExportedGlobalState {
-    fn get_host_value<Caller>(caller: Caller) -> Result<u32, RuntimeError>
+    fn get_host_value<Caller>(caller: &mut Caller) -> Result<u32, RuntimeError>
     where
         Caller: InstanceForImportedGlobalState,
         <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,


### PR DESCRIPTION
## Motivation

After support for reentrant functions was added to Witty (#960), the only way to declare a function as reentrant was to add a generic parameter in the function. This also required adding the constraints for that type in the function, and this code quickly became repetitive in types that exported multiple reentrant functions.

## Proposal

Allow the generic type parameter for the caller (and its constraints) to be defined once in the `impl` block and then shared by all functions inside the block.

## Test Plan

Uses the same integration tests for reentrancy as #960.

## Links

Closes #963 

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
