### PR TITLE
Workaround deadlock in tests during calls to sychronous system APIs

### DIFF
--- a/examples/counter/tests/single_chain.rs
+++ b/examples/counter/tests/single_chain.rs
@@ -11,7 +11,7 @@ use linera_sdk::test::TestValidator;
 ///
 /// Creates the application on a `chain`, initializing it with a 42 then add 15 and obtain 57.
 /// which is then checked.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn single_chain_test() {
     let (validator, bytecode_id) = TestValidator::with_current_bytecode().await;
     let mut chain = validator.new_chain().await;

--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -18,7 +18,7 @@ use std::iter;
 /// Creates a campaign on a `campaign_chain` and sets up the fungible token to use with three
 /// backer chains. Pledges part of each backer's balance to the campaign and then completes it,
 /// collecting the pledges. The final balance of each backer and the campaign owner is checked.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn collect_pledges() {
     let initial_amount = Amount::from_tokens(100);
     let target_amount = Amount::from_tokens(220);
@@ -115,7 +115,7 @@ async fn collect_pledges() {
 /// Creates a campaign on a `campaign_chain` and sets up the fungible token to use with three
 /// backer chains. Pledges part of each backer's balance to the campaign and then completes it,
 /// collecting the pledges. The final balance of each backer and the campaign owner is checked.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn cancel_successful_campaign() {
     let initial_amount = Amount::from_tokens(100);
     let target_amount = Amount::from_tokens(220);

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -50,7 +50,6 @@ async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(
     run_test_create_application(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -59,7 +58,6 @@ async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<
     run_test_create_application(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -165,7 +163,6 @@ async fn test_rocks_db_run_application_with_dependency(
     .await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -179,7 +176,6 @@ async fn test_dynamo_db_run_application_with_dependency(
     .await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -36,7 +36,7 @@ use crate::client::client_tests::MakeScyllaDbStoreClient;
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     run_test_create_application(MakeMemoryStoreClient::with_wasm_runtime(wasm_runtime)).await
 }
@@ -44,7 +44,7 @@ async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(),
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
     run_test_create_application(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
@@ -54,7 +54,7 @@ async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     run_test_create_application(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
 }
@@ -63,7 +63,7 @@ async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_scylla_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     run_test_create_application(MakeScyllaDbStoreClient::with_wasm_runtime(wasm_runtime)).await
 }
@@ -143,7 +143,7 @@ where
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -154,7 +154,7 @@ async fn test_memory_run_application_with_dependency(
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -169,7 +169,7 @@ async fn test_rocks_db_run_application_with_dependency(
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_dynamo_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -183,7 +183,7 @@ async fn test_dynamo_db_run_application_with_dependency(
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_scylla_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -293,7 +293,7 @@ where
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -303,7 +303,7 @@ async fn test_memory_run_reentrant_application(
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -315,7 +315,7 @@ async fn test_rocks_db_run_reentrant_application(
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_dynamo_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -326,7 +326,7 @@ async fn test_dynamo_db_run_reentrant_application(
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_scylla_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -45,7 +45,7 @@ use linera_storage::ScyllaDbStoreClient;
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -56,7 +56,7 @@ async fn test_memory_handle_certificates_to_create_application(
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
@@ -68,7 +68,7 @@ async fn test_rocks_db_handle_certificates_to_create_application(
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_dynamo_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -39,7 +39,7 @@ serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 tracing = { workspace = true }
 wasm-encoder = { workspace = true, optional = true }
 wasmer = { workspace = true, optional = true }

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -159,10 +159,12 @@ macro_rules! impl_contract_system_api {
                 let runtime = tokio::runtime::Handle::current();
 
                 std::thread::scope(|scope| {
-                    scope
-                        .spawn(|| runtime.block_on(future))
-                        .join()
-                        .expect("Panic when running a future in a blocking manner")
+                    tokio::task::block_in_place(|| {
+                        scope
+                            .spawn(|| runtime.block_on(future))
+                            .join()
+                            .expect("Panic when running a future in a blocking manner")
+                    })
                 })
             }
         }

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -29,7 +29,7 @@ use test_case::test_case;
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::WasmerWithSanitizer, 30_453; "wasmer_with_sanitizer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime, 30_453; "wasmtime"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::WasmtimeWithSanitizer, 30_453; "wasmtime_with_sanitizer"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_fuel_for_counter_wasm_application(
     wasm_runtime: WasmRuntime,
     expected_fuel: u64,


### PR DESCRIPTION
## Motivation

Some tests were deadlocking. This happened when a Wasm application performs a call to a synchronous system API that was asynchronous under the hood. The way to make the call synchronous was to block on the thread, which prevented the code to advance if there was only one worker thread for the Tokio runtime.

## Proposal

As a temporary solution, notify Tokio that the worker thread is about to block, and ensure that tests that need it have more than one worker thread.

## Test Plan

Current tests should now not deadlock in some scenarios.

## Links

A proper fix should be implemented in #971

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
