### PR TITLE
Kubernetes deployment for Validators

### DIFF
--- a/kubernetes/dev/validator/linera-proxy.yaml
+++ b/kubernetes/dev/validator/linera-proxy.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: validator-1
+  labels:
+    app: validator-1
+spec: 
+  type: LoadBalancer
+  loadBalancerIP: 34.151.215.158
+  selector:
+    app: validator-1
+  ports:
+    - name: zef
+      protocol: TCP
+      port: 9100
+      targetPort: linera-port
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: validator-1
+spec:
+  selector:
+    matchLabels:
+      app: validator-1
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: validator-1
+    spec:
+      serviceAccountName: linera-serviceaccount
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: linera-proxy
+          imagePullPolicy: Always
+          image: us-docker.pkg.dev/linera-io-dev/linera-docker-repo/zefchain-gcp-test:0.1
+          ports:
+            - containerPort: 9100
+              name: linera-port
+          command: ["./linera-proxy"]
+          args: ["server_1.json", "--kube"]
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP

--- a/kubernetes/dev/validator/linera-server.yaml
+++ b/kubernetes/dev/validator/linera-server.yaml
@@ -1,0 +1,191 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-1-shard-0
+  labels:
+    app: server-1-shard-0
+spec:
+  clusterIP: None
+  selector:
+    app: server-1-shard-0
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: server-1-shard-0
+spec:
+  selector:
+    matchLabels:
+      app: server-1-shard-0
+  serviceName: server-1-shard-0
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: server-1-shard-0
+    spec:
+      serviceAccountName: linera-serviceaccount
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: linera-server
+          image: us-docker.pkg.dev/linera-io-dev/linera-docker-repo/zefchain-gcp-test:0.1
+          imagePullPolicy: Always
+          command: ["./linera-server"]
+          args: ["run", "--storage", "rocksdb:shard_data.db", "--server", "server_1.json", "--shard", "0", "--genesis", "genesis.json", "--kube"]
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-1-shard-1
+  labels:
+    app: server-1-shard-1
+spec:
+  clusterIP: None
+  selector:
+    app: server-1-shard-1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: server-1-shard-1
+spec:
+  selector:
+    matchLabels:
+      app: server-1-shard-1
+  serviceName: server-1-shard-1
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: server-1-shard-1
+    spec:
+      serviceAccountName: linera-serviceaccount
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: linera-server
+          image: us-docker.pkg.dev/linera-io-dev/linera-docker-repo/zefchain-gcp-test:0.1
+          imagePullPolicy: Always
+          command: ["./linera-server"]
+          args: ["run", "--storage", "rocksdb:shard_data.db", "--server", "server_1.json", "--shard", "1", "--genesis", "genesis.json", "--kube"]
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-1-shard-2
+  labels:
+    app: server-1-shard-2
+spec:
+  clusterIP: None
+  selector:
+    app: server-1-shard-2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: server-1-shard-2
+spec:
+  selector:
+    matchLabels:
+      app: server-1-shard-2
+  serviceName: server-1-shard-2
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: server-1-shard-2
+    spec:
+      serviceAccountName: linera-serviceaccount
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: linera-server
+          image: us-docker.pkg.dev/linera-io-dev/linera-docker-repo/zefchain-gcp-test:0.1
+          imagePullPolicy: Always
+          command: ["./linera-server"]
+          args: ["run", "--storage", "rocksdb:shard_data.db", "--server", "server_1.json", "--shard", "2", "--genesis", "genesis.json", "--kube"]
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: server-1-shard-3
+  labels:
+    app: server-1-shard-3
+spec:
+  clusterIP: None
+  selector:
+    app: server-1-shard-3
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: server-1-shard-3
+spec:
+  selector:
+    matchLabels:
+      app: server-1-shard-3
+  serviceName: server-1-shard-3
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: server-1-shard-3
+    spec:
+      serviceAccountName: linera-serviceaccount
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: linera-server
+          image: us-docker.pkg.dev/linera-io-dev/linera-docker-repo/zefchain-gcp-test:0.1
+          imagePullPolicy: Always
+          command: ["./linera-server"]
+          args: ["run", "--storage", "rocksdb:shard_data.db", "--server", "server_1.json", "--shard", "3", "--genesis", "genesis.json", "--kube"]
+          env:
+            - name: MY_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP

--- a/kubernetes/dev/validator/linera-serviceaccount.yaml
+++ b/kubernetes/dev/validator/linera-serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: linera-serviceaccount


### PR DESCRIPTION
## Motivation

Motivation for this is that we need to move things to GCP as a first step towards having Elastic Validators deployed on GCP.

## Proposal

These are the initial configs to deploy the existing static Validators into GCP

## Test Plan

Deploy validators to GCP, call them through a client in my laptop to do a transaction and also benchmark.

## Links

Issue: #910

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
