### PR TITLE
avoid `realpath` in README files

### DIFF
--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -45,7 +45,7 @@ bytecode:
 
 ```bash
 alias linera="$PWD/target/debug/linera"
-export LINERA_WALLET="$(realpath target/debug/wallet.json)"
+export LINERA_WALLET="$PWD/target/debug/wallet.json"
 export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
 
 cd examples/fungible && cargo build --release && cd ../..

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -46,7 +46,7 @@
 //!
 //! ```bash
 //! alias linera="$PWD/target/debug/linera"
-//! export LINERA_WALLET="$(realpath target/debug/wallet.json)"
+//! export LINERA_WALLET="$PWD/target/debug/wallet.json"
 //! export LINERA_STORAGE="rocksdb:$(dirname "$LINERA_WALLET")/linera.db"
 //!
 //! cd examples/fungible && cargo build --release && cd ../..

--- a/examples/social/README.md
+++ b/examples/social/README.md
@@ -37,9 +37,9 @@ Compile the `social` example and create an application with it:
 
 ```bash
 alias linera="$PWD/target/debug/linera"
-export LINERA_WALLET1="$(realpath target/debug/wallet.json)"
+export LINERA_WALLET1="$PWD/target/debug/wallet.json"
 export LINERA_STORAGE1="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
-export LINERA_WALLET2="$(realpath target/debug/wallet_2.json)"
+export LINERA_WALLET2="$PWD/target/debug/wallet_2.json"
 export LINERA_STORAGE2="rocksdb:$(dirname "$LINERA_WALLET2")/linera_2.db"
 
 cd examples/social && cargo build --release && cd ../..

--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -38,9 +38,9 @@
 //!
 //! ```bash
 //! alias linera="$PWD/target/debug/linera"
-//! export LINERA_WALLET1="$(realpath target/debug/wallet.json)"
+//! export LINERA_WALLET1="$PWD/target/debug/wallet.json"
 //! export LINERA_STORAGE1="rocksdb:$(dirname "$LINERA_WALLET1")/linera.db"
-//! export LINERA_WALLET2="$(realpath target/debug/wallet_2.json)"
+//! export LINERA_WALLET2="$PWD/target/debug/wallet_2.json"
 //! export LINERA_STORAGE2="rocksdb:$(dirname "$LINERA_WALLET2")/linera_2.db"
 //!
 //! cd examples/social && cargo build --release && cd ../..


### PR DESCRIPTION
## Motivation

`realpath` doesn't work on MacOS shells by default.

## Proposal

Use `$PWD` instead. This is good enough and also less verbose.

## Test Plan

Tried one example by hand.

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
