### PR TITLE
Restructuration of the database API code

### DIFF
--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -3,13 +3,14 @@
 
 use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient};
 use linera_execution::WasmRuntime;
-use linera_views::rocks_db::RocksDbClient;
-use std::{path::PathBuf, sync::Arc};
-#[cfg(any(test, feature = "test"))]
-use {
-    linera_views::{lru_caching::TEST_CACHE_SIZE, rocks_db::TEST_ROCKS_DB_MAX_STREAM_QUERIES},
-    tempfile::TempDir,
+use linera_views::{
+    common::{CommonStoreConfig, TableStatus},
+    rocks_db::{RocksDbClient, RocksDbContextError},
 };
+use std::{path::PathBuf, sync::Arc};
+
+#[cfg(any(test, feature = "test"))]
+use {linera_views::rocks_db::create_rocks_db_common_config, tempfile::TempDir};
 
 #[cfg(test)]
 #[path = "unit_tests/rocks_db.rs"]
@@ -18,19 +19,35 @@ mod tests;
 type RocksDbStore = DbStore<RocksDbClient>;
 
 impl RocksDbStore {
-    pub fn new(
+    #[cfg(any(test, feature = "test"))]
+    pub async fn new_for_testing(
         dir: PathBuf,
         wasm_runtime: Option<WasmRuntime>,
-        max_stream_queries: usize,
-        cache_size: usize,
-    ) -> Self {
-        let client = RocksDbClient::new(dir, max_stream_queries, cache_size);
-        Self {
+        common_config: CommonStoreConfig,
+    ) -> Result<(Self, TableStatus), RocksDbContextError> {
+        let (client, table_status) = RocksDbClient::new_for_testing(dir, common_config).await?;
+        let store = Self {
             client,
             guards: ChainGuards::default(),
             user_applications: Arc::default(),
             wasm_runtime,
-        }
+        };
+        Ok((store, table_status))
+    }
+
+    pub async fn new(
+        dir: PathBuf,
+        wasm_runtime: Option<WasmRuntime>,
+        common_config: CommonStoreConfig,
+    ) -> Result<(Self, TableStatus), RocksDbContextError> {
+        let (client, table_status) = RocksDbClient::new(dir, common_config).await?;
+        let store = Self {
+            client,
+            guards: ChainGuards::default(),
+            user_applications: Arc::default(),
+            wasm_runtime,
+        };
+        Ok((store, table_status))
     }
 }
 
@@ -40,27 +57,40 @@ impl RocksDbStoreClient {
     #[cfg(any(test, feature = "test"))]
     pub async fn make_test_client(wasm_runtime: Option<WasmRuntime>) -> RocksDbStoreClient {
         let dir = TempDir::new().unwrap();
-        RocksDbStoreClient::new(
+        let common_config = create_rocks_db_common_config();
+        let (store_client, _) = RocksDbStoreClient::new_for_testing(
             dir.path().to_path_buf(),
             wasm_runtime,
-            TEST_ROCKS_DB_MAX_STREAM_QUERIES,
-            TEST_CACHE_SIZE,
+            common_config,
         )
+        .await
+        .expect("store_client");
+        store_client
     }
 
-    pub fn new(
+    #[cfg(any(test, feature = "test"))]
+    pub async fn new_for_testing(
         path: PathBuf,
         wasm_runtime: Option<WasmRuntime>,
-        max_stream_queries: usize,
-        cache_size: usize,
-    ) -> Self {
-        RocksDbStoreClient {
-            client: Arc::new(RocksDbStore::new(
-                path,
-                wasm_runtime,
-                max_stream_queries,
-                cache_size,
-            )),
-        }
+        common_config: CommonStoreConfig,
+    ) -> Result<(Self, TableStatus), RocksDbContextError> {
+        let (store, table_status) =
+            RocksDbStore::new_for_testing(path, wasm_runtime, common_config).await?;
+        let store_client = RocksDbStoreClient {
+            client: Arc::new(store),
+        };
+        Ok((store_client, table_status))
+    }
+
+    pub async fn new(
+        path: PathBuf,
+        wasm_runtime: Option<WasmRuntime>,
+        common_config: CommonStoreConfig,
+    ) -> Result<(Self, TableStatus), RocksDbContextError> {
+        let (store, table_status) = RocksDbStore::new(path, wasm_runtime, common_config).await?;
+        let store_client = RocksDbStoreClient {
+            client: Arc::new(store),
+        };
+        Ok((store_client, table_status))
     }
 }

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -87,7 +87,7 @@ impl<'a> LruPrefixCache {
 /// We take a client, a maximum size and build a LRU-based system.
 #[derive(Clone)]
 pub struct LruCachingKeyValueClient<K> {
-    /// The inner client that is called by the LRU caching one
+    /// The inner client that is called by the LRU cache one
     pub client: K,
     lru_read_keys: Option<Arc<Mutex<LruPrefixCache>>>,
 }
@@ -210,7 +210,7 @@ impl<K> LruCachingKeyValueClient<K>
 where
     K: KeyValueStoreClient,
 {
-    /// Creates a new key-value store client that implements LRU caching.
+    /// Creates a new key-value store client that implements an LRU cache.
     pub fn new(client: K, max_size: usize) -> Self {
         if max_size == 0 {
             Self {

--- a/linera-views/src/unit_tests/dynamo_db_context_tests.rs
+++ b/linera-views/src/unit_tests/dynamo_db_context_tests.rs
@@ -2,12 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{DynamoDbContext, TableName, TableStatus};
-use crate::{
-    dynamo_db::{
-        list_tables, DynamoDbContextError, LocalStackTestContext,
-        TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES, TEST_DYNAMO_DB_MAX_STREAM_QUERIES,
-    },
-    lru_caching::TEST_CACHE_SIZE,
+use crate::dynamo_db::{
+    clear_tables, create_dynamo_db_common_config, list_tables, DynamoDbContextError,
+    LocalStackTestContext,
 };
 use anyhow::Error;
 
@@ -15,12 +12,11 @@ async fn get_table_status(
     localstack: &LocalStackTestContext,
     table: &TableName,
 ) -> Result<TableStatus, DynamoDbContextError> {
-    let (_storage, table_status) = DynamoDbContext::from_config(
+    let common_config = create_dynamo_db_common_config();
+    let (_storage, table_status) = DynamoDbContext::new(
         localstack.dynamo_db_config(),
         table.clone(),
-        Some(TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES),
-        TEST_DYNAMO_DB_MAX_STREAM_QUERIES,
-        TEST_CACHE_SIZE,
+        common_config,
         vec![],
         (),
     )
@@ -33,15 +29,18 @@ async fn get_table_status(
 async fn table_is_created() -> Result<(), Error> {
     let localstack = LocalStackTestContext::new().await?;
     let client = aws_sdk_dynamodb::Client::from_conf(localstack.dynamo_db_config());
-    let table: TableName = "linera".parse().expect("Invalid table name");
+    clear_tables(&client).await?;
+    let table_name = "lineratableiscreated"
+        .parse::<TableName>()
+        .expect("Invalid table name");
 
     let initial_tables = list_tables(&client).await?;
-    assert!(!initial_tables.contains(table.as_ref()));
+    assert!(!initial_tables.contains(table_name.as_ref()));
 
-    let table_status = get_table_status(&localstack, &table).await?;
+    let table_status = get_table_status(&localstack, &table_name).await?;
 
     let tables = list_tables(&client).await?;
-    assert!(tables.contains(table.as_ref()));
+    assert!(tables.contains(table_name.as_ref()));
     assert_eq!(table_status, TableStatus::New);
 
     Ok(())
@@ -52,8 +51,9 @@ async fn table_is_created() -> Result<(), Error> {
 async fn separate_tables_are_created() -> Result<(), Error> {
     let localstack = LocalStackTestContext::new().await?;
     let client = aws_sdk_dynamodb::Client::from_conf(localstack.dynamo_db_config());
-    let first_table: TableName = "first".parse().expect("Invalid table name");
-    let second_table: TableName = "second".parse().expect("Invalid table name");
+    clear_tables(&client).await?;
+    let first_table = "first".parse::<TableName>().expect("Invalid table name");
+    let second_table = "second".parse::<TableName>().expect("Invalid table name");
 
     let initial_tables = list_tables(&client).await?;
     assert!(!initial_tables.contains(first_table.as_ref()));

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -36,7 +36,8 @@ pub enum DatabaseConsistencyError {
 /// See the README.md for additional details.
 #[derive(Clone)]
 pub struct ValueSplittingKeyValueStoreClient<K> {
-    client: K,
+    /// The underlying client of the transformed client.
+    pub client: K,
 }
 
 #[async_trait]

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -164,7 +164,7 @@ async fn test_readings_memory() {
 #[tokio::test]
 async fn test_readings_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_operation = create_rocks_db_test_client();
+        let key_value_operation = create_rocks_db_test_client().await;
         test_readings_vec(key_value_operation, scenario).await;
     }
 }
@@ -289,7 +289,7 @@ async fn test_writings_key_value_store_view_memory() {
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_writings_rocks_db() {
-    let key_value_operation = create_rocks_db_test_client();
+    let key_value_operation = create_rocks_db_test_client().await;
     test_writings_random(key_value_operation).await;
 }
 


### PR DESCRIPTION
## Motivation

The development of the database code has led to different APIs which are a downside. This work unifies and simplifies a lot of database stuff and unfortunately leads to a lot of changes. If needed, this could be broken up into several PRs.

## Proposal

The following changes were made:
* The `create_if_missing` argument is passed to each constructor and the `restart_database` has been removed.
* That led to the introduction of `test_table_existence` code for detecting if there is a table or not.
* We introduced a `new_for_testing` that remove the database before creating it. It is useful for tests.
* Thus we have 4 arguments, `max_concurrent_queries`, `max_stream_queries`, `cache_size` and `create_if_missing`. This led to the introduction of a type `CommonStoreConfig` for RocksDb, DynamoDb, and ScyllaDb.
* The introduction of the `CommonStoreConfig` leads to some simplification of the code all across the tests. In particular, we have a `create_rocks_db_common_config` and similar functions for DynamoDb and ScyllaDb.
* The DynamoDb had 3 constructors, now we have just 1 which simplifies the code all around.
* There were some leftover codes for the S3 work that had been eliminated.
* The DynamoDb code had a TableStatus that was returned. It returned if the database was new or not. This was put for RocksDb and ScyllaDb because that API makes complete sense in general. The `storage.rs` is changed accordingly.
* The `get_table_name` code is moved to common and used also for DynamoDb. For RocksDb, this would require more changes.
* The ScyllaDb code is enhanced by adding the possibility that the database is created from two separate instances with the same `table_name`. This should make the work of a `readme_test.rs` possible.

The changes make sense because the unification of API is a step in the right direction. I could not do all that I wished for. I could not eliminate the LOCALSTACK_GUARD and this requires further investigations. 

## Test Plan

The CI should address that but it starts from a blank state. Testing on laptop is quite important as well.

## Links

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [ ] All good!
- [x] Need to bump the major/minor version number in the next release of the crates.
- [x] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
