### PR TITLE
Fix share_ownership: Don't remove keys.

### DIFF
--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -55,7 +55,9 @@ impl ChainManager {
                 *self =
                     ChainManager::Single(Box::new(SingleOwnerManager::new(*owner, *public_key)));
             }
-            ChainOwnership::Multi { owners } => {
+            ChainOwnership::Multi {
+                public_keys: owners,
+            } => {
                 let owners = owners
                     .iter()
                     .map(|(owner, public_key)| (*owner, *public_key))

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -23,8 +23,8 @@ use tracing::error;
 /// The specific state of a chain managed by multiple owners.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MultiOwnerManager {
-    /// The co-owners of the chain.
-    pub owners: HashMap<Owner, PublicKey>,
+    /// The public keys of the chain's co-owners.
+    pub public_keys: HashMap<Owner, PublicKey>,
     /// Latest authenticated block that we have received (and voted to validate).
     pub proposed: Option<BlockProposal>,
     /// Latest validated proposal that we have seen (and voted to confirm).
@@ -34,9 +34,9 @@ pub struct MultiOwnerManager {
 }
 
 impl MultiOwnerManager {
-    pub fn new(owners: HashMap<Owner, PublicKey>) -> Self {
+    pub fn new(public_keys: HashMap<Owner, PublicKey>) -> Self {
         MultiOwnerManager {
-            owners,
+            public_keys,
             proposed: None,
             locked: None,
             pending: None,
@@ -187,7 +187,7 @@ impl MultiOwnerManager {
     }
 
     pub fn verify_owner(&self, proposal: &BlockProposal) -> Option<PublicKey> {
-        self.owners.get(&proposal.owner).copied()
+        self.public_keys.get(&proposal.owner).copied()
     }
 }
 
@@ -196,9 +196,9 @@ impl MultiOwnerManager {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Eq, PartialEq))]
 pub struct MultiOwnerManagerInfo {
-    /// The co-owners of the chain.
+    /// The public keys of the chain's co-owners.
     /// Using a map instead a hashset because Serde treats HashSet's as vectors.
-    pub owners: HashMap<Owner, PublicKey>,
+    pub public_keys: HashMap<Owner, PublicKey>,
     /// Latest authenticated block that we have received, if requested.
     pub requested_proposed: Option<BlockProposal>,
     /// Latest validated proposal that we have seen (and voted to confirm), if requested.
@@ -216,7 +216,7 @@ pub struct MultiOwnerManagerInfo {
 impl From<&MultiOwnerManager> for MultiOwnerManagerInfo {
     fn from(manager: &MultiOwnerManager) -> Self {
         MultiOwnerManagerInfo {
-            owners: manager.owners.clone(),
+            public_keys: manager.public_keys.clone(),
             requested_proposed: None,
             requested_locked: None,
             pending: manager.pending.as_ref().map(|vote| vote.lite()),

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -47,6 +47,10 @@ impl SingleOwnerManager {
         let new_block = &proposal.content.block;
         let new_round = proposal.content.round;
         ensure!(
+            proposal.validated.is_none(),
+            ChainError::InvalidBlockProposal
+        );
+        ensure!(
             new_round == RoundNumber::default() && proposal.validated.is_none(),
             ChainError::InvalidBlockProposal
         );

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -106,6 +106,8 @@ impl SingleOwnerManager {
 pub struct SingleOwnerManagerInfo {
     /// The owner of the chain.
     pub owner: Owner,
+    /// The owner's public key.
+    pub public_key: PublicKey,
     /// Latest vote we cast.
     pub pending: Option<LiteVote>,
     /// The value we voted for, if requested.
@@ -116,6 +118,7 @@ impl From<&SingleOwnerManager> for SingleOwnerManagerInfo {
     fn from(manager: &SingleOwnerManager) -> Self {
         SingleOwnerManagerInfo {
             owner: manager.owner,
+            public_key: manager.public_key,
             pending: manager.pending.as_ref().map(|vote| vote.lite()),
             requested_pending_value: None,
         }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -371,7 +371,7 @@ where
             }
             ChainManagerInfo::Multi(manager) => {
                 let mut identities = manager
-                    .owners
+                    .public_keys
                     .keys()
                     .filter(|owner| self.known_key_pairs.contains_key(owner));
                 let Some(identity) = identities.next() else {
@@ -1418,7 +1418,7 @@ where
                 vec![manager.public_key, new_public_key]
             }
             ChainManagerInfo::Multi(manager) => manager
-                .owners
+                .public_keys
                 .values()
                 .cloned()
                 .chain(iter::once(new_public_key))

--- a/linera-execution/src/ownership.rs
+++ b/linera-execution/src/ownership.rs
@@ -14,7 +14,9 @@ pub enum ChainOwnership {
     /// The chain is managed by a single owner.
     Single { owner: Owner, public_key: PublicKey },
     /// The chain is managed by multiple owners.
-    Multi { owners: BTreeMap<Owner, PublicKey> },
+    Multi {
+        public_keys: BTreeMap<Owner, PublicKey>,
+    },
 }
 
 impl ChainOwnership {
@@ -27,7 +29,7 @@ impl ChainOwnership {
 
     pub fn multiple(public_keys: impl IntoIterator<Item = PublicKey>) -> Self {
         ChainOwnership::Multi {
-            owners: public_keys
+            public_keys: public_keys
                 .into_iter()
                 .map(|key| (Owner::from(key), key))
                 .collect(),
@@ -50,7 +52,9 @@ impl ChainOwnership {
                     None
                 }
             }
-            ChainOwnership::Multi { owners } => owners.get(owner).copied(),
+            ChainOwnership::Multi {
+                public_keys: owners,
+            } => owners.get(owner).copied(),
             ChainOwnership::None => None,
         }
     }

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -626,6 +626,8 @@ SingleOwnerManagerInfo:
   STRUCT:
     - owner:
         TYPENAME: Owner
+    - public_key:
+        TYPENAME: PublicKey
     - pending:
         OPTION:
           TYPENAME: LiteVote

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -238,7 +238,7 @@ ChainOwnership:
     2:
       Multi:
         STRUCT:
-          - owners:
+          - public_keys:
               MAP:
                 KEY:
                   TYPENAME: Owner
@@ -413,7 +413,7 @@ MessageId:
     - index: U32
 MultiOwnerManagerInfo:
   STRUCT:
-    - owners:
+    - public_keys:
         MAP:
           KEY:
             TYPENAME: Owner


### PR DESCRIPTION
## Motivation

`ChainClient::share_ownership` should only add the new owner, not remove any existing ones.

## Proposal

For multi-owner chains, `share_ownership` should take a list of all existing owners and add the new one.

This PR also adds a sanity check to the single-owner manager, and a minor cleanup to `worker.rs`.

## Test Plan

There are already tests for `share_ownership`. If desired, we can add new ones for the case where there are multiple existing owners, but the details of this will soon change again, when weights are added, so it would be easier to add more tests after that.

## Links

This is mainly to reduce the diff with my WIP for https://github.com/linera-io/linera-protocol/issues/464.

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
