### PR TITLE
Extend chain info query and chain manager with stubs for leader timeouts.

### DIFF
--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -60,6 +60,8 @@ pub struct ChainInfoQuery {
     pub request_received_log_excluding_first_nth: Option<u64>,
     /// Query values from the chain manager, not just votes.
     pub request_manager_values: bool,
+    /// Include a timeout vote for the current round, if appropriate.
+    pub request_leader_timeout: bool,
     /// Query a value that contains a binary blob (e.g. bytecode) required by this chain.
     pub request_blob: Option<CryptoHash>,
 }
@@ -74,6 +76,7 @@ impl ChainInfoQuery {
             request_sent_certificates_in_range: None,
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
+            request_leader_timeout: false,
             request_blob: None,
         }
     }
@@ -105,6 +108,11 @@ impl ChainInfoQuery {
 
     pub fn with_manager_values(mut self) -> Self {
         self.request_manager_values = true;
+        self
+    }
+
+    pub fn with_leader_timeout(mut self) -> Self {
+        self.request_leader_timeout = true;
         self
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -903,7 +903,7 @@ where
             owner,
             signature,
             blobs,
-            validated: _,
+            validated,
         } = &proposal;
         let chain_id = block.chain_id;
         let mut chain = self.storage.load_active_chain(chain_id).await?;
@@ -917,7 +917,7 @@ where
             block.epoch == epoch,
             WorkerError::InvalidEpoch { chain_id, epoch }
         );
-        if let Some(validated) = &proposal.validated {
+        if let Some(validated) = validated {
             validated.check(committee)?;
         }
         // Check the authentication of the block.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -117,8 +117,11 @@ message ChainInfoQuery {
   // Query values from the chain manager, not just votes.
   bool request_manager_values = 7;
 
+  // Request a signed vote for a leader timeout.
+  bool request_leader_timeout = 8;
+
   // Query a value that contains a binary blob (e.g. bytecode) required by this chain.
-  optional bytes request_blob = 8;
+  optional bytes request_blob = 9;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -289,6 +289,7 @@ impl TryFrom<grpc::ChainInfoQuery> for ChainInfoQuery {
                 .request_received_log_excluding_first_nth,
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
+            request_leader_timeout: chain_info_query.request_leader_timeout,
             request_blob,
         })
     }
@@ -316,6 +317,7 @@ impl TryFrom<ChainInfoQuery> for grpc::ChainInfoQuery {
             request_received_log_excluding_first_nth: chain_info_query
                 .request_received_log_excluding_first_nth,
             request_manager_values: chain_info_query.request_manager_values,
+            request_leader_timeout: chain_info_query.request_leader_timeout,
             request_blob,
         })
     }
@@ -579,6 +581,7 @@ pub mod tests {
             }),
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
+            request_leader_timeout: false,
             request_blob: None,
         };
         round_trip_check::<_, grpc::ChainInfoQuery>(chain_info_query_some);

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -201,6 +201,7 @@ ChainInfoQuery:
     - request_received_log_excluding_first_nth:
         OPTION: U64
     - request_manager_values: BOOL
+    - request_leader_timeout: BOOL
     - request_blob:
         OPTION:
           TYPENAME: CryptoHash

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -428,6 +428,9 @@ MultiOwnerManagerInfo:
     - pending:
         OPTION:
           TYPENAME: LiteVote
+    - timeout_vote:
+        OPTION:
+          TYPENAME: LiteVote
     - requested_pending_value:
         OPTION:
           TYPENAME: CertificateValue


### PR DESCRIPTION
## Motivation

This is part of the BFT protocol implementation, but doesn't contain actual handling logic yet.

## Proposal

Add a field to the chain info query to request leader timeout votes. In the future, this will be used to make the validators sign `LeaderTimeout` certificates if a round is stalled, but for now the handlers are stubs.

## Test Plan

No tests yet, since this doesn't include the handling logic yet.

## Links

This is mainly to reduce the diff with my WIP for https://github.com/linera-io/linera-protocol/issues/464.

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
