### PR TITLE
Make Epoch a u32

### DIFF
--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -13,7 +13,7 @@ use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 
 /// A number identifying the configuration of the chain (aka the committee).
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug)]
-pub struct Epoch(pub u64);
+pub struct Epoch(pub u32);
 
 impl Serialize for Epoch {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -35,11 +35,11 @@ impl<'de> Deserialize<'de> for Epoch {
     {
         if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            Ok(Epoch(u64::from_str(&s).map_err(serde::de::Error::custom)?))
+            Ok(Epoch(u32::from_str(&s).map_err(serde::de::Error::custom)?))
         } else {
             #[derive(Deserialize)]
             #[serde(rename = "Epoch")]
-            struct EpochDerived(u64);
+            struct EpochDerived(u32);
 
             let value = EpochDerived::deserialize(deserializer)?;
             Ok(Self(value.0))
@@ -259,8 +259,8 @@ impl std::str::FromStr for Epoch {
     }
 }
 
-impl From<u64> for Epoch {
-    fn from(value: u64) -> Self {
+impl From<u32> for Epoch {
+    fn from(value: u32) -> Self {
         Epoch(value)
     }
 }

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -314,7 +314,7 @@ Destination:
         NEWTYPE:
           TYPENAME: ChannelName
 Epoch:
-  NEWTYPESTRUCT: U64
+  NEWTYPESTRUCT: U32
 Event:
   STRUCT:
     - certificate_hash:


### PR DESCRIPTION
## Motivation

Epochs are expected to last hours rather than minutes, so a `u32` can still represent half a million years' worth of epochs. With a `u64`, the upper four bytes would always be wasted.

## Proposal

Represent the epoch as a `u32`.

## Test Plan

This doesn't change the logic, only the limit of the epoch number.

## Links

N/A

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [x] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [x] All of the above!
