### PR TITLE
Clean up impl_wrapped_number macro.

### DIFF
--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -140,7 +140,7 @@ impl CrowdFunding {
         owner: AccountOwner,
         amount: Amount,
     ) -> Result<(), Error> {
-        ensure!(amount > Amount::zero(), Error::EmptyPledge);
+        ensure!(amount > Amount::ZERO, Error::EmptyPledge);
         // The campaign chain.
         let chain_id = system_api::current_application_id().creation.chain_id;
         // First, move the funds to the campaign chain (under the same owner).
@@ -175,7 +175,7 @@ impl CrowdFunding {
         owner: AccountOwner,
         amount: Amount,
     ) -> Result<(), Error> {
-        ensure!(amount > Amount::zero(), Error::EmptyPledge);
+        ensure!(amount > Amount::ZERO, Error::EmptyPledge);
         self.receive_from_account(owner, amount).await?;
         self.finish_pledge(owner, amount).await
     }
@@ -191,7 +191,7 @@ impl CrowdFunding {
         let session_balances = self.query_session_balances(&sessions).await?;
         let amount = session_balances.iter().sum();
 
-        ensure!(amount > Amount::zero(), Error::EmptyPledge);
+        ensure!(amount > Amount::ZERO, Error::EmptyPledge);
 
         self.collect_session_tokens(sessions, session_balances)
             .await?;

--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -105,7 +105,7 @@ async fn collect_pledges() {
         );
         assert_eq!(
             FungibleTokenAbi::query_account(token_id, &campaign_chain, backer_account).await,
-            Some(Amount::from(0)),
+            Some(Amount::ZERO),
         );
     }
 }
@@ -194,7 +194,7 @@ async fn cancel_successful_campaign() {
 
     assert_eq!(
         FungibleTokenAbi::query_account(token_id, &campaign_chain, campaign_account).await,
-        Some(Amount::from(0)),
+        Some(Amount::ZERO),
     );
 
     for (backer_chain, backer_account, initial_amount) in backers {

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -217,7 +217,7 @@ impl FungibleToken {
             .try_sub_assign(amount)
             .map_err(|_| Error::InsufficientSessionBalance)?;
 
-        let updated_session = (balance > Amount::zero()).then_some(balance);
+        let updated_session = (balance > Amount::ZERO).then_some(balance);
 
         Ok(SessionCallResult {
             inner: self

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -335,7 +335,7 @@ impl MatchingEngine {
             .find(|order| order.order_id == order_id)
             .ok_or(MatchingEngineError::OrderNotPresent)?;
         let new_amount = match cancel_amount {
-            ModifyAmount::All => Amount::zero(),
+            ModifyAmount::All => Amount::ZERO,
             ModifyAmount::Partial(cancel_amount) => {
                 if cancel_amount > state_order.amount {
                     return Err(MatchingEngineError::TooLargeModifyOrder);
@@ -346,7 +346,7 @@ impl MatchingEngine {
         let corr_cancel_amount = state_order.amount.try_sub(new_amount).unwrap();
         state_order.amount = new_amount;
         Self::remove_zero_orders_from_level(view).await?;
-        Ok((corr_cancel_amount, new_amount == Amount::zero()))
+        Ok((corr_cancel_amount, new_amount == Amount::ZERO))
     }
 
     /// Modification of the order from the order_id.
@@ -515,7 +515,7 @@ impl MatchingEngine {
             let fill = min(order.amount, *amount);
             amount.try_sub_assign(fill).unwrap();
             order.amount.try_sub_assign(fill).unwrap();
-            if fill > Amount::zero() {
+            if fill > Amount::ZERO {
                 transfers.extend_from_slice(&Self::get_transfers(
                     nature,
                     fill,
@@ -525,10 +525,10 @@ impl MatchingEngine {
                     price_insert,
                 ));
             }
-            if order.amount == Amount::zero() {
+            if order.amount == Amount::ZERO {
                 remove_order.push((order.owner, order.order_id));
             }
-            if *amount == Amount::zero() {
+            if *amount == Amount::ZERO {
                 break;
             }
         }
@@ -635,12 +635,12 @@ impl MatchingEngine {
                         self.asks.remove_entry(&price_ask)?;
                     }
                     self.remove_order_ids(remove_entry).await?;
-                    if final_amount == Amount::zero() {
+                    if final_amount == Amount::ZERO {
                         break;
                     }
                 }
                 let price_revert = price.revert();
-                if final_amount != Amount::zero() {
+                if final_amount != Amount::ZERO {
                     let view = self.bids.load_entry_mut(&price_revert).await?;
                     let order = OrderEntry {
                         amount: final_amount,
@@ -681,11 +681,11 @@ impl MatchingEngine {
                         self.bids.remove_entry(&price_bid.revert())?;
                     }
                     self.remove_order_ids(remove_entry).await?;
-                    if final_amount == Amount::zero() {
+                    if final_amount == Amount::ZERO {
                         break;
                     }
                 }
-                if final_amount != Amount::zero() {
+                if final_amount != Amount::ZERO {
                     let view = self.asks.load_entry_mut(price).await?;
                     let order = OrderEntry {
                         amount: final_amount,

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -116,7 +116,7 @@ impl ChainManager {
     pub fn check_proposed_block(&self, proposal: &BlockProposal) -> Result<Outcome, ChainError> {
         // When a block is certified, incrementing its height must succeed.
         ensure!(
-            proposal.content.block.height < BlockHeight::max(),
+            proposal.content.block.height < BlockHeight::MAX,
             ChainError::InvalidBlockHeight
         );
         match self {

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -13,7 +13,7 @@ fn test_signed_values() {
     let name1 = ValidatorName(key1.public());
 
     let block = Block {
-        epoch: Epoch::from(0),
+        epoch: Epoch::ZERO,
         chain_id: ChainId::root(1),
         incoming_messages: Vec::new(),
         operations: vec![Operation::System(SystemOperation::Transfer {
@@ -22,7 +22,7 @@ fn test_signed_values() {
             amount: Amount::ONE,
             user_data: UserData::default(),
         })],
-        height: BlockHeight::from(0),
+        height: BlockHeight::ZERO,
         timestamp: Timestamp::default(),
         authenticated_signer: None,
         previous_block_hash: None,
@@ -53,7 +53,7 @@ fn test_certificates() {
     let committee = Committee::make_simple(vec![name1, name2]);
 
     let block = Block {
-        epoch: Epoch::from(0),
+        epoch: Epoch::ZERO,
         chain_id: ChainId::root(1),
         incoming_messages: Vec::new(),
         operations: vec![Operation::System(SystemOperation::Transfer {
@@ -63,7 +63,7 @@ fn test_certificates() {
             user_data: UserData::default(),
         })],
         previous_block_hash: None,
-        height: BlockHeight::from(0),
+        height: BlockHeight::ZERO,
         authenticated_signer: None,
         timestamp: Timestamp::default(),
     };

--- a/linera-chain/src/unit_tests/outbox_tests.rs
+++ b/linera-chain/src/unit_tests/outbox_tests.rs
@@ -6,17 +6,17 @@ use super::*;
 #[tokio::test]
 async fn test_outbox() {
     let mut view = OutboxStateView::new().await;
-    assert!(view.schedule_message(BlockHeight::from(0)).unwrap());
+    assert!(view.schedule_message(BlockHeight::ZERO).unwrap());
     assert!(view.schedule_message(BlockHeight::from(2)).unwrap());
     assert!(view.schedule_message(BlockHeight::from(4)).unwrap());
-    assert!(!view.schedule_message(BlockHeight::from(0)).unwrap());
+    assert!(!view.schedule_message(BlockHeight::ZERO).unwrap());
 
     assert_eq!(view.queue.count(), 3);
     assert_eq!(
         view.mark_messages_as_received(BlockHeight::from(3))
             .await
             .unwrap(),
-        vec![BlockHeight::from(0), BlockHeight::from(2)]
+        vec![BlockHeight::ZERO, BlockHeight::from(2)]
     );
     assert_eq!(
         view.mark_messages_as_received(BlockHeight::from(3))

--- a/linera-core/src/tracker.rs
+++ b/linera-core/src/tracker.rs
@@ -182,7 +182,7 @@ pub mod tests {
     fn test_application_origin() {
         let reason_0 = Reason::NewIncomingMessage {
             origin: Origin::chain(ChainId::root(0)),
-            height: BlockHeight::from(0),
+            height: BlockHeight::ZERO,
         };
         let reason_1 = Reason::NewIncomingMessage {
             origin: Origin::chain(ChainId::root(0)),

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -485,7 +485,7 @@ where
                 .await
                 .unwrap();
         }
-        self.make_client(description.into(), key_pair, None, BlockHeight::from(0))
+        self.make_client(description.into(), key_pair, None, BlockHeight::ZERO)
             .await
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -108,7 +108,7 @@ where
         );
         assert_eq!(
             builder
-                .check_that_validators_have_certificate(sender.chain_id, BlockHeight::from(0), 3)
+                .check_that_validators_have_certificate(sender.chain_id, BlockHeight::ZERO, 3)
                 .await
                 .unwrap()
                 .value,
@@ -120,7 +120,7 @@ where
         Some(Notification {
             reason: Reason::NewBlock { height, .. },
             chain_id,
-        }) if chain_id == ChainId::root(1) && height == BlockHeight::from(0)
+        }) if chain_id == ChainId::root(1) && height == BlockHeight::ZERO
     ));
     Ok(())
 }
@@ -258,7 +258,7 @@ where
     assert_eq!(sender.identity().await.unwrap(), new_owner);
     assert_eq!(
         builder
-            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::from(0), 3)
+            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::ZERO, 3)
             .await
             .unwrap()
             .value,
@@ -334,7 +334,7 @@ where
     ));
     assert_eq!(
         builder
-            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::from(0), 3)
+            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::ZERO, 3)
             .await
             .unwrap()
             .value,
@@ -403,7 +403,7 @@ where
     assert!(sender.key_pair().await.is_ok());
     assert_eq!(
         builder
-            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::from(0), 3)
+            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::ZERO, 3)
             .await
             .unwrap()
             .value,
@@ -575,7 +575,7 @@ where
     // Make a client to try the new chain.
     let new_id = ChainId::child(message_id);
     let mut client = builder
-        .make_client(new_id, new_key_pair, None, BlockHeight::from(0))
+        .make_client(new_id, new_key_pair, None, BlockHeight::ZERO)
         .await?;
     client.receive_certificate(certificate).await.unwrap();
     assert_eq!(
@@ -667,7 +667,7 @@ where
     ));
     // Make a client to try the new chain.
     let mut client = builder
-        .make_client(new_id, new_key_pair, None, BlockHeight::from(0))
+        .make_client(new_id, new_key_pair, None, BlockHeight::ZERO)
         .await?;
     client.receive_certificate(certificate).await.unwrap();
     assert_eq!(
@@ -745,7 +745,7 @@ where
     assert!(sender.key_pair().await.is_ok());
     // Make a client to try the new chain.
     let mut client = builder
-        .make_client(new_id, new_key_pair, None, BlockHeight::from(0))
+        .make_client(new_id, new_key_pair, None, BlockHeight::ZERO)
         .await?;
     // Must process the creation certificate before using the new chain.
     client
@@ -826,7 +826,7 @@ where
     ));
     assert_eq!(
         builder
-            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::from(0), 3)
+            .check_that_validators_have_certificate(sender.chain_id, BlockHeight::ZERO, 3)
             .await
             .unwrap()
             .value,
@@ -897,7 +897,7 @@ where
             CommunicationError::Trusted(crate::node::NodeError::ArithmeticError { .. })
         ))
     ));
-    assert_eq!(sender.next_block_height, BlockHeight::from(0));
+    assert_eq!(sender.next_block_height, BlockHeight::ZERO);
     assert!(sender.pending_block.is_some());
     assert_eq!(
         sender.local_balance().await.unwrap(),
@@ -977,7 +977,7 @@ where
 
     assert_eq!(
         builder
-            .check_that_validators_have_certificate(client1.chain_id, BlockHeight::from(0), 3)
+            .check_that_validators_have_certificate(client1.chain_id, BlockHeight::ZERO, 3)
             .await
             .unwrap()
             .value,
@@ -1005,7 +1005,7 @@ where
     );
 
     // Send back some money.
-    assert_eq!(client2.next_block_height, BlockHeight::from(0));
+    assert_eq!(client2.next_block_height, BlockHeight::ZERO);
     client2
         .transfer_to_account(
             None,
@@ -1304,7 +1304,7 @@ where
         user.receive_certificate(cert).await,
         Err(ChainClientError::CommitteeSynchronizationError)
     ));
-    assert_eq!(user.epoch().await.unwrap(), Epoch::from(0));
+    assert_eq!(user.epoch().await.unwrap(), Epoch::ZERO);
     assert_eq!(
         user.synchronize_from_validators().await.unwrap(),
         Amount::from_tokens(3)
@@ -1312,7 +1312,7 @@ where
 
     // User is a genesis chain so the migration message is not even in the inbox yet.
     user.process_inbox().await.unwrap();
-    assert_eq!(user.epoch().await.unwrap(), Epoch::from(0));
+    assert_eq!(user.epoch().await.unwrap(), Epoch::ZERO);
 
     // Now subscribe explicitly to migrations.
     let cert = user.subscribe_to_new_committees().await.unwrap();

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -131,7 +131,7 @@ where
     };
     let publish_message = SystemMessage::BytecodePublished { operation_index: 0 };
     let publish_block = make_block(
-        Epoch::from(0),
+        Epoch::ZERO,
         publisher_chain.into(),
         vec![publish_operation],
         vec![],
@@ -141,11 +141,11 @@ where
     );
     let publish_block_height = publish_block.height;
     let mut publisher_system_state = SystemExecutionState {
-        epoch: Some(Epoch::from(0)),
+        epoch: Some(Epoch::ZERO),
         description: Some(publisher_chain),
         admin_id: Some(admin_id.into()),
         subscriptions: BTreeSet::new(),
-        committees: [(Epoch::from(0), committee.clone())].into_iter().collect(),
+        committees: [(Epoch::ZERO, committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(publisher_key_pair.public()),
         balance: Amount::ZERO,
         balances: BTreeMap::new(),
@@ -189,7 +189,7 @@ where
         },
     };
     let broadcast_block = make_block(
-        Epoch::from(0),
+        Epoch::ZERO,
         publisher_chain.into(),
         Vec::<SystemOperation>::new(),
         vec![broadcast_message],
@@ -253,7 +253,7 @@ where
         subscription: publisher_channel.clone(),
     };
     let subscribe_block = make_block(
-        Epoch::from(0),
+        Epoch::ZERO,
         creator_chain.into(),
         vec![subscribe_operation],
         vec![],
@@ -263,11 +263,11 @@ where
     );
     let subscribe_block_height = subscribe_block.height;
     let mut creator_system_state = SystemExecutionState {
-        epoch: Some(Epoch::from(0)),
+        epoch: Some(Epoch::ZERO),
         description: Some(creator_chain),
         admin_id: Some(admin_id.into()),
         subscriptions: [publisher_channel].into_iter().collect(),
-        committees: [(Epoch::from(0), committee.clone())].into_iter().collect(),
+        committees: [(Epoch::ZERO, committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(creator_key_pair.public()),
         balance: Amount::ZERO,
         balances: BTreeMap::new(),
@@ -311,7 +311,7 @@ where
         },
     };
     let accept_block = make_block(
-        Epoch::from(0),
+        Epoch::ZERO,
         publisher_chain.into(),
         Vec::<SystemOperation>::new(),
         vec![accept_message],
@@ -375,7 +375,7 @@ where
         name: SystemChannel::PublishedBytecodes.name(),
     };
     let create_block = make_block(
-        Epoch::from(0),
+        Epoch::ZERO,
         creator_chain.into(),
         vec![create_operation],
         vec![IncomingMessage {
@@ -437,7 +437,7 @@ where
     let increment = 5_u64;
     let user_operation = bcs::to_bytes(&increment)?;
     let run_block = make_block(
-        Epoch::from(0),
+        Epoch::ZERO,
         creator_chain.into(),
         vec![Operation::User {
             application_id,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -136,7 +136,7 @@ fn make_block(
 ) -> Block {
     let previous_block_hash = previous_confirmed_block.as_ref().map(|cert| cert.hash());
     let height = match &previous_confirmed_block {
-        None => BlockHeight::from(0),
+        None => BlockHeight::ZERO,
         Some(cert) => cert.value().height().try_add_one().unwrap(),
     };
     Block {
@@ -160,7 +160,7 @@ fn make_transfer_block_proposal(
     previous_confirmed_block: Option<&Certificate>,
 ) -> BlockProposal {
     let block = make_block(
-        Epoch::from(0),
+        Epoch::ZERO,
         chain_id,
         vec![SystemOperation::Transfer {
             owner: None,
@@ -219,7 +219,7 @@ async fn make_transfer_certificate<S>(
         recipient,
         amount,
         incoming_messages,
-        Epoch::from(0),
+        Epoch::ZERO,
         committee,
         balance,
         worker,
@@ -426,7 +426,7 @@ where
         ChainId::root(1),
         &sender_key_pair,
         recipient,
-        Amount::zero(),
+        Amount::ZERO,
         Vec::new(),
         None,
     );
@@ -481,7 +481,7 @@ where
     let key_pair = KeyPair::generate();
     let balance: Amount = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public(), balance)];
-    let epoch = Epoch::from(0);
+    let epoch = Epoch::ZERO;
     let (committee, mut worker) = init_worker_with_chains(client, balances).await;
 
     let make_tick_block = |micros: u64, parent: Option<&Certificate>| {
@@ -798,7 +798,7 @@ where
     )
     .await;
 
-    let epoch = Epoch::from(0);
+    let epoch = Epoch::ZERO;
     let certificate0 = make_certificate(
         &committee,
         &worker,
@@ -822,7 +822,7 @@ where
                     }),
                 ],
                 previous_block_hash: None,
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
             },
@@ -979,7 +979,7 @@ where
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 0,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -993,7 +993,7 @@ where
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 1,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -1038,7 +1038,7 @@ where
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 1,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -1052,7 +1052,7 @@ where
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 0,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -1111,7 +1111,7 @@ where
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 0,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -1125,7 +1125,7 @@ where
                     origin: Origin::chain(ChainId::root(1)),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 1,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -1155,7 +1155,7 @@ where
                 origin: Origin::chain(ChainId::root(1)),
                 event: Event {
                     certificate_hash: certificate0.value.hash(),
-                    height: BlockHeight::from(0),
+                    height: BlockHeight::ZERO,
                     index: 0,
                     authenticated_signer: None,
                     timestamp: Timestamp::from(0),
@@ -1627,7 +1627,7 @@ where
             origin: Origin::chain(ChainId::root(3)),
             event: Event {
                 certificate_hash: CryptoHash::new(&Dummy),
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 index: 0,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
@@ -1658,7 +1658,7 @@ where
         chain.tip_state.get().next_block_height
     );
     assert_eq!(
-        BlockHeight::from(0),
+        BlockHeight::ZERO,
         chain
             .inboxes
             .try_load_entry_mut(&Origin::chain(ChainId::root(3)))
@@ -1696,7 +1696,7 @@ where
             timestamp,
             message: Message::System(SystemMessage::Credit { amount, .. }),
         } if certificate_hash == CryptoHash::new(&Dummy)
-            && height == BlockHeight::from(0)
+            && height == BlockHeight::ZERO
             && timestamp == Timestamp::from(0)
             && amount == Amount::from_tokens(995),
     ));
@@ -1751,11 +1751,7 @@ where
                 sender_key_pair.public(),
                 Amount::ONE,
             ),
-            (
-                ChainDescription::Root(2),
-                PublicKey::debug(2),
-                Amount::max(),
-            ),
+            (ChainDescription::Root(2), PublicKey::debug(2), Amount::MAX),
         ],
     )
     .await;
@@ -1800,7 +1796,7 @@ where
         .await
         .unwrap();
     assert_eq!(
-        Amount::max(),
+        Amount::MAX,
         *new_recipient_chain.execution_state.system.balance.get()
     );
 }
@@ -1894,7 +1890,7 @@ where
             timestamp,
             message: Message::System(SystemMessage::Credit { amount, .. })
         } if certificate_hash == certificate.hash()
-            && height == BlockHeight::from(0)
+            && height == BlockHeight::ZERO
             && timestamp == Timestamp::from(0)
             && amount == Amount::ONE,
     ));
@@ -1972,10 +1968,7 @@ where
         .await
         .unwrap();
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
-    assert_eq!(
-        BlockHeight::from(0),
-        chain.tip_state.get().next_block_height
-    );
+    assert_eq!(BlockHeight::ZERO, chain.tip_state.get().next_block_height);
     assert_eq!(
         BlockHeight::from(1),
         chain
@@ -2005,7 +1998,7 @@ where
             timestamp,
             message: Message::System(SystemMessage::Credit { amount, .. })
         } if certificate_hash == certificate.hash()
-            && height == BlockHeight::from(0)
+            && height == BlockHeight::ZERO
             && timestamp == Timestamp::from(0)
             && amount == Amount::from_tokens(10),
     ));
@@ -2144,7 +2137,7 @@ where
             chain_id: ChainId::root(2),
             reason: Reason::NewIncomingMessage {
                 origin: Origin::chain(ChainId::root(1)),
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
             }
         }]
     );
@@ -2268,7 +2261,7 @@ where
             origin: Origin::chain(ChainId::root(1)),
             event: Event {
                 certificate_hash: certificate.hash(),
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 index: 0,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
@@ -2328,7 +2321,7 @@ where
         response.info.requested_received_log[0],
         ChainAndHeight {
             chain_id: ChainId::root(1),
-            height: BlockHeight::from(0)
+            height: BlockHeight::ZERO
         }
     );
 }
@@ -2445,7 +2438,7 @@ where
     )
     .await;
     let mut committees = BTreeMap::new();
-    committees.insert(Epoch::from(0), committee.clone());
+    committees.insert(Epoch::ZERO, committee.clone());
     let admin_id = ChainId::root(0);
     let admin_channel_subscription = ChannelSubscription {
         chain_id: admin_id,
@@ -2459,12 +2452,12 @@ where
     // Have the admin chain create a user chain.
     let user_id = ChainId::child(MessageId {
         chain_id: admin_id,
-        height: BlockHeight::from(0),
+        height: BlockHeight::ZERO,
         index: 0,
     });
     let user_description = ChainDescription::Child(MessageId {
         chain_id: admin_id,
-        height: BlockHeight::from(0),
+        height: BlockHeight::ZERO,
         index: 0,
     });
     let certificate0 = make_certificate(
@@ -2472,17 +2465,17 @@ where
         &worker,
         HashedValue::new_confirmed(ExecutedBlock {
             block: Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
                 operations: vec![Operation::System(SystemOperation::OpenChain {
                     ownership: ChainOwnership::single(key_pair.public()),
-                    epoch: Epoch::from(0),
+                    epoch: Epoch::ZERO,
                     committees: committees.clone(),
                     admin_id,
                 })],
                 previous_block_hash: None,
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
             },
@@ -2491,7 +2484,7 @@ where
                     user_id,
                     SystemMessage::OpenChain {
                         ownership: ChainOwnership::single(key_pair.public()),
-                        epoch: Epoch::from(0),
+                        epoch: Epoch::ZERO,
                         committees: committees.clone(),
                         admin_id,
                     },
@@ -2505,7 +2498,7 @@ where
                 ),
             ],
             state_hash: make_state_hash(SystemExecutionState {
-                epoch: Some(Epoch::from(0)),
+                epoch: Some(Epoch::ZERO),
                 description: Some(ChainDescription::Root(0)),
                 admin_id: Some(admin_id),
                 subscriptions: BTreeSet::new(),
@@ -2546,7 +2539,7 @@ where
 
     // Create a new committee and transfer money before accepting the subscription.
     let committees2 = BTreeMap::from_iter([
-        (Epoch::from(0), committee.clone()),
+        (Epoch::ZERO, committee.clone()),
         (Epoch::from(1), committee.clone()),
     ]);
     let certificate1 = make_certificate(
@@ -2554,7 +2547,7 @@ where
         &worker,
         HashedValue::new_confirmed(ExecutedBlock {
             block: Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
                 operations: vec![
@@ -2623,7 +2616,7 @@ where
                     origin: Origin::chain(admin_id),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 1,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -2685,7 +2678,7 @@ where
         // The child is active and has not migrated yet.
         let mut user_chain = worker.storage.load_active_chain(user_id).await.unwrap();
         assert_eq!(
-            BlockHeight::from(0),
+            BlockHeight::ZERO,
             user_chain.tip_state.get().next_block_height
         );
         assert_eq!(
@@ -2762,7 +2755,7 @@ where
         &worker,
         HashedValue::new_confirmed(ExecutedBlock {
             block: Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: user_id,
                 incoming_messages: vec![
                     IncomingMessage {
@@ -2807,7 +2800,7 @@ where
                 ],
                 operations: Vec::new(),
                 previous_block_hash: None,
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
             },
@@ -2937,7 +2930,7 @@ where
     )
     .await;
     let mut committees = BTreeMap::new();
-    committees.insert(Epoch::from(0), committee.clone());
+    committees.insert(Epoch::ZERO, committee.clone());
     let admin_id = ChainId::root(0);
     let user_id = ChainId::root(1);
 
@@ -2947,7 +2940,7 @@ where
         &worker,
         HashedValue::new_confirmed(ExecutedBlock {
             block: Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: user_id,
                 incoming_messages: Vec::new(),
                 operations: vec![Operation::System(SystemOperation::Transfer {
@@ -2957,7 +2950,7 @@ where
                     user_data: UserData::default(),
                 })],
                 previous_block_hash: None,
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
             },
@@ -2969,7 +2962,7 @@ where
                 },
             )],
             state_hash: make_state_hash(SystemExecutionState {
-                epoch: Some(Epoch::from(0)),
+                epoch: Some(Epoch::ZERO),
                 description: Some(ChainDescription::Root(1)),
                 admin_id: Some(admin_id),
                 subscriptions: BTreeSet::new(),
@@ -2985,7 +2978,7 @@ where
     );
     // Have the admin chain create a new epoch without retiring the old one.
     let committees2 = BTreeMap::from_iter([
-        (Epoch::from(0), committee.clone()),
+        (Epoch::ZERO, committee.clone()),
         (Epoch::from(1), committee.clone()),
     ]);
     let certificate1 = make_certificate(
@@ -2993,7 +2986,7 @@ where
         &worker,
         HashedValue::new_confirmed(ExecutedBlock {
             block: Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
                 operations: vec![Operation::System(SystemOperation::Admin(
@@ -3003,7 +2996,7 @@ where
                     },
                 ))],
                 previous_block_hash: None,
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
             },
@@ -3052,7 +3045,7 @@ where
     );
     assert_eq!(
         *user_chain.execution_state.system.epoch.get(),
-        Some(Epoch::from(0))
+        Some(Epoch::ZERO)
     );
 
     // .. and the message has gone through.
@@ -3123,7 +3116,7 @@ where
     )
     .await;
     let mut committees = BTreeMap::new();
-    committees.insert(Epoch::from(0), committee.clone());
+    committees.insert(Epoch::ZERO, committee.clone());
     let admin_id = ChainId::root(0);
     let user_id = ChainId::root(1);
 
@@ -3133,7 +3126,7 @@ where
         &worker,
         HashedValue::new_confirmed(ExecutedBlock {
             block: Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: user_id,
                 incoming_messages: Vec::new(),
                 operations: vec![Operation::System(SystemOperation::Transfer {
@@ -3143,7 +3136,7 @@ where
                     user_data: UserData::default(),
                 })],
                 previous_block_hash: None,
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
             },
@@ -3155,7 +3148,7 @@ where
                 },
             )],
             state_hash: make_state_hash(SystemExecutionState {
-                epoch: Some(Epoch::from(0)),
+                epoch: Some(Epoch::ZERO),
                 description: Some(ChainDescription::Root(1)),
                 admin_id: Some(admin_id),
                 subscriptions: BTreeSet::new(),
@@ -3171,7 +3164,7 @@ where
     );
     // Have the admin chain create a new epoch and retire the old one immediately.
     let committees2 = BTreeMap::from_iter([
-        (Epoch::from(0), committee.clone()),
+        (Epoch::ZERO, committee.clone()),
         (Epoch::from(1), committee.clone()),
     ]);
     let committees3 = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
@@ -3180,7 +3173,7 @@ where
         &worker,
         HashedValue::new_confirmed(ExecutedBlock {
             block: Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: admin_id,
                 incoming_messages: Vec::new(),
                 operations: vec![
@@ -3189,11 +3182,11 @@ where
                         committee: committee.clone(),
                     })),
                     Operation::System(SystemOperation::Admin(AdminOperation::RemoveCommittee {
-                        epoch: Epoch::from(0),
+                        epoch: Epoch::ZERO,
                     })),
                 ],
                 previous_block_hash: None,
-                height: BlockHeight::from(0),
+                height: BlockHeight::ZERO,
                 authenticated_signer: None,
                 timestamp: Timestamp::from(0),
             },
@@ -3252,7 +3245,7 @@ where
         );
         assert_eq!(
             *user_chain.execution_state.system.epoch.get(),
-            Some(Epoch::from(0))
+            Some(Epoch::ZERO)
         );
 
         // .. but the message hasn't gone through.
@@ -3272,7 +3265,7 @@ where
                     origin: Origin::chain(user_id),
                     event: Event {
                         certificate_hash: certificate0.value.hash(),
-                        height: BlockHeight::from(0),
+                        height: BlockHeight::ZERO,
                         index: 0,
                         authenticated_signer: None,
                         timestamp: Timestamp::from(0),
@@ -3348,7 +3341,7 @@ async fn test_cross_chain_helper() {
         Recipient::Account(Account::chain(id1)),
         Amount::ONE,
         Vec::new(),
-        Epoch::from(0),
+        Epoch::ZERO,
         &committee,
         Amount::ONE,
         &worker,
@@ -3361,7 +3354,7 @@ async fn test_cross_chain_helper() {
         Recipient::Account(Account::chain(id1)),
         Amount::ONE,
         Vec::new(),
-        Epoch::from(0),
+        Epoch::ZERO,
         &committee,
         Amount::ONE,
         &worker,
@@ -3388,7 +3381,7 @@ async fn test_cross_chain_helper() {
         Recipient::Account(Account::chain(id1)),
         Amount::ONE,
         Vec::new(),
-        Epoch::from(0),
+        Epoch::ZERO,
         &committee,
         Amount::ONE,
         &worker,
@@ -3408,7 +3401,7 @@ async fn test_cross_chain_helper() {
             .select_certificates(
                 &Origin::chain(id0),
                 id1,
-                BlockHeight::from(0),
+                BlockHeight::ZERO,
                 None,
                 vec![certificate0.clone(), certificate1.clone()]
             )
@@ -3445,7 +3438,7 @@ async fn test_cross_chain_helper() {
         .select_certificates(
             &Origin::chain(id0),
             id1,
-            BlockHeight::from(0),
+            BlockHeight::ZERO,
             None,
             vec![certificate1.clone(), certificate0.clone()]
         )
@@ -3455,7 +3448,7 @@ async fn test_cross_chain_helper() {
         .select_certificates(
             &Origin::chain(id1),
             id0,
-            BlockHeight::from(0),
+            BlockHeight::ZERO,
             None,
             vec![certificate0.clone()]
         )
@@ -3473,7 +3466,7 @@ async fn test_cross_chain_helper() {
             .select_certificates(
                 &Origin::chain(id0),
                 id1,
-                BlockHeight::from(0),
+                BlockHeight::ZERO,
                 None,
                 vec![certificate0.clone(), certificate1.clone()]
             )
@@ -3486,7 +3479,7 @@ async fn test_cross_chain_helper() {
             .select_certificates(
                 &Origin::chain(id0),
                 id1,
-                BlockHeight::from(0),
+                BlockHeight::ZERO,
                 None,
                 vec![
                     certificate0.clone(),
@@ -3537,7 +3530,7 @@ async fn test_cross_chain_helper() {
             .select_certificates(
                 &Origin::chain(id0),
                 id1,
-                BlockHeight::from(0),
+                BlockHeight::ZERO,
                 Some(BlockHeight::from(1)),
                 vec![certificate0.clone(), certificate1.clone()]
             )

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -346,7 +346,7 @@ where
                             height,
                             index: _,
                         })) => {
-                            jobs.push((chain_id, BlockHeight::from(0), target_block_height, true));
+                            jobs.push((chain_id, BlockHeight::ZERO, target_block_height, true));
                             chain_id = parent_id;
                             target_block_height = height.try_add_one()?;
                         }
@@ -441,7 +441,7 @@ where
             }
             CommunicateAction::FinalizeBlock(certificate) => {
                 // The only cause for a retry here is the first certificate of a newly opened chain.
-                let retryable = target_block_height == BlockHeight::from(0);
+                let retryable = target_block_height == BlockHeight::ZERO;
                 let info = self.send_certificate(certificate, retryable).await?;
                 match info.manager.pending() {
                     Some(vote) if vote.validator == self.name => {

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -15,6 +15,10 @@ use std::{borrow::Cow, collections::BTreeMap, str::FromStr};
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug)]
 pub struct Epoch(pub u32);
 
+impl Epoch {
+    pub const ZERO: Epoch = Epoch(0);
+}
+
 impl Serialize for Epoch {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -541,7 +541,7 @@ where
                     );
                 }
                 ensure!(
-                    *amount > Amount::zero(),
+                    *amount > Amount::ZERO,
                     SystemExecutionError::IncorrectTransferAmount
                 );
                 let balance = match &owner {
@@ -579,7 +579,7 @@ where
                     SystemExecutionError::UnauthenticatedClaimOwner
                 );
                 ensure!(
-                    *amount > Amount::zero(),
+                    *amount > Amount::ZERO,
                     SystemExecutionError::IncorrectClaimAmount
                 );
                 let message = RawOutgoingMessage {

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 fn message_id(index: u32) -> MessageId {
     MessageId {
         chain_id: ChainId::root(0),
-        height: BlockHeight::from(0),
+        height: BlockHeight::ZERO,
         index,
     }
 }

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -470,7 +470,7 @@ pub mod tests {
             epoch: Epoch::default(),
             incoming_messages: vec![],
             operations: vec![],
-            height: BlockHeight::from(0),
+            height: BlockHeight::ZERO,
             authenticated_signer: None,
             timestamp: Timestamp::default(),
             previous_block_hash: None,
@@ -540,7 +540,7 @@ pub mod tests {
             system_balance: Amount::ZERO,
             block_hash: None,
             timestamp: Timestamp::default(),
-            next_block_height: BlockHeight::from(0),
+            next_block_height: BlockHeight::ZERO,
             state_hash: None,
             requested_committees: None,
             requested_pending_messages: vec![],
@@ -668,7 +668,7 @@ pub mod tests {
         let block_proposal = BlockProposal {
             content: BlockAndRound {
                 block: get_block(),
-                round: RoundNumber::zero(),
+                round: RoundNumber::ZERO,
             },
             owner: Owner::from(KeyPair::generate().public()),
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -112,7 +112,7 @@ impl UserChain {
             key_pair: Some(key_pair),
             block_hash: None,
             timestamp,
-            next_block_height: BlockHeight::from(0),
+            next_block_height: BlockHeight::ZERO,
         }
     }
 }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -299,7 +299,7 @@ impl ClientContext {
                 None => continue,
             };
             let block = Block {
-                epoch: Epoch::from(0),
+                epoch: Epoch::ZERO,
                 chain_id: chain.chain_id,
                 incoming_messages: Vec::new(),
                 operations: vec![Operation::System(SystemOperation::Transfer {
@@ -439,7 +439,7 @@ impl ClientContext {
                 key_pair: key_pair.as_ref().map(|kp| kp.copy()),
                 block_hash: None,
                 timestamp,
-                next_block_height: BlockHeight::from(0),
+                next_block_height: BlockHeight::ZERO,
             });
         }
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -159,12 +159,12 @@ pub trait Store: Sized {
         assert!(!chain.is_active(), "Attempting to create a chain twice");
         let system_state = &mut chain.execution_state.system;
         system_state.description.set(Some(description));
-        system_state.epoch.set(Some(Epoch::from(0)));
+        system_state.epoch.set(Some(Epoch::ZERO));
         system_state.admin_id.set(Some(admin_id));
         system_state
             .committees
             .get_mut()
-            .insert(Epoch::from(0), committee);
+            .insert(Epoch::ZERO, committee);
         system_state
             .ownership
             .set(ChainOwnership::single(public_key));


### PR DESCRIPTION
## Motivation

The wrapped numbers' `zero` and `max` functions don't work in constant contexts. `max` also shadows [`Ord::max`](https://doc.rust-lang.org/std/cmp/trait.Ord.html#method.max).
The standard library uses constants instead.

`impl_wrapped_number!`, as opposed to `impl_strictly_wrapped_number!`, only contains functionality specific to `BlockHeight`.

## Proposal

Rename the strict variant to `impl_wrapped_number!` and remove the other one. Replace `zero` and `max` by constants.

## Test Plan

No logic is changed.

## Links

N/A

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
