### PR TITLE
Add test utilities for creating blocks.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -92,6 +92,18 @@ impl Timestamp {
     pub fn saturating_diff_micros(&self, other: Timestamp) -> u64 {
         self.0.saturating_sub(other.0)
     }
+
+    /// Returns a timestamp `micros` microseconds later than `self`, or the highest possible value
+    /// if it would overflow.
+    pub fn saturating_add_micros(&self, micros: u64) -> Timestamp {
+        Timestamp(self.0.saturating_add(micros))
+    }
+
+    /// Returns a timestamp `micros` microseconds earlier than `self`, or the lowest possible value
+    /// if it would underflow.
+    pub fn saturating_sub_micros(&self, micros: u64) -> Timestamp {
+        Timestamp(self.0.saturating_sub(micros))
+    }
 }
 
 impl From<u64> for Timestamp {

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -8,6 +8,8 @@ pub mod data_types;
 mod inbox;
 mod manager;
 mod outbox;
+#[cfg(any(test, feature = "test"))]
+pub mod test;
 
 pub use chain::ChainStateView;
 use data_types::{Event, Origin};

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Test utilities
+
+use linera_base::{
+    crypto::KeyPair,
+    data_types::{Amount, BlockHeight, Timestamp},
+    identifiers::ChainId,
+};
+use linera_execution::{committee::Epoch, system::Recipient, Operation, SystemOperation};
+
+use crate::data_types::{Block, BlockAndRound, BlockProposal, HashedValue, IncomingMessage};
+
+/// Creates a new child of the given block, with the same timestamp.
+pub fn make_child_block(parent: &HashedValue) -> Block {
+    let parent_value = parent.inner();
+    let parent_block = parent_value.block().unwrap();
+    Block {
+        epoch: parent_value.epoch(),
+        chain_id: parent_value.chain_id(),
+        incoming_messages: vec![],
+        operations: vec![],
+        previous_block_hash: Some(parent.hash()),
+        height: parent_value.height().try_add_one().unwrap(),
+        authenticated_signer: None,
+        timestamp: parent_block.timestamp,
+    }
+}
+
+/// Creates a block at height 0 for a new chain.
+pub fn make_first_block(chain_id: ChainId) -> Block {
+    Block {
+        epoch: Epoch::ZERO,
+        chain_id,
+        incoming_messages: vec![],
+        operations: vec![],
+        previous_block_hash: None,
+        height: BlockHeight::ZERO,
+        authenticated_signer: None,
+        timestamp: Timestamp::default(),
+    }
+}
+
+/// A helper trait to simplify constructing blocks for tests.
+pub trait BlockTestExt: Sized {
+    /// Returns the block with the given operation appended at the end.
+    fn with_operation(self, operation: impl Into<Operation>) -> Self;
+
+    /// Returns the block with a transfer operation appended at the end.
+    fn with_simple_transfer(self, recipient: Recipient, amount: Amount) -> Self;
+
+    /// Returns the block with the given message appended at the end.
+    fn with_incoming_message(self, incoming_message: IncomingMessage) -> Self;
+
+    /// Returns the block with the specified timestamp.
+    fn with_timestamp(self, timestamp: impl Into<Timestamp>) -> Self;
+
+    /// Returns the block with the specified epoch.
+    fn with_epoch(self, epoch: impl Into<Epoch>) -> Self;
+
+    /// Returns a block proposal with round 0, without any blobs or validated block.
+    fn into_simple_proposal(self, key_pair: &KeyPair) -> BlockProposal;
+}
+
+impl BlockTestExt for Block {
+    fn with_operation(mut self, operation: impl Into<Operation>) -> Self {
+        self.operations.push(operation.into());
+        self
+    }
+
+    fn with_simple_transfer(self, recipient: Recipient, amount: Amount) -> Self {
+        self.with_operation(SystemOperation::Transfer {
+            owner: None,
+            recipient,
+            amount,
+            user_data: Default::default(),
+        })
+    }
+
+    fn with_incoming_message(mut self, incoming_message: IncomingMessage) -> Self {
+        self.incoming_messages.push(incoming_message);
+        self
+    }
+
+    fn with_timestamp(mut self, timestamp: impl Into<Timestamp>) -> Self {
+        self.timestamp = timestamp.into();
+        self
+    }
+
+    fn with_epoch(mut self, epoch: impl Into<Epoch>) -> Self {
+        self.epoch = epoch.into();
+        self
+    }
+
+    fn into_simple_proposal(self, key_pair: &KeyPair) -> BlockProposal {
+        BlockProposal::new(
+            BlockAndRound {
+                block: self,
+                round: Default::default(),
+            },
+            key_pair,
+            vec![],
+            None,
+        )
+    }
+}

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::test::{make_first_block, BlockTestExt};
 use linera_base::data_types::Amount;
-use linera_execution::system::{Account, Recipient, SystemOperation, UserData};
+use linera_execution::system::Recipient;
 
 #[test]
 fn test_signed_values() {
@@ -12,21 +13,8 @@ fn test_signed_values() {
     let key2 = KeyPair::generate();
     let name1 = ValidatorName(key1.public());
 
-    let block = Block {
-        epoch: Epoch::ZERO,
-        chain_id: ChainId::root(1),
-        incoming_messages: Vec::new(),
-        operations: vec![Operation::System(SystemOperation::Transfer {
-            owner: None,
-            recipient: Recipient::Account(Account::chain(ChainId::root(2))),
-            amount: Amount::ONE,
-            user_data: UserData::default(),
-        })],
-        height: BlockHeight::ZERO,
-        timestamp: Timestamp::default(),
-        authenticated_signer: None,
-        previous_block_hash: None,
-    };
+    let block =
+        make_first_block(ChainId::root(1)).with_simple_transfer(Recipient::root(2), Amount::ONE);
     let executed_block = ExecutedBlock {
         block,
         messages: Vec::new(),
@@ -52,21 +40,8 @@ fn test_certificates() {
 
     let committee = Committee::make_simple(vec![name1, name2]);
 
-    let block = Block {
-        epoch: Epoch::ZERO,
-        chain_id: ChainId::root(1),
-        incoming_messages: Vec::new(),
-        operations: vec![Operation::System(SystemOperation::Transfer {
-            owner: None,
-            recipient: Recipient::Account(Account::chain(ChainId::root(1))),
-            amount: Amount::ONE,
-            user_data: UserData::default(),
-        })],
-        previous_block_hash: None,
-        height: BlockHeight::ZERO,
-        authenticated_signer: None,
-        timestamp: Timestamp::default(),
-    };
+    let block =
+        make_first_block(ChainId::root(1)).with_simple_transfer(Recipient::root(1), Amount::ONE);
     let executed_block = ExecutedBlock {
         block,
         messages: Vec::new(),

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -70,7 +70,7 @@ where
         Amount::from_tokens(9)
     );
 
-    let account = Recipient::Account(Account::chain(chain1.chain_id()));
+    let account = Recipient::chain(chain1.chain_id());
     let cert = chain1
         .claim(owner1, chain2.chain_id(), account, amt, UserData(None))
         .await

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -184,7 +184,7 @@ where
         .claim(
             owner,
             ChainId::root(2),
-            Recipient::Account(Account::chain(ChainId::root(1))),
+            Recipient::root(1),
             Amount::from_tokens(5),
             UserData(None),
         )
@@ -195,7 +195,7 @@ where
         .claim(
             owner,
             ChainId::root(2),
-            Recipient::Account(Account::chain(ChainId::root(1))),
+            Recipient::root(1),
             Amount::from_tokens(2),
             UserData(None),
         )

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -301,6 +301,19 @@ pub enum Recipient {
     Account(Account),
 }
 
+impl Recipient {
+    /// Returns the default recipient for the given chain (no owner).
+    pub fn chain(chain_id: ChainId) -> Recipient {
+        Recipient::Account(Account::chain(chain_id))
+    }
+
+    /// Returns the default recipient for the root chain with the given index.
+    #[cfg(any(test, feature = "test"))]
+    pub fn root(index: u32) -> Recipient {
+        Recipient::chain(ChainId::root(index))
+    }
+}
+
 /// A system account.
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
 pub struct Account {

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -452,10 +452,10 @@ pub mod tests {
     };
     use linera_chain::{
         data_types::{Block, BlockAndRound, ExecutedBlock, HashedValue},
+        test::make_first_block,
         ChainManagerInfo,
     };
     use linera_core::data_types::ChainInfo;
-    use linera_execution::committee::Epoch;
     use serde::{Deserialize, Serialize};
     use std::{borrow::Cow, fmt::Debug};
 
@@ -465,16 +465,7 @@ pub mod tests {
     impl BcsSignable for Foo {}
 
     fn get_block() -> Block {
-        Block {
-            chain_id: ChainId::root(0),
-            epoch: Epoch::default(),
-            incoming_messages: vec![],
-            operations: vec![],
-            height: BlockHeight::ZERO,
-            authenticated_signer: None,
-            timestamp: Timestamp::default(),
-            previous_block_hash: None,
-        }
+        make_first_block(ChainId::root(0))
     }
 
     /// A convenience function for testing. It converts a type into its

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -304,7 +304,7 @@ impl ClientContext {
                 incoming_messages: Vec::new(),
                 operations: vec![Operation::System(SystemOperation::Transfer {
                     owner: None,
-                    recipient: Recipient::Account(Account::chain(next_recipient)),
+                    recipient: Recipient::chain(next_recipient),
                     amount: Amount::ONE,
                     user_data: UserData::default(),
                 })],


### PR DESCRIPTION
## Motivation

The worker tests contain a lot of repetitive code, mostly for creating blocks. The lack of utilities also makes it hard to write new tests.

## Proposal

Add utility functions for block creation, execution state and others, and deduplicate a lot of code in the `worker_tests` and `wasm_worker_tests`.

## Test Plan

Logically, the tests should be unchanged. This is just a refactoring.

## Links

N/A

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
