### PR TITLE
Implement readme test for ScyllaDb

### DIFF
--- a/docker/local-tests/run-server.sh
+++ b/docker/local-tests/run-server.sh
@@ -8,6 +8,9 @@ SHARD_ID="$(hostname | cut -f4 -d-)"
 ./fetch-config-file.sh genesis.json
 ./fetch-config-file.sh "server_${SERVER_ID}.json"
 
+./linera-server initialize \
+    --storage "rocksdb:shard_data.db" \
+    --genesis genesis.json
 ./linera-server run \
     --storage "rocksdb:shard_data.db" \
     --server "server_${SERVER_ID}.json" \

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -35,18 +35,20 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStoreClient, linera_views::rocks_db::create_rocks_db_common_config,
-    tokio::sync::Semaphore,
+    linera_views::rocks_db::RocksDbKvStoreConfig, tokio::sync::Semaphore,
 };
 
 #[cfg(feature = "aws")]
 use {
     linera_storage::DynamoDbStoreClient,
+    linera_views::dynamo_db::DynamoDbKvStoreConfig,
     linera_views::dynamo_db::{create_dynamo_db_common_config, LocalStackTestContext},
 };
 
 #[cfg(feature = "scylladb")]
 use {
     linera_storage::ScyllaDbStoreClient, linera_views::scylla_db::create_scylla_db_common_config,
+    linera_views::scylla_db::ScyllaDbKvStoreConfig,
 };
 
 #[cfg(any(feature = "aws", feature = "scylladb"))]
@@ -616,11 +618,15 @@ impl StoreBuilder for MakeRocksDbStoreClient {
 
     async fn build(&mut self) -> Result<Self::Store, anyhow::Error> {
         let dir = tempfile::TempDir::new()?;
-        let path = dir.path().to_path_buf();
+        let path_buf = dir.path().to_path_buf();
         self.temp_dirs.push(dir);
         let common_config = create_rocks_db_common_config();
+        let store_config = RocksDbKvStoreConfig {
+            path_buf,
+            common_config,
+        };
         let (store_client, _) =
-            RocksDbStoreClient::new_for_testing(path, self.wasm_runtime, common_config).await?;
+            RocksDbStoreClient::new_for_testing(store_config, self.wasm_runtime).await?;
         Ok(store_client)
     }
 }
@@ -660,14 +666,14 @@ impl StoreBuilder for MakeDynamoDbStoreClient {
         let table = format!("{}_{}", table, self.instance_counter);
         let table_name = table.parse()?;
         let common_config = create_dynamo_db_common_config();
-        self.instance_counter += 1;
-        let (store_client, _) = DynamoDbStoreClient::new_for_testing(
+        let store_config = DynamoDbKvStoreConfig {
             config,
             table_name,
             common_config,
-            self.wasm_runtime,
-        )
-        .await?;
+        };
+        self.instance_counter += 1;
+        let (store_client, _) =
+            DynamoDbStoreClient::new_for_testing(store_config, self.wasm_runtime).await?;
         Ok(store_client)
     }
 }
@@ -716,13 +722,13 @@ impl StoreBuilder for MakeScyllaDbStoreClient {
         let table_name = get_table_name().await;
         let table_name = format!("{}_{}", table_name, self.instance_counter);
         let common_config = create_scylla_db_common_config();
-        let (store_client, _) = ScyllaDbStoreClient::new_for_testing(
-            &self.uri,
+        let store_config = ScyllaDbKvStoreConfig {
+            uri: self.uri.clone(),
             table_name,
             common_config,
-            self.wasm_runtime,
-        )
-        .await?;
+        };
+        let (store_client, _) =
+            ScyllaDbStoreClient::new_for_testing(store_config, self.wasm_runtime).await?;
         Ok(store_client)
     }
 }

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(any(feature = "rocksdb", feature = "aws", feature = "scylladb"))]
+
 use linera_base::{data_types::Amount, identifiers::ChainId};
 use linera_indexer_graphql_client::{
     indexer::{plugins, state, Plugins, State},
@@ -71,11 +73,6 @@ const TRANSFER_DELAY_MILLIS: u64 = 1000;
 #[cfg(not(debug_assertions))]
 const TRANSFER_DELAY_MILLIS: u64 = 100;
 
-#[test_log::test(tokio::test)]
-async fn test_memory_end_to_end_operations_indexer() {
-    run_end_to_end_operations_indexer(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_end_to_end_operations_indexer() {
@@ -101,7 +98,7 @@ async fn run_end_to_end_operations_indexer(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
     local_net.run().await.unwrap();

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -5,7 +5,10 @@ use crate::{
     common::IndexerError,
     runner::{IndexerConfig, Runner},
 };
-use linera_views::{common::CommonStoreConfig, rocks_db::RocksDbClient};
+use linera_views::{
+    common::CommonStoreConfig,
+    rocks_db::{RocksDbClient, RocksDbKvStoreConfig},
+};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -23,9 +26,6 @@ pub struct RocksDbConfig {
     /// The maximal number of entries in the storage cache.
     #[structopt(long, default_value = "1000")]
     cache_size: usize,
-    /// Do not create a table if one is missing
-    #[structopt(long = "do not create a database if missing")]
-    skip_table_creation_when_missing: bool,
 }
 
 pub type RocksDbRunner = Runner<RocksDbClient, RocksDbConfig>;
@@ -33,16 +33,16 @@ pub type RocksDbRunner = Runner<RocksDbClient, RocksDbConfig>;
 impl RocksDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
         let config = IndexerConfig::<RocksDbConfig>::from_args();
-        let (client, _) = RocksDbClient::new(
-            &config.client.storage,
-            CommonStoreConfig {
-                max_concurrent_queries: config.client.max_concurrent_queries,
-                max_stream_queries: config.client.max_stream_queries,
-                cache_size: config.client.cache_size,
-                create_if_missing: !config.client.skip_table_creation_when_missing,
-            },
-        )
-        .await?;
+        let common_config = CommonStoreConfig {
+            max_concurrent_queries: config.client.max_concurrent_queries,
+            max_stream_queries: config.client.max_stream_queries,
+            cache_size: config.client.cache_size,
+        };
+        let store_config = RocksDbKvStoreConfig {
+            path_buf: config.client.storage.as_path().to_path_buf(),
+            common_config,
+        };
+        let client = RocksDbClient::initialize(store_config).await?;
         Self::new(config, client).await
     }
 }

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -5,7 +5,10 @@ use crate::{
     common::IndexerError,
     runner::{IndexerConfig, Runner},
 };
-use linera_views::{common::CommonStoreConfig, scylla_db::ScyllaDbClient};
+use linera_views::{
+    common::CommonStoreConfig,
+    scylla_db::{ScyllaDbClient, ScyllaDbKvStoreConfig},
+};
 use structopt::StructOpt;
 
 #[derive(StructOpt, Clone, Debug)]
@@ -24,9 +27,6 @@ pub struct ScyllaDbConfig {
     /// The maximal number of entries in the storage cache.
     #[structopt(long, default_value = "1000")]
     cache_size: usize,
-    /// Do not create a table if one is missing
-    #[structopt(long = "do not create a database if missing")]
-    skip_table_creation_when_missing: bool,
 }
 
 pub type ScyllaDbRunner = Runner<ScyllaDbClient, ScyllaDbConfig>;
@@ -34,17 +34,17 @@ pub type ScyllaDbRunner = Runner<ScyllaDbClient, ScyllaDbConfig>;
 impl ScyllaDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
         let config = IndexerConfig::<ScyllaDbConfig>::from_args();
-        let (client, _) = ScyllaDbClient::new(
-            &config.client.uri,
-            config.client.table.clone(),
-            CommonStoreConfig {
-                max_concurrent_queries: config.client.max_concurrent_queries,
-                max_stream_queries: config.client.max_stream_queries,
-                cache_size: config.client.cache_size,
-                create_if_missing: !config.client.skip_table_creation_when_missing,
-            },
-        )
-        .await?;
+        let common_config = CommonStoreConfig {
+            max_concurrent_queries: config.client.max_concurrent_queries,
+            max_stream_queries: config.client.max_stream_queries,
+            cache_size: config.client.cache_size,
+        };
+        let store_config = ScyllaDbKvStoreConfig {
+            uri: config.client.uri.clone(),
+            table_name: config.client.table.clone(),
+            common_config,
+        };
+        let (client, _) = ScyllaDbClient::new(store_config).await?;
         Self::new(config, client).await
     }
 }

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(any(feature = "rocksdb", feature = "aws", feature = "scylladb"))]
+
 use linera_service::client::resolve_binary;
 use once_cell::sync::Lazy;
 use std::{io::Read, rc::Rc};
@@ -30,11 +32,6 @@ async fn transfer(client: &reqwest::Client, url: &str, from: ChainId, to: ChainI
         .unwrap();
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_end_to_end_queries() {
-    run_end_to_end_queries(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_end_to_end_queries() {
@@ -59,7 +56,7 @@ async fn run_end_to_end_queries(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
     local_net.generate_initial_validator_config().await.unwrap();
 
     client.create_genesis_config().await.unwrap();

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -82,6 +82,10 @@ matching-engine = { workspace = true }
 amm = { workspace = true }
 
 [[bin]]
+name = "linera-db"
+path = "src/database_tool.rs"
+
+[[bin]]
 name = "linera"
 path = "src/linera.rs"
 

--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -1,0 +1,186 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_service::storage::StorageConfig;
+use linera_views::common::CommonStoreConfig;
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+#[structopt(name = "Clear database", about = "A tool for cleaning up a database")]
+struct DatabaseToolOptions {
+    /// Subcommands. Acceptable values are run and generate.
+    #[structopt(subcommand)]
+    command: DatabaseToolCommand,
+}
+
+#[derive(StructOpt)]
+enum DatabaseToolCommand {
+    /// Subcommands. Acceptable values are delete_all, delete_single, initialize
+
+    /// Delete all the entries of the database
+    #[structopt(name = "delete_all")]
+    DeleteAll {
+        /// Storage configuration for the blockchain history.
+        #[structopt(long = "storage")]
+        storage_config: String,
+
+        /// The maximal number of simultaneous queries to the database
+        #[structopt(long)]
+        max_concurrent_queries: Option<usize>,
+
+        /// The maximal number of simultaneous stream queries to the database
+        #[structopt(long, default_value = "10")]
+        max_stream_queries: usize,
+
+        /// The maximal number of entries in the storage cache.
+        #[structopt(long, default_value = "1000")]
+        cache_size: usize,
+    },
+
+    /// Delete a single table from the database
+    #[structopt(name = "delete_single")]
+    DeleteSingle {
+        /// Storage configuration for the blockchain history.
+        #[structopt(long = "storage")]
+        storage_config: String,
+
+        /// The maximal number of simultaneous queries to the database
+        #[structopt(long)]
+        max_concurrent_queries: Option<usize>,
+
+        /// The maximal number of simultaneous stream queries to the database
+        #[structopt(long, default_value = "10")]
+        max_stream_queries: usize,
+
+        /// The maximal number of entries in the storage cache.
+        #[structopt(long, default_value = "1000")]
+        cache_size: usize,
+    },
+
+    /// Delete a single table from the database
+    #[structopt(name = "existence")]
+    Existence {
+        /// Storage configuration for the blockchain history.
+        #[structopt(long = "storage")]
+        storage_config: String,
+
+        /// The maximal number of simultaneous queries to the database
+        #[structopt(long)]
+        max_concurrent_queries: Option<usize>,
+
+        /// The maximal number of simultaneous stream queries to the database
+        #[structopt(long, default_value = "10")]
+        max_stream_queries: usize,
+
+        /// The maximal number of entries in the storage cache.
+        #[structopt(long, default_value = "1000")]
+        cache_size: usize,
+    },
+
+    /// Initialize a table in the database
+    #[structopt(name = "initialize")]
+    Initialize {
+        /// Storage configuration for the blockchain history.
+        #[structopt(long = "storage")]
+        storage_config: String,
+
+        /// The maximal number of simultaneous queries to the database
+        #[structopt(long)]
+        max_concurrent_queries: Option<usize>,
+
+        /// The maximal number of simultaneous stream queries to the database
+        #[structopt(long, default_value = "10")]
+        max_stream_queries: usize,
+
+        /// The maximal number of entries in the storage cache.
+        #[structopt(long, default_value = "1000")]
+        cache_size: usize,
+    },
+}
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let options = DatabaseToolOptions::from_args();
+
+    match options.command {
+        DatabaseToolCommand::DeleteAll {
+            storage_config,
+            max_concurrent_queries,
+            max_stream_queries,
+            cache_size,
+        } => {
+            let storage_config: StorageConfig = storage_config.parse()?;
+            let common_config = CommonStoreConfig {
+                max_concurrent_queries,
+                max_stream_queries,
+                cache_size,
+            };
+            let full_storage_config = storage_config.add_common_config(common_config).await?;
+            full_storage_config
+                .delete_all()
+                .await
+                .expect("successful delete_all operation");
+        }
+        DatabaseToolCommand::DeleteSingle {
+            storage_config,
+            max_concurrent_queries,
+            max_stream_queries,
+            cache_size,
+        } => {
+            let storage_config: StorageConfig = storage_config.parse()?;
+            let common_config = CommonStoreConfig {
+                max_concurrent_queries,
+                max_stream_queries,
+                cache_size,
+            };
+            let full_storage_config = storage_config.add_common_config(common_config).await?;
+            full_storage_config
+                .delete_single()
+                .await
+                .expect("successful delete_all operation");
+        }
+        DatabaseToolCommand::Existence {
+            storage_config,
+            max_concurrent_queries,
+            max_stream_queries,
+            cache_size,
+        } => {
+            let storage_config: StorageConfig = storage_config.parse()?;
+            let common_config = CommonStoreConfig {
+                max_concurrent_queries,
+                max_stream_queries,
+                cache_size,
+            };
+            let full_storage_config = storage_config.add_common_config(common_config).await?;
+            let test = full_storage_config
+                .test_existence()
+                .await
+                .expect("successful delete_all operation");
+            if test {
+                println!("The database does exist");
+            } else {
+                println!("The database does not exist");
+            }
+        }
+        DatabaseToolCommand::Initialize {
+            storage_config,
+            max_concurrent_queries,
+            max_stream_queries,
+            cache_size,
+        } => {
+            let storage_config: StorageConfig = storage_config.parse()?;
+            let common_config = CommonStoreConfig {
+                max_concurrent_queries,
+                max_stream_queries,
+                cache_size,
+            };
+            let full_storage_config = storage_config.add_common_config(common_config).await?;
+            full_storage_config
+                .initialize()
+                .await
+                .expect("successful delete_all operation");
+        }
+    }
+    tracing::info!("Successful execution of linera-db");
+    Ok(())
+}

--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -57,9 +57,9 @@ enum DatabaseToolCommand {
         cache_size: usize,
     },
 
-    /// Delete a single table from the database
-    #[structopt(name = "existence")]
-    Existence {
+    /// Check existence of a database
+    #[structopt(name = "check_existence")]
+    CheckExistence {
         /// Storage configuration for the blockchain history.
         #[structopt(long = "storage")]
         storage_config: String,
@@ -139,7 +139,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 .await
                 .expect("successful delete_all operation");
         }
-        DatabaseToolCommand::Existence {
+        DatabaseToolCommand::CheckExistence {
             storage_config,
             max_concurrent_queries,
             max_stream_queries,
@@ -157,9 +157,9 @@ async fn main() -> Result<(), anyhow::Error> {
                 .await
                 .expect("successful delete_all operation");
             if test {
-                println!("The database does exist");
+                tracing::error!("The database does exist");
             } else {
-                println!("The database does not exist");
+                tracing::error!("The database does not exist");
             }
         }
         DatabaseToolCommand::Initialize {

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -380,23 +380,25 @@ pub async fn full_initialize_storage(
     config: FullStorageConfig,
     genesis_config: &GenesisConfig,
 ) -> Result<(), anyhow::Error> {
-    let wasm_runtime = None;
     match config {
         FullStorageConfig::Memory(_) => {
             bail!("The initialization should not be called for memory");
         }
         #[cfg(feature = "rocksdb")]
         FullStorageConfig::RocksDb(store_config) => {
+            let wasm_runtime = None;
             let mut client = RocksDbStoreClient::initialize(store_config, wasm_runtime).await?;
             genesis_config.initialize_store(&mut client).await
         }
         #[cfg(feature = "aws")]
         FullStorageConfig::DynamoDb(store_config) => {
+            let wasm_runtime = None;
             let mut client = DynamoDbStoreClient::initialize(store_config, wasm_runtime).await?;
             genesis_config.initialize_store(&mut client).await
         }
         #[cfg(feature = "scylladb")]
         FullStorageConfig::ScyllaDb(store_config) => {
+            let wasm_runtime = None;
             let mut client = ScyllaDbStoreClient::initialize(store_config, wasm_runtime).await?;
             genesis_config.initialize_store(&mut client).await
         }

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -2,127 +2,76 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::config::GenesisConfig;
-use anyhow::format_err;
+use anyhow::{bail, format_err};
 use async_trait::async_trait;
 use linera_execution::WasmRuntime;
 use linera_storage::{MemoryStoreClient, Store, WallClock};
-#[cfg(feature = "aws")]
-use linera_views::dynamo_db::{get_base_config, get_localstack_config};
-use linera_views::{common::CommonStoreConfig, views::ViewError};
+use linera_views::{common::CommonStoreConfig, memory::MemoryKvStoreConfig, views::ViewError};
 use std::str::FromStr;
 
 #[cfg(feature = "rocksdb")]
-use {linera_storage::RocksDbStoreClient, std::path::PathBuf};
+use {
+    linera_storage::RocksDbStoreClient,
+    linera_views::rocks_db::{RocksDbClient, RocksDbKvStoreConfig},
+    std::path::PathBuf,
+};
 
 #[cfg(feature = "aws")]
-use {linera_storage::DynamoDbStoreClient, linera_views::dynamo_db::TableName};
+use {
+    linera_storage::DynamoDbStoreClient,
+    linera_views::dynamo_db::{get_config, DynamoDbClient, DynamoDbKvStoreConfig, TableName},
+};
 
 #[cfg(feature = "scylladb")]
-use {anyhow::bail, linera_storage::ScyllaDbStoreClient};
+use {
+    linera_storage::ScyllaDbStoreClient,
+    linera_views::scylla_db::{ScyllaDbClient, ScyllaDbKvStoreConfig},
+};
 
-#[cfg(any(feature = "rocksdb", feature = "aws", feature = "scylladb"))]
-use linera_views::common::TableStatus;
+/// The Full storage input to the constructor of the database client.
+#[allow(clippy::large_enum_variant)]
+pub enum FullStorageConfig {
+    /// The memory key value store
+    Memory(MemoryKvStoreConfig),
+    /// The RocksDb key value store
+    #[cfg(feature = "rocksdb")]
+    RocksDb(RocksDbKvStoreConfig),
+    /// The DynamoDb key value store
+    #[cfg(feature = "aws")]
+    DynamoDb(DynamoDbKvStoreConfig),
+    /// The ScyllaDb key value store
+    #[cfg(feature = "scylladb")]
+    ScyllaDb(ScyllaDbKvStoreConfig),
+}
 
 /// The description of a storage implementation.
 #[derive(Debug)]
 #[cfg_attr(any(test), derive(Eq, PartialEq))]
 pub enum StorageConfig {
+    /// The memory description
     Memory,
+    /// The RocksDb description
     #[cfg(feature = "rocksdb")]
     RocksDb {
+        /// The path used
         path: PathBuf,
     },
+    /// The DynamoDb description
     #[cfg(feature = "aws")]
     DynamoDb {
+        /// The table name used
         table: TableName,
+        /// Whether to use the localstack system
         use_localstack: bool,
     },
+    /// The ScyllaDb description
     #[cfg(feature = "scylladb")]
     ScyllaDb {
+        /// The URI for accessing the database
         uri: String,
+        /// The table name
         table_name: String,
     },
-}
-
-#[async_trait]
-pub trait Runnable {
-    type Output;
-
-    async fn run<S>(self, storage: S) -> Result<Self::Output, anyhow::Error>
-    where
-        S: Store + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>;
-}
-
-impl StorageConfig {
-    pub async fn run_with_storage<Job>(
-        &self,
-        config: &GenesisConfig,
-        wasm_runtime: Option<WasmRuntime>,
-        common_config: CommonStoreConfig,
-        job: Job,
-    ) -> Result<Job::Output, anyhow::Error>
-    where
-        Job: Runnable,
-    {
-        use StorageConfig::*;
-        match self {
-            Memory => {
-                let mut client = MemoryStoreClient::new(
-                    wasm_runtime,
-                    common_config.max_stream_queries,
-                    WallClock,
-                );
-                config.initialize_store(&mut client).await?;
-                job.run(client).await
-            }
-            #[cfg(feature = "rocksdb")]
-            RocksDb { path } => {
-                if !common_config.create_if_missing {
-                    std::fs::create_dir_all(path)?;
-                }
-                let (mut client, table_status) =
-                    RocksDbStoreClient::new(path.clone(), wasm_runtime, common_config).await?;
-                if table_status == TableStatus::New {
-                    config.initialize_store(&mut client).await?;
-                }
-                job.run(client).await
-            }
-            #[cfg(feature = "aws")]
-            DynamoDb {
-                table,
-                use_localstack,
-            } => {
-                let (mut client, table_status) = if *use_localstack {
-                    let config = get_localstack_config().await?;
-                    DynamoDbStoreClient::new(config, table.clone(), common_config, wasm_runtime)
-                        .await?
-                } else {
-                    let config = get_base_config().await?;
-                    DynamoDbStoreClient::new(&config, table.clone(), common_config, wasm_runtime)
-                        .await?
-                };
-                if table_status == TableStatus::New {
-                    config.initialize_store(&mut client).await?;
-                }
-                job.run(client).await
-            }
-            #[cfg(feature = "scylladb")]
-            ScyllaDb { uri, table_name } => {
-                let (mut client, table_status) = ScyllaDbStoreClient::new(
-                    uri,
-                    table_name.to_string(),
-                    common_config,
-                    wasm_runtime,
-                )
-                .await?;
-                if table_status == TableStatus::New {
-                    config.initialize_store(&mut client).await?;
-                }
-                job.run(client).await
-            }
-        }
-    }
 }
 
 const MEMORY: &str = "memory";
@@ -214,7 +163,264 @@ impl FromStr for StorageConfig {
             let table_name = table_name.unwrap_or("table_storage".to_string());
             return Ok(Self::ScyllaDb { uri, table_name });
         }
-        Err(format_err!("Incorrect storage description: {}", input))
+        print!("available storage: memory");
+        #[cfg(feature = "rocksdb")]
+        print!(", rocksdb");
+        #[cfg(feature = "aws")]
+        print!(", dynamodb");
+        #[cfg(feature = "scylladb")]
+        print!(", scyladb");
+        println!();
+        Err(format_err!("The input has not matched: {}", input))
+    }
+}
+
+impl StorageConfig {
+    /// The addition of the common config to get a full configuration
+    pub async fn add_common_config(
+        &self,
+        common_config: CommonStoreConfig,
+    ) -> Result<FullStorageConfig, anyhow::Error> {
+        match self {
+            StorageConfig::Memory => {
+                let store_config = MemoryKvStoreConfig { common_config };
+                Ok(FullStorageConfig::Memory(store_config))
+            }
+            #[cfg(feature = "rocksdb")]
+            StorageConfig::RocksDb { path } => {
+                let path_buf = path.to_path_buf();
+                let store_config = RocksDbKvStoreConfig {
+                    path_buf,
+                    common_config,
+                };
+                Ok(FullStorageConfig::RocksDb(store_config))
+            }
+            #[cfg(feature = "aws")]
+            StorageConfig::DynamoDb {
+                table,
+                use_localstack,
+            } => {
+                let aws_config = get_config(*use_localstack).await?;
+                let store_config = DynamoDbKvStoreConfig {
+                    config: aws_config,
+                    table_name: table.clone(),
+                    common_config,
+                };
+                Ok(FullStorageConfig::DynamoDb(store_config))
+            }
+            #[cfg(feature = "scylladb")]
+            StorageConfig::ScyllaDb { uri, table_name } => {
+                let store_config = ScyllaDbKvStoreConfig {
+                    uri: uri.to_string(),
+                    table_name: table_name.to_string(),
+                    common_config,
+                };
+                Ok(FullStorageConfig::ScyllaDb(store_config))
+            }
+        }
+    }
+}
+
+impl FullStorageConfig {
+    /// Deletes all the entries in the database
+    pub async fn delete_all(self) -> Result<(), ViewError> {
+        match self {
+            FullStorageConfig::Memory(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "delete_all does not make sense for memory storage".to_string(),
+            }),
+            #[cfg(feature = "rocksdb")]
+            FullStorageConfig::RocksDb(store_config) => {
+                RocksDbClient::delete_all(store_config).await?;
+                Ok(())
+            }
+            #[cfg(feature = "aws")]
+            FullStorageConfig::DynamoDb(store_config) => {
+                DynamoDbClient::delete_all(store_config).await?;
+                Ok(())
+            }
+            #[cfg(feature = "scylladb")]
+            FullStorageConfig::ScyllaDb(store_config) => {
+                ScyllaDbClient::delete_all(store_config).await?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Deletes only one table of the database
+    pub async fn delete_single(self) -> Result<(), ViewError> {
+        match self {
+            FullStorageConfig::Memory(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "delete_single does not make sense for memory storage".to_string(),
+            }),
+            #[cfg(feature = "rocksdb")]
+            FullStorageConfig::RocksDb(store_config) => {
+                RocksDbClient::delete_single(store_config).await?;
+                Ok(())
+            }
+            #[cfg(feature = "aws")]
+            FullStorageConfig::DynamoDb(store_config) => {
+                DynamoDbClient::delete_single(store_config).await?;
+                Ok(())
+            }
+            #[cfg(feature = "scylladb")]
+            FullStorageConfig::ScyllaDb(store_config) => {
+                ScyllaDbClient::delete_single(store_config).await?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Test existence of one table in the database
+    pub async fn test_existence(self) -> Result<bool, ViewError> {
+        match self {
+            FullStorageConfig::Memory(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "existence not make sense for memory storage".to_string(),
+            }),
+            #[cfg(feature = "rocksdb")]
+            FullStorageConfig::RocksDb(store_config) => {
+                Ok(RocksDbClient::test_existence(store_config).await?)
+            }
+            #[cfg(feature = "aws")]
+            FullStorageConfig::DynamoDb(store_config) => {
+                Ok(DynamoDbClient::test_existence(store_config).await?)
+            }
+            #[cfg(feature = "scylladb")]
+            FullStorageConfig::ScyllaDb(store_config) => {
+                Ok(ScyllaDbClient::test_existence(store_config).await?)
+            }
+        }
+    }
+
+    /// Deletes only one table of the database
+    pub async fn initialize(self) -> Result<(), ViewError> {
+        match self {
+            FullStorageConfig::Memory(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "delete_single does not make sense for memory storage".to_string(),
+            }),
+            #[cfg(feature = "rocksdb")]
+            FullStorageConfig::RocksDb(store_config) => {
+                RocksDbClient::initialize(store_config).await?;
+                Ok(())
+            }
+            #[cfg(feature = "aws")]
+            FullStorageConfig::DynamoDb(store_config) => {
+                DynamoDbClient::initialize(store_config).await?;
+                Ok(())
+            }
+            #[cfg(feature = "scylladb")]
+            FullStorageConfig::ScyllaDb(store_config) => {
+                ScyllaDbClient::initialize(store_config).await?;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[async_trait]
+pub trait Runnable {
+    type Output;
+
+    async fn run<S>(self, storage: S) -> Result<Self::Output, anyhow::Error>
+    where
+        S: Store + Clone + Send + Sync + 'static,
+        ViewError: From<S::ContextError>;
+}
+
+// The design is that the initialization of the accounts should be separate
+// from the running of the database.
+// However, that does not apply to the memory client which must be initialized
+// in the same context in which it is used.
+#[allow(unused_variables)]
+pub async fn run_with_storage<Job>(
+    config: FullStorageConfig,
+    genesis_config: &GenesisConfig,
+    wasm_runtime: Option<WasmRuntime>,
+    job: Job,
+) -> Result<Job::Output, anyhow::Error>
+where
+    Job: Runnable,
+{
+    match config {
+        FullStorageConfig::Memory(store_config) => {
+            let mut client = MemoryStoreClient::new(
+                wasm_runtime,
+                store_config.common_config.max_stream_queries,
+                WallClock,
+            );
+            genesis_config.initialize_store(&mut client).await?;
+            job.run(client).await
+        }
+        #[cfg(feature = "rocksdb")]
+        FullStorageConfig::RocksDb(store_config) => {
+            let (client, table_status) =
+                RocksDbStoreClient::new(store_config, wasm_runtime).await?;
+            job.run(client).await
+        }
+        #[cfg(feature = "aws")]
+        FullStorageConfig::DynamoDb(store_config) => {
+            let (client, table_status) =
+                DynamoDbStoreClient::new(store_config, wasm_runtime).await?;
+            job.run(client).await
+        }
+        #[cfg(feature = "scylladb")]
+        FullStorageConfig::ScyllaDb(store_config) => {
+            let (client, table_status) =
+                ScyllaDbStoreClient::new(store_config, wasm_runtime).await?;
+            job.run(client).await
+        }
+    }
+}
+
+#[allow(unused_variables)]
+pub async fn full_initialize_storage(
+    config: FullStorageConfig,
+    genesis_config: &GenesisConfig,
+) -> Result<(), anyhow::Error> {
+    let wasm_runtime = None;
+    match config {
+        FullStorageConfig::Memory(_) => {
+            bail!("The initialization should not be called for memory");
+        }
+        #[cfg(feature = "rocksdb")]
+        FullStorageConfig::RocksDb(store_config) => {
+            let mut client = RocksDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            genesis_config.initialize_store(&mut client).await
+        }
+        #[cfg(feature = "aws")]
+        FullStorageConfig::DynamoDb(store_config) => {
+            let mut client = DynamoDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            genesis_config.initialize_store(&mut client).await
+        }
+        #[cfg(feature = "scylladb")]
+        FullStorageConfig::ScyllaDb(store_config) => {
+            let mut client = ScyllaDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            genesis_config.initialize_store(&mut client).await
+        }
+    }
+}
+
+#[allow(unused_variables)]
+pub async fn test_existence_storage(config: FullStorageConfig) -> Result<bool, anyhow::Error> {
+    match config {
+        FullStorageConfig::Memory(_) => {
+            bail!("The initialization should not be called for memory");
+        }
+        #[cfg(feature = "rocksdb")]
+        FullStorageConfig::RocksDb(store_config) => {
+            Ok(RocksDbClient::test_existence(store_config).await?)
+        }
+        #[cfg(feature = "aws")]
+        FullStorageConfig::DynamoDb(store_config) => {
+            Ok(DynamoDbClient::test_existence(store_config).await?)
+        }
+        #[cfg(feature = "scylladb")]
+        FullStorageConfig::ScyllaDb(store_config) => {
+            Ok(ScyllaDbClient::test_existence(store_config).await?)
+        }
     }
 }
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2,6 +2,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(any(feature = "rocksdb", feature = "aws", feature = "scylladb"))]
+
 mod common;
 
 use common::INTEGRATION_TEST_GUARD;
@@ -49,12 +51,11 @@ async fn test_scylla_db_end_to_end_reconfiguration_simple() {
     run_end_to_end_reconfiguration(Database::ScyllaDb, Network::Simple).await;
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_reconfiguration(database: Database, network: Network) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client = local_net.make_client(network);
-    let client_2 = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
+    let mut client_2 = local_net.make_client(network);
 
     let servers = local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
@@ -65,7 +66,7 @@ async fn run_end_to_end_reconfiguration(database: Database, network: Network) {
 
     let (node_service_2, chain_2) = match network {
         Network::Grpc => {
-            let chain_2 = client.open_and_assign(&client_2).await.unwrap();
+            let chain_2 = client.open_and_assign(&mut client_2).await.unwrap();
             let node_service_2 = client_2.run_node_service(8081).await.unwrap();
             (Some(node_service_2), chain_2)
         }
@@ -157,11 +158,6 @@ async fn run_end_to_end_reconfiguration(database: Database, network: Network) {
     }
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_open_chain_node_service() {
-    run_open_chain_node_service(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_open_chain_node_service() {
@@ -186,7 +182,7 @@ async fn run_open_chain_node_service(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
     local_net.run().await.unwrap();
@@ -269,11 +265,6 @@ async fn run_open_chain_node_service(database: Database) {
     panic!("Failed to receive new block");
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_end_to_end_retry_notification_stream() {
-    run_end_to_end_retry_notification_stream(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_end_to_end_retry_notification_stream() {
@@ -299,8 +290,8 @@ async fn run_end_to_end_retry_notification_stream(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 1).unwrap();
-    let client1 = local_net.make_client(network);
-    let client2 = local_net.make_client(network);
+    let mut client1 = local_net.make_client(network);
+    let mut client2 = local_net.make_client(network);
 
     // Create initial server and client config.
     local_net.generate_initial_validator_config().await.unwrap();
@@ -373,14 +364,13 @@ async fn test_scylla_db_end_to_end_multiple_wallets() {
     run_end_to_end_multiple_wallets(Database::ScyllaDb).await
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_multiple_wallets(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create local_net and two clients.
     let mut local_net = LocalNetwork::new(database, Network::Grpc, 4).unwrap();
-    let client_1 = local_net.make_client(Network::Grpc);
-    let client_2 = local_net.make_client(Network::Grpc);
+    let mut client_1 = local_net.make_client(Network::Grpc);
+    let mut client_2 = local_net.make_client(Network::Grpc);
 
     // Create initial server and client config.
     local_net.generate_initial_validator_config().await.unwrap();
@@ -426,11 +416,6 @@ async fn run_end_to_end_multiple_wallets(database: Database) {
     assert_eq!(client_2.query_balance(chain_2).await.unwrap(), "3.");
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_project_new() {
-    run_project_new(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_project_new() {
@@ -464,11 +449,6 @@ async fn run_project_new(database: Database) {
         .unwrap();
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_project_test() {
-    run_project_test(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_project_test() {
@@ -498,11 +478,6 @@ async fn run_project_test(database: Database) {
         .await;
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_project_publish() {
-    run_project_publish(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_project_publish() {
@@ -528,7 +503,7 @@ async fn run_project_publish(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 1).unwrap();
-    let client = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
@@ -546,11 +521,6 @@ async fn run_project_publish(database: Database) {
     let node_service = client.run_node_service(None).await.unwrap();
 
     assert_eq!(node_service.try_get_applications_uri(&chain).await.len(), 1)
-}
-
-#[test_log::test(tokio::test)]
-async fn test_memory_example_publish() {
-    run_example_publish(Database::Memory).await
 }
 
 #[cfg(feature = "rocksdb")]
@@ -578,7 +548,7 @@ async fn run_example_publish(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 1).unwrap();
-    let client = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
@@ -616,14 +586,13 @@ async fn test_scylla_db_end_to_end_open_multi_owner_chain() {
     run_end_to_end_open_multi_owner_chain(Database::ScyllaDb).await
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_open_multi_owner_chain(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
     let mut runner = LocalNetwork::new(database, Network::Grpc, 4).unwrap();
-    let client1 = runner.make_client(Network::Grpc);
-    let client2 = runner.make_client(Network::Grpc);
+    let mut client1 = runner.make_client(Network::Grpc);
+    let mut client2 = runner.make_client(Network::Grpc);
 
     // Create initial server and client config.
     runner.generate_initial_validator_config().await.unwrap();

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -1,20 +1,20 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(any(feature = "rocksdb", feature = "aws", feature = "scylladb"))]
+
 mod common;
 
 use async_graphql::InputType;
 use common::INTEGRATION_TEST_GUARD;
-use linera_base::{data_types::Amount, identifiers::ChainId};
+use linera_base::{
+    data_types::{Amount, Timestamp},
+    identifiers::{ApplicationId, ChainId},
+};
 use linera_service::client::{ClientWrapper, Database, LocalNetwork, Network};
 use serde_json::{json, Value};
-use std::collections::BTreeMap;
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
-use {
-    linera_base::{data_types::Timestamp, identifiers::ApplicationId},
-    std::time::Duration,
-    tracing::{info, warn},
-};
+use std::{collections::BTreeMap, time::Duration};
+use tracing::{info, warn};
 
 struct Application {
     uri: String,
@@ -122,7 +122,6 @@ impl FungibleApp {
         self.0.query(&query).await
     }
 
-    #[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
     async fn claim(&self, source: fungible::Account, target: fungible::Account, amount: Amount) {
         // Claiming tokens from chain1 to chain2.
         let query = format!(
@@ -136,17 +135,14 @@ impl FungibleApp {
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 struct SocialApp(Application);
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl From<String> for SocialApp {
     fn from(uri: String) -> Self {
         SocialApp(Application { uri })
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl SocialApp {
     async fn subscribe(&self, chain_id: ChainId) -> Value {
         let query = format!("mutation {{ requestSubscribe(field0: \"{chain_id}\") }}");
@@ -164,17 +160,14 @@ impl SocialApp {
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 struct CrowdFundingApp(Application);
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl From<String> for CrowdFundingApp {
     fn from(uri: String) -> Self {
         CrowdFundingApp(Application { uri })
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl CrowdFundingApp {
     async fn pledge_with_transfer(
         &self,
@@ -194,17 +187,14 @@ impl CrowdFundingApp {
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 struct MatchingEngineApp(Application);
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl From<String> for MatchingEngineApp {
     fn from(uri: String) -> Self {
         MatchingEngineApp(Application { uri })
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl MatchingEngineApp {
     async fn get_account_info(
         &self,
@@ -224,17 +214,14 @@ impl MatchingEngineApp {
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 struct AmmApp(Application);
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl From<String> for AmmApp {
     fn from(uri: String) -> Self {
         AmmApp(Application { uri })
     }
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 impl AmmApp {
     async fn add_liquidity(
         &self,
@@ -294,11 +281,6 @@ impl AmmApp {
     }
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_end_to_end_counter() {
-    run_end_to_end_counter(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_end_to_end_counter() {
@@ -326,7 +308,7 @@ async fn run_end_to_end_counter(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
 
     let original_counter_value = 35;
     let increment = 5;
@@ -366,11 +348,6 @@ async fn run_end_to_end_counter(database: Database) {
     node_service.assert_is_running();
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_end_to_end_counter_publish_create() {
-    run_end_to_end_counter_publish_create(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_end_to_end_counter_publish_create() {
@@ -398,7 +375,7 @@ async fn run_end_to_end_counter_publish_create(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client = local_net.make_client(network);
+    let mut client = local_net.make_client(network);
 
     let original_counter_value = 35;
     let increment = 5;
@@ -455,15 +432,14 @@ async fn test_scylla_db_end_to_end_social_user_pub_sub() {
     run_end_to_end_social_user_pub_sub(Database::ScyllaDb).await
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_social_user_pub_sub(database: Database) {
     use social::SocialAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client1 = local_net.make_client(network);
-    let client2 = local_net.make_client(network);
+    let mut client1 = local_net.make_client(network);
+    let mut client2 = local_net.make_client(network);
 
     // Create initial server and client config.
     local_net.generate_initial_validator_config().await.unwrap();
@@ -475,7 +451,7 @@ async fn run_end_to_end_social_user_pub_sub(database: Database) {
     let (contract, service) = local_net.build_example("social").await.unwrap();
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&client2).await.unwrap();
+    let chain2 = client1.open_and_assign(&mut client2).await.unwrap();
     let bytecode_id = client1
         .publish_bytecode(contract, service, None)
         .await
@@ -554,7 +530,6 @@ async fn test_scylla_db_end_to_end_fungible() {
     run_end_to_end_fungible(Database::ScyllaDb).await
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_fungible(database: Database) {
     use fungible::{FungibleTokenAbi, InitialState};
 
@@ -562,8 +537,8 @@ async fn run_end_to_end_fungible(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client1 = local_net.make_client(network);
-    let client2 = local_net.make_client(network);
+    let mut client1 = local_net.make_client(network);
+    let mut client2 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client1.create_genesis_config().await.unwrap();
@@ -574,7 +549,7 @@ async fn run_end_to_end_fungible(database: Database) {
     let (contract, service) = local_net.build_example("fungible").await.unwrap();
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&client2).await.unwrap();
+    let chain2 = client1.open_and_assign(&mut client2).await.unwrap();
 
     // The players
     let account_owner1 = get_fungible_account_owner(&client1);
@@ -668,11 +643,6 @@ async fn run_end_to_end_fungible(database: Database) {
     node_service2.assert_is_running();
 }
 
-#[test_log::test(tokio::test)]
-async fn test_memory_end_to_end_same_wallet_fungible() {
-    run_end_to_end_same_wallet_fungible(Database::Memory).await
-}
-
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_end_to_end_same_wallet_fungible() {
@@ -700,7 +670,7 @@ async fn run_end_to_end_same_wallet_fungible(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client1 = local_net.make_client(network);
+    let mut client1 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client1.create_genesis_config().await.unwrap();
@@ -791,7 +761,6 @@ async fn test_scylla_db_end_to_end_crowd_funding() {
     run_end_to_end_crowd_funding(Database::ScyllaDb).await
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_crowd_funding(database: Database) {
     use crowd_funding::{CrowdFundingAbi, InitializationArgument};
     use fungible::{FungibleTokenAbi, InitialState};
@@ -800,8 +769,8 @@ async fn run_end_to_end_crowd_funding(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client1 = local_net.make_client(network);
-    let client2 = local_net.make_client(network);
+    let mut client1 = local_net.make_client(network);
+    let mut client2 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client1.create_genesis_config().await.unwrap();
@@ -812,7 +781,7 @@ async fn run_end_to_end_crowd_funding(database: Database) {
     let (contract_fungible, service_fungible) = local_net.build_example("fungible").await.unwrap();
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&client2).await.unwrap();
+    let chain2 = client1.open_and_assign(&mut client2).await.unwrap();
 
     // The players
     let account_owner1 = get_fungible_account_owner(&client1); // operator
@@ -935,7 +904,6 @@ async fn test_scylla_db_end_to_end_matching_engine() {
     run_end_to_end_matching_engine(Database::ScyllaDb).await
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_matching_engine(database: Database) {
     use fungible::{FungibleTokenAbi, InitialState};
     use matching_engine::{OrderNature, Parameters, Price};
@@ -944,9 +912,9 @@ async fn run_end_to_end_matching_engine(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client_admin = local_net.make_client(network);
-    let client_a = local_net.make_client(network);
-    let client_b = local_net.make_client(network);
+    let mut client_admin = local_net.make_client(network);
+    let mut client_a = local_net.make_client(network);
+    let mut client_b = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client_admin.create_genesis_config().await.unwrap();
@@ -960,8 +928,8 @@ async fn run_end_to_end_matching_engine(database: Database) {
         local_net.build_example("matching-engine").await.unwrap();
 
     let chain_admin = client_admin.get_wallet().default_chain().unwrap();
-    let chain_a = client_admin.open_and_assign(&client_a).await.unwrap();
-    let chain_b = client_admin.open_and_assign(&client_b).await.unwrap();
+    let chain_a = client_admin.open_and_assign(&mut client_a).await.unwrap();
+    let chain_b = client_admin.open_and_assign(&mut client_b).await.unwrap();
 
     // The players
     let owner_admin = get_fungible_account_owner(&client_admin);
@@ -1201,7 +1169,6 @@ async fn test_scylla_db_end_to_end_amm() {
     run_end_to_end_amm(Database::ScyllaDb).await
 }
 
-#[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_end_to_end_amm(database: Database) {
     use fungible::InitialState;
     use matching_engine::Parameters;
@@ -1210,9 +1177,9 @@ async fn run_end_to_end_amm(database: Database) {
 
     let network = Network::Grpc;
     let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
-    let client_admin = local_net.make_client(network);
-    let client0 = local_net.make_client(network);
-    let client1 = local_net.make_client(network);
+    let mut client_admin = local_net.make_client(network);
+    let mut client0 = local_net.make_client(network);
+    let mut client1 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client_admin.create_genesis_config().await.unwrap();
@@ -1227,8 +1194,8 @@ async fn run_end_to_end_amm(database: Database) {
     let chain_admin = client_admin.get_wallet().default_chain().unwrap();
 
     // User chains
-    let chain0 = client_admin.open_and_assign(&client0).await.unwrap();
-    let chain1 = client_admin.open_and_assign(&client1).await.unwrap();
+    let chain0 = client_admin.open_and_assign(&mut client0).await.unwrap();
+    let chain1 = client_admin.open_and_assign(&mut client1).await.unwrap();
 
     // Admin user
     let owner_admin = get_fungible_account_owner(&client_admin);

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -5,8 +5,8 @@ use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient, WallClock};
 use dashmap::DashMap;
 use linera_execution::WasmRuntime;
 use linera_views::{
-    common::{CommonStoreConfig, TableStatus},
-    dynamo_db::{Config, DynamoDbClient, DynamoDbContextError, TableName},
+    common::TableStatus,
+    dynamo_db::{DynamoDbClient, DynamoDbContextError, DynamoDbKvStoreConfig},
 };
 use std::sync::Arc;
 #[cfg(any(test, feature = "test"))]
@@ -27,13 +27,10 @@ type DynamoDbStore = DbStore<DynamoDbClient>;
 impl DynamoDbStore {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        config: Config,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (client, table_status) =
-            DynamoDbClient::new_for_testing(config, table, common_config).await?;
+        let (client, table_status) = DynamoDbClient::new_for_testing(store_config).await?;
         let store = Self {
             client,
             guards: ChainGuards::default(),
@@ -43,13 +40,25 @@ impl DynamoDbStore {
         Ok((store, table_status))
     }
 
+    pub async fn initialize(
+        store_config: DynamoDbKvStoreConfig,
+        wasm_runtime: Option<WasmRuntime>,
+    ) -> Result<Self, DynamoDbContextError> {
+        let client = DynamoDbClient::initialize(store_config).await?;
+        let store = Self {
+            client,
+            guards: ChainGuards::default(),
+            user_applications: Arc::new(DashMap::new()),
+            wasm_runtime,
+        };
+        Ok(store)
+    }
+
     pub async fn new(
-        config: Config,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (client, table_status) = DynamoDbClient::new(config, table, common_config).await?;
+        let (client, table_status) = DynamoDbClient::new(store_config).await?;
         let store = Self {
             client,
             guards: ChainGuards::default(),
@@ -69,26 +78,23 @@ impl DynamoDbStoreClient<TestClock> {
         let table_name = table.parse().expect("Invalid table name");
         let localstack = LocalStackTestContext::new().await.expect("localstack");
         let common_config = create_dynamo_db_common_config();
-        let (client, _) = DynamoDbStoreClient::new_for_testing(
-            localstack.dynamo_db_config(),
+        let store_config = DynamoDbKvStoreConfig {
+            config: localstack.dynamo_db_config(),
             table_name,
             common_config,
-            wasm_runtime,
-        )
-        .await
-        .expect("client and table_name");
+        };
+        let (client, _) = DynamoDbStoreClient::new_for_testing(store_config, wasm_runtime)
+            .await
+            .expect("client and table_name");
         client
     }
 
     pub async fn new_for_testing(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let (store, table_status) =
-            DynamoDbStore::new_for_testing(config.into(), table, common_config, wasm_runtime)
-                .await?;
+            DynamoDbStore::new_for_testing(store_config, wasm_runtime).await?;
         let store_client = DynamoDbStoreClient {
             client: Arc::new(store),
             clock: TestClock::new(),
@@ -98,14 +104,23 @@ impl DynamoDbStoreClient<TestClock> {
 }
 
 impl DynamoDbStoreClient<WallClock> {
+    pub async fn initialize(
+        store_config: DynamoDbKvStoreConfig,
+        wasm_runtime: Option<WasmRuntime>,
+    ) -> Result<Self, DynamoDbContextError> {
+        let store = DynamoDbStore::initialize(store_config, wasm_runtime).await?;
+        let store_client = DynamoDbStoreClient {
+            client: Arc::new(store),
+            clock: WallClock,
+        };
+        Ok(store_client)
+    }
+
     pub async fn new(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (store, table_status) =
-            DynamoDbStore::new(config.into(), table, common_config, wasm_runtime).await?;
+        let (store, table_status) = DynamoDbStore::new(store_config, wasm_runtime).await?;
         let store_client = DynamoDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -4,10 +4,10 @@
 use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
-    common::{CommonStoreConfig, TableStatus},
-    rocks_db::{RocksDbClient, RocksDbContextError},
+    common::TableStatus,
+    rocks_db::{RocksDbClient, RocksDbContextError, RocksDbKvStoreConfig},
 };
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 
 #[cfg(any(test, feature = "test"))]
 use {crate::TestClock, linera_views::rocks_db::create_rocks_db_common_config, tempfile::TempDir};
@@ -21,11 +21,10 @@ type RocksDbStore = DbStore<RocksDbClient>;
 impl RocksDbStore {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        dir: PathBuf,
+        store_config: RocksDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
-        common_config: CommonStoreConfig,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
-        let (client, table_status) = RocksDbClient::new_for_testing(dir, common_config).await?;
+        let (client, table_status) = RocksDbClient::new_for_testing(store_config).await?;
         let store = Self {
             client,
             guards: ChainGuards::default(),
@@ -35,12 +34,25 @@ impl RocksDbStore {
         Ok((store, table_status))
     }
 
-    pub async fn new(
-        dir: PathBuf,
+    pub async fn initialize(
+        store_config: RocksDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
-        common_config: CommonStoreConfig,
+    ) -> Result<Self, RocksDbContextError> {
+        let client = RocksDbClient::initialize(store_config).await?;
+        let store = Self {
+            client,
+            guards: ChainGuards::default(),
+            user_applications: Arc::default(),
+            wasm_runtime,
+        };
+        Ok(store)
+    }
+
+    pub async fn new(
+        store_config: RocksDbKvStoreConfig,
+        wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
-        let (client, table_status) = RocksDbClient::new(dir, common_config).await?;
+        let (client, table_status) = RocksDbClient::new(store_config).await?;
         let store = Self {
             client,
             guards: ChainGuards::default(),
@@ -57,25 +69,24 @@ pub type RocksDbStoreClient<C> = DbStoreClient<RocksDbClient, C>;
 impl RocksDbStoreClient<TestClock> {
     pub async fn make_test_client(wasm_runtime: Option<WasmRuntime>) -> Self {
         let dir = TempDir::new().unwrap();
+        let path_buf = dir.path().to_path_buf();
         let common_config = create_rocks_db_common_config();
-        let (store_client, _) = RocksDbStoreClient::new_for_testing(
-            dir.path().to_path_buf(),
-            wasm_runtime,
+        let store_config = RocksDbKvStoreConfig {
+            path_buf,
             common_config,
-        )
-        .await
-        .expect("store_client");
+        };
+        let (store_client, _) = RocksDbStoreClient::new_for_testing(store_config, wasm_runtime)
+            .await
+            .expect("store_client");
         store_client
     }
 
-    #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        path: PathBuf,
+        store_config: RocksDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
-        common_config: CommonStoreConfig,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
         let (store, table_status) =
-            RocksDbStore::new_for_testing(path, wasm_runtime, common_config).await?;
+            RocksDbStore::new_for_testing(store_config, wasm_runtime).await?;
         let store_client = RocksDbStoreClient {
             client: Arc::new(store),
             clock: TestClock::new(),
@@ -85,12 +96,23 @@ impl RocksDbStoreClient<TestClock> {
 }
 
 impl RocksDbStoreClient<WallClock> {
-    pub async fn new(
-        path: PathBuf,
+    pub async fn initialize(
+        store_config: RocksDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
-        common_config: CommonStoreConfig,
+    ) -> Result<Self, RocksDbContextError> {
+        let store = RocksDbStore::initialize(store_config, wasm_runtime).await?;
+        let store_client = RocksDbStoreClient {
+            client: Arc::new(store),
+            clock: WallClock,
+        };
+        Ok(store_client)
+    }
+
+    pub async fn new(
+        store_config: RocksDbKvStoreConfig,
+        wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
-        let (store, table_status) = RocksDbStore::new(path, wasm_runtime, common_config).await?;
+        let (store, table_status) = RocksDbStore::new(store_config, wasm_runtime).await?;
         let store_client = RocksDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -4,8 +4,8 @@
 use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
-    common::{CommonStoreConfig, TableStatus},
-    scylla_db::{ScyllaDbClient, ScyllaDbContextError},
+    common::TableStatus,
+    scylla_db::{ScyllaDbClient, ScyllaDbContextError, ScyllaDbKvStoreConfig},
 };
 use std::sync::Arc;
 
@@ -24,13 +24,10 @@ type ScyllaDbStore = DbStore<ScyllaDbClient>;
 impl ScyllaDbStore {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        uri: &str,
-        table_name: String,
-        common_config: CommonStoreConfig,
+        store_config: ScyllaDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
-        let (client, table_status) =
-            ScyllaDbClient::new_for_testing(uri, table_name, common_config).await?;
+        let (client, table_status) = ScyllaDbClient::new_for_testing(store_config).await?;
         let store = Self {
             client,
             guards: ChainGuards::default(),
@@ -40,13 +37,25 @@ impl ScyllaDbStore {
         Ok((store, table_status))
     }
 
+    pub async fn initialize(
+        store_config: ScyllaDbKvStoreConfig,
+        wasm_runtime: Option<WasmRuntime>,
+    ) -> Result<Self, ScyllaDbContextError> {
+        let client = ScyllaDbClient::initialize(store_config).await?;
+        let store = Self {
+            client,
+            guards: ChainGuards::default(),
+            user_applications: Arc::default(),
+            wasm_runtime,
+        };
+        Ok(store)
+    }
+
     pub async fn new(
-        uri: &str,
-        table_name: String,
-        common_config: CommonStoreConfig,
+        store_config: ScyllaDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
-        let (client, table_status) = ScyllaDbClient::new(uri, table_name, common_config).await?;
+        let (client, table_status) = ScyllaDbClient::new(store_config).await?;
         let store = Self {
             client,
             guards: ChainGuards::default(),
@@ -62,24 +71,26 @@ pub type ScyllaDbStoreClient<C> = DbStoreClient<ScyllaDbClient, C>;
 #[cfg(any(test, feature = "test"))]
 impl ScyllaDbStoreClient<TestClock> {
     pub async fn make_test_client(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let uri = "localhost:9042";
+        let uri = "localhost:9042".to_string();
         let table_name = get_table_name().await;
         let common_config = create_scylla_db_common_config();
-        let (client, _) =
-            ScyllaDbStoreClient::new_for_testing(uri, table_name, common_config, wasm_runtime)
-                .await
-                .expect("client");
+        let store_config = ScyllaDbKvStoreConfig {
+            uri,
+            table_name,
+            common_config,
+        };
+        let (client, _) = ScyllaDbStoreClient::new_for_testing(store_config, wasm_runtime)
+            .await
+            .expect("client");
         client
     }
 
     pub async fn new_for_testing(
-        uri: &str,
-        table_name: String,
-        common_config: CommonStoreConfig,
+        store_config: ScyllaDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let (store, table_status) =
-            ScyllaDbStore::new_for_testing(uri, table_name, common_config, wasm_runtime).await?;
+            ScyllaDbStore::new_for_testing(store_config, wasm_runtime).await?;
         let store_client = ScyllaDbStoreClient {
             client: Arc::new(store),
             clock: TestClock::new(),
@@ -89,14 +100,23 @@ impl ScyllaDbStoreClient<TestClock> {
 }
 
 impl ScyllaDbStoreClient<WallClock> {
+    pub async fn initialize(
+        store_config: ScyllaDbKvStoreConfig,
+        wasm_runtime: Option<WasmRuntime>,
+    ) -> Result<Self, ScyllaDbContextError> {
+        let store = ScyllaDbStore::initialize(store_config, wasm_runtime).await?;
+        let store_client = ScyllaDbStoreClient {
+            client: Arc::new(store),
+            clock: WallClock,
+        };
+        Ok(store_client)
+    }
+
     pub async fn new(
-        uri: &str,
-        table_name: String,
-        common_config: CommonStoreConfig,
+        store_config: ScyllaDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
-        let (store, table_status) =
-            ScyllaDbStore::new(uri, table_name, common_config, wasm_runtime).await?;
+        let (store, table_status) = ScyllaDbStore::new(store_config, wasm_runtime).await?;
         let store_client = ScyllaDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -57,4 +57,3 @@ tokio-test = { workspace = true }
 
 [dev-dependencies]
 linera-views = { path = ".", features = ["test"] }
-

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -68,8 +68,6 @@ pub struct CommonStoreConfig {
     pub max_stream_queries: usize,
     /// The cache size being used.
     pub cache_size: usize,
-    /// Creates the database if missing
-    pub create_if_missing: bool,
 }
 
 /// The minimum value for the view tags. Values in 0..MIN_VIEW_TAG are used for other purposes.

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -23,7 +23,6 @@ use aws_sdk_dynamodb::{
     types::{Blob, SdkError},
     Client,
 };
-use aws_types::SdkConfig;
 use futures::future::join_all;
 use serde::{Deserialize, Serialize};
 use static_assertions as sa;
@@ -36,6 +35,7 @@ use {
     crate::lru_caching::TEST_CACHE_SIZE,
     anyhow::{Context, Error},
     aws_sdk_s3::Endpoint,
+    aws_types::SdkConfig,
     std::env,
     tokio::sync::{Mutex, MutexGuard},
 };
@@ -591,27 +591,90 @@ impl DynamoDbClientInternal {
     /// Creates a new [`DynamoDbClientInternal`] instance from scratch using the provided `config` parameters.
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let client = Client::from_conf(config.into());
-        if Self::test_table_existence(&client, &table).await? {
-            client.delete_table().table_name(&table.0).send().await?;
+        let client = Client::from_conf(store_config.config);
+        if Self::test_table_existence(&client, &store_config.table_name).await? {
+            client
+                .delete_table()
+                .table_name(&store_config.table_name.0)
+                .send()
+                .await?;
         }
         let stop_if_table_exists = true;
-        Self::new_internal(client, table, common_config, stop_if_table_exists).await
+        let create_if_missing = true;
+        Self::new_internal(
+            client,
+            store_config.table_name,
+            store_config.common_config,
+            stop_if_table_exists,
+            create_if_missing,
+        )
+        .await
+    }
+
+    /// Testing the existence of a table
+    pub async fn test_existence(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<bool, DynamoDbContextError> {
+        let client = Client::from_conf(store_config.config);
+        Self::test_table_existence(&client, &store_config.table_name).await
+    }
+
+    async fn delete_all(store_config: DynamoDbKvStoreConfig) -> Result<(), DynamoDbContextError> {
+        let client = Client::from_conf(store_config.config);
+        clear_tables(&client).await?;
+        Ok(())
+    }
+
+    async fn delete_single(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<(), DynamoDbContextError> {
+        let client = Client::from_conf(store_config.config);
+        client
+            .delete_table()
+            .table_name(&store_config.table_name.0)
+            .send()
+            .await?;
+        Ok(())
     }
 
     /// Creates a new [`DynamoDbClientInternal`] instance using the provided `config` parameters.
     pub async fn new(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let client = Client::from_conf(config.into());
+        let client = Client::from_conf(store_config.config);
         let stop_if_table_exists = false;
-        Self::new_internal(client, table, common_config, stop_if_table_exists).await
+        let create_if_missing = false;
+        Self::new_internal(
+            client,
+            store_config.table_name,
+            store_config.common_config,
+            stop_if_table_exists,
+            create_if_missing,
+        )
+        .await
+    }
+
+    /// Initializes a RocksDB database from a specified path.
+    pub async fn initialize(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<Self, DynamoDbContextError> {
+        let client = Client::from_conf(store_config.config);
+        let stop_if_table_exists = false;
+        let create_if_missing = true;
+        let (client, table_status) = Self::new_internal(
+            client,
+            store_config.table_name,
+            store_config.common_config,
+            stop_if_table_exists,
+            create_if_missing,
+        )
+        .await?;
+        if table_status == TableStatus::Existing {
+            return Err(DynamoDbContextError::AlreadyExistingDatabase);
+        }
+        Ok(client)
     }
 
     /// Creates a new [`DynamoDbClientInternal`] instance using the provided `config` parameters.
@@ -620,7 +683,9 @@ impl DynamoDbClientInternal {
         table: TableName,
         common_config: CommonStoreConfig,
         stop_if_table_exists: bool,
+        create_if_missing: bool,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
+        let kv_name = format!("table={:?} common_config={:?}", table, common_config);
         let mut existing_table = Self::test_table_existence(&client, &table).await?;
         let semaphore = common_config
             .max_concurrent_queries
@@ -633,10 +698,11 @@ impl DynamoDbClientInternal {
             max_stream_queries,
         };
         if !existing_table {
-            if common_config.create_if_missing {
+            if create_if_missing {
                 existing_table = db.create_table(stop_if_table_exists).await?;
             } else {
-                return Err(DynamoDbContextError::MissingDatabase);
+                tracing::info!("DynamoDb: Missing database for kv_name={}", kv_name);
+                return Err(DynamoDbContextError::MissingDatabase(kv_name));
             }
         }
         let table_status = if existing_table {
@@ -898,39 +964,69 @@ impl DynamoDbClient {
     /// Creates a `DynamoDbClient` from scratch with an LRU cache
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (client, table_name) =
-            DynamoDbClientInternal::new_for_testing(config, table, common_config.clone()).await?;
+        let cache_size = store_config.common_config.cache_size;
+        let (client, table_status) = DynamoDbClientInternal::new_for_testing(store_config).await?;
         let client = ValueSplittingKeyValueStoreClient::new(client);
         let client = Self {
-            client: LruCachingKeyValueClient::new(client, common_config.cache_size),
+            client: LruCachingKeyValueClient::new(client, cache_size),
         };
-        Ok((client, table_name))
+        Ok((client, table_status))
+    }
+
+    /// Initializes a `DynamoDbClient`.
+    pub async fn initialize(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<Self, DynamoDbContextError> {
+        let cache_size = store_config.common_config.cache_size;
+        let client = DynamoDbClientInternal::initialize(store_config).await?;
+        let client = ValueSplittingKeyValueStoreClient::new(client);
+        let client = Self {
+            client: LruCachingKeyValueClient::new(client, cache_size),
+        };
+        Ok(client)
+    }
+
+    /// Deletes all the tables from the database
+    pub async fn test_existence(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<bool, DynamoDbContextError> {
+        DynamoDbClientInternal::test_existence(store_config).await
+    }
+
+    /// Deletes all the tables from the database
+    pub async fn delete_all(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<(), DynamoDbContextError> {
+        DynamoDbClientInternal::delete_all(store_config).await
+    }
+
+    /// Deletes a single table from the database
+    pub async fn delete_single(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<(), DynamoDbContextError> {
+        DynamoDbClientInternal::delete_single(store_config).await
     }
 
     /// Creates a `DynamoDbClient` with an LRU cache
     pub async fn new(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (client, table_name) =
-            DynamoDbClientInternal::new(config, table, common_config.clone()).await?;
+        let cache_size = store_config.common_config.cache_size;
+        let (client, table_name) = DynamoDbClientInternal::new(store_config).await?;
         let client = ValueSplittingKeyValueStoreClient::new(client);
         let client = Self {
-            client: LruCachingKeyValueClient::new(client, common_config.cache_size),
+            client: LruCachingKeyValueClient::new(client, cache_size),
         };
         Ok((client, table_name))
     }
 }
 
 /// Gets the AWS configuration from the environment
-pub async fn get_base_config() -> Result<SdkConfig, DynamoDbContextError> {
+pub async fn get_base_config() -> Result<Config, DynamoDbContextError> {
     let base_config = aws_config::load_from_env().await;
-    Ok(base_config)
+    Ok((&base_config).into())
 }
 
 /// Gets the localstack config
@@ -939,6 +1035,26 @@ pub async fn get_localstack_config() -> Result<Config, DynamoDbContextError> {
     Ok(aws_sdk_dynamodb::config::Builder::from(&base_config)
         .endpoint_resolver(localstack::get_endpoint()?)
         .build())
+}
+
+/// Getting a configuration for the system
+pub async fn get_config(use_localstack: bool) -> Result<Config, DynamoDbContextError> {
+    if use_localstack {
+        get_localstack_config().await
+    } else {
+        get_base_config().await
+    }
+}
+
+/// The initial configuration of the system
+#[derive(Debug)]
+pub struct DynamoDbKvStoreConfig {
+    /// The AWS configuration
+    pub config: Config,
+    /// The table_name used
+    pub table_name: TableName,
+    /// The common configuration of the key value store
+    pub common_config: CommonStoreConfig,
 }
 
 /// An implementation of [`Context`][trait1] based on [`DynamoDbClient`].
@@ -953,14 +1069,11 @@ where
     /// Creates a new [`DynamoDbContext`] instance from scratch from the given AWS configuration.
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
         base_key: Vec<u8>,
         extra: E,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (db, table_status) =
-            DynamoDbClient::new_for_testing(config, table, common_config).await?;
+        let (db, table_status) = DynamoDbClient::new_for_testing(store_config).await?;
         let storage = DynamoDbContext {
             db,
             base_key,
@@ -971,13 +1084,11 @@ where
 
     /// Creates a new [`DynamoDbContext`] instance from the given AWS configuration.
     pub async fn new(
-        config: impl Into<Config>,
-        table: TableName,
-        common_config: CommonStoreConfig,
+        store_config: DynamoDbKvStoreConfig,
         base_key: Vec<u8>,
         extra: E,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (db, table_status) = DynamoDbClient::new(config, table, common_config).await?;
+        let (db, table_status) = DynamoDbClient::new(store_config).await?;
         let storage = DynamoDbContext {
             db,
             base_key,
@@ -1088,7 +1199,11 @@ pub enum DynamoDbContextError {
 
     /// Missing database
     #[error("Missing database")]
-    MissingDatabase,
+    MissingDatabase(String),
+
+    /// Already existing database
+    #[error("Already existing database")]
+    AlreadyExistingDatabase,
 
     /// The length of the value should be at most 400KB.
     #[error("The DynamoDB value should be less than 400KB")]
@@ -1271,27 +1386,32 @@ pub fn create_dynamo_db_common_config() -> CommonStoreConfig {
         max_concurrent_queries: Some(TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES),
         max_stream_queries: TEST_DYNAMO_DB_MAX_STREAM_QUERIES,
         cache_size: TEST_CACHE_SIZE,
-        create_if_missing: true,
     }
 }
 
 /// Creates a basic client that can be used for tests.
 #[cfg(any(test, feature = "test"))]
 pub async fn create_dynamo_db_test_client() -> DynamoDbClient {
-    let localstack = LocalStackTestContext::new().await.expect("localstack");
     let common_config = create_dynamo_db_common_config();
     let table = get_table_name().await;
     let table_name = table.parse().expect("Invalid table name");
-    let (key_value_operation, _) =
-        DynamoDbClient::new_for_testing(localstack.dynamo_db_config(), table_name, common_config)
-            .await
-            .expect("key_value_operation");
+    let use_localstack = true;
+    let config = get_config(use_localstack).await.expect("config");
+    let store_config = DynamoDbKvStoreConfig {
+        config,
+        table_name,
+        common_config,
+    };
+    let (key_value_operation, _) = DynamoDbClient::new_for_testing(store_config)
+        .await
+        .expect("key_value_operation");
     key_value_operation
 }
 
 /// Helper function to list the names of tables registered on DynamoDB.
-#[cfg(any(test, feature = "test"))]
-pub async fn list_tables(client: &aws_sdk_dynamodb::Client) -> Result<Vec<String>, Error> {
+pub async fn list_tables(
+    client: &aws_sdk_dynamodb::Client,
+) -> Result<Vec<String>, DynamoDbContextError> {
     Ok(client
         .list_tables()
         .send()
@@ -1301,8 +1421,7 @@ pub async fn list_tables(client: &aws_sdk_dynamodb::Client) -> Result<Vec<String
 }
 
 /// Helper function to clear all the tables from the database
-#[cfg(any(test, feature = "test"))]
-pub async fn clear_tables(client: &aws_sdk_dynamodb::Client) -> Result<(), Error> {
+pub async fn clear_tables(client: &aws_sdk_dynamodb::Client) -> Result<(), DynamoDbContextError> {
     let tables = list_tables(client).await?;
     for table in tables {
         client.delete_table().table_name(&table).send().await?;

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_interval, ContextFromDb, KeyValueStoreClient},
+    common::{get_interval, CommonStoreConfig, ContextFromDb, KeyValueStoreClient},
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
 };
@@ -11,6 +11,13 @@ use async_lock::{Mutex, MutexGuardArc, RwLock};
 use async_trait::async_trait;
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 use thiserror::Error;
+
+/// The initial configuration of the system
+#[derive(Debug)]
+pub struct MemoryKvStoreConfig {
+    /// The common configuration of the key value store
+    pub common_config: CommonStoreConfig,
+}
 
 /// The number of streams for the test
 pub const TEST_MEMORY_MAX_STREAM_QUERIES: usize = 10;

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -9,13 +9,14 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::{
+    fs,
     ops::{Bound, Bound::Excluded},
-    path::Path,
+    path::PathBuf,
     sync::Arc,
 };
 use thiserror::Error;
 #[cfg(any(test, feature = "test"))]
-use {crate::lru_caching::TEST_CACHE_SIZE, std::fs, tempfile::TempDir};
+use {crate::lru_caching::TEST_CACHE_SIZE, tempfile::TempDir};
 
 /// The number of streams for the test
 pub const TEST_ROCKS_DB_MAX_STREAM_QUERIES: usize = 10;
@@ -32,6 +33,15 @@ pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
 pub struct RocksDbClientInternal {
     db: Arc<DB>,
     max_stream_queries: usize,
+}
+
+/// The initial configuration of the system
+#[derive(Clone, Debug)]
+pub struct RocksDbKvStoreConfig {
+    /// The AWS configuration
+    pub path_buf: PathBuf,
+    /// The common configuration of the key value store
+    pub common_config: CommonStoreConfig,
 }
 
 #[async_trait]
@@ -174,9 +184,11 @@ pub struct RocksDbClient {
 
 impl RocksDbClient {
     /// Returns whether a table already exists.
-    pub async fn test_existence<P: AsRef<Path>>(path: &P) -> Result<bool, RocksDbContextError> {
+    pub async fn test_existence(
+        store_config: RocksDbKvStoreConfig,
+    ) -> Result<bool, RocksDbContextError> {
         let options = rocksdb::Options::default();
-        let result = DB::open(&options, path);
+        let result = DB::open(&options, store_config.path_buf.clone());
         match result {
             Ok(_) => Ok(true),
             Err(error) => match error.kind() {
@@ -188,42 +200,87 @@ impl RocksDbClient {
 
     /// Creates a RocksDB database for unit tests from a specified path.
     #[cfg(any(test, feature = "test"))]
-    pub async fn new_for_testing<P: AsRef<Path>>(
-        path: P,
-        common_config: CommonStoreConfig,
+    pub async fn new_for_testing(
+        store_config: RocksDbKvStoreConfig,
     ) -> Result<(RocksDbClient, TableStatus), RocksDbContextError> {
-        fs::remove_dir_all(&path)?;
-        Self::new(path, common_config).await
+        let path = store_config.path_buf.as_path();
+        fs::remove_dir_all(path)?;
+        let create_if_missing = true;
+        Self::new_internal(store_config, create_if_missing).await
+    }
+
+    /// Creates all RocksDB databases
+    pub async fn delete_all(store_config: RocksDbKvStoreConfig) -> Result<(), RocksDbContextError> {
+        let path = store_config.path_buf.as_path();
+        fs::remove_dir_all(path)?;
+        Ok(())
+    }
+
+    /// Creates all RocksDB databases
+    pub async fn delete_single(
+        store_config: RocksDbKvStoreConfig,
+    ) -> Result<(), RocksDbContextError> {
+        let path = store_config.path_buf.as_path();
+        fs::remove_dir_all(path)?;
+        Ok(())
     }
 
     /// Creates a RocksDB database from a specified path.
-    pub async fn new<P: AsRef<Path>>(
-        path: P,
-        common_config: CommonStoreConfig,
+    pub async fn new(
+        store_config: RocksDbKvStoreConfig,
     ) -> Result<(RocksDbClient, TableStatus), RocksDbContextError> {
+        let create_if_missing = false;
+        Self::new_internal(store_config, create_if_missing).await
+    }
+
+    /// Initializes a RocksDB database from a specified path.
+    pub async fn initialize(
+        store_config: RocksDbKvStoreConfig,
+    ) -> Result<Self, RocksDbContextError> {
+        let create_if_missing = true;
+        let (client, table_status) = Self::new_internal(store_config, create_if_missing).await?;
+        if table_status == TableStatus::Existing {
+            return Err(RocksDbContextError::AlreadyExistingDatabase);
+        }
+        Ok(client)
+    }
+
+    /// Creates a RocksDB database from a specified path.
+    async fn new_internal(
+        store_config: RocksDbKvStoreConfig,
+        create_if_missing: bool,
+    ) -> Result<(RocksDbClient, TableStatus), RocksDbContextError> {
+        let kv_name = format!(
+            "store_config={:?} create_if_missing={:?}",
+            store_config, create_if_missing
+        );
+        let path = store_config.path_buf.as_path();
+        let cache_size = store_config.common_config.cache_size;
+        let max_stream_queries = store_config.common_config.max_stream_queries;
         let mut options = rocksdb::Options::default();
-        let test = Self::test_existence(&path).await?;
+        let test = Self::test_existence(store_config.clone()).await?;
         let table_status = if test {
             TableStatus::Existing
         } else {
             TableStatus::New
         };
-        let db = if common_config.create_if_missing {
+        let db = if create_if_missing {
             options.create_if_missing(true);
             DB::open(&options, path)?
         } else {
             if !test {
-                return Err(RocksDbContextError::MissingDatabase);
+                tracing::info!("RocksDb: Missing database for kv_name={}", kv_name);
+                return Err(RocksDbContextError::MissingDatabase(kv_name));
             }
             DB::open(&options, path)?
         };
         let client = RocksDbClientInternal {
             db: Arc::new(db),
-            max_stream_queries: common_config.max_stream_queries,
+            max_stream_queries,
         };
         let client = ValueSplittingKeyValueStoreClient::new(client);
         let client = Self {
-            client: LruCachingKeyValueClient::new(client, common_config.cache_size),
+            client: LruCachingKeyValueClient::new(client, cache_size),
         };
         Ok((client, table_status))
     }
@@ -236,7 +293,6 @@ pub fn create_rocks_db_common_config() -> CommonStoreConfig {
         max_concurrent_queries: None,
         max_stream_queries: TEST_ROCKS_DB_MAX_STREAM_QUERIES,
         cache_size: TEST_CACHE_SIZE,
-        create_if_missing: true,
     }
 }
 
@@ -244,8 +300,13 @@ pub fn create_rocks_db_common_config() -> CommonStoreConfig {
 #[cfg(any(test, feature = "test"))]
 pub async fn create_rocks_db_test_client() -> RocksDbClient {
     let dir = TempDir::new().unwrap();
+    let path_buf = dir.path().to_path_buf();
     let common_config = create_rocks_db_common_config();
-    let (client, _) = RocksDbClient::new_for_testing(dir, common_config)
+    let store_config = RocksDbKvStoreConfig {
+        path_buf,
+        common_config,
+    };
+    let (client, _) = RocksDbClient::new_for_testing(store_config)
         .await
         .expect("client");
     client
@@ -331,7 +392,11 @@ pub enum RocksDbContextError {
 
     /// Missing database
     #[error("Missing database")]
-    MissingDatabase,
+    MissingDatabase(String),
+
+    /// Already existing database
+    #[error("Already existing database")]
+    AlreadyExistingDatabase,
 
     /// Filesystem error
     #[error("Filesystem error")]

--- a/linera-views/src/unit_tests/dynamo_db_context_tests.rs
+++ b/linera-views/src/unit_tests/dynamo_db_context_tests.rs
@@ -4,23 +4,22 @@
 use super::{DynamoDbContext, TableName, TableStatus};
 use crate::dynamo_db::{
     clear_tables, create_dynamo_db_common_config, list_tables, DynamoDbContextError,
-    LocalStackTestContext,
+    DynamoDbKvStoreConfig, LocalStackTestContext,
 };
 use anyhow::Error;
 
 async fn get_table_status(
     localstack: &LocalStackTestContext,
-    table: &TableName,
+    table_name: &TableName,
 ) -> Result<TableStatus, DynamoDbContextError> {
     let common_config = create_dynamo_db_common_config();
-    let (_storage, table_status) = DynamoDbContext::new(
-        localstack.dynamo_db_config(),
-        table.clone(),
+    let store_config = DynamoDbKvStoreConfig {
+        config: localstack.dynamo_db_config(),
+        table_name: table_name.clone(),
         common_config,
-        vec![],
-        (),
-    )
-    .await?;
+    };
+    let (_storage, table_status) =
+        DynamoDbContext::new_for_testing(store_config, vec![], ()).await?;
     Ok(table_status)
 }
 

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -47,6 +47,10 @@ do
 
     for J in $(seq 0 $((SHARDS_PER_VALIDATOR - 1)))
     do
+        ./linera-server initialize --storage rocksdb:server_"$I"_"$J".db --genesis genesis.json
+    done
+    for J in $(seq 0 $((SHARDS_PER_VALIDATOR - 1)))
+    do
         ./linera-server run --storage rocksdb:server_"$I"_"$J".db --server server_"$I".json --shard "$J" --genesis genesis.json &
     done
 done


### PR DESCRIPTION
## Motivation

The readme test was missing for ScyllaDb, this PR addresses it. This forces a number of changes.

## Proposal

The restructuration is wide-ranging for this simple operation:
* The handling of the different storage has been moved from `storage.rs` to a new file `aggregator.rs` in the linera_views. This is done because the aggregation of the storages is functionally different from what we do with it.
* The `create_if_missing` is eliminated. Instead, when calling `new`, you should have an existing database. If you want to create a new one, then use the `new_for_testing` which is used for the tests.
* For non-test related use, there is a call to `initialize` added to a `linera.rs` and `server.rs` and a new `linera-db` program for initializing.
* The `linera-db` does 3 different operations: delete_all, delete_single, and initialize. Each of those functionality is added to the storage.
* The README.md has been changed so as to handle the storage as input. This allows to simplify `readme_test.rs` and make a nicer code.
* For the initialization of the storage, we now have a single type `RocksDbKvStoreConfig` and similar. It is not as simple as I would like, the AWS has a `Config` that does not implement `Clone` and `Debug`. But that works for the time being.
* There is a corresponding `FullStorageConfig`. Whether we should unify with `StorageConfig` is another issue. Probably to be done when we have the configuration in a file.
* The `Path` type used in `RocksDb` is not clonable and so on. So, instead I use `PathBuf`. Not sure if correct use, but it is very nice here.
* The `TableStatus` has been left though it likely could be removed at least in pub facing interfaces.

So, it is clear that there are more steps to be done. But the PR is already big enough.

## Test Plan

The CI does the job.

## Links

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [ ] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
