### PR TITLE
rename linera-execution::ApplicationId into GenericApplicationId

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -317,7 +317,7 @@ impl<A> Debug for ApplicationId<A> {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename = "UserApplicationId")]
+#[serde(rename = "ApplicationId")]
 struct SerializableApplicationId {
     pub bytecode_id: BytecodeId,
     pub creation: MessageId,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -20,7 +20,7 @@ use linera_base::{
 };
 use linera_execution::{
     system::{Account, SystemMessage},
-    ApplicationId, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView, Message,
+    ExecutionResult, ExecutionRuntimeContext, ExecutionStateView, GenericApplicationId, Message,
     MessageContext, OperationContext, Query, QueryContext, RawExecutionResult, RawOutgoingMessage,
     Response, UserApplicationDescription, UserApplicationId,
 };
@@ -520,7 +520,7 @@ where
             match result {
                 ExecutionResult::System(result) => {
                     self.process_raw_execution_result(
-                        ApplicationId::System,
+                        GenericApplicationId::System,
                         Message::System,
                         messages,
                         height,
@@ -530,7 +530,7 @@ where
                 }
                 ExecutionResult::User(application_id, result) => {
                     self.process_raw_execution_result(
-                        ApplicationId::User(application_id),
+                        GenericApplicationId::User(application_id),
                         |bytes| Message::User {
                             application_id,
                             bytes,
@@ -548,7 +548,7 @@ where
 
     async fn process_raw_execution_result<E, F>(
         &mut self,
-        application_id: ApplicationId,
+        application_id: GenericApplicationId,
         lift: F,
         messages: &mut Vec<OutgoingMessage>,
         height: BlockHeight,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -12,7 +12,7 @@ use linera_base::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    ApplicationId, BytecodeLocation, Message, Operation,
+    BytecodeLocation, GenericApplicationId, Message, Operation,
 };
 use serde::{de::Deserializer, Deserialize, Serialize};
 use std::{
@@ -137,7 +137,7 @@ pub struct Target {
 /// A channel name together with its application id.
 pub struct ChannelFullName {
     /// The application owning the channel.
-    pub application_id: ApplicationId,
+    pub application_id: GenericApplicationId,
     /// The name of the channel.
     pub name: ChannelName,
 }

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -27,8 +27,8 @@ use linera_chain::{
 use linera_execution::{
     committee::Epoch,
     system::{SystemChannel, SystemMessage, SystemOperation},
-    ApplicationId, Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription,
-    ExecutionStateView, Message, Operation, OperationContext, SystemExecutionState,
+    Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
+    GenericApplicationId, Message, Operation, OperationContext, SystemExecutionState,
     UserApplicationDescription, UserApplicationId, WasmApplication, WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, Store};
@@ -338,7 +338,7 @@ where
         parameters: vec![],
     };
     let publish_admin_channel = ChannelFullName {
-        application_id: ApplicationId::System,
+        application_id: GenericApplicationId::System,
         name: SystemChannel::PublishedBytecodes.name(),
     };
     let create_block = make_child_block(&subscribe_certificate.value)

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -30,7 +30,7 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
     system::{Account, AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
-    ApplicationId, ChainOwnership, ChannelSubscription, ExecutionStateView, Message, Query,
+    ChainOwnership, ChannelSubscription, ExecutionStateView, GenericApplicationId, Message, Query,
     Response, SystemExecutionState, SystemQuery, SystemResponse,
 };
 use linera_storage::{MemoryStoreClient, Store};
@@ -2195,7 +2195,7 @@ where
         name: SystemChannel::Admin.name(),
     };
     let admin_channel_full_name = ChannelFullName {
-        application_id: ApplicationId::System,
+        application_id: GenericApplicationId::System,
         name: SystemChannel::Admin.name(),
     };
     let admin_channel_origin = Origin::channel(admin_id, admin_channel_full_name.clone());

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -49,7 +49,7 @@ impl GenericApplicationId {
 }
 
 /// Alias for `linera_base::identifiers::ApplicationId`. Use this alias in the core
-/// protocol where the distinction with the more general enum [`ApplicationId`] matters.
+/// protocol where the distinction with the more general enum [`GenericApplicationId`] matters.
 pub type UserApplicationId<A = ()> = linera_base::identifiers::ApplicationId<A>;
 
 /// Description of the necessary information to run a user application.

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -31,16 +31,16 @@ mod applications_tests;
 
 /// A unique identifier for an application.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
-pub enum ApplicationId {
+pub enum GenericApplicationId {
     /// The system application.
     System,
     /// A user application.
     User(UserApplicationId),
 }
 
-impl ApplicationId {
+impl GenericApplicationId {
     pub fn user_application_id(&self) -> Option<&UserApplicationId> {
-        if let ApplicationId::User(app_id) = self {
+        if let GenericApplicationId::User(app_id) = self {
             Some(app_id)
         } else {
             None
@@ -79,9 +79,9 @@ impl From<&UserApplicationDescription> for UserApplicationId {
     }
 }
 
-impl From<UserApplicationId> for ApplicationId {
+impl From<UserApplicationId> for GenericApplicationId {
     fn from(user_application_id: UserApplicationId) -> Self {
-        ApplicationId::User(user_application_id)
+        GenericApplicationId::User(user_application_id)
     }
 }
 

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -18,7 +18,7 @@ use std::collections::BTreeMap;
 
 doc_scalar!(
     GenericApplicationId,
-    "A unique identifier for an application"
+    "A unique identifier for a user application or for the system application"
 );
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
 doc_scalar!(ChainOwnership, "Represents the owner(s) of a chain");

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -4,7 +4,7 @@
 use crate::{
     committee::{Committee, Epoch, ValidatorName, ValidatorState},
     system::{Recipient, UserData},
-    ApplicationId, Bytecode, ChainOwnership, ChannelSubscription, ExecutionStateView,
+    Bytecode, ChainOwnership, ChannelSubscription, ExecutionStateView, GenericApplicationId,
     SystemExecutionStateView, UserApplicationDescription,
 };
 use async_graphql::{Error, Object};
@@ -16,7 +16,10 @@ use linera_base::{
 use linera_views::{common::Context, views::ViewError};
 use std::collections::BTreeMap;
 
-doc_scalar!(ApplicationId, "A unique identifier for an application");
+doc_scalar!(
+    GenericApplicationId,
+    "A unique identifier for an application"
+);
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
 doc_scalar!(ChainOwnership, "Represents the owner(s) of a chain");
 doc_scalar!(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -14,7 +14,7 @@ pub mod system;
 mod wasm;
 
 pub use applications::{
-    ApplicationId, ApplicationRegistryView, BytecodeLocation, UserApplicationDescription,
+    ApplicationRegistryView, BytecodeLocation, GenericApplicationId, UserApplicationDescription,
     UserApplicationId,
 };
 pub use execution::ExecutionStateView;
@@ -452,10 +452,10 @@ pub enum ExecutionResult {
 }
 
 impl ExecutionResult {
-    pub fn application_id(&self) -> ApplicationId {
+    pub fn application_id(&self) -> GenericApplicationId {
         match self {
-            ExecutionResult::System(_) => ApplicationId::System,
-            ExecutionResult::User(app_id, _) => ApplicationId::User(*app_id),
+            ExecutionResult::System(_) => GenericApplicationId::System,
+            ExecutionResult::User(app_id, _) => GenericApplicationId::User(*app_id),
         }
     }
 }
@@ -554,10 +554,10 @@ impl Operation {
         })
     }
 
-    pub fn application_id(&self) -> ApplicationId {
+    pub fn application_id(&self) -> GenericApplicationId {
         match self {
-            Self::System(_) => ApplicationId::System,
-            Self::User { application_id, .. } => ApplicationId::User(*application_id),
+            Self::System(_) => GenericApplicationId::System,
+            Self::User { application_id, .. } => GenericApplicationId::User(*application_id),
         }
     }
 }
@@ -585,10 +585,10 @@ impl Message {
         })
     }
 
-    pub fn application_id(&self) -> ApplicationId {
+    pub fn application_id(&self) -> GenericApplicationId {
         match self {
-            Self::System(_) => ApplicationId::System,
-            Self::User { application_id, .. } => ApplicationId::User(*application_id),
+            Self::System(_) => GenericApplicationId::System,
+            Self::User { application_id, .. } => GenericApplicationId::User(*application_id),
         }
     }
 }
@@ -616,10 +616,10 @@ impl Query {
         })
     }
 
-    pub fn application_id(&self) -> ApplicationId {
+    pub fn application_id(&self) -> GenericApplicationId {
         match self {
-            Self::System(_) => ApplicationId::System,
-            Self::User { application_id, .. } => ApplicationId::User(*application_id),
+            Self::System(_) => GenericApplicationId::System,
+            Self::User { application_id, .. } => GenericApplicationId::User(*application_id),
         }
     }
 }

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -13,7 +13,7 @@ use linera_chain::{
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
     system::{AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
-    ApplicationId, ChainOwnership, Message, Operation,
+    ChainOwnership, GenericApplicationId, Message, Operation,
 };
 use linera_rpc::RpcMessage;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
@@ -42,7 +42,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<Destination>(&samples)?;
     tracer.trace_type::<ChainDescription>(&samples)?;
     tracer.trace_type::<ChainOwnership>(&samples)?;
-    tracer.trace_type::<ApplicationId>(&samples)?;
+    tracer.trace_type::<GenericApplicationId>(&samples)?;
     tracer.trace_type::<ChainManagerInfo>(&samples)?;
     tracer.trace_type::<CrossChainRequest>(&samples)?;
     tracer.trace_type::<NodeError>(&samples)?;

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -22,6 +22,12 @@ AdminOperation:
               TYPENAME: Epoch
 Amount:
   NEWTYPESTRUCT: U128
+ApplicationId:
+  STRUCT:
+    - bytecode_id:
+        TYPENAME: BytecodeId
+    - creation:
+        TYPENAME: MessageId
 Block:
   STRUCT:
     - chain_id:
@@ -337,7 +343,7 @@ GenericApplicationId:
     1:
       User:
         NEWTYPE:
-          TYPENAME: UserApplicationId
+          TYPENAME: ApplicationId
 HandleCertificateRequest:
   STRUCT:
     - certificate:
@@ -402,7 +408,7 @@ Message:
       User:
         STRUCT:
           - application_id:
-              TYPENAME: UserApplicationId
+              TYPENAME: ApplicationId
           - bytes: BYTES
 MessageId:
   STRUCT:
@@ -538,7 +544,7 @@ Operation:
       User:
         STRUCT:
           - application_id:
-              TYPENAME: UserApplicationId
+              TYPENAME: ApplicationId
           - bytes: BYTES
 Origin:
   STRUCT:
@@ -728,7 +734,7 @@ SystemMessage:
     11:
       RequestApplication:
         NEWTYPE:
-          TYPENAME: UserApplicationId
+          TYPENAME: ApplicationId
 SystemOperation:
   ENUM:
     0:
@@ -814,14 +820,14 @@ SystemOperation:
           - initialization_argument: BYTES
           - required_application_ids:
               SEQ:
-                TYPENAME: UserApplicationId
+                TYPENAME: ApplicationId
     10:
       RequestApplication:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
           - application_id:
-              TYPENAME: UserApplicationId
+              TYPENAME: ApplicationId
     11:
       Admin:
         NEWTYPE:
@@ -839,13 +845,7 @@ UserApplicationDescription:
     - parameters: BYTES
     - required_application_ids:
         SEQ:
-          TYPENAME: UserApplicationId
-UserApplicationId:
-  STRUCT:
-    - bytecode_id:
-        TYPENAME: BytecodeId
-    - creation:
-        TYPENAME: MessageId
+          TYPENAME: ApplicationId
 UserData:
   NEWTYPESTRUCT:
     OPTION:

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -22,14 +22,6 @@ AdminOperation:
               TYPENAME: Epoch
 Amount:
   NEWTYPESTRUCT: U128
-ApplicationId:
-  ENUM:
-    0:
-      System: UNIT
-    1:
-      User:
-        NEWTYPE:
-          TYPENAME: UserApplicationId
 Block:
   STRUCT:
     - chain_id:
@@ -247,7 +239,7 @@ ChainOwnership:
 ChannelFullName:
   STRUCT:
     - application_id:
-        TYPENAME: ApplicationId
+        TYPENAME: GenericApplicationId
     - name:
         TYPENAME: ChannelName
 ChannelName:
@@ -338,6 +330,14 @@ ExecutedBlock:
           TYPENAME: OutgoingMessage
     - state_hash:
         TYPENAME: CryptoHash
+GenericApplicationId:
+  ENUM:
+    0:
+      System: UNIT
+    1:
+      User:
+        NEWTYPE:
+          TYPENAME: UserApplicationId
 HandleCertificateRequest:
   STRUCT:
     - certificate:


### PR DESCRIPTION
## Motivation

Avoid name collisions.

## Proposal

I thought we could remove `linera-execution::ApplicationId` entirely but it's tricky because of pub/sub channels.

## Test Plan

CI

## Release Plan

- [ ] All good!
- [x] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
