### PR TITLE
Changed validator protocol to Grpc

### DIFF
--- a/configuration/prod/validator_1.toml
+++ b/configuration/prod/validator_1.toml
@@ -3,8 +3,8 @@ host = "34.151.215.158"
 port = 19100
 internal_host = "validator-1"
 internal_port = 20100
-external_protocol = { Simple = "Tcp" }
-internal_protocol = { Simple = "Tcp" }
+external_protocol = "Grpc"
+internal_protocol = "Grpc"
 
 # If deploying to GCP, host should be the Kubernetes pod name
 [[shards]]


### PR DESCRIPTION
## Motivation

Prod validators should use Grpc by Default.

## Proposal

Change the validator.toml to Grpc.

## Test Plan

Coming with the Kubernetes integration tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
