### PR TITLE
Added Dockerfile for aarch64 used to run validators locally

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,87 @@
+##############################################################################
+################## Meant to be run with Google Cloud Build ##################
+##############################################################################
+
+# From the root of the repo, use the following command to run:
+#   gcloud builds submit --tag us-docker.pkg.dev/linera-io-dev/linera-docker-repo/<PACKAGE_NAME>:<VERSION_TAG> --timeout="3h" --machine-type=e2-highcpu-32
+# The package name needs that prefix so it stores it in the proper Docker container registry on GCP (Google Cloud Platform).
+# Make sure you specify the <PACKAGE_NAME> and <VERSION_TAG> you want though.
+# The --timeout and --machine-type flags are optional, but building with the default machine type
+# takes considerably longer. The default timeout is 1h, which you'll likely hit if you run with
+# the default machine type.
+
+# Stage 1 - Generate recipe file for dependencies
+FROM lukemathwalker/cargo-chef:latest-rust-slim AS chef
+
+RUN mkdir -p /opt/linera/build
+WORKDIR /opt/linera/build
+
+FROM chef as planner
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 2 - Build dependencies
+FROM chef AS cacher
+
+COPY . .
+COPY --from=planner /opt/linera/build/recipe.json recipe.json
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    clang
+
+RUN cargo chef cook --release --recipe-path recipe.json --target aarch64-unknown-linux-gnu --features kube
+
+# Stage 3 - Do actual build
+FROM chef as builder
+
+COPY . .
+
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    protobuf-compiler \
+    clang
+
+COPY --from=cacher /opt/linera/build/target target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+
+RUN cargo build --release --target aarch64-unknown-linux-gnu --bin linera --bin linera-proxy --bin linera-server --features kube \
+    && strip target/aarch64-unknown-linux-gnu/release/linera \
+    && strip target/aarch64-unknown-linux-gnu/release/linera-proxy \
+    && strip target/aarch64-unknown-linux-gnu/release/linera-server
+
+# Stage 4 - Setup running environment for container
+FROM debian:latest
+
+WORKDIR /opt/linera
+
+RUN apt-get update && apt-get install -y libssl-dev
+
+ENV BUILD_PATH=/opt/linera/build
+
+# Copying binaries
+COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera ./
+COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-server ./
+COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-proxy ./
+
+# Copying configuration files
+COPY --from=builder $BUILD_PATH/configuration/prod/validator_1.toml ./
+
+# Create configuration files for the validator according to the validator's config file.
+# * Private server states are stored in `server*.json`.
+# * `committee.json` is the public description of the Linera committee.
+RUN ./linera-server generate --validators validator_1.toml --committee committee.json
+
+# Create configuration files for 1000 user chains.
+# * Private chain states are stored in one local wallet `wallet.json`.
+# * `genesis.json` will contain the initial balances of chains as well as the initial committee.
+RUN ./linera \
+    --wallet wallet.json \
+    create-genesis-config 1000 \
+    --genesis genesis.json \
+    --initial-funding 100 \
+    --committee committee.json


### PR DESCRIPTION
## Motivation

Enable local validators for Apple Silicon built in Docker and deployed on `kind`.

## Proposal

A second Dockerfile which is customised for `aarch64`.

## Test Plan

`docker build -f Dockerfile.aarch64 .`

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
