### PR TITLE
Move some end-to-end tests back out of the Wasm-specific module.

### DIFF
--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -375,59 +375,6 @@ async fn test_end_to_end_counter_publish_create() {
 }
 
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_multiple_wallets() {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
-
-    // Create local_net and two clients.
-    let mut local_net = LocalNetwork::new(Network::Grpc, 4).unwrap();
-    let client_1 = local_net.make_client(Network::Grpc);
-    let client_2 = local_net.make_client(Network::Grpc);
-
-    // Create initial server and client config.
-    local_net.generate_initial_validator_config().await.unwrap();
-    client_1.create_genesis_config().await.unwrap();
-    client_2.wallet_init(&[]).await.unwrap();
-
-    // Start local network.
-    local_net.run().await.unwrap();
-
-    // Get some chain owned by Client 1.
-    let chain_1 = *client_1.get_wallet().chain_ids().first().unwrap();
-
-    // Generate a key for Client 2.
-    let client_2_key = client_2.keygen().await.unwrap();
-
-    // Open chain on behalf of Client 2.
-    let (message_id, chain_2) = client_1
-        .open_chain(chain_1, Some(client_2_key))
-        .await
-        .unwrap();
-
-    // Assign chain_2 to client_2_key.
-    assert_eq!(
-        chain_2,
-        client_2.assign(client_2_key, message_id).await.unwrap()
-    );
-
-    // Check initial balance of Chain 1.
-    assert_eq!(client_1.query_balance(chain_1).await.unwrap(), "10.");
-
-    // Transfer 5 units from Chain 1 to Chain 2.
-    client_1.transfer("5", chain_1, chain_2).await.unwrap();
-    client_2.synchronize_balance(chain_2).await.unwrap();
-
-    assert_eq!(client_1.query_balance(chain_1).await.unwrap(), "5.");
-    assert_eq!(client_2.query_balance(chain_2).await.unwrap(), "5.");
-
-    // Transfer 2 units from Chain 2 to Chain 1.
-    client_2.transfer("2", chain_2, chain_1).await.unwrap();
-    client_1.synchronize_balance(chain_1).await.unwrap();
-
-    assert_eq!(client_1.query_balance(chain_1).await.unwrap(), "7.");
-    assert_eq!(client_2.query_balance(chain_2).await.unwrap(), "3.");
-}
-
-#[test_log::test(tokio::test)]
 async fn test_end_to_end_social_user_pub_sub() {
     use social::SocialAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1067,66 +1014,6 @@ async fn test_end_to_end_matching_engine() {
     node_service_admin.assert_is_running();
     node_service_a.assert_is_running();
     node_service_b.assert_is_running();
-}
-
-#[test_log::test(tokio::test)]
-async fn test_end_to_end_open_multi_owner_chain() {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
-
-    // Create runner and two clients.
-    let mut runner = LocalNetwork::new(Network::Grpc, 4).unwrap();
-    let client1 = runner.make_client(Network::Grpc);
-    let client2 = runner.make_client(Network::Grpc);
-
-    // Create initial server and client config.
-    runner.generate_initial_validator_config().await.unwrap();
-    client1.create_genesis_config().await.unwrap();
-    client2.wallet_init(&[]).await.unwrap();
-
-    // Start local network.
-    runner.run().await.unwrap();
-
-    let chain1 = *client1.get_wallet().chain_ids().first().unwrap();
-
-    // Generate keys for both clients.
-    let client1_key = client1.keygen().await.unwrap();
-    let client2_key = client2.keygen().await.unwrap();
-
-    // Open chain on behalf of Client 2.
-    let (message_id, chain2) = client1
-        .open_multi_owner_chain(chain1, vec![client1_key, client2_key])
-        .await
-        .unwrap();
-
-    // Assign chain2 to client1_key.
-    assert_eq!(
-        chain2,
-        client1.assign(client1_key, message_id).await.unwrap()
-    );
-
-    // Assign chain2 to client2_key.
-    assert_eq!(
-        chain2,
-        client2.assign(client2_key, message_id).await.unwrap()
-    );
-
-    // Transfer 6 units from Chain 1 to Chain 2.
-    client1.transfer("6", chain1, chain2).await.unwrap();
-    client2.synchronize_balance(chain2).await.unwrap();
-
-    assert_eq!(client1.query_balance(chain1).await.unwrap(), "4.");
-    assert_eq!(client1.query_balance(chain2).await.unwrap(), "6.");
-    assert_eq!(client2.query_balance(chain2).await.unwrap(), "6.");
-
-    // Transfer 2 + 1 units from Chain 2 to Chain 1 using both clients.
-    client2.transfer("2", chain2, chain1).await.unwrap();
-    client1.transfer("1", chain2, chain1).await.unwrap();
-    client1.synchronize_balance(chain1).await.unwrap();
-    client2.synchronize_balance(chain2).await.unwrap();
-
-    assert_eq!(client1.query_balance(chain1).await.unwrap(), "7.");
-    assert_eq!(client1.query_balance(chain2).await.unwrap(), "3.");
-    assert_eq!(client2.query_balance(chain2).await.unwrap(), "3.");
 }
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/1013 all end-to-end tests that were conditionally compiled based on the Wasm flags were moved to a separate module.

However, some of the tests had the conditional compilation attribute by mistake: They don't actually use Wasm.

## Proposal

Move the erroneously moved tests back into the `end_to_end_tests` module.

## Test Plan

No logic is changing, and tests are only moved.

## Links

https://github.com/linera-io/linera-protocol/pull/1013

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
