### PR TITLE
Simplify Runnable trait.

### DIFF
--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1034,14 +1034,14 @@ fn read_json(string: Option<String>, path: Option<PathBuf>) -> Result<Vec<u8>, a
 }
 
 #[async_trait]
-impl<S> Runnable<S> for Job
-where
-    S: Store + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
-{
+impl Runnable for Job {
     type Output = ();
 
-    async fn run(self, storage: S) -> Result<(), anyhow::Error> {
+    async fn run<S>(self, storage: S) -> Result<(), anyhow::Error>
+    where
+        S: Store + Clone + Send + Sync + 'static,
+        ViewError: From<S::ContextError>,
+    {
         let Job(mut context, command) = self;
         use ClientCommand::*;
         match command {

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -177,14 +177,14 @@ impl ServerContext {
 }
 
 #[async_trait]
-impl<S> Runnable<S> for ServerContext
-where
-    S: Store + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
-{
+impl Runnable for ServerContext {
     type Output = ();
 
-    async fn run(self, storage: S) -> Result<(), anyhow::Error> {
+    async fn run<S>(self, storage: S) -> Result<(), anyhow::Error>
+    where
+        S: Store + Clone + Send + Sync + 'static,
+        ViewError: From<S::ContextError>,
+    {
         let listen_address = self.get_listen_address();
 
         // Run the server


### PR DESCRIPTION
## Motivation

`run_with_storage` has an unnecessarily complicated trait bound that depends on several feature flags.

## Proposal

Make the `Runnable` trait work with any `Store` implementation whose `ContextError` can be converted to a `ViewError`. That's all we really need for `run_with_storage`.

Possible alternatives:
* Add an associated `type ContextError` and require that it's `From<S::ContextError>`. In both our `Runnable` implementations that would be set to `ViewError`.
* On the other hand, we could also _remove_ the associated `type Output`, since it's always `()`.

## Test Plan

No logic has changed.

## Links

N/A

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
