### PR TITLE
Persistent volumes for shards

### DIFF
--- a/kubernetes/linera-validator/build_and_redeploy.sh
+++ b/kubernetes/linera-validator/build_and_redeploy.sh
@@ -6,6 +6,10 @@ cloud_mode=false
 port_forward=false
 do_build=true
 
+# Guard clause check if required binaries are installed
+which kind > /dev/null || { echo "Error: kind not installed." ; exit 1 ; }
+which helm > /dev/null || { echo "Error: egrep not installed." ; exit 1 ; }
+
 # Function to display script usage
 usage() {
     echo "Usage: $0 [OPTIONS]"
@@ -75,7 +79,11 @@ if [ "$cloud_mode" = true ]; then
 else
     docker_image="linera-test:latest"
     if [ "$do_build" = true ]; then
-        docker build -f ../../Dockerfile.aarch64 ../../ -t $docker_image || exit 1
+        if [ "$(uname -m)" = "x86_64" ]; then
+            docker build -f ../../Dockerfile ../../ -t $docker_image || exit 1
+        else
+            docker build -f ../../Dockerfile.aarch64 ../../ -t $docker_image || exit 1
+        fi
     fi
 
     kind create cluster

--- a/kubernetes/linera-validator/templates/server.yaml
+++ b/kubernetes/linera-validator/templates/server.yaml
@@ -18,10 +18,19 @@ metadata:
   name: shards
 spec:
   serviceName: "shards"
-  replicas: 2
+  replicas: 10
   selector:
     matchLabels:
       app: shards
+  volumeClaimTemplates:
+    - metadata:
+        name: rocksdb
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 100Mi
   template:
     metadata:
       labels:
@@ -38,7 +47,7 @@ spec:
             [
               "run",
               "--storage",
-              "rocksdb:shard_data.db",
+              "rocksdb:/usr/share/rocksdb/shard_data.db",
               "--server",
               "server_1.json",
               "--shard",
@@ -46,6 +55,9 @@ spec:
               "--genesis",
               "genesis.json",
             ]
+          volumeMounts:
+          - name: rocksdb
+            mountPath: /usr/share/rocksdb
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}


### PR DESCRIPTION
## Motivation

Shard pods used ephemeral storage meaning that if a shard died the corresponding rocksdb instance would also die.

## Proposal

Until we support ScyllaDB, this workaround introduces persistent volumes to Pods so that the rocksdb instance behind each shard is persisted even if a pod dies.

## Test Plan

Tested manually by killing a pod and verifying that the RocksDB directory is unchanged when the `ReplicaSet` controller spins up a new pod.

## Links

https://kubernetes.io/docs/concepts/storage/persistent-volumes/

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
