### PR TITLE
Report the execution step that triggered an execution error

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -31,8 +31,8 @@ pub enum ChainError {
     ArithmeticError(#[from] ArithmeticError),
     #[error("Error in view operation: {0}")]
     ViewError(#[from] ViewError),
-    #[error("Execution error: {0}")]
-    ExecutionError(#[from] ExecutionError),
+    #[error("Execution error: {0} during {1:?}")]
+    ExecutionError(ExecutionError, ChainExecutionContext),
     #[error("Pricing error: {0}")]
     PricingError(#[from] PricingError),
 
@@ -119,4 +119,12 @@ pub enum ChainError {
     InternalError(String),
     #[error("Insufficient balance to pay the fees")]
     InsufficientBalance,
+}
+
+#[derive(Debug)]
+pub enum ChainExecutionContext {
+    Query,
+    DescribeApplication,
+    IncomingMessage(u32),
+    Operation(u32),
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -23,7 +23,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{CertificateValue, ExecutedBlock},
-    ChainError,
+    ChainError, ChainExecutionContext,
 };
 use linera_execution::{
     committee::{Committee, Epoch},
@@ -1201,7 +1201,7 @@ where
             UserData::default(),
         )
         .await,
-        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. })))
+        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
     ));
     // There is no pending block, since the proposal wasn't valid at the time.
     assert!(client2.retry_pending_block().await.unwrap().is_none());
@@ -1395,7 +1395,7 @@ where
             UserData(Some(*b"I'm giving away all of my money!")),
         )
         .await,
-        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. })))
+        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
     ));
     Ok(())
 }

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -23,7 +23,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{CertificateValue, OutgoingMessage},
-    ChainError,
+    ChainError, ChainExecutionContext,
 };
 use linera_execution::{
     pricing::Pricing, Bytecode, ExecutionError, Message, Operation, SystemMessage,
@@ -578,7 +578,7 @@ where
     assert!(matches!(receiver
         .execute_operation(Operation::user(application_id, &transfer)?)
         .await,
-        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::UserError(_)))
+        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::UserError(_), ChainExecutionContext::Operation(_)))
     ));
     receiver.clear_pending_block().await;
 


### PR DESCRIPTION
## Motivation

A quick way to address #989 is to let clients remove incoming messages that fail one by one. To do so, we need better error reporting.

## Proposal

Add a second parameter `ChainExecutionContext` when converting `ExecutionError` into `ChainError`.

## Test Plan

CI

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
