### PR TITLE
More stable environment for vitest

### DIFF
--- a/linera-explorer/package.json
+++ b/linera-explorer/package.json
@@ -14,18 +14,18 @@
     "test": "vitest",
     "serve": "vite --port 3000"
   },
-    "dependencies": {
+  "dependencies": {
     "bootstrap": "^5.3",
     "bootstrap-icons": "^1.10",
     "json-formatter-js": "^2.3",
     "vue": "^3.3"
   },
-    "devDependencies": {
+  "devDependencies": {
     "@graphql-codegen/cli": "^5.0",
     "@graphql-codegen/typescript": "^4.0",
     "@vitejs/plugin-vue": "^4.2",
     "@vue/test-utils": "^2.4",
-    "happy-dom": "^10.11",
+    "jsdom": "^22.1",
     "vite": "^4.4",
     "vitest": "^0.34",
     "vue-tsc": "^1.8",

--- a/linera-explorer/src/components/utils.ts
+++ b/linera-explorer/src/components/utils.ts
@@ -13,10 +13,22 @@ export function operation_id(key: Scalars['OperationKey']['output']): string {
   return (short_crypto_hash(key.chain_id) + '-' + key.height + '-' + key.index)
 }
 
-export async function set_test_config() {
+async function set_test_config_aux() {
   await init()
   config.global.mocks.short_hash = short_crypto_hash
   config.global.mocks.short_app_id = short_app_id
   config.global.mocks.json_load = json_load
   config.global.mocks.operation_id = operation_id
+  return
+}
+
+function timeout(ms: number) : Promise<any> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function set_test_config() : Promise<void> {
+  return set_test_config_aux().catch(async () => {
+    await timeout(1000)
+    await set_test_config_aux()
+  })
 }

--- a/linera-explorer/vite.config.ts
+++ b/linera-explorer/vite.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
   plugins: [ vue() ],
   test: {
     globals: true,
-    environment: 'happy-dom',
+    environment: 'jsdom',
   }
 })


### PR DESCRIPTION
## Motivation

Explorer tests are failing because of unstability of environment or wasm file not available 

## Proposal

- retry intialization of wasm file
- change test environment from 'appy-dom' to 'jsdom'

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
