### PR TITLE
[Issue #987] Replace is_err() with suitable messages

### DIFF
--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -841,7 +841,15 @@ where
         // Insufficient funding
         assert!(matches!(
                 worker.handle_block_proposal(block_proposal).await,
-                Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
+                Err(
+                    WorkerError::ChainError(error)
+                ) if matches!(
+                    *error, 
+                    ChainError::ExecutionError(
+                        ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), 
+                        ChainExecutionContext::Operation(_)
+                    )
+                )
         ));
     }
     {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -24,7 +24,7 @@ use linera_chain::{
         HashedValue, IncomingMessage, LiteVote, Medium, Origin, OutgoingMessage,
         SignatureAggregator,
     },
-    test::{make_child_block, make_first_block, BlockTestExt},
+    test::{make_child_block, make_first_block, multi_manager, BlockTestExt, VoteTestExt},
     ChainError, ChainExecutionContext, ChainManager,
 };
 use linera_execution::{

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2931,7 +2931,7 @@ where
         let mut admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
         assert!(matches!(
             admin_chain.validate_incoming_messages().await,
-            Err(ChainError::MissingCrossChainUpdate{..})
+            Err(ChainError::MissingCrossChainUpdate { .. })
         ));
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -311,7 +311,7 @@ where
         worker
             .handle_block_proposal(bad_signature_block_proposal)
             .await,
-        Err(WorkerError::InvalidSigner { .. })
+            Err(WorkerError::CryptoError(error)) if matches!(error, CryptoError::InvalidSignature{..})
     ));
     assert!(worker
         .storage
@@ -476,7 +476,7 @@ where
         // Timestamp older than previous one
         assert!(matches!(
             worker.handle_block_proposal(block_proposal).await,
-            Err(WorkerError::InvalidTimestamp)
+            Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::InvalidBlockTimestamp{..})
         ));
     }
 }
@@ -538,7 +538,7 @@ where
         worker
             .handle_block_proposal(unknown_sender_block_proposal)
             .await,
-        Err(WorkerError::InvalidSigner { .. })
+        Err(WorkerError::InvalidOwner)
     ));
     assert!(worker
         .storage
@@ -616,7 +616,7 @@ where
 
     assert!(matches!(
         worker.handle_block_proposal(block_proposal1.clone()).await,
-        Err(WorkerError::InvalidBlockChaining)
+        Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::UnexpectedBlockHeight{..})
     ));
     assert!(worker
         .storage
@@ -657,7 +657,7 @@ where
         .is_some());
     assert!(matches!(
         worker.handle_block_proposal(block_proposal0.clone()).await,
-        Err(WorkerError::InvalidBlockChaining)
+        Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::UnexpectedBlockHeight{..})
     ));
 }
 
@@ -1297,7 +1297,7 @@ where
     assert!(matches!(worker
         .fully_handle_certificate(certificate, vec![])
         .await,
-        Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::CertificateSignatureVerificationFailed{..})));
+        Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::InactiveChain{..})));
 }
 
 #[test(tokio::test)]
@@ -3080,7 +3080,7 @@ async fn test_cross_chain_helper() {
             None,
             vec![certificate0.clone()]
         ),
-        Err(WorkerError::InvalidSigner { .. })
+        Err(WorkerError::InvalidCrossChainRequest)
     ));
 
     let helper = CrossChainUpdateHelper {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -390,8 +390,17 @@ where
         worker
             .handle_block_proposal(zero_amount_block_proposal)
             .await,
-            Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::IncorrectTransferAmount), ChainExecutionContext::Operation(_)))
-    ));
+            Err(
+                WorkerError::ChainError(error)
+            ) if matches!(
+                *error, 
+                ChainError::ExecutionError(
+                    ExecutionError::SystemError(SystemExecutionError::IncorrectTransferAmount), 
+                    ChainExecutionContext::Operation(_)
+                )
+            )
+        )
+    );
     assert!(worker
         .storage
         .load_active_chain(ChainId::root(1))
@@ -1108,7 +1117,15 @@ where
         .into_simple_proposal(&sender_key_pair);
     assert!(matches!(
         worker.handle_block_proposal(block_proposal).await,
-        Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
+        Err(
+            WorkerError::ChainError(error)
+        ) if matches!(
+            *error, 
+            ChainError::ExecutionError(
+                ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), 
+                ChainExecutionContext::Operation(_)    
+            )
+        )
     ));
     assert!(worker
         .storage

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -387,20 +387,19 @@ where
         .with_simple_transfer(Recipient::root(2), Amount::ZERO)
         .into_simple_proposal(&sender_key_pair);
     assert!(matches!(
-        worker
-            .handle_block_proposal(zero_amount_block_proposal)
-            .await,
-            Err(
-                WorkerError::ChainError(error)
-            ) if matches!(
-                *error, 
-                ChainError::ExecutionError(
-                    ExecutionError::SystemError(SystemExecutionError::IncorrectTransferAmount), 
-                    ChainExecutionContext::Operation(_)
-                )
+    worker
+        .handle_block_proposal(zero_amount_block_proposal)
+        .await,
+        Err(
+            WorkerError::ChainError(error)
+        ) if matches!(
+            *error,
+            ChainError::ExecutionError(
+                ExecutionError::SystemError(SystemExecutionError::IncorrectTransferAmount),
+                ChainExecutionContext::Operation(_)
             )
         )
-    );
+    ));
     assert!(worker
         .storage
         .load_active_chain(ChainId::root(1))
@@ -844,9 +843,9 @@ where
                 Err(
                     WorkerError::ChainError(error)
                 ) if matches!(
-                    *error, 
+                    *error,
                     ChainError::ExecutionError(
-                        ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), 
+                        ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }),
                         ChainExecutionContext::Operation(_)
                     )
                 )
@@ -1128,10 +1127,10 @@ where
         Err(
             WorkerError::ChainError(error)
         ) if matches!(
-            *error, 
+            *error,
             ChainError::ExecutionError(
-                ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), 
-                ChainExecutionContext::Operation(_)    
+                ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }),
+                ChainExecutionContext::Operation(_)
             )
         )
     ));


### PR DESCRIPTION
## Motivation

To fix #987 

## Proposal

Tried replace is_err() with suitable messages with already exisiting messages

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [ ] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
