### PR TITLE
Add utility functions for testing with different rounds.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -561,13 +561,24 @@ impl CertificateValue {
 }
 
 impl HashedValue {
-    /// Creates a `ConfirmedBlock` with round 0.
+    /// Creates a `ConfirmedBlock` value.
     pub fn new_confirmed(executed_block: ExecutedBlock) -> HashedValue {
         CertificateValue::ConfirmedBlock { executed_block }.into()
     }
 
+    /// Creates a new `ValidatedBlock` value.
     pub fn new_validated(executed_block: ExecutedBlock) -> HashedValue {
         CertificateValue::ValidatedBlock { executed_block }.into()
+    }
+
+    /// Creates a new `LeaderTimeout` value.
+    pub fn new_leader_timeout(chain_id: ChainId, height: BlockHeight, epoch: Epoch) -> HashedValue {
+        CertificateValue::LeaderTimeout {
+            chain_id,
+            height,
+            epoch,
+        }
+        .into()
     }
 
     pub fn hash(&self) -> CryptoHash {

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -5,12 +5,20 @@
 
 use linera_base::{
     crypto::KeyPair,
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, BlockHeight, RoundNumber, Timestamp},
     identifiers::ChainId,
 };
-use linera_execution::{committee::Epoch, system::Recipient, Operation, SystemOperation};
+use linera_execution::{
+    committee::{Committee, Epoch, ValidatorState},
+    pricing::Pricing,
+    system::Recipient,
+    Operation, SystemOperation,
+};
 
-use crate::data_types::{Block, BlockAndRound, BlockProposal, HashedValue, IncomingMessage};
+use crate::data_types::{
+    Block, BlockAndRound, BlockProposal, Certificate, HashedValue, IncomingMessage,
+    SignatureAggregator, Vote,
+};
 
 /// Creates a new child of the given block, with the same timestamp.
 pub fn make_child_block(parent: &HashedValue) -> Block {
@@ -59,8 +67,12 @@ pub trait BlockTestExt: Sized {
     /// Returns the block with the specified epoch.
     fn with_epoch(self, epoch: impl Into<Epoch>) -> Self;
 
-    /// Returns a block proposal with round 0, without any blobs or validated block.
-    fn into_simple_proposal(self, key_pair: &KeyPair) -> BlockProposal;
+    /// Returns a block proposal without any blobs or validated block.
+    fn into_simple_proposal(
+        self,
+        key_pair: &KeyPair,
+        round: impl Into<RoundNumber>,
+    ) -> BlockProposal;
 }
 
 impl BlockTestExt for Block {
@@ -93,15 +105,37 @@ impl BlockTestExt for Block {
         self
     }
 
-    fn into_simple_proposal(self, key_pair: &KeyPair) -> BlockProposal {
-        BlockProposal::new(
-            BlockAndRound {
-                block: self,
-                round: Default::default(),
-            },
-            key_pair,
-            vec![],
-            None,
-        )
+    fn into_simple_proposal(
+        self,
+        key_pair: &KeyPair,
+        round: impl Into<RoundNumber>,
+    ) -> BlockProposal {
+        let content = BlockAndRound {
+            block: self,
+            round: round.into(),
+        };
+        BlockProposal::new(content, key_pair, vec![], None)
+    }
+}
+
+pub trait VoteTestExt: Sized {
+    /// Returns a certificate for a committee consisting only of this validator.
+    fn into_certificate(self) -> Certificate;
+}
+
+impl VoteTestExt for Vote {
+    fn into_certificate(self) -> Certificate {
+        let state = ValidatorState {
+            network_address: "".to_string(),
+            votes: 100,
+        };
+        let committee = Committee::new(
+            vec![(self.validator, state)].into_iter().collect(),
+            Pricing::only_fuel(),
+        );
+        SignatureAggregator::new(self.value, self.round, &committee)
+            .append(self.validator, self.signature)
+            .unwrap()
+            .unwrap()
     }
 }

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -153,7 +153,7 @@ where
         }],
         state_hash: publisher_state_hash,
     });
-    let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
+    let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal, 0);
 
     let info = worker
         .fully_handle_certificate(publish_certificate.clone(), vec![])
@@ -212,7 +212,7 @@ where
         }],
         state_hash: publisher_state_hash,
     });
-    let broadcast_certificate = make_certificate(&committee, &worker, broadcast_block_proposal);
+    let broadcast_certificate = make_certificate(&committee, &worker, broadcast_block_proposal, 0);
 
     let info = worker
         .fully_handle_certificate(broadcast_certificate.clone(), vec![])
@@ -261,7 +261,7 @@ where
         }],
         state_hash: creator_state.crypto_hash().await?,
     });
-    let subscribe_certificate = make_certificate(&committee, &worker, subscribe_block_proposal);
+    let subscribe_certificate = make_certificate(&committee, &worker, subscribe_block_proposal, 0);
 
     let info = worker
         .fully_handle_certificate(subscribe_certificate.clone(), vec![])
@@ -305,7 +305,7 @@ where
         }],
         state_hash: publisher_state_hash,
     });
-    let accept_certificate = make_certificate(&committee, &worker, accept_block_proposal);
+    let accept_certificate = make_certificate(&committee, &worker, accept_block_proposal, 0);
 
     let info = worker
         .fully_handle_certificate(accept_certificate.clone(), vec![])
@@ -389,7 +389,7 @@ where
         }],
         state_hash: creator_state.crypto_hash().await?,
     });
-    let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
+    let create_certificate = make_certificate(&committee, &worker, create_block_proposal, 0);
 
     let info = worker
         .fully_handle_certificate(create_certificate.clone(), vec![])
@@ -435,7 +435,7 @@ where
         messages: vec![],
         state_hash: creator_state.crypto_hash().await?,
     });
-    let run_certificate = make_certificate(&committee, &worker, run_block_proposal);
+    let run_certificate = make_certificate(&committee, &worker, run_block_proposal, 0);
 
     let info = worker
         .fully_handle_certificate(run_certificate.clone(), vec![])


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/1024 is quite large, and difficult to review.

## Proposal

Merge some of the utility functions from https://github.com/linera-io/linera-protocol/pull/1024 separately: These will allow creating certificates in tests that use different round numbers, instead of using 0 everywhere. Also adds a constructor for the leader timeout `HashedValue`.

## Test Plan

No change in logic. This will be used in tests later.

## Links

https://github.com/linera-io/linera-protocol/pull/1024

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
