### PR TITLE
Make execute_block return an ExecutedBlock.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     data_types::{
-        Block, ChainAndHeight, ChannelFullName, Event, IncomingMessage, Medium, Origin,
-        OutgoingMessage, Target,
+        Block, ChainAndHeight, ChannelFullName, Event, ExecutedBlock, IncomingMessage, Medium,
+        Origin, OutgoingMessage, Target,
     },
     inbox::{InboxError, InboxStateView},
     outbox::OutboxStateView,
@@ -421,10 +421,7 @@ where
     /// * As usual, in case of errors, `self` may not be consistent any more and should be thrown
     ///   away.
     /// * Returns the list of messages caused by the block being executed.
-    pub async fn execute_block(
-        &mut self,
-        block: &Block,
-    ) -> Result<(Vec<OutgoingMessage>, CryptoHash), ChainError> {
+    pub async fn execute_block(&mut self, block: Block) -> Result<ExecutedBlock, ChainError> {
         assert_eq!(block.chain_id, self.chain_id());
         let chain_id = self.chain_id();
         ensure!(
@@ -519,7 +516,12 @@ where
         self.manager
             .get_mut()
             .reset(self.execution_state.system.ownership.get());
-        Ok((messages, state_hash))
+        let executed_block = ExecutedBlock {
+            block,
+            messages,
+            state_hash,
+        };
+        Ok(executed_block)
     }
 
     async fn process_execution_results(

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -8,11 +8,11 @@ pub use multi::{MultiOwnerManager, MultiOwnerManagerInfo};
 pub use single::{SingleOwnerManager, SingleOwnerManagerInfo};
 
 use crate::{
-    data_types::{BlockProposal, Certificate, LiteVote, OutgoingMessage, Vote},
+    data_types::{BlockProposal, Certificate, ExecutedBlock, LiteVote, Vote},
     ChainError,
 };
 use linera_base::{
-    crypto::{CryptoHash, KeyPair, PublicKey},
+    crypto::{KeyPair, PublicKey},
     data_types::{BlockHeight, RoundNumber},
     doc_scalar, ensure,
     identifiers::ChainId,
@@ -136,17 +136,14 @@ impl ChainManager {
     pub fn create_vote(
         &mut self,
         proposal: BlockProposal,
-        messages: Vec<OutgoingMessage>,
-        state_hash: CryptoHash,
+        executed_block: ExecutedBlock,
         key_pair: Option<&KeyPair>,
     ) {
         match self {
             ChainManager::Single(manager) => {
-                manager.create_vote(proposal, messages, state_hash, key_pair)
+                manager.create_vote(proposal, executed_block, key_pair)
             }
-            ChainManager::Multi(manager) => {
-                manager.create_vote(proposal, messages, state_hash, key_pair)
-            }
+            ChainManager::Multi(manager) => manager.create_vote(proposal, executed_block, key_pair),
             ChainManager::None => panic!("unexpected chain manager"),
         }
     }

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -4,13 +4,12 @@
 use super::Outcome;
 use crate::{
     data_types::{
-        BlockAndRound, BlockProposal, Certificate, CertificateValue, ExecutedBlock, HashedValue,
-        LiteVote, OutgoingMessage, Vote,
+        BlockProposal, Certificate, CertificateValue, ExecutedBlock, HashedValue, LiteVote, Vote,
     },
     ChainError,
 };
 use linera_base::{
-    crypto::{CryptoHash, KeyPair, PublicKey},
+    crypto::{KeyPair, PublicKey},
     data_types::{BlockHeight, RoundNumber},
     ensure,
     identifiers::{ChainId, Owner},
@@ -144,20 +143,14 @@ impl MultiOwnerManager {
     pub fn create_vote(
         &mut self,
         proposal: BlockProposal,
-        messages: Vec<OutgoingMessage>,
-        state_hash: CryptoHash,
+        executed_block: ExecutedBlock,
         key_pair: Option<&KeyPair>,
     ) {
+        let round = proposal.content.round;
         // Record the proposed block, so it can be supplied to clients that request it.
-        self.proposed = Some(proposal.clone());
+        self.proposed = Some(proposal);
         if let Some(key_pair) = key_pair {
             // Vote to validate.
-            let BlockAndRound { block, round } = proposal.content;
-            let executed_block = ExecutedBlock {
-                block,
-                messages,
-                state_hash,
-            };
             let vote = Vote::new(HashedValue::new_validated(executed_block), round, key_pair);
             self.pending = Some(vote);
         }

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -3,14 +3,11 @@
 
 use super::Outcome;
 use crate::{
-    data_types::{
-        BlockAndRound, BlockProposal, CertificateValue, ExecutedBlock, HashedValue, LiteVote,
-        OutgoingMessage, Vote,
-    },
+    data_types::{BlockProposal, CertificateValue, ExecutedBlock, HashedValue, LiteVote, Vote},
     ChainError,
 };
 use linera_base::{
-    crypto::{CryptoHash, KeyPair, PublicKey},
+    crypto::{KeyPair, PublicKey},
     data_types::RoundNumber,
     ensure,
     identifiers::Owner,
@@ -76,24 +73,17 @@ impl SingleOwnerManager {
     pub fn create_vote(
         &mut self,
         proposal: BlockProposal,
-        messages: Vec<OutgoingMessage>,
-        state_hash: CryptoHash,
+        executed_block: ExecutedBlock,
         key_pair: Option<&KeyPair>,
     ) {
         if let Some(key_pair) = key_pair {
             // Vote to confirm.
-            let BlockAndRound { block, round } = proposal.content;
-            if round != RoundNumber(0) {
+            if proposal.content.round != RoundNumber::ZERO {
                 info!("Single-owner chains always have round number 0.");
                 return;
             }
-            let executed_block = ExecutedBlock {
-                block,
-                messages,
-                state_hash,
-            };
             let value = HashedValue::from(CertificateValue::ConfirmedBlock { executed_block });
-            let vote = Vote::new(value, round, key_pair);
+            let vote = Vote::new(value, RoundNumber::ZERO, key_pair);
             self.pending = Some(vote);
         }
     }


### PR DESCRIPTION
## Motivation

We are still handling a block's outgoing messages and state hash separately in some places. Using the `ExecutedBlock` type is simpler.

## Proposal

Use `ExecutedBlock` more.

## Test Plan

This doesn't add new logic.

## Links

N/A

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
