### PR TITLE
linera net up optionally generates extra wallets

### DIFF
--- a/linera-service/src/cli_wrappers.rs
+++ b/linera-service/src/cli_wrappers.rs
@@ -93,7 +93,7 @@ pub struct ClientWrapper {
 impl ClientWrapper {
     fn new(tmp_dir: Rc<TempDir>, database: Database, network: Network, id: usize) -> Self {
         let storage = match database {
-            Database::RocksDb => format!("rocksdb:client_{}.db", id),
+            Database::RocksDb => format!("rocksdb:{}/client_{}.db", tmp_dir.path().display(), id),
             Database::DynamoDb => format!("dynamodb:client_{}.db:localstack", id),
             Database::ScyllaDb => format!("scylladb:table_client_{}_db", id),
         };
@@ -423,7 +423,15 @@ impl ClientWrapper {
     }
 
     pub fn get_wallet(&self) -> WalletState {
-        WalletState::from_file(self.tmp_dir.path().join(&self.wallet).as_path()).unwrap()
+        WalletState::from_file(self.wallet_path().as_path()).unwrap()
+    }
+
+    pub fn wallet_path(&self) -> PathBuf {
+        self.tmp_dir.path().join(&self.wallet)
+    }
+
+    pub fn storage_path(&self) -> &str {
+        &self.storage
     }
 
     pub fn get_owner(&self) -> Option<Owner> {

--- a/linera-service/src/cli_wrappers.rs
+++ b/linera-service/src/cli_wrappers.rs
@@ -475,6 +475,10 @@ impl ClientWrapper {
         Ok(PublicKey::from_str(stdout.trim())?)
     }
 
+    pub fn default_chain(&self) -> Option<ChainId> {
+        self.get_wallet().default_chain()
+    }
+
     pub async fn assign(&mut self, key: PublicKey, message_id: MessageId) -> Result<ChainId> {
         let stdout = Self::run_command(
             self.run()

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -994,7 +994,11 @@ enum ClientCommand {
 #[derive(StructOpt)]
 enum NetCommand {
     /// Start a Local Linera Network
-    Up,
+    Up {
+        /// The number of extra wallets and user chains to initialise. Default is 0.
+        #[structopt(default_value, long)]
+        wallets: usize,
+    },
 }
 
 #[derive(StructOpt)]
@@ -1753,40 +1757,47 @@ async fn main() -> Result<(), anyhow::Error> {
         }
 
         ClientCommand::Net(net_command) => match net_command {
-            NetCommand::Up => {
+            NetCommand::Up { wallets } => {
                 let network = Network::Grpc;
                 let mut net = LocalNetwork::new(Database::RocksDb, network, 1)?;
                 let client1 = net.make_client(network);
-                let client2 = net.make_client(network);
 
                 net.generate_initial_validator_config().await?;
                 client1.create_genesis_config().await?;
-                client2.wallet_init(&[]).await?;
 
                 // Create initial server and client config.
                 net.run().await?;
-                let net_path = net.net_path();
+
+                for wallet in 0..*wallets {
+                    let extra_wallet = net.make_client(network);
+                    extra_wallet.wallet_init(&[]).await?;
+                    eprintln!("\nExtra wallet {}:", wallet + 1);
+                    eprintln!(
+                        "export LINERA_WALLET=\"{}\"",
+                        extra_wallet.wallet_path().display()
+                    );
+                    eprintln!(
+                        "export LINERA_STORAGE=\"{}\"\n",
+                        extra_wallet.storage_path()
+                    );
+                }
 
                 eprintln!(
                     "\nLinera net directory available at: {}",
-                    net_path.display()
+                    net.net_path().display()
                 );
                 eprintln!("To configure your Linera client for this network, run:\n");
                 eprintln!(
                     "{}",
                     format!(
                         "export LINERA_WALLET=\"{}\"",
-                        net_path.join("wallet_0.json").display()
+                        client1.wallet_path().display()
                     )
                     .bold()
                 );
                 eprintln!(
                     "{}",
-                    format!(
-                        "export LINERA_STORAGE=\"rocksdb:{}\"",
-                        net_path.join("linera.db").display()
-                    )
-                    .bold()
+                    format!("export LINERA_STORAGE=\"{}\"", client1.storage_path()).bold()
                 );
 
                 std::io::stdin().bytes().next();


### PR DESCRIPTION
## Motivation

Local network testing often requires multiple wallets - `linera net up` only initializes a single wallet meaning users need to do this manually.

## Proposal

Add ` --wallets` argument to `linera net up` to specify the number of extra wallets required (defaults to 0).

## Test Plan

Run `linera net up --wallets 3`; in a new terminal use the export commands for one of the extra wallets and run `linera sync-balance`.

## Links

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
