### PR TITLE
Implement ChainClient::request_leader_timeout

### DIFF
--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -558,6 +558,30 @@ where
         assert!(count >= target_count);
         certificate
     }
+
+    /// Tries to find a (confirmation) certificate for the given chain_id and block height, and are
+    /// in the expected round.
+    pub async fn check_that_validators_are_in_round(
+        &self,
+        chain_id: ChainId,
+        block_height: BlockHeight,
+        round: RoundNumber,
+        target_count: usize,
+    ) {
+        let query = ChainInfoQuery::new(chain_id);
+        let mut count = 0;
+        for mut validator in self.validator_clients.clone() {
+            if let Ok(response) = validator.handle_chain_info_query(query.clone()).await {
+                if response.info.manager.current_round() == round
+                    && response.info.next_block_height == block_height
+                    && response.check(validator.name).is_ok()
+                {
+                    count += 1;
+                }
+            }
+        }
+        assert!(count >= target_count);
+    }
 }
 
 #[cfg(feature = "rocksdb")]

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -8,14 +8,14 @@ use crate::{
 };
 use futures::{future, StreamExt};
 use linera_base::{
-    data_types::BlockHeight,
+    data_types::{BlockHeight, RoundNumber},
     identifiers::{ChainDescription, ChainId, MessageId},
 };
 use linera_chain::{
     data_types::{BlockProposal, Certificate, CertificateValue, LiteVote},
     ChainManager,
 };
-use linera_execution::committee::{Committee, ValidatorName};
+use linera_execution::committee::{Committee, Epoch, ValidatorName};
 use linera_storage::Store;
 use linera_views::views::ViewError;
 use std::{
@@ -42,6 +42,11 @@ pub enum CommunicateAction {
     SubmitBlockForValidation(BlockProposal),
     FinalizeBlock(Certificate),
     AdvanceToNextBlockHeight(BlockHeight),
+    RequestLeaderTimeout {
+        height: BlockHeight,
+        round: RoundNumber,
+        epoch: Epoch,
+    },
 }
 
 pub struct ValidatorUpdater<A, S> {
@@ -435,7 +440,8 @@ where
                 proposal.content.block.height
             }
             CommunicateAction::FinalizeBlock(certificate) => certificate.value().height(),
-            CommunicateAction::AdvanceToNextBlockHeight(seq) => *seq,
+            CommunicateAction::AdvanceToNextBlockHeight(height) => *height,
+            CommunicateAction::RequestLeaderTimeout { height, .. } => *height,
         };
         // Update the validator with missing information, if needed.
         self.send_chain_information(chain_id, target_block_height)
@@ -460,6 +466,19 @@ where
                 let retryable = target_block_height == BlockHeight::ZERO;
                 let info = self.send_certificate(certificate, retryable).await?;
                 match info.manager.pending() {
+                    Some(vote) if vote.validator == self.name => {
+                        vote.check()?;
+                        return Ok(Some(vote.clone()));
+                    }
+                    Some(_) | None => {
+                        return Err(NodeError::MissingVoteInValidatorResponse);
+                    }
+                }
+            }
+            CommunicateAction::RequestLeaderTimeout { .. } => {
+                let query = ChainInfoQuery::new(chain_id).with_leader_timeout();
+                let info = self.client.handle_chain_info_query(query).await?.info;
+                match info.manager.timeout_vote() {
                     Some(vote) if vote.validator == self.name => {
                         vote.check()?;
                         return Ok(Some(vote.clone()));


### PR DESCRIPTION
## Motivation

To support the full BFT consensus protocol, the `linera` client will need the ability to request `LeaderTimeout` votes from validators once a round has timed out.

## Proposal

Add `ChainClient::request_leader_timeout`.

## Test Plan

Includes a client test.

An end-to-end test will be added in the future, when the rest of the client-side functionality is added.

## Links

Part of https://github.com/linera-io/linera-protocol/issues/464.

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
