### PR TITLE
Rename "client" to "store" or "node" to disambiguate.

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -51,8 +51,8 @@ use linera_storage::ScyllaDbStoreClient;
 async fn test_memory_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let client = MemoryStoreClient::make_test_client(Some(wasm_runtime)).await;
-    run_test_handle_certificates_to_create_application(client, wasm_runtime).await
+    let store = MemoryStoreClient::make_test_client(Some(wasm_runtime)).await;
+    run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
 #[cfg(feature = "rocksdb")]
@@ -62,8 +62,8 @@ async fn test_memory_handle_certificates_to_create_application(
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let client = RocksDbStoreClient::make_test_client(Some(wasm_runtime)).await;
-    run_test_handle_certificates_to_create_application(client, wasm_runtime).await
+    let store = RocksDbStoreClient::make_test_client(Some(wasm_runtime)).await;
+    run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
 #[ignore]
@@ -74,8 +74,8 @@ async fn test_rocks_db_handle_certificates_to_create_application(
 async fn test_dynamo_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let client = DynamoDbStoreClient::make_test_client(Some(wasm_runtime)).await;
-    run_test_handle_certificates_to_create_application(client, wasm_runtime).await
+    let store = DynamoDbStoreClient::make_test_client(Some(wasm_runtime)).await;
+    run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
 #[ignore]
@@ -86,12 +86,12 @@ async fn test_dynamo_db_handle_certificates_to_create_application(
 async fn test_scylla_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let client = ScyllaDbStoreClient::make_test_client(Some(wasm_runtime)).await;
-    run_test_handle_certificates_to_create_application(client, wasm_runtime).await
+    let store = ScyllaDbStoreClient::make_test_client(Some(wasm_runtime)).await;
+    run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
 async fn run_test_handle_certificates_to_create_application<S>(
-    client: S,
+    store: S,
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error>
 where
@@ -104,7 +104,7 @@ where
     let creator_key_pair = KeyPair::generate();
     let creator_chain = ChainDescription::Root(2);
     let (committee, mut worker) = init_worker_with_chains(
-        client,
+        store,
         vec![
             (publisher_chain, publisher_key_pair.public(), Amount::ZERO),
             (creator_chain, creator_key_pair.public(), Amount::ZERO),

--- a/linera-indexer/example/src/main.rs
+++ b/linera-indexer/example/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), IndexerError> {
 
     let mut runner = RocksDbRunner::load().await?;
     runner
-        .add_plugin(OperationsPlugin::load(runner.client.clone()).await?)
+        .add_plugin(OperationsPlugin::load(runner.store.clone()).await?)
         .await?;
     runner.run().await
 }

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -66,8 +66,8 @@ where
     ViewError: From<DB::Error>,
 {
     /// Loads the indexer using a database backend with an `indexer` prefix.
-    pub async fn load(client: DB) -> Result<Self, IndexerError> {
-        let context = ContextFromDb::create(client.clone(), "indexer".as_bytes().to_vec(), ())
+    pub async fn load(store: DB) -> Result<Self, IndexerError> {
+        let context = ContextFromDb::create(store.clone(), "indexer".as_bytes().to_vec(), ())
             .await
             .map_err(|e| IndexerError::ViewError(e.into()))?;
         let state = State(Arc::new(Mutex::new(StateView::load(context).await?)));

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -26,8 +26,8 @@ where
     where
         Self: Sized;
 
-    /// Loads the plugin from a client
-    async fn load(client: DB) -> Result<Self, IndexerError>
+    /// Loads the plugin from a store
+    async fn load(store: DB) -> Result<Self, IndexerError>
     where
         Self: Sized;
 
@@ -70,7 +70,7 @@ pub fn route<Q: async_graphql::ObjectType + 'static>(
 }
 
 pub async fn load<DB, V: View<ContextFromDb<(), DB>>>(
-    client: DB,
+    store: DB,
     name: &str,
 ) -> Result<Arc<Mutex<V>>, IndexerError>
 where
@@ -78,7 +78,7 @@ where
     DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<DB::Error>,
 {
-    let context = ContextFromDb::create(client, name.as_bytes().to_vec(), ())
+    let context = ContextFromDb::create(store, name.as_bytes().to_vec(), ())
         .await
         .map_err(|e| IndexerError::ViewError(e.into()))?;
     let plugin = V::load(context).await?;

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -42,7 +42,7 @@ impl RocksDbRunner {
             path_buf: config.client.storage.as_path().to_path_buf(),
             common_config,
         };
-        let client = RocksDbClient::initialize(store_config).await?;
-        Self::new(config, client).await
+        let store = RocksDbClient::initialize(store_config).await?;
+        Self::new(config, store).await
     }
 }

--- a/linera-indexer/lib/src/runner.rs
+++ b/linera-indexer/lib/src/runner.rs
@@ -38,7 +38,7 @@ pub struct IndexerConfig<Config: StructOpt> {
 }
 
 pub struct Runner<DB, Config: StructOpt> {
-    pub client: DB,
+    pub store: DB,
     pub config: IndexerConfig<Config>,
     pub indexer: Indexer<DB>,
 }
@@ -57,13 +57,13 @@ where
     ViewError: From<DB::Error>,
 {
     /// Loads a new runner
-    pub async fn new(config: IndexerConfig<Config>, client: DB) -> Result<Self, IndexerError>
+    pub async fn new(config: IndexerConfig<Config>, store: DB) -> Result<Self, IndexerError>
     where
         Self: Sized,
     {
-        let indexer = Indexer::load(client.clone()).await?;
+        let indexer = Indexer::load(store.clone()).await?;
         Ok(Self {
-            client,
+            store,
             config,
             indexer,
         })

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -44,7 +44,7 @@ impl ScyllaDbRunner {
             table_name: config.client.table.clone(),
             common_config,
         };
-        let (client, _) = ScyllaDbClient::new(store_config).await?;
-        Self::new(config, client).await
+        let (store, _) = ScyllaDbClient::new(store_config).await?;
+        Self::new(config, store).await
     }
 }

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -119,11 +119,11 @@ where
         NAME.to_string()
     }
 
-    async fn load(client: DB) -> Result<Self, IndexerError>
+    async fn load(store: DB) -> Result<Self, IndexerError>
     where
         Self: Sized,
     {
-        Ok(Self(load(client, NAME).await?))
+        Ok(Self(load(store, NAME).await?))
     }
 
     async fn register(&self, value: &HashedValue) -> Result<(), IndexerError> {

--- a/linera-sdk/src/test/integration/validator.rs
+++ b/linera-sdk/src/test/integration/validator.rs
@@ -49,7 +49,7 @@ impl Default for TestValidator {
     fn default() -> Self {
         let key_pair = KeyPair::generate();
         let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
-        let client = MemoryStoreClient::new(
+        let store = MemoryStoreClient::new(
             Some(WasmRuntime::default()),
             TEST_MEMORY_MAX_STREAM_QUERIES,
             WallClock,
@@ -58,7 +58,7 @@ impl Default for TestValidator {
         let worker = WorkerState::new(
             "Single validator node".to_string(),
             Some(key_pair.copy()),
-            client,
+            store,
         );
 
         TestValidator {

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -332,7 +332,7 @@ pub trait Runnable {
 
 // The design is that the initialization of the accounts should be separate
 // from the running of the database.
-// However, that does not apply to the memory client which must be initialized
+// However, that does not apply to the memory store which must be initialized
 // in the same context in which it is used.
 #[allow(unused_variables)]
 pub async fn run_with_storage<Job>(
@@ -346,31 +346,30 @@ where
 {
     match config {
         FullStorageConfig::Memory(store_config) => {
-            let mut client = MemoryStoreClient::new(
+            let mut store = MemoryStoreClient::new(
                 wasm_runtime,
                 store_config.common_config.max_stream_queries,
                 WallClock,
             );
-            genesis_config.initialize_store(&mut client).await?;
-            job.run(client).await
+            genesis_config.initialize_store(&mut store).await?;
+            job.run(store).await
         }
         #[cfg(feature = "rocksdb")]
         FullStorageConfig::RocksDb(store_config) => {
-            let (client, table_status) =
-                RocksDbStoreClient::new(store_config, wasm_runtime).await?;
-            job.run(client).await
+            let (store, table_status) = RocksDbStoreClient::new(store_config, wasm_runtime).await?;
+            job.run(store).await
         }
         #[cfg(feature = "aws")]
         FullStorageConfig::DynamoDb(store_config) => {
-            let (client, table_status) =
+            let (store, table_status) =
                 DynamoDbStoreClient::new(store_config, wasm_runtime).await?;
-            job.run(client).await
+            job.run(store).await
         }
         #[cfg(feature = "scylladb")]
         FullStorageConfig::ScyllaDb(store_config) => {
-            let (client, table_status) =
+            let (store, table_status) =
                 ScyllaDbStoreClient::new(store_config, wasm_runtime).await?;
-            job.run(client).await
+            job.run(store).await
         }
     }
 }
@@ -387,20 +386,20 @@ pub async fn full_initialize_storage(
         #[cfg(feature = "rocksdb")]
         FullStorageConfig::RocksDb(store_config) => {
             let wasm_runtime = None;
-            let mut client = RocksDbStoreClient::initialize(store_config, wasm_runtime).await?;
-            genesis_config.initialize_store(&mut client).await
+            let mut store = RocksDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            genesis_config.initialize_store(&mut store).await
         }
         #[cfg(feature = "aws")]
         FullStorageConfig::DynamoDb(store_config) => {
             let wasm_runtime = None;
-            let mut client = DynamoDbStoreClient::initialize(store_config, wasm_runtime).await?;
-            genesis_config.initialize_store(&mut client).await
+            let mut store = DynamoDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            genesis_config.initialize_store(&mut store).await
         }
         #[cfg(feature = "scylladb")]
         FullStorageConfig::ScyllaDb(store_config) => {
             let wasm_runtime = None;
-            let mut client = ScyllaDbStoreClient::initialize(store_config, wasm_runtime).await?;
-            genesis_config.initialize_store(&mut client).await
+            let mut store = ScyllaDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            genesis_config.initialize_store(&mut store).await
         }
     }
 }


### PR DESCRIPTION
## Motivation

We use the name `client` for implementations of `Store`, `ValidatorNode`, and others.
This gets confusing in contexts where different kinds of clients are in play.

## Proposal

Rename `client` to `store` if it is outside of `linera-storage` and `linera-views` and refers to a `Store` implementation.

Rename `client` to `node` if it refers to a `ValidatorNode` implementation.

## Test Plan

No logic is changed.

## Links

N/A

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
