### PR TITLE
Update locked block correctly in multi-owner chains.

### DIFF
--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -129,25 +129,18 @@ impl MultiOwnerManager {
         })
     }
 
-    /// Returns the lowest round where we can still vote to validate a block. This is the round to
-    /// which the current timeout applies.
+    /// Returns the lowest round where we can still vote to validate or confirm a block. This is
+    /// the round to which the current timeout applies.
     ///
-    /// Both having a leader timeout certificate in any given round causes the next one to become
+    /// Having a leader timeout certificate in any given round causes the next one to become
     /// current. Seeing a validated block certificate or a valid proposal in any round causes that
     /// round to become current, unless a higher one already is.
     pub fn current_round(&self) -> RoundNumber {
-        let leader_timeout = self.leader_timeout.as_ref().into_iter();
-        let proposed = self.proposed.as_ref();
-        let validated = proposed.and_then(|proposal| proposal.validated.as_ref());
-        self.locked
+        self.leader_timeout
             .iter()
-            .chain(validated)
-            .map(|certificate| certificate.round)
-            .chain(
-                leader_timeout
-                    .map(|certificate| certificate.round.try_add_one().unwrap_or(RoundNumber::MAX)),
-            )
-            .chain(proposed.map(|proposal| proposal.content.round))
+            .map(|certificate| certificate.round.try_add_one().unwrap_or(RoundNumber::MAX))
+            .chain(self.locked.iter().map(|certificate| certificate.round))
+            .chain(self.proposed.iter().map(|proposal| proposal.content.round))
             .max()
             .unwrap_or_default()
     }
@@ -279,14 +272,21 @@ impl MultiOwnerManager {
         key_pair: Option<&KeyPair>,
         now: Timestamp,
     ) {
-        if let Some(validated) = &proposal.validated {
-            self.update_timeout(validated.round, now);
-        }
         if let Ok(round) = proposal.content.round.try_sub_one() {
             self.update_timeout(round, now);
         }
         // Record the proposed block, so it can be supplied to clients that request it.
         self.proposed = Some(proposal.clone());
+        // If the validated block certificate is more recent, update our locked block.
+        if let Some(validated) = &proposal.validated {
+            if self
+                .locked
+                .as_ref()
+                .map_or(true, |locked| locked.round < validated.round)
+            {
+                self.locked = Some(validated.clone());
+            }
+        }
         if let Some(key_pair) = key_pair {
             // Vote to validate.
             let BlockAndRound { block, round } = proposal.content;


### PR DESCRIPTION
## Motivation

If a validator votes for a block based on a `ValidatedBlock` certificate that is higher than their locked block, they must not vote for their locked block again later. The block from the proposal becomes their new locked block.

## Proposal

Update the locked block when voting to validate a proposed block. This also simplifies `current_round`, because we can rely on `self.locked` being at least as recent as the validated block contained in `self.proposed`.

## Test Plan

The leader timeouts worker test was extended.

## Links

Related to #464.

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
