### PR TITLE
Implementation of the `DynamoDb` and ScyllaDb` end-to-end tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "linera-indexer-plugins",
  "linera-service",
  "linera-service-graphql-client",
+ "linera-views",
  "once_cell",
  "reqwest",
  "serde",

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -33,7 +33,7 @@ use linera_execution::{
     ChainOwnership, ExecutionError, Operation, SystemExecutionError, SystemQuery, SystemResponse,
 };
 use linera_storage::Store;
-use linera_views::views::ViewError;
+use linera_views::{common::set_table_prefix, views::ViewError};
 use std::sync::Arc;
 use test_log::test;
 
@@ -80,6 +80,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::fuel_and_certificate());
@@ -155,6 +156,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::only_fuel());
@@ -245,6 +247,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::fuel_and_certificate());
@@ -315,6 +318,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::fuel_and_certificate());
@@ -393,6 +397,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 0).await?;
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
@@ -559,6 +564,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
     builder
@@ -620,6 +626,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
     builder
@@ -719,6 +726,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
     builder
@@ -807,6 +815,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::all_categories());
@@ -884,6 +893,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 2).await?;
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
@@ -944,6 +954,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
@@ -1074,6 +1085,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::fuel_and_certificate());
@@ -1155,6 +1167,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
@@ -1270,6 +1283,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let mut admin = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
@@ -1385,6 +1399,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::fuel_and_certificate());
@@ -1433,6 +1448,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("client_tests").await;
     let clock = store_builder.clock().clone();
     let mut builder = TestBuilder::new(store_builder, 4, 1).await?;
     let description = ChainDescription::Root(1);

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -20,7 +20,7 @@ use linera_execution::{
     WasmRuntime,
 };
 use linera_storage::Store;
-use linera_views::views::ViewError;
+use linera_views::{common::set_table_prefix, views::ViewError};
 use serde_json::json;
 use std::collections::BTreeMap;
 use test_case::test_case;
@@ -71,6 +71,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("wasm_client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::all_categories());
@@ -194,6 +195,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("wasm_client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::all_categories());
@@ -335,6 +337,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("wasm_client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::all_categories());
@@ -438,6 +441,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("wasm_client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::all_categories());
@@ -632,6 +636,7 @@ where
     B: StoreBuilder,
     ViewError: From<<B::Store as Store>::ContextError>,
 {
+    set_table_prefix("wasm_client_tests").await;
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
         .with_pricing(Pricing::all_categories());

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -32,7 +32,10 @@ use linera_execution::{
     UserApplicationDescription, UserApplicationId, WasmApplication, WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, Store};
-use linera_views::views::{CryptoHashView, ViewError};
+use linera_views::{
+    common::set_table_prefix,
+    views::{CryptoHashView, ViewError},
+};
 use std::sync::Arc;
 use test_case::test_case;
 
@@ -98,6 +101,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("wasm_worker_tests").await;
     let admin_id = ChainDescription::Root(0);
     let publisher_key_pair = KeyPair::generate();
     let publisher_chain = ChainDescription::Root(1);

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -36,7 +36,7 @@ use linera_execution::{
 };
 use linera_storage::{DbStoreClient, MemoryStoreClient, Store, TestClock};
 use linera_views::{
-    common::KeyValueStoreClient,
+    common::{set_table_prefix, KeyValueStoreClient},
     memory::TEST_MEMORY_MAX_STREAM_QUERIES,
     value_splitting::DatabaseConsistencyError,
     views::{CryptoHashView, ViewError},
@@ -299,6 +299,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
         store,
@@ -369,6 +370,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
         store,
@@ -446,6 +448,7 @@ where
     <C as KeyValueStoreClient>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
+    set_table_prefix("worker_tests").await;
     let key_pair = KeyPair::generate();
     let balance: Amount = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public(), balance)];
@@ -534,6 +537,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
         store,
@@ -604,6 +608,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let recipient = Recipient::root(2);
     let (committee, mut worker) = init_worker_with_chains(
@@ -714,6 +719,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
     let recipient = Recipient::root(2);
@@ -1106,6 +1112,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
         store,
@@ -1178,6 +1185,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
         store,
@@ -1246,6 +1254,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
         store,
@@ -1312,6 +1321,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -1369,6 +1379,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -1432,6 +1443,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -1501,6 +1513,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -1627,6 +1640,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -1719,6 +1733,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let key_pair = KeyPair::generate();
     let name = key_pair.public();
     let (committee, mut worker) =
@@ -1816,6 +1831,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -1917,6 +1933,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker(store, /* is_client */ false);
     let certificate = make_transfer_certificate(
@@ -1980,6 +1997,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker(store, /* is_client */ true);
     let certificate = make_transfer_certificate(
@@ -2055,6 +2073,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -2237,6 +2256,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -2305,6 +2325,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
         store,
@@ -2733,6 +2754,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -2878,6 +2900,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    set_table_prefix("worker_tests").await;
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -3302,6 +3325,7 @@ where
     <C as KeyValueStoreClient>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
+    set_table_prefix("worker_tests").await;
     let chain_id = ChainId::root(0);
     let key_pairs = generate_key_pairs(2);
     let (pub_key0, pub_key1) = (key_pairs[0].public(), key_pairs[1].public());

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -24,6 +24,7 @@ linera-indexer = { workspace = true }
 linera-indexer-plugins = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+linera-views = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -16,6 +16,7 @@ use linera_service_graphql_client::{
     applications, block, blocks, chains, request, transfer, Applications, Block, Blocks, Chains,
     Transfer,
 };
+use linera_views::common::set_table_prefix;
 use std::{collections::BTreeMap, str::FromStr};
 
 /// A static lock to prevent integration tests from running in parallel.
@@ -38,14 +39,12 @@ async fn test_rocks_db_end_to_end_queries() {
     run_end_to_end_queries(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_queries() {
     run_end_to_end_queries(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_end_to_end_queries() {
@@ -53,9 +52,10 @@ async fn test_scylla_db_end_to_end_queries() {
 }
 
 async fn run_end_to_end_queries(database: Database) {
+    set_table_prefix("graphql_client_tests").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, 4).await.unwrap();
     let mut client = local_net.make_client(network);
     local_net.generate_initial_validator_config().await.unwrap();
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1776,8 +1776,9 @@ async fn main() -> Result<(), anyhow::Error> {
                     panic!("The local test network must have at least one shard per validator.");
                 }
                 let network = Network::Grpc;
-                let mut net = LocalNetwork::new(Database::RocksDb, network, *validators, *shards)?;
-                let mut client1 = net.make_client(network);
+                let mut net =
+                    LocalNetwork::new(Database::RocksDb, network, *validators, *shards).await?;
+                let client1 = net.make_client(network);
 
                 // Create the initial server and client config.
                 net.generate_initial_validator_config().await?;
@@ -1813,7 +1814,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
                 // Create the extra wallets.
                 for wallet in 0..*wallets {
-                    let mut extra_wallet = net.make_client(network);
+                    let extra_wallet = net.make_client(network);
                     extra_wallet.wallet_init(&[]).await?;
                     let unassigned_key = extra_wallet.keygen().await?;
                     let new_chain_msg_id = client1

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -165,11 +165,11 @@ impl FromStr for StorageConfig {
         }
         print!("available storage: memory");
         #[cfg(feature = "rocksdb")]
-        print!(", rocksdb");
+        print!(", RocksDB");
         #[cfg(feature = "aws")]
-        print!(", dynamodb");
+        print!(", DynamoDB");
         #[cfg(feature = "scylladb")]
-        print!(", scyladb");
+        print!(", ScyllaDB");
         println!();
         Err(format_err!("The input has not matched: {}", input))
     }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -9,6 +9,7 @@ mod common;
 use common::INTEGRATION_TEST_GUARD;
 use linera_base::identifiers::ChainId;
 use linera_service::cli_wrappers::{Database, LocalNetwork, Network};
+use linera_views::common::set_table_prefix;
 use std::time::Duration;
 
 #[cfg(feature = "rocksdb")]
@@ -17,14 +18,12 @@ async fn test_rocks_db_end_to_end_reconfiguration_grpc() {
     run_end_to_end_reconfiguration(Database::RocksDb, Network::Grpc).await;
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_reconfiguration_grpc() {
     run_end_to_end_reconfiguration(Database::DynamoDb, Network::Grpc).await;
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_end_to_end_reconfiguration_grpc() {
@@ -37,14 +36,12 @@ async fn test_rocks_db_end_to_end_reconfiguration_simple() {
     run_end_to_end_reconfiguration(Database::RocksDb, Network::Simple).await;
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_reconfiguration_simple() {
     run_end_to_end_reconfiguration(Database::DynamoDb, Network::Simple).await;
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_end_to_end_reconfiguration_simple() {
@@ -52,10 +49,13 @@ async fn test_scylla_db_end_to_end_reconfiguration_simple() {
 }
 
 async fn run_end_to_end_reconfiguration(database: Database, network: Network) {
+    set_table_prefix("end_to_end").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client = local_net.make_client(network);
-    let mut client_2 = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client = local_net.make_client(network);
+    let client_2 = local_net.make_client(network);
 
     let servers = local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
@@ -66,7 +66,7 @@ async fn run_end_to_end_reconfiguration(database: Database, network: Network) {
 
     let (node_service_2, chain_2) = match network {
         Network::Grpc => {
-            let chain_2 = client.open_and_assign(&mut client_2).await.unwrap();
+            let chain_2 = client.open_and_assign(&client_2).await.unwrap();
             let node_service_2 = client_2.run_node_service(8081).await.unwrap();
             (Some(node_service_2), chain_2)
         }
@@ -164,14 +164,12 @@ async fn test_rocks_db_open_chain_node_service() {
     run_open_chain_node_service(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_open_chain_node_service() {
     run_open_chain_node_service(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_open_chain_node_service() {
@@ -179,10 +177,13 @@ async fn test_scylla_db_open_chain_node_service() {
 }
 
 async fn run_open_chain_node_service(database: Database) {
+    set_table_prefix("end_to_end").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client = local_net.make_client(network);
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
     local_net.run().await.unwrap();
@@ -271,14 +272,12 @@ async fn test_rocks_db_end_to_end_retry_notification_stream() {
     run_end_to_end_retry_notification_stream(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_retry_notification_stream() {
     run_end_to_end_retry_notification_stream(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_end_to_end_retry_notification_stream() {
@@ -286,12 +285,15 @@ async fn test_scylla_db_end_to_end_retry_notification_stream() {
 }
 
 async fn run_end_to_end_retry_notification_stream(database: Database) {
+    set_table_prefix("end_to_end").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client1 = local_net.make_client(network);
-    let mut client2 = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client1 = local_net.make_client(network);
+    let client2 = local_net.make_client(network);
 
     // Create initial server and client config.
     local_net.generate_initial_validator_config().await.unwrap();
@@ -350,14 +352,12 @@ async fn test_rocks_db_end_to_end_multiple_wallets() {
     run_end_to_end_multiple_wallets(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_multiple_wallets() {
     run_end_to_end_multiple_wallets(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_end_to_end_multiple_wallets() {
@@ -365,12 +365,15 @@ async fn test_scylla_db_end_to_end_multiple_wallets() {
 }
 
 async fn run_end_to_end_multiple_wallets(database: Database) {
+    set_table_prefix("end_to_end").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create local_net and two clients.
-    let mut local_net = LocalNetwork::new_for_testing(database, Network::Grpc).unwrap();
-    let mut client_1 = local_net.make_client(Network::Grpc);
-    let mut client_2 = local_net.make_client(Network::Grpc);
+    let mut local_net = LocalNetwork::new_for_testing(database, Network::Grpc)
+        .await
+        .unwrap();
+    let client_1 = local_net.make_client(Network::Grpc);
+    let client_2 = local_net.make_client(Network::Grpc);
 
     // Create initial server and client config.
     local_net.generate_initial_validator_config().await.unwrap();
@@ -422,14 +425,12 @@ async fn test_rocks_db_project_new() {
     run_project_new(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_project_new() {
     run_project_new(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_project_new() {
@@ -437,8 +438,9 @@ async fn test_scylla_db_project_new() {
 }
 
 async fn run_project_new(database: Database) {
+    set_table_prefix("end_to_end").await;
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 0, 0).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, 0, 0).await.unwrap();
     let client = local_net.make_client(network);
 
     let tmp_dir = client.project_new("init-test").await.unwrap();
@@ -455,14 +457,12 @@ async fn test_rocks_db_project_test() {
     run_project_test(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_project_test() {
     run_project_test(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_project_test() {
@@ -470,8 +470,9 @@ async fn test_scylla_db_project_test() {
 }
 
 async fn run_project_test(database: Database) {
+    set_table_prefix("end_to_end").await;
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 0, 0).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, 0, 0).await.unwrap();
     let client = local_net.make_client(network);
     client
         .project_test(&LocalNetwork::example_path("counter").unwrap())
@@ -484,14 +485,12 @@ async fn test_rocks_db_project_publish() {
     run_project_publish(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_project_publish() {
     run_project_publish(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_project_publish() {
@@ -499,11 +498,12 @@ async fn test_scylla_db_project_publish() {
 }
 
 async fn run_project_publish(database: Database) {
+    set_table_prefix("end_to_end").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 1, 1).unwrap();
-    let mut client = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new(database, network, 1, 1).await.unwrap();
+    let client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
@@ -529,14 +529,12 @@ async fn test_rocks_db_example_publish() {
     run_example_publish(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_example_publish() {
     run_example_publish(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_example_publish() {
@@ -544,11 +542,12 @@ async fn test_scylla_db_example_publish() {
 }
 
 async fn run_example_publish(database: Database) {
+    set_table_prefix("end_to_end").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 1, 1).unwrap();
-    let mut client = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new(database, network, 1, 1).await.unwrap();
+    let client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
@@ -572,14 +571,12 @@ async fn test_rocks_db_end_to_end_open_multi_owner_chain() {
     run_end_to_end_open_multi_owner_chain(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_open_multi_owner_chain() {
     run_end_to_end_open_multi_owner_chain(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
 async fn test_scylla_db_end_to_end_open_multi_owner_chain() {
@@ -587,12 +584,15 @@ async fn test_scylla_db_end_to_end_open_multi_owner_chain() {
 }
 
 async fn run_end_to_end_open_multi_owner_chain(database: Database) {
+    set_table_prefix("end_to_end").await;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
-    let mut runner = LocalNetwork::new_for_testing(database, Network::Grpc).unwrap();
-    let mut client1 = runner.make_client(Network::Grpc);
-    let mut client2 = runner.make_client(Network::Grpc);
+    let mut runner = LocalNetwork::new_for_testing(database, Network::Grpc)
+        .await
+        .unwrap();
+    let client1 = runner.make_client(Network::Grpc);
+    let client2 = runner.make_client(Network::Grpc);
 
     // Create initial server and client config.
     runner.generate_initial_validator_config().await.unwrap();

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -8,6 +8,7 @@ mod common;
 #[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 use {
     common::INTEGRATION_TEST_GUARD,
+    linera_views::common::set_table_prefix,
     std::{io::Write, process::ExitStatus},
     tempfile::tempdir,
     tokio::process::Command,
@@ -15,6 +16,7 @@ use {
 
 #[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 async fn run_test_command(storage: &str) -> std::io::Result<ExitStatus> {
+    set_table_prefix("readme_test").await;
     let dir = tempdir().unwrap();
     let file = std::io::BufReader::new(std::fs::File::open("../README.md")?);
     let mut quotes = get_bash_quotes(file)?;

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -12,6 +12,7 @@ use linera_base::{
     identifiers::{ApplicationId, ChainId},
 };
 use linera_service::cli_wrappers::{ClientWrapper, Database, LocalNetwork, Network};
+use linera_views::common::set_table_prefix;
 use serde_json::{json, Value};
 use std::{collections::BTreeMap, time::Duration};
 use tracing::{info, warn};
@@ -283,32 +284,32 @@ impl AmmApp {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_counter() {
-    run_end_to_end_counter(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_counter() {
+    run_wasm_end_to_end_counter(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_counter() {
-    run_end_to_end_counter(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_counter() {
+    run_wasm_end_to_end_counter(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_counter() {
-    run_end_to_end_counter(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_counter() {
+    run_wasm_end_to_end_counter(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_counter(database: Database) {
+async fn run_wasm_end_to_end_counter(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use counter::CounterAbi;
-
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client = local_net.make_client(network);
 
     let original_counter_value = 35;
     let increment = 5;
@@ -350,32 +351,33 @@ async fn run_end_to_end_counter(database: Database) {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_counter_publish_create() {
-    run_end_to_end_counter_publish_create(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_counter_publish_create() {
+    run_wasm_end_to_end_counter_publish_create(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_counter_publish_create() {
-    run_end_to_end_counter_publish_create(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_counter_publish_create() {
+    run_wasm_end_to_end_counter_publish_create(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_counter_publish_create() {
-    run_end_to_end_counter_publish_create(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_counter_publish_create() {
+    run_wasm_end_to_end_counter_publish_create(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_counter_publish_create(database: Database) {
+async fn run_wasm_end_to_end_counter_publish_create(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use counter::CounterAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client = local_net.make_client(network);
 
     let original_counter_value = 35;
     let increment = 5;
@@ -414,32 +416,33 @@ async fn run_end_to_end_counter_publish_create(database: Database) {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_social_user_pub_sub() {
-    run_end_to_end_social_user_pub_sub(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_social_user_pub_sub() {
+    run_wasm_end_to_end_social_user_pub_sub(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_social_user_pub_sub() {
-    run_end_to_end_social_user_pub_sub(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_social_user_pub_sub() {
+    run_wasm_end_to_end_social_user_pub_sub(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_social_user_pub_sub() {
-    run_end_to_end_social_user_pub_sub(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_social_user_pub_sub() {
+    run_wasm_end_to_end_social_user_pub_sub(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_social_user_pub_sub(database: Database) {
+async fn run_wasm_end_to_end_social_user_pub_sub(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use social::SocialAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client1 = local_net.make_client(network);
-    let mut client2 = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client1 = local_net.make_client(network);
+    let client2 = local_net.make_client(network);
 
     // Create initial server and client config.
     local_net.generate_initial_validator_config().await.unwrap();
@@ -451,7 +454,7 @@ async fn run_end_to_end_social_user_pub_sub(database: Database) {
     let (contract, service) = local_net.build_example("social").await.unwrap();
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&mut client2).await.unwrap();
+    let chain2 = client1.open_and_assign(&client2).await.unwrap();
     let bytecode_id = client1
         .publish_bytecode(contract, service, None)
         .await
@@ -512,33 +515,34 @@ async fn run_end_to_end_social_user_pub_sub(database: Database) {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_fungible() {
-    run_end_to_end_fungible(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_fungible() {
+    run_wasm_end_to_end_fungible(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_fungible() {
-    run_end_to_end_fungible(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_fungible() {
+    run_wasm_end_to_end_fungible(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_fungible() {
-    run_end_to_end_fungible(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_fungible() {
+    run_wasm_end_to_end_fungible(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_fungible(database: Database) {
+async fn run_wasm_end_to_end_fungible(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use fungible::{FungibleTokenAbi, InitialState};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client1 = local_net.make_client(network);
-    let mut client2 = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client1 = local_net.make_client(network);
+    let client2 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client1.create_genesis_config().await.unwrap();
@@ -549,7 +553,7 @@ async fn run_end_to_end_fungible(database: Database) {
     let (contract, service) = local_net.build_example("fungible").await.unwrap();
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&mut client2).await.unwrap();
+    let chain2 = client1.open_and_assign(&client2).await.unwrap();
 
     // The players
     let account_owner1 = get_fungible_account_owner(&client1);
@@ -645,32 +649,34 @@ async fn run_end_to_end_fungible(database: Database) {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_same_wallet_fungible() {
-    run_end_to_end_same_wallet_fungible(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_same_wallet_fungible() {
+    run_wasm_end_to_end_same_wallet_fungible(Database::RocksDb).await
 }
 
 #[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_same_wallet_fungible() {
-    run_end_to_end_same_wallet_fungible(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_same_wallet_fungible() {
+    run_wasm_end_to_end_same_wallet_fungible(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_same_wallet_fungible() {
-    run_end_to_end_same_wallet_fungible(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_same_wallet_fungible() {
+    run_wasm_end_to_end_same_wallet_fungible(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_same_wallet_fungible(database: Database) {
+async fn run_wasm_end_to_end_same_wallet_fungible(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use fungible::{FungibleTokenAbi, InitialState};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client1 = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client1 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client1.create_genesis_config().await.unwrap();
@@ -743,34 +749,35 @@ async fn run_end_to_end_same_wallet_fungible(database: Database) {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_crowd_funding() {
-    run_end_to_end_crowd_funding(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_crowd_funding() {
+    run_wasm_end_to_end_crowd_funding(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_crowd_funding() {
-    run_end_to_end_crowd_funding(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_crowd_funding() {
+    run_wasm_end_to_end_crowd_funding(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_crowd_funding() {
-    run_end_to_end_crowd_funding(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_crowd_funding() {
+    run_wasm_end_to_end_crowd_funding(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_crowd_funding(database: Database) {
+async fn run_wasm_end_to_end_crowd_funding(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use crowd_funding::{CrowdFundingAbi, InitializationArgument};
     use fungible::{FungibleTokenAbi, InitialState};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client1 = local_net.make_client(network);
-    let mut client2 = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client1 = local_net.make_client(network);
+    let client2 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client1.create_genesis_config().await.unwrap();
@@ -781,7 +788,7 @@ async fn run_end_to_end_crowd_funding(database: Database) {
     let (contract_fungible, service_fungible) = local_net.build_example("fungible").await.unwrap();
 
     let chain1 = client1.get_wallet().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&mut client2).await.unwrap();
+    let chain2 = client1.open_and_assign(&client2).await.unwrap();
 
     // The players
     let account_owner1 = get_fungible_account_owner(&client1); // operator
@@ -886,35 +893,37 @@ async fn run_end_to_end_crowd_funding(database: Database) {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_matching_engine() {
-    run_end_to_end_matching_engine(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_matching_engine() {
+    run_wasm_end_to_end_matching_engine(Database::RocksDb).await
 }
 
 #[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_matching_engine() {
-    run_end_to_end_matching_engine(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_matching_engine() {
+    run_wasm_end_to_end_matching_engine(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_matching_engine() {
-    run_end_to_end_matching_engine(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_matching_engine() {
+    run_wasm_end_to_end_matching_engine(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_matching_engine(database: Database) {
+async fn run_wasm_end_to_end_matching_engine(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use fungible::{FungibleTokenAbi, InitialState};
     use matching_engine::{MatchingEngineAbi, OrderNature, Parameters, Price};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client_admin = local_net.make_client(network);
-    let mut client_a = local_net.make_client(network);
-    let mut client_b = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client_admin = local_net.make_client(network);
+    let client_a = local_net.make_client(network);
+    let client_b = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client_admin.create_genesis_config().await.unwrap();
@@ -928,8 +937,8 @@ async fn run_end_to_end_matching_engine(database: Database) {
         local_net.build_example("matching-engine").await.unwrap();
 
     let chain_admin = client_admin.get_wallet().default_chain().unwrap();
-    let chain_a = client_admin.open_and_assign(&mut client_a).await.unwrap();
-    let chain_b = client_admin.open_and_assign(&mut client_b).await.unwrap();
+    let chain_a = client_admin.open_and_assign(&client_a).await.unwrap();
+    let chain_b = client_admin.open_and_assign(&client_b).await.unwrap();
 
     // The players
     let owner_admin = get_fungible_account_owner(&client_admin);
@@ -1149,35 +1158,35 @@ async fn run_end_to_end_matching_engine(database: Database) {
 
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_end_to_end_amm() {
-    run_end_to_end_amm(Database::RocksDb).await
+async fn test_rocks_db_wasm_end_to_end_amm() {
+    run_wasm_end_to_end_amm(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_end_to_end_amm() {
-    run_end_to_end_amm(Database::DynamoDb).await
+async fn test_dynamo_db_wasm_end_to_end_amm() {
+    run_wasm_end_to_end_amm(Database::DynamoDb).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_end_to_end_amm() {
-    run_end_to_end_amm(Database::ScyllaDb).await
+async fn test_scylla_db_wasm_end_to_end_amm() {
+    run_wasm_end_to_end_amm(Database::ScyllaDb).await
 }
 
-async fn run_end_to_end_amm(database: Database) {
+async fn run_wasm_end_to_end_amm(database: Database) {
+    set_table_prefix("wasm_end_to_end").await;
     use amm::{AmmAbi, Parameters};
     use fungible::{FungibleTokenAbi, InitialState};
-
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
-    let mut client_admin = local_net.make_client(network);
-    let mut client0 = local_net.make_client(network);
-    let mut client1 = local_net.make_client(network);
+    let mut local_net = LocalNetwork::new_for_testing(database, network)
+        .await
+        .unwrap();
+    let client_admin = local_net.make_client(network);
+    let client0 = local_net.make_client(network);
+    let client1 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
     client_admin.create_genesis_config().await.unwrap();
@@ -1192,8 +1201,8 @@ async fn run_end_to_end_amm(database: Database) {
     let chain_admin = client_admin.get_wallet().default_chain().unwrap();
 
     // User chains
-    let chain0 = client_admin.open_and_assign(&mut client0).await.unwrap();
-    let chain1 = client_admin.open_and_assign(&mut client1).await.unwrap();
+    let chain0 = client_admin.open_and_assign(&client0).await.unwrap();
+    let chain1 = client_admin.open_and_assign(&client1).await.unwrap();
 
     // Admin user
     let owner_admin = get_fungible_account_owner(&client_admin);

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -38,12 +38,12 @@ sha3 = { workspace = true }
 thiserror = { workspace = true }
 linked-hash-map = { workspace = true }
 tempfile = { workspace = true }
+once_cell = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-once_cell = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync"] }
 anyhow = { workspace = true, optional = true }
-tracing = { workspace = true }
 http = { workspace = true }
 rand = { workspace = true }
 scylla = { workspace = true, optional = true }

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -237,10 +237,11 @@ impl RocksDbClient {
     pub async fn initialize(
         store_config: RocksDbKvStoreConfig,
     ) -> Result<Self, RocksDbContextError> {
+        let kv_name = format!("{:?}", store_config);
         let create_if_missing = true;
         let (client, table_status) = Self::new_internal(store_config, create_if_missing).await?;
         if table_status == TableStatus::Existing {
-            return Err(RocksDbContextError::AlreadyExistingDatabase);
+            return Err(RocksDbContextError::AlreadyExistingDatabase(kv_name));
         }
         Ok(client)
     }
@@ -396,7 +397,7 @@ pub enum RocksDbContextError {
 
     /// Already existing database
     #[error("Already existing database")]
-    AlreadyExistingDatabase,
+    AlreadyExistingDatabase(String),
 
     /// Filesystem error
     #[error("Filesystem error")]

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     batch::Batch,
-    common::Context,
+    common::{set_table_prefix, Context},
     memory::{create_memory_context, MemoryContext},
     queue_view::QueueView,
     views::{View, ViewError},
@@ -65,6 +65,7 @@ where
     C: TestContextFactory,
     ViewError: From<<C::Context as Context>::Error>,
 {
+    set_table_prefix("unit_test_views").await;
     use self::Operation::*;
 
     let test_cases = [

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -3,7 +3,7 @@
 
 use linera_views::{
     batch::Batch,
-    common::{get_interval, KeyIterable, KeyValueIterable, KeyValueStoreClient},
+    common::{get_interval, set_table_prefix, KeyIterable, KeyValueIterable, KeyValueStoreClient},
     key_value_store_view::ViewContainer,
     memory::{create_memory_client, create_memory_context},
     test_utils::{get_random_byte_vector, get_random_key_value_vec_prefix, get_small_key_space},
@@ -29,10 +29,11 @@ use linera_views::scylla_db::create_scylla_db_test_client;
 /// * `find_keys_by_prefix` / `find_key_values_by_prefix`
 /// * The ordering of keys returned by `find_keys_by_prefix` and `find_key_values_by_prefix`
 #[cfg(test)]
-async fn test_readings_vec<OP: KeyValueStoreClient + Sync>(
+async fn run_readings_vec<OP: KeyValueStoreClient + Sync>(
     key_value_operation: OP,
     key_value_vec: Vec<(Vec<u8>, Vec<u8>)>,
 ) {
+    set_table_prefix("operation_tests").await;
     // We need a nontrivial key_prefix because dynamo requires a non-trivial prefix
     let mut batch = Batch::new();
     let mut keys = Vec::new();
@@ -148,7 +149,7 @@ fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {
 async fn test_readings_test_memory() {
     for scenario in get_random_test_scenarios() {
         let key_value_operation = create_test_memory_client();
-        test_readings_vec(key_value_operation, scenario).await;
+        run_readings_vec(key_value_operation, scenario).await;
     }
 }
 
@@ -156,7 +157,7 @@ async fn test_readings_test_memory() {
 async fn test_readings_memory() {
     for scenario in get_random_test_scenarios() {
         let key_value_operation = create_memory_client();
-        test_readings_vec(key_value_operation, scenario).await;
+        run_readings_vec(key_value_operation, scenario).await;
     }
 }
 
@@ -165,7 +166,7 @@ async fn test_readings_memory() {
 async fn test_readings_rocks_db() {
     for scenario in get_random_test_scenarios() {
         let key_value_operation = create_rocks_db_test_client().await;
-        test_readings_vec(key_value_operation, scenario).await;
+        run_readings_vec(key_value_operation, scenario).await;
     }
 }
 
@@ -174,7 +175,7 @@ async fn test_readings_rocks_db() {
 async fn test_readings_dynamodb() {
     for scenario in get_random_test_scenarios() {
         let key_value_operation = create_dynamo_db_test_client().await;
-        test_readings_vec(key_value_operation, scenario).await;
+        run_readings_vec(key_value_operation, scenario).await;
     }
 }
 
@@ -183,7 +184,7 @@ async fn test_readings_dynamodb() {
 async fn test_readings_scylla_db() {
     for scenario in get_random_test_scenarios() {
         let key_value_operation = create_scylla_db_test_client().await;
-        test_readings_vec(key_value_operation, scenario).await;
+        run_readings_vec(key_value_operation, scenario).await;
     }
 }
 
@@ -192,7 +193,7 @@ async fn test_readings_key_value_store_view_memory() {
     for scenario in get_random_test_scenarios() {
         let context = create_memory_context();
         let key_value_operation = ViewContainer::new(context).await.unwrap();
-        test_readings_vec(key_value_operation, scenario).await;
+        run_readings_vec(key_value_operation, scenario).await;
     }
 }
 
@@ -205,11 +206,12 @@ async fn test_readings_memory_specific() {
         (vec![0, 2], Vec::new()),
         (vec![0, 2, 0], Vec::new()),
     ];
-    test_readings_vec(key_value_operation, key_value_vec).await;
+    run_readings_vec(key_value_operation, key_value_vec).await;
 }
 
 #[cfg(test)]
-async fn test_writings_random<OP: KeyValueStoreClient + Sync>(key_value_operation: OP) {
+async fn run_writings_random<OP: KeyValueStoreClient + Sync>(key_value_operation: OP) {
+    set_table_prefix("operation_tests").await;
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     let mut kv_state = BTreeMap::new();
     let n_oper = 100;
@@ -270,41 +272,41 @@ async fn test_writings_random<OP: KeyValueStoreClient + Sync>(key_value_operatio
 #[tokio::test]
 async fn test_writings_test_memory() {
     let key_value_operation = create_test_memory_client();
-    test_writings_random(key_value_operation).await;
+    run_writings_random(key_value_operation).await;
 }
 
 #[tokio::test]
 async fn test_writings_memory() {
     let key_value_operation = create_memory_client();
-    test_writings_random(key_value_operation).await;
+    run_writings_random(key_value_operation).await;
 }
 
 #[tokio::test]
 async fn test_writings_key_value_store_view_memory() {
     let context = create_memory_context();
     let key_value_operation = ViewContainer::new(context).await.unwrap();
-    test_writings_random(key_value_operation).await;
+    run_writings_random(key_value_operation).await;
 }
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_writings_rocks_db() {
     let key_value_operation = create_rocks_db_test_client().await;
-    test_writings_random(key_value_operation).await;
+    run_writings_random(key_value_operation).await;
 }
 
 #[cfg(feature = "aws")]
 #[tokio::test]
 async fn test_writings_dynamodb() {
     let key_value_operation = create_dynamo_db_test_client().await;
-    test_writings_random(key_value_operation).await;
+    run_writings_random(key_value_operation).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[tokio::test]
 async fn test_writings_scylla_db() {
     let key_value_operation = create_scylla_db_test_client().await;
-    test_writings_random(key_value_operation).await;
+    run_writings_random(key_value_operation).await;
 }
 
 #[tokio::test]

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -9,7 +9,7 @@ use linera_views::{
         WriteOperation::{Delete, DeletePrefix, Put},
     },
     collection_view::CollectionView,
-    common::Context,
+    common::{set_table_prefix, Context},
     key_value_store_view::{KeyValueStoreMemoryContext, KeyValueStoreView},
     log_view::LogView,
     lru_caching::LruCachingMemoryContext,
@@ -92,6 +92,7 @@ impl StateStore for MemoryTestStore {
     }
 
     async fn load(&mut self, id: usize) -> Result<StateView<Self::Context>, ViewError> {
+        set_table_prefix("view_tests").await;
         let state = self
             .states
             .entry(id)


### PR DESCRIPTION
## Motivation

We want to have the end-to-end tests working for the `DynamoDb` and `ScyllaDb` tests.

## Proposal

The PR does the following:
* We use a shared server for the `ScyllaDb` and `DynamoDb` storages.
* The `LocalNetwork` now uses a `get_table_name` in order to create a unique table so that we can test more than one test with cargo. This means that the storage is accumulating as things go.
* As a consequence the `new` of `LocalNetwork` is now `async`.
* The `ClientWrapper` takes the table_name as input so again separate tables.
* There was a leftover correction that unfortunately passed into `main`. The clients are now `mut` which is actually not needed. I would have expected the `clippy` to detect it, but no. So, here is the cleanup.
* All the `#[ignore]` related to end-to-end tests are removed.
* It addresses 3 bugs in the `DynamoDb` code for large values
* It adds a prefix to the `get_table_name` because when running from one test file to the next like `end_to_end_tests.rs` to `wasm_end_to_end_tests.rs` the counter gets reset to 0.

## Test Plan

The CI works with the exception of two tests which are indicated as `#[ignore]`.

## Links

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [ ] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
