### PR TITLE
Fix local Kubernetes run after storage changes

### DIFF
--- a/kubernetes/linera-validator/redeploy.sh
+++ b/kubernetes/linera-validator/redeploy.sh
@@ -59,9 +59,13 @@ kubectl get svc;
 sleep 2;
 docker rm linera-test-local;
 if [ "$cloud_mode" = true ]; then
-    docker run -d --name linera-test-local us-docker.pkg.dev/linera-io-dev/linera-docker-repo/linera-test-local:latest && docker cp linera-test-local:/opt/linera/wallet.json /tmp/
+    docker run -d --name linera-test-local us-docker.pkg.dev/linera-io-dev/linera-docker-repo/linera-test-local:latest \
+    && docker cp linera-test-local:/opt/linera/wallet.json /tmp/ \
+    && docker cp linera-test-local:/opt/linera/linera.db /tmp/
 else
-    docker run -d --name linera-test-local linera-test:latest && docker cp linera-test-local:/opt/linera/wallet.json /tmp/
+    docker run -d --name linera-test-local linera-test:latest \
+    && docker cp linera-test-local:/opt/linera/wallet.json /tmp/ \
+    && docker cp linera-test-local:/opt/linera/linera.db /tmp/
 fi
 
 echo -e "\nMake sure the terminal you'll run the linera client from has these exports:"

--- a/kubernetes/linera-validator/templates/server.yaml
+++ b/kubernetes/linera-validator/templates/server.yaml
@@ -73,3 +73,22 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+      initContainers:
+        - name: linera-server-initializer
+          image: {{ .Values.lineraImage }}
+          imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
+          command: ["./linera-server"]
+          args:
+            [
+              "initialize",
+              "--storage",
+              "rocksdb:/usr/share/rocksdb/shard_data.db",
+              "--genesis",
+              "genesis.json",
+            ]
+          volumeMounts:
+          - name: rocksdb
+            mountPath: /usr/share/rocksdb
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.logLevel }}


### PR DESCRIPTION
## Motivation

There were some changes made in how storage works, so we need to adapt our local run to it

## Proposal

1. Copy the client's db generated in the Dockerfile over to `/tmp` so things work properly
2. Make sure server's db is initialized before running the server

## Test Plan

Run cluster locally, make sure everything works

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
