### PR TITLE
Listen to all the chains in the wallet

### DIFF
--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -80,7 +80,7 @@ where
     where
         C: ClientContext<P> + Send + 'static,
     {
-        let chain_ids = context.wallet_state().own_chain_ids();
+        let chain_ids = context.wallet_state().chain_ids();
         let context = Arc::new(Mutex::new(context));
         for chain_id in chain_ids {
             Self::run_with_chain_id(

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -121,6 +121,17 @@ impl UserChain {
             next_block_height: BlockHeight::ZERO,
         }
     }
+
+    /// Creates an entry for a chain that we don't own.
+    pub fn make_other(description: ChainDescription, timestamp: Timestamp) -> Self {
+        Self {
+            chain_id: description.into(),
+            key_pair: None,
+            block_hash: None,
+            timestamp,
+            next_block_height: BlockHeight::ZERO,
+        }
+    }
 }
 
 /// A wrapper around `InnerWalletState` which owns a [`FileLock`] to prevent

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1968,7 +1968,6 @@ async fn main() -> Result<(), anyhow::Error> {
                 testing_prng_seed,
             } => {
                 let genesis_config = GenesisConfig::read(genesis_config_path)?;
-                let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
                 let chains = with_other_chains
                     .iter()
                     .filter_map(|chain_id| {
@@ -1976,16 +1975,11 @@ async fn main() -> Result<(), anyhow::Error> {
                             .chains
                             .iter()
                             .find(|(desc, _, _, _)| ChainId::from(*desc) == *chain_id)?;
-                        Some(UserChain::make_initial(&mut rng, *description, *timestamp))
+                        Some(UserChain::make_other(*description, *timestamp))
                     })
                     .collect();
-                let new_prng_seed = if testing_prng_seed.is_some() {
-                    Some(rng.gen())
-                } else {
-                    None
-                };
                 let mut context =
-                    ClientContext::create(&options, genesis_config, new_prng_seed, chains)?;
+                    ClientContext::create(&options, genesis_config, *testing_prng_seed, chains)?;
                 context.save_wallet();
                 options.initialize_storage().await?;
                 Ok(())

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1060,7 +1060,7 @@ enum WalletCommand {
         #[structopt(long = "genesis")]
         genesis_config_path: PathBuf,
 
-        // Other chains to follow.
+        /// Other chains to follow.
         #[structopt(long)]
         with_other_chains: Vec<ChainId>,
 


### PR DESCRIPTION
## Motivation

* Avoid generating fake-key pairs in the case of `linera wallet init --with-other-chains ID`
* Better support unowned chains in the wallet
* Be consistent in listening to all of them

## Proposal

* Introduce `UserChain::make_other`
* Make sure to handle failures of `process_inbox` in the chain listener
* Listen to all chains in the wallet (we will refine later)

## Test Plan

CI

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
