### PR TITLE
Make key generation (optionally) reproducible for manual testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,7 @@ dependencies = [
  "once_cell",
  "parse_duration",
  "proptest",
+ "rand 0.7.3",
  "reqwest",
  "serde",
  "serde_json",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -43,6 +43,7 @@ once_cell = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 tracing = { workspace = true }
 parse_duration = { workspace = true }
+rand07 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 structopt = { workspace = true }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use colored::Colorize;
 use futures::{lock::Mutex, StreamExt};
 use linera_base::{
-    crypto::{KeyPair, PublicKey},
+    crypto::{CryptoRng, KeyPair, PublicKey},
     data_types::{Amount, BlockHeight, RoundNumber, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, MessageId},
 };
@@ -34,6 +34,7 @@ use linera_service::{
 };
 use linera_storage::Store;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
+use rand07::Rng;
 use serde_json::Value;
 use std::{
     env, fs,
@@ -76,6 +77,7 @@ struct ClientContext {
     notification_retry_delay: Duration,
     notification_retries: u32,
     wait_for_outgoing_messages: bool,
+    prng: Box<dyn CryptoRng>,
 }
 
 #[async_trait]
@@ -115,6 +117,7 @@ impl ClientContext {
     fn create(
         options: &ClientOptions,
         genesis_config: GenesisConfig,
+        testing_prng_seed: Option<u64>,
         chains: Vec<UserChain>,
     ) -> Result<Self, anyhow::Error> {
         let wallet_state_path = match &options.wallet_state_path {
@@ -127,8 +130,9 @@ impl ClientContext {
                 wallet_state_path.display()
             )
         }
-        let mut wallet_state = WalletState::create(&wallet_state_path, genesis_config)
-            .with_context(|| format!("Unable to create wallet at {:?}", &wallet_state_path))?;
+        let mut wallet_state =
+            WalletState::create(&wallet_state_path, genesis_config, testing_prng_seed)
+                .with_context(|| format!("Unable to create wallet at {:?}", &wallet_state_path))?;
         chains
             .into_iter()
             .for_each(|chain| wallet_state.insert(chain));
@@ -159,6 +163,7 @@ impl ClientContext {
         let notification_retry_delay = Duration::from_micros(options.notification_retry_delay_us);
         let notification_retries = options.notification_retries;
         let wait_for_outgoing_messages = options.wait_for_outgoing_messages;
+        let prng = wallet_state.make_prng();
 
         ClientContext {
             wallet_state,
@@ -170,6 +175,7 @@ impl ClientContext {
             notification_retry_delay,
             notification_retries,
             wait_for_outgoing_messages,
+            prng,
         }
     }
 
@@ -411,6 +417,7 @@ impl ClientContext {
     }
 
     fn save_wallet(&mut self) {
+        self.wallet_state.refresh_prng_seed(&mut self.prng);
         self.wallet_state
             .write()
             .expect("Unable to write user chains");
@@ -544,6 +551,10 @@ impl ClientContext {
         chain_client.synchronize_from_validators().await?;
         chain_client.process_inbox().await?;
         Ok(bytecode_id)
+    }
+
+    fn generate_key_pair(&mut self) -> KeyPair {
+        KeyPair::generate_from(&mut self.prng)
     }
 }
 
@@ -852,6 +863,11 @@ enum ClientCommand {
         /// Set the price per byte to store and send outgoing cross-chain messages.
         #[structopt(long, default_value = "0")]
         messages_price: Amount,
+
+        /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
+        /// TESTING ONLY.
+        #[structopt(long)]
+        testing_prng_seed: Option<u64>,
     },
 
     /// Watch the network for notifications.
@@ -1025,6 +1041,11 @@ enum WalletCommand {
         // Other chains to follow.
         #[structopt(long)]
         with_other_chains: Vec<ChainId>,
+
+        /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
+        /// TESTING ONLY.
+        #[structopt(long)]
+        testing_prng_seed: Option<u64>,
     },
 }
 
@@ -1131,7 +1152,7 @@ impl Runnable for Job {
                 let (new_public_key, key_pair) = match public_key {
                     Some(key) => (key, None),
                     None => {
-                        let key_pair = KeyPair::generate();
+                        let key_pair = context.generate_key_pair();
                         (key_pair.public(), Some(key_pair))
                     }
                 };
@@ -1700,6 +1721,7 @@ async fn main() -> Result<(), anyhow::Error> {
             fuel_price,
             storage_price,
             messages_price,
+            testing_prng_seed,
         } => {
             let committee_config = CommitteeConfig::read(committee_config_path)
                 .expect("Unable to read committee config file");
@@ -1718,11 +1740,12 @@ async fn main() -> Result<(), anyhow::Error> {
                     )
                 })
                 .unwrap_or_else(Timestamp::now);
+            let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
             let mut chains = vec![];
             for i in 0..*num {
                 let description = ChainDescription::Root(i);
                 // Create keys.
-                let chain = UserChain::make_initial(description, timestamp);
+                let chain = UserChain::make_initial(&mut rng, description, timestamp);
                 // Public "genesis" state.
                 genesis_config.chains.push((
                     description,
@@ -1733,7 +1756,13 @@ async fn main() -> Result<(), anyhow::Error> {
                 // Private keys.
                 chains.push(chain);
             }
-            let mut context = ClientContext::create(&options, genesis_config.clone(), chains)?;
+            let new_prng_seed = if testing_prng_seed.is_some() {
+                Some(rng.gen())
+            } else {
+                None
+            };
+            let mut context =
+                ClientContext::create(&options, genesis_config.clone(), new_prng_seed, chains)?;
             genesis_config.write(genesis_config_path)?;
             context.save_wallet();
             options.initialize_storage().await?;
@@ -1755,7 +1784,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
         ClientCommand::Keygen => {
             let mut context = ClientContext::from_options(&options)?;
-            let key_pair = KeyPair::generate();
+            let key_pair = context.generate_key_pair();
             let public = key_pair.public();
             context.wallet_state.add_unassigned_key_pair(key_pair);
             context.save_wallet();
@@ -1858,8 +1887,10 @@ async fn main() -> Result<(), anyhow::Error> {
             WalletCommand::Init {
                 genesis_config_path,
                 with_other_chains,
+                testing_prng_seed,
             } => {
                 let genesis_config = GenesisConfig::read(genesis_config_path)?;
+                let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
                 let chains = with_other_chains
                     .iter()
                     .filter_map(|chain_id| {
@@ -1867,10 +1898,16 @@ async fn main() -> Result<(), anyhow::Error> {
                             .chains
                             .iter()
                             .find(|(desc, _, _, _)| ChainId::from(*desc) == *chain_id)?;
-                        Some(UserChain::make_initial(*description, *timestamp))
+                        Some(UserChain::make_initial(&mut rng, *description, *timestamp))
                     })
                     .collect();
-                let mut context = ClientContext::create(&options, genesis_config, chains)?;
+                let new_prng_seed = if testing_prng_seed.is_some() {
+                    Some(rng.gen())
+                } else {
+                    None
+                };
+                let mut context =
+                    ClientContext::create(&options, genesis_config, new_prng_seed, chains)?;
                 context.save_wallet();
                 options.initialize_storage().await?;
                 Ok(())

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1021,6 +1021,11 @@ enum NetCommand {
         /// The number of shards per validator in the local test network. Default is 1.
         #[structopt(long, default_value = "1")]
         shards: usize,
+
+        /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
+        /// TESTING ONLY.
+        #[structopt(long)]
+        testing_prng_seed: Option<u64>,
     },
 }
 
@@ -1797,6 +1802,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 wallets,
                 validators,
                 shards,
+                testing_prng_seed,
             } => {
                 if *validators < 1 {
                     panic!("The local test network must have at least one validator.");
@@ -1805,7 +1811,13 @@ async fn main() -> Result<(), anyhow::Error> {
                     panic!("The local test network must have at least one shard per validator.");
                 }
                 let network = Network::Grpc;
-                let mut net = LocalNetwork::new(Database::RocksDb, network, *validators, *shards)?;
+                let mut net = LocalNetwork::new(
+                    Database::RocksDb,
+                    network,
+                    *testing_prng_seed,
+                    *validators,
+                    *shards,
+                )?;
                 let mut client1 = net.make_client(network);
 
                 // Create the initial server and client config.

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -438,7 +438,7 @@ async fn test_scylla_db_project_new() {
 
 async fn run_project_new(database: Database) {
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 0, 0).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, None, 0, 0).unwrap();
     let client = local_net.make_client(network);
 
     let tmp_dir = client.project_new("init-test").await.unwrap();
@@ -471,7 +471,7 @@ async fn test_scylla_db_project_test() {
 
 async fn run_project_test(database: Database) {
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 0, 0).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, None, 0, 0).unwrap();
     let client = local_net.make_client(network);
     client
         .project_test(&LocalNetwork::example_path("counter").unwrap())
@@ -502,7 +502,7 @@ async fn run_project_publish(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 1, 1).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, Some(37), 1, 1).unwrap();
     let mut client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
@@ -547,7 +547,7 @@ async fn run_example_publish(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 1, 1).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, Some(37), 1, 1).unwrap();
     let mut client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -29,16 +29,16 @@ VALIDATOR_FILES=()
 for i in $(seq 1 $NUM_VALIDATORS); do
     VALIDATOR_FILES+=("$CONF_DIR/validator_$i.toml")
 done
-./linera-server generate --validators "${VALIDATOR_FILES[@]}" --committee committee.json
+./linera-server generate --validators "${VALIDATOR_FILES[@]}" --committee committee.json --testing-prng-seed 1
 
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
 
-./linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json
+./linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
 
 # Initialize the second wallet.
-./linera --wallet wallet_2.json --storage rocksdb:linera_2.db wallet init --genesis genesis.json
+./linera --wallet wallet_2.json --storage rocksdb:linera_2.db wallet init --genesis genesis.json --testing-prng-seed 3
 
 # Start servers and create initial chains in DB
 for I in $(seq 1 $NUM_VALIDATORS)


### PR DESCRIPTION
## Motivation

Writing documentation where the generated keys are predictable. This should help readability and eventually testability of the bash scripts in CI.

## Proposal

* Add new CLI options to store a PRNG seed in wallets
* Use it for all key generation
* Same for validator keys

## Links

PR is on top of #1080  

## Test Plan

I ran the `scripts/run_local.sh` manually several times and followed the README file of crowd-funding.
I also run `linera net up` several times and inspected the temporary directory.