### PR TITLE
Avoid using `String::replace` to quote JSON in GraphQL queries

### DIFF
--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -4,7 +4,7 @@ use async_graphql::{scalar, Request, Response};
 use fungible::AccountOwner;
 use linera_sdk::base::{Amount, ArithmeticError, ContractAbi, ServiceAbi};
 use linera_views::views::ViewError;
-use matching_engine::Parameters;
+pub use matching_engine::Parameters;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -906,7 +906,7 @@ async fn test_scylla_db_end_to_end_matching_engine() {
 
 async fn run_end_to_end_matching_engine(database: Database) {
     use fungible::{FungibleTokenAbi, InitialState};
-    use matching_engine::{OrderNature, Parameters, Price};
+    use matching_engine::{MatchingEngineAbi, OrderNature, Parameters, Price};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
@@ -1041,14 +1041,12 @@ async fn run_end_to_end_matching_engine(database: Database) {
     let bytecode_id = node_service_admin
         .publish_bytecode(&chain_admin, contract_matching, service_matching)
         .await;
-    let parameter_str = serde_json::to_string(&parameter).unwrap();
-    let argument_str = serde_json::to_string(&()).unwrap();
     let application_id_matching = node_service_admin
-        .create_application(
+        .create_application::<MatchingEngineAbi>(
             &chain_admin,
             bytecode_id,
-            parameter_str,
-            argument_str,
+            &parameter,
+            &(),
             vec![
                 application_id_fungible0.clone(),
                 application_id_fungible1.clone(),
@@ -1170,8 +1168,8 @@ async fn test_scylla_db_end_to_end_amm() {
 }
 
 async fn run_end_to_end_amm(database: Database) {
-    use fungible::InitialState;
-    use matching_engine::Parameters;
+    use amm::{AmmAbi, Parameters};
+    use fungible::{FungibleTokenAbi, InitialState};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
@@ -1233,20 +1231,20 @@ async fn run_end_to_end_amm(database: Database) {
         .await;
 
     let application_id_fungible0 = node_service_admin
-        .create_application(
+        .create_application::<FungibleTokenAbi>(
             &chain_admin,
             fungible_bytecode_id.clone(),
-            serde_json::to_string(&()).unwrap(),
-            serde_json::to_string(&state_fungible0).unwrap(),
+            &(),
+            &state_fungible0,
             vec![],
         )
         .await;
     let application_id_fungible1 = node_service_admin
-        .create_application(
+        .create_application::<FungibleTokenAbi>(
             &chain_admin,
             fungible_bytecode_id,
-            serde_json::to_string(&()).unwrap(),
-            serde_json::to_string(&state_fungible1).unwrap(),
+            &(),
+            &state_fungible1,
             vec![],
         )
         .await;
@@ -1293,14 +1291,12 @@ async fn run_end_to_end_amm(database: Database) {
     let bytecode_id = node_service_admin
         .publish_bytecode(&chain_admin, contract_amm, service_amm)
         .await;
-    let parameter_str = serde_json::to_string(&parameters).unwrap();
-    let argument_str = serde_json::to_string(&()).unwrap();
     let application_id_amm = node_service_admin
-        .create_application(
+        .create_application::<AmmAbi>(
             &chain_admin,
             bytecode_id,
-            parameter_str,
-            argument_str,
+            &parameters,
+            &(),
             vec![
                 application_id_fungible0.clone(),
                 application_id_fungible1.clone(),


### PR DESCRIPTION
## Motivation

fixes #828

## Proposal

* Use typed ABI interfaces as in the rest of the code.
* Convert to `serde_json::Value` then `async_graphql::Value` via the trait `InputType`.

## Test Plan

CI

## Release Plan

- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
