### PR TITLE
Update locked block from past rounds if we're not a validator.

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -275,6 +275,12 @@ impl<StorageClient> WorkerState<StorageClient> {
         &self.storage
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_key_pair(mut self, key_pair: Option<Arc<KeyPair>>) -> Self {
+        self.key_pair = key_pair;
+        self
+    }
+
     pub(crate) async fn full_certificate(
         &mut self,
         certificate: LiteCertificate<'_>,


### PR DESCRIPTION
## Motivation

For the BFT protocol to be live, the leader of the current round must be able to:
* fetch all the honest validators' locked blocks (a `ValidatedBlock` certificate),
* find the one with the highest round number,
* re-propose that block in the current round, citing the locked block certificate,
* and be sure that this certificate will still be in a greater or equal round than the honest validators' locked blocks.

That is only guaranteed if between the first and last point nobody else can change the validators' locked blocks. That's why sending a `ValidatedBlock` certificate from a past round to a validator won't update their locked block.

However, the leader's client itself is also using a chain manager to collect all the locked blocks, and needs to keep track of the latest one, even if it's not from the current round.

## Proposal

Update the locked block based on an incoming `ValidatedBlock` certificate if:
* it's from the current round, _or_
* it's later than our locked block and we are not a validator (don't have signing keys).

## Test Plan

The worker test was updated to check both that a `ValidatedBlock` certificate from a past round isn't accepted in a validator, and that it is accepted in a non-validator.

## Links

<!--
Optional section for related PRs, related issues, and other references.

Please create issues to track future improvements.
-->

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
