### PR TITLE
Enable WARN-level logging for ScyllaDB/DynamoDB CI.

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -19,6 +19,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: warn
 
 permissions:
   contents: read

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -19,6 +19,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: warn
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation

It's sometimes hard to tell what went wrong if the ScyllaDB or DynamoDB CI fails.

## Proposal

Enable WARN-level logs, just like in `rust.yml`.

## Test Plan

This should make debugging easier, but doesn't change production code.

## Links

N/A

## Release Plan

<!--
How to safely release the changes. Please create issues to track future release work.
-->
- [x] All good!
- [ ] Need to bump the major/minor version number in the next release of the crates.
- [ ] Need to update the developer manual.
- [ ] This PR is adding or removing Cargo features.
- [ ] Release is blocked and/or tracked by other issues (see links above)

## Reviewer Checklist

- [ ] The title and the summary of the PR are short and descriptive.
- [ ] The proposed solution achieves the goals stated in the PR.
- [ ] The test plan is reproducible and provides sufficient coverage.
- [ ] The release plan is adequate.
- [ ] The commits correspond to distinct logical changes.
- [ ] The code follows the [coding guidelines](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md).
- [ ] The proposed changes look correct.
- [ ] The CI is passing.
- [ ] All of the above!
