### PR TITLE
CI: use 16 cores instead of 8 cores

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,7 +50,7 @@ jobs:
         publish_dir: ./target/doc
 
   docsrs:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
 
   build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
 
   build:
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "linera-base"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-graphql",
  "bcs",
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-graphql",
  "async-lock",
@@ -2776,7 +2776,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2816,7 +2816,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "linera-explorer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "linera-rpc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "amm",
  "anyhow",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service-graphql-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "fungible",
  "graphql_client",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -3189,7 +3189,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "convert_case 0.6.0",
  "heck 0.4.1",
@@ -3339,7 +3339,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "either",
@@ -3356,7 +3356,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-macros"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,23 +120,23 @@ wit-bindgen-guest-rust = { version = "0.2.0", package = "linera-wit-bindgen-gues
 wit-bindgen-host-wasmer-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmer-rust" }
 wit-bindgen-host-wasmtime-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmtime-rust" }
 
-linera-base = { version = "0.4.0", path = "./linera-base" }
-linera-chain = { version = "0.4.0", path = "./linera-chain" }
-linera-core = { version = "0.4.0", path = "./linera-core", default-features = false }
-linera-execution = { version = "0.4.0", path = "./linera-execution", default-features = false }
+linera-base = { version = "0.4.1", path = "./linera-base" }
+linera-chain = { version = "0.4.1", path = "./linera-chain" }
+linera-core = { version = "0.4.1", path = "./linera-core", default-features = false }
+linera-execution = { version = "0.4.1", path = "./linera-execution", default-features = false }
 linera-indexer = { path = "./linera-indexer/lib" }
 linera-indexer-example = { path = "./linera-indexer/example" }
 linera-indexer-graphql-client = { path = "./linera-indexer/graphql-client" }
 linera-indexer-plugins = { path = "./linera-indexer/plugins" }
-linera-rpc = { version = "0.4.0", path = "./linera-rpc" }
-linera-storage = { version = "0.4.0", path = "./linera-storage", default-features = false }
-linera-views = { version = "0.4.0", path = "./linera-views", default-features = false }
-linera-views-derive = { version = "0.4.0", path = "./linera-views-derive" }
-linera-witty = { version = "0.4.0", path = "./linera-witty" }
-linera-witty-macros = { version = "0.4.0", path = "./linera-witty-macros" }
-linera-sdk-derive = { version = "0.4.0", path = "./linera-sdk-derive" }
-linera-service = { version = "0.4.0", path = "./linera-service" }
-linera-service-graphql-client = { version = "0.4.0", path = "./linera-service-graphql-client" }
+linera-rpc = { version = "0.4.1", path = "./linera-rpc" }
+linera-storage = { version = "0.4.1", path = "./linera-storage", default-features = false }
+linera-views = { version = "0.4.1", path = "./linera-views", default-features = false }
+linera-views-derive = { version = "0.4.1", path = "./linera-views-derive" }
+linera-witty = { version = "0.4.1", path = "./linera-witty" }
+linera-witty-macros = { version = "0.4.1", path = "./linera-witty-macros" }
+linera-sdk-derive = { version = "0.4.1", path = "./linera-sdk-derive" }
+linera-service = { version = "0.4.1", path = "./linera-service" }
+linera-service-graphql-client = { version = "0.4.1", path = "./linera-service-graphql-client" }
 
 counter = { path = "./examples/counter" }
 meta-counter = { path = "./examples/meta-counter" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "linera-base"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-graphql",
  "bcs",
@@ -1586,7 +1586,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-graphql",
  "async-lock",
@@ -1605,7 +1605,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1634,7 +1634,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1666,7 +1666,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "bcs",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "convert_case 0.6.0",
  "heck 0.4.1",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-base"
-version = "0.4.0"
+version = "0.4.1"
 description = "Base definitions, including cryptography, used by the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-chain"
-version = "0.4.0"
+version = "0.4.1"
 description = "Persistent data and the corresponding logics used by the Linera protocol for chains of blocks, certificates, and cross-chain messaging."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-core"
-version = "0.4.0"
+version = "0.4.1"
 description = "The core Linera protocol, including client and server logic, node synchronization, etc."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-execution"
-version = "0.4.0"
+version = "0.4.1"
 description = "Persistent data and the corresponding logics used by the Linera protocol for runtime and execution of smart contracts / applications."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-explorer/Cargo.toml
+++ b/linera-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-explorer"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Block explorer for the Linera network"
 readme = "README.md"

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-rpc"
-version = "0.4.0"
+version = "0.4.1"
 description = "RPC schemas and networking library for the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-sdk-derive/Cargo.toml
+++ b/linera-sdk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk-derive"
-version = "0.4.0"
+version = "0.4.1"
 description = "The procedural macros for the crate `linera-sdk`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk"
-version = "0.4.0"
+version = "0.4.1"
 description = "Library to support developping Linera applications in Rust."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-service-graphql-client"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A GraphQL client for Linera node service"
 readme = "README.md"

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-service"
-version = "0.4.0"
+version = "0.4.1"
 description = "Executable for clients (aka CLI wallets), proxy (aka validator frontend) and servers of the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-storage"
-version = "0.4.0"
+version = "0.4.1"
 description = "Storage abstractions for the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-views-derive/Cargo.toml
+++ b/linera-views-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-views-derive"
-version = "0.4.0"
+version = "0.4.1"
 description = "The procedural macros for the crate `linera-views`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-views"
-version = "0.4.0"
+version = "0.4.1"
 description = "A library mapping complex data structures onto a key-value store, used by the Linera protocol"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-witty-macros"
-version = "0.4.0"
+version = "0.4.1"
 description = "Procedural macros for generation of WIT compatible host code from Rust code"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-witty"
-version = "0.4.0"
+version = "0.4.1"
 description = "Generation of WIT compatible host code from Rust code"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"


### PR DESCRIPTION
## Motivation

Faster CI

## Proposal

Use Ubuntu 16 cores instead of 8 cores

## Test Plan

CI

Comparing to #1067:
- Scylladb goes from 8min to 5min
- DynamodDb goes from 9min to 8min :-|
- Rust goes from 37min to 28min
