### PR TITLE
Quick fix to skip failing user messages

### DIFF
--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -8,26 +8,16 @@
 
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
-use crate::{
-    client::{
-        client_tests::{MakeMemoryStoreClient, StoreBuilder, TestBuilder},
-        ChainClientError,
-    },
-    local_node::LocalNodeError,
-    worker::WorkerError,
-};
+use crate::client::client_tests::{MakeMemoryStoreClient, StoreBuilder, TestBuilder};
 use async_graphql::Request;
 use linera_base::{
     data_types::Amount,
     identifiers::{ChainDescription, ChainId, Destination, Owner},
 };
-use linera_chain::{
-    data_types::{CertificateValue, OutgoingMessage},
-    ChainError, ChainExecutionContext,
-};
+use linera_chain::data_types::{CertificateValue, OutgoingMessage};
 use linera_execution::{
-    pricing::Pricing, Bytecode, ExecutionError, Message, Operation, SystemMessage,
-    UserApplicationDescription, WasmRuntime,
+    pricing::Pricing, Bytecode, Message, Operation, SystemMessage, UserApplicationDescription,
+    WasmRuntime,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
@@ -575,11 +565,11 @@ where
             owner: sender_owner,
         },
     };
-    assert!(matches!(receiver
+    // TODO(#989): Make user errors fail blocks again.
+    receiver
         .execute_operation(Operation::user(application_id, &transfer)?)
-        .await,
-        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::UserError(_), ChainExecutionContext::Operation(_)))
-    ));
+        .await
+        .unwrap();
     receiver.clear_pending_block().await;
 
     // Try another transfer in the other direction with the correct amount.

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -210,10 +210,13 @@ where
                     .await
             }
         };
-        if let Err(ExecutionError::UserError(message)) = &call_result {
-            tracing::error!("User application reported an error: {message}");
-        }
-        let mut result = call_result?;
+        // TODO(#989): Make user errors fail blocks again.
+        let mut result = if let Err(ExecutionError::UserError(message)) = &call_result {
+            tracing::error!("Ignoring error reported by user application: {message}");
+            RawExecutionResult::default()
+        } else {
+            call_result?
+        };
         // Set the authenticated signer to be used in outgoing messages.
         result.authenticated_signer = signer;
         *remaining_fuel = runtime.remaining_fuel();


### PR DESCRIPTION
## Motivation

Failing user messages currently block chains because clients do not have the logic to skip them (#904, #989).

## Proposal

Skip messages creating user errors for now. This is not the desired semantics (#989) but we need to unblock users (#1071).

## Test Plan

CI

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.

## Links

fixes #904
fixes #1071