### PR TITLE
Make the numbers of validators and shards configurable in `linera net up` and e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3080,6 +3080,7 @@ dependencies = [
  "linera-core",
  "linera-execution",
  "linera-rpc",
+ "linera-service",
  "linera-storage",
  "linera-views",
  "matching-engine",

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -31,7 +31,7 @@ async-graphql = { workspace = true }
 linera-base = { workspace = true }
 linera-indexer-graphql-client = { workspace = true }
 linera-service-graphql-client = { workspace = true }
-linera-service = { workspace = true, features = ["rocksdb"] }
+linera-service = { workspace = true, features = ["rocksdb", "test"] }
 once_cell = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -97,7 +97,7 @@ async fn run_end_to_end_operations_indexer(database: Database) {
     // launching network, service and indexer
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client = local_net.make_client(network);
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [features]
 default = ["wasmer", "rocksdb"]
+test = []
 benchmark = ["linera-base/test"]
 wasmer = ["linera-execution/wasmer", "linera-storage/wasmer"]
 wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
@@ -66,6 +67,7 @@ linera-chain = { workspace = true, features = ["test"] }
 linera-core = { workspace = true, features = ["test"] }
 linera-execution = { workspace = true, features = ["test"] }
 linera-rpc = { workspace = true, features = ["test"] }
+linera-service = { workspace = true, features = ["test"] }
 linera-storage = { workspace = true, features = ["test"] }
 linera-views = { workspace = true, features = ["test"] }
 proptest = { workspace = true }

--- a/linera-service/src/cli_wrappers.rs
+++ b/linera-service/src/cli_wrappers.rs
@@ -563,8 +563,8 @@ impl LocalNetwork {
         database: Database,
         network: Network,
         num_initial_validators: usize,
+        num_shards: usize,
     ) -> Result<Self> {
-        let num_shards = 4;
         Ok(Self {
             database,
             network,
@@ -575,6 +575,17 @@ impl LocalNetwork {
             set_init: HashSet::new(),
             tmp_dir: Rc::new(tempdir()?),
         })
+    }
+
+    #[cfg(any(test, feature = "test"))]
+    pub fn new_for_testing(database: Database, network: Network) -> Result<Self> {
+        let num_validators = 4;
+        let num_shards = match database {
+            Database::RocksDb => 1,
+            Database::DynamoDb => 4,
+            Database::ScyllaDb => 4,
+        };
+        Self::new(database, network, num_validators, num_shards)
     }
 
     pub fn make_client(&mut self, network: Network) -> ClientWrapper {

--- a/linera-service/src/cli_wrappers.rs
+++ b/linera-service/src/cli_wrappers.rs
@@ -542,12 +542,12 @@ impl Validator {
 pub struct LocalNetwork {
     database: Database,
     network: Network,
-    tmp_dir: Rc<TempDir>,
     next_client_id: usize,
     num_initial_validators: usize,
     num_shards: usize,
     local_net: BTreeMap<usize, Validator>,
     set_init: HashSet<(usize, usize)>,
+    tmp_dir: Rc<TempDir>,
 }
 
 impl Drop for LocalNetwork {
@@ -567,13 +567,13 @@ impl LocalNetwork {
         let num_shards = 4;
         Ok(Self {
             database,
-            tmp_dir: Rc::new(tempdir()?),
             network,
             next_client_id: 0,
             num_initial_validators,
             num_shards,
             local_net: BTreeMap::new(),
             set_init: HashSet::new(),
+            tmp_dir: Rc::new(tempdir()?),
         })
     }
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -998,6 +998,10 @@ enum NetCommand {
         /// The number of extra wallets and user chains to initialise. Default is 0.
         #[structopt(default_value, long)]
         wallets: usize,
+
+        /// The number of validators in the local test network. Default is 1.
+        #[structopt(long, default_value = "1")]
+        validators: usize,
     },
 }
 
@@ -1757,20 +1761,50 @@ async fn main() -> Result<(), anyhow::Error> {
         }
 
         ClientCommand::Net(net_command) => match net_command {
-            NetCommand::Up { wallets } => {
+            NetCommand::Up {
+                wallets,
+                validators,
+            } => {
+                if validators < 1 {
+                    panic!("The local test network must have at least one validator.");
+                }
                 let network = Network::Grpc;
-                let mut net = LocalNetwork::new(Database::RocksDb, network, 1)?;
+                let mut net = LocalNetwork::new(Database::RocksDb, network, *validators)?;
                 let mut client1 = net.make_client(network);
 
+                // Create the initial server and client config.
                 net.generate_initial_validator_config().await?;
                 client1.create_genesis_config().await?;
                 let default_chain = client1
                     .default_chain()
                     .expect("initialized client should always have default chain");
 
-                // Create initial server and client config.
+                // Start the validators.
                 net.run().await?;
 
+                // Make time to (hopefully) display the message after the tracing logs.
+                tokio::time::sleep(Duration::from_secs(1)).await;
+
+                // Create the wallet for the initial "root" chains.
+                eprintln!(
+                    "\nA local Linera network was started using the following temporary directory:\n{}\n",
+                    net.net_path().display()
+                );
+                eprintln!("To use the initial wallet of this network, set the following environment variables:\n");
+                eprintln!(
+                    "{}",
+                    format!(
+                        "export LINERA_WALLET=\"{}\"",
+                        client1.wallet_path().display()
+                    )
+                    .bold()
+                );
+                eprintln!(
+                    "{}",
+                    format!("export LINERA_STORAGE=\"{}\"\n", client1.storage_path()).bold()
+                );
+
+                // Create the extra wallets.
                 for wallet in 0..*wallets {
                     let mut extra_wallet = net.make_client(network);
                     extra_wallet.wallet_init(&[]).await?;
@@ -1782,7 +1816,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     extra_wallet
                         .assign(unassigned_key, new_chain_msg_id)
                         .await?;
-                    eprintln!("\nExtra wallet {}:", wallet + 1);
+                    eprintln!("\nExtra user wallet {}:", wallet + 1);
                     eprintln!(
                         "export LINERA_WALLET=\"{}\"",
                         extra_wallet.wallet_path().display()
@@ -1793,26 +1827,10 @@ async fn main() -> Result<(), anyhow::Error> {
                     );
                 }
 
-                eprintln!(
-                    "\nLinera net directory available at: {}",
-                    net.net_path().display()
-                );
-                eprintln!("To configure your Linera client for this network, run:\n");
-                eprintln!(
-                    "{}",
-                    format!(
-                        "export LINERA_WALLET=\"{}\"",
-                        client1.wallet_path().display()
-                    )
-                    .bold()
-                );
-                eprintln!(
-                    "{}",
-                    format!("export LINERA_STORAGE=\"{}\"", client1.storage_path()).bold()
-                );
-
+                eprintln!("\nPress ENTER to terminate the local Linera network and clean the temporary directory.");
                 std::io::stdin().bytes().next();
 
+                eprintln!("Done.");
                 Ok(())
             }
         },

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1002,6 +1002,10 @@ enum NetCommand {
         /// The number of validators in the local test network. Default is 1.
         #[structopt(long, default_value = "1")]
         validators: usize,
+
+        /// The number of shards per validator in the local test network. Default is 1.
+        #[structopt(long, default_value = "1")]
+        shards: usize,
     },
 }
 
@@ -1764,12 +1768,16 @@ async fn main() -> Result<(), anyhow::Error> {
             NetCommand::Up {
                 wallets,
                 validators,
+                shards,
             } => {
-                if validators < 1 {
+                if *validators < 1 {
                     panic!("The local test network must have at least one validator.");
                 }
+                if *shards < 1 {
+                    panic!("The local test network must have at least one shard per validator.");
+                }
                 let network = Network::Grpc;
-                let mut net = LocalNetwork::new(Database::RocksDb, network, *validators)?;
+                let mut net = LocalNetwork::new(Database::RocksDb, network, *validators, *shards)?;
                 let mut client1 = net.make_client(network);
 
                 // Create the initial server and client config.

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -53,7 +53,7 @@ async fn test_scylla_db_end_to_end_reconfiguration_simple() {
 
 async fn run_end_to_end_reconfiguration(database: Database, network: Network) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client = local_net.make_client(network);
     let mut client_2 = local_net.make_client(network);
 
@@ -88,9 +88,9 @@ async fn run_end_to_end_reconfiguration(database: Database, network: Network) {
     // Transfer 3 units
     client.transfer("3", chain_1, chain_2).await.unwrap();
 
-    // Restart last server (dropping it kills the process)
-    local_net.kill_server(4, 3).unwrap();
-    local_net.start_server(4, 3).await.unwrap();
+    // Restart first shard (dropping it kills the process)
+    local_net.kill_server(4, 0).unwrap();
+    local_net.start_server(4, 0).await.unwrap();
 
     // Query balances again
     assert_eq!(client.query_balance(chain_1).await.unwrap(), "7.");
@@ -181,7 +181,7 @@ async fn test_scylla_db_open_chain_node_service() {
 async fn run_open_chain_node_service(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client = local_net.make_client(network);
     local_net.generate_initial_validator_config().await.unwrap();
     client.create_genesis_config().await.unwrap();
@@ -289,7 +289,7 @@ async fn run_end_to_end_retry_notification_stream(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 1).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client1 = local_net.make_client(network);
     let mut client2 = local_net.make_client(network);
 
@@ -368,7 +368,7 @@ async fn run_end_to_end_multiple_wallets(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create local_net and two clients.
-    let mut local_net = LocalNetwork::new(database, Network::Grpc, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, Network::Grpc).unwrap();
     let mut client_1 = local_net.make_client(Network::Grpc);
     let mut client_2 = local_net.make_client(Network::Grpc);
 
@@ -438,7 +438,7 @@ async fn test_scylla_db_project_new() {
 
 async fn run_project_new(database: Database) {
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 0).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, 0, 0).unwrap();
     let client = local_net.make_client(network);
 
     let tmp_dir = client.project_new("init-test").await.unwrap();
@@ -471,7 +471,7 @@ async fn test_scylla_db_project_test() {
 
 async fn run_project_test(database: Database) {
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 0).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, 0, 0).unwrap();
     let client = local_net.make_client(network);
     client
         .project_test(&LocalNetwork::example_path("counter").unwrap())
@@ -502,7 +502,7 @@ async fn run_project_publish(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 1).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, 1, 1).unwrap();
     let mut client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
@@ -547,7 +547,7 @@ async fn run_example_publish(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 1).unwrap();
+    let mut local_net = LocalNetwork::new(database, network, 1, 1).unwrap();
     let mut client = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
@@ -590,7 +590,7 @@ async fn run_end_to_end_open_multi_owner_chain(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
-    let mut runner = LocalNetwork::new(database, Network::Grpc, 4).unwrap();
+    let mut runner = LocalNetwork::new_for_testing(database, Network::Grpc).unwrap();
     let mut client1 = runner.make_client(Network::Grpc);
     let mut client2 = runner.make_client(Network::Grpc);
 

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -307,7 +307,7 @@ async fn run_end_to_end_counter(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client = local_net.make_client(network);
 
     let original_counter_value = 35;
@@ -374,7 +374,7 @@ async fn run_end_to_end_counter_publish_create(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client = local_net.make_client(network);
 
     let original_counter_value = 35;
@@ -437,7 +437,7 @@ async fn run_end_to_end_social_user_pub_sub(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client1 = local_net.make_client(network);
     let mut client2 = local_net.make_client(network);
 
@@ -536,7 +536,7 @@ async fn run_end_to_end_fungible(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client1 = local_net.make_client(network);
     let mut client2 = local_net.make_client(network);
 
@@ -669,7 +669,7 @@ async fn run_end_to_end_same_wallet_fungible(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client1 = local_net.make_client(network);
 
     local_net.generate_initial_validator_config().await.unwrap();
@@ -768,7 +768,7 @@ async fn run_end_to_end_crowd_funding(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client1 = local_net.make_client(network);
     let mut client2 = local_net.make_client(network);
 
@@ -911,7 +911,7 @@ async fn run_end_to_end_matching_engine(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client_admin = local_net.make_client(network);
     let mut client_a = local_net.make_client(network);
     let mut client_b = local_net.make_client(network);
@@ -1174,7 +1174,7 @@ async fn run_end_to_end_amm(database: Database) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let network = Network::Grpc;
-    let mut local_net = LocalNetwork::new(database, network, 4).unwrap();
+    let mut local_net = LocalNetwork::new_for_testing(database, network).unwrap();
     let mut client_admin = local_net.make_client(network);
     let mut client0 = local_net.make_client(network);
     let mut client1 = local_net.make_client(network);


### PR DESCRIPTION
## Motivation

* Make the number of validators and shards configurable in `linera net up`
* Make the default number of shards depend on the database during testing

## Proposal

* Improve output of `linera net up` (not perfect but already better)
* Use rocksdb with 1 shards by default

I also verified that the temporary directory was cleaned up (unless one presses ^C first).

## Test Plan

```
cargo run --bin linera -- net up --wallets 1 --validators 2 --shards 3
```

Sample output:
```
[...]
A local Linera network was started using the following temporary directory:
/var/folders/3y/9r0jlrxj6mncs9d2m1vpvqqh0000gn/T/.tmpKOuBhd

To use the initial wallet of this network, set the following environment variables:

export LINERA_WALLET="/var/folders/3y/9r0jlrxj6mncs9d2m1vpvqqh0000gn/T/.tmpKOuBhd/wallet_0.json"
export LINERA_STORAGE="rocksdb:/var/folders/3y/9r0jlrxj6mncs9d2m1vpvqqh0000gn/T/.tmpKOuBhd/client_0.db"

2023-09-26T06:46:07.168493Z  INFO linera: Saved user chain states

Extra user wallet 1:
export LINERA_WALLET="/var/folders/3y/9r0jlrxj6mncs9d2m1vpvqqh0000gn/T/.tmpKOuBhd/wallet_1.json"
export LINERA_STORAGE="rocksdb:/var/folders/3y/9r0jlrxj6mncs9d2m1vpvqqh0000gn/T/.tmpKOuBhd/client_1.db"

Press ENTER to terminate the local Linera network and clean the temporary directory.

Done.
```

## Release Plan

- (optional) update the developer manual.
