### PR TITLE
Better code for reading several keys in `ScyllaDb`.

### DIFF
--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -120,14 +120,9 @@ impl KeyValueStoreClient for ScyllaDbClientInternal {
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-        // There is probably a better way in ScyllaDB for downloading several keys than this one.
         let client = self.client.deref();
         let _guard = self.acquire().await;
-        let mut handles = Vec::new();
-        for key in keys {
-            let handle = Self::read_key_internal(client, key);
-            handles.push(handle);
-        }
+        let handles = keys.into_iter().map(|key| Self::read_key_internal(client, key));
         let result = join_all(handles).await;
         Ok(result.into_iter().collect::<Result<_, _>>()?)
     }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -122,7 +122,9 @@ impl KeyValueStoreClient for ScyllaDbClientInternal {
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
         let client = self.client.deref();
         let _guard = self.acquire().await;
-        let handles = keys.into_iter().map(|key| Self::read_key_internal(client, key));
+        let handles = keys
+            .into_iter()
+            .map(|key| Self::read_key_internal(client, key));
         let result = join_all(handles).await;
         Ok(result.into_iter().collect::<Result<_, _>>()?)
     }


### PR DESCRIPTION
## Motivation

We want to have better support for concurrency in `ScyllaDb`. This PR allows to read several keys at once.

## Proposal

It is quite straightforward and follows what is done for `DynamoDb`.

## Test Plan

The CI should suffice.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
