### PR TITLE
Removing sleep from build_and_redeploy.sh

### DIFF
--- a/kubernetes/linera-validator/build_and_redeploy.sh
+++ b/kubernetes/linera-validator/build_and_redeploy.sh
@@ -100,22 +100,19 @@ if [ "$port_forward" = true ]; then
     opt_list+=" --port-forward"
 fi
 
-helm uninstall linera-core;
-
-sleep 0.5;
+helm uninstall linera-core --wait;
 
 if [ "$cloud_mode" = true ]; then
-    helm install linera-core . --values values-local-with-cloud-build.yaml || exit 1;
+    helm install linera-core . --values values-local-with-cloud-build.yaml --wait || exit 1;
 else
-    helm install linera-core . --values values-local.yaml || exit 1;
+    helm install linera-core . --values values-local.yaml --wait || exit 1;
 fi
 
-sleep 0.5;
 echo "Pods:";
 kubectl get pods;
 echo -e "\nServices:";
 kubectl get svc;
-sleep 2;
+
 docker rm linera-test-local;
 if [ "$cloud_mode" = true ]; then
     docker run -d --name linera-test-local $docker_image \

--- a/kubernetes/linera-validator/templates/ingress.yaml
+++ b/kubernetes/linera-validator/templates/ingress.yaml
@@ -3,7 +3,10 @@ kind: Service
 metadata:
   name: validator-ingress
 spec:
-  type: LoadBalancer
+  # NodePort here is temporary. LoadBalancer will keep trying to set an external IP,
+  # leaving it in a permanent pending state. Since we port forward anyways, we don't
+  # need that for now, so just using NodePort
+  type: NodePort
   selector:
     app: validator-1
   ports:


### PR DESCRIPTION
## Motivation

There's a wait to tell helm commands to wait until things are initialized. See @christos-h's comments on #1073

## Proposal

Stop using `sleep` and use `--wait` instead

## Test Plan

CI
