### PR TITLE
Resolve bugs in DynamoDb support.

### DIFF
--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -199,7 +199,7 @@ fn build_delete_transact(
         return Err(DynamoDbContextError::ZeroLengthKey);
     }
     if key.len() > MAX_KEY_BYTES {
-        return Err(DynamoDbContextError::TooLongKey);
+        return Err(DynamoDbContextError::KeyTooLong);
     }
     let request = Delete::builder()
         .table_name(&db.table.0)
@@ -217,7 +217,7 @@ fn build_put_transact(
         return Err(DynamoDbContextError::ZeroLengthKey);
     }
     if key.len() > MAX_KEY_BYTES {
-        return Err(DynamoDbContextError::TooLongKey);
+        return Err(DynamoDbContextError::KeyTooLong);
     }
     if value.len() > MAX_VALUE_BYTES {
         return Err(DynamoDbContextError::ValueLengthTooLarge);
@@ -939,7 +939,7 @@ impl KeyValueStoreClient for DynamoDbClientInternal {
             return Err(DynamoDbContextError::ZeroLengthKeyPrefix);
         }
         if key_prefix.len() > MAX_KEY_BYTES {
-            return Err(DynamoDbContextError::TooLongKeyPrefix);
+            return Err(DynamoDbContextError::KeyPrefixTooLong);
         }
         let response = Box::new(
             self.get_query_output(KEY_VALUE_ATTRIBUTE, key_prefix)
@@ -1238,11 +1238,11 @@ pub enum DynamoDbContextError {
 
     /// The key must have at most 1024 bytes
     #[error("The key must have at most 1024 bytes")]
-    TooLongKey,
+    KeyTooLong,
 
     /// The key prefix must have at most 1024 bytes
     #[error("The key prefix must have at most 1024 bytes")]
-    TooLongKeyPrefix,
+    KeyPrefixTooLong,
 
     /// Key prefixes have to be of non-zero length.
     #[error("The key_prefix must be of strictly positive length")]

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -69,9 +69,10 @@ const VALUE_ATTRIBUTE: &str = "item_value";
 /// The attribute for obtaining the primary key (used as a sort key) with the stored value.
 const KEY_VALUE_ATTRIBUTE: &str = "item_key, item_value";
 
+/// TODO(#1084): We remove 600 from 400 * 1024. We need to determine what exactly needs to be done.
 /// Fundamental constants in DynamoDB: The maximum size of a value is 400KB
 /// See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html
-const MAX_VALUE_BYTES: usize = 409600;
+const MAX_VALUE_BYTES: usize = 409000;
 
 /// Fundamental constant in DynamoDB: The maximum size of a key is 1024 bytes
 /// See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -291,6 +291,9 @@ impl DynamoDbBatch {
     }
 
     fn is_fastpath_feasible(&self) -> bool {
+        if self.len() > MAX_TRANSACT_WRITE_ITEM_SIZE {
+            return false;
+        }
         let mut total_size = 0;
         for (key, value) in &self.0.insertions {
             total_size += key.len() + value.len();
@@ -298,7 +301,7 @@ impl DynamoDbBatch {
         for deletion in &self.0.deletions {
             total_size += deletion.len();
         }
-        self.len() <= MAX_TRANSACT_WRITE_ITEM_SIZE && total_size <= MAX_TRANSACT_WRITE_ITEM_BYTES
+        total_size <= MAX_TRANSACT_WRITE_ITEM_BYTES
     }
 
     fn add_journal_header_operations(


### PR DESCRIPTION
## Motivation

The work on the end-to-end tests has revealed some bugs.

## Proposal

The following corrections are done:
* The limit being used was the one for the batch, not the one for the transactions. That is 16M instead of the 4M size. The batch size is removed since we no longer use this feature.
* When checking is the fast path is feasible we used the number of transactions (limit is 100), but actually, we also need to check for the size.
* The error that required the most work for correction is that the journal was put into a single entry. Since it is limited to 400K, this created another error.
* An assert statement was added for the size of the serialized object. Since size is the key point, it makes sense to compute the exact size.
* When creating the journals, each block (which has at most 400K) is grouped together in a single transaction since we prefer single big transaction to several smaller ones. This restructured the code which altogether becomes more modular.

## Test Plan

The CI should do it. The end to end tests revealed the problem. The effective resolution requires one more ingredient: The implementation of the pagination feature for `DynamoDb`.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
