### PR TITLE
Avoid some chain client and chain state locking.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -26,7 +26,7 @@ use linera_chain::{
         Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, HashedValue,
         IncomingMessage, LiteCertificate, LiteVote,
     },
-    ChainError, ChainManagerInfo, ChainStateView,
+    ChainError, ChainManagerInfo,
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
@@ -224,21 +224,6 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
-    /// Obtains a `ChainStateView` for a given `ChainId`.
-    pub async fn chain_state_view(
-        &self,
-        chain_id: Option<ChainId>,
-    ) -> Result<Arc<ChainStateView<S::Context>>, LocalNodeError> {
-        let chain_id = chain_id.unwrap_or(self.chain_id);
-        let chain_state_view = self
-            .node_client
-            .storage_client()
-            .await
-            .load_chain(chain_id)
-            .await?;
-        Ok(Arc::new(chain_state_view))
-    }
-
     /// Obtains the basic `ChainInfo` data for the local chain.
     async fn chain_info(&mut self) -> Result<ChainInfo, LocalNodeError> {
         let query = ChainInfoQuery::new(self.chain_id);
@@ -1723,25 +1708,5 @@ where
             user_data,
         }))
         .await
-    }
-
-    pub async fn read_value(&self, hash: CryptoHash) -> Result<HashedValue, ViewError> {
-        self.node_client
-            .storage_client()
-            .await
-            .read_value(hash)
-            .await
-    }
-
-    pub async fn read_values_downward(
-        &self,
-        from: CryptoHash,
-        limit: u32,
-    ) -> Result<Vec<HashedValue>, ViewError> {
-        self.node_client
-            .storage_client()
-            .await
-            .read_values_downward(from, limit)
-            .await
     }
 }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -463,7 +463,7 @@ where
     #[graphql(cache_control(no_cache))]
     async fn chain(&self, chain_id: ChainId) -> Result<ChainStateExtendedView<S::Context>, Error> {
         let view = self.storage.load_chain(chain_id).await?;
-        Ok(ChainStateExtendedView::new(view))
+        Ok(ChainStateExtendedView::new(Arc::new(view)))
     }
 
     async fn applications(&self, chain_id: ChainId) -> Result<Vec<ApplicationOverview>, Error> {
@@ -546,7 +546,7 @@ impl ChainStateViewExtension {
 }
 
 #[derive(MergedObject)]
-struct ChainStateExtendedView<C>(ChainStateViewExtension, ChainStateView<C>)
+struct ChainStateExtendedView<C>(ChainStateViewExtension, Arc<ChainStateView<C>>)
 where
     C: linera_views::common::Context + Clone + Send + Sync + 'static,
     ViewError: From<C::Error>,
@@ -558,7 +558,7 @@ where
     ViewError: From<C::Error>,
     C::Extra: linera_execution::ExecutionRuntimeContext,
 {
-    fn new(view: ChainStateView<C>) -> Self {
+    fn new(view: Arc<ChainStateView<C>>) -> Self {
         Self(ChainStateViewExtension(view.chain_id()), view)
     }
 }

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -459,6 +459,7 @@ where
     S: Store + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    #[graphql(cache_control(no_cache))]
     async fn chain(&self, chain_id: ChainId) -> Result<ChainStateExtendedView<S::Context>, Error> {
         let client = self.clients.try_client_lock(&chain_id).await?;
         let view = client.chain_state_view(Some(chain_id)).await?;


### PR DESCRIPTION
## Motivation

In #1066 we are seeing deadlocks that seem to be related to chain clients and chain guards. Some of the locking we do isn't even necessary.

## Proposal

Don't cache chain state views returned by the GraphQL `chain` query. Use storage directly in the `QueryRoot`, rather than locking chain clients.

## Test Plan

No business logic was changed.

## Release Plan

N/A

## Links

- Commit that reproduces the deadlock: https://github.com/linera-io/linera-protocol/pull/1066/commits/bc2b84812ca7d03d660e3898c4fcdb03d548a276
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
