### PR TITLE
Share notifiers and cache among chain clients; listen to local notifications.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -190,6 +190,14 @@ impl<P, S> ChainClient<P, S> {
         }
     }
 
+    pub async fn with_notifier_and_cache(mut self, other: &Self) -> Self {
+        self.node_client = self
+            .node_client
+            .with_notifier_and_cache(&other.node_client)
+            .await;
+        self
+    }
+
     pub fn chain_id(&self) -> ChainId {
         self.chain_id
     }
@@ -235,6 +243,11 @@ where
             .load_chain(self.chain_id)
             .await?;
         Ok(Arc::new(chain_state_view))
+    }
+
+    /// Subscribes to notifications from this client's chain.
+    pub async fn subscribe(&mut self) -> Result<NotificationStream, LocalNodeError> {
+        self.node_client.subscribe(vec![self.chain_id]).await
     }
 
     /// Obtains the basic `ChainInfo` data for the local chain.

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -6,8 +6,11 @@ use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery},
     local_node::{LocalNodeClient, LocalNodeError},
     node::{NodeError, NotificationStream, ValidatorNode, ValidatorNodeProvider},
+    notifier::Notifier,
     updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
-    worker::{Notification, Reason, WorkerError, WorkerState},
+    worker::{
+        DeliveryNotifiers, Notification, Reason, WorkerError, WorkerState, DEFAULT_VALUE_CACHE_SIZE,
+    },
 };
 use futures::{
     future,
@@ -36,9 +39,11 @@ use linera_execution::{
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;
+use lru::LruCache;
 use std::{
     collections::{hash_map, BTreeMap, HashMap},
     iter,
+    num::NonZeroUsize,
     pin::Pin,
     sync::Arc,
     time::Duration,
@@ -54,6 +59,90 @@ pub mod client_test_utils;
 #[cfg(test)]
 #[path = "unit_tests/client_tests.rs"]
 mod client_tests;
+
+/// A builder that creates `ChainClients` which share the cache and notifiers.
+pub struct ChainClientBuilder<ValidatorNodeProvider> {
+    /// How to talk to the validators.
+    validator_node_provider: ValidatorNodeProvider,
+    /// Maximum number of pending messages processed at a time in a block.
+    max_pending_messages: usize,
+    /// How much time to wait between attempts when we wait for a cross-chain update.
+    cross_chain_delay: Duration,
+    /// How many times we are willing to retry a block that depends on cross-chain updates.
+    cross_chain_retries: usize,
+    /// Cached values by hash.
+    recent_values: Arc<tokio::sync::Mutex<LruCache<CryptoHash, HashedValue>>>,
+    /// One-shot channels to notify callers when messages of a particular chain have been
+    /// delivered.
+    delivery_notifiers: Arc<tokio::sync::Mutex<DeliveryNotifiers>>,
+    /// References to clients waiting for chain notifications.
+    notifier: Notifier<Notification>,
+}
+
+impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
+    /// Creates a new `ChainClientBuilder` with a new cache and notifiers.
+    pub fn new(
+        validator_node_provider: ValidatorNodeProvider,
+        max_pending_messages: usize,
+        cross_chain_delay: Duration,
+        cross_chain_retries: usize,
+    ) -> Self {
+        let recent_values = Arc::new(tokio::sync::Mutex::new(LruCache::new(
+            NonZeroUsize::try_from(DEFAULT_VALUE_CACHE_SIZE).unwrap(),
+        )));
+        Self {
+            validator_node_provider,
+            max_pending_messages,
+            cross_chain_delay,
+            cross_chain_retries,
+            recent_values,
+            delivery_notifiers: Arc::new(tokio::sync::Mutex::new(DeliveryNotifiers::default())),
+            notifier: Notifier::default(),
+        }
+    }
+
+    /// Creates a new `ChainClient`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn build<StorageClient>(
+        &self,
+        chain_id: ChainId,
+        known_key_pairs: Vec<KeyPair>,
+        storage: StorageClient,
+        admin_id: ChainId,
+        block_hash: Option<CryptoHash>,
+        timestamp: Timestamp,
+        next_block_height: BlockHeight,
+    ) -> ChainClient<ValidatorNodeProvider, StorageClient> {
+        let known_key_pairs = known_key_pairs
+            .into_iter()
+            .map(|kp| (Owner::from(kp.public()), kp))
+            .collect();
+        let state = WorkerState::new_for_client(
+            format!("Client node {:?}", chain_id),
+            storage,
+            self.recent_values.clone(),
+            self.delivery_notifiers.clone(),
+        )
+        .with_allow_inactive_chains(true)
+        .with_allow_messages_from_deprecated_epochs(true);
+        let node_client = LocalNodeClient::new(state, self.notifier.clone());
+        ChainClient {
+            chain_id,
+            known_key_pairs,
+            validator_node_provider: self.validator_node_provider.clone(),
+            admin_id,
+            max_pending_messages: self.max_pending_messages,
+            received_certificate_trackers: HashMap::new(),
+            block_hash,
+            timestamp,
+            next_block_height,
+            pending_block: None,
+            cross_chain_delay: self.cross_chain_delay,
+            cross_chain_retries: self.cross_chain_retries,
+            node_client,
+        }
+    }
+}
 
 /// Client to operate a chain by interacting with validators and the given local storage
 /// implementation.
@@ -172,7 +261,7 @@ impl<P, S> ChainClient<P, S> {
         let state = WorkerState::new(format!("Client node {:?}", chain_id), None, storage_client)
             .with_allow_inactive_chains(true)
             .with_allow_messages_from_deprecated_epochs(true);
-        let node_client = LocalNodeClient::new(state);
+        let node_client = LocalNodeClient::new(state, Notifier::default());
         Self {
             chain_id,
             validator_node_provider,
@@ -188,14 +277,6 @@ impl<P, S> ChainClient<P, S> {
             cross_chain_retries,
             node_client,
         }
-    }
-
-    pub async fn with_notifier_and_cache(mut self, other: &Self) -> Self {
-        self.node_client = self
-            .node_client
-            .with_notifier_and_cache(&other.node_client)
-            .await;
-        self
     }
 
     pub fn chain_id(&self) -> ChainId {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -227,14 +227,12 @@ where
     /// Obtains a `ChainStateView` for a given `ChainId`.
     pub async fn chain_state_view(
         &self,
-        chain_id: Option<ChainId>,
     ) -> Result<Arc<ChainStateView<S::Context>>, LocalNodeError> {
-        let chain_id = chain_id.unwrap_or(self.chain_id);
         let chain_state_view = self
             .node_client
             .storage_client()
             .await
-            .load_chain(chain_id)
+            .load_chain(self.chain_id)
             .await?;
         Ok(Arc::new(chain_state_view))
     }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -142,24 +142,11 @@ where
 }
 
 impl<S> LocalNodeClient<S> {
-    pub fn new(state: WorkerState<S>) -> Self {
-        let node = LocalNode {
-            state,
-            notifier: Notifier::default(),
-        };
+    pub fn new(state: WorkerState<S>, notifier: Notifier<Notification>) -> Self {
+        let node = LocalNode { state, notifier };
         Self {
             node: Arc::new(Mutex::new(node)),
         }
-    }
-
-    pub async fn with_notifier_and_cache(self, other: &Self) -> Self {
-        {
-            let other_node = other.node.lock().await;
-            let mut node = self.node.lock().await;
-            node.notifier = other_node.notifier.clone();
-            node.state.clone_cache(&other_node.state);
-        }
-        self
     }
 }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -151,6 +151,16 @@ impl<S> LocalNodeClient<S> {
             node: Arc::new(Mutex::new(node)),
         }
     }
+
+    pub async fn with_notifier_and_cache(self, other: &Self) -> Self {
+        {
+            let other_node = other.node.lock().await;
+            let mut node = self.node.lock().await;
+            node.notifier = other_node.notifier.clone();
+            node.state.clone_cache(&other_node.state);
+        }
+        self
+    }
 }
 
 impl<S> LocalNodeClient<S>

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -262,6 +262,11 @@ impl<StorageClient> WorkerState<StorageClient> {
         &self.nickname
     }
 
+    pub fn clone_cache(&mut self, other: &Self) {
+        self.recent_values = other.recent_values.clone();
+        self.delivery_notifiers = other.delivery_notifiers.clone();
+    }
+
     /// Returns the storage client so that it can be manipulated or queried.
     #[cfg(not(feature = "test"))]
     pub(crate) fn storage_client(&self) -> &StorageClient {

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -123,19 +123,14 @@ where
     {
         let client = {
             let mut map_guard = clients.map_lock().await;
-            if let Some(client) = map_guard.get(&chain_id) {
-                client.clone()
-            } else {
-                let context_guard = context.lock().await;
-                let mut client = context_guard.make_chain_client(storage.clone(), chain_id);
-                if let Some(other_client) = map_guard.values().next() {
-                    let other_client = other_client.lock().await;
-                    client = client.with_notifier_and_cache(&other_client).await;
-                }
-                let client = Arc::new(Mutex::new(client));
-                map_guard.insert(chain_id, client.clone());
-                client
-            }
+            let context_guard = context.lock().await;
+            map_guard
+                .entry(chain_id)
+                .or_insert_with(|| {
+                    let client = context_guard.make_chain_client(storage.clone(), chain_id);
+                    Arc::new(Mutex::new(client))
+                })
+                .clone()
         };
         let mut stream = ChainClient::listen(client.clone()).await?;
         let mut tracker = NotificationTracker::default();

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -461,14 +461,14 @@ where
 {
     async fn chain(&self, chain_id: ChainId) -> Result<ChainStateExtendedView<S::Context>, Error> {
         let client = self.clients.try_client_lock(&chain_id).await?;
-        let view = client.chain_state_view(Some(chain_id)).await?;
+        let view = client.chain_state_view().await?;
         Ok(ChainStateExtendedView::new(view))
     }
 
     async fn applications(&self, chain_id: ChainId) -> Result<Vec<ApplicationOverview>, Error> {
         let client = self.clients.try_client_lock(&chain_id).await?;
         let applications = client
-            .chain_state_view(Some(chain_id))
+            .chain_state_view()
             .await?
             .execution_state
             .list_applications()
@@ -498,7 +498,7 @@ where
         let hash = match hash {
             Some(hash) => Some(hash),
             None => {
-                let view = client.chain_state_view(Some(chain_id)).await?;
+                let view = client.chain_state_view().await?;
                 view.tip_state.get().block_hash
             }
         };
@@ -521,7 +521,7 @@ where
         let from = match from {
             Some(from) => Some(from),
             None => {
-                let view = client.chain_state_view(Some(chain_id)).await?;
+                let view = client.chain_state_view().await?;
                 view.tip_state.get().block_hash
             }
         };

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -198,10 +198,8 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<impl Stream<Item = Notification>, Error> {
-        let Some(client) = self.clients.client(&chain_id).await else {
-            return Err(Error::new("Unknown chain ID"));
-        };
-        Ok(ChainClient::listen(client).await?)
+        let mut client = self.clients.try_client_lock(&chain_id).await?;
+        Ok(client.subscribe().await?)
     }
 }
 


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/1066 we are seeing a deadlock that is related to the notification stream.

Also, the notification stream for GraphQL subscribers should be based on the local node's view, instead of a merged and filtered version of subscriptions to the validators. It should only contain notifications for the specified chain IDs.

Finally, local workers should share a value cache and delivery notifications, since they also share the same storage.

## Proposal

Add a `ChainClientBuilder` that creates notifiers and a value cache. All `ChainClient`s build with it will share clones of the same notifiers and cache.

`QueryRoot::subscribe` returns a stream from the local notifier.

## Test Plan

This fixes the failing test in https://github.com/linera-io/linera-protocol/pull/1066.

## Links

- https://github.com/linera-io/linera-protocol/pull/1066.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
