### PR TITLE
Insertion of pagination code for `DynamoDb` and putting end-to-end tests for `DynamoDb`.

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -66,7 +66,6 @@ async fn test_rocks_db_handle_certificates_to_create_application(
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -78,11 +77,10 @@ async fn test_dynamo_db_handle_certificates_to_create_application(
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
-#[ignore]
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
-#[test_log::test(tokio::test)]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_scylla_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -79,7 +79,6 @@ async fn test_rocks_db_end_to_end_operations_indexer() {
     run_end_to_end_operations_indexer(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_operations_indexer() {

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -38,7 +38,6 @@ async fn test_rocks_db_end_to_end_queries() {
     run_end_to_end_queries(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_queries() {

--- a/linera-service/src/cli_wrappers.rs
+++ b/linera-service/src/cli_wrappers.rs
@@ -947,7 +947,8 @@ impl NodeService {
     }
 
     pub async fn make_application(&self, chain_id: &ChainId, application_id: &str) -> String {
-        for i in 0..30 {
+        let n_try = 30;
+        for i in 0..n_try {
             tokio::time::sleep(Duration::from_secs(i)).await;
             let values = self.try_get_applications_uri(chain_id).await;
             if let Some(link) = values.get(application_id) {
@@ -955,7 +956,7 @@ impl NodeService {
             }
             warn!("Waiting for application {application_id:?} to be visible on chain {chain_id:?}");
         }
-        panic!("Could not find application URI: {application_id}");
+        panic!("Could not find application URI: {application_id} after {n_try} tries");
     }
 
     pub async fn try_get_applications_uri(&self, chain_id: &ChainId) -> HashMap<String, String> {

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -18,7 +18,6 @@ async fn test_rocks_db_end_to_end_reconfiguration_grpc() {
     run_end_to_end_reconfiguration(Database::RocksDb, Network::Grpc).await;
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_reconfiguration_grpc() {
@@ -37,7 +36,6 @@ async fn test_rocks_db_end_to_end_reconfiguration_simple() {
     run_end_to_end_reconfiguration(Database::RocksDb, Network::Simple).await;
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_reconfiguration_simple() {
@@ -163,7 +161,6 @@ async fn test_rocks_db_open_chain_node_service() {
     run_open_chain_node_service(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_open_chain_node_service() {
@@ -269,7 +266,6 @@ async fn test_rocks_db_end_to_end_retry_notification_stream() {
     run_end_to_end_retry_notification_stream(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_retry_notification_stream() {
@@ -347,7 +343,6 @@ async fn test_rocks_db_end_to_end_multiple_wallets() {
     run_end_to_end_multiple_wallets(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_multiple_wallets() {
@@ -418,7 +413,6 @@ async fn test_rocks_db_project_new() {
     run_project_new(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_project_new() {
@@ -451,7 +445,6 @@ async fn test_rocks_db_project_test() {
     run_project_test(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_project_test() {
@@ -480,7 +473,6 @@ async fn test_rocks_db_project_publish() {
     run_project_publish(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_project_publish() {
@@ -525,7 +517,6 @@ async fn test_rocks_db_example_publish() {
     run_example_publish(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_example_publish() {
@@ -568,7 +559,6 @@ async fn test_rocks_db_end_to_end_open_multi_owner_chain() {
     run_end_to_end_open_multi_owner_chain(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_end_to_end_open_multi_owner_chain() {

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -287,7 +287,6 @@ async fn test_rocks_db_wasm_end_to_end_counter() {
     run_wasm_end_to_end_counter(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_counter() {
@@ -352,7 +351,6 @@ async fn test_rocks_db_wasm_end_to_end_counter_publish_create() {
     run_wasm_end_to_end_counter_publish_create(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_counter_publish_create() {
@@ -415,7 +413,6 @@ async fn test_rocks_db_wasm_end_to_end_social_user_pub_sub() {
     run_wasm_end_to_end_social_user_pub_sub(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_social_user_pub_sub() {
@@ -512,7 +509,6 @@ async fn test_rocks_db_wasm_end_to_end_fungible() {
     run_wasm_end_to_end_fungible(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_fungible() {
@@ -644,7 +640,6 @@ async fn test_rocks_db_wasm_end_to_end_same_wallet_fungible() {
     run_wasm_end_to_end_same_wallet_fungible(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_same_wallet_fungible() {
@@ -741,7 +736,6 @@ async fn test_rocks_db_wasm_end_to_end_crowd_funding() {
     run_wasm_end_to_end_crowd_funding(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_crowd_funding() {
@@ -883,7 +877,6 @@ async fn test_rocks_db_wasm_end_to_end_matching_engine() {
     run_wasm_end_to_end_matching_engine(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_matching_engine() {
@@ -1145,7 +1138,6 @@ async fn test_rocks_db_wasm_end_to_end_amm() {
     run_wasm_end_to_end_amm(Database::RocksDb).await
 }
 
-#[ignore]
 #[cfg(feature = "aws")]
 #[test_log::test(tokio::test)]
 async fn test_dynamo_db_wasm_end_to_end_amm() {


### PR DESCRIPTION
## Motivation

The pagination in DynamoDb is one of the oldest issues in the LineraProtocol. This PR addresses it and implements the subsequent consequences

## Proposal

The following is done:
* When several blocks are needed, several iterators are created which avoid the copy operations. This puts the code in line with other persistent storage.
* Doing so allows implementing download of more than 1M with `DynamoDb`. This exposes bugs in the journaling where the size was incorrect. This led to introducing `serialization_len` and `get_bitsize`.
* This allows removing the `#[ignore]` of the `DynamoDb` test.
* In passing, one `ScyllaDb` test that was still marked as `#[ignore]` was corrected.
* The introduction of `big_write_read` revealed limits for RocksDb that will be addressed in subsequent PR.

fixes #201 

## Test Plan

The CI that has been extended

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
