### PR TITLE
Fix application ID computation.

### DIFF
--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -33,11 +33,13 @@ impl Contract for MetaCounter {
 
     async fn initialize(
         &mut self,
-        _context: &OperationContext,
+        context: &OperationContext,
         _argument: (),
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
         Self::counter_id()?;
-        Ok(ExecutionResult::default())
+        // Send a no-op message to ourselves. This is only for testing contracts that send messages
+        // on initialization. Since the value is 0 it does not change the counter value.
+        Ok(ExecutionResult::default().with_message(context.chain_id, 0))
     }
 
     async fn execute_operation(

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -385,7 +385,7 @@ where
             destination: Destination::Recipient(creator_chain.into()),
             authenticated_signer: None,
             is_skippable: false,
-            message: Message::System(SystemMessage::ApplicationCreated),
+            message: Message::System(SystemMessage::ApplicationCreated { bytecode_id }),
         }],
         state_hash: creator_state.crypto_hash().await?,
     });

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -204,7 +204,7 @@ pub enum SystemMessage {
     /// Notifies that a new application bytecode was published.
     BytecodePublished { operation_index: u32 },
     /// Notifies that a new application was created.
-    ApplicationCreated,
+    ApplicationCreated { bytecode_id: BytecodeId },
     /// Shares the locations of published bytecodes.
     BytecodeLocations {
         locations: Vec<(BytecodeId, BytecodeLocation)>,
@@ -752,7 +752,9 @@ where
                     destination: Destination::Recipient(context.chain_id),
                     authenticated: false,
                     is_skippable: false,
-                    message: SystemMessage::ApplicationCreated,
+                    message: SystemMessage::ApplicationCreated {
+                        bytecode_id: *bytecode_id,
+                    },
                 };
                 result.messages.push(message);
                 new_application = Some((id, initialization_argument.clone()));

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -729,7 +729,10 @@ SystemMessage:
         STRUCT:
           - operation_index: U32
     7:
-      ApplicationCreated: UNIT
+      ApplicationCreated:
+        STRUCT:
+          - bytecode_id:
+              TYPENAME: BytecodeId
     8:
       BytecodeLocations:
         STRUCT:


### PR DESCRIPTION
## Motivation

The application ID is not necessarily derived from the block's last outgoing message: There might be additional messages created by the application's initialization itself.

## Proposal

Find the created application IDs by inspecting the outgoing messages. Do the same for published bytecode and created chains.

Possible alternatives:
* Group the outgoing messages in `ExecutedBlock` by the transaction that created them.
* Put [the application messages](https://github.com/linera-io/linera-protocol/blob/d98e798f99bc6b78d5136d8eeefb1e50ad3fc44a/linera-execution/src/execution.rs#L273) before the `CreatedApplication` message.
* Explicitly include the created application IDs as a separate field in the `ExecutedBlock`.

## Test Plan

I extended the `meta-counter` to send a no-op message to itself on `initialize`. That broke `test_memory_run_application_with_dependency`, as expected. This change fixes it.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/1098.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
