### PR TITLE
Introduction of crash resistant batching for ScyllaDB.

### DIFF
--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -52,7 +52,7 @@ use {
 };
 
 #[cfg(any(feature = "aws", feature = "scylladb"))]
-use linera_views::common::get_table_name;
+use linera_views::test_utils::get_table_name;
 
 use super::ChainClientBuilder;
 

--- a/linera-service/src/cli_wrappers.rs
+++ b/linera-service/src/cli_wrappers.rs
@@ -35,7 +35,7 @@ use tonic_health::proto::{
 use tracing::{info, warn};
 
 #[cfg(any(test, feature = "test"))]
-use linera_views::common::get_table_name;
+use linera_views::test_utils::get_table_name;
 
 /// The name of the environment variable that allows specifying additional arguments to be passed
 /// to the binary when starting a server.

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -13,7 +13,7 @@ use linera_service::{
     util,
 };
 use linera_views::test_utils::get_table_name;
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 #[tokio::test]
 async fn test_resolve_binary() {

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -12,8 +12,8 @@ use linera_service::{
     cli_wrappers::{Database, LocalNetwork, Network},
     util,
 };
-use linera_views::common::get_table_name;
-use std::{path::PathBuf, time::Duration};
+use linera_views::test_utils::get_table_name;
+use std::time::Duration;
 
 #[tokio::test]
 async fn test_resolve_binary() {

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 use {
     crate::TestClock,
     linera_views::{
-        common::get_table_name,
         dynamo_db::{create_dynamo_db_common_config, LocalStackTestContext},
+        test_utils::get_table_name,
     },
 };
 

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 
 #[cfg(any(test, feature = "test"))]
 use {
-    crate::TestClock, linera_views::common::get_table_name,
-    linera_views::scylla_db::create_scylla_db_common_config,
+    crate::TestClock, linera_views::scylla_db::create_scylla_db_common_config,
+    linera_views::test_utils::get_table_name,
 };
 
 #[cfg(test)]

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -110,8 +110,8 @@ impl UnorderedBatch {
         })
     }
 
-    /// From an `UnorderedBatch`, creates a [`UnorderedBatch`] that does contain
-    /// key_prefix_deletions that collide with a `key_prefix_deletions`.
+    /// From an `UnorderedBatch`, creates a [`UnorderedBatch`] doesn't contain
+    /// prefix deletions that collide with an insertion.
     /// This requires accessing the database to read them and translate them
     /// as collection of deletes.
     pub async fn expand_colliding_prefix_deletions<DB: DeletePrefixExpander>(

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -114,19 +114,16 @@ impl UnorderedBatch {
     /// key_prefix_deletions that collide with a `key_prefix_deletions`.
     /// This requires accessing the database to read them and translate them
     /// as collection of deletes.
-    pub async fn expand_colliding_delete_prefixes<DB: DeletePrefixExpander>(
+    pub async fn expand_colliding_prefix_deletions<DB: DeletePrefixExpander>(
         mut self,
         db: &DB,
     ) -> Result<UnorderedBatch, DB::Error> {
-        let mut insert_key = BTreeSet::new();
-        for (key, _) in &self.simple_unordered_batch.insertions {
-            insert_key.insert(key.clone());
-        }
+        let inserted_keys = self.simple_unordered_batch.insertions.iter().map(|x| x.0.clone()).collect::<BTreeSet<_>>();
         let insertions = mem::take(&mut self.simple_unordered_batch.insertions);
         let mut deletions = mem::take(&mut self.simple_unordered_batch.deletions);
         let mut key_prefix_deletions = Vec::new();
         for key_prefix in self.key_prefix_deletions {
-            if !insert_key
+            if !inserted_keys
                 .range(get_interval(key_prefix.clone()))
                 .collect::<Vec<_>>()
                 .is_empty()
@@ -134,7 +131,7 @@ impl UnorderedBatch {
                 for short_key in db.expand_delete_prefix(&key_prefix).await?.iter() {
                     let mut key = key_prefix.clone();
                     key.extend(short_key);
-                    if !insert_key.contains(&key) {
+                    if !inserted_keys.contains(&key) {
                         deletions.push(key);
                     }
                 }
@@ -362,7 +359,7 @@ impl DeletePrefixExpander for MemoryContext<()> {
 
 #[cfg(test)]
 mod tests {
-    use linera_views::{batch::Batch, common::Context, memory::create_memory_context};
+    use linera_views::{batch::{Batch, SimpleUnorderedBatch, UnorderedBatch}, common::Context, memory::create_memory_context};
 
     #[test]
     fn test_simplify_batch1() {
@@ -437,5 +434,21 @@ mod tests {
             vec![vec![1, 2, 3], vec![1, 2, 4], vec![1, 2, 5]]
         );
         assert!(simple_unordered_batch.insertions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_simplify_batch6() {
+        let context = create_memory_context();
+        let insertions = vec![(vec![1, 2, 3],vec![])];
+        let simple_unordered_batch = SimpleUnorderedBatch { insertions: insertions.clone(), deletions: vec![] };
+        let key_prefix_deletions = vec![vec![1,2]];
+        let unordered_batch = UnorderedBatch { simple_unordered_batch, key_prefix_deletions };
+        let unordered_batch_simp = unordered_batch
+            .expand_colliding_prefix_deletions(&context)
+            .await
+            .unwrap();
+        assert!(unordered_batch_simp.simple_unordered_batch.deletions.is_empty());
+        assert_eq!(unordered_batch_simp.simple_unordered_batch.insertions, insertions);
+        assert!(unordered_batch_simp.key_prefix_deletions.is_empty());
     }
 }

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -23,9 +23,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-#[cfg(any(test, feature = "test"))]
-use {rand::Rng, tracing::warn};
-
 #[cfg(test)]
 #[path = "unit_tests/common_tests.rs"]
 mod common_tests;
@@ -48,31 +45,6 @@ pub enum TableStatus {
     New,
     /// Table already existed when the [`KeyValueStoreClient`] instance was created.
     Existing,
-}
-
-#[cfg(any(test, feature = "test"))]
-fn generate_random_alphanumeric_string(length: usize) -> String {
-    // Define the characters that are allowed in the alphanumeric string
-    let charset: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
-
-    let mut rng = rand::thread_rng();
-    let alphanumeric_string: String = (0..length)
-        .map(|_| {
-            let random_index = rng.gen_range(0..charset.len());
-            charset[random_index] as char
-        })
-        .collect();
-
-    alphanumeric_string
-}
-
-/// Returns a unique table name for testing.
-#[cfg(any(test, feature = "test"))]
-pub fn get_table_name() -> String {
-    let entry = generate_random_alphanumeric_string(20);
-    let table_name = format!("table_{}", entry);
-    warn!("Generating table_name={}", table_name);
-    table_name
 }
 
 /// The common initialization parameters for the `KeyValueStore`

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -32,8 +32,8 @@ use thiserror::Error;
 
 #[cfg(any(test, feature = "test"))]
 use {
-    crate::common::get_table_name,
     crate::lru_caching::TEST_CACHE_SIZE,
+    crate::test_utils::get_table_name,
     anyhow::{Context, Error},
     aws_sdk_s3::Endpoint,
     aws_types::SdkConfig,

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -203,8 +203,8 @@ impl ScyllaDbClientInternal {
         //
         // Thus the batch is first simplified. Then when a put operation is colliding after
         // a delete prefix then we are accessing the prefix and removing the keys.
-        let unordered_batch = batch.simplify();
-        let unordered_batch = unordered_batch
+        let mut unordered_batch = batch.simplify();
+        unordered_batch
             .expand_colliding_prefix_deletions(client)
             .await?;
         let session = &client.0;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -200,9 +200,6 @@ impl ScyllaDbClientInternal {
         // the delete takes priority. See the sentence "The first tie-breaking rule when two
         // cells have the same write timestamp is that dead cells win over live cells"
         // from https://github.com/scylladb/scylladb/blob/master/docs/dev/timestamp-conflict-resolution.md
-        //
-        // Thus the batch is first simplified. Then when a put operation is colliding after
-        // a delete prefix then we are accessing the prefix and removing the keys.
         let mut unordered_batch = batch.simplify();
         unordered_batch
             .expand_colliding_prefix_deletions(client)

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -12,10 +12,6 @@
 //! * [`KeyValueStoreClient`][trait1] for a database access.
 //! * [`Context`][trait2] for the context.
 //!
-//! Support for ScyllaDB is experimental and is still missing important features:
-//! TODO(#935): Read several keys at once
-//! TODO(#934): Journaling operations
-//!
 //! [trait1]: common::KeyValueStoreClient
 //! [trait2]: common::Context
 
@@ -205,7 +201,7 @@ impl ScyllaDbClientInternal {
         // Thus the batch is first simplified and then the DeletePrefix that collides are removed.
         let unordered_batch = batch.simplify();
         let unordered_batch = unordered_batch
-            .expand_colliding_delete_prefixes(client)
+            .expand_colliding_prefix_deletions(client)
             .await?;
         let session = &client.0;
         let table_name = &client.1;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -196,9 +196,13 @@ impl ScyllaDbClientInternal {
         client: &ScyllaDbClientPair,
         batch: Batch,
     ) -> Result<(), ScyllaDbContextError> {
-        // We cannot do direct writing of the batch as deletion of key followed by insertion
-        // yield incoherent results.
-        // Thus the batch is first simplified and then the DeletePrefix that collides are removed.
+        // We cannot directly write the batch because if a delete is followed by a write then
+        // the delete takes priority. See the sentence "The first tie-breaking rule when two
+        // cells have the same write timestamp is that dead cells win over live cells"
+        // from https://github.com/scylladb/scylladb/blob/master/docs/dev/timestamp-conflict-resolution.md
+        //
+        // Thus the batch is first simplified. Then when a put operation is colliding after
+        // a delete prefix then we are accessing the prefix and removing the keys.
         let unordered_batch = batch.simplify();
         let unordered_batch = unordered_batch
             .expand_colliding_prefix_deletions(client)

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -20,7 +20,7 @@
 //! [trait2]: common::Context
 
 #[cfg(any(test, feature = "test"))]
-use crate::{common::get_table_name, lru_caching::TEST_CACHE_SIZE};
+use crate::{lru_caching::TEST_CACHE_SIZE, test_utils::get_table_name};
 
 use crate::{
     batch::{Batch, WriteOperation},

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -8,6 +8,39 @@ use crate::batch::{
 
 use rand::{Rng, RngCore};
 use std::collections::HashSet;
+use tracing::warn;
+
+fn generate_random_alphanumeric_string(length: usize) -> String {
+    // Define the characters that are allowed in the alphanumeric string
+    let charset: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+    let mut rng = rand::thread_rng();
+    let alphanumeric_string: String = (0..length)
+        .map(|_| {
+            let random_index = rng.gen_range(0..charset.len());
+            charset[random_index] as char
+        })
+        .collect();
+
+    alphanumeric_string
+}
+
+/// Returns a unique table name for testing.
+pub fn get_table_name() -> String {
+    let entry = generate_random_alphanumeric_string(20);
+    let table_name = format!("table_{}", entry);
+    warn!("Generating table_name={}", table_name);
+    table_name
+}
+
+/// Returns a random key_prefix used for tests
+pub fn get_random_key_prefix() -> Vec<u8> {
+    let mut key_prefix = vec![0];
+    let mut rng = rand::thread_rng();
+    let value: usize = rng.gen();
+    bcs::serialize_into(&mut key_prefix, &value).unwrap();
+    key_prefix
+}
 
 /// Shuffles the values entries randomly
 pub fn random_shuffle<R: RngCore, T: Clone>(rng: &mut R, values: &mut Vec<T>) {

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -91,7 +91,7 @@ pub fn get_random_kset<R: RngCore>(rng: &mut R, n: usize, k: usize) -> Vec<usize
 /// pairs `(key, value)` with key obtained by appending 8 bytes at random to key_prefix
 /// and value obtained by appending 8 bytes to the trivial vector.
 /// We return n such `(key, value)` pairs which are all distinct
-pub fn get_random_key_value_vec_prefix<R: RngCore>(
+pub fn get_random_key_values_prefix<R: RngCore>(
     rng: &mut R,
     key_prefix: Vec<u8>,
     len_key: usize,
@@ -116,8 +116,8 @@ pub fn get_random_key_value_vec_prefix<R: RngCore>(
 
 /// Takes a random number generator rng, a number n and returns n random `(key, value)`
 /// which are all distinct with key and value being of length 8.
-pub fn get_random_key_value_vec<R: RngCore>(rng: &mut R, n: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
-    get_random_key_value_vec_prefix(rng, Vec::new(), 8, 8, n)
+pub fn get_random_key_values<R: RngCore>(rng: &mut R, n: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+    get_random_key_values_prefix(rng, Vec::new(), 8, 8, n)
 }
 
 type VectorPutDelete = (Vec<(Vec<u8>, Vec<u8>)>, usize);
@@ -128,7 +128,7 @@ pub fn get_random_key_value_operations<R: RngCore>(
     n: usize,
     k: usize,
 ) -> VectorPutDelete {
-    let key_value_vector = get_random_key_value_vec_prefix(rng, Vec::new(), 8, 8, n);
+    let key_value_vector = get_random_key_values_prefix(rng, Vec::new(), 8, 8, n);
     (key_value_vector, k)
 }
 

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -21,10 +21,10 @@ use {
 
 #[cfg(feature = "aws")]
 use crate::{
-    common::get_table_name,
     dynamo_db::DynamoDbKvStoreConfig,
     dynamo_db::LocalStackTestContext,
     dynamo_db::{create_dynamo_db_common_config, DynamoDbContext},
+    test_utils::get_table_name,
 };
 
 #[cfg(feature = "scylladb")]

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::{
-    batch::Batch,
-    common::{get_interval, KeyIterable, KeyValueIterable, KeyValueStoreClient},
+    batch::{Batch, WriteOperation},
+    common::{KeyIterable, KeyValueIterable, KeyValueStoreClient},
     key_value_store_view::ViewContainer,
     memory::{create_memory_client, create_memory_context},
-    test_utils::{get_random_byte_vector, get_random_key_value_vec_prefix, get_small_key_space},
+    test_utils::{
+        get_random_byte_vector, get_random_key_prefix, get_random_key_value_vec_prefix,
+        get_small_key_space,
+    },
     value_splitting::create_test_memory_client,
 };
-use rand::{Rng, SeedableRng};
+use rand::{Rng, RngCore, SeedableRng};
 use std::collections::{BTreeMap, HashSet};
 
 #[cfg(feature = "rocksdb")]
@@ -29,8 +32,8 @@ use linera_views::scylla_db::create_scylla_db_test_client;
 /// * `find_keys_by_prefix` / `find_key_values_by_prefix`
 /// * The ordering of keys returned by `find_keys_by_prefix` and `find_key_values_by_prefix`
 #[cfg(test)]
-async fn run_readings_vec<OP: KeyValueStoreClient + Sync>(
-    key_value_store: OP,
+async fn run_reads_vec<C: KeyValueStoreClient + Sync>(
+    key_value_store: C,
     key_value_vec: Vec<(Vec<u8>, Vec<u8>)>,
 ) {
     // We need a nontrivial key_prefix because dynamo requires a non-trivial prefix
@@ -108,6 +111,7 @@ async fn run_readings_vec<OP: KeyValueStoreClient + Sync>(
     }
 }
 
+#[cfg(test)]
 fn get_random_key_value_vec1(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let key_prefix = vec![0];
     let n = 1000;
@@ -115,6 +119,7 @@ fn get_random_key_value_vec1(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     get_random_key_value_vec_prefix(&mut rng, key_prefix, 8, len_value, n)
 }
 
+#[cfg(test)]
 fn get_random_key_value_vec2(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     let key_prefix = vec![0];
@@ -132,6 +137,7 @@ fn get_random_key_value_vec2(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     key_values
 }
 
+#[cfg(test)]
 fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {
     let mut scenarios = Vec::new();
     for len_value in [10, 100] {
@@ -142,59 +148,59 @@ fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {
 }
 
 #[tokio::test]
-async fn test_readings_test_memory() {
+async fn test_reads_test_memory() {
     for scenario in get_random_test_scenarios() {
         let key_value_store = create_test_memory_client();
-        run_readings_vec(key_value_store, scenario).await;
+        run_reads_vec(key_value_store, scenario).await;
     }
 }
 
 #[tokio::test]
-async fn test_readings_memory() {
+async fn test_reads_memory() {
     for scenario in get_random_test_scenarios() {
         let key_value_store = create_memory_client();
-        run_readings_vec(key_value_store, scenario).await;
+        run_reads_vec(key_value_store, scenario).await;
     }
 }
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
-async fn test_readings_rocks_db() {
+async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
         let key_value_store = create_rocks_db_test_client().await;
-        run_readings_vec(key_value_store, scenario).await;
+        run_reads_vec(key_value_store, scenario).await;
     }
 }
 
 #[cfg(feature = "aws")]
 #[tokio::test]
-async fn test_readings_dynamodb() {
+async fn test_reads_dynamodb() {
     for scenario in get_random_test_scenarios() {
         let key_value_store = create_dynamo_db_test_client().await;
-        run_readings_vec(key_value_store, scenario).await;
+        run_reads_vec(key_value_store, scenario).await;
     }
 }
 
 #[cfg(feature = "scylladb")]
 #[tokio::test]
-async fn test_readings_scylla_db() {
+async fn test_reads_scylla_db() {
     for scenario in get_random_test_scenarios() {
         let key_value_store = create_scylla_db_test_client().await;
-        run_readings_vec(key_value_store, scenario).await;
+        run_reads_vec(key_value_store, scenario).await;
     }
 }
 
 #[tokio::test]
-async fn test_readings_key_value_store_view_memory() {
+async fn test_reads_key_value_store_view_memory() {
     for scenario in get_random_test_scenarios() {
         let context = create_memory_context();
         let key_value_store = ViewContainer::new(context).await.unwrap();
-        run_readings_vec(key_value_store, scenario).await;
+        run_reads_vec(key_value_store, scenario).await;
     }
 }
 
 #[tokio::test]
-async fn test_readings_memory_specific() {
+async fn test_reads_memory_specific() {
     let key_value_store = create_memory_client();
     let key_value_vec = vec![
         (vec![0, 1, 255], Vec::new()),
@@ -202,106 +208,180 @@ async fn test_readings_memory_specific() {
         (vec![0, 2], Vec::new()),
         (vec![0, 2, 0], Vec::new()),
     ];
-    run_readings_vec(key_value_store, key_value_vec).await;
+    run_reads_vec(key_value_store, key_value_vec).await;
 }
 
 #[cfg(test)]
-async fn run_writings_random<OP: KeyValueStoreClient + Sync>(key_value_store: OP) {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+fn generate_random_batch<R: RngCore>(rng: &mut R, key_prefix: &[u8], batch_size: usize) -> Batch {
+    let mut batch = Batch::new();
+    // Fully random batch
+    for _ in 0..batch_size {
+        let choice = rng.gen_range(0..8);
+        // Inserting a key
+        if choice < 6 {
+            // Insert
+            let key = get_small_key_space(rng, key_prefix, 4);
+            let len_value = rng.gen_range(0..10); // Could need to be split
+            let value = get_random_byte_vector(rng, &[], len_value);
+            batch.put_key_value_bytes(key.clone(), value.clone());
+        }
+        if choice == 6 {
+            // key might be missing, no matter, it has to work
+            let key = get_small_key_space(rng, key_prefix, 4);
+            batch.delete_key(key);
+        }
+        if choice == 7 {
+            let len = rng.gen_range(1..4); // We want a non-trivial range
+            let delete_key_prefix = get_small_key_space(rng, key_prefix, len);
+            batch.delete_key_prefix(delete_key_prefix.clone());
+        }
+    }
+    batch
+}
+
+#[cfg(test)]
+fn get_key(key_prefix: &[u8], key_suffix: Vec<u8>) -> Vec<u8> {
+    let mut key = key_prefix.to_vec();
+    key.extend(key_suffix);
+    key
+}
+
+#[cfg(test)]
+fn generate_specific_batch(key_prefix: &[u8], option: usize) -> Batch {
+    let mut batch = Batch::new();
+    if option == 0 {
+        let key = get_key(key_prefix, vec![34]);
+        batch.put_key_value_bytes(key.clone(), vec![]);
+        batch.delete_key(key);
+    }
+    if option == 1 {
+        let key1 = get_key(key_prefix, vec![12, 34]);
+        let key2 = get_key(key_prefix, vec![12, 33]);
+        let key3 = get_key(key_prefix, vec![13]);
+        batch.put_key_value_bytes(key1.clone(), vec![]);
+        batch.put_key_value_bytes(key2, vec![]);
+        batch.put_key_value_bytes(key3, vec![]);
+        batch.delete_key(key1);
+        let key_prefix = get_key(key_prefix, vec![12]);
+        batch.delete_key_prefix(key_prefix);
+    }
+    batch
+}
+
+#[cfg(test)]
+fn update_state_from_batch(kv_state: &mut BTreeMap<Vec<u8>, Vec<u8>>, batch: &Batch) {
+    for operation in &batch.operations {
+        match operation {
+            WriteOperation::Put { key, value } => {
+                kv_state.insert(key.to_vec(), value.to_vec());
+            }
+            WriteOperation::Delete { key } => {
+                kv_state.remove(key);
+            }
+            WriteOperation::DeletePrefix { key_prefix } => {
+                kv_state.retain(|key, _| !key.starts_with(key_prefix));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+fn realize_batch(batch: &Batch) -> BTreeMap<Vec<u8>, Vec<u8>> {
     let mut kv_state = BTreeMap::new();
-    let n_oper = 100;
-    let size_batch = 8;
+    update_state_from_batch(&mut kv_state, batch);
+    kv_state
+}
+
+#[cfg(test)]
+async fn read_key_prefix<C: KeyValueStoreClient + Sync>(
+    key_value_store: &C,
+    key_prefix: &[u8],
+) -> BTreeMap<Vec<u8>, Vec<u8>> {
+    let mut key_values = BTreeMap::new();
+    for key_value in key_value_store
+        .find_key_values_by_prefix(key_prefix)
+        .await
+        .unwrap()
+        .iterator()
+    {
+        let (key_suffix, value) = key_value.unwrap();
+        let mut key = key_prefix.to_vec();
+        key.extend(key_suffix);
+        key_values.insert(key, value.to_vec());
+    }
+    key_values
+}
+
+#[cfg(test)]
+async fn run_test_batch_from_blank<C: KeyValueStoreClient + Sync>(
+    key_value_store: &C,
+    key_prefix: Vec<u8>,
+    batch: Batch,
+) {
+    let kv_state = realize_batch(&batch);
+    key_value_store.write_batch(batch, &[]).await.unwrap();
+    // Checking the consistency
+    let key_values = read_key_prefix(key_value_store, &key_prefix).await;
+    assert_eq!(key_values, kv_state);
+}
+
+#[cfg(test)]
+async fn run_writes_from_blank<C: KeyValueStoreClient + Sync>(key_value_store: &C) {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    let n_oper = 1000;
+    let batch_size = 500;
     // key space has size 4^4 = 256 so we necessarily encounter collisions
-    // because the number of generated keys is about size_batch * n_oper = 800 > 256.
-    let key_prefix = vec![0];
+    // because the number of generated keys is about batch_size * n_oper = 800 > 256.
     for _ in 0..n_oper {
-        let mut batch = Batch::new();
-        for _ in 0..size_batch {
-            let choice = rng.gen_range(0..8);
-            // Inserting a key
-            if choice < 5 {
-                // Insert
-                let key = get_small_key_space(&mut rng, &key_prefix, 4);
-                let len_value = rng.gen_range(0..10); // Could need to be split
-                let value = get_random_byte_vector(&mut rng, &[], len_value);
-                batch.put_key_value_bytes(key.clone(), value.clone());
-                kv_state.insert(key, value);
-            }
-            if choice == 6 {
-                // key might be missing, no matter, it has to work
-                let key = get_small_key_space(&mut rng, &key_prefix, 4);
-                kv_state.remove(&key);
-                batch.delete_key(key);
-            }
-            if choice == 7 {
-                let len = rng.gen_range(1..4); // We want a non-trivial range
-                let delete_key_prefix = get_small_key_space(&mut rng, &key_prefix, len);
-                batch.delete_key_prefix(delete_key_prefix.clone());
-                let key_list = kv_state
-                    .range(get_interval(delete_key_prefix.clone()))
-                    .map(|x| x.0.to_vec())
-                    .collect::<Vec<_>>();
-                for key in key_list {
-                    kv_state.remove(&key);
-                }
-            }
-        }
-        key_value_store.write_batch(batch, &[]).await.unwrap();
-        // Checking the consistency
-        let mut key_values = BTreeMap::new();
-        for key_value in key_value_store
-            .find_key_values_by_prefix(&key_prefix)
-            .await
-            .unwrap()
-            .iterator()
-        {
-            let key_value = key_value.unwrap();
-            let mut key = key_prefix.clone();
-            key.extend(key_value.0);
-            key_values.insert(key, key_value.1.to_vec());
-        }
-        assert_eq!(key_values, kv_state);
+        let key_prefix = get_random_key_prefix();
+        let batch = generate_random_batch(&mut rng, &key_prefix, batch_size);
+        run_test_batch_from_blank(key_value_store, key_prefix, batch).await;
+    }
+    for option in 0..2 {
+        let key_prefix = get_random_key_prefix();
+        let batch = generate_specific_batch(&key_prefix, option);
+        run_test_batch_from_blank(key_value_store, key_prefix, batch).await;
     }
 }
 
 #[tokio::test]
-async fn test_writings_test_memory() {
+async fn test_test_memory_writes_from_blank() {
     let key_value_store = create_test_memory_client();
-    run_writings_random(key_value_store).await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
-async fn test_writings_memory() {
+async fn test_memory_writes_from_blank() {
     let key_value_store = create_memory_client();
-    run_writings_random(key_value_store).await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
-async fn test_writings_key_value_store_view_memory() {
+async fn test_key_value_store_view_memory_writes_from_blank() {
     let context = create_memory_context();
     let key_value_store = ViewContainer::new(context).await.unwrap();
-    run_writings_random(key_value_store).await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
-async fn test_writings_rocks_db() {
+async fn test_rocks_db_writes_from_blank() {
     let key_value_store = create_rocks_db_test_client().await;
-    run_writings_random(key_value_store).await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[cfg(feature = "aws")]
 #[tokio::test]
-async fn test_writings_dynamodb() {
+async fn test_dynamo_db_writes_from_blank() {
     let key_value_store = create_dynamo_db_test_client().await;
-    run_writings_random(key_value_store).await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[tokio::test]
-async fn test_writings_scylla_db() {
+async fn test_scylla_db_writes_from_blank() {
     let key_value_store = create_scylla_db_test_client().await;
-    run_writings_random(key_value_store).await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
@@ -331,64 +411,187 @@ async fn test_big_value_read_write() {
 //
 // The size of the value vary as each size has its own issues.
 #[cfg(test)]
-async fn run_big_write_read<OP: KeyValueStoreClient + Sync>(key_value_store: OP) {
+async fn run_big_write_read<C: KeyValueStoreClient + Sync>(
+    key_value_store: C,
+    target_size: usize,
+    value_sizes: Vec<usize>,
+) {
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
-    let target_size = 20000000;
-    for (pos, value_size) in [100, 1000, 200000, 5000000].into_iter().enumerate() {
-        let n_entry = target_size / value_size;
+    for (pos, value_size) in value_sizes.into_iter().enumerate() {
+        let n_entry: usize = target_size / value_size;
         let mut batch = Batch::new();
         let key_prefix = vec![0, pos as u8];
-        let mut key_values1 = BTreeMap::new();
         for i in 0..n_entry {
             let mut key = key_prefix.clone();
             bcs::serialize_into(&mut key, &i).unwrap();
             let value = get_random_byte_vector(&mut rng, &[], value_size);
-            key_values1.insert(key.clone(), value.clone());
             batch.put_key_value_bytes(key, value);
         }
-        key_value_store.write_batch(batch, &[]).await.unwrap();
-        // Checking the consistency
-        let mut key_values2 = BTreeMap::new();
-        for key_value in key_value_store
-            .find_key_values_by_prefix(&key_prefix)
-            .await
-            .unwrap()
-            .iterator()
-        {
-            let (key_suffix, value) = key_value.unwrap();
-            let mut key = key_prefix.clone();
-            key.extend(key_suffix);
-            key_values2.insert(key, value.to_vec());
-        }
-        assert_eq!(key_values1, key_values2);
+        run_test_batch_from_blank(&key_value_store, key_prefix, batch).await;
     }
 }
 
+#[cfg(feature = "scylladb")]
 #[tokio::test]
-async fn test_big_write_read_memory() {
+async fn test_scylla_db_big_write_read() {
+    let key_value_store = create_scylla_db_test_client().await;
+    let value_sizes = vec![1000, 200000, 5000000];
+    let target_size = 14000000;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
+}
+
+#[tokio::test]
+async fn test_memory_big_write_read() {
     let key_value_store = create_memory_client();
-    run_big_write_read(key_value_store).await;
+    let value_sizes = vec![100, 1000, 200000, 5000000];
+    let target_size = 20000000;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 
 // TODO(#1092): That test fails for value of 5M, probably needs value splitting.
 #[ignore]
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
-async fn test_big_write_read_rocks_db() {
+async fn test_rocks_db_big_write_read() {
     let key_value_store = create_rocks_db_test_client().await;
-    run_big_write_read(key_value_store).await;
+    let value_sizes = vec![100, 1000, 200000, 5000000];
+    let target_size = 20000000;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 
 #[cfg(feature = "aws")]
 #[tokio::test]
-async fn test_big_write_read_dynamo_db() {
+async fn test_dynamo_db_big_write_read() {
     let key_value_store = create_dynamo_db_test_client().await;
-    run_big_write_read(key_value_store).await;
+    let value_sizes = vec![100, 1000, 200000, 5000000];
+    let target_size = 20000000;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
+}
+
+#[cfg(test)]
+type StateBatch = (Vec<(Vec<u8>, Vec<u8>)>, Batch);
+
+#[cfg(test)]
+async fn run_test_batch_from_state<C: KeyValueStoreClient + Sync>(
+    key_value_store: &C,
+    key_prefix: Vec<u8>,
+    state_and_batch: StateBatch,
+) {
+    let (key_values, batch) = state_and_batch;
+    let mut batch_insert = Batch::new();
+    let mut kv_state = BTreeMap::new();
+    for (key, value) in key_values {
+        kv_state.insert(key.clone(), value.clone());
+        batch_insert.put_key_value_bytes(key, value);
+    }
+    key_value_store
+        .write_batch(batch_insert, &[])
+        .await
+        .unwrap();
+    update_state_from_batch(&mut kv_state, &batch);
+    key_value_store.write_batch(batch, &[]).await.unwrap();
+    let key_values = read_key_prefix(key_value_store, &key_prefix).await;
+    assert_eq!(key_values, kv_state);
+}
+
+#[cfg(test)]
+fn generate_specific_state_batch(key_prefix: &[u8], option: usize) -> StateBatch {
+    let mut key_values = Vec::new();
+    let mut batch = Batch::new();
+    if option == 0 {
+        // A DeletePrefix followed by an insertion that matches the DeletePrefix
+        let key1 = get_key(key_prefix, vec![1, 3]);
+        let key2 = get_key(key_prefix, vec![1, 4]);
+        let key3 = get_key(key_prefix, vec![1, 4, 5]);
+        key_values.push((key1.clone(), vec![34]));
+        key_values.push((key2.clone(), vec![45]));
+        batch.delete_key_prefix(key2);
+        batch.put_key_value_bytes(key3, vec![23]);
+    }
+    if option == 1 {
+        // Just a DeletePrefix
+        let key1 = get_key(key_prefix, vec![1, 3]);
+        let key2 = get_key(key_prefix, vec![1, 4]);
+        key_values.push((key1.clone(), vec![34]));
+        key_values.push((key2.clone(), vec![45]));
+        batch.delete_key_prefix(key2);
+    }
+    if option == 2 {
+        // A Put followed by a DeletePrefix that matches the Put
+        let key1 = get_key(key_prefix, vec![1, 3]);
+        let key2 = get_key(key_prefix, vec![1, 4]);
+        let key3 = get_key(key_prefix, vec![1, 4, 5]);
+        key_values.push((key1.clone(), vec![34]));
+        key_values.push((key2.clone(), vec![45]));
+        batch.put_key_value_bytes(key3, vec![23]);
+        batch.delete_key_prefix(key2);
+    }
+    if option == 3 {
+        // A Put followed by a Delete on the same value
+        let key1 = get_key(key_prefix, vec![1, 3]);
+        let key2 = get_key(key_prefix, vec![1, 4]);
+        let key3 = get_key(key_prefix, vec![1, 4, 5]);
+        key_values.push((key1.clone(), vec![34]));
+        key_values.push((key2.clone(), vec![45]));
+        batch.put_key_value_bytes(key3.clone(), vec![23]);
+        batch.delete_key(key3);
+    }
+    if option == 4 {
+        // A Delete Key followed by a Put on the same key
+        let key1 = get_key(key_prefix, vec![1, 3]);
+        let key2 = get_key(key_prefix, vec![1, 4]);
+        let key3 = get_key(key_prefix, vec![1, 4, 5]);
+        key_values.push((key1.clone(), vec![34]));
+        key_values.push((key2.clone(), vec![45]));
+        batch.delete_key(key3.clone());
+        batch.put_key_value_bytes(key3, vec![23]);
+    }
+    if option == 5 {
+        // A Delete Key followed by a Put on the same key
+        let key1 = get_key(key_prefix, vec![1, 3]);
+        let key2 = get_key(key_prefix, vec![1, 4]);
+        let key3 = get_key(key_prefix, vec![1, 4, 5]);
+        let key4 = get_key(key_prefix, vec![1, 5]);
+        key_values.push((key1.clone(), vec![34]));
+        key_values.push((key2.clone(), vec![45]));
+        batch.delete_key(key3.clone());
+        batch.put_key_value_bytes(key4, vec![23]);
+    }
+    (key_values, batch)
+}
+
+#[cfg(test)]
+async fn run_writes_from_state<C: KeyValueStoreClient + Sync>(key_value_store: &C) {
+    for option in 0..6 {
+        let key_prefix = get_random_key_prefix();
+        let state_batch = generate_specific_state_batch(&key_prefix, option);
+        run_test_batch_from_state(key_value_store, key_prefix, state_batch).await;
+    }
+}
+
+#[tokio::test]
+async fn test_memory_writes_from_state() {
+    let key_value_store = create_memory_client();
+    run_writes_from_state(&key_value_store).await;
+}
+
+#[cfg(feature = "rocksdb")]
+#[tokio::test]
+async fn test_rocks_db_writes_from_state() {
+    let key_value_store = create_rocks_db_test_client().await;
+    run_writes_from_state(&key_value_store).await;
+}
+
+#[cfg(feature = "aws")]
+#[tokio::test]
+async fn test_dynamo_db_writes_from_state() {
+    let key_value_store = create_dynamo_db_test_client().await;
+    run_writes_from_state(&key_value_store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[tokio::test]
-async fn test_big_write_read_scylla_db() {
+async fn test_scylla_db_writes_from_state() {
     let key_value_store = create_scylla_db_test_client().await;
-    run_big_write_read(key_value_store).await;
+    run_writes_from_state(&key_value_store).await;
 }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -38,12 +38,9 @@ use linera_views::rocks_db::{create_rocks_db_test_client, RocksDbClient, RocksDb
 
 #[cfg(feature = "aws")]
 use linera_views::{
-    common::{get_table_name, CommonStoreConfig},
-    dynamo_db::create_dynamo_db_common_config,
-    dynamo_db::DynamoDbContext,
-    dynamo_db::DynamoDbKvStoreConfig,
-    dynamo_db::LocalStackTestContext,
-    dynamo_db::TableName,
+    common::CommonStoreConfig, dynamo_db::create_dynamo_db_common_config,
+    dynamo_db::DynamoDbContext, dynamo_db::DynamoDbKvStoreConfig, dynamo_db::LocalStackTestContext,
+    dynamo_db::TableName, test_utils::get_table_name,
 };
 
 #[cfg(feature = "scylladb")]

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -22,7 +22,7 @@ use linera_views::{
     register_view::RegisterView,
     set_view::SetView,
     test_utils::{
-        get_random_byte_vector, get_random_key_value_operations, get_random_key_value_vec,
+        get_random_byte_vector, get_random_key_value_operations, get_random_key_values,
         random_shuffle, span_random_reordering_put_delete,
     },
     views::{CryptoHashRootView, HashableView, Hasher, RootView, View, ViewError},
@@ -1022,7 +1022,7 @@ async fn compute_hash_view_iter<R: RngCore>(rng: &mut R, n: usize, k: usize) {
     let mut unord1_hashes = Vec::new();
     let mut unord2_hashes = Vec::new();
     let mut ord_hashes = Vec::new();
-    let key_value_vector = get_random_key_value_vec(rng, n);
+    let key_value_vector = get_random_key_values(rng, n);
     let info_op = get_random_key_value_operations(rng, n, k);
     let n_iter = 4;
     for _ in 0..n_iter {
@@ -1146,7 +1146,7 @@ async fn check_hash_memoization_persistence<S>(
 async fn check_hash_memoization_persistence_large() {
     let n = 100;
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
-    let key_value_vector = get_random_key_value_vec(&mut rng, n);
+    let key_value_vector = get_random_key_values(&mut rng, n);
     let mut store = MemoryTestStore::new().await;
     check_hash_memoization_persistence(&mut rng, &mut store, key_value_vector).await;
 }


### PR DESCRIPTION
## Motivation

The ScyllaDB support is not crash-resistant and that is a problem for operations

## Proposal

We use the batch that allows us to implement this feature. The following changes are done:
* Introduction of a `get_random_key_prefix` for obtaining a `key_prefix`.
* Movement of `get_table_name` and related from `common.rs` to `test_utils.rs`.
* Expansion of the tests to detect more problems.
* Introduce the `write_batch` using the ScyllaDb batches.

There are some limitations on size and I am inquiring on how to address them without changing the rust code.

## Test Plan

CI

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
