### PR TITLE
Change all metrics crate usage to Prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,12 +1750,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "enum-iterator"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,8 +2789,7 @@ dependencies = [
  "linera-views",
  "lru",
  "meta-counter",
- "metrics",
- "metrics-util",
+ "prometheus",
  "proptest",
  "rand 0.8.5",
  "reentrant-counter",
@@ -3085,7 +3078,6 @@ dependencies = [
  "linera-storage",
  "linera-views",
  "matching-engine",
- "metrics-exporter-tcp",
  "once_cell",
  "parse_duration",
  "prometheus",
@@ -3147,7 +3139,8 @@ dependencies = [
  "linera-execution",
  "linera-storage",
  "linera-views",
- "metrics",
+ "once_cell",
+ "prometheus",
  "serde",
  "tempfile",
  "tokio",
@@ -3175,7 +3168,8 @@ dependencies = [
  "linera-views",
  "linera-views-derive",
  "linked-hash-map",
- "metrics",
+ "once_cell",
+ "prometheus",
  "rand 0.8.5",
  "rocksdb",
  "scylla",
@@ -3442,15 +3436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3559,63 +3544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
-dependencies = [
- "ahash 0.8.3",
- "metrics-macros",
- "portable-atomic",
-]
-
-[[package]]
-name = "metrics-exporter-tcp"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a01b6b1e117f56a00114e87b342640ddaab1a4b4d367e1731766a63a11b577"
-dependencies = [
- "bytes",
- "crossbeam-channel",
- "metrics",
- "mio",
- "prost",
- "prost-build",
- "prost-types",
- "tracing",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.31",
-]
-
-[[package]]
-name = "metrics-util"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
-dependencies = [
- "aho-corasick",
- "crossbeam-epoch",
- "crossbeam-utils",
- "hashbrown 0.13.1",
- "indexmap 1.9.3",
- "metrics",
- "num_cpus",
- "ordered-float",
- "quanta",
- "radix_trie",
- "sketches-ddsketch",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3694,15 +3622,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
 ]
 
 [[package]]
@@ -3936,15 +3855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-float"
-version = "3.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a54938017eacd63036332b4ae5c8a49fc8c0c1d6d629893057e4f13609edd06"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4132,12 +4042,6 @@ checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"
@@ -4334,22 +4238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach2",
- "once_cell",
- "raw-cpuid",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4369,16 +4257,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
 
 [[package]]
 name = "rand"
@@ -4480,15 +4358,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5223,12 +5092,6 @@ dependencies = [
  "console",
  "similar",
 ]
-
-[[package]]
-name = "sketches-ddsketch"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,7 @@ members = [
         "linera-witty-macros",
         "linera-witty/test-modules",
 ]
-exclude = [
-        "examples",
-        "scripts",
-]
+exclude = ["examples", "scripts"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -66,9 +63,6 @@ hex = "0.4.3"
 http = "0.2.7"
 log = "0.4.17"
 lru = "0.9.0"
-metrics = "0.21.0"
-metrics-exporter-tcp = "0.8.0"
-metrics-util = "0.15.0"
 linked-hash-map = "0.5.3"
 once_cell = "1.17.1"
 parse_duration = "2.1.1"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1663,6 +1663,7 @@ dependencies = [
  "linera-storage",
  "linera-views",
  "lru",
+ "prometheus",
  "proptest",
  "rand 0.8.5",
  "serde",
@@ -1757,7 +1758,8 @@ dependencies = [
  "linera-chain",
  "linera-execution",
  "linera-views",
- "metrics",
+ "once_cell",
+ "prometheus",
  "serde",
  "tempfile",
  "tokio",
@@ -1779,7 +1781,8 @@ dependencies = [
  "linera-base",
  "linera-views-derive",
  "linked-hash-map",
- "metrics",
+ "once_cell",
+ "prometheus",
  "rand 0.8.5",
  "serde",
  "sha3",
@@ -2089,28 +2092,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8ebbd1a9e57bbab77b9facae7f5136aea44c356943bf9a198f647da64285d6"
-dependencies = [
- "ahash 0.8.3",
- "metrics-macros",
- "portable-atomic",
-]
-
-[[package]]
-name = "metrics-macros"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,12 +2302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "portable-atomic"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2376,6 +2351,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "proptest"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2385,12 @@ dependencies = [
  "tempfile",
  "unarray",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "psm"

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -35,6 +35,7 @@ linera-execution = { workspace = true }
 linera-storage = { workspace = true }
 linera-views = { workspace = true }
 lru = { workspace = true }
+prometheus = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
@@ -54,8 +55,6 @@ fungible = { workspace = true }
 linera-core = { path = ".", default-features = false, features = ["test"] }
 linera-views = { workspace = true }
 meta-counter = { workspace = true }
-metrics = { workspace = true }
-metrics-util = { workspace = true }
 reentrant-counter = { workspace = true }
 serde_json = { workspace = true }
 social = { workspace = true }

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -13,7 +13,8 @@ use linera_storage::{
     WRITE_VALUE_COUNTER,
 };
 use linera_views::{views::ViewError, LOAD_VIEW_COUNTER, SAVE_VIEW_COUNTER};
-use recorder::{BenchRecorder, BenchRecorderMeasurement};
+use prometheus::core::Collector;
+use recorder::BenchRecorderMeasurement;
 use std::time::Duration;
 use tokio::runtime;
 
@@ -98,20 +99,14 @@ fn criterion_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {
     });
 }
 
-fn create_recorder() -> BenchRecorder {
-    let recorder = BenchRecorder::default();
-    recorder.clone().install().unwrap();
-    recorder
-}
-
 criterion_group!(
     name = benches;
     config = Criterion::default()
         .measurement_time(Duration::from_secs(40))
-        .with_measurement(BenchRecorderMeasurement::new(create_recorder(), vec![
-            READ_VALUE_COUNTER, WRITE_VALUE_COUNTER,
-            READ_CERTIFICATE_COUNTER, WRITE_CERTIFICATE_COUNTER,
-            LOAD_VIEW_COUNTER, SAVE_VIEW_COUNTER
+        .with_measurement(BenchRecorderMeasurement::new(vec![
+            READ_VALUE_COUNTER.desc()[0].fq_name.as_str(), WRITE_VALUE_COUNTER.desc()[0].fq_name.as_str(),
+            READ_CERTIFICATE_COUNTER.desc()[0].fq_name.as_str(), WRITE_CERTIFICATE_COUNTER.desc()[0].fq_name.as_str(),
+            LOAD_VIEW_COUNTER.desc()[0].fq_name.as_str(), SAVE_VIEW_COUNTER.desc()[0].fq_name.as_str(),
         ]));
     targets = criterion_benchmark
 );

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -19,7 +19,6 @@ wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
 rocksdb = ["linera-views/rocksdb", "linera-core/rocksdb", "linera-storage/rocksdb"]
 aws = ["linera-views/aws", "linera-core/aws", "linera-storage/aws"]
 scylladb = ["linera-views/scylladb", "linera-core/scylladb", "linera-storage/scylladb"]
-prometheus-metrics = ["dep:prometheus"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -44,10 +43,9 @@ linera-execution = { workspace = true }
 linera-rpc = { workspace = true }
 linera-storage = { workspace = true }
 linera-views = { workspace = true }
-metrics-exporter-tcp = { workspace = true }
 once_cell = { workspace = true }
 parse_duration = { workspace = true }
-prometheus = { workspace = true, optional = true }
+prometheus = { workspace = true }
 rand07 = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -10,7 +10,6 @@ pub mod config;
 pub mod grpc_proxy;
 pub mod node_service;
 pub mod project;
-#[cfg(feature = "prometheus-metrics")]
 pub mod prometheus_server;
 pub mod storage;
 pub mod util;

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -16,12 +16,11 @@ use linera_rpc::{
     simple_network,
     transport::TransportProtocol,
 };
-#[cfg(feature = "prometheus-metrics")]
-use linera_service::prometheus_server;
 use linera_service::{
     config::{
         CommitteeConfig, Export, GenesisConfig, Import, ValidatorConfig, ValidatorServerConfig,
     },
+    prometheus_server,
     storage::{full_initialize_storage, run_with_storage, Runnable, StorageConfig},
 };
 use linera_storage::Store;
@@ -160,23 +159,7 @@ impl ServerContext {
     fn start_metrics(host: &str, port: &u16) {
         match format!("{}:{}", host, port).parse::<SocketAddr>() {
             Err(err) => panic!("Invalid metrics address for {host}:{port}: {err}"),
-            #[cfg(not(feature = "prometheus-metrics"))]
-            Ok(address) => Self::start_metrics_impl(address),
-            #[cfg(feature = "prometheus-metrics")]
             Ok(address) => prometheus_server::start_metrics(address),
-        }
-    }
-
-    #[cfg(not(feature = "prometheus-metrics"))]
-    fn start_metrics_impl(address: SocketAddr) {
-        if let Err(error) = metrics_exporter_tcp::TcpBuilder::new()
-            .listen_address(address)
-            .install()
-        {
-            panic!(
-                "Could not install TCP metrics exporter in address: {:?}: {:?}",
-                address, error
-            );
         }
     }
 

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -12,7 +12,13 @@ edition = "2021"
 
 [features]
 default = ["wasmer", "rocksdb"]
-test = ["tokio/rt", "tokio/test-util", "tokio/time", "linera-execution/test", "linera-views/test"]
+test = [
+    "tokio/rt",
+    "tokio/test-util",
+    "tokio/time",
+    "linera-execution/test",
+    "linera-views/test",
+]
 wasmer = ["linera-execution/wasmer"]
 wasmtime = ["linera-execution/wasmtime"]
 aws = ["linera-views/aws"]
@@ -28,7 +34,8 @@ linera-base = { workspace = true }
 linera-chain = { workspace = true }
 linera-execution = { workspace = true }
 linera-views = { workspace = true, features = ["metrics"] }
-metrics = { workspace = true }
+once_cell = { workspace = true }
+prometheus = { workspace = true }
 serde = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -128,7 +128,7 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
     let increment_counter = if root {
         quote! {
             linera_views::increment_counter(
-                linera_views::LOAD_VIEW_COUNTER,
+                &linera_views::LOAD_VIEW_COUNTER,
                 stringify!(#struct_name),
                 &context.base_key(),
             );
@@ -202,7 +202,7 @@ fn generate_save_delete_view_code(input: ItemStruct) -> TokenStream2 {
             async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
                 use linera_views::{common::Context, batch::Batch, views::View};
                 linera_views::increment_counter(
-                    linera_views::SAVE_VIEW_COUNTER,
+                    &linera_views::SAVE_VIEW_COUNTER,
                     stringify!(#struct_name),
                     &self.context().base_key(),
                 );
@@ -739,7 +739,7 @@ pub mod tests {
                     ) -> Result<Self, linera_views::views::ViewError> {
                         use linera_views::{futures::join, common::Context};
                         linera_views::increment_counter(
-                            linera_views::LOAD_VIEW_COUNTER,
+                            &linera_views::LOAD_VIEW_COUNTER,
                             stringify!(TestView),
                             &context.base_key(),
                         );
@@ -859,7 +859,7 @@ pub mod tests {
                     async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
                         use linera_views::{common::Context, batch::Batch, views::View};
                         linera_views::increment_counter(
-                            linera_views::SAVE_VIEW_COUNTER,
+                            &linera_views::SAVE_VIEW_COUNTER,
                             stringify!(TestView),
                             &self.context().base_key(),
                         );

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -19,7 +19,7 @@ test = ["anyhow", "tokio/macros", "tokio/parking_lot"]
 aws = ["aws-config", "aws-sdk-dynamodb", "aws-sdk-s3", "aws-smithy-http", "aws-types"]
 scylladb = ["scylla"]
 db_timings = []
-metrics = ["dep:hex", "dep:metrics"]
+metrics = ["dep:hex"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -32,7 +32,8 @@ hex = { workspace = true, optional = true }
 linera-base = { workspace = true }
 linera-views-derive = { workspace = true }
 linked-hash-map = { workspace = true }
-metrics = { workspace = true, optional = true }
+once_cell = { workspace = true }
+prometheus = { workspace = true }
 serde = { workspace = true }
 sha3 = { workspace = true }
 static_assertions = { workspace = true }

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -128,25 +128,45 @@ pub mod test_utils;
 /// Re-exports used by the derive macros of this library.
 #[doc(hidden)]
 pub use {
-    async_lock, async_trait::async_trait, futures, generic_array, linera_base::crypto, serde, sha3,
+    async_lock,
+    async_trait::async_trait,
+    futures, generic_array,
+    linera_base::crypto,
+    once_cell::sync::Lazy,
+    prometheus::{register_int_counter_vec, IntCounterVec},
+    serde, sha3,
 };
 
 /// Does nothing. Use the metrics feature to enable.
 #[cfg(not(feature = "metrics"))]
-pub fn increment_counter(_name: &str, _struct_name: &str, _base_key: &[u8]) {}
+pub fn increment_counter(_counter: &Lazy<IntCounterVec>, _struct_name: &str, _base_key: &[u8]) {}
 
 /// Increments the metrics counter with the given name, with the struct and base key as labels.
 #[cfg(feature = "metrics")]
-pub fn increment_counter(name: &'static str, struct_name: &str, base_key: &[u8]) {
+pub fn increment_counter(counter: &Lazy<IntCounterVec>, struct_name: &str, base_key: &[u8]) {
     let base_key = hex::encode(base_key);
-    let labels = [("type", struct_name.into()), ("base_key", base_key)];
-    metrics::increment_counter!(name, &labels,);
+    let labels = [struct_name, &base_key];
+    counter.with_label_values(&labels).inc();
 }
 
 /// The metric counting how often a view is read from storage.
-pub const LOAD_VIEW_COUNTER: &str = "load_view";
+pub static LOAD_VIEW_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "load_view",
+        "The metric counting how often a view is read from storage",
+        &["type", "base_key"]
+    )
+    .expect("Counter can be created")
+});
 /// The metric counting how often a view is written from storage.
-pub const SAVE_VIEW_COUNTER: &str = "save_view";
+pub static SAVE_VIEW_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "save_view",
+        "The metric counting how often a view is written from storage",
+        &["type", "base_key"]
+    )
+    .expect("Counter can be created")
+});
 
 #[cfg(all(feature = "aws", target_arch = "wasm32"))]
 compile_error!("Cannot build AWS features for the Wasm target");


### PR DESCRIPTION
## Motivation

We're moving everything to Prometheus

## Proposal

So getting rid of the `metrics` crate usage

## Test Plan

Ran the benchmark locally, saw the metrics in Prometheus


![Screenshot 2023-10-09 at 20.50.09.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/72237226-d9fc-463e-8448-46304a15709c/Screenshot%202023-10-09%20at%2020.50.09.png)

![Screenshot 2023-10-09 at 20.49.37.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/457408f1-6980-467c-9adb-07f0bd52a877/Screenshot%202023-10-09%20at%2020.49.37.png)

![Screenshot 2023-10-09 at 20.49.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/297a2014-ab6f-430d-8636-1cd68abb9363/Screenshot%202023-10-09%20at%2020.49.19.png)

![Screenshot 2023-10-09 at 20.49.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/fc230794-79c8-4fee-9749-d786f5287807/Screenshot%202023-10-09%20at%2020.49.03.png)


## Release Plan

- This PR is adding or removing Cargo features.

