### PR TITLE
Rename some storage types to match the `Store` trait name.

### DIFF
--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -34,20 +34,20 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 #[cfg(feature = "rocksdb")]
 use {
-    linera_storage::RocksDbStoreClient, linera_views::rocks_db::create_rocks_db_common_config,
+    linera_storage::RocksDbStore, linera_views::rocks_db::create_rocks_db_common_config,
     linera_views::rocks_db::RocksDbKvStoreConfig, tokio::sync::Semaphore,
 };
 
 #[cfg(feature = "aws")]
 use {
-    linera_storage::DynamoDbStoreClient,
+    linera_storage::DynamoDbStore,
     linera_views::dynamo_db::DynamoDbKvStoreConfig,
     linera_views::dynamo_db::{create_dynamo_db_common_config, LocalStackTestContext},
 };
 
 #[cfg(feature = "scylladb")]
 use {
-    linera_storage::ScyllaDbStoreClient, linera_views::scylla_db::create_scylla_db_common_config,
+    linera_storage::ScyllaDbStore, linera_views::scylla_db::create_scylla_db_common_config,
     linera_views::scylla_db::ScyllaDbKvStoreConfig,
 };
 
@@ -626,29 +626,29 @@ impl MakeMemoryStoreClient {
 
 #[cfg(feature = "rocksdb")]
 #[derive(Default)]
-pub struct MakeRocksDbStoreClient {
+pub struct MakeRocksDbStore {
     temp_dirs: Vec<tempfile::TempDir>,
     wasm_runtime: Option<WasmRuntime>,
     clock: TestClock,
 }
 
 #[cfg(feature = "rocksdb")]
-impl MakeRocksDbStoreClient {
-    /// Creates a [`MakeRocksDbStoreClient`] that uses the specified [`WasmRuntime`] to run Wasm
+impl MakeRocksDbStore {
+    /// Creates a [`MakeRocksDbStore`] that uses the specified [`WasmRuntime`] to run Wasm
     /// applications.
     #[allow(dead_code)]
     pub fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
-        MakeRocksDbStoreClient {
+        MakeRocksDbStore {
             wasm_runtime: wasm_runtime.into(),
-            ..MakeRocksDbStoreClient::default()
+            ..MakeRocksDbStore::default()
         }
     }
 }
 
 #[cfg(feature = "rocksdb")]
 #[async_trait]
-impl StoreBuilder for MakeRocksDbStoreClient {
-    type Store = RocksDbStoreClient<TestClock>;
+impl StoreBuilder for MakeRocksDbStore {
+    type Store = RocksDbStore<TestClock>;
 
     async fn build(&mut self) -> Result<Self::Store, anyhow::Error> {
         let dir = tempfile::TempDir::new()?;
@@ -659,12 +659,9 @@ impl StoreBuilder for MakeRocksDbStoreClient {
             path_buf,
             common_config,
         };
-        let (store_client, _) = RocksDbStoreClient::new_for_testing(
-            store_config,
-            self.wasm_runtime,
-            self.clock.clone(),
-        )
-        .await?;
+        let (store_client, _) =
+            RocksDbStore::new_for_testing(store_config, self.wasm_runtime, self.clock.clone())
+                .await?;
         Ok(store_client)
     }
 
@@ -675,7 +672,7 @@ impl StoreBuilder for MakeRocksDbStoreClient {
 
 #[cfg(feature = "aws")]
 #[derive(Default)]
-pub struct MakeDynamoDbStoreClient {
+pub struct MakeDynamoDbStore {
     instance_counter: usize,
     localstack: Option<LocalStackTestContext>,
     wasm_runtime: Option<WasmRuntime>,
@@ -683,22 +680,22 @@ pub struct MakeDynamoDbStoreClient {
 }
 
 #[cfg(feature = "aws")]
-impl MakeDynamoDbStoreClient {
-    /// Creates a [`MakeDynamoDbStoreClient`] that uses the specified [`WasmRuntime`] to run Wasm
+impl MakeDynamoDbStore {
+    /// Creates a [`MakeDynamoDbStore`] that uses the specified [`WasmRuntime`] to run Wasm
     /// applications.
     #[allow(dead_code)]
     pub fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
-        MakeDynamoDbStoreClient {
+        MakeDynamoDbStore {
             wasm_runtime: wasm_runtime.into(),
-            ..MakeDynamoDbStoreClient::default()
+            ..MakeDynamoDbStore::default()
         }
     }
 }
 
 #[cfg(feature = "aws")]
 #[async_trait]
-impl StoreBuilder for MakeDynamoDbStoreClient {
-    type Store = DynamoDbStoreClient<TestClock>;
+impl StoreBuilder for MakeDynamoDbStore {
+    type Store = DynamoDbStore<TestClock>;
 
     async fn build(&mut self) -> Result<Self::Store, anyhow::Error> {
         if self.localstack.is_none() {
@@ -715,12 +712,9 @@ impl StoreBuilder for MakeDynamoDbStoreClient {
             common_config,
         };
         self.instance_counter += 1;
-        let (store_client, _) = DynamoDbStoreClient::new_for_testing(
-            store_config,
-            self.wasm_runtime,
-            self.clock.clone(),
-        )
-        .await?;
+        let (store_client, _) =
+            DynamoDbStore::new_for_testing(store_config, self.wasm_runtime, self.clock.clone())
+                .await?;
         Ok(store_client)
     }
 
@@ -730,7 +724,7 @@ impl StoreBuilder for MakeDynamoDbStoreClient {
 }
 
 #[cfg(feature = "scylladb")]
-pub struct MakeScyllaDbStoreClient {
+pub struct MakeScyllaDbStore {
     instance_counter: usize,
     uri: String,
     wasm_runtime: Option<WasmRuntime>,
@@ -738,13 +732,13 @@ pub struct MakeScyllaDbStoreClient {
 }
 
 #[cfg(feature = "scylladb")]
-impl Default for MakeScyllaDbStoreClient {
+impl Default for MakeScyllaDbStore {
     fn default() -> Self {
         let instance_counter = 0;
         let uri = "localhost:9042".to_string();
         let wasm_runtime = None;
         let clock = TestClock::new();
-        MakeScyllaDbStoreClient {
+        MakeScyllaDbStore {
             instance_counter,
             uri,
             wasm_runtime,
@@ -754,22 +748,22 @@ impl Default for MakeScyllaDbStoreClient {
 }
 
 #[cfg(feature = "scylladb")]
-impl MakeScyllaDbStoreClient {
-    /// Creates a [`MakeScyllaDbStoreClient`] that uses the specified [`WasmRuntime`] to run Wasm
+impl MakeScyllaDbStore {
+    /// Creates a [`MakeScyllaDbStore`] that uses the specified [`WasmRuntime`] to run Wasm
     /// applications.
     #[allow(dead_code)]
     pub fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
-        MakeScyllaDbStoreClient {
+        MakeScyllaDbStore {
             wasm_runtime: wasm_runtime.into(),
-            ..MakeScyllaDbStoreClient::default()
+            ..MakeScyllaDbStore::default()
         }
     }
 }
 
 #[cfg(feature = "scylladb")]
 #[async_trait]
-impl StoreBuilder for MakeScyllaDbStoreClient {
-    type Store = ScyllaDbStoreClient<TestClock>;
+impl StoreBuilder for MakeScyllaDbStore {
+    type Store = ScyllaDbStore<TestClock>;
 
     async fn build(&mut self) -> Result<Self::Store, anyhow::Error> {
         self.instance_counter += 1;
@@ -781,12 +775,9 @@ impl StoreBuilder for MakeScyllaDbStoreClient {
             table_name,
             common_config,
         };
-        let (store_client, _) = ScyllaDbStoreClient::new_for_testing(
-            store_config,
-            self.wasm_runtime,
-            self.clock.clone(),
-        )
-        .await?;
+        let (store_client, _) =
+            ScyllaDbStore::new_for_testing(store_config, self.wasm_runtime, self.clock.clone())
+                .await?;
         Ok(store_client)
     }
 

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -659,10 +659,10 @@ impl StoreBuilder for MakeRocksDbStore {
             path_buf,
             common_config,
         };
-        let (store_client, _) =
+        let (store, _) =
             RocksDbStore::new_for_testing(store_config, self.wasm_runtime, self.clock.clone())
                 .await?;
-        Ok(store_client)
+        Ok(store)
     }
 
     fn clock(&self) -> &TestClock {
@@ -712,10 +712,10 @@ impl StoreBuilder for MakeDynamoDbStore {
             common_config,
         };
         self.instance_counter += 1;
-        let (store_client, _) =
+        let (store, _) =
             DynamoDbStore::new_for_testing(store_config, self.wasm_runtime, self.clock.clone())
                 .await?;
-        Ok(store_client)
+        Ok(store)
     }
 
     fn clock(&self) -> &TestClock {
@@ -775,10 +775,10 @@ impl StoreBuilder for MakeScyllaDbStore {
             table_name,
             common_config,
         };
-        let (store_client, _) =
+        let (store, _) =
             ScyllaDbStore::new_for_testing(store_config, self.wasm_runtime, self.clock.clone())
                 .await?;
-        Ok(store_client)
+        Ok(store)
     }
 
     fn clock(&self) -> &TestClock {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -38,13 +38,13 @@ use std::sync::Arc;
 use test_log::test;
 
 #[cfg(feature = "rocksdb")]
-use crate::client::client_test_utils::{MakeRocksDbStoreClient, ROCKS_DB_SEMAPHORE};
+use crate::client::client_test_utils::{MakeRocksDbStore, ROCKS_DB_SEMAPHORE};
 
 #[cfg(feature = "aws")]
-use crate::client::client_test_utils::MakeDynamoDbStoreClient;
+use crate::client::client_test_utils::MakeDynamoDbStore;
 
 #[cfg(feature = "scylladb")]
-use crate::client::client_test_utils::MakeScyllaDbStoreClient;
+use crate::client::client_test_utils::MakeScyllaDbStore;
 
 #[test(tokio::test)]
 pub async fn test_memory_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
@@ -56,21 +56,21 @@ pub async fn test_memory_initiating_valid_transfer_with_notifications() -> Resul
 #[test(tokio::test)]
 async fn test_rocks_db_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_initiating_valid_transfer_with_notifications(MakeRocksDbStoreClient::default()).await
+    run_test_initiating_valid_transfer_with_notifications(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
 {
-    run_test_initiating_valid_transfer_with_notifications(MakeDynamoDbStoreClient::default()).await
+    run_test_initiating_valid_transfer_with_notifications(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
 {
-    run_test_initiating_valid_transfer_with_notifications(MakeScyllaDbStoreClient::default()).await
+    run_test_initiating_valid_transfer_with_notifications(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_initiating_valid_transfer_with_notifications<B>(
@@ -135,19 +135,19 @@ async fn test_memory_claim_amount() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_claim_amount() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_claim_amount(MakeRocksDbStoreClient::default()).await
+    run_test_claim_amount(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_claim_amount() -> Result<(), anyhow::Error> {
-    run_test_claim_amount(MakeDynamoDbStoreClient::default()).await
+    run_test_claim_amount(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_claim_amount() -> Result<(), anyhow::Error> {
-    run_test_claim_amount(MakeScyllaDbStoreClient::default()).await
+    run_test_claim_amount(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_claim_amount<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -225,19 +225,19 @@ async fn test_memory_rotate_key_pair() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_rotate_key_pair() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_rotate_key_pair(MakeRocksDbStoreClient::default()).await
+    run_test_rotate_key_pair(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_rotate_key_pair() -> Result<(), anyhow::Error> {
-    run_test_rotate_key_pair(MakeDynamoDbStoreClient::default()).await
+    run_test_rotate_key_pair(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_rotate_key_pair() -> Result<(), anyhow::Error> {
-    run_test_rotate_key_pair(MakeScyllaDbStoreClient::default()).await
+    run_test_rotate_key_pair(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_rotate_key_pair<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -295,19 +295,19 @@ async fn test_memory_transfer_ownership() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_transfer_ownership() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_transfer_ownership(MakeRocksDbStoreClient::default()).await
+    run_test_transfer_ownership(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_transfer_ownership() -> Result<(), anyhow::Error> {
-    run_test_transfer_ownership(MakeDynamoDbStoreClient::default()).await
+    run_test_transfer_ownership(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_transfer_ownership() -> Result<(), anyhow::Error> {
-    run_test_transfer_ownership(MakeScyllaDbStoreClient::default()).await
+    run_test_transfer_ownership(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_transfer_ownership<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -373,19 +373,19 @@ async fn test_memory_share_ownership() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_share_ownership() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_share_ownership(MakeRocksDbStoreClient::default()).await
+    run_test_share_ownership(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_share_ownership() -> Result<(), anyhow::Error> {
-    run_test_share_ownership(MakeDynamoDbStoreClient::default()).await
+    run_test_share_ownership(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_share_ownership() -> Result<(), anyhow::Error> {
-    run_test_share_ownership(MakeScyllaDbStoreClient::default()).await
+    run_test_share_ownership(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_share_ownership<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -539,19 +539,19 @@ async fn test_memory_open_chain_then_close_it() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_open_chain_then_close_it() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_open_chain_then_close_it(MakeRocksDbStoreClient::default()).await
+    run_test_open_chain_then_close_it(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_close_it(MakeDynamoDbStoreClient::default()).await
+    run_test_open_chain_then_close_it(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_close_it(MakeScyllaDbStoreClient::default()).await
+    run_test_open_chain_then_close_it(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_open_chain_then_close_it<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -600,19 +600,19 @@ async fn test_memory_transfer_then_open_chain() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_transfer_then_open_chain() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_transfer_then_open_chain(MakeRocksDbStoreClient::default()).await
+    run_test_transfer_then_open_chain(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    run_test_transfer_then_open_chain(MakeDynamoDbStoreClient::default()).await
+    run_test_transfer_then_open_chain(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    run_test_transfer_then_open_chain(MakeScyllaDbStoreClient::default()).await
+    run_test_transfer_then_open_chain(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_transfer_then_open_chain<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -699,19 +699,19 @@ async fn test_memory_open_chain_then_transfer() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_open_chain_then_transfer() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_open_chain_then_transfer(MakeRocksDbStoreClient::default()).await
+    run_test_open_chain_then_transfer(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_transfer(MakeDynamoDbStoreClient::default()).await
+    run_test_open_chain_then_transfer(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_transfer(MakeScyllaDbStoreClient::default()).await
+    run_test_open_chain_then_transfer(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_open_chain_then_transfer<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -787,19 +787,19 @@ async fn test_memory_close_chain() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_close_chain() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_close_chain(MakeRocksDbStoreClient::default()).await
+    run_test_close_chain(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_close_chain() -> Result<(), anyhow::Error> {
-    run_test_close_chain(MakeDynamoDbStoreClient::default()).await
+    run_test_close_chain(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_close_chain() -> Result<(), anyhow::Error> {
-    run_test_close_chain(MakeScyllaDbStoreClient::default()).await
+    run_test_close_chain(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_close_chain<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -862,19 +862,19 @@ async fn test_memory_initiating_valid_transfer_too_many_faults() -> Result<(), a
 #[test(tokio::test)]
 async fn test_rocks_db_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_initiating_valid_transfer_too_many_faults(MakeRocksDbStoreClient::default()).await
+    run_test_initiating_valid_transfer_too_many_faults(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_too_many_faults(MakeDynamoDbStoreClient::default()).await
+    run_test_initiating_valid_transfer_too_many_faults(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_too_many_faults(MakeScyllaDbStoreClient::default()).await
+    run_test_initiating_valid_transfer_too_many_faults(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_initiating_valid_transfer_too_many_faults<B>(
@@ -924,19 +924,19 @@ async fn test_memory_bidirectional_transfer() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_bidirectional_transfer() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_bidirectional_transfer(MakeRocksDbStoreClient::default()).await
+    run_test_bidirectional_transfer(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    run_test_bidirectional_transfer(MakeDynamoDbStoreClient::default()).await
+    run_test_bidirectional_transfer(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylla")]
 #[test(tokio::test)]
 async fn test_scylla_db_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    run_test_bidirectional_transfer(MakeScyllaDbStoreClient::default()).await
+    run_test_bidirectional_transfer(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_bidirectional_transfer<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -1054,19 +1054,19 @@ async fn test_memory_receiving_unconfirmed_transfer() -> Result<(), anyhow::Erro
 #[test(tokio::test)]
 async fn test_rocks_db_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_receiving_unconfirmed_transfer(MakeRocksDbStoreClient::default()).await
+    run_test_receiving_unconfirmed_transfer(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer(MakeDynamoDbStoreClient::default()).await
+    run_test_receiving_unconfirmed_transfer(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer(MakeScyllaDbStoreClient::default()).await
+    run_test_receiving_unconfirmed_transfer(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_receiving_unconfirmed_transfer<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -1123,7 +1123,7 @@ async fn test_rocks_db_receiving_unconfirmed_transfer_with_lagging_sender_balanc
 ) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
     run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        MakeRocksDbStoreClient::default(),
+        MakeRocksDbStore::default(),
     )
     .await
 }
@@ -1133,7 +1133,7 @@ async fn test_rocks_db_receiving_unconfirmed_transfer_with_lagging_sender_balanc
 async fn test_dynamo_db_receiving_unconfirmed_transfer_with_lagging_sender_balances(
 ) -> Result<(), anyhow::Error> {
     run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        MakeDynamoDbStoreClient::default(),
+        MakeDynamoDbStore::default(),
     )
     .await
 }
@@ -1143,7 +1143,7 @@ async fn test_dynamo_db_receiving_unconfirmed_transfer_with_lagging_sender_balan
 async fn test_scylla_db_receiving_unconfirmed_transfer_with_lagging_sender_balances(
 ) -> Result<(), anyhow::Error> {
     run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        MakeScyllaDbStoreClient::default(),
+        MakeScyllaDbStore::default(),
     )
     .await
 }
@@ -1250,19 +1250,19 @@ async fn test_memory_change_voting_rights() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_change_voting_rights() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_change_voting_rights(MakeRocksDbStoreClient::default()).await
+    run_test_change_voting_rights(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_change_voting_rights() -> Result<(), anyhow::Error> {
-    run_test_change_voting_rights(MakeDynamoDbStoreClient::default()).await
+    run_test_change_voting_rights(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_change_voting_rights() -> Result<(), anyhow::Error> {
-    run_test_change_voting_rights(MakeScyllaDbStoreClient::default()).await
+    run_test_change_voting_rights(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_change_voting_rights<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -1413,19 +1413,19 @@ async fn test_memory_request_leader_timeout() -> Result<(), anyhow::Error> {
 #[test(tokio::test)]
 async fn test_rocks_db_request_leader_timeout() -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_request_leader_timeout(MakeRocksDbStoreClient::default()).await
+    run_test_request_leader_timeout(MakeRocksDbStore::default()).await
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_request_leader_timeout() -> Result<(), anyhow::Error> {
-    run_test_request_leader_timeout(MakeDynamoDbStoreClient::default()).await
+    run_test_request_leader_timeout(MakeDynamoDbStore::default()).await
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_request_leader_timeout() -> Result<(), anyhow::Error> {
-    run_test_request_leader_timeout(MakeScyllaDbStoreClient::default()).await
+    run_test_request_leader_timeout(MakeScyllaDbStore::default()).await
 }
 
 async fn run_test_request_leader_timeout<B>(store_builder: B) -> Result<(), anyhow::Error>

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -26,13 +26,13 @@ use std::collections::BTreeMap;
 use test_case::test_case;
 
 #[cfg(feature = "rocksdb")]
-use crate::client::client_tests::{MakeRocksDbStoreClient, ROCKS_DB_SEMAPHORE};
+use crate::client::client_tests::{MakeRocksDbStore, ROCKS_DB_SEMAPHORE};
 
 #[cfg(feature = "aws")]
-use crate::client::client_tests::MakeDynamoDbStoreClient;
+use crate::client::client_tests::MakeDynamoDbStore;
 
 #[cfg(feature = "scylladb")]
-use crate::client::client_tests::MakeScyllaDbStoreClient;
+use crate::client::client_tests::MakeScyllaDbStore;
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -47,7 +47,7 @@ async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(),
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_create_application(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_create_application(MakeRocksDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "aws")]
@@ -55,7 +55,7 @@ async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    run_test_create_application(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_create_application(MakeDynamoDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "scylladb")]
@@ -63,7 +63,7 @@ async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_scylla_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    run_test_create_application(MakeScyllaDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_create_application(MakeScyllaDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 async fn run_test_create_application<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -157,10 +157,8 @@ async fn test_rocks_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_run_application_with_dependency(MakeRocksDbStoreClient::with_wasm_runtime(
-        wasm_runtime,
-    ))
-    .await
+    run_test_run_application_with_dependency(MakeRocksDbStore::with_wasm_runtime(wasm_runtime))
+        .await
 }
 
 #[cfg(feature = "aws")]
@@ -170,10 +168,8 @@ async fn test_rocks_db_run_application_with_dependency(
 async fn test_dynamo_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_run_application_with_dependency(MakeDynamoDbStoreClient::with_wasm_runtime(
-        wasm_runtime,
-    ))
-    .await
+    run_test_run_application_with_dependency(MakeDynamoDbStore::with_wasm_runtime(wasm_runtime))
+        .await
 }
 
 #[cfg(feature = "scylladb")]
@@ -183,10 +179,8 @@ async fn test_dynamo_db_run_application_with_dependency(
 async fn test_scylla_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_run_application_with_dependency(MakeScyllaDbStoreClient::with_wasm_runtime(
-        wasm_runtime,
-    ))
-    .await
+    run_test_run_application_with_dependency(MakeScyllaDbStore::with_wasm_runtime(wasm_runtime))
+        .await
 }
 
 async fn run_test_run_application_with_dependency<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -304,8 +298,7 @@ async fn test_rocks_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_run_reentrant_application(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime))
-        .await
+    run_test_run_reentrant_application(MakeRocksDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "aws")]
@@ -315,8 +308,7 @@ async fn test_rocks_db_run_reentrant_application(
 async fn test_dynamo_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_run_reentrant_application(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime))
-        .await
+    run_test_run_reentrant_application(MakeDynamoDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "scylladb")]
@@ -326,8 +318,7 @@ async fn test_dynamo_db_run_reentrant_application(
 async fn test_scylla_db_run_reentrant_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_run_reentrant_application(MakeScyllaDbStoreClient::with_wasm_runtime(wasm_runtime))
-        .await
+    run_test_run_reentrant_application(MakeScyllaDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 async fn run_test_run_reentrant_application<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -410,7 +401,7 @@ async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<()
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_cross_chain_message(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_cross_chain_message(MakeRocksDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "aws")]
@@ -420,7 +411,7 @@ async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<
 async fn test_dynamo_db_cross_chain_message(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_cross_chain_message(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_cross_chain_message(MakeDynamoDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "scylladb")]
@@ -430,7 +421,7 @@ async fn test_dynamo_db_cross_chain_message(
 async fn test_scylla_db_cross_chain_message(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_cross_chain_message(MakeScyllaDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_cross_chain_message(MakeScyllaDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 async fn run_test_cross_chain_message<B>(store_builder: B) -> Result<(), anyhow::Error>
@@ -604,7 +595,7 @@ async fn test_rocks_db_user_pub_sub_channels(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_user_pub_sub_channels(MakeRocksDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_user_pub_sub_channels(MakeRocksDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "aws")]
@@ -614,7 +605,7 @@ async fn test_rocks_db_user_pub_sub_channels(
 async fn test_dynamo_db_user_pub_sub_channels(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_user_pub_sub_channels(MakeDynamoDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_user_pub_sub_channels(MakeDynamoDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 #[cfg(feature = "scylladb")]
@@ -624,7 +615,7 @@ async fn test_dynamo_db_user_pub_sub_channels(
 async fn test_scylla_db_user_pub_sub_channels(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    run_test_user_pub_sub_channels(MakeScyllaDbStoreClient::with_wasm_runtime(wasm_runtime)).await
+    run_test_user_pub_sub_channels(MakeScyllaDbStore::with_wasm_runtime(wasm_runtime)).await
 }
 
 async fn run_test_user_pub_sub_channels<B>(store_builder: B) -> Result<(), anyhow::Error>

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -37,13 +37,13 @@ use std::sync::Arc;
 use test_case::test_case;
 
 #[cfg(feature = "rocksdb")]
-use linera_storage::RocksDbStoreClient;
+use linera_storage::RocksDbStore;
 
 #[cfg(feature = "aws")]
-use linera_storage::DynamoDbStoreClient;
+use linera_storage::DynamoDbStore;
 
 #[cfg(feature = "scylladb")]
-use linera_storage::ScyllaDbStoreClient;
+use linera_storage::ScyllaDbStore;
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -62,7 +62,7 @@ async fn test_memory_handle_certificates_to_create_application(
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let store = RocksDbStoreClient::make_test_store(Some(wasm_runtime)).await;
+    let store = RocksDbStore::make_test_store(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
@@ -73,7 +73,7 @@ async fn test_rocks_db_handle_certificates_to_create_application(
 async fn test_dynamo_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let store = DynamoDbStoreClient::make_test_store(Some(wasm_runtime)).await;
+    let store = DynamoDbStore::make_test_store(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
@@ -84,7 +84,7 @@ async fn test_dynamo_db_handle_certificates_to_create_application(
 async fn test_scylla_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let store = ScyllaDbStoreClient::make_test_store(Some(wasm_runtime)).await;
+    let store = ScyllaDbStore::make_test_store(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -51,7 +51,7 @@ use linera_storage::ScyllaDbStoreClient;
 async fn test_memory_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let store = MemoryStoreClient::make_test_client(Some(wasm_runtime)).await;
+    let store = MemoryStoreClient::make_test_store(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
@@ -62,7 +62,7 @@ async fn test_memory_handle_certificates_to_create_application(
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let store = RocksDbStoreClient::make_test_client(Some(wasm_runtime)).await;
+    let store = RocksDbStoreClient::make_test_store(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
@@ -73,7 +73,7 @@ async fn test_rocks_db_handle_certificates_to_create_application(
 async fn test_dynamo_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let store = DynamoDbStoreClient::make_test_client(Some(wasm_runtime)).await;
+    let store = DynamoDbStoreClient::make_test_store(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 
@@ -84,7 +84,7 @@ async fn test_dynamo_db_handle_certificates_to_create_application(
 async fn test_scylla_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let store = ScyllaDbStoreClient::make_test_client(Some(wasm_runtime)).await;
+    let store = ScyllaDbStoreClient::make_test_store(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(store, wasm_runtime).await
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -34,7 +34,7 @@ use linera_execution::{
     Message, Query, Response, SystemExecutionError, SystemExecutionState, SystemQuery,
     SystemResponse,
 };
-use linera_storage::{DbStoreClient, MemoryStoreClient, Store, TestClock};
+use linera_storage::{DbStore, MemoryStoreClient, Store, TestClock};
 use linera_views::{
     common::KeyValueStoreClient,
     memory::TEST_MEMORY_MAX_STREAM_QUERIES,
@@ -46,15 +46,13 @@ use std::{collections::BTreeMap, iter};
 use test_log::test;
 
 #[cfg(feature = "rocksdb")]
-use {
-    linera_core::client::client_test_utils::ROCKS_DB_SEMAPHORE, linera_storage::RocksDbStoreClient,
-};
+use {linera_core::client::client_test_utils::ROCKS_DB_SEMAPHORE, linera_storage::RocksDbStore};
 
 #[cfg(feature = "aws")]
-use linera_storage::DynamoDbStoreClient;
+use linera_storage::DynamoDbStore;
 
 #[cfg(feature = "scylladb")]
-use linera_storage::ScyllaDbStoreClient;
+use linera_storage::ScyllaDbStore;
 
 #[derive(Serialize, Deserialize)]
 struct Dummy;
@@ -276,21 +274,21 @@ async fn test_memory_handle_block_proposal_bad_signature() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_bad_signature() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_bad_signature(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_bad_signature() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_bad_signature(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_bad_signature() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_bad_signature(store).await;
 }
 
@@ -346,21 +344,21 @@ async fn test_memory_handle_block_proposal_zero_amount() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_zero_amount() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_zero_amount(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_zero_amount() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_zero_amount(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_zero_amount() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_zero_amount(store).await;
 }
 
@@ -421,25 +419,25 @@ async fn test_memory_handle_block_proposal_ticks() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_ticks() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_ticks(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_ticks() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_ticks(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_ticks() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_ticks(store).await;
 }
 
-async fn run_test_handle_block_proposal_ticks<C>(store: DbStoreClient<C, TestClock>)
+async fn run_test_handle_block_proposal_ticks<C>(store: DbStore<C, TestClock>)
 where
     C: KeyValueStoreClient + Clone + Send + Sync + 'static,
     ViewError: From<<C as KeyValueStoreClient>::Error>,
@@ -511,21 +509,21 @@ async fn test_memory_handle_block_proposal_unknown_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_unknown_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_unknown_sender(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_unknown_sender() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_unknown_sender(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_unknown_sender() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_unknown_sender(store).await;
 }
 
@@ -581,21 +579,21 @@ async fn test_memory_handle_block_proposal_with_chaining() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_with_chaining() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_with_chaining(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_with_chaining() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_with_chaining(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_with_chaining() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_with_chaining(store).await;
 }
 
@@ -691,21 +689,21 @@ async fn test_memory_handle_block_proposal_with_incoming_messages() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_with_incoming_messages() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_with_incoming_messages(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_with_incoming_messages() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_with_incoming_messages(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_with_incoming_messages() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_with_incoming_messages(store).await;
 }
 
@@ -1083,21 +1081,21 @@ async fn test_memory_handle_block_proposal_exceed_balance() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_exceed_balance() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_exceed_balance(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_exceed_balance() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_exceed_balance(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_exceed_balance() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_exceed_balance(store).await;
 }
 
@@ -1155,21 +1153,21 @@ async fn test_memory_handle_block_proposal() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal(store).await;
 }
 
@@ -1223,21 +1221,21 @@ async fn test_memory_handle_block_proposal_replay() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_replay() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_replay(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_replay() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_replay(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_replay() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_block_proposal_replay(store).await;
 }
 
@@ -1289,21 +1287,21 @@ async fn test_memory_handle_certificate_unknown_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_unknown_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_unknown_sender(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_unknown_sender() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_unknown_sender(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_unknown_sender() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_unknown_sender(store).await;
 }
 
@@ -1346,21 +1344,21 @@ async fn test_memory_handle_certificate_wrong_owner() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_wrong_owner() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_wrong_owner(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_wrong_owner() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_wrong_owner(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_wrong_owner() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_wrong_owner(store).await;
 }
 
@@ -1409,21 +1407,21 @@ async fn test_memory_handle_certificate_bad_block_height() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_bad_block_height() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_bad_block_height(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_bad_block_height() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_bad_block_height(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_bad_block_height() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_bad_block_height(store).await;
 }
 
@@ -1478,21 +1476,21 @@ async fn test_memory_handle_certificate_with_anticipated_incoming_message() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_with_anticipated_incoming_message() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_with_anticipated_incoming_message() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_with_anticipated_incoming_message() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(store).await;
 }
 
@@ -1604,21 +1602,21 @@ async fn test_memory_handle_certificate_receiver_balance_overflow() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_receiver_balance_overflow() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_receiver_balance_overflow(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_receiver_balance_overflow() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_receiver_balance_overflow(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_receiver_balance_overflow() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_receiver_balance_overflow(store).await;
 }
 
@@ -1696,21 +1694,21 @@ async fn test_memory_handle_certificate_receiver_equal_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_receiver_equal_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_receiver_equal_sender(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_receiver_equal_sender() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_receiver_equal_sender(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_receiver_equal_sender() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_receiver_equal_sender(store).await;
 }
 
@@ -1793,21 +1791,21 @@ async fn test_memory_handle_cross_chain_request() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_cross_chain_request() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_cross_chain_request() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request(store).await;
 }
 
@@ -1894,21 +1892,21 @@ async fn test_memory_handle_cross_chain_request_no_recipient_chain() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request_no_recipient_chain() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_cross_chain_request_no_recipient_chain() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_cross_chain_request_no_recipient_chain() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(store).await;
 }
 
@@ -1957,21 +1955,21 @@ async fn test_memory_handle_cross_chain_request_no_recipient_chain_on_client() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request_no_recipient_chain_on_client() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_cross_chain_request_no_recipient_chain_on_client() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_cross_chain_request_no_recipient_chain_on_client() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(store).await;
 }
 
@@ -2032,21 +2030,21 @@ async fn test_memory_handle_certificate_to_active_recipient() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_to_active_recipient() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_to_active_recipient(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_to_active_recipient() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_to_active_recipient(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_to_active_recipient() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_to_active_recipient(store).await;
 }
 
@@ -2214,21 +2212,21 @@ async fn test_memory_handle_certificate_to_inactive_recipient() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_to_inactive_recipient() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_handle_certificate_to_inactive_recipient(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_to_inactive_recipient() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_handle_certificate_to_inactive_recipient(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_to_inactive_recipient() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_handle_certificate_to_inactive_recipient(store).await;
 }
 
@@ -2282,21 +2280,21 @@ async fn test_memory_chain_creation_with_committee_creation() {
 #[test(tokio::test)]
 async fn test_rocks_db_chain_creation_with_committee_creation() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_chain_creation_with_committee_creation(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_chain_creation_with_committee_creation() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_chain_creation_with_committee_creation(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_chain_creation_with_committee_creation() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_chain_creation_with_committee_creation(store).await;
 }
 
@@ -2710,21 +2708,21 @@ async fn test_memory_transfers_and_committee_creation() {
 #[test(tokio::test)]
 async fn test_rocks_db_transfers_and_committee_creation() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_transfers_and_committee_creation(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_transfers_and_committee_creation() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_transfers_and_committee_creation(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_transfers_and_committee_creation() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_transfers_and_committee_creation(store).await;
 }
 
@@ -2855,21 +2853,21 @@ async fn test_memory_transfers_and_committee_removal() {
 #[test(tokio::test)]
 async fn test_rocks_db_transfers_and_committee_removal() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_transfers_and_committee_removal(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_transfers_and_committee_removal() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_transfers_and_committee_removal(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_transfers_and_committee_removal() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_transfers_and_committee_removal(store).await;
 }
 
@@ -3277,25 +3275,25 @@ async fn test_memory_leader_timeouts() {
 #[test(tokio::test)]
 async fn test_rocks_db_leader_timeouts() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     run_test_leader_timeouts(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_leader_timeouts() {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     run_test_leader_timeouts(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_leader_timeouts() {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     run_test_leader_timeouts(store).await;
 }
 
-async fn run_test_leader_timeouts<C>(store: DbStoreClient<C, TestClock>)
+async fn run_test_leader_timeouts<C>(store: DbStore<C, TestClock>)
 where
     C: KeyValueStoreClient + Clone + Send + Sync + 'static,
     ViewError: From<<C as KeyValueStoreClient>::Error>,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -268,7 +268,7 @@ fn generate_key_pairs(count: usize) -> Vec<KeyPair> {
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_bad_signature() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_bad_signature(store).await;
 }
 
@@ -276,21 +276,21 @@ async fn test_memory_handle_block_proposal_bad_signature() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_bad_signature() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_bad_signature(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_bad_signature() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_bad_signature(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_bad_signature() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_bad_signature(store).await;
 }
 
@@ -338,7 +338,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_zero_amount() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_zero_amount(store).await;
 }
 
@@ -346,21 +346,21 @@ async fn test_memory_handle_block_proposal_zero_amount() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_zero_amount() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_zero_amount(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_zero_amount() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_zero_amount(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_zero_amount() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_zero_amount(store).await;
 }
 
@@ -413,7 +413,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_ticks() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_ticks(store).await;
 }
 
@@ -421,21 +421,21 @@ async fn test_memory_handle_block_proposal_ticks() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_ticks() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_ticks(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_ticks() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_ticks(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_ticks() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_ticks(store).await;
 }
 
@@ -503,7 +503,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_unknown_sender() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_unknown_sender(store).await;
 }
 
@@ -511,21 +511,21 @@ async fn test_memory_handle_block_proposal_unknown_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_unknown_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_unknown_sender(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_unknown_sender() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_unknown_sender(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_unknown_sender() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_unknown_sender(store).await;
 }
 
@@ -573,7 +573,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_with_chaining() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_chaining(store).await;
 }
 
@@ -581,21 +581,21 @@ async fn test_memory_handle_block_proposal_with_chaining() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_with_chaining() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_chaining(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_with_chaining() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_chaining(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_with_chaining() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_chaining(store).await;
 }
 
@@ -683,7 +683,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_with_incoming_messages() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_incoming_messages(store).await;
 }
 
@@ -691,21 +691,21 @@ async fn test_memory_handle_block_proposal_with_incoming_messages() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_with_incoming_messages() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_incoming_messages(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_with_incoming_messages() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_incoming_messages(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_with_incoming_messages() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_with_incoming_messages(store).await;
 }
 
@@ -1075,7 +1075,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_exceed_balance() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_exceed_balance(store).await;
 }
 
@@ -1083,21 +1083,21 @@ async fn test_memory_handle_block_proposal_exceed_balance() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_exceed_balance() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_exceed_balance(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_exceed_balance() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_exceed_balance(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_exceed_balance() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_exceed_balance(store).await;
 }
 
@@ -1147,7 +1147,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal(store).await;
 }
 
@@ -1155,21 +1155,21 @@ async fn test_memory_handle_block_proposal() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal(store).await;
 }
 
@@ -1215,7 +1215,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_block_proposal_replay() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_replay(store).await;
 }
 
@@ -1223,21 +1223,21 @@ async fn test_memory_handle_block_proposal_replay() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_replay() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_replay(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_block_proposal_replay() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_replay(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_block_proposal_replay() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_block_proposal_replay(store).await;
 }
 
@@ -1281,7 +1281,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_unknown_sender() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_unknown_sender(store).await;
 }
 
@@ -1289,21 +1289,21 @@ async fn test_memory_handle_certificate_unknown_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_unknown_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_unknown_sender(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_unknown_sender() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_unknown_sender(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_unknown_sender() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_unknown_sender(store).await;
 }
 
@@ -1338,7 +1338,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_wrong_owner() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_wrong_owner(store).await;
 }
 
@@ -1346,21 +1346,21 @@ async fn test_memory_handle_certificate_wrong_owner() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_wrong_owner() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_wrong_owner(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_wrong_owner() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_wrong_owner(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_wrong_owner() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_wrong_owner(store).await;
 }
 
@@ -1401,7 +1401,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_bad_block_height() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_bad_block_height(store).await;
 }
 
@@ -1409,21 +1409,21 @@ async fn test_memory_handle_certificate_bad_block_height() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_bad_block_height() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_bad_block_height(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_bad_block_height() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_bad_block_height(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_bad_block_height() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_bad_block_height(store).await;
 }
 
@@ -1470,7 +1470,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_with_anticipated_incoming_message() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(store).await;
 }
 
@@ -1478,21 +1478,21 @@ async fn test_memory_handle_certificate_with_anticipated_incoming_message() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_with_anticipated_incoming_message() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_with_anticipated_incoming_message() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_with_anticipated_incoming_message() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(store).await;
 }
 
@@ -1596,7 +1596,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_receiver_balance_overflow() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_balance_overflow(store).await;
 }
 
@@ -1604,21 +1604,21 @@ async fn test_memory_handle_certificate_receiver_balance_overflow() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_receiver_balance_overflow() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_balance_overflow(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_receiver_balance_overflow() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_balance_overflow(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_receiver_balance_overflow() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_balance_overflow(store).await;
 }
 
@@ -1688,7 +1688,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_receiver_equal_sender() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_equal_sender(store).await;
 }
 
@@ -1696,21 +1696,21 @@ async fn test_memory_handle_certificate_receiver_equal_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_receiver_equal_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_equal_sender(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_receiver_equal_sender() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_equal_sender(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_receiver_equal_sender() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_receiver_equal_sender(store).await;
 }
 
@@ -1785,7 +1785,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_cross_chain_request() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request(store).await;
 }
 
@@ -1793,21 +1793,21 @@ async fn test_memory_handle_cross_chain_request() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_cross_chain_request() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_cross_chain_request() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request(store).await;
 }
 
@@ -1886,7 +1886,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_cross_chain_request_no_recipient_chain() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(store).await;
 }
 
@@ -1894,21 +1894,21 @@ async fn test_memory_handle_cross_chain_request_no_recipient_chain() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request_no_recipient_chain() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_cross_chain_request_no_recipient_chain() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_cross_chain_request_no_recipient_chain() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(store).await;
 }
 
@@ -1949,7 +1949,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_cross_chain_request_no_recipient_chain_on_client() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(store).await;
 }
 
@@ -1957,21 +1957,21 @@ async fn test_memory_handle_cross_chain_request_no_recipient_chain_on_client() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request_no_recipient_chain_on_client() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_cross_chain_request_no_recipient_chain_on_client() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_cross_chain_request_no_recipient_chain_on_client() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(store).await;
 }
 
@@ -2024,7 +2024,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_to_active_recipient() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_active_recipient(store).await;
 }
 
@@ -2032,21 +2032,21 @@ async fn test_memory_handle_certificate_to_active_recipient() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_to_active_recipient() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_active_recipient(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_to_active_recipient() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_active_recipient(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_to_active_recipient() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_active_recipient(store).await;
 }
 
@@ -2206,7 +2206,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_handle_certificate_to_inactive_recipient() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_inactive_recipient(store).await;
 }
 
@@ -2214,21 +2214,21 @@ async fn test_memory_handle_certificate_to_inactive_recipient() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_to_inactive_recipient() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_inactive_recipient(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_handle_certificate_to_inactive_recipient() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_inactive_recipient(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_handle_certificate_to_inactive_recipient() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_handle_certificate_to_inactive_recipient(store).await;
 }
 
@@ -2274,7 +2274,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_chain_creation_with_committee_creation() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_chain_creation_with_committee_creation(store).await;
 }
 
@@ -2282,21 +2282,21 @@ async fn test_memory_chain_creation_with_committee_creation() {
 #[test(tokio::test)]
 async fn test_rocks_db_chain_creation_with_committee_creation() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_chain_creation_with_committee_creation(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_chain_creation_with_committee_creation() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_chain_creation_with_committee_creation(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_chain_creation_with_committee_creation() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_chain_creation_with_committee_creation(store).await;
 }
 
@@ -2702,7 +2702,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_transfers_and_committee_creation() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_creation(store).await;
 }
 
@@ -2710,21 +2710,21 @@ async fn test_memory_transfers_and_committee_creation() {
 #[test(tokio::test)]
 async fn test_rocks_db_transfers_and_committee_creation() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_creation(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_transfers_and_committee_creation() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_creation(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_transfers_and_committee_creation() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_creation(store).await;
 }
 
@@ -2847,7 +2847,7 @@ where
 
 #[test(tokio::test)]
 async fn test_memory_transfers_and_committee_removal() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_removal(store).await;
 }
 
@@ -2855,21 +2855,21 @@ async fn test_memory_transfers_and_committee_removal() {
 #[test(tokio::test)]
 async fn test_rocks_db_transfers_and_committee_removal() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_removal(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_transfers_and_committee_removal() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_removal(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_transfers_and_committee_removal() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_transfers_and_committee_removal(store).await;
 }
 
@@ -3269,7 +3269,7 @@ async fn test_cross_chain_helper() {
 
 #[test(tokio::test)]
 async fn test_memory_leader_timeouts() {
-    let store = MemoryStoreClient::make_test_client(None).await;
+    let store = MemoryStoreClient::make_test_store(None).await;
     run_test_leader_timeouts(store).await;
 }
 
@@ -3277,21 +3277,21 @@ async fn test_memory_leader_timeouts() {
 #[test(tokio::test)]
 async fn test_rocks_db_leader_timeouts() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     run_test_leader_timeouts(store).await;
 }
 
 #[cfg(feature = "aws")]
 #[test(tokio::test)]
 async fn test_dynamo_db_leader_timeouts() {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     run_test_leader_timeouts(store).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[test(tokio::test)]
 async fn test_scylla_db_leader_timeouts() {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     run_test_leader_timeouts(store).await;
 }
 

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -12,20 +12,20 @@ use tracing::error;
 
 #[cfg(feature = "rocksdb")]
 use {
-    linera_storage::RocksDbStoreClient,
+    linera_storage::RocksDbStore,
     linera_views::rocks_db::{RocksDbClient, RocksDbKvStoreConfig},
     std::path::PathBuf,
 };
 
 #[cfg(feature = "aws")]
 use {
-    linera_storage::DynamoDbStoreClient,
+    linera_storage::DynamoDbStore,
     linera_views::dynamo_db::{get_config, DynamoDbClient, DynamoDbKvStoreConfig, TableName},
 };
 
 #[cfg(feature = "scylladb")]
 use {
-    linera_storage::ScyllaDbStoreClient,
+    linera_storage::ScyllaDbStore,
     linera_views::scylla_db::{ScyllaDbClient, ScyllaDbKvStoreConfig},
 };
 
@@ -356,19 +356,17 @@ where
         }
         #[cfg(feature = "rocksdb")]
         FullStorageConfig::RocksDb(store_config) => {
-            let (store, table_status) = RocksDbStoreClient::new(store_config, wasm_runtime).await?;
+            let (store, table_status) = RocksDbStore::new(store_config, wasm_runtime).await?;
             job.run(store).await
         }
         #[cfg(feature = "aws")]
         FullStorageConfig::DynamoDb(store_config) => {
-            let (store, table_status) =
-                DynamoDbStoreClient::new(store_config, wasm_runtime).await?;
+            let (store, table_status) = DynamoDbStore::new(store_config, wasm_runtime).await?;
             job.run(store).await
         }
         #[cfg(feature = "scylladb")]
         FullStorageConfig::ScyllaDb(store_config) => {
-            let (store, table_status) =
-                ScyllaDbStoreClient::new(store_config, wasm_runtime).await?;
+            let (store, table_status) = ScyllaDbStore::new(store_config, wasm_runtime).await?;
             job.run(store).await
         }
     }
@@ -386,19 +384,19 @@ pub async fn full_initialize_storage(
         #[cfg(feature = "rocksdb")]
         FullStorageConfig::RocksDb(store_config) => {
             let wasm_runtime = None;
-            let mut store = RocksDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            let mut store = RocksDbStore::initialize(store_config, wasm_runtime).await?;
             genesis_config.initialize_store(&mut store).await
         }
         #[cfg(feature = "aws")]
         FullStorageConfig::DynamoDb(store_config) => {
             let wasm_runtime = None;
-            let mut store = DynamoDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            let mut store = DynamoDbStore::initialize(store_config, wasm_runtime).await?;
             genesis_config.initialize_store(&mut store).await
         }
         #[cfg(feature = "scylladb")]
         FullStorageConfig::ScyllaDb(store_config) => {
             let wasm_runtime = None;
-            let mut store = ScyllaDbStoreClient::initialize(store_config, wasm_runtime).await?;
+            let mut store = ScyllaDbStore::initialize(store_config, wasm_runtime).await?;
             genesis_config.initialize_store(&mut store).await
         }
     }

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient, WallClock};
+use crate::{chain_guards::ChainGuards, DbStoreClient, DbStoreInner, WallClock};
 use dashmap::DashMap;
 use linera_execution::WasmRuntime;
 use linera_views::{
@@ -22,9 +22,9 @@ use {
 #[path = "unit_tests/dynamo_db.rs"]
 mod tests;
 
-type DynamoDbStore = DbStore<DynamoDbClient>;
+type DynamoDbStoreInner = DbStoreInner<DynamoDbClient>;
 
-impl DynamoDbStore {
+impl DynamoDbStoreInner {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
         store_config: DynamoDbKvStoreConfig,
@@ -96,7 +96,7 @@ impl DynamoDbStoreClient<TestClock> {
         clock: TestClock,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let (store, table_status) =
-            DynamoDbStore::new_for_testing(store_config, wasm_runtime).await?;
+            DynamoDbStoreInner::new_for_testing(store_config, wasm_runtime).await?;
         let store_client = DynamoDbStoreClient {
             client: Arc::new(store),
             clock,
@@ -110,7 +110,7 @@ impl DynamoDbStoreClient<WallClock> {
         store_config: DynamoDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, DynamoDbContextError> {
-        let store = DynamoDbStore::initialize(store_config, wasm_runtime).await?;
+        let store = DynamoDbStoreInner::initialize(store_config, wasm_runtime).await?;
         let store_client = DynamoDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,
@@ -122,7 +122,7 @@ impl DynamoDbStoreClient<WallClock> {
         store_config: DynamoDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (store, table_status) = DynamoDbStore::new(store_config, wasm_runtime).await?;
+        let (store, table_status) = DynamoDbStoreInner::new(store_config, wasm_runtime).await?;
         let store_client = DynamoDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -73,7 +73,7 @@ pub type DynamoDbStoreClient<C> = DbStoreClient<DynamoDbClient, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl DynamoDbStoreClient<TestClock> {
-    pub async fn make_test_client(wasm_runtime: Option<WasmRuntime>) -> Self {
+    pub async fn make_test_store(wasm_runtime: Option<WasmRuntime>) -> Self {
         let table = get_table_name();
         let table_name = table.parse().expect("Invalid table name");
         let localstack = LocalStackTestContext::new().await.expect("localstack");

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -97,11 +97,11 @@ impl DynamoDbStore<TestClock> {
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let (store, table_status) =
             DynamoDbStoreInner::new_for_testing(store_config, wasm_runtime).await?;
-        let store_client = DynamoDbStore {
+        let store = DynamoDbStore {
             client: Arc::new(store),
             clock,
         };
-        Ok((store_client, table_status))
+        Ok((store, table_status))
     }
 }
 
@@ -111,11 +111,11 @@ impl DynamoDbStore<WallClock> {
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, DynamoDbContextError> {
         let store = DynamoDbStoreInner::initialize(store_config, wasm_runtime).await?;
-        let store_client = DynamoDbStore {
+        let store = DynamoDbStore {
             client: Arc::new(store),
             clock: WallClock,
         };
-        Ok(store_client)
+        Ok(store)
     }
 
     pub async fn new(
@@ -123,10 +123,10 @@ impl DynamoDbStore<WallClock> {
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let (store, table_status) = DynamoDbStoreInner::new(store_config, wasm_runtime).await?;
-        let store_client = DynamoDbStore {
+        let store = DynamoDbStore {
             client: Arc::new(store),
             clock: WallClock,
         };
-        Ok((store_client, table_status))
+        Ok((store, table_status))
     }
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -13,12 +13,12 @@ mod rocks_db;
 mod scylla_db;
 
 #[cfg(feature = "aws")]
-pub use crate::dynamo_db::DynamoDbStoreClient;
+pub use crate::dynamo_db::DynamoDbStore;
 pub use crate::memory::MemoryStoreClient;
 #[cfg(feature = "rocksdb")]
-pub use crate::rocks_db::RocksDbStoreClient;
+pub use crate::rocks_db::RocksDbStore;
 #[cfg(feature = "scylladb")]
-pub use crate::scylla_db::ScyllaDbStoreClient;
+pub use crate::scylla_db::ScyllaDbStore;
 
 use crate::chain_guards::ChainGuards;
 use async_trait::async_trait;
@@ -253,8 +253,8 @@ pub struct DbStoreInner<Client> {
 }
 
 #[derive(Clone)]
-/// A DbStoreClient wrapping with Arc
-pub struct DbStoreClient<Client, Clock> {
+/// A DbStore wrapping with Arc
+pub struct DbStore<Client, Clock> {
     client: Arc<DbStoreInner<Client>>,
     pub clock: Clock,
 }
@@ -315,7 +315,7 @@ impl TestClock {
 }
 
 #[async_trait]
-impl<Client, C> Store for DbStoreClient<Client, C>
+impl<Client, C> Store for DbStore<Client, C>
 where
     Client: KeyValueStoreClient + Clone + Send + Sync + 'static,
     C: Clock + Clone + Send + Sync + 'static,
@@ -437,7 +437,7 @@ where
     }
 }
 
-impl<Client, C> DbStoreClient<Client, C>
+impl<Client, C> DbStore<Client, C>
 where
     Client: KeyValueStoreClient + Clone + Send + Sync + 'static,
     C: Clock,

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -245,7 +245,7 @@ pub trait Store: Sized {
 }
 
 /// A store implemented from a [`KeyValueStoreClient`]
-pub struct DbStore<Client> {
+pub struct DbStoreInner<Client> {
     client: Client,
     guards: ChainGuards,
     user_applications: Arc<DashMap<UserApplicationId, UserApplicationCode>>,
@@ -255,7 +255,7 @@ pub struct DbStore<Client> {
 #[derive(Clone)]
 /// A DbStoreClient wrapping with Arc
 pub struct DbStoreClient<Client, Clock> {
-    client: Arc<DbStore<Client>>,
+    client: Arc<DbStoreInner<Client>>,
     pub clock: Clock,
 }
 

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -24,7 +24,7 @@ pub type MemoryStoreClient<C> = DbStoreClient<MemoryClient, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl MemoryStoreClient<crate::TestClock> {
-    pub async fn make_test_client(wasm_runtime: Option<WasmRuntime>) -> Self {
+    pub async fn make_test_store(wasm_runtime: Option<WasmRuntime>) -> Self {
         let clock = crate::TestClock::new();
         let max_stream_queries = linera_views::memory::TEST_MEMORY_MAX_STREAM_QUERIES;
         MemoryStoreClient::new(wasm_runtime, max_stream_queries, clock)

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{chain_guards::ChainGuards, DbStoreClient, DbStoreInner};
+use crate::{chain_guards::ChainGuards, DbStore, DbStoreInner};
 use linera_execution::WasmRuntime;
 use linera_views::memory::{create_memory_client_stream_queries, MemoryClient};
 use std::sync::Arc;
@@ -20,7 +20,7 @@ impl MemoryStore {
     }
 }
 
-pub type MemoryStoreClient<C> = DbStoreClient<MemoryClient, C>;
+pub type MemoryStoreClient<C> = DbStore<MemoryClient, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl MemoryStoreClient<crate::TestClock> {

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient};
+use crate::{chain_guards::ChainGuards, DbStoreClient, DbStoreInner};
 use linera_execution::WasmRuntime;
 use linera_views::memory::{create_memory_client_stream_queries, MemoryClient};
 use std::sync::Arc;
 
-type MemoryStore = DbStore<MemoryClient>;
+type MemoryStore = DbStoreInner<MemoryClient>;
 
 impl MemoryStore {
     pub fn new(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize) -> Self {

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -67,7 +67,7 @@ pub type RocksDbStoreClient<C> = DbStoreClient<RocksDbClient, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl RocksDbStoreClient<TestClock> {
-    pub async fn make_test_client(wasm_runtime: Option<WasmRuntime>) -> Self {
+    pub async fn make_test_store(wasm_runtime: Option<WasmRuntime>) -> Self {
         let dir = TempDir::new().unwrap();
         let path_buf = dir.path().to_path_buf();
         let common_config = create_rocks_db_common_config();

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -75,11 +75,11 @@ impl RocksDbStore<TestClock> {
             path_buf,
             common_config,
         };
-        let (store_client, _) =
+        let (store, _) =
             RocksDbStore::new_for_testing(store_config, wasm_runtime, TestClock::new())
                 .await
-                .expect("store_client");
-        store_client
+                .expect("store");
+        store
     }
 
     pub async fn new_for_testing(
@@ -89,11 +89,11 @@ impl RocksDbStore<TestClock> {
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
         let (store, table_status) =
             RocksDbStoreInner::new_for_testing(store_config, wasm_runtime).await?;
-        let store_client = RocksDbStore {
+        let store = RocksDbStore {
             client: Arc::new(store),
             clock,
         };
-        Ok((store_client, table_status))
+        Ok((store, table_status))
     }
 }
 
@@ -103,11 +103,11 @@ impl RocksDbStore<WallClock> {
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, RocksDbContextError> {
         let store = RocksDbStoreInner::initialize(store_config, wasm_runtime).await?;
-        let store_client = RocksDbStore {
+        let store = RocksDbStore {
             client: Arc::new(store),
             clock: WallClock,
         };
-        Ok(store_client)
+        Ok(store)
     }
 
     pub async fn new(
@@ -115,10 +115,10 @@ impl RocksDbStore<WallClock> {
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
         let (store, table_status) = RocksDbStoreInner::new(store_config, wasm_runtime).await?;
-        let store_client = RocksDbStore {
+        let store = RocksDbStore {
             client: Arc::new(store),
             clock: WallClock,
         };
-        Ok((store_client, table_status))
+        Ok((store, table_status))
     }
 }

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient, WallClock};
+use crate::{chain_guards::ChainGuards, DbStoreClient, DbStoreInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
@@ -16,9 +16,9 @@ use {crate::TestClock, linera_views::rocks_db::create_rocks_db_common_config, te
 #[path = "unit_tests/rocks_db.rs"]
 mod tests;
 
-type RocksDbStore = DbStore<RocksDbClient>;
+type RocksDbStoreInner = DbStoreInner<RocksDbClient>;
 
-impl RocksDbStore {
+impl RocksDbStoreInner {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
         store_config: RocksDbKvStoreConfig,
@@ -88,7 +88,7 @@ impl RocksDbStoreClient<TestClock> {
         clock: TestClock,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
         let (store, table_status) =
-            RocksDbStore::new_for_testing(store_config, wasm_runtime).await?;
+            RocksDbStoreInner::new_for_testing(store_config, wasm_runtime).await?;
         let store_client = RocksDbStoreClient {
             client: Arc::new(store),
             clock,
@@ -102,7 +102,7 @@ impl RocksDbStoreClient<WallClock> {
         store_config: RocksDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, RocksDbContextError> {
-        let store = RocksDbStore::initialize(store_config, wasm_runtime).await?;
+        let store = RocksDbStoreInner::initialize(store_config, wasm_runtime).await?;
         let store_client = RocksDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,
@@ -114,7 +114,7 @@ impl RocksDbStoreClient<WallClock> {
         store_config: RocksDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
-        let (store, table_status) = RocksDbStore::new(store_config, wasm_runtime).await?;
+        let (store, table_status) = RocksDbStoreInner::new(store_config, wasm_runtime).await?;
         let store_client = RocksDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -70,7 +70,7 @@ pub type ScyllaDbStoreClient<C> = DbStoreClient<ScyllaDbClient, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl ScyllaDbStoreClient<TestClock> {
-    pub async fn make_test_client(wasm_runtime: Option<WasmRuntime>) -> Self {
+    pub async fn make_test_store(wasm_runtime: Option<WasmRuntime>) -> Self {
         let uri = "localhost:9042".to_string();
         let table_name = get_table_name();
         let common_config = create_scylla_db_common_config();

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -93,11 +93,11 @@ impl ScyllaDbStore<TestClock> {
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let (store, table_status) =
             ScyllaDbStoreInner::new_for_testing(store_config, wasm_runtime).await?;
-        let store_client = ScyllaDbStore {
+        let store = ScyllaDbStore {
             client: Arc::new(store),
             clock,
         };
-        Ok((store_client, table_status))
+        Ok((store, table_status))
     }
 }
 
@@ -107,11 +107,11 @@ impl ScyllaDbStore<WallClock> {
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, ScyllaDbContextError> {
         let store = ScyllaDbStoreInner::initialize(store_config, wasm_runtime).await?;
-        let store_client = ScyllaDbStore {
+        let store = ScyllaDbStore {
             client: Arc::new(store),
             clock: WallClock,
         };
-        Ok(store_client)
+        Ok(store)
     }
 
     pub async fn new(
@@ -119,10 +119,10 @@ impl ScyllaDbStore<WallClock> {
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let (store, table_status) = ScyllaDbStoreInner::new(store_config, wasm_runtime).await?;
-        let store_client = ScyllaDbStore {
+        let store = ScyllaDbStore {
             client: Arc::new(store),
             clock: WallClock,
         };
-        Ok((store_client, table_status))
+        Ok((store, table_status))
     }
 }

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{chain_guards::ChainGuards, DbStore, DbStoreClient, WallClock};
+use crate::{chain_guards::ChainGuards, DbStoreClient, DbStoreInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
@@ -19,9 +19,9 @@ use {
 #[path = "unit_tests/scylla_db.rs"]
 mod tests;
 
-type ScyllaDbStore = DbStore<ScyllaDbClient>;
+type ScyllaDbStoreInner = DbStoreInner<ScyllaDbClient>;
 
-impl ScyllaDbStore {
+impl ScyllaDbStoreInner {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
         store_config: ScyllaDbKvStoreConfig,
@@ -92,7 +92,7 @@ impl ScyllaDbStoreClient<TestClock> {
         clock: TestClock,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let (store, table_status) =
-            ScyllaDbStore::new_for_testing(store_config, wasm_runtime).await?;
+            ScyllaDbStoreInner::new_for_testing(store_config, wasm_runtime).await?;
         let store_client = ScyllaDbStoreClient {
             client: Arc::new(store),
             clock,
@@ -106,7 +106,7 @@ impl ScyllaDbStoreClient<WallClock> {
         store_config: ScyllaDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, ScyllaDbContextError> {
-        let store = ScyllaDbStore::initialize(store_config, wasm_runtime).await?;
+        let store = ScyllaDbStoreInner::initialize(store_config, wasm_runtime).await?;
         let store_client = ScyllaDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,
@@ -118,7 +118,7 @@ impl ScyllaDbStoreClient<WallClock> {
         store_config: ScyllaDbKvStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
-        let (store, table_status) = ScyllaDbStore::new(store_config, wasm_runtime).await?;
+        let (store, table_status) = ScyllaDbStoreInner::new(store_config, wasm_runtime).await?;
         let store_client = ScyllaDbStoreClient {
             client: Arc::new(store),
             clock: WallClock,

--- a/linera-storage/src/unit_tests/dynamo_db.rs
+++ b/linera-storage/src/unit_tests/dynamo_db.rs
@@ -8,7 +8,7 @@ use std::mem;
 /// Tests if released guards don't use memory.
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
-    let store = DynamoDbStoreClient::make_test_client(None).await;
+    let store = DynamoDbStoreClient::make_test_store(None).await;
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(store.client.guards.active_guards(), 0);

--- a/linera-storage/src/unit_tests/dynamo_db.rs
+++ b/linera-storage/src/unit_tests/dynamo_db.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{DynamoDbStoreClient, Store};
+use crate::{DynamoDbStore, Store};
 use linera_base::identifiers::ChainId;
 use std::mem;
 
 /// Tests if released guards don't use memory.
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
-    let store = DynamoDbStoreClient::make_test_store(None).await;
+    let store = DynamoDbStore::make_test_store(None).await;
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(store.client.guards.active_guards(), 0);

--- a/linera-storage/src/unit_tests/rocks_db.rs
+++ b/linera-storage/src/unit_tests/rocks_db.rs
@@ -9,7 +9,7 @@ use std::mem;
 /// Tests if released guards don't use memory.
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
-    let store = RocksDbStoreClient::make_test_client(None).await;
+    let store = RocksDbStoreClient::make_test_store(None).await;
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(store.client.guards.active_guards(), 0);

--- a/linera-storage/src/unit_tests/rocks_db.rs
+++ b/linera-storage/src/unit_tests/rocks_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::RocksDbStoreClient;
+use super::RocksDbStore;
 use crate::Store;
 use linera_base::identifiers::ChainId;
 use std::mem;
@@ -9,7 +9,7 @@ use std::mem;
 /// Tests if released guards don't use memory.
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
-    let store = RocksDbStoreClient::make_test_store(None).await;
+    let store = RocksDbStore::make_test_store(None).await;
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(store.client.guards.active_guards(), 0);

--- a/linera-storage/src/unit_tests/scylla_db.rs
+++ b/linera-storage/src/unit_tests/scylla_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::ScyllaDbStoreClient;
+use super::ScyllaDbStore;
 use crate::Store;
 use linera_base::identifiers::ChainId;
 use std::mem;
@@ -9,7 +9,7 @@ use std::mem;
 /// Tests if released guards don't use memory.
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
-    let store = ScyllaDbStoreClient::make_test_store(None).await;
+    let store = ScyllaDbStore::make_test_store(None).await;
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(store.client.guards.active_guards(), 0);

--- a/linera-storage/src/unit_tests/scylla_db.rs
+++ b/linera-storage/src/unit_tests/scylla_db.rs
@@ -9,7 +9,7 @@ use std::mem;
 /// Tests if released guards don't use memory.
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
-    let store = ScyllaDbStoreClient::make_test_client(None).await;
+    let store = ScyllaDbStoreClient::make_test_store(None).await;
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(store.client.guards.active_guards(), 0);


### PR DESCRIPTION
## Motivation

The trait `Store` is currently implemented by e.g. `RocksDbStoreClient`, not by `RocksDbStore`. This is confusing.

## Proposal

Rename `RocksDbStore` to `RocksDbStoreInner`, and `RocksDbStoreClient` to `RocksDbStore`. Same for the other backends.

Also rename `make_test_client` to `make_test_store`.

## Test Plan

Only renaming, no new logic.

## Links

- Discussion on an earlier PR: https://github.com/linera-io/linera-protocol/pull/1045#discussion_r1331943190
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
