### PR TITLE
Optimize debug builds in CI

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -45,9 +45,13 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
+    - name: Build the main workspace
       run: |
-        cargo build --locked --features aws,test
+        RUSTFLAGS="-C opt-level=3 -C debuginfo=1" cargo build --locked --features aws,test
+    - name: Build example applications
+      run: |
+        cd examples
+        cargo build --locked --release --target wasm32-unknown-unknown
     - name: Setup local DynamoDB instance
       run: |
         docker run --rm -d --name local-dynamodb -p 8000:8000/tcp amazon/dynamodb-local
@@ -58,4 +62,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: test
         LOCALSTACK_ENDPOINT: http://localhost:8000
       run: |
-        cargo test --locked --features aws -- dynamo
+        RUSTFLAGS="-C opt-level=3 -C debuginfo=1" cargo test --locked --features aws -- dynamo

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -47,7 +47,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       run: |
-        cargo build --locked --features aws
+        cargo build --locked --features aws,test
     - name: Setup local DynamoDB instance
       run: |
         docker run --rm -d --name local-dynamodb -p 8000:8000/tcp amazon/dynamodb-local

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,19 +53,19 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build the main workspace with the default features
+      run: |
+        RUSTFLAGS="-C opt-level=3 -C debuginfo=1" cargo build --all-targets --locked --features test
     - name: Build example applications
       run: |
         cd examples
         cargo build --locked --release --target wasm32-unknown-unknown
-    - name: Compile the workspace with the default features
-      run: |
-        cargo build --all-targets --locked --features test
     - name: Run all tests using the default features
       run: |
-        cargo test --locked
+        RUSTFLAGS="-C opt-level=3 -C debuginfo=1" cargo test --locked
     - name: Run some extra execution tests with wasmtime
       run: |
-        cargo test --locked -p linera-execution --features wasmtime
+        RUSTFLAGS="-C opt-level=3 -C debuginfo=1" cargo test --locked -p linera-execution --features wasmtime
     - name: Run Wasm application tests
       run: |
         cd examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,25 +57,19 @@ jobs:
       run: |
         cd examples
         cargo build --locked --release --target wasm32-unknown-unknown
-    - name: Compile the workspace with the default features (test)
+    - name: Compile the workspace with the default features
       run: |
-        cargo test --locked --no-run
-    - name: Compile the workspace with the default features (build)
-      run: |
-        cargo build --locked
+        cargo build --all-targets --locked --features test
     - name: Run all tests using the default features
       run: |
         cargo test --locked
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime
-    - name: Build Wasm test runner
-      # use debug mode to avoid building wasmtime in release mode
-      run: |
-        cargo build --locked --bin linera-wasm-test-runner
     - name: Run Wasm application tests
       run: |
         cd examples
+        # use debug mode to avoid building wasmtime in release mode
         CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=../target/debug/linera-wasm-test-runner cargo test --target wasm32-unknown-unknown
         cargo test --locked --target x86_64-unknown-linux-gnu
     - name: Run Witty integration tests

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -45,12 +45,16 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Build
+    - name: Build the main workspace
       run: |
-        cargo build --locked --features scylladb,test
+        RUSTFLAGS="-C opt-level=3 -C debuginfo=1" cargo build --locked --features scylladb,test
+    - name: Build example applications
+      run: |
+        cd examples
+        cargo build --locked --release --target wasm32-unknown-unknown
     - name: Setup local ScyllaDB instance
       run: |
         docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla
     - name: Run ScyllaDB tests
       run: |
-        cargo test --locked --features scylladb -- scylla
+        RUSTFLAGS="-C opt-level=3 -C debuginfo=1" cargo test --locked --features scylladb -- scylla

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -47,7 +47,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build
       run: |
-        cargo build --locked --features scylladb
+        cargo build --locked --features scylladb,test
     - name: Setup local ScyllaDB instance
       run: |
         docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla


### PR DESCRIPTION
## Motivation

Sadly, we're reaching the point where debug builds by default are too slow.

## Proposal

Use Rust flags ` -C opt-level=3 -C debuginfo=1` for the main protocol (but do not for Wasm examples)

## Test Plan

CI