### PR TITLE
Use anyhow's ensure and Context where appropriate.

### DIFF
--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -10,7 +10,7 @@ mod graphql;
 mod input_type;
 mod js_utils;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use futures::prelude::*;
 use gql_service::{
     applications, applications::ApplicationsApplications as Application, block,
@@ -234,7 +234,7 @@ async fn block(node: &str, chain_id: ChainId, hash: Option<CryptoHash>) -> Resul
     let block = request::<gql_service::Block, _>(&client, node, variables)
         .await?
         .block
-        .ok_or_else(|| anyhow!("no block found"))?;
+        .context("no block found")?;
     let hash = block.hash;
     Ok((
         Page::Block(Box::new(block)),
@@ -306,7 +306,7 @@ async fn operation(
         request::<gql_operations::GetOperation, _>(&client, &operations_indexer, variables)
             .await?
             .operation
-            .ok_or_else(|| anyhow!("no operation found"))?;
+            .context("no operation found")?;
     Ok((
         Page::Operation(operation.clone()),
         format!(
@@ -567,13 +567,11 @@ async fn page(
         }
         "blocks" => blocks(node, chain_id, None, Some(20)).await,
         "applications" => applications(node, chain_id).await,
-        "application" => match find_arg(args, "app").map(|v| parse(&v)) {
-            None => Err(anyhow!("unknown application")),
-            Some(app_js) => {
-                let app = from_value::<Application>(app_js).unwrap();
-                application(app).await
-            }
-        },
+        "application" => {
+            let app_arg = find_arg(args, "app").context("unknown application")?;
+            let app = from_value::<Application>(parse(&app_arg)).unwrap();
+            application(app).await
+        }
         "operation" => {
             let height = find_arg_map(args, "height", BlockHeight::from_str)?;
             let index = find_arg_map(args, "index", usize::from_str)?;
@@ -590,10 +588,10 @@ async fn page(
             }
         }
         "operations" => operations(indexer, chain_id).await,
-        "plugin" => match find_arg(args, "plugin") {
-            None => Err(anyhow!("unknown plugin")),
-            Some(name) => plugin(&name, indexer).await,
-        },
+        "plugin" => {
+            let name = find_arg(args, "plugin").context("unknown plugin")?;
+            plugin(&name, indexer).await
+        }
         "error" => {
             let msg = find_arg(args, "msg").unwrap_or("unknown error".to_string());
             Err(anyhow::Error::msg(msg))

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -569,7 +569,8 @@ async fn page(
         "applications" => applications(node, chain_id).await,
         "application" => {
             let app_arg = find_arg(args, "app").context("unknown application")?;
-            let app = from_value::<Application>(parse(&app_arg)).unwrap();
+            let app =
+                from_value::<Application>(parse(&app_arg)).expect("cannot parse applications");
             application(app).await
         }
         "operation" => {

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Context as _, Result};
 use std::path::PathBuf;
 use tokio::process::Command;
 use tracing::{debug, error};
@@ -42,18 +42,19 @@ pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result
         .arg("--version")
         .output()
         .await
-        .map_err(|e| {
-            anyhow!(
-            "Failed to execute and retrieve version from the binary {name} in directory {}: {e}",
-            current_binary_path.display())
+        .with_context(|| {
+            format!(
+                "Failed to execute and retrieve version from the binary {name} in directory {}",
+                current_binary_path.display()
+            )
         })?
         .stdout;
     let found_version = String::from_utf8_lossy(&version_message)
         .trim()
         .split(' ')
         .last()
-        .ok_or_else(|| {
-            anyhow!(
+        .with_context(|| {
+            format!(
                 "Passing --version to the binary {name} in directory {} returned an empty result",
                 current_binary_path.display()
             )


### PR DESCRIPTION
## Motivation

Compared to using `anyhow!` or `bail!` directly,
* The `anyhow::Context` methods are more concise and preserve more information about the original error. (The resulting `anyhow::Error` can still be downcast.)
* `anyhow::ensure!` is more concise and—at least if the condition is not a negation—often more readable.

## Proposal

Replace some usages of `anyhow!` and `bail!`.

Import `Context as _` to avoid confusion with `linera-views`' `Context` trait.

Qualify `anyhow::ensure!` to avoid confusion with `linera-base`'s `ensure!` macro.
We could extend the latter at some point to accept formatting arguments.

## Test Plan

No logic has changed.

## Links

- Related discussion: https://github.com/linera-io/linera-protocol/pull/1107#discussion_r1353232197
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
