### PR TITLE
Reads the list of all the tables that have been installed for `DynamoDb` and `ScyllaDb`.

### DIFF
--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -324,12 +324,13 @@ impl FullStorageConfig {
         match self {
             FullStorageConfig::Memory(_) => Err(ViewError::ContextError {
                 backend: "memory".to_string(),
-                error: "delete_single does not make sense for memory storage".to_string(),
+                error: "list_tables is not supported for the memory storage".to_string(),
             }),
             #[cfg(feature = "rocksdb")]
-            FullStorageConfig::RocksDb(_) => {
-                panic!("Currently the list_tables is not supported for RocksDb");
-            }
+            FullStorageConfig::RocksDb(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "list_tables is not currently supported for the RocksDb storage".to_string(),
+            }),
             #[cfg(feature = "aws")]
             FullStorageConfig::DynamoDb(store_config) => {
                 let tables = DynamoDbClient::list_tables(store_config).await?;

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -318,6 +318,30 @@ impl FullStorageConfig {
             }
         }
     }
+
+    /// List all the tables of the database
+    pub async fn list_tables(self) -> Result<Vec<String>, ViewError> {
+        match self {
+            FullStorageConfig::Memory(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "delete_single does not make sense for memory storage".to_string(),
+            }),
+            #[cfg(feature = "rocksdb")]
+            FullStorageConfig::RocksDb(_) => {
+                panic!("Currently the list_tables is not supported for RocksDb");
+            }
+            #[cfg(feature = "aws")]
+            FullStorageConfig::DynamoDb(store_config) => {
+                let tables = DynamoDbClient::list_tables(store_config).await?;
+                Ok(tables)
+            }
+            #[cfg(feature = "scylladb")]
+            FullStorageConfig::ScyllaDb(store_config) => {
+                let tables = ScyllaDbClient::list_tables(store_config).await?;
+                Ok(tables)
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -623,7 +623,9 @@ impl DynamoDbClientInternal {
         Ok(())
     }
 
-    async fn list_tables(store_config: DynamoDbKvStoreConfig) -> Result<Vec<String>, DynamoDbContextError> {
+    async fn list_tables(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<Vec<String>, DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         get_list_tables(&client).await
     }

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -627,7 +627,7 @@ impl DynamoDbClientInternal {
         store_config: DynamoDbKvStoreConfig,
     ) -> Result<Vec<String>, DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
-        get_list_tables(&client).await
+        list_tables_from_client(&client).await
     }
 
     async fn delete_single(
@@ -1602,7 +1602,7 @@ pub async fn create_dynamo_db_test_client() -> DynamoDbClient {
 }
 
 /// Helper function to list the names of tables registered on DynamoDB.
-pub async fn get_list_tables(
+pub async fn list_tables_from_client(
     client: &aws_sdk_dynamodb::Client,
 ) -> Result<Vec<String>, DynamoDbContextError> {
     Ok(client
@@ -1615,7 +1615,7 @@ pub async fn get_list_tables(
 
 /// Helper function to clear all the tables from the database
 pub async fn clear_tables(client: &aws_sdk_dynamodb::Client) -> Result<(), DynamoDbContextError> {
-    let tables = get_list_tables(client).await?;
+    let tables = list_tables_from_client(client).await?;
     for table in tables {
         client.delete_table().table_name(&table).send().await?;
     }

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -623,6 +623,11 @@ impl DynamoDbClientInternal {
         Ok(())
     }
 
+    async fn list_tables(store_config: DynamoDbKvStoreConfig) -> Result<Vec<String>, DynamoDbContextError> {
+        let client = Client::from_conf(store_config.config);
+        get_list_tables(&client).await
+    }
+
     async fn delete_single(
         store_config: DynamoDbKvStoreConfig,
     ) -> Result<(), DynamoDbContextError> {
@@ -1177,6 +1182,13 @@ impl DynamoDbClient {
         DynamoDbClientInternal::test_existence(store_config).await
     }
 
+    /// List all the tables of the database
+    pub async fn list_tables(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<Vec<String>, DynamoDbContextError> {
+        DynamoDbClientInternal::list_tables(store_config).await
+    }
+
     /// Deletes all the tables from the database
     pub async fn delete_all(
         store_config: DynamoDbKvStoreConfig,
@@ -1588,7 +1600,7 @@ pub async fn create_dynamo_db_test_client() -> DynamoDbClient {
 }
 
 /// Helper function to list the names of tables registered on DynamoDB.
-pub async fn list_tables(
+pub async fn get_list_tables(
     client: &aws_sdk_dynamodb::Client,
 ) -> Result<Vec<String>, DynamoDbContextError> {
     Ok(client
@@ -1601,7 +1613,7 @@ pub async fn list_tables(
 
 /// Helper function to clear all the tables from the database
 pub async fn clear_tables(client: &aws_sdk_dynamodb::Client) -> Result<(), DynamoDbContextError> {
-    let tables = list_tables(client).await?;
+    let tables = get_list_tables(client).await?;
     for table in tables {
         client.delete_table().table_name(&table).send().await?;
     }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -692,6 +692,13 @@ impl ScyllaDbClient {
         ScyllaDbClientInternal::delete_all(store_config).await
     }
 
+    /// Delete all the tables of a database
+    pub async fn list_tables(
+        store_config: ScyllaDbKvStoreConfig,
+    ) -> Result<Vec<String>, ScyllaDbContextError> {
+        ScyllaDbClientInternal::list_tables(store_config).await
+    }
+
     /// Deletes a single table from the database
     pub async fn delete_single(
         store_config: ScyllaDbKvStoreConfig,

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -491,15 +491,17 @@ impl ScyllaDbClientInternal {
         Ok(client)
     }
 
-    async fn list_tables(store_config: ScyllaDbKvStoreConfig) -> Result<Vec<String>, ScyllaDbContextError> {
+    async fn list_tables(
+        store_config: ScyllaDbKvStoreConfig,
+    ) -> Result<Vec<String>, ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
             .build()
             .await?;
-        let rows = session.query("DESCRIBE KEYSPACE kv",&[]).await?;
+        let rows = session.query("DESCRIBE KEYSPACE kv", &[]).await?;
         let mut tables = Vec::new();
         if let Some(rows) = rows.rows {
-            for row in rows.into_typed::<(String,String,String,String)>() {
+            for row in rows.into_typed::<(String, String, String, String)>() {
                 let value = row.unwrap();
                 if value.1 == "table" {
                     tables.push(value.2);

--- a/linera-views/src/unit_tests/dynamo_db_context_tests.rs
+++ b/linera-views/src/unit_tests/dynamo_db_context_tests.rs
@@ -3,7 +3,7 @@
 
 use super::{DynamoDbContext, TableName, TableStatus};
 use crate::dynamo_db::{
-    clear_tables, create_dynamo_db_common_config, list_tables, DynamoDbContextError,
+    clear_tables, create_dynamo_db_common_config, get_list_tables, DynamoDbContextError,
     DynamoDbKvStoreConfig, LocalStackTestContext,
 };
 use anyhow::Error;
@@ -33,12 +33,12 @@ async fn table_is_created() -> Result<(), Error> {
         .parse::<TableName>()
         .expect("Invalid table name");
 
-    let initial_tables = list_tables(&client).await?;
+    let initial_tables = get_list_tables(&client).await?;
     assert!(!initial_tables.contains(table_name.as_ref()));
 
     let table_status = get_table_status(&localstack, &table_name).await?;
 
-    let tables = list_tables(&client).await?;
+    let tables = get_list_tables(&client).await?;
     assert!(tables.contains(table_name.as_ref()));
     assert_eq!(table_status, TableStatus::New);
 
@@ -54,14 +54,14 @@ async fn separate_tables_are_created() -> Result<(), Error> {
     let first_table = "first".parse::<TableName>().expect("Invalid table name");
     let second_table = "second".parse::<TableName>().expect("Invalid table name");
 
-    let initial_tables = list_tables(&client).await?;
+    let initial_tables = get_list_tables(&client).await?;
     assert!(!initial_tables.contains(first_table.as_ref()));
     assert!(!initial_tables.contains(second_table.as_ref()));
 
     let first_table_status = get_table_status(&localstack, &first_table).await?;
     let second_table_status = get_table_status(&localstack, &second_table).await?;
 
-    let tables = list_tables(&client).await?;
+    let tables = get_list_tables(&client).await?;
     assert!(tables.contains(first_table.as_ref()));
     assert!(tables.contains(second_table.as_ref()));
     assert_eq!(first_table_status, TableStatus::New);

--- a/linera-views/src/unit_tests/dynamo_db_context_tests.rs
+++ b/linera-views/src/unit_tests/dynamo_db_context_tests.rs
@@ -3,7 +3,7 @@
 
 use super::{DynamoDbContext, TableName, TableStatus};
 use crate::dynamo_db::{
-    clear_tables, create_dynamo_db_common_config, get_list_tables, DynamoDbContextError,
+    clear_tables, create_dynamo_db_common_config, list_tables_from_client, DynamoDbContextError,
     DynamoDbKvStoreConfig, LocalStackTestContext,
 };
 use anyhow::Error;
@@ -33,12 +33,12 @@ async fn table_is_created() -> Result<(), Error> {
         .parse::<TableName>()
         .expect("Invalid table name");
 
-    let initial_tables = get_list_tables(&client).await?;
+    let initial_tables = list_tables_from_client(&client).await?;
     assert!(!initial_tables.contains(table_name.as_ref()));
 
     let table_status = get_table_status(&localstack, &table_name).await?;
 
-    let tables = get_list_tables(&client).await?;
+    let tables = list_tables_from_client(&client).await?;
     assert!(tables.contains(table_name.as_ref()));
     assert_eq!(table_status, TableStatus::New);
 
@@ -54,14 +54,14 @@ async fn separate_tables_are_created() -> Result<(), Error> {
     let first_table = "first".parse::<TableName>().expect("Invalid table name");
     let second_table = "second".parse::<TableName>().expect("Invalid table name");
 
-    let initial_tables = get_list_tables(&client).await?;
+    let initial_tables = list_tables_from_client(&client).await?;
     assert!(!initial_tables.contains(first_table.as_ref()));
     assert!(!initial_tables.contains(second_table.as_ref()));
 
     let first_table_status = get_table_status(&localstack, &first_table).await?;
     let second_table_status = get_table_status(&localstack, &second_table).await?;
 
-    let tables = get_list_tables(&client).await?;
+    let tables = list_tables_from_client(&client).await?;
     assert!(tables.contains(first_table.as_ref()));
     assert!(tables.contains(second_table.as_ref()));
     assert_eq!(first_table_status, TableStatus::New);


### PR DESCRIPTION
## Motivation

When working, it is useful to have the list of tables that have been created.

## Proposal

The proposal is introducing the feature and consist of the following actions:
* Exposition of the already existing `list_tables` of `DynamoDb`.
* Creation of the `list_tables` functionality for `ScyllaDb`.
* Addition of the feature to the `linera-db` tool.
The list is printed directly with a `println` statement and I could not find a better way.

## Test Plan

It is not part of the CI but I have tested the feature on my laptop both for `ScyllaDb` and `DynamoDb`.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
