### PR TITLE
Introduce error codes for `linera-db` tool

### DIFF
--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -265,7 +265,7 @@ async fn main() {
     let error_code = match evaluate_options(options).await {
         Ok(code) => code,
         Err(msg) => {
-            println!("Error is {:?}", msg);
+            tracing::error!("Error is {:?}", msg);
             2
         }
     };

--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -78,6 +78,26 @@ enum DatabaseToolCommand {
         cache_size: usize,
     },
 
+    /// Check absence of a database
+    #[structopt(name = "check_absence")]
+    CheckAbsence {
+        /// Storage configuration for the blockchain history.
+        #[structopt(long = "storage")]
+        storage_config: String,
+
+        /// The maximal number of simultaneous queries to the database
+        #[structopt(long)]
+        max_concurrent_queries: Option<usize>,
+
+        /// The maximal number of simultaneous stream queries to the database
+        #[structopt(long, default_value = "10")]
+        max_stream_queries: usize,
+
+        /// The maximal number of entries in the storage cache.
+        #[structopt(long, default_value = "1000")]
+        cache_size: usize,
+    },
+
     /// Initialize a table in the database
     #[structopt(name = "initialize")]
     Initialize {
@@ -119,7 +139,7 @@ enum DatabaseToolCommand {
     },
 }
 
-async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Error> {
+async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::Error> {
     match options.command {
         DatabaseToolCommand::DeleteAll {
             storage_config,
@@ -134,10 +154,7 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Er
                 cache_size,
             };
             let full_storage_config = storage_config.add_common_config(common_config).await?;
-            full_storage_config
-                .delete_all()
-                .await
-                .expect("successful delete_all operation");
+            full_storage_config.delete_all().await?;
         }
         DatabaseToolCommand::DeleteSingle {
             storage_config,
@@ -152,10 +169,7 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Er
                 cache_size,
             };
             let full_storage_config = storage_config.add_common_config(common_config).await?;
-            full_storage_config
-                .delete_single()
-                .await
-                .expect("successful delete_all operation");
+            full_storage_config.delete_single().await?;
         }
         DatabaseToolCommand::CheckExistence {
             storage_config,
@@ -170,14 +184,35 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Er
                 cache_size,
             };
             let full_storage_config = storage_config.add_common_config(common_config).await?;
-            let test = full_storage_config
-                .test_existence()
-                .await
-                .expect("successful delete_all operation");
+            let test = full_storage_config.test_existence().await?;
             if test {
-                process::exit(0);
+                tracing::info!("The database does exist");
+                return Ok(0);
             } else {
-                process::exit(1);
+                tracing::info!("The database does not exist");
+                return Ok(1);
+            }
+        }
+        DatabaseToolCommand::CheckAbsence {
+            storage_config,
+            max_concurrent_queries,
+            max_stream_queries,
+            cache_size,
+        } => {
+            let storage_config: StorageConfig = storage_config.parse()?;
+            let common_config = CommonStoreConfig {
+                max_concurrent_queries,
+                max_stream_queries,
+                cache_size,
+            };
+            let full_storage_config = storage_config.add_common_config(common_config).await?;
+            let test = full_storage_config.test_existence().await?;
+            if test {
+                tracing::info!("The database does exist");
+                return Ok(1);
+            } else {
+                tracing::info!("The database does not exist");
+                return Ok(0);
             }
         }
         DatabaseToolCommand::Initialize {
@@ -193,10 +228,7 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Er
                 cache_size,
             };
             let full_storage_config = storage_config.add_common_config(common_config).await?;
-            full_storage_config
-                .initialize()
-                .await
-                .expect("successful delete_all operation");
+            full_storage_config.initialize().await?;
         }
         DatabaseToolCommand::ListTables {
             storage_config,
@@ -211,15 +243,12 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Er
                 cache_size,
             };
             let full_storage_config = storage_config.add_common_config(common_config).await?;
-            let tables = full_storage_config
-                .list_tables()
-                .await
-                .expect("successful list_tables operation");
+            let tables = full_storage_config.list_tables().await?;
             println!("The list of tables is {:?}", tables);
         }
     }
     tracing::info!("Successful execution of linera-db");
-    Ok(())
+    Ok(0)
 }
 
 #[tokio::main]
@@ -234,8 +263,11 @@ async fn main() {
 
     let options = DatabaseToolOptions::from_args();
     let error_code = match evaluate_options(options).await {
-        Ok(_) => 0,
-        Err(_) => 2,
+        Ok(code) => code,
+        Err(msg) => {
+            println!("Error is {:?}", msg);
+            2
+        }
     };
     process::exit(error_code);
 }

--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -97,6 +97,26 @@ enum DatabaseToolCommand {
         #[structopt(long, default_value = "1000")]
         cache_size: usize,
     },
+
+    /// List the tables of the database
+    #[structopt(name = "list_tables")]
+    ListTables {
+        /// Storage configuration for the blockchain history.
+        #[structopt(long = "storage")]
+        storage_config: String,
+
+        /// The maximal number of simultaneous queries to the database
+        #[structopt(long)]
+        max_concurrent_queries: Option<usize>,
+
+        /// The maximal number of simultaneous stream queries to the database
+        #[structopt(long, default_value = "10")]
+        max_stream_queries: usize,
+
+        /// The maximal number of entries in the storage cache.
+        #[structopt(long, default_value = "1000")]
+        cache_size: usize,
+    },
 }
 
 async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Error> {
@@ -177,6 +197,25 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<(), anyhow::Er
                 .initialize()
                 .await
                 .expect("successful delete_all operation");
+        }
+        DatabaseToolCommand::ListTables {
+            storage_config,
+            max_concurrent_queries,
+            max_stream_queries,
+            cache_size,
+        } => {
+            let storage_config: StorageConfig = storage_config.parse()?;
+            let common_config = CommonStoreConfig {
+                max_concurrent_queries,
+                max_stream_queries,
+                cache_size,
+            };
+            let full_storage_config = storage_config.add_common_config(common_config).await?;
+            let tables = full_storage_config
+                .list_tables()
+                .await
+                .expect("successful list_tables operation");
+            println!("The list of tables is {:?}", tables);
         }
     }
     tracing::info!("Successful execution of linera-db");

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -308,6 +308,31 @@ impl FullStorageConfig {
             }
         }
     }
+
+    /// List all the tables of the database
+    pub async fn list_tables(self) -> Result<Vec<String>, ViewError> {
+        match self {
+            FullStorageConfig::Memory(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "list_tables is not supported for the memory storage".to_string(),
+            }),
+            #[cfg(feature = "rocksdb")]
+            FullStorageConfig::RocksDb(_) => Err(ViewError::ContextError {
+                backend: "memory".to_string(),
+                error: "list_tables is not currently supported for the RocksDb storage".to_string(),
+            }),
+            #[cfg(feature = "aws")]
+            FullStorageConfig::DynamoDb(store_config) => {
+                let tables = DynamoDbClient::list_tables(store_config).await?;
+                Ok(tables)
+            }
+            #[cfg(feature = "scylladb")]
+            FullStorageConfig::ScyllaDb(store_config) => {
+                let tables = ScyllaDbClient::list_tables(store_config).await?;
+                Ok(tables)
+            }
+        }
+    }
 }
 
 #[async_trait]

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Context as _, Result};
 use std::path::PathBuf;
 use tokio::process::Command;
 use tracing::{debug, error};
@@ -42,18 +42,19 @@ pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result
         .arg("--version")
         .output()
         .await
-        .map_err(|e| {
-            anyhow!(
-            "Failed to execute and retrieve version from the binary {name} in directory {}: {e}",
-            current_binary_path.display())
+        .with_context(|| {
+            format!(
+                "Failed to execute and retrieve version from the binary {name} in directory {}",
+                current_binary_path.display()
+            )
         })?
         .stdout;
     let found_version = String::from_utf8_lossy(&version_message)
         .trim()
         .split(' ')
         .last()
-        .ok_or_else(|| {
-            anyhow!(
+        .with_context(|| {
+            format!(
                 "Passing --version to the binary {name} in directory {} returned an empty result",
                 current_binary_path.display()
             )

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -623,6 +623,13 @@ impl DynamoDbClientInternal {
         Ok(())
     }
 
+    async fn list_tables(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<Vec<String>, DynamoDbContextError> {
+        let client = Client::from_conf(store_config.config);
+        list_tables_from_client(&client).await
+    }
+
     async fn delete_single(
         store_config: DynamoDbKvStoreConfig,
     ) -> Result<(), DynamoDbContextError> {
@@ -1177,6 +1184,13 @@ impl DynamoDbClient {
         DynamoDbClientInternal::test_existence(store_config).await
     }
 
+    /// List all the tables of the database
+    pub async fn list_tables(
+        store_config: DynamoDbKvStoreConfig,
+    ) -> Result<Vec<String>, DynamoDbContextError> {
+        DynamoDbClientInternal::list_tables(store_config).await
+    }
+
     /// Deletes all the tables from the database
     pub async fn delete_all(
         store_config: DynamoDbKvStoreConfig,
@@ -1588,7 +1602,7 @@ pub async fn create_dynamo_db_test_client() -> DynamoDbClient {
 }
 
 /// Helper function to list the names of tables registered on DynamoDB.
-pub async fn list_tables(
+pub async fn list_tables_from_client(
     client: &aws_sdk_dynamodb::Client,
 ) -> Result<Vec<String>, DynamoDbContextError> {
     Ok(client
@@ -1601,7 +1615,7 @@ pub async fn list_tables(
 
 /// Helper function to clear all the tables from the database
 pub async fn clear_tables(client: &aws_sdk_dynamodb::Client) -> Result<(), DynamoDbContextError> {
-    let tables = list_tables(client).await?;
+    let tables = list_tables_from_client(client).await?;
     for table in tables {
         client.delete_table().table_name(&table).send().await?;
     }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -491,6 +491,26 @@ impl ScyllaDbClientInternal {
         Ok(client)
     }
 
+    async fn list_tables(
+        store_config: ScyllaDbKvStoreConfig,
+    ) -> Result<Vec<String>, ScyllaDbContextError> {
+        let session = SessionBuilder::new()
+            .known_node(store_config.uri.as_str())
+            .build()
+            .await?;
+        let rows = session.query("DESCRIBE KEYSPACE kv", &[]).await?;
+        let mut tables = Vec::new();
+        if let Some(rows) = rows.rows {
+            for row in rows.into_typed::<(String, String, String, String)>() {
+                let value = row.unwrap();
+                if value.1 == "table" {
+                    tables.push(value.2);
+                }
+            }
+        }
+        Ok(tables)
+    }
+
     async fn delete_all(store_config: ScyllaDbKvStoreConfig) -> Result<(), ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
@@ -672,6 +692,13 @@ impl ScyllaDbClient {
         store_config: ScyllaDbKvStoreConfig,
     ) -> Result<(), ScyllaDbContextError> {
         ScyllaDbClientInternal::delete_all(store_config).await
+    }
+
+    /// Delete all the tables of a database
+    pub async fn list_tables(
+        store_config: ScyllaDbKvStoreConfig,
+    ) -> Result<Vec<String>, ScyllaDbContextError> {
+        ScyllaDbClientInternal::list_tables(store_config).await
     }
 
     /// Deletes a single table from the database

--- a/linera-views/src/unit_tests/dynamo_db_context_tests.rs
+++ b/linera-views/src/unit_tests/dynamo_db_context_tests.rs
@@ -3,7 +3,7 @@
 
 use super::{DynamoDbContext, TableName, TableStatus};
 use crate::dynamo_db::{
-    clear_tables, create_dynamo_db_common_config, list_tables, DynamoDbContextError,
+    clear_tables, create_dynamo_db_common_config, list_tables_from_client, DynamoDbContextError,
     DynamoDbKvStoreConfig, LocalStackTestContext,
 };
 use anyhow::Error;
@@ -33,12 +33,12 @@ async fn table_is_created() -> Result<(), Error> {
         .parse::<TableName>()
         .expect("Invalid table name");
 
-    let initial_tables = list_tables(&client).await?;
+    let initial_tables = list_tables_from_client(&client).await?;
     assert!(!initial_tables.contains(table_name.as_ref()));
 
     let table_status = get_table_status(&localstack, &table_name).await?;
 
-    let tables = list_tables(&client).await?;
+    let tables = list_tables_from_client(&client).await?;
     assert!(tables.contains(table_name.as_ref()));
     assert_eq!(table_status, TableStatus::New);
 
@@ -54,14 +54,14 @@ async fn separate_tables_are_created() -> Result<(), Error> {
     let first_table = "first".parse::<TableName>().expect("Invalid table name");
     let second_table = "second".parse::<TableName>().expect("Invalid table name");
 
-    let initial_tables = list_tables(&client).await?;
+    let initial_tables = list_tables_from_client(&client).await?;
     assert!(!initial_tables.contains(first_table.as_ref()));
     assert!(!initial_tables.contains(second_table.as_ref()));
 
     let first_table_status = get_table_status(&localstack, &first_table).await?;
     let second_table_status = get_table_status(&localstack, &second_table).await?;
 
-    let tables = list_tables(&client).await?;
+    let tables = list_tables_from_client(&client).await?;
     assert!(tables.contains(first_table.as_ref()));
     assert!(tables.contains(second_table.as_ref()));
     assert_eq!(first_table_status, TableStatus::New);


### PR DESCRIPTION
## Motivation

It was deemed preferable by practitioners that the error code returned by `linera-db` reflects the conclusion of the request. This is thus implemented.

## Proposal

We simply use a `std::process` and write down the stuff accordingly.

## Test Plan

The CI has not changed, but the feature was tested on the command line by yours truly.
