### PR TITLE
add missing canonicalize for util::resolve_binary

### DIFF
--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -14,7 +14,8 @@ pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result
         std::env::args()
             .next()
             .expect("args should start with the current binary path"),
-    );
+    )
+    .canonicalize()?;
     current_binary_path.pop();
 
     #[cfg(any(test, feature = "test"))]
@@ -38,6 +39,7 @@ pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result
     }
 
     // Quick version check.
+    debug!("Checking the version of {}", path.display());
     let version_message = Command::new(&path)
         .arg("--version")
         .output()
@@ -67,6 +69,7 @@ pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result
         );
         bail!("Incorrect version for binary {name}");
     }
+    debug!("{} has version {version}", path.display());
 
     Ok(path)
 }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -529,6 +529,28 @@ async fn run_project_publish(database: Database) {
     assert_eq!(node_service.try_get_applications_uri(&chain).await.len(), 1)
 }
 
+#[test_log::test(tokio::test)]
+async fn test_linera_net_up_simple() {
+    use std::{
+        io::Write,
+        process::{Command, Stdio},
+    };
+
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+
+    // Using a relative path to test the resolution of other binaries in this case.
+    let mut command = Command::new("../target/debug/linera");
+    command.args(["net", "up"]);
+    let mut child = command.stdin(Stdio::piped()).spawn().unwrap();
+
+    let mut stdin = child.stdin.take().unwrap();
+    std::thread::spawn(move || {
+        stdin.write_all(b"\n").unwrap();
+    });
+
+    assert!(child.wait().unwrap().success());
+}
+
 #[cfg(feature = "rocksdb")]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_example_publish() {


### PR DESCRIPTION
## Motivation

Fix `cargo build --bins && target/debug/linera net up` after #1107 

## Proposal

Make `util::resolve_binary` return an absolute path.

The issue occurs when the current binary is a relative path. Before #1107, `cargo_force_build_binary` was calling `.canonicalize()`.

## Test Plan

CI

The new integration test covers this use case:
```
cargo build --bins && target/debug/linera net up
```
