### PR TITLE
Correct an error in `ScyllaDb` and handle one more scenario in the tests

### DIFF
--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -295,7 +295,7 @@ impl ScyllaDbClientInternal {
             None => {
                 let values = (key_prefix,);
                 let query = format!(
-                    "SELECT k FROM kv.{} WHERE dummy = 0 AND k >= ? ALLOW FILTERING",
+                    "SELECT k,v FROM kv.{} WHERE dummy = 0 AND k >= ? ALLOW FILTERING",
                     table_name
                 );
                 session.query(query, values).await?

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -557,13 +557,23 @@ fn generate_specific_state_batch(key_prefix: &[u8], option: usize) -> StateBatch
         batch.delete_key(key3.clone());
         batch.put_key_value_bytes(key4, vec![23]);
     }
+    if option == 6 {
+        let key1 = get_key(key_prefix, vec![0]);
+        let key2 = get_key(key_prefix, vec![]);
+        key_values.push((key1, vec![33]));
+        batch.delete_key_prefix(key2);
+    }
     (key_values, batch)
 }
 
 #[cfg(test)]
 async fn run_writes_from_state<C: KeyValueStoreClient + Sync>(key_value_store: &C) {
-    for option in 0..6 {
-        let key_prefix = get_random_key_prefix();
+    for option in 0..7 {
+        let key_prefix = if option == 6 {
+            vec![255, 255, 255]
+        } else {
+            get_random_key_prefix()
+        };
         let state_batch = generate_specific_state_batch(&key_prefix, option);
         run_test_batch_from_state(key_value_store, key_prefix, state_batch).await;
     }


### PR DESCRIPTION
## Motivation

The case of prefix of the form `[255, ..., 255]` is handled separately in some storages. It deserves to be tested.

## Proposal

A bug in the `ScyllaDb` code is corrected. However, that error does not appear to introduce a bug so there is more discussion to be had with `ScyllaDb` people.

## Test Plan

The improved CI.

## Release Plan

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
