### PR TITLE
Make parts of cli_wrapper test-only.

### DIFF
--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -4,22 +4,23 @@
 //! Helper module to call the binaries of `linera-service` with appropriate command-line
 //! arguments.
 
+#[cfg(any(test, feature = "test"))]
+mod test_utils;
+
+#[cfg(any(test, feature = "test"))]
+pub use test_utils::{ApplicationWrapper, NodeService};
+
 use crate::{config::WalletState, util};
 use anyhow::{Context, Result};
-use async_graphql::InputType;
 use linera_base::{
-    abi::ContractAbi,
     crypto::PublicKey,
     data_types::RoundNumber,
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{ChainId, MessageId, Owner},
 };
-use linera_execution::Bytecode;
-use serde::{de::DeserializeOwned, ser::Serialize};
-use serde_json::{json, value::Value};
+use serde::ser::Serialize;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     env, fs,
-    marker::PhantomData,
     ops::RangeInclusive,
     path::{Path, PathBuf},
     process::Stdio,
@@ -34,16 +35,9 @@ use tonic_health::proto::{
 };
 use tracing::{info, warn};
 
-#[cfg(any(test, feature = "test"))]
-use linera_views::test_utils::get_table_name;
-
 /// The name of the environment variable that allows specifying additional arguments to be passed
 /// to the binary when starting a server.
 const SERVER_ENV: &str = "LINERA_SERVER_PARAMS";
-
-/// The name of the environment variable that allows specifying additional arguments to be passed
-/// to the node-service command of the client.
-const CLIENT_SERVICE_ENV: &str = "LINERA_CLIENT_SERVICE_PARAMS";
 
 #[derive(Copy, Clone)]
 pub enum Network {
@@ -72,13 +66,6 @@ impl Network {
             Network::Simple => "{ Simple = \"Tcp\" }",
         }
     }
-
-    fn external_short(&self) -> &'static str {
-        match self {
-            Network::Grpc => "grpc",
-            Network::Simple => "tcp",
-        }
-    }
 }
 
 pub struct ClientWrapper {
@@ -86,6 +73,7 @@ pub struct ClientWrapper {
     storage: String,
     wallet: String,
     max_pending_messages: usize,
+    #[cfg_attr(not(any(test, feature = "test")), allow(dead_code))]
     network: Network,
     pub tmp_dir: Rc<TempDir>,
 }
@@ -228,149 +216,6 @@ impl ClientWrapper {
         Ok(String::from_utf8(output.stdout)?)
     }
 
-    pub async fn publish_and_create<A: ContractAbi>(
-        &self,
-        contract: PathBuf,
-        service: PathBuf,
-        parameters: &A::Parameters,
-        argument: &A::InitializationArgument,
-        required_application_ids: &[ApplicationId],
-        publisher: impl Into<Option<ChainId>>,
-    ) -> Result<ApplicationId<A>> {
-        let json_parameters = serde_json::to_string(parameters)?;
-        let json_argument = serde_json::to_string(argument)?;
-        let mut command = self.run().await?;
-        command
-            .arg("publish-and-create")
-            .args([contract, service])
-            .args(publisher.into().iter().map(ChainId::to_string))
-            .args(["--json-parameters", &json_parameters])
-            .args(["--json-argument", &json_argument]);
-        if !required_application_ids.is_empty() {
-            command.arg("--required-application-ids");
-            command.args(
-                required_application_ids
-                    .iter()
-                    .map(ApplicationId::to_string),
-            );
-        }
-        let stdout = Self::run_command(&mut command).await?;
-        Ok(stdout.trim().parse::<ApplicationId>()?.with_abi())
-    }
-
-    pub async fn publish_bytecode(
-        &self,
-        contract: PathBuf,
-        service: PathBuf,
-        publisher: impl Into<Option<ChainId>>,
-    ) -> Result<BytecodeId> {
-        let stdout = Self::run_command(
-            self.run()
-                .await?
-                .arg("publish-bytecode")
-                .args([contract, service])
-                .args(publisher.into().iter().map(ChainId::to_string)),
-        )
-        .await?;
-        Ok(stdout.trim().parse()?)
-    }
-
-    pub async fn create_application<A: ContractAbi>(
-        &self,
-        bytecode_id: &BytecodeId,
-        argument: &A::InitializationArgument,
-        creator: impl Into<Option<ChainId>>,
-    ) -> Result<ApplicationId<A>> {
-        let json_argument = serde_json::to_string(argument)?;
-        let stdout = Self::run_command(
-            self.run()
-                .await?
-                .arg("create-application")
-                .arg(bytecode_id.to_string())
-                .args(["--json-argument", &json_argument])
-                .args(creator.into().iter().map(ChainId::to_string)),
-        )
-        .await?;
-        Ok(stdout.trim().parse::<ApplicationId>()?.with_abi())
-    }
-
-    pub async fn run_node_service(&self, port: impl Into<Option<u16>>) -> Result<NodeService> {
-        let port = port.into().unwrap_or(8080);
-        let mut command = self.run().await?;
-        command.arg("service");
-        if let Ok(var) = env::var(CLIENT_SERVICE_ENV) {
-            command.args(var.split_whitespace());
-        }
-        let child = command
-            .args(["--port".to_string(), port.to_string()])
-            .spawn()?;
-        let client = reqwest::Client::new();
-        for i in 0..10 {
-            tokio::time::sleep(Duration::from_secs(i)).await;
-            let request = client
-                .get(format!("http://localhost:{}/", port))
-                .send()
-                .await;
-            if request.is_ok() {
-                info!("Node service has started");
-                return Ok(NodeService { port, child });
-            } else {
-                warn!("Waiting for node service to start");
-            }
-        }
-        panic!("Failed to start node service");
-    }
-
-    pub async fn query_validators(&self, chain_id: Option<ChainId>) -> Result<()> {
-        let mut command = self.run().await?;
-        command.arg("query-validators");
-        if let Some(chain_id) = chain_id {
-            command.arg(&chain_id.to_string());
-        }
-        Self::run_command(&mut command).await?;
-        Ok(())
-    }
-
-    pub async fn query_balance(&self, chain_id: ChainId) -> Result<String> {
-        let stdout = Self::run_command(
-            self.run()
-                .await?
-                .arg("query-balance")
-                .arg(&chain_id.to_string()),
-        )
-        .await?;
-        let amount = stdout.trim().to_string();
-        Ok(amount)
-    }
-
-    pub async fn transfer(&self, amount: &str, from: ChainId, to: ChainId) -> Result<()> {
-        Self::run_command(
-            self.run()
-                .await?
-                .arg("transfer")
-                .arg(amount)
-                .args(["--from", &from.to_string()])
-                .args(["--to", &to.to_string()]),
-        )
-        .await?;
-        Ok(())
-    }
-
-    #[cfg(benchmark)]
-    async fn benchmark(&self, max_in_flight: usize) {
-        assert!(self
-            .run()
-            .await
-            .arg("benchmark")
-            .args(["--max-in-flight", &max_in_flight.to_string()])
-            .spawn()
-            .unwrap()
-            .wait()
-            .await
-            .unwrap()
-            .success());
-    }
-
     pub async fn open_chain(
         &self,
         from: ChainId,
@@ -452,31 +297,6 @@ impl ClientWrapper {
         self.get_wallet().get(chain).is_some()
     }
 
-    pub async fn set_validator(&self, name: &str, port: usize, votes: usize) -> Result<()> {
-        let address = format!("{}:127.0.0.1:{}", self.network.external_short(), port);
-        Self::run_command(
-            self.run()
-                .await?
-                .arg("set-validator")
-                .args(["--name", name])
-                .args(["--address", &address])
-                .args(["--votes", &votes.to_string()]),
-        )
-        .await?;
-        Ok(())
-    }
-
-    pub async fn remove_validator(&self, name: &str) -> Result<()> {
-        Self::run_command(
-            self.run()
-                .await?
-                .arg("remove-validator")
-                .args(["--name", name]),
-        )
-        .await?;
-        Ok(())
-    }
-
     pub async fn keygen(&self) -> Result<PublicKey> {
         let stdout = Self::run_command(self.run().await?.arg("keygen")).await?;
         Ok(PublicKey::from_str(stdout.trim())?)
@@ -501,15 +321,19 @@ impl ClientWrapper {
         Ok(chain_id)
     }
 
-    pub async fn synchronize_balance(&self, chain_id: ChainId) -> Result<()> {
-        Self::run_command(
-            self.run()
-                .await?
-                .arg("sync-balance")
-                .arg(&chain_id.to_string()),
-        )
-        .await?;
-        Ok(())
+    #[cfg(benchmark)]
+    async fn benchmark(&self, max_in_flight: usize) {
+        assert!(self
+            .run()
+            .await
+            .arg("benchmark")
+            .args(["--max-in-flight", &max_in_flight.to_string()])
+            .spawn()
+            .unwrap()
+            .wait()
+            .await
+            .unwrap()
+            .success());
     }
 }
 
@@ -588,26 +412,6 @@ impl LocalNetwork {
             set_init: HashSet::new(),
             tmp_dir: Rc::new(tempdir()?),
         })
-    }
-
-    #[cfg(any(test, feature = "test"))]
-    pub fn new_for_testing(database: Database, network: Network) -> Result<Self> {
-        let seed = 37;
-        let table_name = get_table_name();
-        let num_validators = 4;
-        let num_shards = match database {
-            Database::RocksDb => 1,
-            Database::DynamoDb => 4,
-            Database::ScyllaDb => 4,
-        };
-        Self::new(
-            database,
-            network,
-            Some(seed),
-            table_name,
-            num_validators,
-            num_shards,
-        )
     }
 
     pub fn make_client(&mut self, network: Network) -> ClientWrapper {
@@ -915,224 +719,5 @@ impl LocalNetwork {
         let service = release_dir.join(format!("{}_service.wasm", name.replace('-', "_")));
 
         Ok((contract, service))
-    }
-}
-
-pub struct NodeService {
-    port: u16,
-    child: Child,
-}
-
-impl NodeService {
-    pub fn port(&self) -> u16 {
-        self.port
-    }
-
-    pub fn assert_is_running(&mut self) {
-        if let Some(status) = self.child.try_wait().unwrap() {
-            assert!(status.success());
-        }
-    }
-
-    pub async fn process_inbox(&self, chain_id: &ChainId) {
-        let query = format!("mutation {{ processInbox(chainId: \"{chain_id}\") }}");
-        self.query_node(&query).await;
-    }
-
-    pub async fn make_application<A: ContractAbi>(
-        &self,
-        chain_id: &ChainId,
-        application_id: &ApplicationId<A>,
-    ) -> ApplicationWrapper<A> {
-        let application_id = application_id.forget_abi().to_string();
-        let n_try = 30;
-        for i in 0..n_try {
-            tokio::time::sleep(Duration::from_secs(i)).await;
-            let values = self.try_get_applications_uri(chain_id).await;
-            if let Some(link) = values.get(&application_id) {
-                return ApplicationWrapper::from(link.to_string());
-            }
-            warn!("Waiting for application {application_id:?} to be visible on chain {chain_id:?}");
-        }
-        panic!("Could not find application URI: {application_id} after {n_try} tries");
-    }
-
-    pub async fn try_get_applications_uri(&self, chain_id: &ChainId) -> HashMap<String, String> {
-        let query = format!("query {{ applications(chainId: \"{chain_id}\") {{ id link }}}}");
-        let data = self.query_node(&query).await;
-        data["applications"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|a| {
-                let id = a["id"].as_str().unwrap().to_string();
-                let link = a["link"].as_str().unwrap().to_string();
-                (id, link)
-            })
-            .collect()
-    }
-
-    pub async fn publish_bytecode(
-        &self,
-        chain_id: &ChainId,
-        contract: PathBuf,
-        service: PathBuf,
-    ) -> BytecodeId {
-        let contract_code = Bytecode::load_from_file(&contract).await.unwrap();
-        let service_code = Bytecode::load_from_file(&service).await.unwrap();
-        let query = format!(
-            "mutation {{ publishBytecode(chainId: {}, contract: {}, service: {}) }}",
-            chain_id.to_value(),
-            contract_code.to_value(),
-            service_code.to_value(),
-        );
-        let data = self.query_node(&query).await;
-        let bytecode_str = data["publishBytecode"].as_str().unwrap();
-        bytecode_str.parse().unwrap()
-    }
-
-    pub async fn query_node(&self, query: &str) -> Value {
-        let n_try = 30;
-        for i in 0..n_try {
-            tokio::time::sleep(Duration::from_secs(i)).await;
-            let url = format!("http://localhost:{}/", self.port);
-            let client = reqwest::Client::new();
-            let response = client
-                .post(url)
-                .json(&json!({ "query": query }))
-                .send()
-                .await
-                .unwrap();
-            if !response.status().is_success() {
-                panic!(
-                    "Query \"{}\" failed: {}",
-                    query.get(..200).unwrap_or(query),
-                    response.text().await.unwrap()
-                );
-            }
-            let value: Value = response.json().await.unwrap();
-            if let Some(errors) = value.get("errors") {
-                warn!(
-                    "Query \"{}\" failed: {}",
-                    query.get(..200).unwrap_or(query),
-                    errors
-                );
-            } else {
-                return value["data"].clone();
-            }
-        }
-        panic!(
-            "Query \"{}\" failed after {} retries.",
-            query.get(..200).unwrap_or(query),
-            n_try
-        );
-    }
-
-    pub async fn create_application<A: ContractAbi>(
-        &self,
-        chain_id: &ChainId,
-        bytecode_id: &BytecodeId,
-        parameters: &A::Parameters,
-        argument: &A::InitializationArgument,
-        required_application_ids: &[ApplicationId],
-    ) -> ApplicationId<A> {
-        let json_required_applications_ids = required_application_ids
-            .iter()
-            .map(ApplicationId::to_string)
-            .collect::<Vec<_>>()
-            .to_value();
-        // Convert to `serde_json::Value` then `async_graphql::Value` via the trait `InputType`.
-        let new_parameters = serde_json::to_value(parameters).unwrap().to_value();
-        let new_argument = serde_json::to_value(argument).unwrap().to_value();
-        let query = format!(
-            "mutation {{ createApplication(\
-                 chainId: \"{chain_id}\",
-                 bytecodeId: \"{bytecode_id}\", \
-                 parameters: {new_parameters}, \
-                 initializationArgument: {new_argument}, \
-                 requiredApplicationIds: {json_required_applications_ids}) \
-             }}"
-        );
-        let data = self.query_node(&query).await;
-        let app_id_str = data["createApplication"].as_str().unwrap().trim();
-        app_id_str.parse::<ApplicationId>().unwrap().with_abi()
-    }
-
-    pub async fn request_application<A: ContractAbi>(
-        &self,
-        chain_id: &ChainId,
-        application_id: &ApplicationId<A>,
-    ) -> String {
-        let application_id = application_id.forget_abi();
-        let query = format!(
-            "mutation {{ requestApplication(\
-                 chainId: \"{chain_id}\", \
-                 applicationId: \"{application_id}\") \
-             }}"
-        );
-        let data = self.query_node(&query).await;
-        serde_json::from_value(data["requestApplication"].clone()).unwrap()
-    }
-}
-
-pub struct ApplicationWrapper<A> {
-    uri: String,
-    _phantom: PhantomData<A>,
-}
-
-impl<A> ApplicationWrapper<A> {
-    pub async fn raw_query(&self, query: impl AsRef<str>) -> Value {
-        let query = query.as_ref();
-        let client = reqwest::Client::new();
-        let response = client
-            .post(&self.uri)
-            .json(&json!({ "query": query }))
-            .send()
-            .await
-            .unwrap();
-        if !response.status().is_success() {
-            panic!(
-                "Query \"{}\" failed: {}",
-                query.get(..200).unwrap_or(query),
-                response.text().await.unwrap()
-            );
-        }
-        let value: Value = response.json().await.unwrap();
-        if let Some(errors) = value.get("errors") {
-            panic!(
-                "Query \"{}\" failed: {}",
-                query.get(..200).unwrap_or(query),
-                errors
-            );
-        }
-        value["data"].clone()
-    }
-
-    pub async fn query(&self, query: impl AsRef<str>) -> Value {
-        let query = query.as_ref();
-        self.raw_query(&format!("query {{ {query} }}")).await
-    }
-
-    pub async fn query_json<T: DeserializeOwned>(&self, query: impl AsRef<str>) -> T {
-        let query = query.as_ref().trim();
-        let name = query
-            .split_once(|ch: char| !ch.is_alphanumeric())
-            .map_or(query, |(name, _)| name);
-        let data = self.query(query).await;
-        serde_json::from_value(data[name].clone()).unwrap()
-    }
-
-    pub async fn mutate(&self, mutation: impl AsRef<str>) -> Value {
-        let mutation = mutation.as_ref();
-        self.raw_query(&format!("mutation {{ {mutation} }}")).await
-    }
-}
-
-impl<A> From<String> for ApplicationWrapper<A> {
-    fn from(uri: String) -> ApplicationWrapper<A> {
-        ApplicationWrapper {
-            uri,
-            _phantom: PhantomData,
-        }
     }
 }

--- a/linera-service/src/cli_wrappers/test_utils.rs
+++ b/linera-service/src/cli_wrappers/test_utils.rs
@@ -1,0 +1,435 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{ClientWrapper, Database, LocalNetwork, Network};
+use anyhow::Result;
+use async_graphql::InputType;
+use linera_base::{
+    abi::ContractAbi,
+    identifiers::{ApplicationId, BytecodeId, ChainId},
+};
+use linera_execution::Bytecode;
+use linera_views::test_utils::get_table_name;
+use serde::de::DeserializeOwned;
+use serde_json::{json, value::Value};
+use std::{collections::HashMap, env, marker::PhantomData, path::PathBuf, time::Duration};
+use tokio::process::Child;
+use tracing::{info, warn};
+
+/// The name of the environment variable that allows specifying additional arguments to be passed
+/// to the node-service command of the client.
+const CLIENT_SERVICE_ENV: &str = "LINERA_CLIENT_SERVICE_PARAMS";
+
+impl Network {
+    fn external_short(&self) -> &'static str {
+        match self {
+            Network::Grpc => "grpc",
+            Network::Simple => "tcp",
+        }
+    }
+}
+
+impl LocalNetwork {
+    pub fn new_for_testing(database: Database, network: Network) -> Result<Self> {
+        let seed = 37;
+        let table_name = get_table_name();
+        let num_validators = 4;
+        let num_shards = match database {
+            Database::RocksDb => 1,
+            Database::DynamoDb => 4,
+            Database::ScyllaDb => 4,
+        };
+        Self::new(
+            database,
+            network,
+            Some(seed),
+            table_name,
+            num_validators,
+            num_shards,
+        )
+    }
+}
+
+impl ClientWrapper {
+    pub async fn publish_and_create<A: ContractAbi>(
+        &self,
+        contract: PathBuf,
+        service: PathBuf,
+        parameters: &A::Parameters,
+        argument: &A::InitializationArgument,
+        required_application_ids: &[ApplicationId],
+        publisher: impl Into<Option<ChainId>>,
+    ) -> Result<ApplicationId<A>> {
+        let json_parameters = serde_json::to_string(parameters)?;
+        let json_argument = serde_json::to_string(argument)?;
+        let mut command = self.run().await?;
+        command
+            .arg("publish-and-create")
+            .args([contract, service])
+            .args(publisher.into().iter().map(ChainId::to_string))
+            .args(["--json-parameters", &json_parameters])
+            .args(["--json-argument", &json_argument]);
+        if !required_application_ids.is_empty() {
+            command.arg("--required-application-ids");
+            command.args(
+                required_application_ids
+                    .iter()
+                    .map(ApplicationId::to_string),
+            );
+        }
+        let stdout = Self::run_command(&mut command).await?;
+        Ok(stdout.trim().parse::<ApplicationId>()?.with_abi())
+    }
+
+    pub async fn publish_bytecode(
+        &self,
+        contract: PathBuf,
+        service: PathBuf,
+        publisher: impl Into<Option<ChainId>>,
+    ) -> Result<BytecodeId> {
+        let stdout = Self::run_command(
+            self.run()
+                .await?
+                .arg("publish-bytecode")
+                .args([contract, service])
+                .args(publisher.into().iter().map(ChainId::to_string)),
+        )
+        .await?;
+        Ok(stdout.trim().parse()?)
+    }
+
+    pub async fn create_application<A: ContractAbi>(
+        &self,
+        bytecode_id: &BytecodeId,
+        argument: &A::InitializationArgument,
+        creator: impl Into<Option<ChainId>>,
+    ) -> Result<ApplicationId<A>> {
+        let json_argument = serde_json::to_string(argument)?;
+        let stdout = Self::run_command(
+            self.run()
+                .await?
+                .arg("create-application")
+                .arg(bytecode_id.to_string())
+                .args(["--json-argument", &json_argument])
+                .args(creator.into().iter().map(ChainId::to_string)),
+        )
+        .await?;
+        Ok(stdout.trim().parse::<ApplicationId>()?.with_abi())
+    }
+
+    pub async fn run_node_service(&self, port: impl Into<Option<u16>>) -> Result<NodeService> {
+        let port = port.into().unwrap_or(8080);
+        let mut command = self.run().await?;
+        command.arg("service");
+        if let Ok(var) = env::var(CLIENT_SERVICE_ENV) {
+            command.args(var.split_whitespace());
+        }
+        let child = command
+            .args(["--port".to_string(), port.to_string()])
+            .spawn()?;
+        let client = reqwest::Client::new();
+        for i in 0..10 {
+            tokio::time::sleep(Duration::from_secs(i)).await;
+            let request = client
+                .get(format!("http://localhost:{}/", port))
+                .send()
+                .await;
+            if request.is_ok() {
+                info!("Node service has started");
+                return Ok(NodeService { port, child });
+            } else {
+                warn!("Waiting for node service to start");
+            }
+        }
+        panic!("Failed to start node service");
+    }
+
+    pub async fn query_validators(&self, chain_id: Option<ChainId>) -> Result<()> {
+        let mut command = self.run().await?;
+        command.arg("query-validators");
+        if let Some(chain_id) = chain_id {
+            command.arg(&chain_id.to_string());
+        }
+        Self::run_command(&mut command).await?;
+        Ok(())
+    }
+
+    pub async fn query_balance(&self, chain_id: ChainId) -> Result<String> {
+        let stdout = Self::run_command(
+            self.run()
+                .await?
+                .arg("query-balance")
+                .arg(&chain_id.to_string()),
+        )
+        .await?;
+        let amount = stdout.trim().to_string();
+        Ok(amount)
+    }
+
+    pub async fn transfer(&self, amount: &str, from: ChainId, to: ChainId) -> Result<()> {
+        Self::run_command(
+            self.run()
+                .await?
+                .arg("transfer")
+                .arg(amount)
+                .args(["--from", &from.to_string()])
+                .args(["--to", &to.to_string()]),
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn set_validator(&self, name: &str, port: usize, votes: usize) -> Result<()> {
+        let address = format!("{}:127.0.0.1:{}", self.network.external_short(), port);
+        Self::run_command(
+            self.run()
+                .await?
+                .arg("set-validator")
+                .args(["--name", name])
+                .args(["--address", &address])
+                .args(["--votes", &votes.to_string()]),
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn remove_validator(&self, name: &str) -> Result<()> {
+        Self::run_command(
+            self.run()
+                .await?
+                .arg("remove-validator")
+                .args(["--name", name]),
+        )
+        .await?;
+        Ok(())
+    }
+
+    pub async fn synchronize_balance(&self, chain_id: ChainId) -> Result<()> {
+        Self::run_command(
+            self.run()
+                .await?
+                .arg("sync-balance")
+                .arg(&chain_id.to_string()),
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+pub struct NodeService {
+    pub(crate) port: u16,
+    pub(crate) child: Child,
+}
+
+impl NodeService {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn assert_is_running(&mut self) {
+        if let Some(status) = self.child.try_wait().unwrap() {
+            assert!(status.success());
+        }
+    }
+
+    pub async fn process_inbox(&self, chain_id: &ChainId) {
+        let query = format!("mutation {{ processInbox(chainId: \"{chain_id}\") }}");
+        self.query_node(&query).await;
+    }
+
+    pub async fn make_application<A: ContractAbi>(
+        &self,
+        chain_id: &ChainId,
+        application_id: &ApplicationId<A>,
+    ) -> ApplicationWrapper<A> {
+        let application_id = application_id.forget_abi().to_string();
+        let n_try = 30;
+        for i in 0..n_try {
+            tokio::time::sleep(Duration::from_secs(i)).await;
+            let values = self.try_get_applications_uri(chain_id).await;
+            if let Some(link) = values.get(&application_id) {
+                return ApplicationWrapper::from(link.to_string());
+            }
+            warn!("Waiting for application {application_id:?} to be visible on chain {chain_id:?}");
+        }
+        panic!("Could not find application URI: {application_id} after {n_try} tries");
+    }
+
+    pub async fn try_get_applications_uri(&self, chain_id: &ChainId) -> HashMap<String, String> {
+        let query = format!("query {{ applications(chainId: \"{chain_id}\") {{ id link }}}}");
+        let data = self.query_node(&query).await;
+        data["applications"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|a| {
+                let id = a["id"].as_str().unwrap().to_string();
+                let link = a["link"].as_str().unwrap().to_string();
+                (id, link)
+            })
+            .collect()
+    }
+
+    pub async fn publish_bytecode(
+        &self,
+        chain_id: &ChainId,
+        contract: PathBuf,
+        service: PathBuf,
+    ) -> BytecodeId {
+        let contract_code = Bytecode::load_from_file(&contract).await.unwrap();
+        let service_code = Bytecode::load_from_file(&service).await.unwrap();
+        let query = format!(
+            "mutation {{ publishBytecode(chainId: {}, contract: {}, service: {}) }}",
+            chain_id.to_value(),
+            contract_code.to_value(),
+            service_code.to_value(),
+        );
+        let data = self.query_node(&query).await;
+        let bytecode_str = data["publishBytecode"].as_str().unwrap();
+        bytecode_str.parse().unwrap()
+    }
+
+    pub async fn query_node(&self, query: &str) -> Value {
+        let n_try = 30;
+        for i in 0..n_try {
+            tokio::time::sleep(Duration::from_secs(i)).await;
+            let url = format!("http://localhost:{}/", self.port);
+            let client = reqwest::Client::new();
+            let response = client
+                .post(url)
+                .json(&json!({ "query": query }))
+                .send()
+                .await
+                .unwrap();
+            if !response.status().is_success() {
+                panic!(
+                    "Query \"{}\" failed: {}",
+                    query.get(..200).unwrap_or(query),
+                    response.text().await.unwrap()
+                );
+            }
+            let value: Value = response.json().await.unwrap();
+            if let Some(errors) = value.get("errors") {
+                warn!(
+                    "Query \"{}\" failed: {}",
+                    query.get(..200).unwrap_or(query),
+                    errors
+                );
+            } else {
+                return value["data"].clone();
+            }
+        }
+        panic!(
+            "Query \"{}\" failed after {} retries.",
+            query.get(..200).unwrap_or(query),
+            n_try
+        );
+    }
+
+    pub async fn create_application<A: ContractAbi>(
+        &self,
+        chain_id: &ChainId,
+        bytecode_id: &BytecodeId,
+        parameters: &A::Parameters,
+        argument: &A::InitializationArgument,
+        required_application_ids: &[ApplicationId],
+    ) -> ApplicationId<A> {
+        let json_required_applications_ids = required_application_ids
+            .iter()
+            .map(ApplicationId::to_string)
+            .collect::<Vec<_>>()
+            .to_value();
+        // Convert to `serde_json::Value` then `async_graphql::Value` via the trait `InputType`.
+        let new_parameters = serde_json::to_value(parameters).unwrap().to_value();
+        let new_argument = serde_json::to_value(argument).unwrap().to_value();
+        let query = format!(
+            "mutation {{ createApplication(\
+                     chainId: \"{chain_id}\",
+                     bytecodeId: \"{bytecode_id}\", \
+                     parameters: {new_parameters}, \
+                     initializationArgument: {new_argument}, \
+                     requiredApplicationIds: {json_required_applications_ids}) \
+                 }}"
+        );
+        let data = self.query_node(&query).await;
+        let app_id_str = data["createApplication"].as_str().unwrap().trim();
+        app_id_str.parse::<ApplicationId>().unwrap().with_abi()
+    }
+
+    pub async fn request_application<A: ContractAbi>(
+        &self,
+        chain_id: &ChainId,
+        application_id: &ApplicationId<A>,
+    ) -> String {
+        let application_id = application_id.forget_abi();
+        let query = format!(
+            "mutation {{ requestApplication(\
+                     chainId: \"{chain_id}\", \
+                     applicationId: \"{application_id}\") \
+                 }}"
+        );
+        let data = self.query_node(&query).await;
+        serde_json::from_value(data["requestApplication"].clone()).unwrap()
+    }
+}
+pub struct ApplicationWrapper<A> {
+    uri: String,
+    _phantom: PhantomData<A>,
+}
+
+impl<A> ApplicationWrapper<A> {
+    pub async fn raw_query(&self, query: impl AsRef<str>) -> Value {
+        let query = query.as_ref();
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&self.uri)
+            .json(&json!({ "query": query }))
+            .send()
+            .await
+            .unwrap();
+        if !response.status().is_success() {
+            panic!(
+                "Query \"{}\" failed: {}",
+                query.get(..200).unwrap_or(query),
+                response.text().await.unwrap()
+            );
+        }
+        let value: Value = response.json().await.unwrap();
+        if let Some(errors) = value.get("errors") {
+            panic!(
+                "Query \"{}\" failed: {}",
+                query.get(..200).unwrap_or(query),
+                errors
+            );
+        }
+        value["data"].clone()
+    }
+
+    pub async fn query(&self, query: impl AsRef<str>) -> Value {
+        let query = query.as_ref();
+        self.raw_query(&format!("query {{ {query} }}")).await
+    }
+
+    pub async fn query_json<T: DeserializeOwned>(&self, query: impl AsRef<str>) -> T {
+        let query = query.as_ref().trim();
+        let name = query
+            .split_once(|ch: char| !ch.is_alphanumeric())
+            .map_or(query, |(name, _)| name);
+        let data = self.query(query).await;
+        serde_json::from_value(data[name].clone()).unwrap()
+    }
+
+    pub async fn mutate(&self, mutation: impl AsRef<str>) -> Value {
+        let mutation = mutation.as_ref();
+        self.raw_query(&format!("mutation {{ {mutation} }}")).await
+    }
+}
+
+impl<A> From<String> for ApplicationWrapper<A> {
+    fn from(uri: String) -> ApplicationWrapper<A> {
+        ApplicationWrapper {
+            uri,
+            _phantom: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Half the code in the `cli_wrappers` module is only used in tests, and was also written with tests in mind, e.g. with lots of `unwrap`s.

## Proposal

Feature-gate the test-only code; move it to a `test_utils` submodule that is only compiled for tests.

## Test Plan

No logic was changed. Everything still builds, both with and without the `test` feature.


## Links

- The idea came up in this discussion: https://github.com/linera-io/linera-protocol/pull/1121#discussion_r1356926389
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
