### PR TITLE
Scylla db in validator

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,10 +49,17 @@ RUN apt-get update && apt-get install -y \
 COPY --from=cacher /opt/linera/build/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 
-RUN cargo build --release --target x86_64-unknown-linux-gnu --bin linera --bin linera-proxy --bin linera-server \
+RUN cargo build --release \
+    --target x86_64-unknown-linux-gnu \
+    --bin linera \
+    --bin linera-proxy \
+    --bin linera-server \
+    --bin linera-db \
+    --features scylladb \
     && strip target/x86_64-unknown-linux-gnu/release/linera \
     && strip target/x86_64-unknown-linux-gnu/release/linera-proxy \
-    && strip target/x86_64-unknown-linux-gnu/release/linera-server
+    && strip target/x86_64-unknown-linux-gnu/release/linera-server \
+    && strip target/x86_64-unknown-linux-gnu/release/linera-db
 
 # Stage 4 - Setup running environment for container
 FROM debian:latest
@@ -67,6 +74,7 @@ ENV BUILD_PATH=/opt/linera/build
 COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera ./
 COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera-server ./
 COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera-proxy ./
+COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera-db ./
 
 # Copying configuration files
 COPY --from=builder $BUILD_PATH/configuration/prod/validator_1.toml ./
@@ -74,6 +82,10 @@ COPY --from=builder $BUILD_PATH/configuration/prod/validator_1.toml ./
 # Copy entrypoint
 COPY docker/server-entrypoint.sh .
 RUN chmod +x server-entrypoint.sh
+
+# Copy init
+COPY docker/server-init.sh .
+RUN chmod +x server-init.sh
 
 # Create configuration files for the validator according to the validator's config file.
 # * Private server states are stored in `server*.json`.

--- a/docker/Dockerfile.aarch64
+++ b/docker/Dockerfile.aarch64
@@ -49,10 +49,17 @@ RUN apt-get update && apt-get install -y \
 COPY --from=cacher /opt/linera/build/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 
-RUN cargo build --release --target aarch64-unknown-linux-gnu --bin linera --bin linera-proxy --bin linera-server \
+RUN cargo build --release \
+    --target aarch64-unknown-linux-gnu \
+    --bin linera \
+    --bin linera-proxy \
+    --bin linera-server \
+    --bin linera-db \
+    --features scylladb \
     && strip target/aarch64-unknown-linux-gnu/release/linera \
     && strip target/aarch64-unknown-linux-gnu/release/linera-proxy \
     && strip target/aarch64-unknown-linux-gnu/release/linera-server
+    && strip target/aarch64-unknown-linux-gnu/release/linera-db
 
 # Stage 4 - Setup running environment for container
 FROM debian:latest
@@ -67,6 +74,7 @@ ENV BUILD_PATH=/opt/linera/build
 COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera ./
 COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-server ./
 COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-proxy ./
+COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-db ./
 
 # Copying configuration files
 COPY --from=builder $BUILD_PATH/configuration/prod/validator_1.toml ./
@@ -74,6 +82,10 @@ COPY --from=builder $BUILD_PATH/configuration/prod/validator_1.toml ./
 # Copy entrypoint
 COPY docker/server-entrypoint.sh .
 RUN chmod +x server-entrypoint.sh
+
+# Copy init
+COPY docker/server-init.sh .
+RUN chmod +x server-init.sh
 
 # Create configuration files for the validator according to the validator's config file.
 # * Private server states are stored in `server*.json`.

--- a/docker/Dockerfile.local
+++ b/docker/Dockerfile.local
@@ -49,10 +49,17 @@ RUN apt-get update && apt-get install -y \
 COPY --from=cacher /opt/linera/build/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 
-RUN cargo build --release --target x86_64-unknown-linux-gnu --bin linera --bin linera-proxy --bin linera-server \
+RUN cargo build --release \
+    --target x86_64-unknown-linux-gnu \
+    --bin linera \
+    --bin linera-proxy \
+    --bin linera-server \
+    --bin linera-db \
+    --features scylladb \
     && strip target/x86_64-unknown-linux-gnu/release/linera \
     && strip target/x86_64-unknown-linux-gnu/release/linera-proxy \
-    && strip target/x86_64-unknown-linux-gnu/release/linera-server
+    && strip target/x86_64-unknown-linux-gnu/release/linera-server \
+    && strip target/x86_64-unknown-linux-gnu/release/linera-db
 
 # Stage 4 - Setup running environment for container
 FROM debian:latest
@@ -67,6 +74,7 @@ ENV BUILD_PATH=/opt/linera/build
 COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera ./
 COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera-server ./
 COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera-proxy ./
+COPY --from=builder $BUILD_PATH/target/x86_64-unknown-linux-gnu/release/linera-db ./
 
 # Copying configuration files
 COPY --from=builder $BUILD_PATH/configuration/k8s-local/validator_1.toml ./
@@ -74,6 +82,10 @@ COPY --from=builder $BUILD_PATH/configuration/k8s-local/validator_1.toml ./
 # Copy entrypoint
 COPY docker/server-entrypoint.sh .
 RUN chmod +x server-entrypoint.sh
+
+# Copy init
+COPY docker/server-init.sh .
+RUN chmod +x server-init.sh
 
 # Create configuration files for the validator according to the validator's config file.
 # * Private server states are stored in `server*.json`.

--- a/docker/Dockerfile.local-aarch64
+++ b/docker/Dockerfile.local-aarch64
@@ -49,10 +49,17 @@ RUN apt-get update && apt-get install -y \
 COPY --from=cacher /opt/linera/build/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo
 
-RUN cargo build --release --target aarch64-unknown-linux-gnu --bin linera --bin linera-proxy --bin linera-server \
+RUN cargo build --release \
+    --target aarch64-unknown-linux-gnu \
+    --bin linera \
+    --bin linera-proxy \
+    --bin linera-server \
+    --bin linera-db \
+    --features scylladb \
     && strip target/aarch64-unknown-linux-gnu/release/linera \
     && strip target/aarch64-unknown-linux-gnu/release/linera-proxy \
     && strip target/aarch64-unknown-linux-gnu/release/linera-server
+    && strip target/aarch64-unknown-linux-gnu/release/linera-db
 
 # Stage 4 - Setup running environment for container
 FROM debian:latest
@@ -67,6 +74,7 @@ ENV BUILD_PATH=/opt/linera/build
 COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera ./
 COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-server ./
 COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-proxy ./
+COPY --from=builder $BUILD_PATH/target/aarch64-unknown-linux-gnu/release/linera-db ./
 
 # Copying configuration files
 COPY --from=builder $BUILD_PATH/configuration/k8s-local/validator_1.toml ./
@@ -74,6 +82,10 @@ COPY --from=builder $BUILD_PATH/configuration/k8s-local/validator_1.toml ./
 # Copy entrypoint
 COPY docker/server-entrypoint.sh .
 RUN chmod +x server-entrypoint.sh
+
+# Copy init
+COPY docker/server-init.sh .
+RUN chmod +x server-init.sh
 
 # Create configuration files for the validator according to the validator's config file.
 # * Private server states are stored in `server*.json`.

--- a/docker/server-entrypoint.sh
+++ b/docker/server-entrypoint.sh
@@ -4,7 +4,7 @@
 ORDINAL="${HOSTNAME##*-}"
 
 exec ./linera-server run \
-  --storage rocksdb:/usr/share/rocksdb/shard_data.db \
+  --storage scylladb:tcp:scylladb.default.svc.cluster.local:9042 \
   --server server_1.json \
   --shard $ORDINAL \
   --genesis genesis.json

--- a/docker/server-init.sh
+++ b/docker/server-init.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+./linera-db check_existence --storage "scylladb:tcp:scylladb.default.svc.cluster.local:9042"
+status=$?
+
+if [ $status -eq 0 ]; then
+  exit 0
+elif [ $status -eq 1 ]; then
+  ./linera-server initialize \
+    --storage scylladb:tcp:scylladb.default.svc.cluster.local:9042 \
+    --genesis genesis.json || exit 1;
+else
+  exit $status
+fi

--- a/kubernetes/linera-validator/Chart.lock
+++ b/kubernetes/linera-validator/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   version: 51.0.3
 digest: sha256:09cdfe713d61b9671bb887d3ea87b8cf81944f5c71651b50962c08076f065655
-generated: "2023-09-15T18:27:11.747913606+01:00"
+generated: "2023-10-13T14:37:09.36563529+01:00"

--- a/kubernetes/linera-validator/build_and_redeploy.sh
+++ b/kubernetes/linera-validator/build_and_redeploy.sh
@@ -103,9 +103,9 @@ fi
 helm uninstall linera-core --wait;
 
 if [ "$cloud_mode" = true ]; then
-    helm install linera-core . --values values-local-with-cloud-build.yaml --wait || exit 1;
+    helm install linera-core . --values values-local-with-cloud-build.yaml --wait --set installCRDs=true || exit 1;
 else
-    helm install linera-core . --values values-local.yaml --wait || exit 1;
+    helm install linera-core . --values values-local.yaml --wait --set installCRDs=true || exit 1;
 fi
 
 echo "Pods:";

--- a/kubernetes/linera-validator/templates/scylladb.yaml
+++ b/kubernetes/linera-validator/templates/scylladb.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: scylladb
+  labels:
+    app: scylladb
+spec:
+  ports:
+    - port: 9042
+      name: cql
+  clusterIP: None
+  selector:
+    app: scylladb
+
+---
+
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: scylladb
+spec:
+  serviceName: "scylladb"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scylladb
+  template:
+    metadata:
+      labels:
+        app: scylladb
+    spec:
+      containers:
+        - name: scylladb
+          image: scylladb/scylla:5.2
+          ports:
+            - containerPort: 9042
+              name: cql
+          volumeMounts:
+            - name: scylladb-data
+              mountPath: /var/lib/scylla
+      volumes:
+        - name: scylladb-config
+          emptyDir: {}
+
+  volumeClaimTemplates:
+    - metadata:
+        name: scylladb-data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 10Gi

--- a/kubernetes/linera-validator/templates/server.yaml
+++ b/kubernetes/linera-validator/templates/server.yaml
@@ -24,15 +24,6 @@ spec:
   selector:
     matchLabels:
       app: shards
-  volumeClaimTemplates:
-    - metadata:
-        name: rocksdb
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        storageClassName: "standard"
-        resources:
-          requests:
-            storage: 100Mi
   template:
     metadata:
       labels:
@@ -45,9 +36,6 @@ spec:
           image: {{ .Values.lineraImage }}
           imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
           command: ["./server-entrypoint.sh"]
-          volumeMounts:
-          - name: rocksdb
-            mountPath: /usr/share/rocksdb
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
@@ -67,21 +55,12 @@ spec:
         - name: linera-server-initializer
           image: {{ .Values.lineraImage }}
           imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
-          command: ["./linera-server"]
-          args:
-            [
-              "initialize",
-              "--storage",
-              "rocksdb:/usr/share/rocksdb/shard_data.db",
-              "--genesis",
-              "genesis.json",
-            ]
-          volumeMounts:
-          - name: rocksdb
-            mountPath: /usr/share/rocksdb
+          command: ["./server-init.sh"]
           env:
             - name: RUST_LOG
               value: {{ .Values.logLevel }}
+            - name: RUST_BACKTRACE
+              value: "1"
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -125,7 +125,7 @@ impl FromStr for StorageConfig {
         if let Some(s) = input.strip_prefix(SCYLLA_DB) {
             let mut uri: Option<String> = None;
             let mut table_name: Option<String> = None;
-            let parse_error: &'static str = "Correct format is (https|http)://db_hostname:port.";
+            let parse_error: &'static str = "Correct format is tcp:db_hostname:port.";
             if !s.is_empty() {
                 let mut parts = s.split(':');
                 while let Some(part) = parts.next() {


### PR DESCRIPTION
## Motivation

Linera validators require a horizontally scalable database, in this case ScyllaDB.

## Proposal

Add ScyllaDB as the default database for Kubernetes validators - replacing RocksDB. 

For now this is a single instance (not the horizontally scalable Helm deployment).

## Test Plan

1. `./build_and_redeploy.sh --clean`
2. Copy/Paste the generated wallet exports
3. `linera sync-balance`

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
