### PR TITLE
Make it possible to use `linera net up` in bash scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ source scripts/linera_net_helper.sh
 # Make sure to compile the Linera binaries.
 # cargo build -p linera-service --bins
 
-# Run a local test network with the default parameters and 1 extra user wallet.
+# Run a local test network with the default parameters and 0 extra user wallets.
 spawn_and_set_wallet_env_vars \
-    target/debug/linera net up --extra-wallets 1
+    target/debug/linera net up --extra-wallets 0
 
 # Initial client of the chains created at genesis.
-CLIENT=(target/debug/linera --wallet-id 0)
+CLIENT=(target/debug/linera --with-wallet 0)
 
 # Print the set of validators.
 ${CLIENT[@]} query-validators

--- a/README.md
+++ b/README.md
@@ -36,33 +36,31 @@ The Linera protocol repository is broken down into the following crates and subd
 ## Quickstart with the Linera service CLI
 
 ```bash
+# Make sure to compile the Linera binaries and add them in the $PATH.
+# cargo build -p linera-service --bins
+export PATH="$PWD/target/debug:$PATH"
+
 # Import the optional bash helper function `spawn_and_set_wallet_env_vars`.
 source scripts/linera_net_helper.sh
 
-# Make sure to compile the Linera binaries.
-# cargo build -p linera-service --bins
-
 # Run a local test network with the default parameters and 0 extra user wallets.
 spawn_and_set_wallet_env_vars \
-    target/debug/linera net up --extra-wallets 0
-
-# Initial client of the chains created at genesis.
-CLIENT=(target/debug/linera --with-wallet 0)
+    linera net up --extra-wallets 0
 
 # Print the set of validators.
-${CLIENT[@]} query-validators
+linera -w0 query-validators
 
 # Query some of the chains created at genesis
 CHAIN1="e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
 CHAIN2="256e1dbc00482ddd619c293cc0df94d366afe7980022bb22d99e33036fd465dd"
-${CLIENT[@]} query-balance "$CHAIN1"
-${CLIENT[@]} query-balance "$CHAIN2"
+linera -w0 query-balance "$CHAIN1"
+linera -w0 query-balance "$CHAIN2"
 
 # Transfer 10 units then 5 back
-${CLIENT[@]} transfer 10 --from "$CHAIN1" --to "$CHAIN2"
-${CLIENT[@]} transfer 5 --from "$CHAIN2" --to "$CHAIN1"
+linera -w0 transfer 10 --from "$CHAIN1" --to "$CHAIN2"
+linera -w0 transfer 5 --from "$CHAIN2" --to "$CHAIN1"
 
 # Query balances again
-${CLIENT[@]} query-balance "$CHAIN1"
-${CLIENT[@]} query-balance "$CHAIN2"
+linera -w0 query-balance "$CHAIN1"
+linera -w0 query-balance "$CHAIN2"
 ```

--- a/README.md
+++ b/README.md
@@ -35,108 +35,24 @@ The Linera protocol repository is broken down into the following crates and subd
 
 ## Quickstart with the Linera service CLI
 
-The following script can be run with `cargo test`.
-
 ```bash
-storage="ROCKSDB"
+# Import the optional bash helper function `spawn_and_set_wallet_env_vars`.
+source scripts/linera_net_helper.sh
 
-if [ $# -eq 1 ]
-then
-    if [ "$1" == 'DYNAMODB' ]
-    then
-        storage="DYNAMODB"
-    fi
-    if [ "$1" == 'SCYLLADB' ]
-    then
-        storage="SCYLLADB"
-    fi
-fi
+# Make sure to compile the Linera binaries.
+# cargo build -p linera-service --bins
 
-# For debug builds:
-if [ "$storage" = "ROCKSDB" ]
-then
-    cargo build && cd target/debug
-elif [ "$storage" = "DYNAMODB" ]
-then
-    cargo build --features aws && cd target/debug
-elif [ "$storage" = "SCYLLADB" ]
-then
-    cargo build --features scylladb && cd target/debug
-fi
+# Run a local test network with the default parameters and 1 extra user wallet.
+spawn_and_set_wallet_env_vars \
+    target/debug/linera net up --extra-wallets 1
 
-# For release builds:
-# cargo build --release && cd target/release
+# Initial client of the chains created at genesis.
+CLIENT=(target/debug/linera --wallet-id 0)
 
-# Clean up data files
-rm -rf *.json *.txt *.db
-rm -rf linera.db
-if [ "$storage" = "ROCKSDB" ]
-then
-    rm -rf server_?_?.db
-elif [ "$storage" = "DYNAMODB" ]
-then
-    ./linera-db delete_all --storage dynamodb:table:localstack
-elif [ "$storage" = "SCYLLADB" ]
-then
-    ./linera-db delete_all --storage scylladb:
-fi
-
-
-
-
-# Make sure to clean up child processes on exit.
-trap 'kill $(jobs -p)' EXIT
-
-# Create configuration files for 4 validators with 4 shards each.
-# * Private server states are stored in `server*.json`.
-# * `committee.json` is the public description of the Linera committee.
-./linera-server generate --validators ../../configuration/local/validator_{1,2,3,4}.toml --committee committee.json
-
-# Command line prefix for client calls
-CLIENT=(./linera --storage rocksdb:linera.db --wallet wallet.json --max-pending-messages 10000)
-
-# Create configuration files for 10 user chains.
-# * Private chain states are stored in one local wallet `wallet.json`.
-# * `genesis.json` will contain the initial balances of chains as well as the initial committee.
-${CLIENT[@]} create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json
-
-# Start servers and create initial chains in DB
-for I in 1 2 3 4
-do
-    ./linera-proxy server_"$I".json &
-    if [ "$storage" = "ROCKSDB" ]
-    then
-        for J in $(seq 0 3)
-        do
-            ./linera-server initialize --storage rocksdb:server_"$I"_"$J".db --genesis genesis.json
-        done
-        for J in $(seq 0 3)
-        do
-            ./linera-server run --storage rocksdb:server_"$I"_"$J".db --server server_"$I".json --shard "$J" --genesis genesis.json &
-        done
-    elif [ "$storage" = "DYNAMODB" ]
-    then
-        ./linera-server initialize --storage dynamodb:server-"$I":localstack --genesis genesis.json
-        for J in $(seq 0 3)
-        do
-            ./linera-server run --storage dynamodb:server-"$I":localstack --server server_"$I".json --shard "$J" --genesis genesis.json &
-        done
-    elif [ "$storage" = "SCYLLADB" ]
-    then
-        ./linera-server initialize --storage scylladb:table_server_"$I" --genesis genesis.json
-        for J in $(seq 0 3)
-        do
-            ./linera-server run --storage scylladb:table_server_"$I" --server server_"$I".json --shard "$J" --genesis genesis.json &
-        done
-    fi
-done
-
+# Print the set of validators.
 ${CLIENT[@]} query-validators
 
-# Give some time for server startup
-sleep 5
-
-# Query balance for first and last user chain, root chains 0 and 9
+# Query some of the chains created at genesis
 CHAIN1="e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
 CHAIN2="256e1dbc00482ddd619c293cc0df94d366afe7980022bb22d99e33036fd465dd"
 ${CLIENT[@]} query-balance "$CHAIN1"
@@ -149,6 +65,4 @@ ${CLIENT[@]} transfer 5 --from "$CHAIN2" --to "$CHAIN1"
 # Query balances again
 ${CLIENT[@]} query-balance "$CHAIN1"
 ${CLIENT[@]} query-balance "$CHAIN2"
-
-cd ../..
 ```

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -279,7 +279,7 @@ impl WalletState {
         let file_lock = FileLock::lock(path, block, file).with_context(|| {
             format!(
                 "Error getting write lock to wallet \"{}\". Please make sure the file exists \
-             and that it is not in use by another process already.",
+                 and that it is not in use by another process already.",
                 path.display()
             )
         })?;
@@ -301,7 +301,7 @@ impl WalletState {
         let file_lock = FileLock::lock(path, block, file).with_context(|| {
             format!(
                 "Error getting write lock to wallet \"{}\". Please make sure the file exists \
-             and that it is not in use by another process already.",
+                 and that it is not in use by another process already.",
                 path.display()
             )
         })?;

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -276,10 +276,13 @@ impl WalletState {
     pub fn from_file(path: &Path) -> Result<Self, anyhow::Error> {
         let file = FileOptions::new().read(true).write(true);
         let block = false;
-        let file_lock = FileLock::lock(path, block, file).context(
-            "Error getting write lock to wallet. Please make sure a node service isn't \
-             running locally, only one client can use a wallet at a time.",
-        )?;
+        let file_lock = FileLock::lock(path, block, file).with_context(|| {
+            format!(
+                "Error getting write lock to wallet \"{}\". Please make sure the file exists \
+             and that it is not in use by another process already.",
+                path.display()
+            )
+        })?;
         let inner = serde_json::from_reader(BufReader::new(&file_lock.file))?;
         Ok(Self {
             inner,
@@ -295,10 +298,13 @@ impl WalletState {
     ) -> Result<Self, anyhow::Error> {
         let file = FileOptions::new().create(true).write(true).read(true);
         let block = false;
-        let file_lock = FileLock::lock(path, block, file).context(
-            "Error getting write lock to wallet. Please make sure a node service isn't \
-             running locally, only one client can use a wallet at a time.",
-        )?;
+        let file_lock = FileLock::lock(path, block, file).with_context(|| {
+            format!(
+                "Error getting write lock to wallet \"{}\". Please make sure the file exists \
+             and that it is not in use by another process already.",
+                path.display()
+            )
+        })?;
         let mut reader = BufReader::new(&file_lock.file);
         if reader.fill_buf()?.is_empty() {
             let inner = InnerWallet {

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1022,7 +1022,7 @@ enum NetCommand {
     Up {
         /// The number of extra wallets and user chains to initialise. Default is 0.
         #[structopt(default_value, long)]
-        wallets: usize,
+        extra_wallets: usize,
 
         /// The number of validators in the local test network. Default is 1.
         #[structopt(long, default_value = "1")]
@@ -1820,7 +1820,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
         ClientCommand::Net(net_command) => match net_command {
             NetCommand::Up {
-                wallets,
+                extra_wallets,
                 validators,
                 shards,
                 testing_prng_seed,
@@ -1861,9 +1861,9 @@ async fn main() -> Result<(), anyhow::Error> {
                     "\nA local test network was started using the following temporary directory:\n{}\n",
                     net.net_path().display()
                 );
-                let suffix = if *wallets > 0 {
+                let suffix = if *extra_wallets > 0 {
                     eprintln!("To use the initial wallet and the extra wallets of this test network, you may set \
-                               the environment variables LINERA_WALLET_$N and LINERA_STORAGE_$N (N = 0..{wallets}) as follows (on /dev/stdout), \
+                               the environment variables LINERA_WALLET_$N and LINERA_STORAGE_$N (N = 0..{extra_wallets}) as follows (on /dev/stdout), \
                                then use the option `--wallet-id $N` (or `-w $N` for short) to select a wallet in the linera tool.\n");
                     "_0"
                 } else {
@@ -1889,7 +1889,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 );
 
                 // Create the extra wallets.
-                for wallet in 1..=*wallets {
+                for wallet in 1..=*extra_wallets {
                     let extra_wallet = net.make_client(network);
                     extra_wallet.wallet_init(&[]).await?;
                     let unassigned_key = extra_wallet.keygen().await?;

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1861,9 +1861,13 @@ async fn main() -> Result<(), anyhow::Error> {
                     net.net_path().display()
                 );
                 let suffix = if let Some(extra_wallets) = *extra_wallets {
-                    eprintln!("To use the initial wallet and the extra wallets of this test network, you may set \
-                               the environment variables LINERA_WALLET_$N and LINERA_STORAGE_$N (N = 0..={extra_wallets}) as follows (on /dev/stdout), \
-                               then use the option `--with-wallet $N` (or `-w $N` for short) to select a wallet in the linera tool.\n");
+                    eprintln!(
+                        "To use the initial wallet and the extra wallets of this test \
+                         network, you may set the environment variables LINERA_WALLET_$N \
+                         and LINERA_STORAGE_$N (N = 0..={extra_wallets}) as printed on \
+                         the standard output, then use the option `--with-wallet $N` (or \
+                         `-w $N` for short) to select a wallet in the linera tool.\n"
+                    );
                     "_0"
                 } else {
                     eprintln!("To use the initial wallet of this test network, you may set \

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -2,52 +2,70 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Context as _, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{debug, error};
 
 /// Attempts to resolve the path and test the version of the given binary against our
-/// package version. This is meant for binaries of the Linera repository.
+/// package version.
+///
+/// This is meant for binaries of the Linera repository. We use the current running binary
+/// to locate the parent directory where to look for the given name.
 pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result<PathBuf> {
-    debug!("Resolving binary {name} based on the current binary path.");
-    let mut current_binary_path = PathBuf::from(
-        std::env::args()
-            .next()
-            .expect("args should start with the current binary path"),
-    )
-    .canonicalize()?;
-    current_binary_path.pop();
+    let current_binary = std::env::current_exe()?;
+    resolve_binary_in_same_directory_as(&current_binary, name, package).await
+}
+
+/// Same as [`resolve_binary`] but gives the option to specify a binary path to use as
+/// reference. The path may be relative or absolute but it must point to a valid file on
+/// disk.
+pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
+    current_binary: P,
+    name: &'static str,
+    package: &'static str,
+) -> Result<PathBuf> {
+    let current_binary = current_binary.as_ref();
+    debug!(
+        "Resolving binary {name} based on the current binary path: {}",
+        current_binary.display()
+    );
+    let mut current_binary_parent = current_binary
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize '{}'", current_binary.display()))?;
+    current_binary_parent.pop();
 
     #[cfg(any(test, feature = "test"))]
     // Test binaries are typically in target/debug/deps while crate binaries are in target/debug
     // (same thing for target/release).
-    if current_binary_path.ends_with("target/debug/deps")
-        || current_binary_path.ends_with("target/release/deps")
+    let current_binary_parent = if current_binary_parent.ends_with("target/debug/deps")
+        || current_binary_parent.ends_with("target/release/deps")
     {
-        current_binary_path.pop();
-    }
+        PathBuf::from(current_binary_parent.parent().unwrap())
+    } else {
+        current_binary_parent
+    };
 
-    let path = current_binary_path.join(name);
+    let binary = current_binary_parent.join(name);
     let version = env!("CARGO_PKG_VERSION");
-    if !path.exists() {
+    if !binary.exists() {
         error!(
             "Cannot find a binary {name} in the directory {}. \
              Consider using `cargo install {package}` or `cargo build -p {package}`",
-            current_binary_path.display()
+            current_binary_parent.display()
         );
         bail!("Failed to resolve binary {name}");
     }
 
     // Quick version check.
-    debug!("Checking the version of {}", path.display());
-    let version_message = Command::new(&path)
+    debug!("Checking the version of {}", binary.display());
+    let version_message = Command::new(&binary)
         .arg("--version")
         .output()
         .await
         .with_context(|| {
             format!(
                 "Failed to execute and retrieve version from the binary {name} in directory {}",
-                current_binary_path.display()
+                current_binary_parent.display()
             )
         })?
         .stdout;
@@ -58,18 +76,18 @@ pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result
         .with_context(|| {
             format!(
                 "Passing --version to the binary {name} in directory {} returned an empty result",
-                current_binary_path.display()
+                current_binary_parent.display()
             )
         })?
         .to_string();
     if version != found_version {
         error!("The binary {name} in directory {} should have version {version} (found {found_version}). \
                 Consider using `cargo install {package} --version '{version}'` or `cargo build -p {package}`",
-               current_binary_path.display()
+               current_binary_parent.display()
         );
         bail!("Incorrect version for binary {name}");
     }
-    debug!("{} has version {version}", path.display());
+    debug!("{} has version {version}", binary.display());
 
-    Ok(path)
+    Ok(binary)
 }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -540,7 +540,7 @@ async fn run_project_publish(database: Database) {
 #[test_log::test(tokio::test)]
 async fn test_linera_net_up_simple() {
     use std::{
-        io::Write,
+        io::{BufRead, BufReader},
         process::{Command, Stdio},
     };
 
@@ -548,14 +548,43 @@ async fn test_linera_net_up_simple() {
 
     let mut command = Command::new(env!("CARGO_BIN_EXE_linera"));
     command.args(["net", "up"]);
-    let mut child = command.stdin(Stdio::piped()).spawn().unwrap();
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
 
-    let mut stdin = child.stdin.take().unwrap();
-    std::thread::spawn(move || {
-        stdin.write_all(b"\n").unwrap();
-    });
+    let stdout = BufReader::new(child.stdout.take().unwrap());
+    let stderr = BufReader::new(child.stderr.take().unwrap());
 
-    assert!(child.wait().unwrap().success());
+    for line in stderr.lines() {
+        let line = line.unwrap();
+        if line.starts_with("READY!") {
+            let mut exports = stdout.lines();
+            assert!(exports
+                .next()
+                .unwrap()
+                .unwrap()
+                .starts_with("export LINERA_WALLET="));
+            assert!(exports
+                .next()
+                .unwrap()
+                .unwrap()
+                .starts_with("export LINERA_STORAGE="));
+            assert_eq!(exports.next().unwrap().unwrap(), "");
+
+            // Send SIGINT to the child process.
+            Command::new("kill")
+                .args(["-s", "INT", &child.id().to_string()])
+                .output()
+                .unwrap();
+
+            assert!(exports.next().is_none());
+            assert!(child.wait().unwrap().success());
+            return;
+        }
+    }
+    panic!("Unexpected EOF for stderr");
 }
 
 #[cfg(feature = "rocksdb")]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -546,8 +546,7 @@ async fn test_linera_net_up_simple() {
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
-    // Using a relative path to test the resolution of other binaries in this case.
-    let mut command = Command::new("../target/debug/linera");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_linera"));
     command.args(["net", "up"]);
     let mut child = command.stdin(Stdio::piped()).spawn().unwrap();
 

--- a/linera-service/tests/util_tests.rs
+++ b/linera-service/tests/util_tests.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "rocksdb")]
+
+use linera_service::util;
+use std::path::Path;
+
+#[test_log::test(tokio::test)]
+async fn test_resolve_binary_with_test_default() {
+    util::resolve_binary("linera", "linera-service")
+        .await
+        .unwrap();
+}
+
+#[test_log::test(tokio::test)]
+async fn test_resolve_binary_from_relative_path() {
+    util::resolve_binary_in_same_directory_as(
+        "../target/debug/linera",
+        "linera-proxy",
+        "linera-service",
+    )
+    .await
+    .unwrap();
+}
+
+#[test_log::test(tokio::test)]
+async fn test_resolve_binary_from_absolute_path() {
+    let path = Path::new("../target/debug/linera").canonicalize().unwrap();
+    util::resolve_binary_in_same_directory_as(&path, "linera-proxy", "linera-service")
+        .await
+        .unwrap();
+}

--- a/linera-service/tests/util_tests.rs
+++ b/linera-service/tests/util_tests.rs
@@ -9,26 +9,41 @@ use std::path::Path;
 
 #[test_log::test(tokio::test)]
 async fn test_resolve_binary_with_test_default() {
-    util::resolve_binary("linera", "linera-service")
+    let path = util::resolve_binary("linera", "linera-service")
         .await
         .unwrap();
+    assert!(path.exists());
+    // Since we're in a test, we can use the environment variables `CARGO_BIN_EXE_*`.
+    assert_eq!(path, Path::new(env!("CARGO_BIN_EXE_linera")));
 }
 
 #[test_log::test(tokio::test)]
 async fn test_resolve_binary_from_relative_path() {
-    util::resolve_binary_in_same_directory_as(
-        "../target/debug/linera",
+    let debug_or_release = Path::new(env!("CARGO_BIN_EXE_linera"))
+        .parent()
+        .unwrap()
+        .file_name()
+        .unwrap();
+    let path = util::resolve_binary_in_same_directory_as(
+        Path::new("../target").join(debug_or_release).join("linera"),
         "linera-proxy",
         "linera-service",
     )
     .await
     .unwrap();
+    assert!(path.exists());
+    assert_eq!(path, Path::new(env!("CARGO_BIN_EXE_linera-proxy")));
 }
 
 #[test_log::test(tokio::test)]
 async fn test_resolve_binary_from_absolute_path() {
-    let path = Path::new("../target/debug/linera").canonicalize().unwrap();
-    util::resolve_binary_in_same_directory_as(&path, "linera-proxy", "linera-service")
-        .await
-        .unwrap();
+    let path = util::resolve_binary_in_same_directory_as(
+        env!("CARGO_BIN_EXE_linera"),
+        "linera-proxy",
+        "linera-service",
+    )
+    .await
+    .unwrap();
+    assert!(path.exists());
+    assert_eq!(path, Path::new(env!("CARGO_BIN_EXE_linera-proxy")));
 }

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -1,0 +1,22 @@
+# Copyright (c) Zefchain Labs, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Runs a command such as `linera net up` in the background.
+# - Records stdout
+# - Waits for the background process to print READY! on stderr
+# - Then executes the bash command recorded from stdout
+# - Returns without killing the process
+function spawn_and_set_wallet_env_vars() {
+    DIR=$(mktemp -d "${TMPDIR:-.}tmp-XXXXX") || exit 1
+    OUT="$DIR/out"
+    ERR="$DIR/err"
+    mkfifo "$ERR" || exit 1
+
+    trap 'jobs -p | xargs -r kill && rm -rf "$DIR"' EXIT
+
+    "$@" 2> >(tee "$ERR") 1>"$OUT" &
+
+    sed -n '/^READY!/q' <"$ERR" || exit 1
+
+    source "$OUT"
+}


### PR DESCRIPTION
## Motivation

Deprecate the bash logic to spawn a local test network, make sure we catch regression with `linera net up`

## Proposal

* Separate stdout and stderr in `linera net up`
* Interpret stdout in bash to define the appropriate wallet environment variables
* Create a helper script with some logics to wait for READY! to be output so that we don't have to use `sleep` in bash
* Introduce an option --with-wallet N to select a different pair of environment variables ending with _$N
* Add signal handlers so that ^C (SIGINT) and SIGTERM don't create zombie processes.
* Rename linera --wallets M into --extra-wallets M. If present (including M=0), the stdout is modified, so that environment variables end with _{0..=M}

## Test Plan

CI

Also works in interactive shells (although it's a bit dirty as adds a `trap`)
```
source scripts/linera_net_helper.sh

spawn_and_set_wallet_env_vars \
    linera net up

linera sync-balance
```

## Release Plan

- Need to bump the major version number in the next release of the crates.
- Need to update the developer manual for the renamed option?

## Links

- stacked on #1130 