### PR TITLE
Implement the metric tracking client from a client

### DIFF
--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -832,7 +832,7 @@ struct QueryResults {
 // Inspired by https://depth-first.com/articles/2020/06/22/returning-rust-iterators/
 #[doc(hidden)]
 #[allow(clippy::type_complexity)]
-pub struct DynamoDbKeyBlockIterator<'a> {
+pub struct DynamoDbKeyIterator<'a> {
     prefix_len: usize,
     pos: usize,
     iters: Vec<
@@ -842,7 +842,7 @@ pub struct DynamoDbKeyBlockIterator<'a> {
     >,
 }
 
-impl<'a> Iterator for DynamoDbKeyBlockIterator<'a> {
+impl<'a> Iterator for DynamoDbKeyIterator<'a> {
     type Item = Result<&'a [u8], DynamoDbContextError>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -868,7 +868,7 @@ pub struct DynamoDbKeys {
 }
 
 impl KeyIterable<DynamoDbContextError> for DynamoDbKeys {
-    type Iterator<'a> = DynamoDbKeyBlockIterator<'a> where Self: 'a;
+    type Iterator<'a> = DynamoDbKeyIterator<'a> where Self: 'a;
 
     fn iterator(&self) -> Self::Iterator<'_> {
         let pos = 0;
@@ -877,7 +877,7 @@ impl KeyIterable<DynamoDbContextError> for DynamoDbKeys {
             let iter = response.items.iter().flatten();
             iters.push(iter);
         }
-        DynamoDbKeyBlockIterator {
+        DynamoDbKeyIterator {
             prefix_len: self.result_queries.prefix_len,
             pos,
             iters,

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -58,6 +58,9 @@ pub mod batch;
 /// The definitions used for the `KeyValueStoreClient` and `Context`.
 pub mod common;
 
+/// The code for keeping track of reads and writes.
+pub mod storage_metric;
+
 /// The code for handling big values by splitting them into several small ones.
 pub mod value_splitting;
 

--- a/linera-views/src/storage_metric.rs
+++ b/linera-views/src/storage_metric.rs
@@ -11,11 +11,11 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 /// Array containing metric data for this client
-/// This can be used for storage-fees or for other
+/// This can be used for storage fees or for other
 /// benchmarking purposes.
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
 pub struct MetricStat {
-    /// The total number of read_key and read_multi_key
+    /// The total number of keys read in calls to `read_key` and `read_multi_key`
     pub n_reads: usize,
     /// The number of missed cases in read_key and read_multi_key
     pub n_miss_reads: usize,

--- a/linera-views/src/storage_metric.rs
+++ b/linera-views/src/storage_metric.rs
@@ -193,12 +193,12 @@ mod tests {
         batch::Batch,
         common::KeyValueStoreClient,
         memory::MemoryClient,
-        storage_metric::{get_metric_memory_client, metric, MetricKeyValueClient, MetricStat},
+        storage_metric::{get_metric_memory_client, MetricKeyValueClient, MetricStat},
     };
 
     async fn get_memory_test_state() -> MetricKeyValueClient<MemoryClient> {
         let client = get_metric_memory_client();
-        assert_eq!(metric(&client).await, MetricStat::default());
+        assert_eq!(client.metric(), MetricStat::default());
         let mut batch = Batch::new();
         batch.put_key_value_bytes(vec![1, 2, 3], vec![1]);
         batch.put_key_value_bytes(vec![1, 2, 4], vec![2, 2]);
@@ -208,7 +208,7 @@ mod tests {
         batch.delete_key_prefix(vec![2, 3]);
         client.write_batch(batch, &[]).await.unwrap();
         assert_eq!(
-            metric(&client).await,
+            client.metric(),
             MetricStat {
                 n_reads: 0,
                 n_miss_reads: 0,
@@ -227,7 +227,7 @@ mod tests {
         let client = get_memory_test_state().await;
         client.read_key_bytes(&[1, 3, 3]).await.unwrap();
         assert_eq!(
-            metric(&client).await,
+            client.metric(),
             MetricStat {
                 n_reads: 1,
                 n_miss_reads: 0,
@@ -245,7 +245,7 @@ mod tests {
         let client = get_memory_test_state().await;
         client.read_key_bytes(&[1, 4, 4]).await.unwrap();
         assert_eq!(
-            metric(&client).await,
+            client.metric(),
             MetricStat {
                 n_reads: 1,
                 n_miss_reads: 1,
@@ -266,7 +266,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            metric(&client).await,
+            client.metric(),
             MetricStat {
                 n_reads: 2,
                 n_miss_reads: 0,
@@ -284,7 +284,7 @@ mod tests {
         let client = get_memory_test_state().await;
         client.find_keys_by_prefix(&[1, 2]).await.unwrap();
         assert_eq!(
-            metric(&client).await,
+            client.metric(),
             MetricStat {
                 n_reads: 0,
                 n_miss_reads: 0,
@@ -302,7 +302,7 @@ mod tests {
         let client = get_memory_test_state().await;
         client.find_key_values_by_prefix(&[1, 2]).await.unwrap();
         assert_eq!(
-            metric(&client).await,
+            client.metric(),
             MetricStat {
                 n_reads: 0,
                 n_miss_reads: 0,

--- a/linera-views/src/storage_metric.rs
+++ b/linera-views/src/storage_metric.rs
@@ -1,0 +1,192 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+use crate::{
+    batch::{Batch, WriteOperation},
+    common::{KeyIterable, KeyValueStoreClient},
+};
+use std::sync::Arc;
+use async_lock::RwLock;
+
+/// Array containing data for this client
+#[derive(Clone, Default, Debug)]
+pub struct MetricStat {
+    /// The total number of read_key and read_multi_key
+    n_reads: usize,
+    /// The number of missed cases in read_key and read_multi_key
+    n_miss_reads: usize,
+    /// The number of Put in the batches
+    n_puts: usize,
+    /// The total number of Delete in the batches
+    n_deletes: usize,
+    /// The total number of DeletePrefix in the batches
+    n_delete_prefix: usize,
+    /// The total data that went into the Batches
+    size_writes: usize,
+    /// The total data being read from
+    size_reads: usize,
+}
+
+/// The `MetricKeyValueClient` encapsulates a client and also measures the operations
+/// being done
+#[derive(Clone)]
+pub struct MetricKeyValueClient<K> {
+    /// The inner client that is called by the LRU cache one
+    pub client: K,
+    /// The data contained in the running of this container
+    pub metric_stat: Arc<RwLock<MetricStat>>,
+}
+
+/// A container for a KeyIterable and a counter
+struct KeyIterableCounter<K, I> {
+    /// The counter
+    pub metric_stat: MetricStat,
+    /// The key iterable
+    pub key_iterable: I,
+    _store_client: std::marker::PhantomData<K>,
+}
+
+impl<K> KeyIterable<K::Error> for KeyIterableCounter<K, K::Keys>
+where
+    K: KeyValueStoreClient,
+    <K as KeyValueStoreClient>::Keys: KeyIterable<<K as KeyValueStoreClient>::Error>
+{
+    type Iterator<'a> = KeyIteratorCounter<'a, K, <<K as KeyValueStoreClient>::Keys as KeyIterable<K::Error>>::Iterator<'a>>
+    where
+        Self: 'a;
+
+    fn iterator(&self) -> Self::Iterator<'_> {
+        let iter = self.key_iterable.iterator();
+        let metric_stat = self.metric_stat.clone();
+        KeyIteratorCounter { metric_stat, iter, _store_client: std::marker::PhantomData }
+    }
+}
+
+/// The corresponding Iterator
+struct KeyIteratorCounter<'a, K, I> {
+    /// The counter
+    pub metric_stat: MetricStat,
+    /// The key iterator
+    pub iter: I,
+    _store_client: std::marker::PhantomData<&'a K>,
+}
+
+impl<'a, K> Iterator for KeyIteratorCounter<'a, K, <<K as KeyValueStoreClient>::Keys as KeyIterable<K::Error>>::Iterator<'a>>
+where
+    K: KeyValueStoreClient,
+    <K as KeyValueStoreClient>::Keys: KeyIterable<<K as KeyValueStoreClient>::Error>
+{
+    type Item = Result<&'a [u8], <K as KeyValueStoreClient>::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+
+
+/*
+Two types:
+---Standard case (Vec<Vec<u8>>):
+   * T1 : Vec<Vec<u8>>
+   * T2 : SimpleKeyIterator<'a, E>
+---DynamoDb
+   * T1 : DynamoDbKeys
+   * T2 : DynamoDbKeyBlockIterator<'a>
+---Our case here
+   * T1: KeyIterableCounter<K> (basically (metric_stat, K::Keys)
+   * T2: KeyIteratorCounter<K>
+
+The link is established via
+   T2 = T1::Iterator
+
+ */
+
+
+
+#[async_trait]
+impl<K> KeyValueStoreClient for MetricKeyValueClient<K>
+where
+    K: KeyValueStoreClient + Send + Sync,
+{
+    // The LRU cache does not change the underlying client's size limit.
+    const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
+    type Error = K::Error;
+    type Keys = K::Keys;
+    type KeyValues = K::KeyValues;
+
+    fn max_stream_queries(&self) -> usize {
+        self.client.max_stream_queries()
+    }
+
+    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        let read = self.client.read_key_bytes(key).await?;
+        let mut metric_stat = self.metric_stat.write().await;
+        metric_stat.n_reads += 1;
+        match &read {
+            None => {
+                metric_stat.n_miss_reads += 1;
+            },
+            Some(value) => {
+                metric_stat.size_reads += value.len();
+            },
+        }
+        Ok(read)
+    }
+
+    async fn read_multi_key_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        let multi_read = self.client.read_multi_key_bytes(keys).await?;
+        let mut metric_stat = self.metric_stat.write().await;
+        for read in &multi_read {
+            match read {
+                None => {
+                    metric_stat.n_miss_reads += 1;
+                },
+                Some(value) => {
+                    metric_stat.size_reads += value.len();
+                },
+            }
+        }
+        Ok(multi_read)
+    }
+
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+        self.client.find_keys_by_prefix(key_prefix).await
+    }
+
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, Self::Error> {
+        self.client.find_key_values_by_prefix(key_prefix).await
+    }
+
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), Self::Error> {
+        let mut metric_stat = self.metric_stat.write().await;
+        for operation in &batch.operations {
+            match operation {
+                WriteOperation::Delete { key } => {
+                    metric_stat.n_deletes += 1;
+                    metric_stat.size_writes += key.len();
+                },
+                WriteOperation::Put { key, value } => {
+                    metric_stat.n_puts += 1;
+                    metric_stat.size_writes += key.len() + value.len();
+                },
+                WriteOperation::DeletePrefix { key_prefix } => {
+                    metric_stat.n_delete_prefix += 1;
+                    metric_stat.size_writes += key_prefix.len();
+                },
+            }
+        }
+        self.client.write_batch(batch, base_key).await
+    }
+
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+        self.client.clear_journal(base_key).await
+    }
+}

--- a/linera-views/src/storage_metric.rs
+++ b/linera-views/src/storage_metric.rs
@@ -6,9 +6,30 @@ use crate::{
     common::{KeyIterable, KeyValueIterable, KeyValueStoreClient},
     memory::{create_memory_client, MemoryClient},
 };
-use async_lock::RwLock;
 use async_trait::async_trait;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Array containing metric data for this client
+/// This can be used for storage fees or for other
+/// benchmarking purposes.
+#[derive(Clone, Default, Debug)]
+pub struct AtomicMetricStat {
+    /// The total number of keys read in calls to `read_key` and `read_multi_key`
+    pub n_reads: Arc<AtomicUsize>,
+    /// The number of missed cases in read_key and read_multi_key
+    pub n_miss_reads: Arc<AtomicUsize>,
+    /// The number of Put in the batches
+    pub n_puts: Arc<AtomicUsize>,
+    /// The total number of Delete in the batches
+    pub n_deletes: Arc<AtomicUsize>,
+    /// The total number of DeletePrefix in the batches
+    pub n_delete_prefix: Arc<AtomicUsize>,
+    /// The total data that went into the Batches
+    pub size_writes: Arc<AtomicUsize>,
+    /// The total data being read from
+    pub size_reads: Arc<AtomicUsize>,
+}
 
 /// Array containing metric data for this client
 /// This can be used for storage fees or for other
@@ -31,6 +52,10 @@ pub struct MetricStat {
     pub size_reads: usize,
 }
 
+
+
+
+
 /// The `MetricKeyValueClient` encapsulates a client and creates a new one that
 /// measures the operations being done
 #[derive(Clone)]
@@ -38,7 +63,7 @@ pub struct MetricKeyValueClient<K> {
     /// The inner client that is called by the metric one
     pub client: K,
     /// The data contained in the running of this container
-    pub metric_stat: Arc<RwLock<MetricStat>>,
+    pub metric_stat: AtomicMetricStat,
 }
 
 #[async_trait]
@@ -57,14 +82,13 @@ where
 
     async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let read = self.client.read_key_bytes(key).await?;
-        let mut metric_stat = self.metric_stat.write().await;
-        metric_stat.n_reads += 1;
+        self.metric_stat.n_reads.fetch_add(1, Ordering::Relaxed);
         match &read {
             None => {
-                metric_stat.n_miss_reads += 1;
+                self.metric_stat.n_miss_reads.fetch_add(1, Ordering::Relaxed);
             }
             Some(value) => {
-                metric_stat.size_reads += value.len();
+                self.metric_stat.size_reads.fetch_add(value.len(), Ordering::Relaxed);
             }
         }
         Ok(read)
@@ -76,15 +100,14 @@ where
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
         let n_keys = keys.len();
         let multi_read = self.client.read_multi_key_bytes(keys).await?;
-        let mut metric_stat = self.metric_stat.write().await;
-        metric_stat.n_reads += n_keys;
+        self.metric_stat.n_reads.fetch_add(n_keys, Ordering::Relaxed);
         for read in &multi_read {
             match read {
                 None => {
-                    metric_stat.n_miss_reads += 1;
+                    self.metric_stat.n_miss_reads.fetch_add(1, Ordering::Relaxed);
                 }
                 Some(value) => {
-                    metric_stat.size_reads += value.len();
+                    self.metric_stat.size_reads.fetch_add(value.len(), Ordering::Relaxed);
                 }
             }
         }
@@ -92,10 +115,9 @@ where
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
-        let mut metric_stat = self.metric_stat.write().await;
         let keys = self.client.find_keys_by_prefix(key_prefix).await?;
         for key in keys.iterator() {
-            metric_stat.size_reads += key?.len();
+            self.metric_stat.size_reads.fetch_add(key?.len(), Ordering::Relaxed);
         }
         Ok(keys)
     }
@@ -104,30 +126,28 @@ where
         &self,
         key_prefix: &[u8],
     ) -> Result<Self::KeyValues, Self::Error> {
-        let mut metric_stat = self.metric_stat.write().await;
         let key_values = self.client.find_key_values_by_prefix(key_prefix).await?;
         for key_value in key_values.iterator() {
             let key_value = key_value?;
-            metric_stat.size_reads += key_value.0.len() + key_value.1.len();
+            self.metric_stat.size_reads.fetch_add(key_value.0.len() + key_value.1.len(), Ordering::Relaxed);
         }
         Ok(key_values)
     }
 
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), Self::Error> {
-        let mut metric_stat = self.metric_stat.write().await;
         for operation in &batch.operations {
             match operation {
                 WriteOperation::Delete { key } => {
-                    metric_stat.n_deletes += 1;
-                    metric_stat.size_writes += key.len();
+                    self.metric_stat.n_deletes.fetch_add(1, Ordering::Relaxed);
+                    self.metric_stat.size_writes.fetch_add(key.len(), Ordering::Relaxed);
                 }
                 WriteOperation::Put { key, value } => {
-                    metric_stat.n_puts += 1;
-                    metric_stat.size_writes += key.len() + value.len();
+                    self.metric_stat.n_puts.fetch_add(1, Ordering::Relaxed);
+                    self.metric_stat.size_writes.fetch_add(key.len() + value.len(), Ordering::Relaxed);
                 }
                 WriteOperation::DeletePrefix { key_prefix } => {
-                    metric_stat.n_delete_prefix += 1;
-                    metric_stat.size_writes += key_prefix.len();
+                    self.metric_stat.n_deletes.fetch_add(1, Ordering::Relaxed);
+                    self.metric_stat.size_writes.fetch_add(key_prefix.len(), Ordering::Relaxed);
                 }
             }
         }
@@ -139,22 +159,32 @@ where
     }
 }
 
+impl<K> MetricKeyValueClient<K>
+where
+    K: KeyValueStoreClient + Send + Sync,
+{
+    /// Returning the current metric information
+    pub fn metric(&self) -> MetricStat {
+        let n_reads = self.metric_stat.n_reads.load(Ordering::Relaxed);
+        let n_miss_reads = self.metric_stat.n_miss_reads.load(Ordering::Relaxed);
+        let n_puts = self.metric_stat.n_puts.load(Ordering::Relaxed);
+        let n_deletes = self.metric_stat.n_deletes.load(Ordering::Relaxed);
+        let n_delete_prefix = self.metric_stat.n_delete_prefix.load(Ordering::Relaxed);
+        let size_writes = self.metric_stat.size_writes.load(Ordering::Relaxed);
+        let size_reads = self.metric_stat.size_reads.load(Ordering::Relaxed);
+        MetricStat { n_reads, n_miss_reads, n_puts, n_deletes, n_delete_prefix, size_writes, size_reads }
+    }
+}
+
+
 /// Create a new client
 pub fn get_metric_memory_client() -> MetricKeyValueClient<MemoryClient> {
     let client = create_memory_client();
-    let metric_stat = MetricStat::default();
-    let metric_stat = Arc::new(RwLock::new(metric_stat));
+    let metric_stat = AtomicMetricStat::default();
     MetricKeyValueClient {
         client,
         metric_stat,
     }
-}
-
-/// Returning the current metric information
-pub async fn metric(client: &MetricKeyValueClient<MemoryClient>) -> MetricStat {
-    let metric_stat = &client.metric_stat;
-    let metric_stat = metric_stat.read().await;
-    *metric_stat
 }
 
 #[cfg(test)]

--- a/linera-views/src/storage_metric.rs
+++ b/linera-views/src/storage_metric.rs
@@ -10,7 +10,9 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 use std::sync::Arc;
 
-/// Array containing data for this client
+/// Array containing metric data for this client
+/// This can be used for storage-fees or for other
+/// benchmarking purposes.
 #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
 pub struct MetricStat {
     /// The total number of read_key and read_multi_key
@@ -29,11 +31,11 @@ pub struct MetricStat {
     pub size_reads: usize,
 }
 
-/// The `MetricKeyValueClient` encapsulates a client and also measures the operations
-/// being done
+/// The `MetricKeyValueClient` encapsulates a client and creates a new one that
+/// measures the operations being done
 #[derive(Clone)]
 pub struct MetricKeyValueClient<K> {
-    /// The inner client that is called by the LRU cache one
+    /// The inner client that is called by the metric one
     pub client: K,
     /// The data contained in the running of this container
     pub metric_stat: Arc<RwLock<MetricStat>>,
@@ -44,7 +46,6 @@ impl<K> KeyValueStoreClient for MetricKeyValueClient<K>
 where
     K: KeyValueStoreClient + Send + Sync,
 {
-    // The LRU cache does not change the underlying client's size limit.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
     type Error = K::Error;
     type Keys = K::Keys;


### PR DESCRIPTION
## Motivation

For purposes of storage fees and benchmarking we implement a transformer (that is something similar to `ValueSplittingKeyValueStoreClient` and `LruCachingKeyValueClient`) that takes a client and returns another one that does the tracking. The effective implementation in the SDK is deferred to further works.

## Proposal

The code is fairly straightforward. For the `find_keys_by_prefix` I initially went into a wild goose chase
of trying to implement a new `Self::Keys` that updates the sizes as it is processed. This was very complicated
(lifetimes, auxiliary types, RwLockWriteGuard, etc.) and ultimately unsuccessful.

There is much wiggle room in the `MetricStat` type. It could be too detailed or not enough. Also, timings would be inserted or done in another transformer. That is expected to be resolved in the review.

## Test Plan

A number of CI tests were added to test the feature.

## Release Plan

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
