### PR TITLE
Fix hang in `find_key_values`

### DIFF
--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -356,7 +356,7 @@ macro_rules! impl_view_system_api {
                 &mut self,
                 key_prefix: &[u8],
             ) -> Result<Self::FindKeyValues, Self::Error> {
-                Ok(HostFuture::new(
+                Ok(self.new_host_future(
                     self.runtime()
                         .find_key_values_by_prefix(key_prefix.to_owned()),
                 ))


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Calls to the `find_key_values` function available in the Wasm system API could hang. The root cause was that the host future that executes the functionality was not added to the contract's host future queue.

This led to two issues, the first is that execution could be non-deterministic, since the call could complete before or after other asynchronous calls in different validators since the host future queue could not enforce deterministic completion order of the future.

The second is that execution could hang. This happened when the call to the store layer didn't complete immediately and there were no other remaining asynchronous calls still in execution. More precisely, when the host future queue is empty and when the call returns `Poll::Pending`. When it eventually needs to progress again, it notifies the task's waker (forwarded from the waker used by the Wasm guest future). The guest Wasm instance's `GuestFuture` is woken up and polled, but since the host future queue is empty, it cancels the poll without calling the actual guest Wasm instance. This prevents the guest from polling the host future handling the call, so it hangs.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add `find_key_values` to host future queue. This ensures that the future is polled correctly when it needs to progress.

## Test Plan

<!-- How to test that the changes are correct. -->
This was tested using the [instructions](https://github.com/linera-io/linera-protocol/issues/1097#issuecomment-1761560436) provided by @afck.
#334 should also cover this issue.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

Fixes #1097 
<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
