### PR TITLE
Fix resolve_binary (again)

### DIFF
--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -2,52 +2,70 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Context as _, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::process::Command;
 use tracing::{debug, error};
 
 /// Attempts to resolve the path and test the version of the given binary against our
-/// package version. This is meant for binaries of the Linera repository.
+/// package version.
+///
+/// This is meant for binaries of the Linera repository. We use the current running binary
+/// to locate the parent directory where to look for the given name.
 pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result<PathBuf> {
-    debug!("Resolving binary {name} based on the current binary path.");
-    let mut current_binary_path = PathBuf::from(
-        std::env::args()
-            .next()
-            .expect("args should start with the current binary path"),
-    )
-    .canonicalize()?;
-    current_binary_path.pop();
+    let current_binary = std::env::current_exe()?;
+    resolve_binary_in_same_directory_as(&current_binary, name, package).await
+}
+
+/// Same as [`resolve_binary`] but gives the option to specify a binary path to use as
+/// reference. The path may be relative or absolute but it must point to a valid file on
+/// disk.
+pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
+    current_binary: P,
+    name: &'static str,
+    package: &'static str,
+) -> Result<PathBuf> {
+    let current_binary = current_binary.as_ref();
+    debug!(
+        "Resolving binary {name} based on the current binary path: {}",
+        current_binary.display()
+    );
+    let mut current_binary_parent = current_binary
+        .canonicalize()
+        .with_context(|| format!("Failed to canonicalize '{}'", current_binary.display()))?;
+    current_binary_parent.pop();
 
     #[cfg(any(test, feature = "test"))]
     // Test binaries are typically in target/debug/deps while crate binaries are in target/debug
     // (same thing for target/release).
-    if current_binary_path.ends_with("target/debug/deps")
-        || current_binary_path.ends_with("target/release/deps")
+    let current_binary_parent = if current_binary_parent.ends_with("target/debug/deps")
+        || current_binary_parent.ends_with("target/release/deps")
     {
-        current_binary_path.pop();
-    }
+        PathBuf::from(current_binary_parent.parent().unwrap())
+    } else {
+        current_binary_parent
+    };
 
-    let path = current_binary_path.join(name);
+    let binary = current_binary_parent.join(name);
     let version = env!("CARGO_PKG_VERSION");
-    if !path.exists() {
+    if !binary.exists() {
         error!(
             "Cannot find a binary {name} in the directory {}. \
              Consider using `cargo install {package}` or `cargo build -p {package}`",
-            current_binary_path.display()
+            current_binary_parent.display()
         );
         bail!("Failed to resolve binary {name}");
     }
 
     // Quick version check.
-    debug!("Checking the version of {}", path.display());
-    let version_message = Command::new(&path)
+    debug!("Checking the version of {}", binary.display());
+    let version_message = Command::new(&binary)
         .arg("--version")
         .output()
         .await
         .with_context(|| {
             format!(
                 "Failed to execute and retrieve version from the binary {name} in directory {}",
-                current_binary_path.display()
+                current_binary_parent.display()
             )
         })?
         .stdout;
@@ -58,18 +76,18 @@ pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result
         .with_context(|| {
             format!(
                 "Passing --version to the binary {name} in directory {} returned an empty result",
-                current_binary_path.display()
+                current_binary_parent.display()
             )
         })?
         .to_string();
     if version != found_version {
         error!("The binary {name} in directory {} should have version {version} (found {found_version}). \
                 Consider using `cargo install {package} --version '{version}'` or `cargo build -p {package}`",
-               current_binary_path.display()
+               current_binary_parent.display()
         );
         bail!("Incorrect version for binary {name}");
     }
-    debug!("{} has version {version}", path.display());
+    debug!("{} has version {version}", binary.display());
 
-    Ok(path)
+    Ok(binary)
 }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -546,8 +546,7 @@ async fn test_linera_net_up_simple() {
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
-    // Using a relative path to test the resolution of other binaries in this case.
-    let mut command = Command::new("../target/debug/linera");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_linera"));
     command.args(["net", "up"]);
     let mut child = command.stdin(Stdio::piped()).spawn().unwrap();
 

--- a/linera-service/tests/util_tests.rs
+++ b/linera-service/tests/util_tests.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "rocksdb")]
+
+use linera_service::util;
+use std::path::Path;
+
+#[test_log::test(tokio::test)]
+async fn test_resolve_binary_with_test_default() {
+    util::resolve_binary("linera", "linera-service")
+        .await
+        .unwrap();
+}
+
+#[test_log::test(tokio::test)]
+async fn test_resolve_binary_from_relative_path() {
+    util::resolve_binary_in_same_directory_as(
+        "../target/debug/linera",
+        "linera-proxy",
+        "linera-service",
+    )
+    .await
+    .unwrap();
+}
+
+#[test_log::test(tokio::test)]
+async fn test_resolve_binary_from_absolute_path() {
+    let path = Path::new("../target/debug/linera").canonicalize().unwrap();
+    util::resolve_binary_in_same_directory_as(&path, "linera-proxy", "linera-service")
+        .await
+        .unwrap();
+}

--- a/linera-service/tests/util_tests.rs
+++ b/linera-service/tests/util_tests.rs
@@ -9,26 +9,41 @@ use std::path::Path;
 
 #[test_log::test(tokio::test)]
 async fn test_resolve_binary_with_test_default() {
-    util::resolve_binary("linera", "linera-service")
+    let path = util::resolve_binary("linera", "linera-service")
         .await
         .unwrap();
+    assert!(path.exists());
+    // Since we're in a test, we can use the environment variables `CARGO_BIN_EXE_*`.
+    assert_eq!(path, Path::new(env!("CARGO_BIN_EXE_linera")));
 }
 
 #[test_log::test(tokio::test)]
 async fn test_resolve_binary_from_relative_path() {
-    util::resolve_binary_in_same_directory_as(
-        "../target/debug/linera",
+    let debug_or_release = Path::new(env!("CARGO_BIN_EXE_linera"))
+        .parent()
+        .unwrap()
+        .file_name()
+        .unwrap();
+    let path = util::resolve_binary_in_same_directory_as(
+        Path::new("../target").join(debug_or_release).join("linera"),
         "linera-proxy",
         "linera-service",
     )
     .await
     .unwrap();
+    assert!(path.exists());
+    assert_eq!(path, Path::new(env!("CARGO_BIN_EXE_linera-proxy")));
 }
 
 #[test_log::test(tokio::test)]
 async fn test_resolve_binary_from_absolute_path() {
-    let path = Path::new("../target/debug/linera").canonicalize().unwrap();
-    util::resolve_binary_in_same_directory_as(&path, "linera-proxy", "linera-service")
-        .await
-        .unwrap();
+    let path = util::resolve_binary_in_same_directory_as(
+        env!("CARGO_BIN_EXE_linera"),
+        "linera-proxy",
+        "linera-service",
+    )
+    .await
+    .unwrap();
+    assert!(path.exists());
+    assert_eq!(path, Path::new(env!("CARGO_BIN_EXE_linera-proxy")));
 }


### PR DESCRIPTION
## Motivation

* Some variable names were confusing
* The case of a current binary (e.g. `linera`) in the PATH was working only for interactive bash shells. It appears that only those set $0 to be the full resolved path. Non-interactive bash shell will $0 set to `linera`. (This happens to me in the next PR.)

## Proposal

* Fix variable names
* Use `std::env::current_exe()` instead of `argv[0]` to find the fully resolved path to current executable.
* Add the long-overdue unit tests.

## Test Plan

CI
