### PR TITLE
Log number of blocks executed metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,6 +2762,8 @@ dependencies = [
  "linera-chain",
  "linera-execution",
  "linera-views",
+ "once_cell",
+ "prometheus",
  "rand_chacha 0.3.1",
  "rand_distr",
  "serde",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1639,6 +1639,8 @@ dependencies = [
  "linera-base",
  "linera-execution",
  "linera-views",
+ "once_cell",
+ "prometheus",
  "rand_chacha 0.3.1",
  "rand_distr",
  "serde",

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -21,6 +21,8 @@ futures = { workspace = true }
 linera-base = { workspace = true }
 linera-execution = { workspace = true }
 linera-views = { workspace = true, features = ["metrics"] }
+once_cell = { workspace = true }
+prometheus = { workspace = true }
 rand_chacha = { workspace = true }
 rand_distr = { workspace = true, features = ["serde1"] }
 serde = { workspace = true }


### PR DESCRIPTION
## Motivation

Going through the metrics here: https://docs.google.com/spreadsheets/d/1tHo8iKzrlkuYeN2Yu7a6MfwQd-P2KNA9BlnhcASoEQY/edit?pli=1#gid=0

## Proposal

Implementing number of blocks executer Counter metric

## Test Plan

Ran validator locally, ran a benchmark against it, and saw metric properly logged:

![Screenshot 2023-10-16 at 17.03.46.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/9aad4e21-524a-4ffd-9d1c-3dedabac0f78/Screenshot%202023-10-16%20at%2017.03.46.png)

