### PR TITLE
Log Wasm fuel used per block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,6 +2834,7 @@ dependencies = [
  "linera-wit-bindgen-host-wasmtime-rust",
  "lru",
  "once_cell",
+ "prometheus",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1699,6 +1699,7 @@ dependencies = [
  "linera-wit-bindgen-host-wasmer-rust",
  "lru",
  "once_cell",
+ "prometheus",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -35,6 +35,7 @@ linera-views = { workspace = true, features = ["metrics"] }
 linera-views-derive = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }
+prometheus = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -20,6 +20,8 @@ use linera_views::{
     views::{View, ViewError},
 };
 use linera_views_derive::CryptoHashView;
+use once_cell::sync::Lazy;
+use prometheus::{register_histogram_vec, HistogramVec};
 
 #[cfg(any(test, feature = "test"))]
 use {
@@ -29,6 +31,16 @@ use {
     std::collections::BTreeMap,
     std::sync::Arc,
 };
+
+pub static WASM_FUEL_USED_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "wasm_fuel_used_per_block",
+        "Wasm fuel used per block",
+        // Can add labels here
+        &[]
+    )
+    .expect("Counter can be created")
+});
 
 /// A view accessing the execution state of a chain.
 #[derive(Debug, CryptoHashView)]
@@ -165,6 +177,7 @@ where
         action: UserAction<'_>,
         remaining_fuel: &mut u64,
     ) -> Result<Vec<ExecutionResult>, ExecutionError> {
+        let initial_remaining_fuel = *remaining_fuel;
         // Try to load the application. This may fail if the corresponding
         // bytecode-publishing certificate doesn't exist yet on this validator.
         let description = self
@@ -220,6 +233,9 @@ where
         // Set the authenticated signer to be used in outgoing messages.
         result.authenticated_signer = signer;
         *remaining_fuel = runtime.remaining_fuel();
+        WASM_FUEL_USED_PER_BLOCK
+            .with_label_values(&[])
+            .observe((initial_remaining_fuel - *remaining_fuel) as f64);
 
         // Check that applications were correctly stacked and unstacked.
         assert_eq!(applications.len(), 1);


### PR DESCRIPTION
## Motivation

Logging some metrics from our list

## Proposal

Implementing number of rounds in proposals Histogram metric

## Test Plan

Ran validator locally, published and created a Fungible application, and saw metric properly logged:


![Screenshot 2023-10-17 at 14.24.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/3a7f9ef7-b72d-47ea-be5d-0073467b8abd/Screenshot%202023-10-17%20at%2014.24.19.png)

