### PR TITLE
Log number of rounds in certificates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2793,6 +2793,7 @@ dependencies = [
  "linera-views",
  "lru",
  "meta-counter",
+ "once_cell",
  "prometheus",
  "proptest",
  "rand 0.8.5",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "linera-storage",
  "linera-views",
  "lru",
+ "once_cell",
  "prometheus",
  "proptest",
  "rand 0.8.5",

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -560,6 +560,14 @@ impl CertificateValue {
         self.executed_block()
             .map(|executed_block| &executed_block.block)
     }
+
+    pub fn to_log_str(&self) -> &str {
+        match self {
+            CertificateValue::ConfirmedBlock { .. } => "confirmed_block",
+            CertificateValue::ValidatedBlock { .. } => "validated_block",
+            CertificateValue::LeaderTimeout { .. } => "leader_timeout",
+        }
+    }
 }
 
 impl ExecutedBlock {

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -35,6 +35,7 @@ linera-execution = { workspace = true }
 linera-storage = { workspace = true }
 linera-views = { workspace = true }
 lru = { workspace = true }
+once_cell = { workspace = true }
 prometheus = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }


### PR DESCRIPTION
## Motivation

Logging some metrics from our list

## Proposal

Implementing number of rounds in certificates Histogram metric

## Test Plan

Ran validator locally, ran a benchmark against it, and saw metric properly logged:

![Screenshot 2023-10-17 at 15.43.20.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/10b06ab8-017d-41ee-82ff-a5efcbe36857/Screenshot%202023-10-17%20at%2015.43.20.png)

