### PR TITLE
Use anyhow in CLI wrappers instead of panicking.

### DIFF
--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -192,5 +192,5 @@ async fn run_end_to_end_operations_indexer(database: Database) {
     }
 
     indexer_running(&mut indexer);
-    node_service.assert_is_running();
+    node_service.ensure_is_running().unwrap();
 }

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -61,7 +61,7 @@ async fn run_end_to_end_queries(database: Database) {
     local_net.run().await.unwrap();
 
     let node_chains = {
-        let wallet = client.get_wallet();
+        let wallet = client.get_wallet().unwrap();
         (wallet.default_chain(), wallet.chain_ids())
     };
     let chain_id = node_chains.0.unwrap();
@@ -135,7 +135,7 @@ async fn run_end_to_end_queries(database: Database) {
     .unwrap()
     .block;
 
-    node_service.assert_is_running();
+    node_service.ensure_is_running().unwrap();
 }
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
## Motivation

Production code should usually return errors instead of panicking.

## Proposal

Use `anyhow` in `cli_wrappers` instead of `unwrap()`, `panic!` and `expect()`.

Only `build_example` and `example_path` was made test-only, since these are about the Linera example applications.

## Test Plan

No logic has changed.

## Links

- Supersedes https://github.com/linera-io/linera-protocol/pull/1124.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
