### PR TITLE
Add message counts to `ExecutedBlock`.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     data_types::{
-        Block, ChainAndHeight, ChannelFullName, Event, IncomingMessage, Medium, Origin,
-        OutgoingMessage, Target,
+        Block, BlockExecutionOutcome, ChainAndHeight, ChannelFullName, Event, IncomingMessage,
+        Medium, Origin, OutgoingMessage, Target,
     },
     inbox::{InboxError, InboxStateView},
     outbox::OutboxStateView,
@@ -453,7 +453,7 @@ where
         &mut self,
         block: &Block,
         now: Timestamp,
-    ) -> Result<(Vec<OutgoingMessage>, Vec<u32>, CryptoHash), ChainError> {
+    ) -> Result<BlockExecutionOutcome, ChainError> {
         let start_time = Instant::now();
 
         assert_eq!(block.chain_id, self.chain_id());
@@ -563,7 +563,11 @@ where
         BLOCK_EXECUTION_LATENCY
             .with_label_values(&[])
             .observe(start_time.elapsed().as_secs_f64());
-        Ok((messages, message_counts, state_hash))
+        Ok(BlockExecutionOutcome {
+            messages,
+            message_counts,
+            state_hash,
+        })
     }
 
     async fn process_execution_results(

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -8,11 +8,11 @@ use linera_base::{
     crypto::{BcsHashable, BcsSignable, CryptoHash, KeyPair, Signature},
     data_types::{BlockHeight, RoundNumber, Timestamp},
     doc_scalar, ensure,
-    identifiers::{ApplicationId, BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner},
+    identifiers::{ChainId, ChannelName, Destination, MessageId, Owner},
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    BytecodeLocation, GenericApplicationId, Message, Operation, SystemMessage,
+    BytecodeLocation, GenericApplicationId, Message, Operation,
 };
 use serde::{de::Deserializer, Deserialize, Serialize};
 use std::{
@@ -184,6 +184,10 @@ pub struct OutgoingMessage {
 pub struct ExecutedBlock {
     pub block: Block,
     pub messages: Vec<OutgoingMessage>,
+    /// For each transaction, the cumulative number of messages created by this and all previous
+    /// transactions, i.e. `message_counts[i]` is the index of the first message created by
+    /// transaction `i + 1` or later.
+    pub message_counts: Vec<u32>,
     pub state_hash: CryptoHash,
 }
 
@@ -548,53 +552,22 @@ impl CertificateValue {
 }
 
 impl ExecutedBlock {
-    /// Returns the IDs of all applications that were created in this block.
-    pub fn created_application_ids(&self) -> impl Iterator<Item = ApplicationId> + '_ {
-        self.enumerate_messages()
-            .filter_map(|(index, outgoing_message)| {
-                if let Message::System(SystemMessage::ApplicationCreated { bytecode_id }) =
-                    outgoing_message.message
-                {
-                    Some(ApplicationId {
-                        bytecode_id,
-                        creation: self.message_id(index),
-                    })
-                } else {
-                    None
-                }
-            })
-    }
-
-    /// Returns the IDs of all bytecodes that were published in this block.
-    pub fn published_bytecode_ids(&self) -> impl Iterator<Item = BytecodeId> + '_ {
-        self.enumerate_messages()
-            .filter_map(|(index, outgoing_message)| {
-                matches!(
-                    outgoing_message.message,
-                    Message::System(SystemMessage::BytecodePublished { .. })
-                )
-                .then(|| BytecodeId::new(self.message_id(index)))
-            })
-    }
-
-    /// Returns the IDs of all messages that created a new chain in this block.
-    ///
-    /// Given the creation message ID `id`, the chain description is `ChainDescription::Child(id)`,
-    /// and the chain ID is `ChainId::from(ChainDescription::Child(id))`.
-    pub fn open_chain_message_ids(&self) -> impl Iterator<Item = MessageId> + '_ {
-        self.enumerate_messages()
-            .filter_map(|(index, outgoing_message)| {
-                matches!(
-                    outgoing_message.message,
-                    Message::System(SystemMessage::OpenChain { .. })
-                )
-                .then(|| self.message_id(index))
-            })
-    }
-
-    /// Returns all pairs of a message index and its outgoing message.
-    fn enumerate_messages(&self) -> impl Iterator<Item = (u32, &OutgoingMessage)> + '_ {
-        (0..=u32::MAX).zip(&self.messages)
+    /// Returns the `message_index`th outgoing message created by the `operation_index`th operation,
+    /// or `None` if there is no such operation or message.
+    pub fn message_id_for_operation(
+        &self,
+        operation_index: usize,
+        message_index: u32,
+    ) -> Option<MessageId> {
+        let block = &self.block;
+        let transaction_index = block.incoming_messages.len().checked_add(operation_index)?;
+        let first_message_index = match transaction_index.checked_sub(1) {
+            None => 0,
+            Some(index) => *self.message_counts.get(index)?,
+        };
+        let index = first_message_index.checked_add(message_index)?;
+        let next_transaction_index = *self.message_counts.get(transaction_index)?;
+        (index < next_transaction_index).then_some(self.message_id(index))
     }
 
     /// Returns the message ID belonging to the `index`th outgoing message in this block.

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -8,11 +8,11 @@ pub use multi::{MultiOwnerManager, MultiOwnerManagerInfo};
 pub use single::{SingleOwnerManager, SingleOwnerManagerInfo};
 
 use crate::{
-    data_types::{BlockProposal, Certificate, LiteVote, OutgoingMessage, Vote},
+    data_types::{BlockExecutionOutcome, BlockProposal, Certificate, LiteVote, Vote},
     ChainError,
 };
 use linera_base::{
-    crypto::{CryptoHash, KeyPair, PublicKey},
+    crypto::{KeyPair, PublicKey},
     data_types::{BlockHeight, RoundNumber, Timestamp},
     doc_scalar, ensure,
     identifiers::ChainId,
@@ -142,24 +142,13 @@ impl ChainManager {
     pub fn create_vote(
         &mut self,
         proposal: BlockProposal,
-        messages: Vec<OutgoingMessage>,
-        message_counts: Vec<u32>,
-        state_hash: CryptoHash,
+        outcome: BlockExecutionOutcome,
         key_pair: Option<&KeyPair>,
         now: Timestamp,
     ) {
         match self {
-            ChainManager::Single(manager) => {
-                manager.create_vote(proposal, messages, message_counts, state_hash, key_pair)
-            }
-            ChainManager::Multi(manager) => manager.create_vote(
-                proposal,
-                messages,
-                message_counts,
-                state_hash,
-                key_pair,
-                now,
-            ),
+            ChainManager::Single(manager) => manager.create_vote(proposal, outcome, key_pair),
+            ChainManager::Multi(manager) => manager.create_vote(proposal, outcome, key_pair, now),
             ChainManager::None => panic!("unexpected chain manager"),
         }
     }

--- a/linera-chain/src/manager/mod.rs
+++ b/linera-chain/src/manager/mod.rs
@@ -143,17 +143,23 @@ impl ChainManager {
         &mut self,
         proposal: BlockProposal,
         messages: Vec<OutgoingMessage>,
+        message_counts: Vec<u32>,
         state_hash: CryptoHash,
         key_pair: Option<&KeyPair>,
         now: Timestamp,
     ) {
         match self {
             ChainManager::Single(manager) => {
-                manager.create_vote(proposal, messages, state_hash, key_pair)
+                manager.create_vote(proposal, messages, message_counts, state_hash, key_pair)
             }
-            ChainManager::Multi(manager) => {
-                manager.create_vote(proposal, messages, state_hash, key_pair, now)
-            }
+            ChainManager::Multi(manager) => manager.create_vote(
+                proposal,
+                messages,
+                message_counts,
+                state_hash,
+                key_pair,
+                now,
+            ),
             ChainManager::None => panic!("unexpected chain manager"),
         }
     }

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -53,13 +53,13 @@
 use super::Outcome;
 use crate::{
     data_types::{
-        BlockAndRound, BlockProposal, Certificate, CertificateValue, ExecutedBlock, HashedValue,
-        LiteVote, OutgoingMessage, Vote,
+        BlockAndRound, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue,
+        HashedValue, LiteVote, Vote,
     },
     ChainError,
 };
 use linera_base::{
-    crypto::{CryptoHash, KeyPair, PublicKey},
+    crypto::{KeyPair, PublicKey},
     data_types::{BlockHeight, RoundNumber, Timestamp},
     ensure,
     identifiers::{ChainId, Owner},
@@ -268,9 +268,7 @@ impl MultiOwnerManager {
     pub fn create_vote(
         &mut self,
         proposal: BlockProposal,
-        messages: Vec<OutgoingMessage>,
-        message_counts: Vec<u32>,
-        state_hash: CryptoHash,
+        outcome: BlockExecutionOutcome,
         key_pair: Option<&KeyPair>,
         now: Timestamp,
     ) {
@@ -292,12 +290,7 @@ impl MultiOwnerManager {
         if let Some(key_pair) = key_pair {
             // Vote to validate.
             let BlockAndRound { block, round } = proposal.content;
-            let executed_block = ExecutedBlock {
-                block,
-                messages,
-                message_counts,
-                state_hash,
-            };
+            let executed_block = outcome.with(block);
             let vote = Vote::new(HashedValue::new_validated(executed_block), round, key_pair);
             self.pending = Some(vote);
         }

--- a/linera-chain/src/manager/multi.rs
+++ b/linera-chain/src/manager/multi.rs
@@ -269,6 +269,7 @@ impl MultiOwnerManager {
         &mut self,
         proposal: BlockProposal,
         messages: Vec<OutgoingMessage>,
+        message_counts: Vec<u32>,
         state_hash: CryptoHash,
         key_pair: Option<&KeyPair>,
         now: Timestamp,
@@ -294,6 +295,7 @@ impl MultiOwnerManager {
             let executed_block = ExecutedBlock {
                 block,
                 messages,
+                message_counts,
                 state_hash,
             };
             let vote = Vote::new(HashedValue::new_validated(executed_block), round, key_pair);

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -77,6 +77,7 @@ impl SingleOwnerManager {
         &mut self,
         proposal: BlockProposal,
         messages: Vec<OutgoingMessage>,
+        message_counts: Vec<u32>,
         state_hash: CryptoHash,
         key_pair: Option<&KeyPair>,
     ) {
@@ -90,6 +91,7 @@ impl SingleOwnerManager {
             let executed_block = ExecutedBlock {
                 block,
                 messages,
+                message_counts,
                 state_hash,
             };
             let value = HashedValue::from(CertificateValue::ConfirmedBlock { executed_block });

--- a/linera-chain/src/manager/single.rs
+++ b/linera-chain/src/manager/single.rs
@@ -4,13 +4,13 @@
 use super::Outcome;
 use crate::{
     data_types::{
-        BlockAndRound, BlockProposal, CertificateValue, ExecutedBlock, HashedValue, LiteVote,
-        OutgoingMessage, Vote,
+        BlockAndRound, BlockExecutionOutcome, BlockProposal, CertificateValue, HashedValue,
+        LiteVote, Vote,
     },
     ChainError,
 };
 use linera_base::{
-    crypto::{CryptoHash, KeyPair, PublicKey},
+    crypto::{KeyPair, PublicKey},
     data_types::RoundNumber,
     ensure,
     identifiers::Owner,
@@ -76,9 +76,7 @@ impl SingleOwnerManager {
     pub fn create_vote(
         &mut self,
         proposal: BlockProposal,
-        messages: Vec<OutgoingMessage>,
-        message_counts: Vec<u32>,
-        state_hash: CryptoHash,
+        outcome: BlockExecutionOutcome,
         key_pair: Option<&KeyPair>,
     ) {
         if let Some(key_pair) = key_pair {
@@ -88,12 +86,7 @@ impl SingleOwnerManager {
                 info!("Single-owner chains always have round number 0.");
                 return;
             }
-            let executed_block = ExecutedBlock {
-                block,
-                messages,
-                message_counts,
-                state_hash,
-            };
+            let executed_block = outcome.with(block);
             let value = HashedValue::from(CertificateValue::ConfirmedBlock { executed_block });
             let vote = Vote::new(value, round, key_pair);
             self.pending = Some(vote);

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -18,6 +18,7 @@ fn test_signed_values() {
     let executed_block = ExecutedBlock {
         block,
         messages: Vec::new(),
+        message_counts: vec![1],
         state_hash: CryptoHash::new(&Dummy),
     };
     let value = HashedValue::new_confirmed(executed_block);
@@ -45,6 +46,7 @@ fn test_certificates() {
     let executed_block = ExecutedBlock {
         block,
         messages: Vec::new(),
+        message_counts: vec![1],
         state_hash: CryptoHash::new(&Dummy),
     };
     let value = HashedValue::new_confirmed(executed_block);

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -149,6 +149,7 @@ where
             is_skippable: false,
             message: Message::System(publish_message.clone()),
         }],
+        message_counts: vec![1],
         state_hash: publisher_state_hash,
     });
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
@@ -208,6 +209,7 @@ where
             is_skippable: false,
             message: Message::System(broadcast_message.clone()),
         }],
+        message_counts: vec![1],
         state_hash: publisher_state_hash,
     });
     let broadcast_certificate = make_certificate(&committee, &worker, broadcast_block_proposal);
@@ -257,6 +259,7 @@ where
             is_skippable: false,
             message: Message::System(subscribe_message.clone()),
         }],
+        message_counts: vec![1],
         state_hash: creator_state.crypto_hash().await?,
     });
     let subscribe_certificate = make_certificate(&committee, &worker, subscribe_block_proposal);
@@ -301,6 +304,7 @@ where
                 id: creator_chain.into(),
             }),
         }],
+        message_counts: vec![1],
         state_hash: publisher_state_hash,
     });
     let accept_certificate = make_certificate(&committee, &worker, accept_block_proposal);
@@ -385,6 +389,7 @@ where
             is_skippable: false,
             message: Message::System(SystemMessage::ApplicationCreated { bytecode_id }),
         }],
+        message_counts: vec![0, 1],
         state_hash: creator_state.crypto_hash().await?,
     });
     let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
@@ -431,6 +436,7 @@ where
     let run_block_proposal = HashedValue::new_confirmed(ExecutedBlock {
         block: run_block,
         messages: vec![],
+        message_counts: vec![0],
         state_hash: creator_state.crypto_hash().await?,
     });
     let run_certificate = make_certificate(&committee, &worker, run_block_proposal);

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -387,7 +387,7 @@ where
             destination: Destination::Recipient(creator_chain.into()),
             authenticated_signer: None,
             is_skippable: false,
-            message: Message::System(SystemMessage::ApplicationCreated { bytecode_id }),
+            message: Message::System(SystemMessage::ApplicationCreated),
         }],
         message_counts: vec![0, 1],
         state_hash: creator_state.crypto_hash().await?,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -211,6 +211,11 @@ async fn make_transfer_certificate_for_epoch<S>(
         None => make_first_block(chain_id),
         Some(cert) => make_child_block(&cert.value),
     };
+    let message_counts = incoming_messages
+        .iter()
+        .map(|_| 0)
+        .chain(iter::once(1))
+        .collect();
     let block = Block {
         epoch,
         incoming_messages,
@@ -228,6 +233,7 @@ async fn make_transfer_certificate_for_epoch<S>(
     let value = HashedValue::new_confirmed(ExecutedBlock {
         block,
         messages,
+        message_counts,
         state_hash,
     });
     make_certificate(committee, worker, value)
@@ -479,6 +485,7 @@ where
         let value = HashedValue::new_confirmed(ExecutedBlock {
             block,
             messages: vec![],
+            message_counts: vec![],
             state_hash,
         });
         make_certificate(&committee, &worker, value)
@@ -744,6 +751,7 @@ where
                 direct_credit_message(ChainId::root(2), Amount::ONE),
                 direct_credit_message(ChainId::root(2), Amount::from_tokens(2)),
             ],
+            message_counts: vec![1, 2],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: [(epoch, committee.clone())].into_iter().collect(),
                 ownership: ChainOwnership::single(sender_key_pair.public()),
@@ -764,6 +772,7 @@ where
                 ChainId::root(2),
                 Amount::from_tokens(3),
             )],
+            message_counts: vec![1],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: [(epoch, committee.clone())].into_iter().collect(),
                 ownership: ChainOwnership::single(sender_key_pair.public()),
@@ -1017,6 +1026,7 @@ where
             HashedValue::new_confirmed(ExecutedBlock {
                 block: block_proposal.content.block,
                 messages: vec![direct_credit_message(ChainId::root(3), Amount::ONE)],
+                message_counts: vec![0, 1],
                 state_hash: make_state_hash(SystemExecutionState {
                     committees: [(epoch, committee.clone())].into_iter().collect(),
                     ownership: ChainOwnership::single(recipient_key_pair.public()),
@@ -2364,6 +2374,7 @@ where
                     },
                 ),
             ],
+            message_counts: vec![2],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: committees.clone(),
                 ownership: ChainOwnership::single(key_pair.public()),
@@ -2423,6 +2434,7 @@ where
                 ),
                 direct_credit_message(user_id, Amount::from_tokens(2)),
             ],
+            message_counts: vec![1, 2],
             state_hash: make_state_hash(SystemExecutionState {
                 epoch: Some(Epoch::from(1)),
                 description: Some(ChainDescription::Root(0)),
@@ -2466,6 +2478,7 @@ where
                 user_id,
                 SystemMessage::Notify { id: user_id },
             )],
+            message_counts: vec![1],
             state_hash: make_state_hash(SystemExecutionState {
                 // The root chain knows both committees at the end.
                 committees: committees2.clone(),
@@ -2626,6 +2639,7 @@ where
                     },
                 }),
             messages: Vec::new(),
+            message_counts: vec![0, 0, 0, 0],
             state_hash: make_state_hash(SystemExecutionState {
                 subscriptions: [ChannelSubscription {
                     chain_id: admin_id,
@@ -2758,6 +2772,7 @@ where
             block: make_first_block(user_id)
                 .with_simple_transfer(Recipient::chain(admin_id), Amount::ONE),
             messages: vec![direct_credit_message(admin_id, Amount::ONE)],
+            message_counts: vec![1],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: committees.clone(),
                 ownership: ChainOwnership::single(key_pair1.public()),
@@ -2789,6 +2804,7 @@ where
                     committees: committees2.clone(),
                 },
             )],
+            message_counts: vec![1],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: committees2.clone(),
                 ownership: ChainOwnership::single(key_pair0.public()),
@@ -2903,6 +2919,7 @@ where
             block: make_first_block(user_id)
                 .with_simple_transfer(Recipient::chain(admin_id), Amount::ONE),
             messages: vec![direct_credit_message(admin_id, Amount::ONE)],
+            message_counts: vec![1],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: committees.clone(),
                 ownership: ChainOwnership::single(key_pair1.public()),
@@ -2946,6 +2963,7 @@ where
                     },
                 ),
             ],
+            message_counts: vec![1, 2],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: committees3.clone(),
                 ownership: ChainOwnership::single(key_pair0.public()),
@@ -3009,6 +3027,7 @@ where
                     },
                 }),
             messages: Vec::new(),
+            message_counts: vec![0],
             state_hash: make_state_hash(SystemExecutionState {
                 committees: committees3.clone(),
                 ownership: ChainOwnership::single(key_pair0.public()),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -176,6 +176,8 @@ pub enum WorkerError {
     IncorrectStateHash,
     #[error("The given messages are not what we computed after executing the block")]
     IncorrectMessages,
+    #[error("The given message counts are not what we computed after executing the block")]
+    IncorrectMessageCounts,
     #[error("The timestamp of a Tick operation is in the future.")]
     InvalidTimestamp,
     #[error("We don't have the value for the certificate.")]
@@ -364,14 +366,8 @@ where
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         let mut chain = self.storage.load_active_chain(block.chain_id).await?;
         let now = self.storage.current_time();
-        let (messages, message_counts, state_hash) = chain.execute_block(&block, now).await?;
+        let executed_block = chain.execute_block(&block, now).await?.with(block);
         let response = ChainInfoResponse::new(&chain, None);
-        let executed_block = ExecutedBlock {
-            block,
-            messages,
-            message_counts,
-            state_hash,
-        };
         // Do not save the new state.
         Ok((executed_block, response))
     }
@@ -561,18 +557,17 @@ where
         chain.remove_events_from_inboxes(block).await?;
         // We should always agree on the messages and state hash.
         let now = self.storage.current_time();
-        let (verified_messages, verified_message_counts, verified_state_hash) =
-            chain.execute_block(block, now).await?;
+        let verified_outcome = chain.execute_block(block, now).await?;
         ensure!(
-            *messages == verified_messages,
+            *messages == verified_outcome.messages,
             WorkerError::IncorrectMessages
         );
         ensure!(
-            *message_counts == verified_message_counts,
-            WorkerError::IncorrectMessages
+            *message_counts == verified_outcome.message_counts,
+            WorkerError::IncorrectMessageCounts
         );
         ensure!(
-            *state_hash == verified_state_hash,
+            *state_hash == verified_outcome.state_hash,
             WorkerError::IncorrectStateHash
         );
         // Advance to next block height.
@@ -1014,21 +1009,14 @@ where
             tokio::time::sleep(Duration::from_micros(time_till_block)).await;
         }
         let now = self.storage.current_time();
-        let (messages, message_counts, state_hash) = chain.execute_block(block, now).await?;
+        let outcome = chain.execute_block(block, now).await?;
         // Verify that the resulting chain would have no unconfirmed incoming messages.
         chain.validate_incoming_messages().await?;
         // Reset all the staged changes as we were only validating things.
         chain.rollback();
         // Create the vote and store it in the chain state.
         let manager = chain.manager.get_mut();
-        manager.create_vote(
-            proposal,
-            messages,
-            message_counts,
-            state_hash,
-            self.key_pair(),
-            now,
-        );
+        manager.create_vote(proposal, outcome, self.key_pair(), now);
         // Cache the value we voted on, so the client doesn't have to send it again.
         if let Some(vote) = manager.pending() {
             self.cache_recent_value(Cow::Borrowed(&vote.value)).await;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -35,6 +35,15 @@ use thiserror::Error;
 #[cfg(any(test, feature = "test"))]
 use {crate::applications::ApplicationRegistry, std::collections::BTreeSet};
 
+/// The relative index of the `OpenChain` message created by the `OpenChain` operation.
+pub static OPEN_CHAIN_MESSAGE_INDEX: u32 = 0;
+/// The relative index of the `ApplicationCreated` message created by the `CreateApplication`
+/// operation.
+pub static CREATE_APPLICATION_MESSAGE_INDEX: u32 = 0;
+/// The relative index of the `BytecodePublished` message created by the `PublishBytecode`
+/// operation.
+pub static PUBLISH_BYTECODE_MESSAGE_INDEX: u32 = 0;
+
 /// A view accessing the execution state of the system of a chain.
 #[derive(Debug, HashableView)]
 pub struct SystemExecutionStateView<C> {
@@ -518,6 +527,7 @@ where
                         subscription,
                     },
                 };
+                debug_assert_eq!(0, OPEN_CHAIN_MESSAGE_INDEX);
                 result.messages.extend([e1, e2]);
             }
             ChangeOwner { new_public_key } => {
@@ -728,6 +738,7 @@ where
                         operation_index: context.index,
                     },
                 };
+                debug_assert_eq!(0, PUBLISH_BYTECODE_MESSAGE_INDEX);
                 result.messages.push(message);
             }
             CreateApplication {
@@ -756,6 +767,7 @@ where
                         bytecode_id: *bytecode_id,
                     },
                 };
+                debug_assert_eq!(0, CREATE_APPLICATION_MESSAGE_INDEX);
                 result.messages.push(message);
                 new_application = Some((id, initialization_argument.clone()));
             }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -213,7 +213,7 @@ pub enum SystemMessage {
     /// Notifies that a new application bytecode was published.
     BytecodePublished { operation_index: u32 },
     /// Notifies that a new application was created.
-    ApplicationCreated { bytecode_id: BytecodeId },
+    ApplicationCreated,
     /// Shares the locations of published bytecodes.
     BytecodeLocations {
         locations: Vec<(BytecodeId, BytecodeLocation)>,
@@ -256,7 +256,7 @@ impl SystemMessage {
             | SystemMessage::SetCommittees { .. }
             | SystemMessage::Subscribe { .. }
             | SystemMessage::Unsubscribe { .. }
-            | SystemMessage::ApplicationCreated { .. }
+            | SystemMessage::ApplicationCreated
             | SystemMessage::Notify { .. }
             | SystemMessage::RequestApplication(_) => Box::new(iter::empty()),
         }
@@ -527,7 +527,6 @@ where
                         subscription,
                     },
                 };
-                debug_assert_eq!(0, OPEN_CHAIN_MESSAGE_INDEX);
                 result.messages.extend([e1, e2]);
             }
             ChangeOwner { new_public_key } => {
@@ -738,7 +737,6 @@ where
                         operation_index: context.index,
                     },
                 };
-                debug_assert_eq!(0, PUBLISH_BYTECODE_MESSAGE_INDEX);
                 result.messages.push(message);
             }
             CreateApplication {
@@ -763,11 +761,8 @@ where
                     destination: Destination::Recipient(context.chain_id),
                     authenticated: false,
                     is_skippable: false,
-                    message: SystemMessage::ApplicationCreated {
-                        bytecode_id: *bytecode_id,
-                    },
+                    message: SystemMessage::ApplicationCreated,
                 };
-                debug_assert_eq!(0, CREATE_APPLICATION_MESSAGE_INDEX);
                 result.messages.push(message);
                 new_application = Some((id, initialization_argument.clone()));
             }
@@ -899,7 +894,7 @@ where
                     self.registry.register_published_bytecode(*id, *location)?;
                 }
             }
-            ApplicationCreated { .. } | Notify { .. } => (),
+            ApplicationCreated | Notify { .. } => (),
             OpenChain { .. } => {
                 // This special message is executed immediately when cross-chain requests are received.
             }
@@ -986,5 +981,182 @@ where
             balance: *self.balance.get(),
         };
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ExecutionStateView, TestExecutionRuntimeContext};
+    use linera_base::{
+        crypto::{BcsSignable, KeyPair},
+        data_types::BlockHeight,
+        identifiers::ApplicationId,
+    };
+    use linera_views::memory::MemoryContext;
+
+    #[derive(Deserialize, Serialize)]
+    pub struct Dummy;
+
+    impl BcsSignable for Dummy {}
+
+    #[tokio::test]
+    async fn bytecode_message_index() {
+        let description = ChainDescription::Root(5);
+        let chain_id = ChainId::from(description);
+        let state = SystemExecutionState {
+            description: Some(description),
+            ..SystemExecutionState::default()
+        };
+        let mut view =
+            ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+                state,
+            )
+            .await;
+
+        let height = BlockHeight::from(7);
+        let next_message_index = 8;
+        let operation_index = 2;
+        let context = OperationContext {
+            chain_id,
+            authenticated_signer: None,
+            height,
+            index: operation_index,
+            next_message_index,
+        };
+        let operation = SystemOperation::PublishBytecode {
+            contract: Bytecode::new(vec![]),
+            service: Bytecode::new(vec![]),
+        };
+        let (result, new_application) = view
+            .system
+            .execute_operation(&context, &operation)
+            .await
+            .unwrap();
+        assert_eq!(new_application, None);
+        assert_eq!(
+            result.messages[PUBLISH_BYTECODE_MESSAGE_INDEX as usize].message,
+            SystemMessage::BytecodePublished { operation_index }
+        );
+    }
+
+    #[tokio::test]
+    async fn application_message_index() {
+        let description = ChainDescription::Root(5);
+        let chain_id = ChainId::from(description);
+        let state = SystemExecutionState {
+            description: Some(description),
+            ..SystemExecutionState::default()
+        };
+        let mut view =
+            ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+                state,
+            )
+            .await;
+
+        let height = BlockHeight::from(7);
+        let next_message_index = 8;
+        let operation_index = 2;
+        let context = OperationContext {
+            chain_id,
+            authenticated_signer: None,
+            height,
+            index: operation_index,
+            next_message_index,
+        };
+
+        let bytecode_id = BytecodeId::new(MessageId {
+            chain_id,
+            height: BlockHeight::from(5),
+            index: 0,
+        });
+        let location = BytecodeLocation {
+            certificate_hash: CryptoHash::new(&Dummy),
+            operation_index: 1,
+        };
+        view.system
+            .registry
+            .register_published_bytecode(bytecode_id, location)
+            .unwrap();
+
+        let operation = SystemOperation::CreateApplication {
+            bytecode_id,
+            parameters: vec![],
+            initialization_argument: vec![],
+            required_application_ids: vec![],
+        };
+        let (result, new_application) = view
+            .system
+            .execute_operation(&context, &operation)
+            .await
+            .unwrap();
+        assert_eq!(
+            result.messages[CREATE_APPLICATION_MESSAGE_INDEX as usize].message,
+            SystemMessage::ApplicationCreated
+        );
+        let creation = MessageId {
+            chain_id,
+            height,
+            index: next_message_index + CREATE_APPLICATION_MESSAGE_INDEX,
+        };
+        let id = ApplicationId {
+            bytecode_id,
+            creation,
+        };
+        assert_eq!(new_application, Some((id, vec![])));
+    }
+
+    #[tokio::test]
+    async fn open_chain_message_index() {
+        let description = ChainDescription::Root(6);
+        let epoch = Epoch(1);
+        let admin_id = ChainId::root(0);
+        let chain_id = ChainId::from(description);
+        let committees = BTreeMap::new();
+        let state = SystemExecutionState {
+            description: Some(description),
+            epoch: Some(epoch),
+            admin_id: Some(admin_id),
+            committees: committees.clone(),
+            ..SystemExecutionState::default()
+        };
+        let mut view =
+            ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+                state,
+            )
+            .await;
+
+        let height = BlockHeight::from(2);
+        let next_message_index = 5;
+        let operation_index = 8;
+        let context = OperationContext {
+            chain_id,
+            authenticated_signer: None,
+            height,
+            index: operation_index,
+            next_message_index,
+        };
+        let ownership = ChainOwnership::single(KeyPair::generate().public());
+        let operation = SystemOperation::OpenChain {
+            ownership: ownership.clone(),
+            committees: committees.clone(),
+            epoch,
+            admin_id,
+        };
+        let (result, new_application) = view
+            .system
+            .execute_operation(&context, &operation)
+            .await
+            .unwrap();
+        assert_eq!(new_application, None);
+        assert_eq!(
+            result.messages[OPEN_CHAIN_MESSAGE_INDEX as usize].message,
+            SystemMessage::OpenChain {
+                ownership,
+                committees,
+                admin_id,
+                epoch
+            }
+        );
     }
 }

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -17,7 +17,7 @@ test('Block mounting', () => {
               timestamp: 1694097511817833,
               authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
               previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-              incomingMessages: [ {
+              incomingMessages: [{
                 origin: {
                   medium: "Direct",
                   sender: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
@@ -28,14 +28,14 @@ test('Block mounting', () => {
                   height: 5,
                   index: 0,
                   message: {
-                    System: { BytecodePublished: {operation_index: 0 } }
+                    System: { BytecodePublished: { operation_index: 0 } }
                   },
                   timestamp: 1694097510206912
                 }
-              } ],
+              }],
               operations: []
             },
-            messages: [ {
+            messages: [{
               destination: { Subscribers: [1] },
               authenticatedSigner: null,
               isSkippable: false,
@@ -45,14 +45,15 @@ test('Block mounting', () => {
                     locations: [
                       [
                         "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
-                        { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 } ],
+                        { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
                       [
                         "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
-                        { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 } ] ]
+                        { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
                   }
                 }
               }
-            } ],
+            }],
+            messageCounts: [1],
             stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a"
           }
         }

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -19,7 +19,7 @@ test('Blocks mounting', () => {
                   timestamp: 1694097511817833,
                   authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
                   previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-                  incomingMessages: [ {
+                  incomingMessages: [{
                     origin: {
                       medium: "Direct",
                       sender: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
@@ -30,14 +30,14 @@ test('Blocks mounting', () => {
                       height: 5,
                       index: 0,
                       message: {
-                        System: { BytecodePublished: {operation_index: 0 } }
+                        System: { BytecodePublished: { operation_index: 0 } }
                       },
                       timestamp: 1694097510206912
                     }
-                  } ],
+                  }],
                   operations: []
                 },
-                messages: [ {
+                messages: [{
                   destination: { Subscribers: [1] },
                   authenticatedSigner: null,
                   isSkippable: false,
@@ -47,14 +47,15 @@ test('Blocks mounting', () => {
                         locations: [
                           [
                             "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
-                            { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 } ],
+                            { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
                           [
                             "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
-                            { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 } ] ]
+                            { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
                       }
                     }
                   }
-                } ],
+                }],
+                messageCounts: [1],
                 stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a"
               }
             }

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -607,6 +607,7 @@ pub mod tests {
             HashedValue::new_validated(ExecutedBlock {
                 block: get_block(),
                 messages: vec![],
+                message_counts: vec![],
                 state_hash: CryptoHash::new(&Foo("test".into())),
             }),
             RoundNumber(3),
@@ -618,6 +619,7 @@ pub mod tests {
         let blobs = vec![HashedValue::new_validated(ExecutedBlock {
             block: get_block(),
             messages: vec![],
+            message_counts: vec![],
             state_hash: CryptoHash::new(&Foo("also test".into())),
         })];
         let request = HandleCertificateRequest {
@@ -666,12 +668,14 @@ pub mod tests {
             blobs: vec![HashedValue::new_confirmed(ExecutedBlock {
                 block: get_block(),
                 messages: vec![],
+                message_counts: vec![],
                 state_hash: CryptoHash::new(&Foo("execution state".into())),
             })],
             validated: Some(Certificate::new(
                 HashedValue::new_validated(ExecutedBlock {
                     block: get_block(),
                     messages: vec![],
+                    message_counts: vec![],
                     state_hash: CryptoHash::new(&Foo("validated".into())),
                 }),
                 RoundNumber(3),

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -731,10 +731,7 @@ SystemMessage:
         STRUCT:
           - operation_index: U32
     7:
-      ApplicationCreated:
-        STRUCT:
-          - bytecode_id:
-              TYPENAME: BytecodeId
+      ApplicationCreated: UNIT
     8:
       BytecodeLocations:
         STRUCT:

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -339,6 +339,8 @@ ExecutedBlock:
     - messages:
         SEQ:
           TYPENAME: OutgoingMessage
+    - message_counts:
+        SEQ: U32
     - state_hash:
         TYPENAME: CryptoHash
 GenericApplicationId:

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -38,6 +38,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           isSkippable
           message
         }
+        messageCounts
         stateHash
       }
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -245,6 +245,12 @@ A block, together with the messages and the state hash resulting from its execut
 type ExecutedBlock {
 	block: Block!
 	messages: [OutgoingMessage!]!
+	"""
+	For each transaction, the cumulative number of messages created by this and all previous
+	transactions, i.e. `message_counts[i]` is the index of the first message created by
+	transaction `i + 1` or later.
+	"""
+	messageCounts: [Int!]!
 	stateHash: CryptoHash!
 }
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -167,6 +167,7 @@ mod from {
             let block::BlockBlockValueExecutedBlock {
                 block,
                 messages,
+                message_counts,
                 state_hash,
             } = val;
             let messages: Vec<OutgoingMessage> =
@@ -174,6 +175,7 @@ mod from {
             ExecutedBlock {
                 block: block.into(),
                 messages,
+                message_counts: message_counts.into_iter().map(|c| c as u32).collect(),
                 state_hash,
             }
         }


### PR DESCRIPTION
## Motivation

When creating a new application, publishing bytecode or opening a new chain, we currently iterate through the executed block's outgoing messages to find the ID of the message used in the application ID, bytecode ID or chain ID.

In general, the current `ExecutedBlock` structure does not allow mapping the transactions (incoming messages and operations) to the outgoing messages they produced. The outgoing messages are all in one single vector.

## Proposal

Store another vector of cumulative message counts. This way, one can look up the index of the first outgoing message belonging to a particular transaction.

## Test Plan

There are already tests for the three chain operations that use this. These would fail if we now returned wrong IDs.

## Release Plan

- Might need to bump the major/minor version number in the next release of the crates? It changes the format of a `Certificate`.

## Links

- Closes #1102.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
