### PR TITLE
Fix RUST_LOG=debug cargo test readme

### DIFF
--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -27,7 +27,10 @@ async fn test_examples_in_readme() -> std::io::Result<()> {
     write!(&mut test_script, "{}", quote)?;
 
     let status = Command::new("bash")
-        .current_dir("..") // root of the repo
+        // Run from the root of the repo.
+        .current_dir("..")
+        // Increase log verbosity to verify that services can write to stderr.
+        .env("RUST_LOG", "linera_service=debug")
         .arg("-e")
         .arg("-x")
         .arg(dir.path().join("test.sh"))

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -14,7 +14,11 @@ function spawn_and_set_wallet_env_vars() {
 
     trap 'jobs -p | xargs -r kill && rm -rf "$DIR"' EXIT
 
-    "$@" 2> >(tee "$ERR") 1>"$OUT" &
+    (
+        # Ignoring SIGPIPE to keep `tee` alive after `sed` exits below, closing $ERR.
+        trap '' PIPE
+        "$@" 2> >(tee "$ERR" 2>/dev/null) 1>"$OUT" &
+    )
 
     sed -n '/^READY!/q' <"$ERR" || exit 1
 


### PR DESCRIPTION
## Motivation

Fix `RUST_LOG=debug cargo test readme` (broken by #1126)

## Proposal

Call `trap SIGPIPE` to keep `tee` alive.

## Test Plan

CI
