### PR TITLE
CI: build example applications ahead of tests for DynamoDb and ScyllaDb

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -45,6 +45,10 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build example applications
+      run: |
+        cd examples
+        cargo build --locked --release --target wasm32-unknown-unknown
     - name: Build
       run: |
         cargo build --locked --features aws

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -45,6 +45,10 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build example applications
+      run: |
+        cd examples
+        cargo build --locked --release --target wasm32-unknown-unknown
     - name: Build
       run: |
         cargo build --locked --features scylladb


### PR DESCRIPTION
## Motivation

We do this for Rocksdb tests. Applications are built in the middle of the tests otherwise.

## Proposal

Copy the relevant CI step.

## Test Plan

CI
