### PR TITLE
Make Linera net helper script available to users of `cargo install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ The Linera protocol repository is broken down into the following crates and subd
 # cargo build -p linera-service --bins
 export PATH="$PWD/target/debug:$PATH"
 
-# Import the optional bash helper function `spawn_and_set_wallet_env_vars`.
-source scripts/linera_net_helper.sh
+# Import the optional helper function `spawn_and_set_wallet_env_vars`.
+source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
 
 # Run a local test network with the default parameters and 0 extra user wallets.
+# This will set environment variables LINERA_{WALLET,STORAGE}_0 referenced by -w0 below.
 spawn_and_set_wallet_env_vars \
     linera net up --extra-wallets 0
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ The Linera protocol repository is broken down into the following crates and subd
 # cargo build -p linera-service --bins
 export PATH="$PWD/target/debug:$PATH"
 
-# Import the optional helper function `spawn_and_set_wallet_env_vars`.
+# Import the optional helper function `linera_spawn_and_read_wallet_variables`.
 source /dev/stdin <<<"$(linera net helper 2>/dev/null)"
 
 # Run a local test network with the default parameters and 0 extra user wallets.
 # This will set environment variables LINERA_{WALLET,STORAGE}_0 referenced by -w0 below.
-spawn_and_set_wallet_env_vars \
+linera_spawn_and_read_wallet_variables \
     linera net up --extra-wallets 0
 
 # Print the set of validators.

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1941,7 +1941,7 @@ async fn main() -> Result<(), anyhow::Error> {
             NetCommand::Helper => {
                 info!("You may append the following script to your `~/.bash_profile` or `source` it when needed.");
                 info!(
-                    "This will install a function `spawn_and_set_wallet_env_vars` to facilitate \
+                    "This will install a function `linera_spawn_and_read_wallet_variables` to facilitate \
                        testing with a local Linera network"
                 );
                 println!("{}", include_str!("../template/linera_net_helper.sh"));

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1040,6 +1040,10 @@ enum NetCommand {
         #[structopt(long, default_value = "table_default")]
         table_name: String,
     },
+
+    /// Print a bash helper script to make `linera net up` easier to use. The script is
+    /// meant to be installed in `~/.bash_profile` or sourced when needed.
+    Helper,
 }
 
 #[derive(StructOpt)]
@@ -1931,6 +1935,16 @@ async fn main() -> Result<(), anyhow::Error> {
                     _ = sigterm.recv() => (),
                 }
                 eprintln!("\nDone.");
+                Ok(())
+            }
+
+            NetCommand::Helper => {
+                info!("You may append the following script to your `~/.bash_profile` or `source` it when needed.");
+                info!(
+                    "This will install a function `spawn_and_set_wallet_env_vars` to facilitate \
+                       testing with a local Linera network"
+                );
+                println!("{}", include_str!("../template/linera_net_helper.sh"));
                 Ok(())
             }
         },

--- a/linera-service/template/linera_net_helper.sh
+++ b/linera-service/template/linera_net_helper.sh
@@ -1,0 +1,1 @@
+../../scripts/linera_net_helper.sh

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -3,7 +3,7 @@
 # - Waits for the background process to print READY! on stderr
 # - Then executes the bash command recorded from stdout
 # - Returns without killing the process
-function spawn_and_set_wallet_env_vars() {
+function linera_spawn_and_read_wallet_variables() {
     DIR=$(mktemp -d "${TMPDIR:-.}tmp-XXXXX") || exit 1
     OUT="$DIR/out"
     ERR="$DIR/err"

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -1,6 +1,3 @@
-# Copyright (c) Zefchain Labs, Inc.
-# SPDX-License-Identifier: Apache-2.0
-
 # Runs a command such as `linera net up` in the background.
 # - Records stdout
 # - Waits for the background process to print READY! on stderr

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -4,20 +4,37 @@
 # - Then executes the bash command recorded from stdout
 # - Returns without killing the process
 function linera_spawn_and_read_wallet_variables() {
-    DIR=$(mktemp -d "${TMPDIR:-.}tmp-XXXXX") || exit 1
-    OUT="$DIR/out"
-    ERR="$DIR/err"
-    mkfifo "$ERR" || exit 1
+    LINERA_TMP_DIR=$(mktemp -d "${TMPDIR:-.}tmp-XXXXX") || exit 1
 
-    trap 'jobs -p | xargs -r kill && rm -rf "$DIR"' EXIT
+    # Clean up the temporary directory in case we exit.
+    trap 'rm -rf "$LINERA_TMP_DIR"' EXIT
+
+    LINERA_TMP_PID="$LINERA_TMP_DIR/pid"
+    LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
+    LINERA_TMP_ERR="$LINERA_TMP_DIR/err"
+    mkfifo "$LINERA_TMP_ERR" || exit 1
 
     (
-        # Ignoring SIGPIPE to keep `tee` alive after `sed` exits below, closing $ERR.
+        # Ignoring SIGPIPE to keep `tee` alive after `sed` exits below, closing
+        # LINERA_TMP_ERR.
         trap '' PIPE
-        "$@" 2> >(tee "$ERR" 2>/dev/null) 1>"$OUT" &
+
+        # Start the main process.
+        "$@" 2> >(tee "$LINERA_TMP_ERR" 2>/dev/null) 1>"$LINERA_TMP_OUT" &
+
+        # Remember the PID of the service for later.
+        jobs -p > "$LINERA_TMP_PID"
     )
+    LINERA_NET_PID=$(cat "$LINERA_TMP_PID")
 
-    sed -n '/^READY!/q' <"$ERR" || exit 1
+    # When the shell exits, we will clean up the top-level jobs (if any), the temporary
+    # directory, and the main process. Handling future top-level jobs here is useful
+    # because calling `trap` again will be replace this handler.
+    trap 'jobs -p | xargs -r kill && rm -rf "$LINERA_TMP_DIR" && kill "$LINERA_NET_PID"' EXIT
 
-    source "$OUT"
+    # Read from LINERA_TMP_ERR until the string "READY!" is found.
+    sed -n '/^READY!/q' <"$LINERA_TMP_ERR" || exit 1
+
+    # Source the Bash commands output by the server.
+    source "$LINERA_TMP_OUT"
 }


### PR DESCRIPTION
## Motivation

Currently `linera_net_helper.sh` requires the Linera repository.

## Proposal

Create a new command `linera net helper` that prints the script on stdout.

Users may append the script to their `~/.bash_profile` or `source` it every time.

## Test Plan

Modified README example.
