### PR TITLE
Implement storage fees and limits

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -23,7 +23,7 @@ use linera_execution::{
     system::{Account, SystemMessage},
     ExecutionResult, ExecutionRuntimeContext, ExecutionStateView, GenericApplicationId, Message,
     MessageContext, OperationContext, Query, QueryContext, RawExecutionResult, RawOutgoingMessage,
-    Response, RuntimeTracker, UserApplicationDescription, UserApplicationId,
+    ResourceTracker, Response, UserApplicationDescription, UserApplicationId,
 };
 use linera_views::{
     common::Context,
@@ -509,7 +509,7 @@ where
         let mut message_counts = Vec::new();
         let maximum_bytes_read = policy.maximum_bytes_read;
         let maximum_bytes_written = policy.maximum_bytes_written;
-        let mut runtime_track = RuntimeTracker {
+        let mut tracker = ResourceTracker {
             used_fuel: 0,
             num_reads: 0,
             bytes_read: 0,
@@ -533,12 +533,7 @@ where
             };
             let results = self
                 .execution_state
-                .execute_message(
-                    &context,
-                    &message.event.message,
-                    &policy,
-                    &mut runtime_track,
-                )
+                .execute_message(&context, &message.event.message, &policy, &mut tracker)
                 .await
                 .map_err(|err| {
                     ChainError::ExecutionError(err, ChainExecutionContext::IncomingMessage(index))
@@ -562,7 +557,7 @@ where
             };
             let results = self
                 .execution_state
-                .execute_operation(&context, operation, &policy, &mut runtime_track)
+                .execute_operation(&context, operation, &policy, &mut tracker)
                 .await
                 .map_err(|err| {
                     ChainError::ExecutionError(err, ChainExecutionContext::Operation(index))
@@ -592,7 +587,7 @@ where
             .observe(start_time.elapsed().as_secs_f64());
         WASM_FUEL_USED_PER_BLOCK
             .with_label_values(&[])
-            .observe(runtime_track.used_fuel as f64);
+            .observe(tracker.used_fuel as f64);
         Ok(BlockExecutionOutcome {
             messages,
             message_counts,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -563,6 +563,9 @@ where
         Self::sub_assign_fees(balance, credit)?;
         Self::sub_assign_fees(balance, pricing.fuel_price(used_fuel)?)?;
         Self::sub_assign_fees(balance, pricing.messages_price(&messages)?)?;
+        Self::sub_assign_fees(balance, pricing.storage_n_read_price(&runtime_meter.n_read)?)?;
+        Self::sub_assign_fees(balance, pricing.storage_byte_read_price(&runtime_meter.bytes_read)?)?;
+        Self::sub_assign_fees(balance, pricing.storage_byte_write_price(&runtime_meter.bytes_write)?)?;
 
         // Recompute the state hash.
         let state_hash = self.execution_state.crypto_hash().await?;

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -495,8 +495,8 @@ where
 
         balance.try_add_assign(credit)?;
         Self::sub_assign_fees(balance, pricing.certificate_price())?;
-        Self::sub_assign_fees(balance, pricing.storage_price(&block.incoming_messages)?)?;
-        Self::sub_assign_fees(balance, pricing.storage_price(&block.operations)?)?;
+        Self::sub_assign_fees(balance, pricing.storage_byte_write_price(&block.incoming_messages)?)?;
+        Self::sub_assign_fees(balance, pricing.storage_byte_write_price(&block.operations)?)?;
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -507,7 +507,6 @@ where
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
-        //        let available_fuel = pricing.remaining_fuel(*balance);
         let maximum_bytes_read = pricing.maximum_bytes_read;
         let maximum_bytes_written = pricing.maximum_bytes_written;
         let mut runtime_limits = RuntimeLimits {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -497,28 +497,28 @@ where
         Self::sub_assign_fees(balance, pricing.certificate_price())?;
         Self::sub_assign_fees(
             balance,
-            pricing.storage_bytes_write_price(&block.incoming_messages)?,
+            pricing.storage_bytes_written_price(&block.incoming_messages)?,
         )?;
         Self::sub_assign_fees(
             balance,
-            pricing.storage_bytes_write_price(&block.operations)?,
+            pricing.storage_bytes_written_price(&block.operations)?,
         )?;
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
         let available_fuel = pricing.remaining_fuel(*balance);
-        let n_read = 0;
+        let num_reads = 0;
         let bytes_read = 0;
-        let bytes_write = 0;
+        let bytes_written = 0;
         let maximum_bytes_read = pricing.maximum_bytes_read;
-        let maximum_bytes_write = pricing.maximum_bytes_write;
+        let maximum_bytes_written = pricing.maximum_bytes_written;
         let mut runtime_meter = RuntimeMeter {
             remaining_fuel: available_fuel,
-            n_read,
+            num_reads,
             bytes_read,
-            bytes_write,
+            bytes_written,
             maximum_bytes_read,
-            maximum_bytes_write,
+            maximum_bytes_written,
         };
         for (index, message) in block.incoming_messages.iter().enumerate() {
             let index = u32::try_from(index).map_err(|_| ArithmeticError::Overflow)?;
@@ -578,7 +578,7 @@ where
         Self::sub_assign_fees(balance, pricing.messages_price(&messages)?)?;
         Self::sub_assign_fees(
             balance,
-            pricing.storage_n_read_price(&runtime_meter.n_read)?,
+            pricing.storage_num_reads_price(&runtime_meter.num_reads)?,
         )?;
         Self::sub_assign_fees(
             balance,
@@ -586,7 +586,7 @@ where
         )?;
         Self::sub_assign_fees(
             balance,
-            pricing.storage_bytes_write_price(&runtime_meter.bytes_write)?,
+            pricing.storage_bytes_written_price(&runtime_meter.bytes_written)?,
         )?;
 
         // Recompute the state hash.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -479,7 +479,7 @@ where
             return Err(ChainError::InactiveChain(chain_id));
         };
 
-        let pricing = committee.pricing().clone();
+        let policy = committee.policy().clone();
         let credit: Amount = block
             .incoming_messages
             .iter()
@@ -495,20 +495,20 @@ where
         let balance = self.execution_state.system.balance.get_mut();
 
         balance.try_add_assign(credit)?;
-        sub_assign_fees(balance, pricing.certificate_price())?;
+        sub_assign_fees(balance, policy.certificate_price())?;
         sub_assign_fees(
             balance,
-            pricing.storage_bytes_written_price(&block.incoming_messages)?,
+            policy.storage_bytes_written_price(&block.incoming_messages)?,
         )?;
         sub_assign_fees(
             balance,
-            pricing.storage_bytes_written_price(&block.operations)?,
+            policy.storage_bytes_written_price(&block.operations)?,
         )?;
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
-        let maximum_bytes_read = pricing.maximum_bytes_read;
-        let maximum_bytes_written = pricing.maximum_bytes_written;
+        let maximum_bytes_read = policy.maximum_bytes_read;
+        let maximum_bytes_written = policy.maximum_bytes_written;
         let mut runtime_limits = RuntimeLimits {
             maximum_bytes_read,
             maximum_bytes_written,
@@ -532,7 +532,7 @@ where
                 .execute_message(
                     &context,
                     &message.event.message,
-                    &pricing,
+                    &policy,
                     &mut runtime_limits,
                 )
                 .await
@@ -558,7 +558,7 @@ where
             };
             let results = self
                 .execution_state
-                .execute_operation(&context, operation, &pricing, &mut runtime_limits)
+                .execute_operation(&context, operation, &policy, &mut runtime_limits)
                 .await
                 .map_err(|err| {
                     ChainError::ExecutionError(err, ChainExecutionContext::Operation(index))

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -498,11 +498,11 @@ where
         sub_assign_fees(balance, policy.certificate_price())?;
         sub_assign_fees(
             balance,
-            policy.storage_bytes_written_price(&block.incoming_messages)?,
+            policy.storage_bytes_written_price_raw(&block.incoming_messages)?,
         )?;
         sub_assign_fees(
             balance,
-            policy.storage_bytes_written_price(&block.operations)?,
+            policy.storage_bytes_written_price_raw(&block.operations)?,
         )?;
 
         let mut messages = Vec::new();

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -507,15 +507,15 @@ where
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
-        let maximum_bytes_read = policy.maximum_bytes_read;
-        let maximum_bytes_written = policy.maximum_bytes_written;
+        let maximum_bytes_left_to_read = policy.maximum_bytes_read_per_block;
+        let maximum_bytes_left_to_write = policy.maximum_bytes_written_per_block;
         let mut tracker = ResourceTracker {
             used_fuel: 0,
             num_reads: 0,
             bytes_read: 0,
             bytes_written: 0,
-            maximum_bytes_read,
-            maximum_bytes_written,
+            maximum_bytes_left_to_read,
+            maximum_bytes_left_to_write,
         };
         for (index, message) in block.incoming_messages.iter().enumerate() {
             let index = u32::try_from(index).map_err(|_| ArithmeticError::Overflow)?;

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -23,7 +23,7 @@ use linera_execution::{
     system::{Account, SystemMessage},
     ExecutionResult, ExecutionRuntimeContext, ExecutionStateView, GenericApplicationId, Message,
     MessageContext, OperationContext, Query, QueryContext, RawExecutionResult, RawOutgoingMessage,
-    Response, RuntimeGlobalMeter, UserApplicationDescription, UserApplicationId,
+    Response, RuntimeLimits, UserApplicationDescription, UserApplicationId,
 };
 use linera_views::{
     common::Context,
@@ -510,7 +510,7 @@ where
         //        let available_fuel = pricing.remaining_fuel(*balance);
         let maximum_bytes_read = pricing.maximum_bytes_read;
         let maximum_bytes_written = pricing.maximum_bytes_written;
-        let mut runtime_global_meter = RuntimeGlobalMeter {
+        let mut runtime_limits = RuntimeLimits {
             maximum_bytes_read,
             maximum_bytes_written,
         };
@@ -534,7 +534,7 @@ where
                     &context,
                     &message.event.message,
                     &pricing,
-                    &mut runtime_global_meter,
+                    &mut runtime_limits,
                 )
                 .await
                 .map_err(|err| {
@@ -559,7 +559,7 @@ where
             };
             let results = self
                 .execution_state
-                .execute_operation(&context, operation, &pricing, &mut runtime_global_meter)
+                .execute_operation(&context, operation, &pricing, &mut runtime_limits)
                 .await
                 .map_err(|err| {
                     ChainError::ExecutionError(err, ChainExecutionContext::Operation(index))

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -18,7 +18,7 @@ use linera_base::{
     data_types::{ArithmeticError, BlockHeight, RoundNumber, Timestamp},
     identifiers::ChainId,
 };
-use linera_execution::{pricing::PricingError, ExecutionError};
+use linera_execution::{policy::PricingError, ExecutionError};
 use linera_views::views::ViewError;
 pub use manager::{
     ChainManager, ChainManagerInfo, MultiOwnerManagerInfo, Outcome as ChainManagerOutcome,

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -10,7 +10,7 @@ use linera_base::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorState},
-    pricing::Pricing,
+    policy::ResourceControlPolicy,
     system::Recipient,
     Operation, SystemOperation,
 };
@@ -128,7 +128,7 @@ impl VoteTestExt for Vote {
         };
         let committee = Committee::new(
             vec![(self.validator, state)].into_iter().collect(),
-            Pricing::only_fuel(),
+            ResourceControlPolicy::only_fuel(),
         );
         SignatureAggregator::new(self.value, self.round, &committee)
             .append(self.validator, self.signature)

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -18,7 +18,7 @@ use linera_base::{
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 use linera_execution::{
     committee::{Committee, ValidatorName},
-    pricing::Pricing,
+    policy::ResourceControlPolicy,
     WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, Store, TestClock};
@@ -413,9 +413,9 @@ where
         })
     }
 
-    pub fn with_pricing(mut self, pricing: Pricing) -> Self {
+    pub fn with_policy(mut self, policy: ResourceControlPolicy) -> Self {
         let validators = self.initial_committee.validators().clone();
-        self.initial_committee = Committee::new(validators, pricing);
+        self.initial_committee = Committee::new(validators, policy);
         self
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -28,7 +28,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    pricing::Pricing,
+    policy::ResourceControlPolicy,
     system::{Account, Recipient, SystemOperation, UserData},
     ChainOwnership, ExecutionError, Operation, SystemExecutionError, SystemQuery, SystemResponse,
 };
@@ -82,7 +82,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_certificate());
     let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -157,7 +157,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::only_fuel());
+        .with_policy(ResourceControlPolicy::only_fuel());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -247,7 +247,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_certificate());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -317,7 +317,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_certificate());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -809,7 +809,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::all_categories());
+        .with_policy(ResourceControlPolicy::all_categories());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -1076,7 +1076,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_certificate());
     let mut client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;
@@ -1280,7 +1280,7 @@ where
 
     // Create a new committee.
     let validators = builder.initial_committee.validators().clone();
-    let committee = Committee::new(validators, Pricing::only_fuel());
+    let committee = Committee::new(validators, ResourceControlPolicy::only_fuel());
     admin.stage_new_committee(committee).await.unwrap();
     assert_eq!(admin.next_block_height, BlockHeight::from(1));
     assert!(admin.pending_block.is_none());
@@ -1387,7 +1387,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_certificate());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -16,8 +16,8 @@ use linera_base::{
 };
 use linera_chain::data_types::{CertificateValue, OutgoingMessage};
 use linera_execution::{
-    policy::ResourceControlPolicy, Bytecode, Message, Operation, SystemMessage, UserApplicationDescription,
-    WasmRuntime,
+    policy::ResourceControlPolicy, Bytecode, Message, Operation, SystemMessage,
+    UserApplicationDescription, WasmRuntime,
 };
 use linera_storage::Store;
 use linera_views::views::ViewError;

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -16,7 +16,7 @@ use linera_base::{
 };
 use linera_chain::data_types::{CertificateValue, OutgoingMessage};
 use linera_execution::{
-    pricing::Pricing, Bytecode, Message, Operation, SystemMessage, UserApplicationDescription,
+    policy::ResourceControlPolicy, Bytecode, Message, Operation, SystemMessage, UserApplicationDescription,
     WasmRuntime,
 };
 use linera_storage::Store;
@@ -73,7 +73,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::all_categories());
+        .with_policy(ResourceControlPolicy::all_categories());
     let mut publisher = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
         .await?;
@@ -190,7 +190,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::all_categories());
+        .with_policy(ResourceControlPolicy::all_categories());
     // Will publish the bytecodes.
     let mut publisher = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
@@ -328,7 +328,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::all_categories());
+        .with_policy(ResourceControlPolicy::all_categories());
     // Will publish the bytecodes.
     let mut publisher = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
@@ -431,7 +431,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::all_categories());
+        .with_policy(ResourceControlPolicy::all_categories());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
         .await?;
@@ -625,7 +625,7 @@ where
 {
     let mut builder = TestBuilder::new(store_builder, 4, 1)
         .await?
-        .with_pricing(Pricing::all_categories());
+        .with_policy(ResourceControlPolicy::all_categories());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::ONE)
         .await?;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -1,3 +1,4 @@
+
 // Copyright (c) Facebook, Inc. and its affiliates.
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
@@ -26,7 +27,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Epoch,
-    pricing::Pricing,
+    policy::ResourceControlPolicy,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
     GenericApplicationId, Message, Operation, OperationContext, RuntimeLimits,
@@ -425,7 +426,7 @@ where
         next_message_index: 0,
     };
     let mut runtime_limits = RuntimeLimits::default();
-    let pricing = Pricing::default();
+    let policy = ResourceControlPolicy::default();
     creator_state
         .execute_operation(
             &operation_context,
@@ -433,7 +434,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            &pricing,
+            &policy,
             &mut runtime_limits,
         )
         .await?;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -25,8 +25,8 @@ use linera_chain::{
     test::{make_child_block, make_first_block, BlockTestExt},
 };
 use linera_execution::{
-    get_default_runtime_meter,
     committee::Epoch,
+    get_default_runtime_meter,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
     GenericApplicationId, Message, Operation, OperationContext, SystemExecutionState,

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -29,7 +29,7 @@ use linera_execution::{
     pricing::Pricing,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
-    GenericApplicationId, Message, Operation, OperationContext, RuntimeGlobalMeter,
+    GenericApplicationId, Message, Operation, OperationContext, RuntimeLimits,
     SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmApplication,
     WasmRuntime,
 };
@@ -424,7 +424,7 @@ where
         index: 0,
         next_message_index: 0,
     };
-    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::new_for_testing();
     let pricing = Pricing::default();
     creator_state
         .execute_operation(
@@ -434,7 +434,7 @@ where
                 bytes: user_operation,
             },
             &pricing,
-            &mut runtime_global_meter,
+            &mut runtime_limits,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(5));

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -29,7 +29,7 @@ use linera_execution::{
     policy::ResourceControlPolicy,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
-    GenericApplicationId, Message, Operation, OperationContext, RuntimeLimits,
+    GenericApplicationId, Message, Operation, OperationContext, RuntimeTracker,
     SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmApplication,
     WasmRuntime,
 };
@@ -424,7 +424,7 @@ where
         index: 0,
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::default();
+    let mut runtime_tracker = RuntimeTracker::default();
     let policy = ResourceControlPolicy::default();
     creator_state
         .execute_operation(
@@ -434,7 +434,7 @@ where
                 bytes: user_operation,
             },
             &policy,
-            &mut runtime_limits,
+            &mut runtime_tracker,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(5));

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -26,10 +26,9 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Epoch,
-    get_default_runtime_meter,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
-    GenericApplicationId, Message, Operation, OperationContext, SystemExecutionState,
+    GenericApplicationId, Message, Operation, OperationContext, RuntimeMeter, SystemExecutionState,
     UserApplicationDescription, UserApplicationId, WasmApplication, WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, Store};
@@ -423,7 +422,7 @@ where
         index: 0,
         next_message_index: 0,
     };
-    let mut runtime_meter = get_default_runtime_meter();
+    let mut runtime_meter = RuntimeMeter::new_for_testing();
     creator_state
         .execute_operation(
             &operation_context,

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -26,10 +26,12 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Epoch,
+    pricing::Pricing,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
-    GenericApplicationId, Message, Operation, OperationContext, RuntimeMeter, SystemExecutionState,
-    UserApplicationDescription, UserApplicationId, WasmApplication, WasmRuntime,
+    GenericApplicationId, Message, Operation, OperationContext, RuntimeGlobalMeter,
+    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmApplication,
+    WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, Store};
 use linera_views::views::{CryptoHashView, ViewError};
@@ -422,7 +424,8 @@ where
         index: 0,
         next_message_index: 0,
     };
-    let mut runtime_meter = RuntimeMeter::new_for_testing();
+    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let pricing = Pricing::default();
     creator_state
         .execute_operation(
             &operation_context,
@@ -430,7 +433,8 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            &mut runtime_meter,
+            &pricing,
+            &mut runtime_global_meter,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(5));

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -424,7 +424,7 @@ where
         index: 0,
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::default();
     let pricing = Pricing::default();
     creator_state
         .execute_operation(

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -29,7 +29,7 @@ use linera_execution::{
     policy::ResourceControlPolicy,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
-    GenericApplicationId, Message, Operation, OperationContext, RuntimeTracker,
+    GenericApplicationId, Message, Operation, OperationContext, ResourceTracker,
     SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmApplication,
     WasmRuntime,
 };
@@ -424,7 +424,7 @@ where
         index: 0,
         next_message_index: 0,
     };
-    let mut runtime_tracker = RuntimeTracker::default();
+    let mut tracker = ResourceTracker::default();
     let policy = ResourceControlPolicy::default();
     creator_state
         .execute_operation(
@@ -434,7 +434,7 @@ where
                 bytes: user_operation,
             },
             &policy,
-            &mut runtime_tracker,
+            &mut tracker,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(5));

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -25,6 +25,7 @@ use linera_chain::{
     test::{make_child_block, make_first_block, BlockTestExt},
 };
 use linera_execution::{
+    get_default_runtime_meter,
     committee::Epoch,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
@@ -422,6 +423,7 @@ where
         index: 0,
         next_message_index: 0,
     };
+    let mut runtime_meter = get_default_runtime_meter();
     creator_state
         .execute_operation(
             &operation_context,
@@ -429,7 +431,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            &mut 10_000_000,
+            &mut runtime_meter,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(5));

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -1,4 +1,3 @@
-
 // Copyright (c) Facebook, Inc. and its affiliates.
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -211,10 +211,7 @@ impl<'a> From<&'a Committee> for CommitteeFull<'a> {
 
 impl From<CommitteeMinimal<'static>> for Committee {
     fn from(committee_min: CommitteeMinimal) -> Committee {
-        let CommitteeMinimal {
-            validators,
-            policy,
-        } = committee_min;
+        let CommitteeMinimal { validators, policy } = committee_min;
         Committee::new(validators.into_owned(), policy.into_owned())
     }
 }
@@ -290,7 +287,10 @@ impl Epoch {
 }
 
 impl Committee {
-    pub fn new(validators: BTreeMap<ValidatorName, ValidatorState>, policy: ResourceControlPolicy) -> Self {
+    pub fn new(
+        validators: BTreeMap<ValidatorName, ValidatorState>,
+        policy: ResourceControlPolicy,
+    ) -> Self {
         let total_votes = validators.values().fold(0, |sum, state| sum + state.votes);
         // Let N = 3f + 1 + k such that 0 <= k <= 2. (Notably ⌊k / 3⌋ = 0 and ⌊(2 - k) / 3⌋ = 0.)
         // The following thresholds verify:

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -233,9 +233,9 @@ where
         };
         // Set the authenticated signer to be used in outgoing messages.
         result.authenticated_signer = signer;
-        let runtime_local_meter = runtime.runtime_local_meter();
+        let runtime_counts = runtime.runtime_counts();
         let balance = self.system.balance.get_mut();
-        update_limits(balance, runtime_limits, pricing, runtime_local_meter)?;
+        update_limits(balance, runtime_limits, pricing, runtime_counts)?;
         WASM_FUEL_USED_PER_BLOCK.with_label_values(&[]).observe(
             (initial_remaining_fuel - pricing.remaining_fuel(balance.clone())) as f64,
         );

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -130,7 +130,7 @@ where
             .user_applications()
             .insert(application_id, application);
 
-        let mut runtime_limits = RuntimeLimits::new_for_testing();
+        let mut runtime_limits = RuntimeLimits::default();
         let pricing = Pricing::default();
         self.run_user_action(
             application_id,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -5,8 +5,8 @@ use crate::{
     runtime::{ApplicationStatus, ExecutionRuntime, SessionManager},
     system::SystemExecutionStateView,
     ContractRuntime, ExecutionError, ExecutionResult, ExecutionRuntimeContext, Message,
-    MessageContext, Operation, OperationContext, ResourceControlPolicy, Query, QueryContext, RawExecutionResult,
-    RawOutgoingMessage, Response, RuntimeLimits, SystemMessage,
+    MessageContext, Operation, OperationContext, Query, QueryContext, RawExecutionResult,
+    RawOutgoingMessage, ResourceControlPolicy, Response, RuntimeLimits, SystemMessage,
     UserApplicationDescription, UserApplicationId,
 };
 use linera_base::{
@@ -235,9 +235,9 @@ where
         let runtime_counts = runtime.runtime_counts();
         let balance = self.system.balance.get_mut();
         runtime_limits.update_limits(balance, policy, runtime_counts)?;
-        WASM_FUEL_USED_PER_BLOCK.with_label_values(&[]).observe(
-            (initial_remaining_fuel - policy.remaining_fuel(balance.clone())) as f64,
-        );
+        WASM_FUEL_USED_PER_BLOCK
+            .with_label_values(&[])
+            .observe((initial_remaining_fuel - policy.remaining_fuel(balance.clone())) as f64);
 
         // Check that applications were correctly stacked and unstacked.
         assert_eq!(applications.len(), 1);

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -234,10 +234,6 @@ where
             return Err(ExecutionError::ExcessiveRead);
         }
         if runtime_meter.bytes_write > runtime_meter.maximum_bytes_write {
-            println!(
-                "bytes_write={:?} maximum_bytes_write={:?}",
-                runtime_meter.bytes_write, runtime_meter.maximum_bytes_write
-            );
             return Err(ExecutionError::ExcessiveWrite);
         }
         WASM_FUEL_USED_PER_BLOCK

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -131,11 +131,11 @@ where
 
         let mut runtime_meter = RuntimeMeter {
             remaining_fuel: 10_000_000,
-            n_read: 0,
+            num_reads: 0,
             bytes_read: 0,
-            bytes_write: 0,
+            bytes_written: 0,
             maximum_bytes_read: u64::MAX,
-            maximum_bytes_write: u64::MAX,
+            maximum_bytes_written: u64::MAX,
         };
         self.run_user_action(application_id, chain_id, action, &mut runtime_meter)
             .await?;
@@ -233,7 +233,7 @@ where
         if runtime_meter.bytes_read > runtime_meter.maximum_bytes_read {
             return Err(ExecutionError::ExcessiveRead);
         }
-        if runtime_meter.bytes_write > runtime_meter.maximum_bytes_write {
+        if runtime_meter.bytes_written > runtime_meter.maximum_bytes_written {
             return Err(ExecutionError::ExcessiveWrite);
         }
         WASM_FUEL_USED_PER_BLOCK

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    update_limits,
     runtime::{ApplicationStatus, ExecutionRuntime, SessionManager},
     system::SystemExecutionStateView,
     ContractRuntime, ExecutionError, ExecutionResult, ExecutionRuntimeContext, Message,
@@ -235,7 +234,7 @@ where
         result.authenticated_signer = signer;
         let runtime_counts = runtime.runtime_counts();
         let balance = self.system.balance.get_mut();
-        update_limits(balance, runtime_limits, pricing, runtime_counts)?;
+        runtime_limits.update_limits(balance, pricing, runtime_counts)?;
         WASM_FUEL_USED_PER_BLOCK.with_label_values(&[]).observe(
             (initial_remaining_fuel - pricing.remaining_fuel(balance.clone())) as f64,
         );

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -237,7 +237,7 @@ where
         runtime_limits.update_limits(balance, policy, runtime_counts)?;
         WASM_FUEL_USED_PER_BLOCK
             .with_label_values(&[])
-            .observe((initial_remaining_fuel - policy.remaining_fuel(balance.clone())) as f64);
+            .observe((initial_remaining_fuel - policy.remaining_fuel(*balance)) as f64);
 
         // Check that applications were correctly stacked and unstacked.
         assert_eq!(applications.len(), 1);

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -227,6 +227,12 @@ where
         // Set the authenticated signer to be used in outgoing messages.
         result.authenticated_signer = signer;
         *runtime_meter = runtime.runtime_meter();
+        if runtime_meter.bytes_read > runtime_meter.maximum_bytes_read {
+            return Err(ExecutionError::ExcessiveRead);
+        }
+        if runtime_meter.bytes_write > runtime_meter.maximum_bytes_write {
+            return Err(ExecutionError::ExcessiveWrite);
+        }
         WASM_FUEL_USED_PER_BLOCK
             .with_label_values(&[])
             .observe((initial_remaining_fuel - *remaining_fuel) as f64);

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -75,7 +75,7 @@ pub struct RuntimeLimits {
 
 /// The entries of the runtime related to storage
 #[derive(Copy, Debug, Clone)]
-pub struct RuntimeTracker {
+pub struct ResourceTracker {
     /// The used fuel in the computation
     pub used_fuel: u64,
     /// The number of reads in the computation
@@ -84,16 +84,16 @@ pub struct RuntimeTracker {
     pub bytes_read: u64,
     /// The total number of bytes written
     pub bytes_written: u64,
-    /// The maximum size of read allowed per block
+    /// The maximum size of read that remains available for use
     pub maximum_bytes_read: u64,
-    /// The maximum size of write allowed per block
+    /// The maximum size of write that remains available for use
     pub maximum_bytes_written: u64,
 }
 
 #[cfg(any(test, feature = "test"))]
-impl Default for RuntimeTracker {
+impl Default for ResourceTracker {
     fn default() -> Self {
-        RuntimeTracker {
+        ResourceTracker {
             used_fuel: 0,
             num_reads: 0,
             bytes_read: 0,
@@ -116,7 +116,7 @@ impl Default for RuntimeLimits {
     }
 }
 
-impl RuntimeTracker {
+impl ResourceTracker {
     /// Update the limits for the maximum and update the balance.
     /// The substraction are guaranteed to work correctly and the
     /// checks are occurring in the runtime.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -87,7 +87,7 @@ impl RuntimeLimits {
         policy: &ResourceControlPolicy,
         runtime_counts: RuntimeCounts,
     ) -> Result<(), ExecutionError> {
-        let initial_fuel = policy.remaining_fuel(balance.clone());
+        let initial_fuel = policy.remaining_fuel(*balance);
         let used_fuel = initial_fuel.saturating_sub(runtime_counts.remaining_fuel);
         sub_assign_fees(balance, policy.fuel_price(used_fuel)?)?;
         sub_assign_fees(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -89,6 +89,10 @@ pub enum ExecutionError {
     ApplicationIsInUse,
     #[error("Attempted to get an entry that is not locked")]
     ApplicationStateNotLocked,
+    #[error("Excessive readings from storage")]
+    ExcessiveRead,
+    #[error("Excessive writings to storage")]
+    ExcessiveWrite,
 
     #[error("Bytecode ID {0:?} is invalid")]
     InvalidBytecodeId(BytecodeId),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -117,7 +117,7 @@ impl Default for RuntimeLimits {
 }
 
 impl ResourceTracker {
-    /// Update the limits for the maximum and update the balance.
+    /// Updates the limits for the maximum and updates the balance.
     /// The substraction are guaranteed to work correctly and the
     /// checks are occurring in the runtime.
     pub fn update_limits(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -71,8 +71,8 @@ pub struct RuntimeLimits {
 impl Default for RuntimeLimits {
     fn default() -> Self {
         RuntimeLimits {
-            maximum_bytes_read: u64::MAX,
-            maximum_bytes_written: u64::MAX,
+            maximum_bytes_read: u64::MAX / 2,
+            maximum_bytes_written: u64::MAX / 2,
         }
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -68,10 +68,12 @@ pub struct RuntimeMeter {
 }
 
 #[cfg(any(test, feature = "test"))]
-pub fn get_default_runtime_meter() -> RuntimeMeter {
-    RuntimeMeter {
-        remaining_fuel: 10_000_000,
-        ..Default::default()
+impl RuntimeMeter {
+    pub fn new_for_testing() -> RuntimeMeter {
+        RuntimeMeter {
+            remaining_fuel: 10_000_000,
+            ..Default::default()
+        }
     }
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -60,7 +60,7 @@ pub fn sub_assign_fees(balance: &mut Amount, fees: Amount) -> Result<(), Pricing
 
 /// The entries of the runtime related to fuel and storage
 #[derive(Copy, Debug, Clone)]
-pub struct RuntimeGlobalMeter {
+pub struct RuntimeLimits {
     /// The maximum size of read allowed per block
     pub maximum_bytes_read: u64,
     /// The maximum size of write allowed per block
@@ -82,7 +82,7 @@ pub struct RuntimeLocalMeter {
 
 pub fn update_limits(
     balance: &mut Amount,
-    runtime_global_meter: &mut RuntimeGlobalMeter,
+    runtime_limits: &mut RuntimeLimits,
     pricing: &Pricing,
     runtime_local: RuntimeLocalMeter,
 ) -> Result<(), ExecutionError> {
@@ -94,13 +94,13 @@ pub fn update_limits(
         pricing.storage_num_reads_price(&runtime_local.num_reads)?,
     )?;
     let bytes_read = runtime_local.bytes_read;
-    runtime_global_meter.maximum_bytes_read -= bytes_read;
+    runtime_limits.maximum_bytes_read -= bytes_read;
     sub_assign_fees(
         balance,
         pricing.storage_bytes_read_price(&bytes_read)?,
     )?;
     let bytes_written = runtime_local.bytes_written;
-    runtime_global_meter.maximum_bytes_written -= bytes_written;
+    runtime_limits.maximum_bytes_written -= bytes_written;
     sub_assign_fees(
         balance,
         pricing.storage_bytes_written_price(&bytes_written)?,
@@ -109,18 +109,18 @@ pub fn update_limits(
 }
 
 #[cfg(any(test, feature = "test"))]
-impl RuntimeGlobalMeter {
-    pub fn new_for_testing() -> RuntimeGlobalMeter {
-        RuntimeGlobalMeter {
+impl RuntimeLimits {
+    pub fn new_for_testing() -> RuntimeLimits {
+        RuntimeLimits {
             maximum_bytes_read: u64::MAX,
             maximum_bytes_written: u64::MAX,
         }
     }
 }
 
-impl Default for RuntimeGlobalMeter {
+impl Default for RuntimeLimits {
     fn default() -> Self {
-        RuntimeGlobalMeter {
+        RuntimeLimits {
             maximum_bytes_read: u64::MAX,
             maximum_bytes_written: u64::MAX,
         }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -69,24 +69,24 @@ pub struct RuntimeMeter {
 
 #[cfg(any(test, feature = "test"))]
 pub fn get_default_runtime_meter() -> RuntimeMeter {
-    let mut runtime_meter = RuntimeMeter::default();
-    runtime_meter.remaining_fuel = 10_000_000;
-    runtime_meter
-}
-
-
-
-impl Default for RuntimeMeter {
-    fn default() -> Self {
-        RuntimeMeter { remaining_fuel: 0,
-                       n_read: 0,
-                       bytes_read: 0,
-                       bytes_write: 0,
-                       maximum_bytes_read: u64::MAX,
-                       maximum_bytes_write: u64::MAX }
+    RuntimeMeter {
+        remaining_fuel: 10_000_000,
+        ..Default::default()
     }
 }
 
+impl Default for RuntimeMeter {
+    fn default() -> Self {
+        RuntimeMeter {
+            remaining_fuel: 0,
+            n_read: 0,
+            bytes_read: 0,
+            bytes_write: 0,
+            maximum_bytes_read: u64::MAX,
+            maximum_bytes_write: u64::MAX,
+        }
+    }
+}
 
 /// An implementation of [`UserApplication`]
 pub type UserApplicationCode = Arc<dyn UserApplication + Send + Sync + 'static>;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -56,15 +56,15 @@ pub struct RuntimeMeter {
     /// The remaining fuel
     pub remaining_fuel: u64,
     /// The number of read operations
-    pub n_read: u64,
+    pub num_reads: u64,
     /// The bytes that have been read
     pub bytes_read: u64,
     /// The bytes that have been written
-    pub bytes_write: u64,
-    /// The maximum size of read allowed
+    pub bytes_written: u64,
+    /// The maximum size of read allowed per block
     pub maximum_bytes_read: u64,
-    /// The maximum size of write allowed
-    pub maximum_bytes_write: u64,
+    /// The maximum size of write allowed per block
+    pub maximum_bytes_written: u64,
 }
 
 #[cfg(any(test, feature = "test"))]
@@ -81,11 +81,11 @@ impl Default for RuntimeMeter {
     fn default() -> Self {
         RuntimeMeter {
             remaining_fuel: 0,
-            n_read: 0,
+            num_reads: 0,
             bytes_read: 0,
-            bytes_write: 0,
+            bytes_written: 0,
             maximum_bytes_read: u64::MAX,
-            maximum_bytes_write: u64::MAX,
+            maximum_bytes_written: u64::MAX,
         }
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -67,6 +67,15 @@ pub struct RuntimeLimits {
     pub maximum_bytes_written: u64,
 }
 
+impl Default for RuntimeLimits {
+    fn default() -> Self {
+        RuntimeLimits {
+            maximum_bytes_read: u64::MAX,
+            maximum_bytes_written: u64::MAX,
+        }
+    }
+}
+
 /// The entries of the runtime related to fuel and storage
 #[derive(Copy, Debug, Clone)]
 pub struct RuntimeLocalMeter {
@@ -106,25 +115,6 @@ pub fn update_limits(
         pricing.storage_bytes_written_price(&bytes_written)?,
     )?;
     Ok(())
-}
-
-#[cfg(any(test, feature = "test"))]
-impl RuntimeLimits {
-    pub fn new_for_testing() -> RuntimeLimits {
-        RuntimeLimits {
-            maximum_bytes_read: u64::MAX,
-            maximum_bytes_written: u64::MAX,
-        }
-    }
-}
-
-impl Default for RuntimeLimits {
-    fn default() -> Self {
-        RuntimeLimits {
-            maximum_bytes_read: u64::MAX,
-            maximum_bytes_written: u64::MAX,
-        }
-    }
 }
 
 /// An implementation of [`UserApplication`]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -118,8 +118,6 @@ impl Default for RuntimeLimits {
 
 impl ResourceTracker {
     /// Updates the limits for the maximum and updates the balance.
-    /// The substraction are guaranteed to work correctly and the
-    /// checks are occurring in the runtime.
     pub fn update_limits(
         &mut self,
         balance: &mut Amount,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -50,6 +50,44 @@ use serde::{Deserialize, Serialize};
 use std::{io, path::Path, str::FromStr, sync::Arc};
 use thiserror::Error;
 
+/// The entries of the runtime related to fuel and storage
+#[derive(Copy, Debug, Clone)]
+pub struct RuntimeMeter {
+    /// The remaining fuel
+    pub remaining_fuel: u64,
+    /// The number of read operations
+    pub n_read: u64,
+    /// The bytes that have been read
+    pub bytes_read: u64,
+    /// The bytes that have been written
+    pub bytes_write: u64,
+    /// The maximum size of read allowed
+    pub maximum_bytes_read: u64,
+    /// The maximum size of write allowed
+    pub maximum_bytes_write: u64,
+}
+
+#[cfg(any(test, feature = "test"))]
+pub fn get_default_runtime_meter() -> RuntimeMeter {
+    let mut runtime_meter = RuntimeMeter::default();
+    runtime_meter.remaining_fuel = 10_000_000;
+    runtime_meter
+}
+
+
+
+impl Default for RuntimeMeter {
+    fn default() -> Self {
+        RuntimeMeter { remaining_fuel: 0,
+                       n_read: 0,
+                       bytes_read: 0,
+                       bytes_write: 0,
+                       maximum_bytes_read: u64::MAX,
+                       maximum_bytes_write: u64::MAX }
+    }
+}
+
+
 /// An implementation of [`UserApplication`]
 pub type UserApplicationCode = Arc<dyn UserApplication + Send + Sync + 'static>;
 
@@ -315,6 +353,9 @@ pub struct CallResult {
 pub trait ContractRuntime: BaseRuntime {
     /// Returns the amount of execution fuel remaining before execution is aborted.
     fn remaining_fuel(&self) -> u64;
+
+    /// Returns the remaining fuel as well as the storage related information on the state
+    fn runtime_meter(&self) -> RuntimeMeter;
 
     /// Sets the amount of execution fuel remaining before execution is aborted.
     fn set_remaining_fuel(&self, remaining_fuel: u64);

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -58,7 +58,7 @@ pub fn sub_assign_fees(balance: &mut Amount, fees: Amount) -> Result<(), Pricing
         .map_err(|_| ArithmeticError::Underflow)?)
 }
 
-/// The entries of the runtime related to fuel and storage
+/// The entries of the runtime related to storage
 #[derive(Copy, Debug, Clone)]
 pub struct RuntimeLimits {
     /// The maximum size of read allowed per block

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -12,7 +12,7 @@ pub mod policy;
 mod runtime;
 pub mod system;
 mod wasm;
-use crate::policy::{ResourceControlPolicy, PricingError};
+use crate::policy::{PricingError, ResourceControlPolicy};
 
 pub use applications::{
     ApplicationRegistryView, BytecodeLocation, GenericApplicationId, UserApplicationDescription,
@@ -96,21 +96,13 @@ impl RuntimeLimits {
         )?;
         let bytes_read = runtime_counts.bytes_read;
         self.maximum_bytes_read -= bytes_read;
-        sub_assign_fees(
-            balance,
-            policy.storage_bytes_read_price(&bytes_read)?,
-        )?;
+        sub_assign_fees(balance, policy.storage_bytes_read_price(&bytes_read)?)?;
         let bytes_written = runtime_counts.bytes_written;
         self.maximum_bytes_written -= bytes_written;
-        sub_assign_fees(
-            balance,
-            policy.storage_bytes_written_price(&bytes_written)?,
-        )?;
+        sub_assign_fees(balance, policy.storage_bytes_written_price(&bytes_written)?)?;
         Ok(())
     }
 }
-
-
 
 /// The entries of the runtime related to fuel and storage
 #[derive(Copy, Debug, Clone)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -68,9 +68,9 @@ pub struct RuntimeLimits {
     /// maximum budget of bytes written
     pub max_budget_bytes_written: u64,
     /// The maximum size of read allowed per block
-    pub maximum_bytes_read: u64,
+    pub maximum_bytes_left_to_read: u64,
     /// The maximum size of write allowed per block
-    pub maximum_bytes_written: u64,
+    pub maximum_bytes_left_to_write: u64,
 }
 
 /// The entries of the runtime related to storage
@@ -85,9 +85,9 @@ pub struct ResourceTracker {
     /// The total number of bytes written
     pub bytes_written: u64,
     /// The maximum size of read that remains available for use
-    pub maximum_bytes_read: u64,
+    pub maximum_bytes_left_to_read: u64,
     /// The maximum size of write that remains available for use
-    pub maximum_bytes_written: u64,
+    pub maximum_bytes_left_to_write: u64,
 }
 
 #[cfg(any(test, feature = "test"))]
@@ -98,8 +98,8 @@ impl Default for ResourceTracker {
             num_reads: 0,
             bytes_read: 0,
             bytes_written: 0,
-            maximum_bytes_read: u64::MAX / 2,
-            maximum_bytes_written: u64::MAX / 2,
+            maximum_bytes_left_to_read: u64::MAX / 2,
+            maximum_bytes_left_to_write: u64::MAX / 2,
         }
     }
 }
@@ -110,8 +110,8 @@ impl Default for RuntimeLimits {
             max_budget_num_reads: u64::MAX / 2,
             max_budget_bytes_read: u64::MAX / 2,
             max_budget_bytes_written: u64::MAX / 2,
-            maximum_bytes_read: u64::MAX / 2,
-            maximum_bytes_written: u64::MAX / 2,
+            maximum_bytes_left_to_read: u64::MAX / 2,
+            maximum_bytes_left_to_write: u64::MAX / 2,
         }
     }
 }
@@ -139,12 +139,12 @@ impl ResourceTracker {
         self.num_reads += runtime_counts.num_reads;
         // The number of bytes read
         let bytes_read = runtime_counts.bytes_read;
-        self.maximum_bytes_read -= bytes_read;
+        self.maximum_bytes_left_to_read -= bytes_read;
         self.bytes_read += runtime_counts.bytes_read;
         sub_assign_fees(balance, policy.storage_bytes_read_price(&bytes_read)?)?;
         // The number of bytes written
         let bytes_written = runtime_counts.bytes_written;
-        self.maximum_bytes_written -= bytes_written;
+        self.maximum_bytes_left_to_write -= bytes_written;
         self.bytes_written += bytes_written;
         sub_assign_fees(balance, policy.storage_bytes_written_price(&bytes_written)?)?;
         Ok(())
@@ -162,8 +162,8 @@ impl ResourceTracker {
             max_budget_num_reads,
             max_budget_bytes_read,
             max_budget_bytes_written,
-            maximum_bytes_read: self.maximum_bytes_read,
-            maximum_bytes_written: self.maximum_bytes_written,
+            maximum_bytes_left_to_read: self.maximum_bytes_left_to_read,
+            maximum_bytes_left_to_write: self.maximum_bytes_left_to_write,
         }
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -51,7 +51,7 @@ use serde::{Deserialize, Serialize};
 use std::{io, path::Path, str::FromStr, sync::Arc};
 use thiserror::Error;
 
-/// substract an amount to a balence and report an error if that is impossible
+/// Substracts an amount from a balance and reports an error if that is impossible
 pub fn sub_assign_fees(balance: &mut Amount, fees: Amount) -> Result<(), PricingError> {
     Ok(balance
         .try_sub_assign(fees)
@@ -67,6 +67,7 @@ pub struct RuntimeLimits {
     pub maximum_bytes_written: u64,
 }
 
+#[cfg(any(test, feature = "test"))]
 impl Default for RuntimeLimits {
     fn default() -> Self {
         RuntimeLimits {

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -57,17 +57,17 @@ impl ResourceControlPolicy {
     }
 
     pub fn storage_num_reads_price(&self, size: &u64) -> Result<Amount, PricingError> {
-        let size = u128::try_from(*size).map_err(|_| ArithmeticError::Overflow)?;
+        let size = *size as u128;
         Ok(self.storage_num_reads.try_mul(size)?)
     }
 
     pub fn storage_bytes_read_price(&self, size: &u64) -> Result<Amount, PricingError> {
-        let size = u128::try_from(*size).map_err(|_| ArithmeticError::Overflow)?;
+        let size = *size as u128;
         Ok(self.storage_bytes_read.try_mul(size)?)
     }
 
     pub fn storage_bytes_written_price(&self, size: &u64) -> Result<Amount, PricingError> {
-        let size = u128::try_from(*size).map_err(|_| ArithmeticError::Overflow)?;
+        let size = *size as u128;
         Ok(self.storage_bytes_written.try_mul(size)?)
     }
 

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 
 /// A collection of costs associated with blocks in validators.
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, InputObject)]
-pub struct Pricing {
+pub struct ResourceControlPolicy {
     /// The base price for each certificate, to compensate for the communication and signing
     /// overhead.
     pub certificate: Amount,
@@ -30,9 +30,9 @@ pub struct Pricing {
     pub messages: Amount,
 }
 
-impl Default for Pricing {
+impl Default for ResourceControlPolicy {
     fn default() -> Self {
-        Pricing {
+        ResourceControlPolicy {
             certificate: Amount::default(),
             fuel: Amount::default(),
             storage_num_reads: Amount::default(),
@@ -45,7 +45,7 @@ impl Default for Pricing {
     }
 }
 
-impl Pricing {
+impl ResourceControlPolicy {
     pub fn certificate_price(&self) -> Amount {
         self.certificate
     }
@@ -92,7 +92,7 @@ impl Pricing {
     /// This can be used in tests that need whole numbers in their chain balance and don't expect
     /// to execute any Wasm code.
     pub fn only_fuel() -> Self {
-        Pricing {
+        ResourceControlPolicy {
             certificate: Amount::ZERO,
             fuel: Amount::from_atto(1_000_000_000_000),
             storage_num_reads: Amount::ZERO,
@@ -110,7 +110,7 @@ impl Pricing {
     /// This can be used in tests that don't expect to execute any Wasm code, and that keep track of
     /// how many certificates were created.
     pub fn fuel_and_certificate() -> Self {
-        Pricing {
+        ResourceControlPolicy {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000_000),
             storage_num_reads: Amount::ZERO,
@@ -125,7 +125,7 @@ impl Pricing {
     #[cfg(any(test, feature = "test"))]
     /// Creates a pricing where all categories have a small non-zero cost.
     pub fn all_categories() -> Self {
-        Pricing {
+        ResourceControlPolicy {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000),
             storage_num_reads: Amount::ZERO,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -38,8 +38,8 @@ impl Default for ResourceControlPolicy {
             storage_num_reads: Amount::default(),
             storage_bytes_read: Amount::default(),
             storage_bytes_written: Amount::default(),
-            maximum_bytes_read: u64::MAX,
-            maximum_bytes_written: u64::MAX,
+            maximum_bytes_read: u64::MAX / 2,
+            maximum_bytes_written: u64::MAX / 2,
             messages: Amount::default(),
         }
     }
@@ -98,8 +98,8 @@ impl ResourceControlPolicy {
             storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::ZERO,
             storage_bytes_written: Amount::ZERO,
-            maximum_bytes_read: u64::MAX,
-            maximum_bytes_written: u64::MAX,
+            maximum_bytes_read: u64::MAX / 2,
+            maximum_bytes_written: u64::MAX / 2,
             messages: Amount::ZERO,
         }
     }

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -56,19 +56,19 @@ impl ResourceControlPolicy {
         Ok(self.messages.try_mul(size)?)
     }
 
-    pub fn storage_num_reads_price(&self, size: &u64) -> Result<Amount, PricingError> {
-        let size = *size as u128;
-        Ok(self.storage_num_reads.try_mul(size)?)
+    pub fn storage_num_reads_price(&self, count: &u64) -> Result<Amount, PricingError> {
+        let count = *count as u128;
+        Ok(self.storage_num_reads.try_mul(count)?)
     }
 
-    pub fn storage_bytes_read_price(&self, size: &u64) -> Result<Amount, PricingError> {
-        let size = *size as u128;
-        Ok(self.storage_bytes_read.try_mul(size)?)
+    pub fn storage_bytes_read_price(&self, count: &u64) -> Result<Amount, PricingError> {
+        let count = *count as u128;
+        Ok(self.storage_bytes_read.try_mul(count)?)
     }
 
-    pub fn storage_bytes_written_price(&self, size: &u64) -> Result<Amount, PricingError> {
-        let size = *size as u128;
-        Ok(self.storage_bytes_written.try_mul(size)?)
+    pub fn storage_bytes_written_price(&self, count: &u64) -> Result<Amount, PricingError> {
+        let count = *count as u128;
+        Ok(self.storage_bytes_written.try_mul(count)?)
     }
 
     pub fn storage_bytes_written_price_raw(

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -23,9 +23,9 @@ pub struct ResourceControlPolicy {
     /// The cost to store data per byte
     pub storage_bytes_written: Amount,
     /// The maximum data to read per block
-    pub maximum_bytes_read: u64,
+    pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
-    pub maximum_bytes_written: u64,
+    pub maximum_bytes_written_per_block: u64,
     /// The cost to store and send cross-chain messages, per byte.
     pub messages: Amount,
 }
@@ -38,8 +38,8 @@ impl Default for ResourceControlPolicy {
             storage_num_reads: Amount::default(),
             storage_bytes_read: Amount::default(),
             storage_bytes_written: Amount::default(),
-            maximum_bytes_read: u64::MAX / 2,
-            maximum_bytes_written: u64::MAX / 2,
+            maximum_bytes_read_per_block: u64::MAX / 2,
+            maximum_bytes_written_per_block: u64::MAX / 2,
             messages: Amount::default(),
         }
     }
@@ -101,8 +101,8 @@ impl ResourceControlPolicy {
             storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::ZERO,
             storage_bytes_written: Amount::ZERO,
-            maximum_bytes_read: u64::MAX / 2,
-            maximum_bytes_written: u64::MAX / 2,
+            maximum_bytes_read_per_block: u64::MAX / 2,
+            maximum_bytes_written_per_block: u64::MAX / 2,
             messages: Amount::ZERO,
         }
     }
@@ -119,8 +119,8 @@ impl ResourceControlPolicy {
             storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::ZERO,
             storage_bytes_written: Amount::ZERO,
-            maximum_bytes_read: u64::MAX,
-            maximum_bytes_written: u64::MAX,
+            maximum_bytes_read_per_block: u64::MAX,
+            maximum_bytes_written_per_block: u64::MAX,
             messages: Amount::ZERO,
         }
     }
@@ -134,8 +134,8 @@ impl ResourceControlPolicy {
             storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::from_atto(100),
             storage_bytes_written: Amount::from_atto(1_000),
-            maximum_bytes_read: u64::MAX,
-            maximum_bytes_written: u64::MAX,
+            maximum_bytes_read_per_block: u64::MAX,
+            maximum_bytes_written_per_block: u64::MAX,
             messages: Amount::from_atto(1),
         }
     }

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -56,19 +56,22 @@ impl ResourceControlPolicy {
         Ok(self.messages.try_mul(size)?)
     }
 
-    pub fn storage_num_reads_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
-        let size =
-            u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
+    pub fn storage_num_reads_price(&self, size: &u64) -> Result<Amount, PricingError> {
+        let size = u128::try_from(*size).map_err(|_| ArithmeticError::Overflow)?;
         Ok(self.storage_num_reads.try_mul(size)?)
     }
 
-    pub fn storage_bytes_read_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
-        let size =
-            u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
+    pub fn storage_bytes_read_price(&self, size: &u64) -> Result<Amount, PricingError> {
+        let size = u128::try_from(*size).map_err(|_| ArithmeticError::Overflow)?;
         Ok(self.storage_bytes_read.try_mul(size)?)
     }
 
-    pub fn storage_bytes_written_price(
+    pub fn storage_bytes_written_price(&self, size: &u64) -> Result<Amount, PricingError> {
+        let size = u128::try_from(*size).map_err(|_| ArithmeticError::Overflow)?;
+        Ok(self.storage_bytes_written.try_mul(size)?)
+    }
+
+    pub fn storage_bytes_written_price_raw(
         &self,
         data: &impl Serialize,
     ) -> Result<Amount, PricingError> {

--- a/linera-execution/src/pricing.rs
+++ b/linera-execution/src/pricing.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// A collection of costs associated with blocks in validators.
-#[derive(Eq, PartialEq, Hash, Clone, Debug, Default, Serialize, Deserialize, InputObject)]
+#[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, InputObject)]
 pub struct Pricing {
     /// The base price for each certificate, to compensate for the communication and signing
     /// overhead.
@@ -28,6 +28,21 @@ pub struct Pricing {
     pub maximum_bytes_write: u64,
     /// The cost to store and send cross-chain messages, per byte.
     pub messages: Amount,
+}
+
+impl Default for Pricing {
+    fn default() -> Self {
+        Pricing {
+            certificate: Amount::default(),
+            fuel: Amount::default(),
+            storage_n_read: Amount::default(),
+            storage_bytes_read: Amount::default(),
+            storage_bytes_write: Amount::default(),
+            maximum_bytes_read: u64::MAX,
+            maximum_bytes_write: u64::MAX,
+            messages: Amount::default(),
+        }
+    }
 }
 
 impl Pricing {

--- a/linera-execution/src/pricing.rs
+++ b/linera-execution/src/pricing.rs
@@ -17,15 +17,15 @@ pub struct Pricing {
     /// The price per unit of fuel used when executing messages and operations for user applications.
     pub fuel: Amount,
     /// The cost to read data per operation
-    pub storage_n_read: Amount,
+    pub storage_num_reads: Amount,
     /// The cost to read data per byte
     pub storage_bytes_read: Amount,
     /// The cost to store data per byte
-    pub storage_bytes_write: Amount,
-    /// The maximum data to read
+    pub storage_bytes_written: Amount,
+    /// The maximum data to read per block
     pub maximum_bytes_read: u64,
-    /// The maximum data to write
-    pub maximum_bytes_write: u64,
+    /// The maximum data to write per block
+    pub maximum_bytes_written: u64,
     /// The cost to store and send cross-chain messages, per byte.
     pub messages: Amount,
 }
@@ -35,11 +35,11 @@ impl Default for Pricing {
         Pricing {
             certificate: Amount::default(),
             fuel: Amount::default(),
-            storage_n_read: Amount::default(),
+            storage_num_reads: Amount::default(),
             storage_bytes_read: Amount::default(),
-            storage_bytes_write: Amount::default(),
+            storage_bytes_written: Amount::default(),
             maximum_bytes_read: u64::MAX,
-            maximum_bytes_write: u64::MAX,
+            maximum_bytes_written: u64::MAX,
             messages: Amount::default(),
         }
     }
@@ -56,10 +56,10 @@ impl Pricing {
         Ok(self.messages.try_mul(size)?)
     }
 
-    pub fn storage_n_read_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+    pub fn storage_num_reads_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
-        Ok(self.storage_n_read.try_mul(size)?)
+        Ok(self.storage_num_reads.try_mul(size)?)
     }
 
     pub fn storage_bytes_read_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
@@ -68,10 +68,10 @@ impl Pricing {
         Ok(self.storage_bytes_read.try_mul(size)?)
     }
 
-    pub fn storage_bytes_write_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+    pub fn storage_bytes_written_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
-        Ok(self.storage_bytes_write.try_mul(size)?)
+        Ok(self.storage_bytes_written.try_mul(size)?)
     }
 
     pub fn fuel_price(&self, fuel: u64) -> Result<Amount, PricingError> {
@@ -92,11 +92,11 @@ impl Pricing {
         Pricing {
             certificate: Amount::ZERO,
             fuel: Amount::from_atto(1_000_000_000_000),
-            storage_n_read: Amount::ZERO,
+            storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::ZERO,
-            storage_bytes_write: Amount::ZERO,
+            storage_bytes_written: Amount::ZERO,
             maximum_bytes_read: u64::MAX,
-            maximum_bytes_write: u64::MAX,
+            maximum_bytes_written: u64::MAX,
             messages: Amount::ZERO,
         }
     }
@@ -110,11 +110,11 @@ impl Pricing {
         Pricing {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000_000),
-            storage_n_read: Amount::ZERO,
+            storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::ZERO,
-            storage_bytes_write: Amount::ZERO,
+            storage_bytes_written: Amount::ZERO,
             maximum_bytes_read: u64::MAX,
-            maximum_bytes_write: u64::MAX,
+            maximum_bytes_written: u64::MAX,
             messages: Amount::ZERO,
         }
     }
@@ -125,11 +125,11 @@ impl Pricing {
         Pricing {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000),
-            storage_n_read: Amount::ZERO,
+            storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::from_atto(100),
-            storage_bytes_write: Amount::from_atto(1_000),
+            storage_bytes_written: Amount::from_atto(1_000),
             maximum_bytes_read: u64::MAX,
-            maximum_bytes_write: u64::MAX,
+            maximum_bytes_written: u64::MAX,
             messages: Amount::from_atto(1),
         }
     }

--- a/linera-execution/src/pricing.rs
+++ b/linera-execution/src/pricing.rs
@@ -41,7 +41,19 @@ impl Pricing {
         Ok(self.messages.try_mul(size)?)
     }
 
-    pub fn storage_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+    pub fn storage_n_read_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+        let size =
+            u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
+        Ok(self.storage_n_read.try_mul(size)?)
+    }
+
+    pub fn storage_byte_read_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+        let size =
+            u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
+        Ok(self.storage_byte_read.try_mul(size)?)
+    }
+
+    pub fn storage_byte_write_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
         Ok(self.storage_byte_write.try_mul(size)?)

--- a/linera-execution/src/pricing.rs
+++ b/linera-execution/src/pricing.rs
@@ -16,8 +16,16 @@ pub struct Pricing {
     pub certificate: Amount,
     /// The price per unit of fuel used when executing messages and operations for user applications.
     pub fuel: Amount,
-    /// The cost to store a block's operations and incoming messages, per byte.
-    pub storage: Amount,
+    /// The cost to read data per operation
+    pub storage_n_read: Amount,
+    /// The cost to read data per byte
+    pub storage_byte_read: Amount,
+    /// The cost to store data per byte
+    pub storage_byte_write: Amount,
+    /// The maximum data to read
+    pub maximum_byte_read: usize,
+    /// The maximum data to write
+    pub maximum_byte_write: usize,
     /// The cost to store and send cross-chain messages, per byte.
     pub messages: Amount,
 }
@@ -36,7 +44,7 @@ impl Pricing {
     pub fn storage_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
-        Ok(self.storage.try_mul(size)?)
+        Ok(self.storage_byte_write.try_mul(size)?)
     }
 
     pub fn fuel_price(&self, fuel: u64) -> Result<Amount, PricingError> {
@@ -57,7 +65,11 @@ impl Pricing {
         Pricing {
             certificate: Amount::ZERO,
             fuel: Amount::from_atto(1_000_000_000_000),
-            storage: Amount::ZERO,
+            storage_n_read: Amount::ZERO,
+            storage_byte_read: Amount::ZERO,
+            storage_byte_write: Amount::ZERO,
+            maximum_byte_read: usize::MAX,
+            maximum_byte_write: usize::MAX,
             messages: Amount::ZERO,
         }
     }
@@ -71,7 +83,11 @@ impl Pricing {
         Pricing {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000_000),
-            storage: Amount::ZERO,
+            storage_n_read: Amount::ZERO,
+            storage_byte_read: Amount::ZERO,
+            storage_byte_write: Amount::ZERO,
+            maximum_byte_read: usize::MAX,
+            maximum_byte_write: usize::MAX,
             messages: Amount::ZERO,
         }
     }
@@ -82,7 +98,11 @@ impl Pricing {
         Pricing {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000),
-            storage: Amount::from_atto(1_000),
+            storage_n_read: Amount::ZERO,
+            storage_byte_read: Amount::from_atto(100),
+            storage_byte_write: Amount::from_atto(1_000),
+            maximum_byte_read: usize::MAX,
+            maximum_byte_write: usize::MAX,
             messages: Amount::from_atto(1),
         }
     }

--- a/linera-execution/src/pricing.rs
+++ b/linera-execution/src/pricing.rs
@@ -19,13 +19,13 @@ pub struct Pricing {
     /// The cost to read data per operation
     pub storage_n_read: Amount,
     /// The cost to read data per byte
-    pub storage_byte_read: Amount,
+    pub storage_bytes_read: Amount,
     /// The cost to store data per byte
-    pub storage_byte_write: Amount,
+    pub storage_bytes_write: Amount,
     /// The maximum data to read
-    pub maximum_byte_read: usize,
+    pub maximum_bytes_read: u64,
     /// The maximum data to write
-    pub maximum_byte_write: usize,
+    pub maximum_bytes_write: u64,
     /// The cost to store and send cross-chain messages, per byte.
     pub messages: Amount,
 }
@@ -47,16 +47,16 @@ impl Pricing {
         Ok(self.storage_n_read.try_mul(size)?)
     }
 
-    pub fn storage_byte_read_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+    pub fn storage_bytes_read_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
-        Ok(self.storage_byte_read.try_mul(size)?)
+        Ok(self.storage_bytes_read.try_mul(size)?)
     }
 
-    pub fn storage_byte_write_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+    pub fn storage_bytes_write_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
-        Ok(self.storage_byte_write.try_mul(size)?)
+        Ok(self.storage_bytes_write.try_mul(size)?)
     }
 
     pub fn fuel_price(&self, fuel: u64) -> Result<Amount, PricingError> {
@@ -78,10 +78,10 @@ impl Pricing {
             certificate: Amount::ZERO,
             fuel: Amount::from_atto(1_000_000_000_000),
             storage_n_read: Amount::ZERO,
-            storage_byte_read: Amount::ZERO,
-            storage_byte_write: Amount::ZERO,
-            maximum_byte_read: usize::MAX,
-            maximum_byte_write: usize::MAX,
+            storage_bytes_read: Amount::ZERO,
+            storage_bytes_write: Amount::ZERO,
+            maximum_bytes_read: u64::MAX,
+            maximum_bytes_write: u64::MAX,
             messages: Amount::ZERO,
         }
     }
@@ -96,10 +96,10 @@ impl Pricing {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000_000),
             storage_n_read: Amount::ZERO,
-            storage_byte_read: Amount::ZERO,
-            storage_byte_write: Amount::ZERO,
-            maximum_byte_read: usize::MAX,
-            maximum_byte_write: usize::MAX,
+            storage_bytes_read: Amount::ZERO,
+            storage_bytes_write: Amount::ZERO,
+            maximum_bytes_read: u64::MAX,
+            maximum_bytes_write: u64::MAX,
             messages: Amount::ZERO,
         }
     }
@@ -111,10 +111,10 @@ impl Pricing {
             certificate: Amount::from_milli(1),
             fuel: Amount::from_atto(1_000_000_000),
             storage_n_read: Amount::ZERO,
-            storage_byte_read: Amount::from_atto(100),
-            storage_byte_write: Amount::from_atto(1_000),
-            maximum_byte_read: usize::MAX,
-            maximum_byte_write: usize::MAX,
+            storage_bytes_read: Amount::from_atto(100),
+            storage_bytes_write: Amount::from_atto(1_000),
+            maximum_bytes_read: u64::MAX,
+            maximum_bytes_write: u64::MAX,
             messages: Amount::from_atto(1),
         }
     }

--- a/linera-execution/src/pricing.rs
+++ b/linera-execution/src/pricing.rs
@@ -68,7 +68,10 @@ impl Pricing {
         Ok(self.storage_bytes_read.try_mul(size)?)
     }
 
-    pub fn storage_bytes_written_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
+    pub fn storage_bytes_written_price(
+        &self,
+        data: &impl Serialize,
+    ) -> Result<Amount, PricingError> {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
         Ok(self.storage_bytes_written.try_mul(size)?)

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     execution::ExecutionStateView, BaseRuntime, CallResult, ContractRuntime, ExecutionError,
-    ExecutionResult, ExecutionRuntimeContext, RuntimeLimits, RuntimeCounts, ServiceRuntime,
+    ExecutionResult, ExecutionRuntimeContext, RuntimeCounts, RuntimeLimits, ServiceRuntime,
     SessionId, UserApplicationCode, UserApplicationDescription, UserApplicationId,
 };
 use async_lock::{Mutex, MutexGuard, MutexGuardArc, RwLockWriteGuardArc};

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -35,11 +35,11 @@ use std::{
 pub(crate) struct ExecutionRuntime<'a, C, const WRITABLE: bool> {
     /// The amount of fuel available for executing the application.
     remaining_fuel: Arc<AtomicU64>,
-    /// the number of read
+    /// The number of reads
     num_reads: Arc<AtomicU64>,
     /// the total size being read
     bytes_read: Arc<AtomicU64>,
-    /// the total size being write
+    /// The total size being written
     bytes_written: Arc<AtomicU64>,
     /// The maximum size of read allowed
     maximum_bytes_read: u64,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -328,7 +328,7 @@ impl<'a, C, const W: bool> ExecutionRuntime<'a, C, W> {
         if bytes >= self.runtime_limits.max_budget_bytes_read {
             return Err(ExecutionError::ArithmeticError(ArithmeticError::Overflow));
         }
-        if bytes >= self.runtime_limits.maximum_bytes_read {
+        if bytes >= self.runtime_limits.maximum_bytes_left_to_read {
             return Err(ExecutionError::ExcessiveRead);
         }
         Ok(())
@@ -343,7 +343,7 @@ impl<'a, C, const W: bool> ExecutionRuntime<'a, C, W> {
         if bytes >= self.runtime_limits.max_budget_bytes_written {
             return Err(ExecutionError::ArithmeticError(ArithmeticError::Overflow));
         }
-        if bytes >= self.runtime_limits.maximum_bytes_written {
+        if bytes >= self.runtime_limits.maximum_bytes_left_to_write {
             return Err(ExecutionError::ExcessiveWrite);
         }
         Ok(())

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -407,10 +407,11 @@ where
                 let keys = view.find_keys_by_prefix(&key_prefix).await?;
                 self.n_read.fetch_add(1, Ordering::Relaxed);
                 for key in &keys {
-                    self.bytes_read.fetch_add(key.len() as u64, Ordering::Relaxed);
+                    self.bytes_read
+                        .fetch_add(key.len() as u64, Ordering::Relaxed);
                 }
                 Ok(keys)
-            },
+            }
             None => Err(ExecutionError::ApplicationStateNotLocked),
         }
     }
@@ -432,7 +433,7 @@ where
                     self.bytes_read.fetch_add(size as u64, Ordering::Relaxed);
                 }
                 Ok(key_values)
-            },
+            }
             None => Err(ExecutionError::ApplicationStateNotLocked),
         }
     }
@@ -486,7 +487,14 @@ where
         let bytes_write = self.bytes_write.load(Ordering::Acquire);
         let maximum_bytes_read = self.maximum_bytes_read;
         let maximum_bytes_write = self.maximum_bytes_write;
-        RuntimeMeter { remaining_fuel, n_read, bytes_read, bytes_write, maximum_bytes_read, maximum_bytes_write }
+        RuntimeMeter {
+            remaining_fuel,
+            n_read,
+            bytes_read,
+            bytes_write,
+            maximum_bytes_read,
+            maximum_bytes_write,
+        }
     }
 
     fn set_remaining_fuel(&self, remaining_fuel: u64) {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     execution::ExecutionStateView, BaseRuntime, CallResult, ContractRuntime, ExecutionError,
-    ExecutionResult, ExecutionRuntimeContext, RuntimeLimits, RuntimeLocalMeter, ServiceRuntime,
+    ExecutionResult, ExecutionRuntimeContext, RuntimeLimits, RuntimeCounts, ServiceRuntime,
     SessionId, UserApplicationCode, UserApplicationDescription, UserApplicationId,
 };
 use async_lock::{Mutex, MutexGuard, MutexGuardArc, RwLockWriteGuardArc};
@@ -506,12 +506,12 @@ where
         self.remaining_fuel.load(Ordering::Acquire)
     }
 
-    fn runtime_local_meter(&self) -> RuntimeLocalMeter {
+    fn runtime_counts(&self) -> RuntimeCounts {
         let remaining_fuel = self.remaining_fuel.load(Ordering::Acquire);
         let num_reads = self.num_reads.load(Ordering::Acquire);
         let bytes_read = self.bytes_read.load(Ordering::Acquire);
         let bytes_written = self.bytes_written.load(Ordering::Acquire);
-        RuntimeLocalMeter {
+        RuntimeCounts {
             remaining_fuel,
             num_reads,
             bytes_read,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     execution::ExecutionStateView, BaseRuntime, CallResult, ContractRuntime, ExecutionError,
-    ExecutionResult, ExecutionRuntimeContext, RuntimeGlobalMeter, RuntimeLocalMeter, ServiceRuntime,
+    ExecutionResult, ExecutionRuntimeContext, RuntimeLimits, RuntimeLocalMeter, ServiceRuntime,
     SessionId, UserApplicationCode, UserApplicationDescription, UserApplicationId,
 };
 use async_lock::{Mutex, MutexGuard, MutexGuardArc, RwLockWriteGuardArc};
@@ -110,15 +110,15 @@ where
         session_manager: &'a mut SessionManager,
         execution_results: &'a mut Vec<ExecutionResult>,
         fuel: u64,
-        runtime_global_meter: RuntimeGlobalMeter,
+        runtime_limits: RuntimeLimits,
     ) -> Self {
         assert_eq!(chain_id, execution_state.context().extra().chain_id());
         let remaining_fuel = Arc::new(AtomicU64::new(fuel));
         let num_reads = Arc::new(AtomicU64::new(0));
         let bytes_read = Arc::new(AtomicU64::new(0));
         let bytes_written = Arc::new(AtomicU64::new(0));
-        let maximum_bytes_read = runtime_global_meter.maximum_bytes_read;
-        let maximum_bytes_written = runtime_global_meter.maximum_bytes_written;
+        let maximum_bytes_read = runtime_limits.maximum_bytes_read;
+        let maximum_bytes_written = runtime_limits.maximum_bytes_written;
         Self {
             remaining_fuel,
             num_reads,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -42,7 +42,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::default();
     let pricing = Pricing::default();
     let result = view
         .execute_operation(
@@ -213,7 +213,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::default();
     let pricing = Pricing::default();
     let result = view
         .execute_operation(
@@ -286,7 +286,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::default();
     let pricing = Pricing::default();
     let result = view
         .execute_operation(

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -12,7 +12,7 @@ use linera_base::{
     data_types::BlockHeight,
     identifiers::{ChainDescription, ChainId, Owner, SessionId},
 };
-use linera_execution::{pricing::Pricing, *};
+use linera_execution::{policy::ResourceControlPolicy, *};
 use linera_views::{batch::Batch, common::Context, memory::MemoryContext, views::View};
 use std::sync::Arc;
 
@@ -43,7 +43,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         next_message_index: 0,
     };
     let mut runtime_limits = RuntimeLimits::default();
-    let pricing = Pricing::default();
+    let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
             &context,
@@ -51,7 +51,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![],
             },
-            &pricing,
+            &policy,
             &mut runtime_limits,
         )
         .await;
@@ -214,7 +214,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         next_message_index: 0,
     };
     let mut runtime_limits = RuntimeLimits::default();
-    let pricing = Pricing::default();
+    let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
             &context,
@@ -222,7 +222,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![1],
             },
-            &pricing,
+            &policy,
             &mut runtime_limits,
         )
         .await
@@ -287,7 +287,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         next_message_index: 0,
     };
     let mut runtime_limits = RuntimeLimits::default();
-    let pricing = Pricing::default();
+    let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
             &context,
@@ -295,7 +295,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
                 application_id: app_id,
                 bytes: vec![],
             },
-            &pricing,
+            &policy,
             &mut runtime_limits,
         )
         .await;

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -42,7 +42,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_tracker = RuntimeTracker::default();
+    let mut tracker = ResourceTracker::default();
     let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
@@ -52,7 +52,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 bytes: vec![],
             },
             &policy,
-            &mut runtime_tracker,
+            &mut tracker,
         )
         .await;
 
@@ -213,7 +213,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_tracker = RuntimeTracker::default();
+    let mut tracker = ResourceTracker::default();
     let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
@@ -223,7 +223,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 bytes: vec![1],
             },
             &policy,
-            &mut runtime_tracker,
+            &mut tracker,
         )
         .await
         .unwrap();
@@ -286,7 +286,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_tracker = RuntimeTracker::default();
+    let mut tracker = ResourceTracker::default();
     let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
@@ -296,7 +296,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
                 bytes: vec![],
             },
             &policy,
-            &mut runtime_tracker,
+            &mut tracker,
         )
         .await;
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -42,7 +42,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::default();
+    let mut runtime_tracker = RuntimeTracker::default();
     let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
@@ -52,7 +52,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 bytes: vec![],
             },
             &policy,
-            &mut runtime_limits,
+            &mut runtime_tracker,
         )
         .await;
 
@@ -213,7 +213,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::default();
+    let mut runtime_tracker = RuntimeTracker::default();
     let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
@@ -223,7 +223,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 bytes: vec![1],
             },
             &policy,
-            &mut runtime_limits,
+            &mut runtime_tracker,
         )
         .await
         .unwrap();
@@ -286,7 +286,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::default();
+    let mut runtime_tracker = RuntimeTracker::default();
     let policy = ResourceControlPolicy::default();
     let result = view
         .execute_operation(
@@ -296,7 +296,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
                 bytes: vec![],
             },
             &policy,
-            &mut runtime_limits,
+            &mut runtime_tracker,
         )
         .await;
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -42,7 +42,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::new_for_testing();
     let pricing = Pricing::default();
     let result = view
         .execute_operation(
@@ -52,7 +52,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 bytes: vec![],
             },
             &pricing,
-            &mut runtime_global_meter,
+            &mut runtime_limits,
         )
         .await;
 
@@ -213,7 +213,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::new_for_testing();
     let pricing = Pricing::default();
     let result = view
         .execute_operation(
@@ -223,7 +223,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 bytes: vec![1],
             },
             &pricing,
-            &mut runtime_global_meter,
+            &mut runtime_limits,
         )
         .await
         .unwrap();
@@ -286,7 +286,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::new_for_testing();
     let pricing = Pricing::default();
     let result = view
         .execute_operation(
@@ -296,7 +296,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
                 bytes: vec![],
             },
             &pricing,
-            &mut runtime_global_meter,
+            &mut runtime_limits,
         )
         .await;
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -42,7 +42,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-
+    let mut runtime_meter = get_default_runtime_meter();
     let result = view
         .execute_operation(
             &context,
@@ -50,7 +50,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![],
             },
-            &mut 10_000_000,
+            &mut runtime_meter,
         )
         .await;
 
@@ -211,6 +211,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
+    let mut runtime_meter = get_default_runtime_meter();
     let result = view
         .execute_operation(
             &context,
@@ -218,7 +219,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![1],
             },
-            &mut 10_000_000,
+            &mut runtime_meter,
         )
         .await
         .unwrap();
@@ -281,7 +282,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-
+    let mut runtime_meter = get_default_runtime_meter();
     let result = view
         .execute_operation(
             &context,
@@ -289,7 +290,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
                 application_id: app_id,
                 bytes: vec![],
             },
-            &mut 10_000_000,
+            &mut runtime_meter,
         )
         .await;
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -42,7 +42,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_meter = get_default_runtime_meter();
+    let mut runtime_meter = RuntimeMeter::new_for_testing();
     let result = view
         .execute_operation(
             &context,
@@ -211,7 +211,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_meter = get_default_runtime_meter();
+    let mut runtime_meter = RuntimeMeter::new_for_testing();
     let result = view
         .execute_operation(
             &context,
@@ -282,7 +282,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_meter = get_default_runtime_meter();
+    let mut runtime_meter = RuntimeMeter::new_for_testing();
     let result = view
         .execute_operation(
             &context,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -12,7 +12,7 @@ use linera_base::{
     data_types::BlockHeight,
     identifiers::{ChainDescription, ChainId, Owner, SessionId},
 };
-use linera_execution::*;
+use linera_execution::{pricing::Pricing, *};
 use linera_views::{batch::Batch, common::Context, memory::MemoryContext, views::View};
 use std::sync::Arc;
 
@@ -42,7 +42,8 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_meter = RuntimeMeter::new_for_testing();
+    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let pricing = Pricing::default();
     let result = view
         .execute_operation(
             &context,
@@ -50,7 +51,8 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![],
             },
-            &mut runtime_meter,
+            &pricing,
+            &mut runtime_global_meter,
         )
         .await;
 
@@ -211,7 +213,8 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_meter = RuntimeMeter::new_for_testing();
+    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let pricing = Pricing::default();
     let result = view
         .execute_operation(
             &context,
@@ -219,7 +222,8 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: app_id,
                 bytes: vec![1],
             },
-            &mut runtime_meter,
+            &pricing,
+            &mut runtime_global_meter,
         )
         .await
         .unwrap();
@@ -282,7 +286,8 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         authenticated_signer: Some(owner),
         next_message_index: 0,
     };
-    let mut runtime_meter = RuntimeMeter::new_for_testing();
+    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let pricing = Pricing::default();
     let result = view
         .execute_operation(
             &context,
@@ -290,7 +295,8 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
                 application_id: app_id,
                 bytes: vec![],
             },
-            &mut runtime_meter,
+            &pricing,
+            &mut runtime_global_meter,
         )
         .await;
 

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -39,7 +39,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::default();
     let pricing = Pricing::default();
     let results = view
         .execute_operation(
@@ -85,7 +85,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
-    let mut runtime_limits = RuntimeLimits::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::default();
     let pricing = Pricing::default();
     let results = view
         .execute_message(

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -9,9 +9,10 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
+    pricing::Pricing,
     system::{Account, Recipient, UserData},
     ExecutionResult, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionResult, Response, RuntimeMeter, SystemExecutionState,
+    Query, QueryContext, RawExecutionResult, Response, RuntimeGlobalMeter, SystemExecutionState,
     SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
@@ -38,9 +39,15 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_meter = RuntimeMeter::new_for_testing();
+    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let pricing = Pricing::default();
     let results = view
-        .execute_operation(&context, &Operation::System(operation), &mut runtime_meter)
+        .execute_operation(
+            &context,
+            &Operation::System(operation),
+            &pricing,
+            &mut runtime_global_meter,
+        )
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::ZERO);
@@ -78,9 +85,15 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
-    let mut runtime_meter = RuntimeMeter::new_for_testing();
+    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let pricing = Pricing::default();
     let results = view
-        .execute_message(&context, &Message::System(message), &mut runtime_meter)
+        .execute_message(
+            &context,
+            &Message::System(message),
+            &pricing,
+            &mut runtime_global_meter,
+        )
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -9,11 +9,10 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
-    get_default_runtime_meter,
     system::{Account, Recipient, UserData},
     ExecutionResult, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionResult, Response, SystemExecutionState, SystemMessage,
-    SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
+    Query, QueryContext, RawExecutionResult, Response, RuntimeMeter, SystemExecutionState,
+    SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
 use serde::{Deserialize, Serialize};
@@ -39,7 +38,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_meter = get_default_runtime_meter();
+    let mut runtime_meter = RuntimeMeter::new_for_testing();
     let results = view
         .execute_operation(&context, &Operation::System(operation), &mut runtime_meter)
         .await
@@ -79,7 +78,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
-    let mut runtime_meter = get_default_runtime_meter();
+    let mut runtime_meter = RuntimeMeter::new_for_testing();
     let results = view
         .execute_message(&context, &Message::System(message), &mut runtime_meter)
         .await

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -12,7 +12,7 @@ use linera_execution::{
     pricing::Pricing,
     system::{Account, Recipient, UserData},
     ExecutionResult, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionResult, Response, RuntimeGlobalMeter, SystemExecutionState,
+    Query, QueryContext, RawExecutionResult, Response, RuntimeLimits, SystemExecutionState,
     SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
@@ -39,14 +39,14 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::new_for_testing();
     let pricing = Pricing::default();
     let results = view
         .execute_operation(
             &context,
             &Operation::System(operation),
             &pricing,
-            &mut runtime_global_meter,
+            &mut runtime_limits,
         )
         .await
         .unwrap();
@@ -85,14 +85,14 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
-    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::new_for_testing();
     let pricing = Pricing::default();
     let results = view
         .execute_message(
             &context,
             &Message::System(message),
             &pricing,
-            &mut runtime_global_meter,
+            &mut runtime_limits,
         )
         .await
         .unwrap();

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -9,7 +9,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
-    pricing::Pricing,
+    policy::ResourceControlPolicy,
     system::{Account, Recipient, UserData},
     ExecutionResult, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
     Query, QueryContext, RawExecutionResult, Response, RuntimeLimits, SystemExecutionState,
@@ -40,12 +40,12 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         next_message_index: 0,
     };
     let mut runtime_limits = RuntimeLimits::default();
-    let pricing = Pricing::default();
+    let policy = ResourceControlPolicy::default();
     let results = view
         .execute_operation(
             &context,
             &Operation::System(operation),
-            &pricing,
+            &policy,
             &mut runtime_limits,
         )
         .await
@@ -86,12 +86,12 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         authenticated_signer: None,
     };
     let mut runtime_limits = RuntimeLimits::default();
-    let pricing = Pricing::default();
+    let policy = ResourceControlPolicy::default();
     let results = view
         .execute_message(
             &context,
             &Message::System(message),
-            &pricing,
+            &policy,
             &mut runtime_limits,
         )
         .await

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -9,6 +9,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
+    get_default_runtime_meter,
     system::{Account, Recipient, UserData},
     ExecutionResult, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
     Query, QueryContext, RawExecutionResult, Response, SystemExecutionState, SystemMessage,
@@ -38,8 +39,9 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
+    let mut runtime_meter = get_default_runtime_meter();
     let results = view
-        .execute_operation(&context, &Operation::System(operation), &mut 10_000_000)
+        .execute_operation(&context, &Operation::System(operation), &mut runtime_meter)
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::ZERO);
@@ -77,8 +79,9 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
+    let mut runtime_meter = get_default_runtime_meter();
     let results = view
-        .execute_message(&context, &Message::System(message), &mut 10_000_000)
+        .execute_message(&context, &Message::System(message), &mut runtime_meter)
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -12,7 +12,7 @@ use linera_execution::{
     policy::ResourceControlPolicy,
     system::{Account, Recipient, UserData},
     ExecutionResult, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionResult, Response, RuntimeTracker, SystemExecutionState,
+    Query, QueryContext, RawExecutionResult, ResourceTracker, Response, SystemExecutionState,
     SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
@@ -39,14 +39,14 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_tracker = RuntimeTracker::default();
+    let mut tracker = ResourceTracker::default();
     let policy = ResourceControlPolicy::default();
     let results = view
         .execute_operation(
             &context,
             &Operation::System(operation),
             &policy,
-            &mut runtime_tracker,
+            &mut tracker,
         )
         .await
         .unwrap();
@@ -85,15 +85,10 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
-    let mut runtime_tracker = RuntimeTracker::default();
+    let mut tracker = ResourceTracker::default();
     let policy = ResourceControlPolicy::default();
     let results = view
-        .execute_message(
-            &context,
-            &Message::System(message),
-            &policy,
-            &mut runtime_tracker,
-        )
+        .execute_message(&context, &Message::System(message), &policy, &mut tracker)
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -12,7 +12,7 @@ use linera_execution::{
     policy::ResourceControlPolicy,
     system::{Account, Recipient, UserData},
     ExecutionResult, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionResult, Response, RuntimeLimits, SystemExecutionState,
+    Query, QueryContext, RawExecutionResult, Response, RuntimeTracker, SystemExecutionState,
     SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
@@ -39,14 +39,14 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut runtime_limits = RuntimeLimits::default();
+    let mut runtime_tracker = RuntimeTracker::default();
     let policy = ResourceControlPolicy::default();
     let results = view
         .execute_operation(
             &context,
             &Operation::System(operation),
             &policy,
-            &mut runtime_limits,
+            &mut runtime_tracker,
         )
         .await
         .unwrap();
@@ -85,14 +85,14 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
-    let mut runtime_limits = RuntimeLimits::default();
+    let mut runtime_tracker = RuntimeTracker::default();
     let policy = ResourceControlPolicy::default();
     let results = view
         .execute_message(
             &context,
             &Message::System(message),
             &policy,
-            &mut runtime_limits,
+            &mut runtime_tracker,
         )
         .await
         .unwrap();

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -70,8 +70,10 @@ async fn test_fuel_for_counter_wasm_application(
     };
     let increments = [2_u64, 9, 7, 1000];
     let available_fuel = 10_000_000;
-    let mut runtime_meter = RuntimeMeter::default();
-    runtime_meter.remaining_fuel = available_fuel;
+    let mut runtime_meter = RuntimeMeter {
+        remaining_fuel: available_fuel,
+        ..Default::default()
+    };
     for increment in &increments {
         let result = view
             .execute_operation(

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -13,8 +13,8 @@ use linera_base::{
 };
 use linera_execution::{
     policy::ResourceControlPolicy, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView,
-    Operation, OperationContext, Query, QueryContext, RawExecutionResult, Response, RuntimeTracker,
-    SystemExecutionState, TestExecutionRuntimeContext, WasmApplication, WasmRuntime,
+    Operation, OperationContext, Query, QueryContext, RawExecutionResult, ResourceTracker,
+    Response, SystemExecutionState, TestExecutionRuntimeContext, WasmApplication, WasmRuntime,
 };
 use linera_views::{memory::MemoryContext, views::View};
 use serde_json::json;
@@ -73,7 +73,7 @@ async fn test_fuel_for_counter_wasm_application(
         fuel: Amount::from_atto(1),
         ..ResourceControlPolicy::default()
     };
-    let mut runtime_tracker = RuntimeTracker::default();
+    let mut tracker = ResourceTracker::default();
     let amount = Amount::from_tokens(1);
     *view.system.balance.get_mut() = amount;
     for increment in &increments {
@@ -82,7 +82,7 @@ async fn test_fuel_for_counter_wasm_application(
                 &context,
                 &Operation::user(app_id, increment).unwrap(),
                 &policy,
-                &mut runtime_tracker,
+                &mut tracker,
             )
             .await?;
         assert_eq!(
@@ -93,7 +93,7 @@ async fn test_fuel_for_counter_wasm_application(
             )]
         );
     }
-    assert_eq!(runtime_tracker.used_fuel, expected_fuel);
+    assert_eq!(tracker.used_fuel, expected_fuel);
 
     let context = QueryContext {
         chain_id: ChainId::root(0),

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -13,7 +13,7 @@ use linera_base::{
 };
 use linera_execution::{
     policy::ResourceControlPolicy, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView,
-    Operation, OperationContext, Query, QueryContext, RawExecutionResult, Response, RuntimeLimits,
+    Operation, OperationContext, Query, QueryContext, RawExecutionResult, Response, RuntimeTracker,
     SystemExecutionState, TestExecutionRuntimeContext, WasmApplication, WasmRuntime,
 };
 use linera_views::{memory::MemoryContext, views::View};
@@ -73,7 +73,7 @@ async fn test_fuel_for_counter_wasm_application(
         fuel: Amount::from_atto(1),
         ..ResourceControlPolicy::default()
     };
-    let mut runtime_limits = RuntimeLimits::default();
+    let mut runtime_tracker = RuntimeTracker::default();
     let amount = Amount::from_tokens(1);
     let available_fuel = policy.remaining_fuel(amount);
     *view.system.balance.get_mut() = amount;
@@ -83,7 +83,7 @@ async fn test_fuel_for_counter_wasm_application(
                 &context,
                 &Operation::user(app_id, increment).unwrap(),
                 &policy,
-                &mut runtime_limits,
+                &mut runtime_tracker,
             )
             .await?;
         assert_eq!(

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -75,7 +75,6 @@ async fn test_fuel_for_counter_wasm_application(
     };
     let mut runtime_tracker = RuntimeTracker::default();
     let amount = Amount::from_tokens(1);
-    let available_fuel = policy.remaining_fuel(amount);
     *view.system.balance.get_mut() = amount;
     for increment in &increments {
         let result = view
@@ -94,9 +93,7 @@ async fn test_fuel_for_counter_wasm_application(
             )]
         );
     }
-    let balance = view.system.balance.get();
-    let remaining_fuel = policy.remaining_fuel(*balance);
-    assert_eq!(available_fuel - remaining_fuel, expected_fuel);
+    assert_eq!(runtime_tracker.used_fuel, expected_fuel);
 
     let context = QueryContext {
         chain_id: ChainId::root(0),

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -13,7 +13,7 @@ use linera_base::{
 };
 use linera_base::data_types::Amount;
 use linera_execution::{
-    pricing::Pricing, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView, Operation,
+    policy::ResourceControlPolicy, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView, Operation,
     OperationContext, Query, QueryContext, RawExecutionResult, Response, RuntimeLimits,
     SystemExecutionState, TestExecutionRuntimeContext, WasmApplication, WasmRuntime,
 };
@@ -71,16 +71,16 @@ async fn test_fuel_for_counter_wasm_application(
         next_message_index: 0,
     };
     let increments = [2_u64, 9, 7, 1000];
-    let pricing = Pricing::default();
+    let policy = ResourceControlPolicy::default();
     let mut runtime_limits = RuntimeLimits::default();
     let balance = Amount::from_tokens(20);
-    let available_fuel = pricing.remaining_fuel(balance);
+    let available_fuel = policy.remaining_fuel(balance);
     for increment in &increments {
         let result = view
             .execute_operation(
                 &context,
                 &Operation::user(app_id, increment).unwrap(),
-                &pricing,
+                &policy,
                 &mut runtime_limits,
             )
             .await?;
@@ -92,7 +92,7 @@ async fn test_fuel_for_counter_wasm_application(
             )]
         );
     }
-    let remaining_fuel = pricing.remaining_fuel(balance);
+    let remaining_fuel = policy.remaining_fuel(balance);
     assert_eq!(available_fuel - remaining_fuel, expected_fuel);
 
     let context = QueryContext {

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -69,8 +69,10 @@ async fn test_fuel_for_counter_wasm_application(
         next_message_index: 0,
     };
     let increments = [2_u64, 9, 7, 1000];
-    let mut policy = ResourceControlPolicy::default();
-    policy.fuel = Amount::from_atto(1);
+    let policy = ResourceControlPolicy {
+        fuel: Amount::from_atto(1),
+        ..ResourceControlPolicy::default()
+    };
     let mut runtime_limits = RuntimeLimits::default();
     let amount = Amount::from_tokens(1);
     let available_fuel = policy.remaining_fuel(amount);

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -14,7 +14,7 @@ use linera_base::{
 use linera_base::data_types::Amount;
 use linera_execution::{
     pricing::Pricing, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView, Operation,
-    OperationContext, Query, QueryContext, RawExecutionResult, Response, RuntimeGlobalMeter,
+    OperationContext, Query, QueryContext, RawExecutionResult, Response, RuntimeLimits,
     SystemExecutionState, TestExecutionRuntimeContext, WasmApplication, WasmRuntime,
 };
 use linera_views::{memory::MemoryContext, views::View};
@@ -72,7 +72,7 @@ async fn test_fuel_for_counter_wasm_application(
     };
     let increments = [2_u64, 9, 7, 1000];
     let pricing = Pricing::default();
-    let mut runtime_global_meter = RuntimeGlobalMeter::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::new_for_testing();
     let balance = Amount::from_tokens(20);
     let available_fuel = pricing.remaining_fuel(balance);
     for increment in &increments {
@@ -81,7 +81,7 @@ async fn test_fuel_for_counter_wasm_application(
                 &context,
                 &Operation::user(app_id, increment).unwrap(),
                 &pricing,
-                &mut runtime_global_meter,
+                &mut runtime_limits,
             )
             .await?;
         assert_eq!(

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -72,7 +72,7 @@ async fn test_fuel_for_counter_wasm_application(
     };
     let increments = [2_u64, 9, 7, 1000];
     let pricing = Pricing::default();
-    let mut runtime_limits = RuntimeLimits::new_for_testing();
+    let mut runtime_limits = RuntimeLimits::default();
     let balance = Amount::from_tokens(20);
     let available_fuel = pricing.remaining_fuel(balance);
     for increment in &increments {

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -594,10 +594,10 @@ Pricing:
         TYPENAME: Amount
     - storage_bytes_read:
         TYPENAME: Amount
-    - storage_bytes_write:
+    - storage_bytes_written:
         TYPENAME: Amount
     - maximum_bytes_read: U64
-    - maximum_bytes_write: U64
+    - maximum_bytes_written: U64
     - messages:
         TYPENAME: Amount
 PublicKey:

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -609,8 +609,8 @@ ResourceControlPolicy:
         TYPENAME: Amount
     - storage_bytes_written:
         TYPENAME: Amount
-    - maximum_bytes_read: U64
-    - maximum_bytes_written: U64
+    - maximum_bytes_read_per_block: U64
+    - maximum_bytes_written_per_block: U64
     - messages:
         TYPENAME: Amount
 RoundNumber:

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -590,7 +590,7 @@ Pricing:
         TYPENAME: Amount
     - fuel:
         TYPENAME: Amount
-    - storage_n_read:
+    - storage_num_reads:
         TYPENAME: Amount
     - storage_bytes_read:
         TYPENAME: Amount

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -584,7 +584,20 @@ OutgoingMessage:
 Owner:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
-ResourceControlPolicy
+PublicKey:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 32
+Recipient:
+  ENUM:
+    0:
+      Burn: UNIT
+    1:
+      Account:
+        NEWTYPE:
+          TYPENAME: Account
+ResourceControlPolicy:
   STRUCT:
     - certificate:
         TYPENAME: Amount
@@ -600,19 +613,6 @@ ResourceControlPolicy
     - maximum_bytes_written: U64
     - messages:
         TYPENAME: Amount
-PublicKey:
-  NEWTYPESTRUCT:
-    TUPLEARRAY:
-      CONTENT: U8
-      SIZE: 32
-Recipient:
-  ENUM:
-    0:
-      Burn: UNIT
-    1:
-      Account:
-        NEWTYPE:
-          TYPENAME: Account
 RoundNumber:
   NEWTYPESTRUCT: U32
 RpcMessage:

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -268,8 +268,8 @@ Committee:
             TYPENAME: ValidatorName
           VALUE:
             TYPENAME: ValidatorState
-    - pricing:
-        TYPENAME: Pricing
+    - policy:
+        TYPENAME: ResourceControlPolicy
 CrossChainRequest:
   ENUM:
     0:
@@ -584,7 +584,7 @@ OutgoingMessage:
 Owner:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
-Pricing:
+ResourceControlPolicy
   STRUCT:
     - certificate:
         TYPENAME: Amount

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -590,8 +590,14 @@ Pricing:
         TYPENAME: Amount
     - fuel:
         TYPENAME: Amount
-    - storage:
+    - storage_n_read:
         TYPENAME: Amount
+    - storage_bytes_read:
+        TYPENAME: Amount
+    - storage_bytes_write:
+        TYPENAME: Amount
+    - maximum_bytes_read: U64
+    - maximum_bytes_write: U64
     - messages:
         TYPENAME: Amount
 PublicKey:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -434,7 +434,7 @@ input Pricing {
 	"""
 	The cost to read data per operation
 	"""
-	storageNRead: Amount!
+	storageNumReads: Amount!
 	"""
 	The cost to read data per byte
 	"""
@@ -442,15 +442,15 @@ input Pricing {
 	"""
 	The cost to store data per byte
 	"""
-	storageBytesWrite: Amount!
+	storageBytesWritten: Amount!
 	"""
-	The maximum data to read
+	The maximum data to read per block
 	"""
 	maximumBytesRead: Int!
 	"""
-	The maximum data to write
+	The maximum data to write per block
 	"""
-	maximumBytesWrite: Int!
+	maximumBytesWritten: Int!
 	"""
 	The cost to store and send cross-chain messages, per byte.
 	"""

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -209,9 +209,9 @@ input Committee {
 	"""
 	validityThreshold: Int!
 	"""
-	The pricing agreed on for this epoch.
+	The policy agreed on for this epoch.
 	"""
-	pricing: Pricing!
+	policy: ResourceControlPolicy!
 }
 
 """
@@ -419,9 +419,27 @@ The owner of a chain. This is currently the hash of the owner's public key used 
 scalar Owner
 
 """
+A signature public key
+"""
+scalar PublicKey
+
+type QueryRoot {
+	chain(chainId: ChainId!): ChainStateExtendedView!
+	applications(chainId: ChainId!): [ApplicationOverview!]!
+	chains: Chains!
+	block(hash: CryptoHash, chainId: ChainId!): HashedValue
+	blocks(from: CryptoHash, chainId: ChainId!, limit: Int): [HashedValue!]!
+}
+
+"""
+The recipient of a transfer
+"""
+scalar Recipient
+
+"""
 A collection of costs associated with blocks in validators.
 """
-input Pricing {
+input ResourceControlPolicy {
 	"""
 	The base price for each certificate, to compensate for the communication and signing
 	overhead.
@@ -456,24 +474,6 @@ input Pricing {
 	"""
 	messages: Amount!
 }
-
-"""
-A signature public key
-"""
-scalar PublicKey
-
-type QueryRoot {
-	chain(chainId: ChainId!): ChainStateExtendedView!
-	applications(chainId: ChainId!): [ApplicationOverview!]!
-	chains: Chains!
-	block(hash: CryptoHash, chainId: ChainId!): HashedValue
-	blocks(from: CryptoHash, chainId: ChainId!, limit: Int): [HashedValue!]!
-}
-
-"""
-The recipient of a transfer
-"""
-scalar Recipient
 
 """
 A number to identify successive attempts to decide a value in a consensus protocol.

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -432,9 +432,25 @@ input Pricing {
 	"""
 	fuel: Amount!
 	"""
-	The cost to store a block's operations and incoming messages, per byte.
+	The cost to read data per operation
 	"""
-	storage: Amount!
+	storageNRead: Amount!
+	"""
+	The cost to read data per byte
+	"""
+	storageBytesRead: Amount!
+	"""
+	The cost to store data per byte
+	"""
+	storageBytesWrite: Amount!
+	"""
+	The maximum data to read
+	"""
+	maximumBytesRead: Int!
+	"""
+	The maximum data to write
+	"""
+	maximumBytesWrite: Int!
 	"""
 	The cost to store and send cross-chain messages, per byte.
 	"""

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -464,11 +464,11 @@ input ResourceControlPolicy {
 	"""
 	The maximum data to read per block
 	"""
-	maximumBytesRead: Int!
+	maximumBytesReadPerBlock: Int!
 	"""
 	The maximum data to write per block
 	"""
-	maximumBytesWritten: Int!
+	maximumBytesWrittenPerBlock: Int!
 	"""
 	The cost to store and send cross-chain messages, per byte.
 	"""

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -16,7 +16,7 @@ use linera_base::{
 use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
 use linera_execution::{
     committee::{Committee, ValidatorName, ValidatorState},
-    pricing::Pricing,
+    policy::ResourceControlPolicy,
 };
 use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
 use linera_storage::Store;
@@ -78,7 +78,7 @@ impl Import for CommitteeConfig {}
 impl Export for CommitteeConfig {}
 
 impl CommitteeConfig {
-    pub fn into_committee(self, pricing: Pricing) -> Committee {
+    pub fn into_committee(self, policy: ResourceControlPolicy) -> Committee {
         let validators = self
             .validators
             .into_iter()
@@ -92,7 +92,7 @@ impl CommitteeConfig {
                 )
             })
             .collect();
-        Committee::new(validators, pricing)
+        Committee::new(validators, policy)
     }
 }
 
@@ -435,19 +435,19 @@ pub struct GenesisConfig {
     pub committee: CommitteeConfig,
     pub admin_id: ChainId,
     pub chains: Vec<(ChainDescription, PublicKey, Amount, Timestamp)>,
-    pub pricing: Pricing,
+    pub policy: ResourceControlPolicy,
 }
 
 impl Import for GenesisConfig {}
 impl Export for GenesisConfig {}
 
 impl GenesisConfig {
-    pub fn new(committee: CommitteeConfig, admin_id: ChainId, pricing: Pricing) -> Self {
+    pub fn new(committee: CommitteeConfig, admin_id: ChainId, policy: ResourceControlPolicy) -> Self {
         Self {
             committee,
             admin_id,
             chains: Vec::new(),
-            pricing,
+            policy,
         }
     }
 
@@ -472,6 +472,6 @@ impl GenesisConfig {
     }
 
     pub fn create_committee(&self) -> Committee {
-        self.committee.clone().into_committee(self.pricing.clone())
+        self.committee.clone().into_committee(self.policy.clone())
     }
 }

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -442,7 +442,11 @@ impl Import for GenesisConfig {}
 impl Export for GenesisConfig {}
 
 impl GenesisConfig {
-    pub fn new(committee: CommitteeConfig, admin_id: ChainId, policy: ResourceControlPolicy) -> Self {
+    pub fn new(
+        committee: CommitteeConfig,
+        admin_id: ChainId,
+        policy: ResourceControlPolicy,
+    ) -> Self {
         Self {
             committee,
             admin_id,

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -811,7 +811,7 @@ enum ClientCommand {
 
         /// Set the price per byte to read data per operation
         #[structopt(long)]
-        storage_n_read: Option<Amount>,
+        storage_num_reads: Option<Amount>,
 
         /// Set the price per byte to read data per byte
         #[structopt(long)]
@@ -819,15 +819,15 @@ enum ClientCommand {
 
         /// Set the price per byte to write data per byte
         #[structopt(long)]
-        storage_bytes_write: Option<Amount>,
+        storage_bytes_written: Option<Amount>,
 
-        /// Set the maximum quantity of data to read
+        /// Set the maximum quantity of data to read per block
         #[structopt(long)]
         maximum_bytes_read: Option<u64>,
 
-        /// Set the maximum quantity of data to write
+        /// Set the maximum quantity of data to write per block
         #[structopt(long)]
-        maximum_bytes_write: Option<u64>,
+        maximum_bytes_written: Option<u64>,
 
         /// Set the price per byte to store and send outgoing cross-chain messages.
         #[structopt(long)]
@@ -883,7 +883,7 @@ enum ClientCommand {
 
         /// Set the price per operation to read data
         #[structopt(long, default_value = "0")]
-        storage_n_read_price: Amount,
+        storage_num_reads_price: Amount,
 
         /// Set the price per byte to read data
         #[structopt(long, default_value = "0")]
@@ -891,15 +891,15 @@ enum ClientCommand {
 
         /// Set the price per byte to write data
         #[structopt(long, default_value = "0")]
-        storage_bytes_write_price: Amount,
+        storage_bytes_written_price: Amount,
 
-        /// Set the maximum read data
+        /// Set the maximum read data per block
         #[structopt(long)]
         maximum_bytes_read_price: Option<u64>,
 
-        /// Set the maximum write data
+        /// Set the maximum write data per block
         #[structopt(long)]
-        maximum_bytes_write_price: Option<u64>,
+        maximum_bytes_written_price: Option<u64>,
 
         /// Set the price per byte to store and send outgoing cross-chain messages.
         #[structopt(long, default_value = "0")]
@@ -1382,11 +1382,11 @@ impl Runnable for Job {
                     Pricing {
                         certificate,
                         fuel,
-                        storage_n_read,
+                        storage_num_reads,
                         storage_bytes_read,
-                        storage_bytes_write,
+                        storage_bytes_written,
                         maximum_bytes_read,
-                        maximum_bytes_write,
+                        maximum_bytes_written,
                         messages,
                     } => {
                         if let Some(certificate) = certificate {
@@ -1395,20 +1395,20 @@ impl Runnable for Job {
                         if let Some(fuel) = fuel {
                             pricing.fuel = fuel;
                         }
-                        if let Some(storage_n_read) = storage_n_read {
-                            pricing.storage_n_read = storage_n_read;
+                        if let Some(storage_num_reads) = storage_num_reads {
+                            pricing.storage_num_reads = storage_num_reads;
                         }
                         if let Some(storage_bytes_read) = storage_bytes_read {
                             pricing.storage_bytes_read = storage_bytes_read;
                         }
-                        if let Some(storage_bytes_write) = storage_bytes_write {
-                            pricing.storage_bytes_write = storage_bytes_write;
+                        if let Some(storage_bytes_written) = storage_bytes_written {
+                            pricing.storage_bytes_written = storage_bytes_written;
                         }
                         if let Some(maximum_bytes_read) = maximum_bytes_read {
                             pricing.maximum_bytes_read = maximum_bytes_read;
                         }
-                        if let Some(maximum_bytes_write) = maximum_bytes_write {
-                            pricing.maximum_bytes_write = maximum_bytes_write;
+                        if let Some(maximum_bytes_written) = maximum_bytes_written {
+                            pricing.maximum_bytes_written = maximum_bytes_written;
                         }
                         if let Some(messages) = messages {
                             pricing.messages = messages;
@@ -1419,26 +1419,26 @@ impl Runnable for Job {
                             {:.2} per unit of fuel used in the read per operation\n\
                             {:.2} per unit of fuel used in the read per byte\n\
                             {:.2} per unit of fuel used in the write per byte\n\
-                            {:.2} maximum number bytes read\n\
-                            {:.2} maximum number bytes written\n\
+                            {:.2} maximum number bytes read per block\n\
+                            {:.2} maximum number bytes written per block\n\
                             {:.2} per byte of operations and incoming messages\n\
                             {:.2} per byte of outgoing messages",
                             pricing.certificate,
                             pricing.fuel,
-                            pricing.storage_n_read,
+                            pricing.storage_num_reads,
                             pricing.storage_bytes_read,
-                            pricing.storage_bytes_write,
+                            pricing.storage_bytes_written,
                             pricing.maximum_bytes_read,
-                            pricing.maximum_bytes_write,
+                            pricing.maximum_bytes_written,
                             pricing.messages
                         );
                         if certificate.is_none()
                             && fuel.is_none()
-                            && storage_n_read.is_none()
+                            && storage_num_reads.is_none()
                             && storage_bytes_read.is_none()
-                            && storage_bytes_write.is_none()
+                            && storage_bytes_written.is_none()
                             && maximum_bytes_read.is_none()
-                            && maximum_bytes_write.is_none()
+                            && maximum_bytes_written.is_none()
                             && messages.is_none()
                         {
                             return Ok(());
@@ -1811,11 +1811,11 @@ async fn main() -> Result<(), anyhow::Error> {
             num,
             certificate_price,
             fuel_price,
-            storage_n_read_price,
+            storage_num_reads_price,
             storage_bytes_read_price,
-            storage_bytes_write_price,
+            storage_bytes_written_price,
             maximum_bytes_read_price,
-            maximum_bytes_write_price,
+            maximum_bytes_written_price,
             messages_price,
             testing_prng_seed,
         } => {
@@ -1825,18 +1825,18 @@ async fn main() -> Result<(), anyhow::Error> {
                 Some(value) => value,
                 None => u64::MAX,
             };
-            let maximum_bytes_write = match *maximum_bytes_write_price {
+            let maximum_bytes_written = match *maximum_bytes_written_price {
                 Some(value) => value,
                 None => u64::MAX,
             };
             let pricing = Pricing {
                 certificate: *certificate_price,
                 fuel: *fuel_price,
-                storage_n_read: *storage_n_read_price,
+                storage_num_reads: *storage_num_reads_price,
                 storage_bytes_read: *storage_bytes_read_price,
-                storage_bytes_write: *storage_bytes_write_price,
+                storage_bytes_written: *storage_bytes_written_price,
                 maximum_bytes_read,
-                maximum_bytes_write,
+                maximum_bytes_written,
                 messages: *messages_price,
             };
             let mut genesis_config =

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -815,19 +815,19 @@ enum ClientCommand {
 
         /// Set the price per byte to read data per byte
         #[structopt(long)]
-        storage_byte_read: Option<Amount>,
+        storage_bytes_read: Option<Amount>,
 
         /// Set the price per byte to write data per byte
         #[structopt(long)]
-        storage_byte_write: Option<Amount>,
+        storage_bytes_write: Option<Amount>,
 
         /// Set the maximum quantity of data to read
         #[structopt(long)]
-        maximum_byte_read: Option<usize>,
+        maximum_bytes_read: Option<u64>,
 
         /// Set the maximum quantity of data to write
         #[structopt(long)]
-        maximum_byte_write: Option<usize>,
+        maximum_bytes_write: Option<u64>,
 
         /// Set the price per byte to store and send outgoing cross-chain messages.
         #[structopt(long)]
@@ -887,19 +887,19 @@ enum ClientCommand {
 
         /// Set the price per byte to read data
         #[structopt(long, default_value = "0")]
-        storage_byte_read_price: Amount,
+        storage_bytes_read_price: Amount,
 
         /// Set the price per byte to write data
         #[structopt(long, default_value = "0")]
-        storage_byte_write_price: Amount,
+        storage_bytes_write_price: Amount,
 
         /// Set the maximum read data
         #[structopt(long)]
-        maximum_byte_read_price: Option<usize>,
+        maximum_bytes_read_price: Option<u64>,
 
         /// Set the maximum write data
         #[structopt(long)]
-        maximum_byte_write_price: Option<usize>,
+        maximum_bytes_write_price: Option<u64>,
 
         /// Set the price per byte to store and send outgoing cross-chain messages.
         #[structopt(long, default_value = "0")]
@@ -1383,10 +1383,10 @@ impl Runnable for Job {
                         certificate,
                         fuel,
                         storage_n_read,
-                        storage_byte_read,
-                        storage_byte_write,
-                        maximum_byte_read,
-                        maximum_byte_write,
+                        storage_bytes_read,
+                        storage_bytes_write,
+                        maximum_bytes_read,
+                        maximum_bytes_write,
                         messages,
                     } => {
                         if let Some(certificate) = certificate {
@@ -1398,17 +1398,17 @@ impl Runnable for Job {
                         if let Some(storage_n_read) = storage_n_read {
                             pricing.storage_n_read = storage_n_read;
                         }
-                        if let Some(storage_byte_read) = storage_byte_read {
-                            pricing.storage_byte_read = storage_byte_read;
+                        if let Some(storage_bytes_read) = storage_bytes_read {
+                            pricing.storage_bytes_read = storage_bytes_read;
                         }
-                        if let Some(storage_byte_write) = storage_byte_write {
-                            pricing.storage_byte_write = storage_byte_write;
+                        if let Some(storage_bytes_write) = storage_bytes_write {
+                            pricing.storage_bytes_write = storage_bytes_write;
                         }
-                        if let Some(maximum_byte_read) = maximum_byte_read {
-                            pricing.maximum_byte_read = maximum_byte_read;
+                        if let Some(maximum_bytes_read) = maximum_bytes_read {
+                            pricing.maximum_bytes_read = maximum_bytes_read;
                         }
-                        if let Some(maximum_byte_write) = maximum_byte_write {
-                            pricing.maximum_byte_write = maximum_byte_write;
+                        if let Some(maximum_bytes_write) = maximum_bytes_write {
+                            pricing.maximum_bytes_write = maximum_bytes_write;
                         }
                         if let Some(messages) = messages {
                             pricing.messages = messages;
@@ -1426,19 +1426,19 @@ impl Runnable for Job {
                             pricing.certificate,
                             pricing.fuel,
                             pricing.storage_n_read,
-                            pricing.storage_byte_read,
-                            pricing.storage_byte_write,
-                            pricing.maximum_byte_read,
-                            pricing.maximum_byte_write,
+                            pricing.storage_bytes_read,
+                            pricing.storage_bytes_write,
+                            pricing.maximum_bytes_read,
+                            pricing.maximum_bytes_write,
                             pricing.messages
                         );
                         if certificate.is_none()
                             && fuel.is_none()
                             && storage_n_read.is_none()
-                            && storage_byte_read.is_none()
-                            && storage_byte_write.is_none()
-                            && maximum_byte_read.is_none()
-                            && maximum_byte_write.is_none()
+                            && storage_bytes_read.is_none()
+                            && storage_bytes_write.is_none()
+                            && maximum_bytes_read.is_none()
+                            && maximum_bytes_write.is_none()
                             && messages.is_none()
                         {
                             return Ok(());
@@ -1812,31 +1812,31 @@ async fn main() -> Result<(), anyhow::Error> {
             certificate_price,
             fuel_price,
             storage_n_read_price,
-            storage_byte_read_price,
-            storage_byte_write_price,
-            maximum_byte_read_price,
-            maximum_byte_write_price,
+            storage_bytes_read_price,
+            storage_bytes_write_price,
+            maximum_bytes_read_price,
+            maximum_bytes_write_price,
             messages_price,
             testing_prng_seed,
         } => {
             let committee_config = CommitteeConfig::read(committee_config_path)
                 .expect("Unable to read committee config file");
-            let maximum_byte_read = match *maximum_byte_read_price {
+            let maximum_bytes_read = match *maximum_bytes_read_price {
                 Some(value) => value,
-                None => usize::MAX,
+                None => u64::MAX,
             };
-            let maximum_byte_write = match *maximum_byte_write_price {
+            let maximum_bytes_write = match *maximum_bytes_write_price {
                 Some(value) => value,
-                None => usize::MAX,
+                None => u64::MAX,
             };
             let pricing = Pricing {
                 certificate: *certificate_price,
                 fuel: *fuel_price,
                 storage_n_read: *storage_n_read_price,
-                storage_byte_read: *storage_byte_read_price,
-                storage_byte_write: *storage_byte_write_price,
-                maximum_byte_read,
-                maximum_byte_write,
+                storage_bytes_read: *storage_bytes_read_price,
+                storage_bytes_write: *storage_bytes_write_price,
+                maximum_bytes_read,
+                maximum_bytes_write,
                 messages: *messages_price,
             };
             let mut genesis_config =

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -823,11 +823,11 @@ enum ClientCommand {
 
         /// Set the maximum quantity of data to read per block
         #[structopt(long)]
-        maximum_bytes_read: Option<u64>,
+        maximum_bytes_read_per_block: Option<u64>,
 
         /// Set the maximum quantity of data to write per block
         #[structopt(long)]
-        maximum_bytes_written: Option<u64>,
+        maximum_bytes_written_per_block: Option<u64>,
 
         /// Set the price per byte to store and send outgoing cross-chain messages.
         #[structopt(long)]
@@ -895,11 +895,11 @@ enum ClientCommand {
 
         /// Set the maximum read data per block
         #[structopt(long)]
-        maximum_bytes_read_price: Option<u64>,
+        maximum_bytes_read_per_block: Option<u64>,
 
         /// Set the maximum write data per block
         #[structopt(long)]
-        maximum_bytes_written_price: Option<u64>,
+        maximum_bytes_written_per_block: Option<u64>,
 
         /// Set the price per byte to store and send outgoing cross-chain messages.
         #[structopt(long, default_value = "0")]
@@ -1387,8 +1387,8 @@ impl Runnable for Job {
                         storage_num_reads,
                         storage_bytes_read,
                         storage_bytes_written,
-                        maximum_bytes_read,
-                        maximum_bytes_written,
+                        maximum_bytes_read_per_block,
+                        maximum_bytes_written_per_block,
                         messages,
                     } => {
                         if let Some(certificate) = certificate {
@@ -1406,11 +1406,14 @@ impl Runnable for Job {
                         if let Some(storage_bytes_written) = storage_bytes_written {
                             policy.storage_bytes_written = storage_bytes_written;
                         }
-                        if let Some(maximum_bytes_read) = maximum_bytes_read {
-                            policy.maximum_bytes_read = maximum_bytes_read;
+                        if let Some(maximum_bytes_read_per_block) = maximum_bytes_read_per_block {
+                            policy.maximum_bytes_read_per_block = maximum_bytes_read_per_block;
                         }
-                        if let Some(maximum_bytes_written) = maximum_bytes_written {
-                            policy.maximum_bytes_written = maximum_bytes_written;
+                        if let Some(maximum_bytes_written_per_block) =
+                            maximum_bytes_written_per_block
+                        {
+                            policy.maximum_bytes_written_per_block =
+                                maximum_bytes_written_per_block;
                         }
                         if let Some(messages) = messages {
                             policy.messages = messages;
@@ -1431,16 +1434,16 @@ impl Runnable for Job {
                             policy.storage_bytes_read,
                             policy.storage_bytes_written,
                             policy.messages,
-                            policy.maximum_bytes_read,
-                            policy.maximum_bytes_written
+                            policy.maximum_bytes_read_per_block,
+                            policy.maximum_bytes_written_per_block
                         );
                         if certificate.is_none()
                             && fuel.is_none()
                             && storage_num_reads.is_none()
                             && storage_bytes_read.is_none()
                             && storage_bytes_written.is_none()
-                            && maximum_bytes_read.is_none()
-                            && maximum_bytes_written.is_none()
+                            && maximum_bytes_read_per_block.is_none()
+                            && maximum_bytes_written_per_block.is_none()
                             && messages.is_none()
                         {
                             return Ok(());
@@ -1816,18 +1819,18 @@ async fn main() -> Result<(), anyhow::Error> {
             storage_num_reads_price,
             storage_bytes_read_price,
             storage_bytes_written_price,
-            maximum_bytes_read_price,
-            maximum_bytes_written_price,
+            maximum_bytes_read_per_block,
+            maximum_bytes_written_per_block,
             messages_price,
             testing_prng_seed,
         } => {
             let committee_config = CommitteeConfig::read(committee_config_path)
                 .expect("Unable to read committee config file");
-            let maximum_bytes_read = match *maximum_bytes_read_price {
+            let maximum_bytes_read_per_block = match *maximum_bytes_read_per_block {
                 Some(value) => value,
                 None => u64::MAX,
             };
-            let maximum_bytes_written = match *maximum_bytes_written_price {
+            let maximum_bytes_written_per_block = match *maximum_bytes_written_per_block {
                 Some(value) => value,
                 None => u64::MAX,
             };
@@ -1837,8 +1840,8 @@ async fn main() -> Result<(), anyhow::Error> {
                 storage_num_reads: *storage_num_reads_price,
                 storage_bytes_read: *storage_bytes_read_price,
                 storage_bytes_written: *storage_bytes_written_price,
-                maximum_bytes_read,
-                maximum_bytes_written,
+                maximum_bytes_read_per_block,
+                maximum_bytes_written_per_block,
                 messages: *messages_price,
             };
             let mut genesis_config =

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1335,7 +1335,9 @@ impl Runnable for Job {
                 context.save_wallet();
             }
 
-            command @ (SetValidator { .. } | RemoveValidator { .. } | ResourceControlPolicy { .. }) => {
+            command @ (SetValidator { .. }
+            | RemoveValidator { .. }
+            | ResourceControlPolicy { .. }) => {
                 info!("Starting operations to change validator set");
                 let time_start = Instant::now();
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1416,12 +1416,12 @@ impl Runnable for Job {
                         info!(
                             "Pricing:\n\
                             {:.2} base cost per block\n\
-                            {:.2} per unit of fuel used in the read per operation\n\
-                            {:.2} per unit of fuel used in the read per byte\n\
-                            {:.2} per unit of fuel used in the write per byte\n\
+                            {:.2} per byte of operations and incoming messages\n\
+                            {:.2} per byte operation\n\
+                            {:.2} per bytes read\n\
+                            {:.2} per bytes written\n\
                             {:.2} maximum number bytes read per block\n\
                             {:.2} maximum number bytes written per block\n\
-                            {:.2} per byte of operations and incoming messages\n\
                             {:.2} per byte of outgoing messages",
                             pricing.certificate,
                             pricing.fuel,

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -171,6 +171,25 @@ impl Batch {
         Self::default()
     }
 
+    /// The total size of the batch
+    pub fn size(&self) -> usize {
+        let mut size = 0;
+        for operation in &self.operations {
+            match operation {
+                WriteOperation::Delete { key } => {
+                    size += key.len();
+                }
+                WriteOperation::Put { key, value } => {
+                    size += key.len() + value.len();
+                }
+                WriteOperation::DeletePrefix { key_prefix } => {
+                    size += key_prefix.len();
+                }
+            }
+        }
+        size
+    }
+
     /// Builds a batch from a builder function.
     pub async fn build<F>(builder: F) -> Result<Self, ViewError>
     where

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -401,8 +401,7 @@ where
             return Ok(None);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
-        let value = self.context.read_key_bytes(&key).await?;
-        Ok(value)
+        Ok(self.context.read_key_bytes(&key).await?)
     }
 
     /// Obtains the values of a range of indices


### PR DESCRIPTION
## Motivation

We need to implement the storage fees for the linera-protocol. This version implements it in a rather straightforward way. We are counting the number of reads and writes, not the total data used.

## Proposal

* The `pricing.rs` module is significantly extended to separate writes from reads.
* The `remaining_fuel` is replaced by a `runtime_meter` that accounts for all the operation being done.
* As opposed to what we initially planned, all the computation is done in `runtime.rs`.
* As discussed beforehand, we also added limits and those limits are part of the `pricing.rs` code.

## Test Plan

CI so far, needs to extend.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
