### PR TITLE
Prometheus log fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,6 @@ dependencies = [
  "linera-wit-bindgen-host-wasmtime-rust",
  "lru",
  "once_cell",
- "prometheus",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1700,7 +1700,6 @@ dependencies = [
  "linera-wit-bindgen-host-wasmer-rust",
  "lru",
  "once_cell",
- "prometheus",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -49,6 +49,7 @@ pub static NUM_BLOCKS_EXECUTED: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .expect("Counter creation should not fail")
 });
+
 pub static BLOCK_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "block_execution_latency",
@@ -57,6 +58,16 @@ pub static BLOCK_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
         &[]
     )
     .expect("Counter creation should not fail")
+});
+
+pub static WASM_FUEL_USED_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "wasm_fuel_used_per_block",
+        "Wasm fuel used per block",
+        // Can add labels here
+        &[]
+    )
+    .expect("Counter can be created")
 });
 
 /// A view accessing the state of a chain.
@@ -563,6 +574,9 @@ where
         BLOCK_EXECUTION_LATENCY
             .with_label_values(&[])
             .observe(start_time.elapsed().as_secs_f64());
+        WASM_FUEL_USED_PER_BLOCK
+            .with_label_values(&[])
+            .observe(used_fuel as f64);
         Ok(BlockExecutionOutcome {
             messages,
             message_counts,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -561,7 +561,7 @@ impl CertificateValue {
             .map(|executed_block| &executed_block.block)
     }
 
-    pub fn to_log_str(&self) -> &str {
+    pub fn to_log_str(&self) -> &'static str {
         match self {
             CertificateValue::ConfirmedBlock { .. } => "confirmed_block",
             CertificateValue::ValidatedBlock { .. } => "validated_block",

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1077,7 +1077,8 @@ where
             }
         );
 
-        let certificate_for_logging = certificate.clone();
+        let round = certificate.round;
+        let log_str = certificate.value().to_log_str();
         let mut duplicated = false;
         let (info, actions) = match certificate.value() {
             CertificateValue::ValidatedBlock { .. } => {
@@ -1103,8 +1104,8 @@ where
 
         if !duplicated {
             NUM_ROUNDS_IN_CERTIFICATE
-                .with_label_values(&[certificate_for_logging.value().to_log_str()])
-                .observe(certificate_for_logging.round.0 as f64);
+                .with_label_values(&[log_str])
+                .observe(round.0 as f64);
         }
         Ok((info, actions))
     }

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -35,7 +35,6 @@ linera-views = { workspace = true, features = ["metrics"] }
 linera-views-derive = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }
-prometheus = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Motivation

It's wasteful to clone a whole certificate, since it can potentially contain large blobs of data like bytecode.

We were meaning to measure the fuel usage per block, not per user action.

## Proposal

Avoid cloning the certificate: Just copy the round number and certificate type description.

Move the fuel log to `execute_block`.

## Test Plan

@andresilva91: Could you repeat the local test you did for https://github.com/linera-io/linera-protocol/pull/1137 and confirm the outcome is the same?

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
