### PR TITLE
Simplify linera_net_helper script

### DIFF
--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -9,23 +9,12 @@ function linera_spawn_and_read_wallet_variables() {
     # Clean up the temporary directory in case we exit.
     trap 'rm -rf "$LINERA_TMP_DIR"' EXIT
 
-    LINERA_TMP_PID="$LINERA_TMP_DIR/pid"
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"
     mkfifo "$LINERA_TMP_ERR" || exit 1
 
-    (
-        # Ignoring SIGPIPE to keep `tee` alive after `sed` exits below, closing
-        # LINERA_TMP_ERR.
-        trap '' PIPE
-
-        # Start the main process.
-        "$@" 2> >(tee "$LINERA_TMP_ERR" 2>/dev/null) 1>"$LINERA_TMP_OUT" &
-
-        # Remember the PID of the service for later.
-        jobs -p > "$LINERA_TMP_PID"
-    )
-    LINERA_NET_PID=$(cat "$LINERA_TMP_PID")
+    "$@" >"$LINERA_TMP_OUT" 2>"$LINERA_TMP_ERR" &
+    LINERA_NET_PID=$!
 
     # When the shell exits, we will clean up the top-level jobs (if any), the temporary
     # directory, and the main process. Handling future top-level jobs here is useful
@@ -33,8 +22,11 @@ function linera_spawn_and_read_wallet_variables() {
     trap 'jobs -p | xargs -r kill && rm -rf "$LINERA_TMP_DIR" && kill "$LINERA_NET_PID"' EXIT
 
     # Read from LINERA_TMP_ERR until the string "READY!" is found.
-    sed -n '/^READY!/q' <"$LINERA_TMP_ERR" || exit 1
+    sed '/^READY!/q' <"$LINERA_TMP_ERR" || exit 1
 
     # Source the Bash commands output by the server.
     source "$LINERA_TMP_OUT"
+
+    # Continue to output the command's stderr onto stdout.
+    cat "$LINERA_TMP_ERR" &
 }

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -9,7 +9,7 @@ function linera_spawn_and_read_wallet_variables() {
     # When the shell exits, we will clean up the top-level jobs (if any), the temporary
     # directory, and the main process. Handling future top-level jobs here is useful
     # because calling `trap` again will be replace this handler.
-    trap 'jobs -p | xargs -r kill && rm -rf "$LINERA_TMP_DIR"' EXIT
+    trap 'jobs -p | xargs -r kill; rm -rf "$LINERA_TMP_DIR"' EXIT
 
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"

--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -6,20 +6,16 @@
 function linera_spawn_and_read_wallet_variables() {
     LINERA_TMP_DIR=$(mktemp -d "${TMPDIR:-.}tmp-XXXXX") || exit 1
 
-    # Clean up the temporary directory in case we exit.
-    trap 'rm -rf "$LINERA_TMP_DIR"' EXIT
+    # When the shell exits, we will clean up the top-level jobs (if any), the temporary
+    # directory, and the main process. Handling future top-level jobs here is useful
+    # because calling `trap` again will be replace this handler.
+    trap 'jobs -p | xargs -r kill && rm -rf "$LINERA_TMP_DIR"' EXIT
 
     LINERA_TMP_OUT="$LINERA_TMP_DIR/out"
     LINERA_TMP_ERR="$LINERA_TMP_DIR/err"
     mkfifo "$LINERA_TMP_ERR" || exit 1
 
     "$@" >"$LINERA_TMP_OUT" 2>"$LINERA_TMP_ERR" &
-    LINERA_NET_PID=$!
-
-    # When the shell exits, we will clean up the top-level jobs (if any), the temporary
-    # directory, and the main process. Handling future top-level jobs here is useful
-    # because calling `trap` again will be replace this handler.
-    trap 'jobs -p | xargs -r kill && rm -rf "$LINERA_TMP_DIR" && kill "$LINERA_NET_PID"' EXIT
 
     # Read from LINERA_TMP_ERR until the string "READY!" is found.
     sed '/^READY!/q' <"$LINERA_TMP_ERR" || exit 1


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->

@ma2bd and I were discussing what could be done to improve this script, since it currently causes `tee` to throw a lot of errors which are then suppressed, with some performance implications.  I meditated on it a little bit and came up with the following simplification, which seems to work in my tests.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->

Instead of using `tee` in the spawned process and trap `SIGPIPE` to ensure it isn't accidentally terminated, let `sed` print its pattern space directly, and then simply pick up the FIFO with `cat` (in the background) when it's done.

An alternative approach is possible if we're willing to have `linera net up` (and similar commands that output commands to be sourced on `stdout`) close the channel when they're done, which is slightly simpler.  It's not clear to me what the convention is within the `linera` codebase about how to structure these things, but as a UX concern it seems like we should have a common language — so I haven't implemented any changes here for now, continuing to listen for the magic `READY!` string.  In the same vein, this PR preserves previous behaviour of the net helper which is to redirect the child process' `stderr` to the parent process' `stdout`; I'm not sure if this was intentional.

## Test Plan

<!-- How to test that the changes are correct. -->

Use the `linera net helper` function to run some commands, e.g.

```console
$ eval "$(linera net helper)"
$ linera_spawn_and_read_wallet_variables linera net up
```

Alternatively, use the README integration tests, which include bash scripts that use `linera net helper` heavily:

```console
$ cargo test -p linera-service readme
```

This branch (based on `main`) includes one such test, or alternatively the branch at https://github.com/linera-io/linera-protocol/pull/1158 contains many more for more complete testing.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

Apart from performance, this PR should introduce no user-visible changes.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
