### PR TITLE
Log proxy side metrics to Prometheus

### DIFF
--- a/configuration/k8s-local/validator_1.toml
+++ b/configuration/k8s-local/validator_1.toml
@@ -1,6 +1,8 @@
 server_config_path = "server_1.json"
 host = "127.0.0.1"
 port = 19100
+metrics_host = "validator-1"
+metrics_port = 21100
 internal_host = "validator-1"
 internal_port = 20100
 external_protocol = "Grpc"

--- a/configuration/local/validator_1.toml
+++ b/configuration/local/validator_1.toml
@@ -1,6 +1,8 @@
 server_config_path = "server_1.json"
 host = "127.0.0.1"
 port = 19100
+metrics_host = "127.0.0.1"
+metrics_port = 21100
 internal_host = "127.0.0.1"
 internal_port = 20100
 external_protocol = "Grpc"

--- a/configuration/local/validator_2.toml
+++ b/configuration/local/validator_2.toml
@@ -3,6 +3,8 @@ host = "127.0.0.1"
 port = 9200
 internal_host = "127.0.0.1"
 internal_port = 10200
+metrics_host = "127.0.0.1"
+metrics_port = 11200
 external_protocol = "Grpc"
 internal_protocol = "Grpc"
 

--- a/configuration/local/validator_3.toml
+++ b/configuration/local/validator_3.toml
@@ -3,6 +3,8 @@ host = "127.0.0.1"
 port = 9300
 internal_host = "127.0.0.1"
 internal_port = 10300
+metrics_host = "127.0.0.1"
+metrics_port = 11300
 external_protocol = "Grpc"
 internal_protocol = "Grpc"
 

--- a/configuration/local/validator_4.toml
+++ b/configuration/local/validator_4.toml
@@ -3,6 +3,8 @@ host = "127.0.0.1"
 port = 9400
 internal_host = "127.0.0.1"
 internal_port = 10400
+metrics_host = "127.0.0.1"
+metrics_port = 11400
 external_protocol = "Grpc"
 internal_protocol = "Grpc"
 

--- a/configuration/prod/validator_1.toml
+++ b/configuration/prod/validator_1.toml
@@ -1,6 +1,8 @@
 server_config_path = "server_1.json"
 host = "34.151.215.158"
 port = 19100
+metrics_host = "validator-1"
+metrics_port = 21100
 internal_host = "validator-1"
 internal_port = 20100
 external_protocol = "Grpc"

--- a/docker/local-tests/setup.sh
+++ b/docker/local-tests/setup.sh
@@ -20,6 +20,8 @@ host = "validator-${server}"
 port = 19100
 internal_host = "validator-${server}"
 internal_port = 20100
+metrics_host = "validator-${server}"
+metrics_port = 21100
 external_protocol = { Simple = "Tcp" }
 internal_protocol = { Simple = "Tcp" }
 EOF

--- a/kubernetes/linera-validator/templates/ingress.yaml
+++ b/kubernetes/linera-validator/templates/ingress.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: validator-ingress
+  name: validator-1
+  labels:
+    app: validator-1
 spec:
   # NodePort here is temporary. LoadBalancer will keep trying to set an external IP,
   # leaving it in a permanent pending state. Since we port forward anyways, we don't
@@ -14,3 +16,6 @@ spec:
       protocol: TCP
       port: 19100
       targetPort: linera-port
+    - name: metrics
+      protocol: TCP
+      port: 21100

--- a/kubernetes/linera-validator/templates/prometheus.yaml
+++ b/kubernetes/linera-validator/templates/prometheus.yaml
@@ -16,3 +16,22 @@ spec:
   selector:
     matchLabels:
       app: shards
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    release: linera-core
+  name: validator-1
+spec:
+  endpoints:
+  - port: metrics
+    path: /metrics
+    scheme: http
+  jobLabel: validator-1
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      app: validator-1

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: validator
+      app: validator-1
   replicas: 1
   template:
     metadata:
       labels:
-        app: validator
+        app: validator-1
     spec:
       serviceAccountName: linera-admin
       terminationGracePeriodSeconds: 10
@@ -19,8 +19,8 @@ spec:
           imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
           image: {{ .Values.lineraImage }}
           ports:
-            - containerPort: 19100
-              name: linera-port
+            - name: linera-port
+              containerPort: 19100
           command: ["./linera-proxy"]
           args: ["server_1.json"]
           env:

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -95,6 +95,10 @@ pub struct ValidatorInternalNetworkPreConfig<P> {
     pub host: String,
     /// The port the proxy listens on on the internal network.
     pub port: u16,
+    /// The host name of the proxy's metrics endpoint.
+    pub metrics_host: String,
+    /// The port of the proxy's metrics endpoint.
+    pub metrics_port: u16,
 }
 
 impl<P> ValidatorInternalNetworkPreConfig<P> {
@@ -104,6 +108,8 @@ impl<P> ValidatorInternalNetworkPreConfig<P> {
             shards: self.shards.clone(),
             host: self.host.clone(),
             port: self.port,
+            metrics_host: self.metrics_host.clone(),
+            metrics_port: self.metrics_port,
         }
     }
 }

--- a/linera-service/src/cli_wrappers.rs
+++ b/linera-service/src/cli_wrappers.rs
@@ -616,8 +616,12 @@ impl LocalNetwork {
         10000 + i * 100
     }
 
-    fn metrics_port(i: usize) -> usize {
+    fn proxy_metrics_port(i: usize) -> usize {
         11000 + i * 100
+    }
+
+    fn shard_metrics_port(i: usize, j: usize) -> usize {
+        11000 + i * 100 + j
     }
 
     fn configuration_string(&self, server_number: usize) -> Result<String> {
@@ -625,7 +629,7 @@ impl LocalNetwork {
         let path = self.tmp_dir.path().join(format!("validator_{n}.toml"));
         let port = Self::proxy_port(n);
         let internal_port = Self::internal_port(n);
-        let metrics_port = Self::metrics_port(n);
+        let metrics_port = Self::proxy_metrics_port(n);
         let external_protocol = self.network.external();
         let internal_protocol = self.network.internal();
         let mut content = format!(
@@ -635,13 +639,15 @@ impl LocalNetwork {
                 port = {port}
                 internal_host = "127.0.0.1"
                 internal_port = {internal_port}
+                metrics_host = "127.0.0.1"
+                metrics_port = {metrics_port}
                 external_protocol = {external_protocol}
                 internal_protocol = {internal_protocol}
             "#
         );
         for k in 1..=self.num_shards {
             let shard_port = Self::shard_port(n, k);
-            let shard_metrics_port = metrics_port + k;
+            let shard_metrics_port = Self::shard_metrics_port(n, k);
             content.push_str(&format!(
                 r#"
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -228,6 +228,12 @@ struct ValidatorOptions {
     /// The port of the validator
     port: u16,
 
+    /// The host for the metrics endpoint
+    metrics_host: String,
+
+    /// The port for the metrics endpoint
+    metrics_port: u16,
+
     /// The host of the proxy in the internal network.
     internal_host: String,
 
@@ -258,6 +264,8 @@ fn make_server_config<R: CryptoRng>(
         shards: options.shards,
         host: options.internal_host,
         port: options.internal_port,
+        metrics_host: options.metrics_host,
+        metrics_port: options.metrics_port,
     };
     let key = KeyPair::generate_from(rng);
     let name = ValidatorName(key.public());
@@ -379,6 +387,7 @@ async fn main() {
         .with_writer(std::io::stderr)
         .with_env_filter(env_filter)
         .init();
+
     let options = ServerOptions::from_args();
 
     match options.command {
@@ -493,6 +502,8 @@ mod test {
             port = 9000
             internal_host = "internal_host"
             internal_port = 10000
+            metrics_host = "metrics_host"
+            metrics_port = 5000
             external_protocol = { Simple = "Tcp" }
             internal_protocol = { Simple = "Udp" }
 
@@ -519,6 +530,8 @@ mod test {
                 port: 9000,
                 internal_host: "internal_host".into(),
                 internal_port: 10000,
+                metrics_host: "metrics_host".into(),
+                metrics_port: 5000,
                 shards: vec![
                     ShardConfig {
                         host: "host1".into(),


### PR DESCRIPTION
## Motivation

We need metrics on the Proxy side

## Proposal

Adding Prometheus metrics support on the proxy side

## Test Plan

1. Ran validator locally with `./build_and_redeploy.sh --port-forward --clean` with a test metric (v10 on Graphite has it)
2. Port forwarded the Prometheus UI `kubectl port-forward prometheus-linera-core-kube-prometheu-prometheus-0 9090`
3. Went to http://127.0.0.1:9090/graph to see the metric properly logged:


![Screenshot 2023-10-27 at 12.48.07.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/2a4561a8-e088-4dbc-9cdd-b376572f0dc5.png)

