### PR TITLE
Partially undo renaming of query_application

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -160,13 +160,13 @@ where
         self.context().extra().chain_id()
     }
 
-    pub async fn handle_query(&mut self, query: &Query) -> Result<Response, ChainError> {
+    pub async fn query_application(&mut self, query: &Query) -> Result<Response, ChainError> {
         let context = QueryContext {
             chain_id: self.chain_id(),
         };
         let response = self
             .execution_state
-            .handle_query(&context, query)
+            .query_application(&context, query)
             .await
             .map_err(|error| ChainError::ExecutionError(error, ChainExecutionContext::Query))?;
         Ok(response)

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1344,8 +1344,11 @@ where
     }
 
     /// Queries an application.
-    pub async fn handle_query(&self, query: &Query) -> Result<Response, ChainClientError> {
-        let response = self.node_client.handle_query(self.chain_id, query).await?;
+    pub async fn query_application(&self, query: &Query) -> Result<Response, ChainClientError> {
+        let response = self
+            .node_client
+            .query_application(self.chain_id, query)
+            .await?;
         Ok(response)
     }
 
@@ -1356,7 +1359,7 @@ where
     ) -> Result<SystemResponse, ChainClientError> {
         let response = self
             .node_client
-            .handle_query(self.chain_id, &Query::System(query))
+            .query_application(self.chain_id, &Query::System(query))
             .await?;
         match response {
             Response::System(response) => Ok(response),
@@ -1373,7 +1376,10 @@ where
         query: &A::Query,
     ) -> Result<A::QueryResponse, ChainClientError> {
         let query = Query::user(application_id, query)?;
-        let response = self.node_client.handle_query(self.chain_id, &query).await?;
+        let response = self
+            .node_client
+            .query_application(self.chain_id, &query)
+            .await?;
         match response {
             Response::User(response) => Ok(serde_json::from_slice(&response)?),
             _ => Err(ChainClientError::InternalError(

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -238,13 +238,13 @@ where
         Ok(self.handle_chain_info_query(query).await?.info)
     }
 
-    pub async fn handle_query(
+    pub async fn query_application(
         &self,
         chain_id: ChainId,
         query: &Query,
     ) -> Result<Response, LocalNodeError> {
         let mut node = self.node.lock().await;
-        let response = node.state.handle_query(chain_id, query).await?;
+        let response = node.state.query_application(chain_id, query).await?;
         Ok(response)
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2083,7 +2083,7 @@ where
     .await;
     assert_eq!(
         worker
-            .handle_query(ChainId::root(1), &Query::System(SystemQuery))
+            .query_application(ChainId::root(1), &Query::System(SystemQuery))
             .await
             .unwrap(),
         Response::System(SystemResponse {
@@ -2093,7 +2093,7 @@ where
     );
     assert_eq!(
         worker
-            .handle_query(ChainId::root(2), &Query::System(SystemQuery))
+            .query_application(ChainId::root(2), &Query::System(SystemQuery))
             .await
             .unwrap(),
         Response::System(SystemResponse {
@@ -2127,7 +2127,7 @@ where
     assert!(info.manager.pending().is_none());
     assert_eq!(
         worker
-            .handle_query(ChainId::root(1), &Query::System(SystemQuery))
+            .query_application(ChainId::root(1), &Query::System(SystemQuery))
             .await
             .unwrap(),
         Response::System(SystemResponse {
@@ -2170,7 +2170,7 @@ where
 
     assert_eq!(
         worker
-            .handle_query(ChainId::root(2), &Query::System(SystemQuery))
+            .query_application(ChainId::root(2), &Query::System(SystemQuery))
             .await
             .unwrap(),
         Response::System(SystemResponse {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -427,13 +427,13 @@ where
     }
 
     /// Executes a [`Query`] for an application's state on a specific chain.
-    pub async fn handle_query(
+    pub async fn query_application(
         &mut self,
         chain_id: ChainId,
         query: &Query,
     ) -> Result<Response, WorkerError> {
         let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let response = chain.handle_query(query).await?;
+        let response = chain.query_application(query).await?;
         Ok(response)
     }
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -324,7 +324,7 @@ where
         }
     }
 
-    pub async fn handle_query(
+    pub async fn query_application(
         &mut self,
         context: &QueryContext,
         query: &Query,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -241,7 +241,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
     };
     assert_eq!(
-        view.handle_query(
+        view.query_application(
             &context,
             &Query::User {
                 application_id: app_id,

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -101,7 +101,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
     };
     let response = view
-        .handle_query(&context, &Query::System(SystemQuery))
+        .query_application(&context, &Query::System(SystemQuery))
         .await
         .unwrap();
     assert_eq!(

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -99,7 +99,7 @@ async fn test_fuel_for_counter_wasm_application(
     );
     let request = async_graphql::Request::new("query { value }");
     let Response::User(serialized_value) = view
-        .handle_query(&context, &Query::user(app_id, &request).unwrap())
+        .query_application(&context, &Query::user(app_id, &request).unwrap())
         .await?
     else {
         panic!("unexpected response")

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -470,7 +470,7 @@ impl ActiveChain {
             .validator
             .worker()
             .await
-            .handle_query(
+            .query_application(
                 self.id(),
                 &Query::User {
                     application_id: application_id.forget_abi(),

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -756,7 +756,7 @@ where
         let Some(client) = self.clients.client_lock(&chain_id).await else {
             return Err(NodeServiceError::UnknownChainId);
         };
-        let response = client.handle_query(&query).await?;
+        let response = client.query_application(&query).await?;
         let user_response_bytes = match response {
             Response::System(_) => unreachable!("cannot get a system response for a user query"),
             Response::User(user) => user,


### PR DESCRIPTION
## Motivation

#1151 was a bit heavy handed and broke name patterns in `linera-chain` and `linera-execution`.

## Proposal

Partially undo #1151

## Test Plan

CI
