### PR TITLE
Log proxy request count

### DIFF
--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -22,7 +22,7 @@ use linera_rpc::{
     grpc_pool::ConnectionPool,
 };
 use once_cell::sync::Lazy;
-use prometheus::{register_histogram_vec, HistogramVec};
+use prometheus::{register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec};
 use std::{
     fmt::Debug,
     net::SocketAddr,
@@ -43,6 +43,16 @@ pub static PROXY_REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "proxy_request_latency",
         "Proxy request latency",
+        // Can add labels here
+        &[]
+    )
+    .expect("Counter can be created")
+});
+
+pub static PROXY_REQUEST_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "proxy_request_count",
+        "Proxy request count",
         // Can add labels here
         &[]
     )
@@ -86,6 +96,7 @@ where
             PROXY_REQUEST_LATENCY
                 .with_label_values(&[])
                 .observe(start.elapsed().as_secs_f64());
+            PROXY_REQUEST_COUNT.with_label_values(&[]).inc();
             Ok(response)
         }
         .boxed()


### PR DESCRIPTION
## Motivation

Logging some metrics from our list

## Proposal

Implementing proxy request count Counter metric

## Test Plan

1. Ran validator locally with `./build_and_redeploy.sh --port-forward --clean`
2. Built the binaries with `cargo build --features benchmark`
3. Ran a benchmark against it with `./linera benchmark`
4. Port forwarded the Prometheus UI `kubectl port-forward prometheus-linera-core-kube-prometheu-prometheus-0 9090`
5. Went to http://127.0.0.1:9090/graph to see the metric properly logged:

![Screenshot 2023-10-27 at 18.41.54.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/c681e0b9-a249-4459-a59f-af61e6fbad62.png)

