### PR TITLE
Implement a `max_key_size()`

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -411,7 +411,7 @@ pub trait BaseRuntime: Send + Sync {
     async fn unlock_view_user_state(&self) -> Result<(), ExecutionError>;
 
     /// Reads the key from the KV store
-    async fn read_key_bytes(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError>;
+    async fn read_value_bytes(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError>;
 
     /// Reads the data from the keys having a specific prefix.
     async fn find_keys_by_prefix(

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -419,7 +419,7 @@ where
         }
     }
 
-    async fn read_key_bytes(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
+    async fn read_value_bytes(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
         let state = self.active_view_user_states_mut().await;
         let view = state
             .get(&self.application_id())

--- a/linera-execution/src/wasm/runtime_actor/handlers.rs
+++ b/linera-execution/src/wasm/runtime_actor/handlers.rs
@@ -51,10 +51,10 @@ where
             BaseRequest::UnlockViewUserState { response_sender } => {
                 response_sender.respond(self.unlock_view_user_state().await?)
             }
-            BaseRequest::ReadKeyBytes {
+            BaseRequest::ReadValueBytes {
                 key,
                 response_sender,
-            } => response_sender.respond(self.read_key_bytes(key).await?),
+            } => response_sender.respond(self.read_value_bytes(key).await?),
             BaseRequest::FindKeysByPrefix {
                 key_prefix,
                 response_sender,

--- a/linera-execution/src/wasm/runtime_actor/requests.rs
+++ b/linera-execution/src/wasm/runtime_actor/requests.rs
@@ -55,7 +55,7 @@ pub enum BaseRequest {
     },
 
     /// Requests to read an entry from the key-value store.
-    ReadKeyBytes {
+    ReadValueBytes {
         key: Vec<u8>,
         response_sender: oneshot::Sender<Option<Vec<u8>>>,
     },
@@ -100,8 +100,8 @@ impl Debug for BaseRequest {
             BaseRequest::UnlockViewUserState { .. } => formatter
                 .debug_struct("BaseRequest::UnlockViewUserState")
                 .finish_non_exhaustive(),
-            BaseRequest::ReadKeyBytes { key, .. } => formatter
-                .debug_struct("BaseRequest::ReadKeyBytes")
+            BaseRequest::ReadValueBytes { key, .. } => formatter
+                .debug_struct("BaseRequest::ReadValueBytes")
                 .field("key", key)
                 .finish_non_exhaustive(),
             BaseRequest::FindKeysByPrefix { key_prefix, .. } => formatter

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -379,7 +379,7 @@ macro_rules! impl_view_system_api_for_service {
         impl view_system_api::ViewSystemApi for $view_system_api {
             type Error = ExecutionError;
 
-            type ReadKeyBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
+            type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
             type FindKeys = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
             type FindKeyValues = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
 
@@ -387,13 +387,13 @@ macro_rules! impl_view_system_api_for_service {
                 error.into()
             }
 
-            fn read_key_bytes_new(
+            fn read_value_bytes_new(
                 &mut self,
                 key: &[u8],
-            ) -> Result<Self::ReadKeyBytes, Self::Error> {
+            ) -> Result<Self::ReadValueBytes, Self::Error> {
                 Ok(Mutex::new(Some(self.runtime.send_request(
                     |response_sender| {
-                        ServiceRequest::Base(BaseRequest::ReadKeyBytes {
+                        ServiceRequest::Base(BaseRequest::ReadValueBytes {
                             key: key.to_owned(),
                             response_sender,
                         })
@@ -401,9 +401,9 @@ macro_rules! impl_view_system_api_for_service {
                 )?)))
             }
 
-            fn read_key_bytes_wait(
+            fn read_value_bytes_wait(
                 &mut self,
-                promise: &Self::ReadKeyBytes,
+                promise: &Self::ReadValueBytes,
             ) -> Result<Option<Vec<u8>>, Self::Error> {
                 let receiver = promise
                     .try_lock()
@@ -487,7 +487,7 @@ macro_rules! impl_view_system_api_for_contract {
         impl view_system_api::ViewSystemApi for $view_system_api {
             type Error = ExecutionError;
 
-            type ReadKeyBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
+            type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
             type FindKeys = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
             type FindKeyValues = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
 
@@ -495,13 +495,13 @@ macro_rules! impl_view_system_api_for_contract {
                 error.into()
             }
 
-            fn read_key_bytes_new(
+            fn read_value_bytes_new(
                 &mut self,
                 key: &[u8],
-            ) -> Result<Self::ReadKeyBytes, Self::Error> {
+            ) -> Result<Self::ReadValueBytes, Self::Error> {
                 Ok(Mutex::new(Some(self.runtime.send_request(
                     |response_sender| {
-                        ContractRequest::Base(BaseRequest::ReadKeyBytes {
+                        ContractRequest::Base(BaseRequest::ReadValueBytes {
                             key: key.to_owned(),
                             response_sender,
                         })

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -509,9 +509,9 @@ macro_rules! impl_view_system_api_for_contract {
                 )?)))
             }
 
-            fn read_key_bytes_wait(
+            fn read_value_bytes_wait(
                 &mut self,
-                promise: &Self::ReadKeyBytes,
+                promise: &Self::ReadValueBytes,
             ) -> Result<Option<Vec<u8>>, Self::Error> {
                 let receiver = promise
                     .try_lock()

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -96,7 +96,7 @@ impl UserApplication for TestApplication {
         // Modify our state.
         let chosen_key = vec![0];
         runtime.lock_view_user_state().await?;
-        let state = runtime.read_key_bytes(chosen_key.clone()).await?;
+        let state = runtime.read_value_bytes(chosen_key.clone()).await?;
         let mut state = state.unwrap_or_default();
         state.extend(operation);
         let mut batch = Batch::new();
@@ -180,7 +180,7 @@ impl UserApplication for TestApplication {
     ) -> Result<Vec<u8>, ExecutionError> {
         let chosen_key = vec![0];
         runtime.lock_view_user_state().await?;
-        let state = runtime.read_key_bytes(chosen_key).await?;
+        let state = runtime.read_value_bytes(chosen_key).await?;
         let state = state.unwrap_or_default();
         runtime.unlock_view_user_state().await?;
         Ok(state)

--- a/linera-sdk/mock_system_api.wit
+++ b/linera-sdk/mock_system_api.wit
@@ -20,7 +20,7 @@ mocked-store-and-unlock: func(value: list<u8>) -> bool
 mocked-lock: func() -> bool
 mocked-unlock: func() -> bool
 
-mocked-read-key-bytes: func(key: list<u8>) -> option<list<u8>>
+mocked-read-value-bytes: func(key: list<u8>) -> option<list<u8>>
 mocked-find-keys: func(prefix: list<u8>) -> list<list<u8>>
 mocked-find-key-values: func(prefix: list<u8>) -> list<tuple<list<u8>,list<u8>>>
 mocked-write-batch: func(operations: list<write-operation>)

--- a/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
+++ b/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
@@ -930,7 +930,7 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
 
     linker.func_wrap2_async(
         "view_system_api",
-        "read-key-bytes::new: func(key: list<u8>) -> handle<read-key-bytes>",
+        "read-value-bytes::new: func(key: list<u8>) -> handle<read-value-bytes>",
         move |mut caller: Caller<'_, Resources>, key_address: i32, key_length: i32| {
             Box::new(async move {
                 let key = load_bytes(&mut caller, key_address, key_length);
@@ -942,15 +942,15 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
     )?;
     linker.func_wrap2_async(
         "view_system_api",
-        "read-key-bytes::wait: func(self: handle<read-key-bytes>) -> option<list<u8>>",
+        "read-value-bytes::wait: func(self: handle<read-key-bytes>) -> option<list<u8>>",
         move |mut caller: Caller<'_, Resources>, handle: i32, return_offset: i32| {
             Box::new(async move {
                 let function = get_function(
                     &mut caller,
-                    "mocked-read-key-bytes: func(key: list<u8>) -> option<list<u8>>",
+                    "mocked-read-value-bytes: func(key: list<u8>) -> option<list<u8>>",
                 )
                 .expect(
-                    "Missing `mocked-read-key-bytes` function in the module. \
+                    "Missing `mocked-read-value-bytes` function in the module. \
                     Please ensure `linera_sdk::test::mock_key_value_store` was called",
                 );
 
@@ -963,11 +963,11 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
 
                 let (result_offset,) = function
                     .typed::<(i32, i32), (i32,), _>(&mut caller)
-                    .expect("Incorrect `mocked-read-key-bytes` function signature")
+                    .expect("Incorrect `mocked-read-value-bytes` function signature")
                     .call_async(&mut caller, (key_address, key_length))
                     .await
                     .expect(
-                        "Failed to call `mocked-read-key-bytes` function. \
+                        "Failed to call `mocked-read-value-bytes` function. \
                         Please ensure `linera_sdk::test::mock_key_value_store` was called",
                     );
 
@@ -1216,7 +1216,7 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
     let resource_names = [
         "load",
         "lock",
-        "read-key-bytes",
+        "read-value-bytes",
         "find-keys",
         "find-key-values",
         "write-batch",

--- a/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
+++ b/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
@@ -942,7 +942,7 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
     )?;
     linker.func_wrap2_async(
         "view_system_api",
-        "read-value-bytes::wait: func(self: handle<read-key-bytes>) -> option<list<u8>>",
+        "read-value-bytes::wait: func(self: handle<read-value-bytes>) -> option<list<u8>>",
         move |mut caller: Caller<'_, Resources>, handle: i32, return_offset: i32| {
             Box::new(async move {
                 let function = get_function(

--- a/linera-sdk/src/test/unit/mod.rs
+++ b/linera-sdk/src/test/unit/mod.rs
@@ -201,13 +201,13 @@ impl wit::MockSystemApi for MockSystemApi {
         }
     }
 
-    fn mocked_read_key_bytes(key: Vec<u8>) -> Option<Vec<u8>> {
+    fn mocked_read_value_bytes(key: Vec<u8>) -> Option<Vec<u8>> {
         unsafe { MOCK_KEY_VALUE_STORE.as_mut() }
             .expect(
-                "Unexpected call to `read_key_bytes` system API. \
+                "Unexpected call to `read_value_bytes` system API. \
                 Please call `mock_key_value_store` first.",
             )
-            .read_key_bytes(&key)
+            .read_value_bytes(&key)
             .now_or_never()
             .expect("Attempt to read from key-value store while it is being written to")
             .expect("Failed to read from memory store")

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -12,6 +12,14 @@ use linera_views::{
     views::ViewError,
 };
 
+/// We need to have a maximum key size that handles all possible underlying
+/// size and the constrain so far is DynamoDb which has a key length of 1024.
+/// That key length is decreased by 4 due to the use of a value splitting.
+/// Then the KeyValueStorClient needs to handle some base_key and so we
+/// reduce to 900. Depending of the size, the error can occur in system_api
+/// or in the KeyValueStoreView.
+const MAX_KEY_SIZE: usize = 900;
+
 /// A type to interface with the key value storage provided to applications.
 #[derive(Default, Clone)]
 pub struct KeyValueStore;
@@ -40,7 +48,7 @@ impl KeyValueStoreClient for KeyValueStore {
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_key_size(&self) -> usize {
-        usize::MAX
+        MAX_KEY_SIZE
     }
 
     fn max_stream_queries(&self) -> usize {
@@ -48,6 +56,9 @@ impl KeyValueStoreClient for KeyValueStore {
     }
 
     async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        if key.len() > MAX_KEY_SIZE {
+            return Err(ViewError::KeyTooLong);
+        }
         let promise = wit::ReadKeyBytes::new(key);
         yield_once().await;
         Ok(promise.wait())
@@ -59,6 +70,9 @@ impl KeyValueStoreClient for KeyValueStore {
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
         let mut results = Vec::new();
         for key in keys {
+            if key.len() > MAX_KEY_SIZE {
+                return Err(ViewError::KeyTooLong);
+            }
             let value = self.read_key_bytes(&key).await?;
             results.push(value);
         }
@@ -66,6 +80,9 @@ impl KeyValueStoreClient for KeyValueStore {
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, ViewError> {
+        if key_prefix.len() > MAX_KEY_SIZE {
+            return Err(ViewError::KeyTooLong);
+        }
         let keys = self.find_keys_by_prefix_load(key_prefix).await;
         Ok(keys)
     }
@@ -74,6 +91,9 @@ impl KeyValueStoreClient for KeyValueStore {
         &self,
         key_prefix: &[u8],
     ) -> Result<Self::KeyValues, ViewError> {
+        if key_prefix.len() > MAX_KEY_SIZE {
+            return Err(ViewError::KeyTooLong);
+        }
         let key_values = self.find_key_values_by_prefix_load(key_prefix).await;
         Ok(key_values)
     }
@@ -83,12 +103,21 @@ impl KeyValueStoreClient for KeyValueStore {
         for op in &batch.operations {
             match op {
                 WriteOperation::Delete { key } => {
+                    if key.len() > MAX_KEY_SIZE {
+                        return Err(ViewError::KeyTooLong);
+                    }
                     list_oper.push(wit::WriteOperation::Delete(key));
                 }
                 WriteOperation::Put { key, value } => {
+                    if key.len() > MAX_KEY_SIZE {
+                        return Err(ViewError::KeyTooLong);
+                    }
                     list_oper.push(wit::WriteOperation::Put((key, value)))
                 }
                 WriteOperation::DeletePrefix { key_prefix } => {
+                    if key_prefix.len() > MAX_KEY_SIZE {
+                        return Err(ViewError::KeyTooLong);
+                    }
                     list_oper.push(wit::WriteOperation::Deleteprefix(key_prefix))
                 }
             }

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -39,6 +39,10 @@ impl KeyValueStoreClient for KeyValueStore {
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
+    fn max_key_size(&self) -> usize {
+        usize::MAX
+    }
+
     fn max_stream_queries(&self) -> usize {
         1
     }

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -55,16 +55,16 @@ impl KeyValueStoreClient for KeyValueStore {
         1
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         if key.len() > MAX_KEY_SIZE {
             return Err(ViewError::KeyTooLong);
         }
-        let promise = wit::ReadKeyBytes::new(key);
+        let promise = wit::ReadValueBytes::new(key);
         yield_once().await;
         Ok(promise.wait())
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
@@ -73,7 +73,7 @@ impl KeyValueStoreClient for KeyValueStore {
             if key.len() > MAX_KEY_SIZE {
                 return Err(ViewError::KeyTooLong);
             }
-            let value = self.read_key_bytes(&key).await?;
+            let value = self.read_value_bytes(&key).await?;
             results.push(value);
         }
         Ok(results)

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -15,7 +15,7 @@ use linera_views::{
 /// We need to have a maximum key size that handles all possible underlying
 /// sizes. The constraint so far is DynamoDb which has a key length of 1024.
 /// That key length is decreased by 4 due to the use of a value splitting.
-/// Then the KeyValueStorClient needs to handle some base_key and so we
+/// Then the KeyValueStoreClient needs to handle some base_key and so we
 /// reduce to 900. Depending on the size, the error can occur in system_api
 /// or in the KeyValueStoreView.
 const MAX_KEY_SIZE: usize = 900;
@@ -99,30 +99,30 @@ impl KeyValueStoreClient for KeyValueStore {
     }
 
     async fn write_batch(&self, batch: Batch, _base_key: &[u8]) -> Result<(), ViewError> {
-        let mut list_oper = Vec::new();
-        for op in &batch.operations {
-            match op {
+        let mut operations = Vec::new();
+        for operation in &batch.operations {
+            match operation {
                 WriteOperation::Delete { key } => {
                     if key.len() > MAX_KEY_SIZE {
                         return Err(ViewError::KeyTooLong);
                     }
-                    list_oper.push(wit::WriteOperation::Delete(key));
+                    operations.push(wit::WriteOperation::Delete(key));
                 }
                 WriteOperation::Put { key, value } => {
                     if key.len() > MAX_KEY_SIZE {
                         return Err(ViewError::KeyTooLong);
                     }
-                    list_oper.push(wit::WriteOperation::Put((key, value)))
+                    operations.push(wit::WriteOperation::Put((key, value)))
                 }
                 WriteOperation::DeletePrefix { key_prefix } => {
                     if key_prefix.len() > MAX_KEY_SIZE {
                         return Err(ViewError::KeyTooLong);
                     }
-                    list_oper.push(wit::WriteOperation::Deleteprefix(key_prefix))
+                    operations.push(wit::WriteOperation::Deleteprefix(key_prefix))
                 }
             }
         }
-        wit::write_batch(&list_oper);
+        wit::write_batch(&operations);
         Ok(())
     }
 

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -13,10 +13,10 @@ use linera_views::{
 };
 
 /// We need to have a maximum key size that handles all possible underlying
-/// size and the constrain so far is DynamoDb which has a key length of 1024.
+/// sizes. The constraint so far is DynamoDb which has a key length of 1024.
 /// That key length is decreased by 4 due to the use of a value splitting.
 /// Then the KeyValueStorClient needs to handle some base_key and so we
-/// reduce to 900. Depending of the size, the error can occur in system_api
+/// reduce to 900. Depending on the size, the error can occur in system_api
 /// or in the KeyValueStoreView.
 const MAX_KEY_SIZE: usize = 900;
 

--- a/linera-sdk/view_system_api.wit
+++ b/linera-sdk/view_system_api.wit
@@ -1,5 +1,5 @@
 resource read-value-bytes {
-    static new: func(key: list<u8>) -> read-key-bytes
+    static new: func(key: list<u8>) -> read-value-bytes
     wait: func() -> option<list<u8>>
 }
 

--- a/linera-sdk/view_system_api.wit
+++ b/linera-sdk/view_system_api.wit
@@ -1,4 +1,4 @@
-resource read-key-bytes {
+resource read-value-bytes {
     static new: func(key: list<u8>) -> read-key-bytes
     wait: func() -> option<list<u8>>
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -379,7 +379,8 @@ where
 
     async fn read_value(&self, hash: CryptoHash) -> Result<HashedValue, ViewError> {
         let value_key = bcs::to_bytes(&BaseKey::Value(hash))?;
-        let maybe_value: Option<CertificateValue> = self.client.client.read_key(&value_key).await?;
+        let maybe_value: Option<CertificateValue> =
+            self.client.client.read_value(&value_key).await?;
         let id = match &maybe_value {
             Some(value) => value.chain_id().to_string(),
             None => "not found".to_string(),
@@ -428,8 +429,10 @@ where
         let cert_key = bcs::to_bytes(&BaseKey::Certificate(hash))?;
         let value_key = bcs::to_bytes(&BaseKey::Value(hash))?;
         let (cert_result, value_result) = tokio::join!(
-            self.client.client.read_key::<LiteCertificate>(&cert_key),
-            self.client.client.read_key::<CertificateValue>(&value_key)
+            self.client.client.read_value::<LiteCertificate>(&cert_key),
+            self.client
+                .client
+                .read_value::<CertificateValue>(&value_key)
         );
         if let Ok(maybe_value) = &value_result {
             let id = match maybe_value {

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -76,7 +76,7 @@ where
 
     async fn load(context: C) -> Result<Self, ViewError> {
         let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_key(&key).await?;
+        let hash = context.read_value(&key).await?;
         Ok(Self {
             context,
             was_cleared: false,

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -38,14 +38,6 @@ pub(crate) enum Update<T> {
     Set(T),
 }
 
-/// We need to have a maximum key size that handles all possible underlying
-/// sizes. The constraint so far is DynamoDb which has a key length of 1024.
-/// That key length is decreased by 4 due to the use of a value splitting.
-/// Then the KeyValueStoreClient needs to handle some base_key and so we
-/// reduce to 900. Depending on the size, the error can occur in system_api
-/// or in the KeyValueStoreView.
-pub const COMMON_MAX_KEY_SIZE: usize = 900;
-
 /// Status of a table at the creation time of a [`KeyValueStoreClient`] instance.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TableStatus {

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -165,6 +165,9 @@ pub trait KeyValueStoreClient {
     /// Returns type for key-value search operations.
     type KeyValues: KeyValueIterable<Self::Error>;
 
+    /// The maximal size of keys that can be stored.
+    fn max_key_size(&self) -> usize;
+
     /// Retrieve the number of stream queries.
     fn max_stream_queries(&self) -> usize;
 
@@ -314,6 +317,9 @@ pub trait Context {
 
     /// Returns type for key-value search operations.
     type KeyValues: KeyValueIterable<Self::Error>;
+
+    /// The maximal size of keys that can be stored.
+    fn max_key_size(&self) -> usize;
 
     /// Retrieve the number of stream queries.
     fn max_stream_queries(&self) -> usize;
@@ -495,6 +501,10 @@ where
     type Error = DB::Error;
     type Keys = DB::Keys;
     type KeyValues = DB::KeyValues;
+
+    fn max_key_size(&self) -> usize {
+        self.db.max_key_size()
+    }
 
     fn max_stream_queries(&self) -> usize {
         self.db.max_stream_queries()

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -170,14 +170,14 @@ const MAX_TRANSACT_WRITE_ITEM_BYTES: usize = 4194304;
 /// The DynamoDb database is potentially handling an infinite number of connections.
 /// However, for testing or some other purpose we really need to decrease the number of
 /// connections.
-pub const TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES: usize = 10;
+const TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES: usize = 10;
 
 /// The number of entries in a stream of the tests can be controlled by this parameter for tests.
-pub const TEST_DYNAMO_DB_MAX_STREAM_QUERIES: usize = 10;
+const TEST_DYNAMO_DB_MAX_STREAM_QUERIES: usize = 10;
 
 /// Fundamental constants in DynamoDB: The maximum size of a TransactWriteItem is 100.
 /// See <https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html>
-pub const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = 100;
+const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = 100;
 
 /// Builds the key attributes for a table item.
 ///
@@ -1116,6 +1116,10 @@ impl KeyValueStoreClient for DynamoDbClientInternal {
     type Keys = DynamoDbKeys;
     type KeyValues = DynamoDbKeyValues;
 
+    fn max_key_size(&self) -> usize {
+        MAX_KEY_BYTES
+    }
+
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
     }
@@ -1189,6 +1193,10 @@ impl KeyValueStoreClient for DynamoDbClient {
     type Error = DynamoDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    fn max_key_size(&self) -> usize {
+        MAX_KEY_BYTES - 4
+    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -795,6 +795,9 @@ impl DynamoDbClientInternal {
         key_prefix: &[u8],
         start_key_map: Option<HashMap<String, AttributeValue>>,
     ) -> Result<QueryOutput, DynamoDbContextError> {
+        if key_prefix.len() > MAX_KEY_BYTES {
+            return Err(DynamoDbContextError::KeyTooLong);
+        }
         let _guard = self.acquire().await;
         let response = self
             .client

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -1110,13 +1110,10 @@ impl DynamoDbClientInternal {
 #[async_trait]
 impl KeyValueStoreClient for DynamoDbClientInternal {
     const MAX_VALUE_SIZE: usize = VISIBLE_MAX_VALUE_SIZE;
+    const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Error = DynamoDbContextError;
     type Keys = DynamoDbKeys;
     type KeyValues = DynamoDbKeyValues;
-
-    fn max_key_size(&self) -> usize {
-        MAX_KEY_SIZE
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
@@ -1190,13 +1187,10 @@ pub struct DynamoDbClient {
 #[async_trait]
 impl KeyValueStoreClient for DynamoDbClient {
     const MAX_VALUE_SIZE: usize = DynamoDbClientInternal::MAX_VALUE_SIZE;
+    const MAX_KEY_SIZE: usize = MAX_KEY_SIZE - 4;
     type Error = DynamoDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        MAX_KEY_SIZE - 4
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -44,7 +44,7 @@ where
 
     async fn load(context: C) -> Result<Self, ViewError> {
         let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_key(&key).await?;
+        let hash = context.read_value(&key).await?;
         let base_key = context.base_tag(KeyTag::Index as u8);
         let inner = W::load(context.clone_with_base_key(base_key)).await?;
         Ok(Self {

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -84,7 +84,7 @@ where
 
     async fn load(context: C) -> Result<Self, ViewError> {
         let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_key(&key).await?;
+        let hash = context.read_value(&key).await?;
         Ok(Self {
             context,
             was_cleared: false,
@@ -408,7 +408,7 @@ where
             return Ok(None);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
-        Ok(self.context.read_key_bytes(&key).await?)
+        Ok(self.context.read_value_bytes(&key).await?)
     }
 
     /// Obtains the values of a range of indices
@@ -449,7 +449,7 @@ where
             }
         }
         if !self.was_cleared {
-            let values = self.context.read_multi_key_bytes(vector_query).await?;
+            let values = self.context.read_multi_values_bytes(vector_query).await?;
             for (i, value) in missed_indices.into_iter().zip(values) {
                 result[i] = value;
             }
@@ -788,12 +788,12 @@ where
         1
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
         let view = self.view.read().await;
         view.get(key).await
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, ViewError> {

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -51,7 +51,7 @@ where
         let key1 = context.base_tag(KeyTag::Store as u8);
         let key2 = context.base_tag(KeyTag::Hash as u8);
         let keys = vec![key1, key2];
-        let values_bytes = context.read_multi_key_bytes(keys).await?;
+        let values_bytes = context.read_multi_values_bytes(keys).await?;
         let stored_count = from_bytes_opt(&values_bytes[0])?.unwrap_or_default();
         let hash = from_bytes_opt(&values_bytes[1])?;
         Ok(Self {
@@ -183,7 +183,7 @@ where
             self.new_values.get(index).cloned()
         } else if index < self.stored_count {
             let key = self.context.derive_tag_key(KeyTag::Index as u8, &index)?;
-            self.context.read_key(&key).await?
+            self.context.read_value(&key).await?
         } else {
             self.new_values.get(index - self.stored_count).cloned()
         };
@@ -222,7 +222,7 @@ where
                     result.push(self.new_values.get(index - self.stored_count).cloned());
                 }
             }
-            let values = self.context.read_multi_key(keys).await?;
+            let values = self.context.read_multi_values(keys).await?;
             for (pos, value) in positions.into_iter().zip(values) {
                 *result.get_mut(pos).unwrap() = value;
             }
@@ -238,7 +238,7 @@ where
             keys.push(key);
         }
         let mut values = Vec::with_capacity(count);
-        for entry in self.context.read_multi_key(keys).await? {
+        for entry in self.context.read_multi_values(keys).await? {
             match entry {
                 None => {
                     return Err(ViewError::MissingEntries);

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -97,11 +97,15 @@ impl<K> KeyValueStoreClient for LruCachingKeyValueClient<K>
 where
     K: KeyValueStoreClient + Send + Sync,
 {
-    // The LRU cache does not change the underlying client's size limit.
+    // The LRU cache does not change the underlying client's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
     type Error = K::Error;
     type Keys = K::Keys;
     type KeyValues = K::KeyValues;
+
+    fn max_key_size(&self) -> usize {
+        self.client.max_key_size()
+    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -99,13 +99,10 @@ where
 {
     // The LRU cache does not change the underlying client's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
+    const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
     type Error = K::Error;
     type Keys = K::Keys;
     type KeyValues = K::KeyValues;
-
-    fn max_key_size(&self) -> usize {
-        self.client.max_key_size()
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -60,7 +60,7 @@ where
 
     async fn load(context: C) -> Result<Self, ViewError> {
         let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_key(&key).await?;
+        let hash = context.read_value(&key).await?;
         Ok(Self {
             context,
             was_cleared: false,
@@ -197,14 +197,14 @@ where
             return Ok(None);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, &short_key);
-        Ok(self.context.read_key(&key).await?)
+        Ok(self.context.read_value(&key).await?)
     }
 
     /// Loads the value in updates if that is at all possible.
     async fn load_value(&mut self, short_key: &[u8]) -> Result<(), ViewError> {
         if !self.was_cleared && !self.updates.contains_key(short_key) {
             let key = self.context.base_tag_index(KeyTag::Index as u8, short_key);
-            let value = self.context.read_key(&key).await?;
+            let value = self.context.read_value(&key).await?;
             if let Some(value) = value {
                 self.updates.insert(short_key.to_vec(), Update::Set(value));
             }
@@ -510,7 +510,7 @@ where
             Entry::Vacant(e) if self.was_cleared => e.insert(Update::Set(V::default())),
             Entry::Vacant(e) => {
                 let key = self.context.base_tag_index(KeyTag::Index as u8, &short_key);
-                let value = self.context.read_key(&key).await?.unwrap_or_default();
+                let value = self.context.read_value(&key).await?.unwrap_or_default();
                 e.insert(Update::Set(value))
             }
             Entry::Occupied(entry) => {

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -48,12 +48,12 @@ impl KeyValueStoreClient for MemoryClient {
         self.max_stream_queries
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
         let map = self.map.read().await;
         Ok(map.get(key).cloned())
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -36,13 +36,10 @@ pub struct MemoryClient {
 #[async_trait]
 impl KeyValueStoreClient for MemoryClient {
     const MAX_VALUE_SIZE: usize = usize::MAX;
+    const MAX_KEY_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        usize::MAX
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -40,6 +40,10 @@ impl KeyValueStoreClient for MemoryClient {
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
+    fn max_key_size(&self) -> usize {
+        usize::MAX
+    }
+
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
     }

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -53,7 +53,7 @@ where
         let key1 = context.base_tag(KeyTag::Store as u8);
         let key2 = context.base_tag(KeyTag::Hash as u8);
         let keys = vec![key1, key2];
-        let values_bytes = context.read_multi_key_bytes(keys).await?;
+        let values_bytes = context.read_multi_values_bytes(keys).await?;
         let stored_indices = from_bytes_opt(&values_bytes[0])?.unwrap_or_default();
         let hash = from_bytes_opt(&values_bytes[1])?;
         Ok(Self {
@@ -148,7 +148,7 @@ where
 {
     async fn get(&self, index: usize) -> Result<Option<T>, ViewError> {
         let key = self.context.derive_tag_key(KeyTag::Index as u8, &index)?;
-        Ok(self.context.read_key(&key).await?)
+        Ok(self.context.read_value(&key).await?)
     }
 
     /// Reads the front value, if any.
@@ -264,7 +264,7 @@ where
             keys.push(key)
         }
         let mut values = Vec::with_capacity(count);
-        for entry in self.context.read_multi_key(keys).await? {
+        for entry in self.context.read_multi_values(keys).await? {
             match entry {
                 None => {
                     return Err(ViewError::MissingEntries);

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -61,7 +61,7 @@ where
 
     async fn load(context: C) -> Result<Self, ViewError> {
         let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_key(&key).await?;
+        let hash = context.read_value(&key).await?;
         Ok(Self {
             context,
             was_cleared: false,

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -45,7 +45,7 @@ where
         let key1 = context.base_tag(KeyTag::Value as u8);
         let key2 = context.base_tag(KeyTag::Hash as u8);
         let keys = vec![key1, key2];
-        let values_bytes = context.read_multi_key_bytes(keys).await?;
+        let values_bytes = context.read_multi_values_bytes(keys).await?;
         let stored_value = Box::new(from_bytes_opt(&values_bytes[0])?.unwrap_or_default());
         let hash = from_bytes_opt(&values_bytes[1])?;
         Ok(Self {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -19,11 +19,15 @@ use thiserror::Error;
 use {crate::lru_caching::TEST_CACHE_SIZE, tempfile::TempDir};
 
 /// The number of streams for the test
-pub const TEST_ROCKS_DB_MAX_STREAM_QUERIES: usize = 10;
+const TEST_ROCKS_DB_MAX_STREAM_QUERIES: usize = 10;
 
 // The maximum size of values in RocksDB is 3 GB
 // That is 3221225472 and so for offset reason we decrease by 400
 const MAX_VALUE_SIZE: usize = 3221225072;
+
+// The maximum size of keys in RocksDB is 8 MB
+// 8388608 and so for offset reason we decrease by 400
+const MAX_KEY_SIZE: usize = 8388208;
 
 /// The RocksDB client that we use.
 pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
@@ -50,6 +54,10 @@ impl KeyValueStoreClient for RocksDbClientInternal {
     type Error = RocksDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    fn max_key_size(&self) -> usize {
+        MAX_KEY_SIZE
+    }
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
@@ -321,6 +329,10 @@ impl KeyValueStoreClient for RocksDbClient {
     type Error = RocksDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    fn max_key_size(&self) -> usize {
+        self.client.max_key_size()
+    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -53,13 +53,10 @@ pub struct RocksDbKvStoreConfig {
 #[async_trait]
 impl KeyValueStoreClient for RocksDbClientInternal {
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
+    const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Error = RocksDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        MAX_KEY_SIZE
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
@@ -350,13 +347,10 @@ pub type RocksDbContext<E> = ContextFromDb<E, RocksDbClient>;
 #[async_trait]
 impl KeyValueStoreClient for RocksDbClient {
     const MAX_VALUE_SIZE: usize = usize::MAX;
+    const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Error = RocksDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        self.client.max_key_size()
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -19,6 +19,7 @@ use thiserror::Error;
 use {crate::lru_caching::TEST_CACHE_SIZE, tempfile::TempDir};
 
 /// The number of streams for the test
+#[cfg(any(test, feature = "test"))]
 const TEST_ROCKS_DB_MAX_STREAM_QUERIES: usize = 10;
 
 // The maximum size of values in RocksDB is 3 GB
@@ -182,13 +183,13 @@ impl KeyValueStoreClient for RocksDbClientInternal {
                             return Err(RocksDbContextError::KeyTooLong);
                         }
                         inner_batch.delete(&key)
-                    },
+                    }
                     WriteOperation::Put { key, value } => {
                         if key.len() > MAX_KEY_SIZE {
                             return Err(RocksDbContextError::KeyTooLong);
                         }
                         inner_batch.put(&key, value)
-                    },
+                    }
                     WriteOperation::DeletePrefix { key_prefix } => {
                         if key_prefix.len() > MAX_KEY_SIZE {
                             return Err(RocksDbContextError::KeyTooLong);

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -64,7 +64,7 @@ impl KeyValueStoreClient for RocksDbClientInternal {
         self.max_stream_queries
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksDbContextError> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksDbContextError> {
         if key.len() > MAX_KEY_SIZE {
             return Err(RocksDbContextError::KeyTooLong);
         }
@@ -73,7 +73,7 @@ impl KeyValueStoreClient for RocksDbClientInternal {
         Ok(tokio::task::spawn_blocking(move || client.db.get(&key)).await??)
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, RocksDbContextError> {
@@ -366,15 +366,15 @@ impl KeyValueStoreClient for RocksDbClient {
         self.client.max_stream_queries()
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksDbContextError> {
-        self.client.read_key_bytes(key).await
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksDbContextError> {
+        self.client.read_value_bytes(key).await
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, RocksDbContextError> {
-        self.client.read_multi_key_bytes(keys).await
+        self.client.read_multi_values_bytes(keys).await
     }
 
     async fn find_keys_by_prefix(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -55,8 +55,8 @@ const TEST_SCYLLA_DB_MAX_STREAM_QUERIES: usize = 10;
 /// "There is a hard limit at 16MB, and nothing bigger than that can arrive at once
 ///  at the database at any particular time"
 /// So, we set up the maximal size of 15M for the values and 1M for the keys
-const MAX_VALUE_BYTES: usize = 15728640;
-const MAX_KEY_BYTES: usize = 1048576;
+const MAX_VALUE_SIZE: usize = 15728640;
+const MAX_KEY_SIZE: usize = 1048576;
 
 /// The client itself and the keeping of the count of active connections.
 #[derive(Clone)]
@@ -113,13 +113,13 @@ impl From<ScyllaDbContextError> for crate::views::ViewError {
 
 #[async_trait]
 impl KeyValueStoreClient for ScyllaDbClientInternal {
-    const MAX_VALUE_SIZE: usize = MAX_VALUE_BYTES;
+    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
     type Error = ScyllaDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_key_size(&self) -> usize {
-        MAX_KEY_BYTES
+        MAX_KEY_SIZE
     }
 
     fn max_stream_queries(&self) -> usize {
@@ -192,7 +192,7 @@ impl ScyllaDbClientInternal {
         client: &ScyllaDbClientPair,
         key: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, ScyllaDbContextError> {
-        if key.len() > MAX_KEY_BYTES {
+        if key.len() > MAX_KEY_SIZE {
             return Err(ScyllaDbContextError::KeyTooLong);
         }
         let session = &client.0;
@@ -235,7 +235,7 @@ impl ScyllaDbClientInternal {
             table_name
         );
         for key_prefix in unordered_batch.key_prefix_deletions {
-            if key_prefix.len() > MAX_KEY_BYTES {
+            if key_prefix.len() > MAX_KEY_SIZE {
                 return Err(ScyllaDbContextError::KeyTooLong);
             }
             match get_upper_bound_option(&key_prefix) {
@@ -262,7 +262,7 @@ impl ScyllaDbClientInternal {
             table_name
         );
         for (key, value) in unordered_batch.simple_unordered_batch.insertions {
-            if key.len() > MAX_KEY_BYTES {
+            if key.len() > MAX_KEY_SIZE {
                 return Err(ScyllaDbContextError::KeyTooLong);
             }
             let values = vec![key, value];
@@ -277,7 +277,7 @@ impl ScyllaDbClientInternal {
         client: &ScyllaDbClientPair,
         key_prefix: Vec<u8>,
     ) -> Result<Vec<Vec<u8>>, ScyllaDbContextError> {
-        if key_prefix.len() > MAX_KEY_BYTES {
+        if key_prefix.len() > MAX_KEY_SIZE {
             return Err(ScyllaDbContextError::KeyTooLong);
         }
         let session = &client.0;
@@ -317,7 +317,7 @@ impl ScyllaDbClientInternal {
         client: &ScyllaDbClientPair,
         key_prefix: Vec<u8>,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ScyllaDbContextError> {
-        if key_prefix.len() > MAX_KEY_BYTES {
+        if key_prefix.len() > MAX_KEY_SIZE {
             return Err(ScyllaDbContextError::KeyTooLong);
         }
         let session = &client.0;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -126,13 +126,13 @@ impl KeyValueStoreClient for ScyllaDbClientInternal {
         self.max_stream_queries
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let client = self.client.deref();
         let _guard = self.acquire().await;
-        Self::read_key_internal(client, key.to_vec()).await
+        Self::read_value_internal(client, key.to_vec()).await
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
@@ -140,7 +140,7 @@ impl KeyValueStoreClient for ScyllaDbClientInternal {
         let _guard = self.acquire().await;
         let handles = keys
             .into_iter()
-            .map(|key| Self::read_key_internal(client, key));
+            .map(|key| Self::read_value_internal(client, key));
         let result = join_all(handles).await;
         Ok(result.into_iter().collect::<Result<_, _>>()?)
     }
@@ -188,7 +188,7 @@ impl ScyllaDbClientInternal {
         }
     }
 
-    async fn read_key_internal(
+    async fn read_value_internal(
         client: &ScyllaDbClientPair,
         key: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, ScyllaDbContextError> {
@@ -645,15 +645,15 @@ impl KeyValueStoreClient for ScyllaDbClient {
         self.client.max_stream_queries()
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-        self.client.read_key_bytes(key).await
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+        self.client.read_value_bytes(key).await
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-        self.client.read_multi_key_bytes(keys).await
+        self.client.read_multi_values_bytes(keys).await
     }
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -29,6 +29,7 @@ use crate::{
 use async_lock::{Semaphore, SemaphoreGuard};
 use async_trait::async_trait;
 use futures::future::join_all;
+use linera_base::ensure;
 use scylla::{
     frame::request::batch::BatchType,
     query::Query,
@@ -192,9 +193,7 @@ impl ScyllaDbClientInternal {
         client: &ScyllaDbClientPair,
         key: Vec<u8>,
     ) -> Result<Option<Vec<u8>>, ScyllaDbContextError> {
-        if key.len() > MAX_KEY_SIZE {
-            return Err(ScyllaDbContextError::KeyTooLong);
-        }
+        ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbContextError::KeyTooLong);
         let session = &client.0;
         let table_name = &client.1;
         // Read the value of a key
@@ -235,9 +234,10 @@ impl ScyllaDbClientInternal {
             table_name
         );
         for key_prefix in unordered_batch.key_prefix_deletions {
-            if key_prefix.len() > MAX_KEY_SIZE {
-                return Err(ScyllaDbContextError::KeyTooLong);
-            }
+            ensure!(
+                key_prefix.len() <= MAX_KEY_SIZE,
+                ScyllaDbContextError::KeyTooLong
+            );
             match get_upper_bound_option(&key_prefix) {
                 None => {
                     let values = vec![key_prefix];
@@ -262,9 +262,7 @@ impl ScyllaDbClientInternal {
             table_name
         );
         for (key, value) in unordered_batch.simple_unordered_batch.insertions {
-            if key.len() > MAX_KEY_SIZE {
-                return Err(ScyllaDbContextError::KeyTooLong);
-            }
+            ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbContextError::KeyTooLong);
             let values = vec![key, value];
             batch_values.push(values);
             batch_query.append_statement(Query::new(query4.clone()));
@@ -277,9 +275,10 @@ impl ScyllaDbClientInternal {
         client: &ScyllaDbClientPair,
         key_prefix: Vec<u8>,
     ) -> Result<Vec<Vec<u8>>, ScyllaDbContextError> {
-        if key_prefix.len() > MAX_KEY_SIZE {
-            return Err(ScyllaDbContextError::KeyTooLong);
-        }
+        ensure!(
+            key_prefix.len() <= MAX_KEY_SIZE,
+            ScyllaDbContextError::KeyTooLong
+        );
         let session = &client.0;
         let table_name = &client.1;
         // Read the value of a key
@@ -317,9 +316,10 @@ impl ScyllaDbClientInternal {
         client: &ScyllaDbClientPair,
         key_prefix: Vec<u8>,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ScyllaDbContextError> {
-        if key_prefix.len() > MAX_KEY_SIZE {
-            return Err(ScyllaDbContextError::KeyTooLong);
-        }
+        ensure!(
+            key_prefix.len() <= MAX_KEY_SIZE,
+            ScyllaDbContextError::KeyTooLong
+        );
         let session = &client.0;
         let table_name = &client.1;
         // Read the value of a key

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -115,13 +115,10 @@ impl From<ScyllaDbContextError> for crate::views::ViewError {
 #[async_trait]
 impl KeyValueStoreClient for ScyllaDbClientInternal {
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
+    const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Error = ScyllaDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        MAX_KEY_SIZE
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.max_stream_queries
@@ -633,13 +630,10 @@ pub struct ScyllaDbKvStoreConfig {
 #[async_trait]
 impl KeyValueStoreClient for ScyllaDbClient {
     const MAX_VALUE_SIZE: usize = ScyllaDbClientInternal::MAX_VALUE_SIZE;
+    const MAX_KEY_SIZE: usize = ScyllaDbClientInternal::MAX_KEY_SIZE;
     type Error = <ScyllaDbClientInternal as KeyValueStoreClient>::Error;
     type Keys = <ScyllaDbClientInternal as KeyValueStoreClient>::Keys;
     type KeyValues = <ScyllaDbClientInternal as KeyValueStoreClient>::KeyValues;
-
-    fn max_key_size(&self) -> usize {
-        self.client.max_key_size()
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -42,7 +42,7 @@ where
 
     async fn load(context: C) -> Result<Self, ViewError> {
         let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_key(&key).await?;
+        let hash = context.read_value(&key).await?;
         Ok(Self {
             context,
             was_cleared: false,
@@ -176,7 +176,7 @@ where
             return Ok(false);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, &short_key);
-        match self.context.read_key_bytes(&key).await? {
+        match self.context.read_value_bytes(&key).await? {
             None => Ok(false),
             Some(_) => Ok(true),
         }

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -52,7 +52,6 @@ where
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_key_size(&self) -> usize {
-        // We decrease by 4 because of the constraint
         self.client.max_key_size() - 4
     }
 

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -59,10 +59,10 @@ where
         self.client.max_stream_queries()
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let mut big_key = key.to_vec();
         big_key.extend(&[0, 0, 0, 0]);
-        let value = self.client.read_key_bytes(&big_key).await?;
+        let value = self.client.read_value_bytes(&big_key).await?;
         let Some(value) = value else {
             return Ok(None);
         };
@@ -76,7 +76,7 @@ where
             let big_key_segment = Self::get_segment_key(key, i)?;
             big_keys.push(big_key_segment);
         }
-        let segments = self.client.read_multi_key_bytes(big_keys).await?;
+        let segments = self.client.read_multi_values_bytes(big_keys).await?;
         for segment in segments {
             match segment {
                 None => {
@@ -90,7 +90,7 @@ where
         Ok(Some(big_value))
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
@@ -100,7 +100,7 @@ where
             big_key.extend(&[0, 0, 0, 0]);
             big_keys.push(big_key);
         }
-        let values = self.client.read_multi_key_bytes(big_keys).await?;
+        let values = self.client.read_multi_values_bytes(big_keys).await?;
         let mut big_values = Vec::<Option<Vec<u8>>>::new();
         let mut keys_add = Vec::new();
         let mut n_blocks = Vec::new();
@@ -125,7 +125,7 @@ where
         if !keys_add.is_empty() {
             let mut segments = self
                 .client
-                .read_multi_key_bytes(keys_add)
+                .read_multi_values_bytes(keys_add)
                 .await?
                 .into_iter();
             for (idx, count) in n_blocks.iter().enumerate() {
@@ -302,15 +302,15 @@ impl KeyValueStoreClient for TestMemoryClientInternal {
         TEST_MEMORY_MAX_STREAM_QUERIES
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
-        self.client.read_key_bytes(key).await
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
+        self.client.read_value_bytes(key).await
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {
-        self.client.read_multi_key_bytes(keys).await
+        self.client.read_multi_values_bytes(keys).await
     }
 
     async fn find_keys_by_prefix(
@@ -369,15 +369,15 @@ impl KeyValueStoreClient for TestMemoryClient {
         self.client.max_stream_queries()
     }
 
-    async fn read_key_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
-        self.client.read_key_bytes(key).await
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
+        self.client.read_value_bytes(key).await
     }
 
-    async fn read_multi_key_bytes(
+    async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, MemoryContextError> {
-        self.client.read_multi_key_bytes(keys).await
+        self.client.read_multi_values_bytes(keys).await
     }
 
     async fn find_keys_by_prefix(
@@ -509,14 +509,14 @@ mod tests {
         let value = Vec::from([0; MAX_LEN + 1]);
         batch.put_key_value_bytes(key.clone(), value.clone());
         big_client.write_batch(batch, &[]).await.unwrap();
-        let value_read = big_client.read_key_bytes(&key).await.unwrap();
+        let value_read = big_client.read_value_bytes(&key).await.unwrap();
         assert_eq!(value_read, Some(value));
         // Write a key with a smaller value
         let mut batch = Batch::new();
         let value = Vec::from([0, 1]);
         batch.put_key_value_bytes(key.clone(), value.clone());
         big_client.write_batch(batch, &[]).await.unwrap();
-        let value_read = big_client.read_key_bytes(&key).await.unwrap();
+        let value_read = big_client.read_value_bytes(&key).await.unwrap();
         assert_eq!(value_read, Some(value));
         // Two segments are present even though only one is used
         let keys = client.find_keys_by_prefix(&[0]).await.unwrap();
@@ -538,7 +538,7 @@ mod tests {
         }
         batch.put_key_value_bytes(key.clone(), value.clone());
         big_client.write_batch(batch, &[]).await.unwrap();
-        let value_read = big_client.read_key_bytes(&key).await.unwrap();
+        let value_read = big_client.read_value_bytes(&key).await.unwrap();
         assert_eq!(value_read, Some(value.clone()));
         // Reading the segments and checking
         let mut value_concat = Vec::<u8>::new();
@@ -547,7 +547,7 @@ mod tests {
             let mut bytes = bcs::to_bytes(&index).unwrap();
             bytes.reverse();
             segment_key.extend(bytes);
-            let value_read = client.read_key_bytes(&segment_key).await.unwrap();
+            let value_read = client.read_value_bytes(&segment_key).await.unwrap();
             let Some(value_read) = value_read else {
                 unreachable!()
             };

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -51,6 +51,11 @@ where
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
+    fn max_key_size(&self) -> usize {
+        // We decrease by 4 because of the constraint
+        self.client.max_key_size() - 4
+    }
+
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()
     }
@@ -290,6 +295,10 @@ impl KeyValueStoreClient for TestMemoryClientInternal {
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
+    fn max_key_size(&self) -> usize {
+        usize::MAX
+    }
+
     fn max_stream_queries(&self) -> usize {
         TEST_MEMORY_MAX_STREAM_QUERIES
     }
@@ -352,6 +361,10 @@ impl KeyValueStoreClient for TestMemoryClient {
     type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+    fn max_key_size(&self) -> usize {
+        usize::MAX
+    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -47,13 +47,10 @@ where
     K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
 {
     const MAX_VALUE_SIZE: usize = usize::MAX;
+    const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE - 4;
     type Error = K::Error;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        self.client.max_key_size() - 4
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()
@@ -290,13 +287,10 @@ impl KeyValueStoreClient for TestMemoryClientInternal {
     // We set up the MAX_VALUE_SIZE to the artificially low value of 100
     // purely for testing purposes.
     const MAX_VALUE_SIZE: usize = 100;
+    const MAX_KEY_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        usize::MAX
-    }
 
     fn max_stream_queries(&self) -> usize {
         TEST_MEMORY_MAX_STREAM_QUERIES
@@ -357,13 +351,10 @@ pub struct TestMemoryClient {
 #[async_trait]
 impl KeyValueStoreClient for TestMemoryClient {
     const MAX_VALUE_SIZE: usize = usize::MAX;
+    const MAX_KEY_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_key_size(&self) -> usize {
-        usize::MAX
-    }
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -79,6 +79,10 @@ pub enum ViewError {
         error: String,
     },
 
+    /// The key must not be too long
+    #[error("The key must not be too long")]
+    KeyTooLong,
+
     /// Errors can happen within the Wasm guest and have to be transmitted within the Host/Guest where only elementary types can pass.
     #[error("Following error occurs in wasm code: {0}")]
     WasmHostGuestError(String),


### PR DESCRIPTION
## Motivation

We need to handle the maximal key size in a cleaner way. So, we had to 

## Proposal

The feature took much trouble to implement and the solution was the following:
* For ScyllaDb, we declare the limit to be 1M while the total size is actually 16M for a transaction.
* We cannot have a hard constant because for the `KeyValueStoreClient` it depends on the size of the `base_key`.
* For the system_api, we need to have a constant that is not dependent on the underlying storage.
* In the end we should have size problem before accessing to the database.

## Test Plan

The CI should take care of it.

## Release Plan

There is nothing specific about the PR that impacts the release.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
