### PR TITLE
Simplify the input for `linera_db`.

### DIFF
--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -24,18 +24,6 @@ enum DatabaseToolCommand {
         /// Storage configuration for the blockchain history.
         #[structopt(long = "storage")]
         storage_config: String,
-
-        /// The maximal number of simultaneous queries to the database
-        #[structopt(long)]
-        max_concurrent_queries: Option<usize>,
-
-        /// The maximal number of simultaneous stream queries to the database
-        #[structopt(long, default_value = "10")]
-        max_stream_queries: usize,
-
-        /// The maximal number of entries in the storage cache.
-        #[structopt(long, default_value = "1000")]
-        cache_size: usize,
     },
 
     /// Delete a single table from the database
@@ -44,18 +32,6 @@ enum DatabaseToolCommand {
         /// Storage configuration for the blockchain history.
         #[structopt(long = "storage")]
         storage_config: String,
-
-        /// The maximal number of simultaneous queries to the database
-        #[structopt(long)]
-        max_concurrent_queries: Option<usize>,
-
-        /// The maximal number of simultaneous stream queries to the database
-        #[structopt(long, default_value = "10")]
-        max_stream_queries: usize,
-
-        /// The maximal number of entries in the storage cache.
-        #[structopt(long, default_value = "1000")]
-        cache_size: usize,
     },
 
     /// Check existence of a database
@@ -64,18 +40,6 @@ enum DatabaseToolCommand {
         /// Storage configuration for the blockchain history.
         #[structopt(long = "storage")]
         storage_config: String,
-
-        /// The maximal number of simultaneous queries to the database
-        #[structopt(long)]
-        max_concurrent_queries: Option<usize>,
-
-        /// The maximal number of simultaneous stream queries to the database
-        #[structopt(long, default_value = "10")]
-        max_stream_queries: usize,
-
-        /// The maximal number of entries in the storage cache.
-        #[structopt(long, default_value = "1000")]
-        cache_size: usize,
     },
 
     /// Check absence of a database
@@ -84,18 +48,6 @@ enum DatabaseToolCommand {
         /// Storage configuration for the blockchain history.
         #[structopt(long = "storage")]
         storage_config: String,
-
-        /// The maximal number of simultaneous queries to the database
-        #[structopt(long)]
-        max_concurrent_queries: Option<usize>,
-
-        /// The maximal number of simultaneous stream queries to the database
-        #[structopt(long, default_value = "10")]
-        max_stream_queries: usize,
-
-        /// The maximal number of entries in the storage cache.
-        #[structopt(long, default_value = "1000")]
-        cache_size: usize,
     },
 
     /// Initialize a table in the database
@@ -104,18 +56,6 @@ enum DatabaseToolCommand {
         /// Storage configuration for the blockchain history.
         #[structopt(long = "storage")]
         storage_config: String,
-
-        /// The maximal number of simultaneous queries to the database
-        #[structopt(long)]
-        max_concurrent_queries: Option<usize>,
-
-        /// The maximal number of simultaneous stream queries to the database
-        #[structopt(long, default_value = "10")]
-        max_stream_queries: usize,
-
-        /// The maximal number of entries in the storage cache.
-        #[structopt(long, default_value = "1000")]
-        cache_size: usize,
     },
 
     /// List the tables of the database
@@ -124,65 +64,26 @@ enum DatabaseToolCommand {
         /// Storage configuration for the blockchain history.
         #[structopt(long = "storage")]
         storage_config: String,
-
-        /// The maximal number of simultaneous queries to the database
-        #[structopt(long)]
-        max_concurrent_queries: Option<usize>,
-
-        /// The maximal number of simultaneous stream queries to the database
-        #[structopt(long, default_value = "10")]
-        max_stream_queries: usize,
-
-        /// The maximal number of entries in the storage cache.
-        #[structopt(long, default_value = "1000")]
-        cache_size: usize,
     },
 }
 
 async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::Error> {
     match options.command {
-        DatabaseToolCommand::DeleteAll {
-            storage_config,
-            max_concurrent_queries,
-            max_stream_queries,
-            cache_size,
-        } => {
+        DatabaseToolCommand::DeleteAll { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig {
-                max_concurrent_queries,
-                max_stream_queries,
-                cache_size,
-            };
+            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             full_storage_config.delete_all().await?;
         }
-        DatabaseToolCommand::DeleteSingle {
-            storage_config,
-            max_concurrent_queries,
-            max_stream_queries,
-            cache_size,
-        } => {
+        DatabaseToolCommand::DeleteSingle { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig {
-                max_concurrent_queries,
-                max_stream_queries,
-                cache_size,
-            };
+            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             full_storage_config.delete_single().await?;
         }
-        DatabaseToolCommand::CheckExistence {
-            storage_config,
-            max_concurrent_queries,
-            max_stream_queries,
-            cache_size,
-        } => {
+        DatabaseToolCommand::CheckExistence { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig {
-                max_concurrent_queries,
-                max_stream_queries,
-                cache_size,
-            };
+            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             let test = full_storage_config.test_existence().await?;
             if test {
@@ -193,18 +94,9 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::E
                 return Ok(1);
             }
         }
-        DatabaseToolCommand::CheckAbsence {
-            storage_config,
-            max_concurrent_queries,
-            max_stream_queries,
-            cache_size,
-        } => {
+        DatabaseToolCommand::CheckAbsence { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig {
-                max_concurrent_queries,
-                max_stream_queries,
-                cache_size,
-            };
+            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             let test = full_storage_config.test_existence().await?;
             if test {
@@ -215,33 +107,15 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::E
                 return Ok(0);
             }
         }
-        DatabaseToolCommand::Initialize {
-            storage_config,
-            max_concurrent_queries,
-            max_stream_queries,
-            cache_size,
-        } => {
+        DatabaseToolCommand::Initialize { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig {
-                max_concurrent_queries,
-                max_stream_queries,
-                cache_size,
-            };
+            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             full_storage_config.initialize().await?;
         }
-        DatabaseToolCommand::ListTables {
-            storage_config,
-            max_concurrent_queries,
-            max_stream_queries,
-            cache_size,
-        } => {
+        DatabaseToolCommand::ListTables { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig {
-                max_concurrent_queries,
-                max_stream_queries,
-                cache_size,
-            };
+            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             let tables = full_storage_config.list_tables().await?;
             println!("The list of tables is {:?}", tables);

--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -68,22 +68,20 @@ enum DatabaseToolCommand {
 }
 
 async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::Error> {
+    let common_config = CommonStoreConfig::default();
     match options.command {
         DatabaseToolCommand::DeleteAll { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             full_storage_config.delete_all().await?;
         }
         DatabaseToolCommand::DeleteSingle { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             full_storage_config.delete_single().await?;
         }
         DatabaseToolCommand::CheckExistence { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             let test = full_storage_config.test_existence().await?;
             if test {
@@ -96,7 +94,6 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::E
         }
         DatabaseToolCommand::CheckAbsence { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             let test = full_storage_config.test_existence().await?;
             if test {
@@ -109,13 +106,11 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::E
         }
         DatabaseToolCommand::Initialize { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             full_storage_config.initialize().await?;
         }
         DatabaseToolCommand::ListTables { storage_config } => {
             let storage_config: StorageConfig = storage_config.parse()?;
-            let common_config = CommonStoreConfig::default();
             let full_storage_config = storage_config.add_common_config(common_config).await?;
             let tables = full_storage_config.list_tables().await?;
             println!("The list of tables is {:?}", tables);

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -58,6 +58,16 @@ pub struct CommonStoreConfig {
     pub cache_size: usize,
 }
 
+impl Default for CommonStoreConfig {
+    fn default() -> Self {
+        CommonStoreConfig {
+            max_concurrent_queries: None,
+            max_stream_queries: 10,
+            cache_size: 1000,
+        }
+    }
+}
+
 /// The minimum value for the view tags. Values in 0..MIN_VIEW_TAG are used for other purposes.
 pub const MIN_VIEW_TAG: u8 = 1;
 


### PR DESCRIPTION
## Motivation

The three entries `max_concurrent_queries`, `max_stream_queries` and `cache_size` were not used for the `linera_db` tool. So it is better to remove them.

## Proposal

The following was done:
* Simplify the input 
* Implement a `Default` for the `CommonStoreConfig`.

## Test Plan

The CI should do as needed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
