### PR TITLE
Copy existing binaries to Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,7 +13,6 @@ npm-debug.log
 README-secret.md
 # github related files
 .github/
-target
 scripts/target
 examples/target
 Dockerfile

--- a/docker/Dockerfile.copy
+++ b/docker/Dockerfile.copy
@@ -1,0 +1,40 @@
+FROM debian:latest
+
+RUN mkdir -p /opt/linera
+
+WORKDIR /opt/linera
+
+# Copying binaries
+COPY target/release/linera .
+COPY target/release/linera-server .
+COPY target/release/linera-proxy .
+COPY target/release/linera-db .
+
+# Copying configuration files
+COPY configuration/k8s-local/validator_1.toml .
+
+# Copy entrypoint
+COPY docker/server-entrypoint.sh .
+RUN chmod +x server-entrypoint.sh
+
+# Copy init
+COPY docker/server-init.sh .
+RUN chmod +x server-init.sh
+
+RUN apt-get update && apt-get install -y libssl-dev
+
+# Create configuration files for the validator according to the validator's config file.
+# * Private server states are stored in `server*.json`.
+# * `committee.json` is the public description of the Linera committee.
+RUN ./linera-server generate --validators validator_1.toml --committee committee.json
+
+# Create configuration files for 1000 user chains.
+# * Private chain states are stored in one local wallet `wallet.json`.
+# * `genesis.json` will contain the initial balances of chains as well as the initial committee.
+RUN ./linera \
+    --wallet wallet.json \
+    --storage rocksdb:linera.db \
+    create-genesis-config 1000 \
+    --genesis genesis.json \
+    --initial-funding 100 \
+    --committee committee.json


### PR DESCRIPTION
## Motivation

Development cycles are slow when deploying a local cluster because of how slow the Docker build is, which also slows down CI.

## Proposal

Let's have an option to build locally the binaries (outside of Docker) then just copy them over to build the image. This should speed up development cycles for people using Linux. AFAIK there are no Apple M1 Silicon Docker images that we could use, so people not using Linux (me) are out of luck on this.

## Test Plan

This will be triggered in the following PR by CI, which we'll use as a test for this (I can't test it locally because I don't have a Linux machine)