### PR TITLE
Add linera faucet command.

### DIFF
--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{connection::EmptyFields, EmptySubscription, Error, Object, Schema};
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
+use axum::{http::StatusCode, response, response::IntoResponse, Extension, Router, Server};
+use futures::lock::Mutex;
+use linera_base::{
+    crypto::PublicKey,
+    data_types::Amount,
+    identifiers::{ChainId, MessageId},
+};
+use linera_core::{
+    client::{ChainClient, ChainClientError},
+    node::ValidatorNodeProvider,
+};
+use linera_execution::{
+    system::{Recipient, UserData},
+    ChainOwnership,
+};
+use linera_storage::Store;
+use linera_views::views::ViewError;
+use serde_json::json;
+use std::{net::SocketAddr, num::NonZeroU16, sync::Arc};
+use thiserror::Error as ThisError;
+use tower_http::cors::CorsLayer;
+use tracing::{error, info};
+
+use crate::util;
+
+/// The root GraphQL mutation type.
+pub struct MutationRoot<P, S> {
+    client: Arc<Mutex<ChainClient<P, S>>>,
+    amount: Amount,
+}
+
+#[derive(Debug, ThisError)]
+#[error(transparent)]
+struct FaucetError(#[from] ChainClientError);
+
+impl IntoResponse for FaucetError {
+    fn into_response(self) -> response::Response {
+        let code = StatusCode::INTERNAL_SERVER_ERROR;
+        let json = json!({"error": self.0.to_string()});
+        (code, json.to_string()).into_response()
+    }
+}
+
+#[Object]
+impl<P, S> MutationRoot<P, S>
+where
+    P: ValidatorNodeProvider + Send + Sync + 'static,
+    S: Store + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
+{
+    /// Creates a new chain with the given authentication key, and transfers tokens to it.
+    async fn claim(&self, public_key: PublicKey) -> Result<MessageId, Error> {
+        let ownership = ChainOwnership::single(public_key);
+        let mut client = self.client.lock().await;
+        let (message_id, _) = client.open_chain(ownership).await?;
+        let chain_id = ChainId::child(message_id);
+        let recipient = Recipient::chain(chain_id);
+        let _certificate = client
+            .transfer(None, self.amount, recipient, UserData::default())
+            .await?;
+        Ok(message_id)
+    }
+}
+
+/// A GraphQL interface to request a new chain with tokens.
+#[derive(Clone)]
+pub struct FaucetService<P, S> {
+    client: Arc<Mutex<ChainClient<P, S>>>,
+    port: NonZeroU16,
+    amount: Amount,
+}
+
+impl<P, S> FaucetService<P, S>
+where
+    P: ValidatorNodeProvider + Send + Sync + Clone + 'static,
+    S: Store + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
+{
+    /// Creates a new instance of the faucet service.
+    pub fn new(port: NonZeroU16, client: ChainClient<P, S>, amount: Amount) -> Self {
+        Self {
+            client: Arc::new(Mutex::new(client)),
+            port,
+            amount,
+        }
+    }
+
+    pub fn schema(&self) -> Schema<EmptyFields, MutationRoot<P, S>, EmptySubscription> {
+        let mutation_root = MutationRoot {
+            client: self.client.clone(),
+            amount: self.amount,
+        };
+        Schema::build(EmptyFields, mutation_root, EmptySubscription).finish()
+    }
+
+    /// Runs the faucet.
+    pub async fn run(self) -> Result<(), anyhow::Error> {
+        let port = self.port.get();
+        let index_handler = axum::routing::get(util::graphiql).post(Self::index_handler);
+
+        let app = Router::new()
+            .route("/", index_handler)
+            .route("/ready", axum::routing::get(|| async { "ready!" }))
+            .route_service("/ws", GraphQLSubscription::new(self.schema()))
+            .layer(Extension(self.clone()))
+            .layer(CorsLayer::permissive());
+
+        info!("GraphiQL IDE: http://localhost:{}", port);
+
+        Server::bind(&SocketAddr::from(([127, 0, 0, 1], port)))
+            .serve(app.into_make_service())
+            .await?;
+
+        Ok(())
+    }
+
+    /// Executes a GraphQL query and generates a response for our `Schema`.
+    async fn index_handler(service: Extension<Self>, request: GraphQLRequest) -> GraphQLResponse {
+        let schema = service.0.schema();
+        schema.execute(request.into_inner()).await.into()
+    }
+}

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod chain_listener;
 pub mod cli_wrappers;
 pub mod config;
+pub mod faucet;
 pub mod grpc_proxy;
 pub mod node_service;
 pub mod project;

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, ensure, Context as _, Result};
+use async_graphql::http::GraphiQLSource;
 use async_trait::async_trait;
+use axum::response::{self, IntoResponse};
+use http::Uri;
 use std::{
     path::{Path, PathBuf},
     process::Stdio,
@@ -223,4 +226,13 @@ impl QuotedBashScript {
 
         Ok(result)
     }
+}
+
+/// Returns an HTML response constructing the GraphiQL web page for the given URI.
+pub(crate) async fn graphiql(uri: Uri) -> impl IntoResponse {
+    let source = GraphiQLSource::build()
+        .endpoint(uri.path())
+        .subscription_endpoint("/ws")
+        .finish();
+    response::Html(source)
 }


### PR DESCRIPTION
## Motivation

For Devnet new users should be able to start using the network by just requesting a new user chain with some tokens from a faucet.

## Proposal

Add a `linera faucet` command that works like `linera service` except its only query is a `claim` mutation that creates a new chain for a given public key, and adds some tokens to it.

Rate limiting will be added in a separate PR.

## Test Plan

An end-to-end test that verifies that a new chain has been created and credited.

## Release Plan

- Need to update the developer manual.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
