### PR TITLE
Return chain ID and certificate hashes from the faucet claim mutation.

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -677,7 +677,9 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
         .run_faucet(None, chain1, Amount::from_tokens(2))
         .await
         .unwrap();
-    let (message_id, chain2) = faucet.claim(&client2_key).await.unwrap();
+    let outcome = faucet.claim(&client2_key).await.unwrap();
+    let chain2 = outcome.chain_id;
+    let message_id = outcome.message_id;
 
     // Assign chain2 to client2_key.
     assert_eq!(


### PR DESCRIPTION
## Motivation

GraphQL mutations should always return the certificate hash.

## Proposal

Return a `ClaimOutcome` from the faucet `claim` mutation, containing more information.

## Test Plan

The test has been updated.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
