### PR TITLE
Add initial balance to OpenChain.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -401,6 +401,7 @@ where
             epoch,
             committees,
             admin_id,
+            balance,
         }) = message
         {
             // Initialize ourself.
@@ -411,6 +412,7 @@ where
                 committees.clone(),
                 *admin_id,
                 timestamp,
+                *balance,
             );
             // Recompute the state hash.
             let hash = self.execution_state.crypto_hash().await?;

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1532,6 +1532,7 @@ where
     pub async fn open_chain(
         &mut self,
         ownership: ChainOwnership,
+        balance: Amount,
     ) -> Result<(MessageId, Certificate), ChainClientError> {
         self.prepare_chain().await?;
         let (epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
@@ -1545,6 +1546,7 @@ where
                     committees,
                     admin_id: self.admin_id,
                     epoch,
+                    balance,
                 })],
             )
             .await?;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -574,7 +574,7 @@ where
     let new_key_pair = KeyPair::generate();
     // Open the new chain.
     let (message_id, certificate) = sender
-        .open_chain(ChainOwnership::single(new_key_pair.public()))
+        .open_chain(ChainOwnership::single(new_key_pair.public()), Amount::ZERO)
         .await
         .unwrap();
     assert_eq!(sender.next_block_height, BlockHeight::from(1));
@@ -650,7 +650,7 @@ where
         .unwrap();
     // Open the new chain.
     let (open_chain_message_id, certificate) = sender
-        .open_chain(ChainOwnership::single(new_key_pair.public()))
+        .open_chain(ChainOwnership::single(new_key_pair.public()), Amount::ZERO)
         .await
         .unwrap();
     let new_id2 = ChainId::child(open_chain_message_id);
@@ -734,7 +734,7 @@ where
     let new_key_pair = KeyPair::generate();
     // Open the new chain.
     let (message_id, creation_certificate) = sender
-        .open_chain(ChainOwnership::single(new_key_pair.public()))
+        .open_chain(ChainOwnership::single(new_key_pair.public()), Amount::ZERO)
         .await
         .unwrap();
     let new_id = ChainId::child(message_id);

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2359,6 +2359,7 @@ where
                 epoch: Epoch::ZERO,
                 committees: committees.clone(),
                 admin_id,
+                balance: Amount::ZERO,
             }),
             messages: vec![
                 direct_outgoing_message(
@@ -2368,6 +2369,7 @@ where
                         epoch: Epoch::ZERO,
                         committees: committees.clone(),
                         admin_id,
+                        balance: Amount::ZERO,
                     },
                 ),
                 direct_outgoing_message(
@@ -2612,6 +2614,7 @@ where
                             epoch: Epoch::from(0),
                             committees: committees.clone(),
                             admin_id,
+                            balance: Amount::ZERO,
                         }),
                     },
                 })

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -508,14 +508,12 @@ where
                         epoch: *epoch
                     }
                 );
-                if *new_balance > Amount::ZERO {
-                    let balance = self.balance.get_mut();
-                    balance.try_sub_assign(*new_balance).map_err(|_| {
-                        SystemExecutionError::InsufficientFunding {
-                            current_balance: *balance,
-                        }
-                    })?;
-                }
+                let balance = self.balance.get_mut();
+                balance.try_sub_assign(*new_balance).map_err(|_| {
+                    SystemExecutionError::InsufficientFunding {
+                        current_balance: *balance,
+                    }
+                })?;
                 let e1 = RawOutgoingMessage {
                     destination: Destination::Recipient(child_id),
                     authenticated: false,

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -676,6 +676,8 @@ SystemMessage:
                   TYPENAME: Epoch
                 VALUE:
                   TYPENAME: Committee
+          - balance:
+              TYPENAME: Amount
     3:
       SetCommittees:
         STRUCT:
@@ -772,6 +774,8 @@ SystemOperation:
                   TYPENAME: Epoch
                 VALUE:
                   TYPENAME: Committee
+          - balance:
+              TYPENAME: Amount
     3:
       CloseChain: UNIT
     4:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -318,12 +318,12 @@ type MutationRoot {
 	Creates (or activates) a new chain by installing the given authentication key.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openChain(chainId: ChainId!, publicKey: PublicKey!): ChainId!
+	openChain(chainId: ChainId!, publicKey: PublicKey!, balance: Amount): ChainId!
 	"""
 	Creates (or activates) a new chain by installing the given authentication keys.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openMultiOwnerChain(chainId: ChainId!, publicKeys: [PublicKey!]!, weights: [Int!], multiLeaderRounds: Int): ChainId!
+	openMultiOwnerChain(chainId: ChainId!, publicKeys: [PublicKey!]!, weights: [Int!], multiLeaderRounds: Int, balance: Amount): ChainId!
 	"""
 	Closes the chain.
 	"""

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -754,7 +754,7 @@ impl Faucet {
     pub async fn claim(&self, public_key: &PublicKey) -> Result<ClaimOutcome> {
         let query = format!(
             "mutation {{ claim(publicKey: \"{public_key}\") {{ \
-                messageId chainId openChainCertificateHash transferCertificateHash \
+                messageId chainId certificateHash \
             }} }}"
         );
         let url = format!("http://localhost:{}/", self.port);
@@ -789,21 +789,15 @@ impl Faucet {
             .context("chain ID not found")?
             .parse()
             .context("could not parse chain ID")?;
-        let open_chain_certificate_hash = data["openChainCertificateHash"]
+        let certificate_hash = data["certificateHash"]
             .as_str()
-            .context("OpenChain certificate hash not found")?
+            .context("Certificate hash not found")?
             .parse()
-            .context("could not parse OpenChain certificate hash")?;
-        let transfer_certificate_hash = data["transferCertificateHash"]
-            .as_str()
-            .context("Transfer certificate hash not found")?
-            .parse()
-            .context("could not parse Transfer certificate hash")?;
+            .context("could not parse certificate hash")?;
         let outcome = ClaimOutcome {
             message_id,
             chain_id,
-            open_chain_certificate_hash,
-            transfer_certificate_hash,
+            certificate_hash,
         };
         Ok(outcome)
     }

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -747,6 +747,13 @@ impl Faucet {
         Self { port, child }
     }
 
+    pub async fn terminate(mut self) -> Result<()> {
+        self.child
+            .kill()
+            .await
+            .context("terminating faucet service")
+    }
+
     pub fn ensure_is_running(&mut self) -> Result<()> {
         self.child.ensure_is_running()
     }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -681,6 +681,16 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     let chain2 = outcome.chain_id;
     let message_id = outcome.message_id;
 
+    faucet.ensure_is_running().unwrap();
+    faucet.terminate().await.unwrap();
+
+    // Chain 1 should have paid two tokens.
+    client1.synchronize_balance(chain1).await.unwrap();
+    assert_eq!(
+        client1.query_balance(chain1).await.unwrap(),
+        Amount::from_tokens(8)
+    );
+
     // Assign chain2 to client2_key.
     assert_eq!(
         chain2,
@@ -701,8 +711,6 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
         client2.query_balance(chain2).await.unwrap(),
         Amount::from_tokens(1)
     );
-
-    faucet.ensure_is_running().unwrap();
     net.ensure_is_running().unwrap();
     net.terminate().await.unwrap();
 }


### PR DESCRIPTION
## Motivation

The faucet currently creates two blocks for each user: One to create their chain and then one to transfer their initial balance.

And in general, a chain without any balance can't be used for anything, so the command-line and GraphQL commands for opening a chain will usually be followed by a transfer as well.

## Proposal

Add a `balance` field to the `OpenChain` operation and message itself, so the parent chain can send an initial amount of tokens along that is credited to the child from the start.

## Test Plan

The faucet test now exercises this.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
