### PR TITLE
Some fixes on build_and_redeploy

### DIFF
--- a/kubernetes/linera-validator/build_and_redeploy.sh
+++ b/kubernetes/linera-validator/build_and_redeploy.sh
@@ -85,13 +85,14 @@ if [ -n "$cloud_mode" ]; then
 else
     docker_image="linera-test:latest"
     if [ -n "$do_build" ]; then
+        arch="$(uname -m)"
         docker build \
             -f ../../docker/Dockerfile \
-            ${copy+--build-arg binaries=target/release} \
+            ${copy:+--build-arg binaries=target/release} \
             --build-arg environment=k8s-local \
-            --build-arg target="$(uname -m)-unknown-linux-gnu" \
+            --build-arg target="${arch/#arm/aarch}"-unknown-linux-gnu \
             ../../ \
-            -t "$docker_image"
+            -t "$docker_image" || exit 1
     fi
 fi
 


### PR DESCRIPTION
## Motivation

There was a bug in the `${copy+--build-arg binaries=target/release}` line I missed during review. From my understanding, like this if `copy` is set at all, even just `copy=`, it'll still trigger the substitution. Which means this will always trigger the copy code path.
Another thing was that `uname -m` on the mac returns `arm64`, and we're actually looking for `aarch64`.
Also, if `docker build` fails, we should fail the script.

## Proposal

For the first issue, changing to use `${copy:+--build-arg binaries=target/release}` instead. In this case, only if `copy` is actually set to something the substitution will be triggered.
For the second issue, changed that portion of the code back closer to what it used to be.
For the third one, fail the script if `docker build` fails.

## Test Plan

Tested the different variations of `build_and_redeploy.sh` locally, and CI will do the Copy testing for me as I haven't figured out how to cross compile yet
