### PR TITLE
Add --faucet argument to wallet init command.

### DIFF
--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -9,7 +9,7 @@ pub mod local_net;
 /// How to run a linera wallet and its GraphQL service.
 mod wallet;
 
-pub use wallet::{ApplicationWrapper, ClientWrapper, NodeService};
+pub use wallet::{ApplicationWrapper, ClientWrapper, Faucet, NodeService};
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -693,7 +693,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     faucet.ensure_is_running().unwrap();
     faucet.terminate().await.unwrap();
 
-    // Chain 1 should have paid four tokens.
+    // Chain 1 should have transferred four tokens, two to each child. So it should have six left.
     client1.synchronize_balance(chain1).await.unwrap();
     assert_eq!(
         client1.query_balance(chain1).await.unwrap(),

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -252,7 +252,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client();
-    client2.wallet_init(&[]).await.unwrap();
+    client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2).await.unwrap();
@@ -339,7 +339,7 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client();
-    client2.wallet_init(&[]).await.unwrap();
+    client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2).await.unwrap();
@@ -537,7 +537,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client();
-    client2.wallet_init(&[]).await.unwrap();
+    client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2).await.unwrap();
@@ -666,8 +666,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     let client_a = net.make_client();
     let client_b = net.make_client();
 
-    client_a.wallet_init(&[]).await.unwrap();
-    client_b.wallet_init(&[]).await.unwrap();
+    client_a.wallet_init(&[], None).await.unwrap();
+    client_b.wallet_init(&[], None).await.unwrap();
 
     // Create initial server and client config.
     let (contract_fungible_a, service_fungible_a) =
@@ -928,8 +928,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
 
     let client0 = net.make_client();
     let client1 = net.make_client();
-    client0.wallet_init(&[]).await.unwrap();
-    client1.wallet_init(&[]).await.unwrap();
+    client0.wallet_init(&[], None).await.unwrap();
+    client1.wallet_init(&[], None).await.unwrap();
 
     let (contract_fungible, service_fungible) =
         client_admin.build_example("fungible").await.unwrap();


### PR DESCRIPTION
## Motivation

For devnet and testnet, clients need an easy way to initialize their wallet with a new chain and some tokens from the faucet.

## Proposal

Add a `--faucet` argument to the `wallet init` command. If a URL is specified, it will claim tokens from the faucet service at that URL.

## Test Plan

The faucet end-to-end test has been extended.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
