### PR TITLE
Fix Cloud builds

### DIFF
--- a/kubernetes/linera-validator/build_and_redeploy.sh
+++ b/kubernetes/linera-validator/build_and_redeploy.sh
@@ -90,7 +90,6 @@ else
         docker build \
             -f ../../docker/Dockerfile \
             ${copy:+--build-arg binaries=target/release} \
-            --build-arg environment=k8s-local \
             --build-arg target="${arch/#arm/aarch}"-unknown-linux-gnu \
             ../../ \
             -t "$docker_image"

--- a/test-cloudbuild-local.yaml
+++ b/test-cloudbuild-local.yaml
@@ -1,5 +1,6 @@
 steps:
-- name: 'gcr.io/cloud-builders/docker'
+- name: 'docker:latest'
+  entrypoint: 'docker'
   args: [ 'build', '-t', 'us-docker.pkg.dev/linera-io-dev/linera-docker-repo/linera-test-local:latest', '-f', 'docker/Dockerfile', '.' ]
 images:
 - 'us-docker.pkg.dev/linera-io-dev/linera-docker-repo/linera-test-local:latest'


### PR DESCRIPTION
## Motivation

Since the recent Dockerfile changes, cloud build has been broken

## Proposal

Seems like GCP was using an older version of Docker for the cloud builds, that was triggering some bug where the `builder_copy` stage was being triggered everytime, regardless of the arguments. Forcing an up to date version of Docker to be used fixes that bug. Also, `COPY --chmod` requires `BuildKit`, so just doing separate commands as installing `BuildKit` on GCP seems non-trivial.

## Test Plan

Ran `./build_and_redeploy.sh --port-forward --clean --cloud`, saw everything work as intended

