### PR TITLE
Fix helm install when running Cloud built image locally

### DIFF
--- a/kubernetes/linera-validator/values-local-with-cloud-build.yaml
+++ b/kubernetes/linera-validator/values-local-with-cloud-build.yaml
@@ -7,14 +7,10 @@ logLevel: "debug"
 loki-stack:
   loki:
     enabled: true
+    isDefault: false
     persistence:
       enabled: true
       size: 1Gi
-  grafana:
-    enabled: true
-    sidecar:
-      datasources:
-        enabled: true
   promtail:
     enabled: true
     config:


### PR DESCRIPTION
## Motivation

When trying to `helm install` with an image that was built with cloud build, it was failing

## Proposal

Mimick `values` for local runs instead of GCP runs

## Test Plan

`./build_and_redeploy.sh --port-forward --clean --cloud`, saw everything build and be deployed locally correctly

