### PR TITLE
Simplify GenesisConfig.

### DIFF
--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -445,7 +445,8 @@ Next Block Height:  {}"#,
 pub struct GenesisConfig {
     pub committee: CommitteeConfig,
     pub admin_id: ChainId,
-    pub chains: Vec<(ChainDescription, PublicKey, Amount, Timestamp)>,
+    pub timestamp: Timestamp,
+    pub chains: Vec<(u32, PublicKey, Amount)>,
     pub policy: ResourceControlPolicy,
 }
 
@@ -456,11 +457,13 @@ impl GenesisConfig {
     pub fn new(
         committee: CommitteeConfig,
         admin_id: ChainId,
+        timestamp: Timestamp,
         policy: ResourceControlPolicy,
     ) -> Self {
         Self {
             committee,
             admin_id,
+            timestamp,
             chains: Vec::new(),
             policy,
         }
@@ -471,15 +474,15 @@ impl GenesisConfig {
         S: Store + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        for (description, public_key, balance, timestamp) in &self.chains {
+        for (chain_number, public_key, balance) in &self.chains {
             store
                 .create_chain(
                     self.create_committee(),
                     self.admin_id,
-                    *description,
+                    ChainDescription::Root(*chain_number),
                     *public_key,
                     *balance,
-                    *timestamp,
+                    self.timestamp,
                 )
                 .await?;
         }

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -446,7 +446,7 @@ pub struct GenesisConfig {
     pub committee: CommitteeConfig,
     pub admin_id: ChainId,
     pub timestamp: Timestamp,
-    pub chains: Vec<(u32, PublicKey, Amount)>,
+    pub chains: Vec<(PublicKey, Amount)>,
     pub policy: ResourceControlPolicy,
 }
 
@@ -474,12 +474,12 @@ impl GenesisConfig {
         S: Store + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        for (chain_number, public_key, balance) in &self.chains {
+        for (chain_number, (public_key, balance)) in (0..).zip(&self.chains) {
             store
                 .create_chain(
                     self.create_committee(),
                     self.admin_id,
-                    ChainDescription::Root(*chain_number),
+                    ChainDescription::Root(chain_number),
                     *public_key,
                     *balance,
                     self.timestamp,

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1959,7 +1959,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 let chain = UserChain::make_initial(&mut rng, description, timestamp);
                 // Public "genesis" state.
                 let key = chain.key_pair.as_ref().unwrap().public();
-                genesis_config.chains.push((i, key, *initial_funding));
+                genesis_config.chains.push((key, *initial_funding));
                 // Private keys.
                 chains.push(chain);
             }
@@ -2147,11 +2147,9 @@ async fn main() -> Result<(), anyhow::Error> {
                 let chains = with_other_chains
                     .iter()
                     .filter_map(|chain_id| {
-                        let (i, _, _) = genesis_config
-                            .chains
-                            .iter()
-                            .find(|(i, _, _)| ChainId::root(*i) == *chain_id)?;
-                        let description = ChainDescription::Root(*i);
+                        let i = (0..(genesis_config.chains.len() as u32))
+                            .find(|i| ChainId::root(*i) == *chain_id)?;
+                        let description = ChainDescription::Root(i);
                         Some(UserChain::make_other(description, timestamp))
                     })
                     .collect();


### PR DESCRIPTION
## Motivation

There's no need for root chains to be initialized with different timestamps.

They also all have a `ChainDescription::Root(_)` description, as none of them are children.

## Proposal

Move the `timestamp` field out of the `chains` field: There's only one, for all chains.

Replace the chain description with a `u32`: the _root_ chain number.

## Test Plan

There were no significant changes in the business logic.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
