### PR TITLE
Implement the total stored size in storage fees

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -528,7 +528,7 @@ where
             bytes_written: 0,
             maximum_bytes_left_to_read,
             maximum_bytes_left_to_write,
-            change_stored_size: 0,
+            stored_size_delta: 0,
         };
         // The first incoming message of any child chain must be `OpenChain`. A root chain must
         // already be initialized

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -517,7 +517,6 @@ where
         };
 
         let policy = committee.policy().clone();
-
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
         let maximum_bytes_left_to_read = policy.maximum_bytes_read_per_block;
@@ -529,6 +528,7 @@ where
             bytes_written: 0,
             maximum_bytes_left_to_read,
             maximum_bytes_left_to_write,
+            change_stored_size: 0,
         };
         // The first incoming message of any child chain must be `OpenChain`. A root chain must
         // already be initialized

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -22,6 +22,8 @@ pub struct ResourceControlPolicy {
     pub storage_bytes_read: Amount,
     /// The cost to store data per byte
     pub storage_bytes_written: Amount,
+    /// The cost of the total storage used
+    pub storage_bytes_stored: Amount,
     /// The maximum data to read per block
     pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
@@ -38,6 +40,7 @@ impl Default for ResourceControlPolicy {
             storage_num_reads: Amount::default(),
             storage_bytes_read: Amount::default(),
             storage_bytes_written: Amount::default(),
+            storage_bytes_stored: Amount::default(),
             maximum_bytes_read_per_block: u64::MAX / 2,
             maximum_bytes_written_per_block: u64::MAX / 2,
             messages: Amount::default(),
@@ -56,19 +59,16 @@ impl ResourceControlPolicy {
         Ok(self.messages.try_mul(size)?)
     }
 
-    pub fn storage_num_reads_price(&self, count: &u64) -> Result<Amount, PricingError> {
-        let count = *count as u128;
-        Ok(self.storage_num_reads.try_mul(count)?)
+    pub fn storage_num_reads_price(&self, count: u64) -> Result<Amount, PricingError> {
+        Ok(self.storage_num_reads.try_mul(count as u128)?)
     }
 
-    pub fn storage_bytes_read_price(&self, count: &u64) -> Result<Amount, PricingError> {
-        let count = *count as u128;
-        Ok(self.storage_bytes_read.try_mul(count)?)
+    pub fn storage_bytes_read_price(&self, count: u64) -> Result<Amount, PricingError> {
+        Ok(self.storage_bytes_read.try_mul(count as u128)?)
     }
 
-    pub fn storage_bytes_written_price(&self, count: &u64) -> Result<Amount, PricingError> {
-        let count = *count as u128;
-        Ok(self.storage_bytes_written.try_mul(count)?)
+    pub fn storage_bytes_written_price(&self, count: u64) -> Result<Amount, PricingError> {
+        Ok(self.storage_bytes_written.try_mul(count as u128)?)
     }
 
     pub fn storage_bytes_written_price_raw(
@@ -78,6 +78,10 @@ impl ResourceControlPolicy {
         let size =
             u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
         Ok(self.storage_bytes_written.try_mul(size)?)
+    }
+
+    pub fn storage_bytes_stored_price(&self, count: u64) -> Result<Amount, PricingError> {
+        Ok(self.storage_bytes_stored.try_mul(count as u128)?)
     }
 
     pub fn fuel_price(&self, fuel: u64) -> Result<Amount, PricingError> {
@@ -101,6 +105,7 @@ impl ResourceControlPolicy {
             storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::ZERO,
             storage_bytes_written: Amount::ZERO,
+            storage_bytes_stored: Amount::ZERO,
             maximum_bytes_read_per_block: u64::MAX / 2,
             maximum_bytes_written_per_block: u64::MAX / 2,
             messages: Amount::ZERO,
@@ -119,6 +124,7 @@ impl ResourceControlPolicy {
             storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::ZERO,
             storage_bytes_written: Amount::ZERO,
+            storage_bytes_stored: Amount::ZERO,
             maximum_bytes_read_per_block: u64::MAX,
             maximum_bytes_written_per_block: u64::MAX,
             messages: Amount::ZERO,
@@ -134,6 +140,7 @@ impl ResourceControlPolicy {
             storage_num_reads: Amount::ZERO,
             storage_bytes_read: Amount::from_atto(100),
             storage_bytes_written: Amount::from_atto(1_000),
+            storage_bytes_stored: Amount::ZERO,
             maximum_bytes_read_per_block: u64::MAX,
             maximum_bytes_written_per_block: u64::MAX,
             messages: Amount::from_atto(1),

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -35,7 +35,7 @@ pub struct ResourceTracker {
     /// The total number of bytes written
     pub bytes_written: u64,
     /// The change in the total data being stored
-    pub change_stored_size: i32,
+    pub stored_size_delta: i32,
     /// The maximum size of read that remains available for use
     pub maximum_bytes_left_to_read: u64,
     /// The maximum size of write that remains available for use
@@ -50,7 +50,7 @@ impl Default for ResourceTracker {
             num_reads: 0,
             bytes_read: 0,
             bytes_written: 0,
-            change_stored_size: 0,
+            stored_size_delta: 0,
             maximum_bytes_left_to_read: u64::MAX / 2,
             maximum_bytes_left_to_write: u64::MAX / 2,
         }
@@ -140,5 +140,5 @@ pub struct RuntimeCounts {
     /// The bytes that have been written
     pub bytes_written: u64,
     /// The change in the total data stored
-    pub change_stored_size: i32,
+    pub stored_size_delta: i32,
 }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -34,6 +34,8 @@ pub struct ResourceTracker {
     pub bytes_read: u64,
     /// The total number of bytes written
     pub bytes_written: u64,
+    /// The change in the total data being stored
+    pub change_stored_size: i32,
     /// The maximum size of read that remains available for use
     pub maximum_bytes_left_to_read: u64,
     /// The maximum size of write that remains available for use
@@ -48,6 +50,7 @@ impl Default for ResourceTracker {
             num_reads: 0,
             bytes_read: 0,
             bytes_written: 0,
+            change_stored_size: 0,
             maximum_bytes_left_to_read: u64::MAX / 2,
             maximum_bytes_left_to_write: u64::MAX / 2,
         }
@@ -91,19 +94,19 @@ impl ResourceTracker {
         // The number of reads
         Self::sub_assign_fees(
             balance,
-            policy.storage_num_reads_price(&runtime_counts.num_reads)?,
+            policy.storage_num_reads_price(runtime_counts.num_reads)?,
         )?;
         self.num_reads += runtime_counts.num_reads;
         // The number of bytes read
         let bytes_read = runtime_counts.bytes_read;
         self.maximum_bytes_left_to_read -= bytes_read;
         self.bytes_read += runtime_counts.bytes_read;
-        Self::sub_assign_fees(balance, policy.storage_bytes_read_price(&bytes_read)?)?;
+        Self::sub_assign_fees(balance, policy.storage_bytes_read_price(bytes_read)?)?;
         // The number of bytes written
         let bytes_written = runtime_counts.bytes_written;
         self.maximum_bytes_left_to_write -= bytes_written;
         self.bytes_written += bytes_written;
-        Self::sub_assign_fees(balance, policy.storage_bytes_written_price(&bytes_written)?)?;
+        Self::sub_assign_fees(balance, policy.storage_bytes_written_price(bytes_written)?)?;
         Ok(())
     }
 
@@ -136,4 +139,6 @@ pub struct RuntimeCounts {
     pub bytes_read: u64,
     /// The bytes that have been written
     pub bytes_written: u64,
+    /// The change in the total data stored
+    pub change_stored_size: i32,
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -597,9 +597,9 @@ where
             .remove(&self.application_id())
         {
             Some(mut view) => {
-                let stored_size = view.total_size().sum() as i32;
+                let stored_size = view.total_size().sum_i32()?;
                 view.write_batch(batch).await?;
-                let new_stored_size = view.total_size().sum() as i32;
+                let new_stored_size = view.total_size().sum_i32()?;
                 let increment = new_stored_size - stored_size;
                 self.change_stored_size
                     .fetch_add(increment, Ordering::Relaxed);

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -27,7 +27,7 @@ use std::{
     collections::{btree_map, BTreeMap},
     ops::DerefMut,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicI64, AtomicU64, Ordering},
         Arc,
     },
 };
@@ -104,6 +104,7 @@ where
     ViewError: From<C::Error>,
     C::Extra: ExecutionRuntimeContext,
 {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         chain_id: ChainId,
         applications: &'a mut Vec<ApplicationStatus>,
@@ -127,6 +128,7 @@ where
             bytes_read: AtomicU64::new(0),
             bytes_written: AtomicU64::new(0),
             runtime_limits,
+            change_stored_size,
             chain_id,
         }
     }
@@ -535,11 +537,13 @@ where
         let num_reads = self.num_reads.load(Ordering::Acquire);
         let bytes_read = self.bytes_read.load(Ordering::Acquire);
         let bytes_written = self.bytes_written.load(Ordering::Acquire);
+        let change_stored_size = self.change_stored_size.load(Ordering::Acquire);
         RuntimeCounts {
             remaining_fuel,
             num_reads,
             bytes_read,
             bytes_written,
+            change_stored_size,
         }
     }
 
@@ -581,6 +585,7 @@ where
     }
 
     async fn write_batch_and_unlock(&self, batch: Batch) -> Result<(), ExecutionError> {
+        // Update the write costs
         let size = batch.size() as u64;
         self.increment_bytes_written(size)?;
         // Write the batch and make the view available again.
@@ -589,7 +594,15 @@ where
             .await
             .remove(&self.application_id())
         {
-            Some(mut view) => Ok(view.write_batch(batch).await?),
+            Some(mut view) => {
+                let stored_size = view.stored_size() as i64;
+                view.write_batch(batch).await?;
+                let new_stored_size = view.stored_size() as i64;
+                let increment = new_stored_size - stored_size;
+                self.change_stored_size
+                    .fetch_add(increment, Ordering::Relaxed);
+                Ok(())
+            }
             None => Err(ExecutionError::ApplicationStateNotLocked),
         }
     }

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -564,6 +564,8 @@ ResourceControlPolicy:
         TYPENAME: Amount
     - storage_bytes_written:
         TYPENAME: Amount
+    - storage_bytes_stored:
+        TYPENAME: Amount
     - maximum_bytes_read_per_block: U64
     - maximum_bytes_written_per_block: U64
     - messages:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -505,6 +505,10 @@ input ResourceControlPolicy {
 	"""
 	storageBytesWritten: Amount!
 	"""
+	The cost of the total storage used
+	"""
+	storageBytesStored: Amount!
+	"""
 	The maximum data to read per block
 	"""
 	maximumBytesReadPerBlock: Int!

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -843,6 +843,10 @@ enum ClientCommand {
         #[structopt(long)]
         storage_bytes_written: Option<Amount>,
 
+        /// Set the price per byte stored
+        #[structopt(long)]
+        storage_bytes_stored: Option<Amount>,
+
         /// Set the maximum quantity of data to read per block
         #[structopt(long)]
         maximum_bytes_read_per_block: Option<u64>,
@@ -914,6 +918,10 @@ enum ClientCommand {
         /// Set the price per byte to write data
         #[structopt(long, default_value = "0")]
         storage_bytes_written_price: Amount,
+
+        /// Set the price per byte stored
+        #[structopt(long, default_value = "0")]
+        storage_bytes_stored_price: Amount,
 
         /// Set the maximum read data per block
         #[structopt(long)]
@@ -1462,6 +1470,7 @@ impl Runnable for Job {
                         storage_num_reads,
                         storage_bytes_read,
                         storage_bytes_written,
+                        storage_bytes_stored,
                         maximum_bytes_read_per_block,
                         maximum_bytes_written_per_block,
                         messages,
@@ -1480,6 +1489,9 @@ impl Runnable for Job {
                         }
                         if let Some(storage_bytes_written) = storage_bytes_written {
                             policy.storage_bytes_written = storage_bytes_written;
+                        }
+                        if let Some(storage_bytes_stored) = storage_bytes_stored {
+                            policy.storage_bytes_stored = storage_bytes_stored;
                         }
                         if let Some(maximum_bytes_read_per_block) = maximum_bytes_read_per_block {
                             policy.maximum_bytes_read_per_block = maximum_bytes_read_per_block;
@@ -1500,6 +1512,7 @@ impl Runnable for Job {
                             {:.2} cost per byte operation\n\
                             {:.2} cost per bytes read\n\
                             {:.2} cost per bytes written\n\
+                            {:.2} cost per bytes stored\n\
                             {:.2} per byte of outgoing messages\n\
                             {:.2} maximum number bytes read per block\n\
                             {:.2} maximum number bytes written per block",
@@ -1508,6 +1521,7 @@ impl Runnable for Job {
                             policy.storage_num_reads,
                             policy.storage_bytes_read,
                             policy.storage_bytes_written,
+                            policy.storage_bytes_stored,
                             policy.messages,
                             policy.maximum_bytes_read_per_block,
                             policy.maximum_bytes_written_per_block
@@ -1517,6 +1531,7 @@ impl Runnable for Job {
                             && storage_num_reads.is_none()
                             && storage_bytes_read.is_none()
                             && storage_bytes_written.is_none()
+                            && storage_bytes_stored.is_none()
                             && maximum_bytes_read_per_block.is_none()
                             && maximum_bytes_written_per_block.is_none()
                             && messages.is_none()
@@ -2180,6 +2195,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
             storage_num_reads_price,
             storage_bytes_read_price,
             storage_bytes_written_price,
+            storage_bytes_stored_price,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
             messages_price,
@@ -2202,6 +2218,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 storage_num_reads: *storage_num_reads_price,
                 storage_bytes_read: *storage_bytes_read_price,
                 storage_bytes_written: *storage_bytes_written_price,
+                storage_bytes_stored: *storage_bytes_stored_price,
                 maximum_bytes_read_per_block,
                 maximum_bytes_written_per_block,
                 messages: *messages_price,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -69,7 +69,10 @@ impl SizeData {
 
     /// Sums both terms
     pub fn sum_i32(&mut self) -> Result<i32, ViewError> {
-        let sum = self.key + self.value;
+        let sum = self
+            .key
+            .checked_add(self.value)
+            .ok_or(ArithmeticError::Overflow)?;
         Ok(i32::try_from(sum).map_err(|_| ArithmeticError::Overflow)?)
     }
 

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use async_lock::Mutex;
 use async_trait::async_trait;
-use linera_base::ensure;
+use linera_base::{data_types::ArithmeticError, ensure};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -65,6 +65,12 @@ impl SizeData {
     /// Sums both terms
     pub fn sum(&mut self) -> u32 {
         self.key + self.value
+    }
+
+    /// Sums both terms
+    pub fn sum_i32(&mut self) -> Result<i32, ViewError> {
+        let sum = self.key + self.value;
+        Ok(i32::try_from(sum).map_err(|_| ArithmeticError::Overflow)?)
     }
 
     /// Add a size to the existing SizeData

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -62,6 +62,11 @@ pub struct SizeData {
 }
 
 impl SizeData {
+    /// Sums both terms
+    pub fn sum(&mut self) -> u32 {
+        self.key + self.value
+    }
+
     /// Add a size to the existing SizeData
     pub fn add_assign(&mut self, size: SizeData) {
         self.key += size.key;
@@ -154,9 +159,6 @@ where
                 }
             }
         } else {
-            if self.deleted_prefixes.is_empty() && self.updates.is_empty() {
-                return Ok(());
-            }
             for index in mem::take(&mut self.deleted_prefixes) {
                 let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
                 batch.delete_key_prefix(key);
@@ -702,7 +704,6 @@ where
     }
 
     /// Deletes a key_prefix.
-<<<<<<< HEAD
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::create_memory_context;
@@ -719,29 +720,6 @@ where
         let mut batch = Batch::new();
         batch.delete_key_prefix(key_prefix);
         self.write_batch(batch).await
-=======
-    fn delete_prefix(&mut self, key_prefix: Vec<u8>) {
-        *self.hash.get_mut() = None;
-        let key_list: Vec<Vec<u8>> = self
-            .updates
-            .range(get_interval(key_prefix.clone()))
-            .map(|x| x.0.to_vec())
-            .collect();
-        for key in key_list {
-            self.updates.remove(&key);
-        }
-        if !self.was_cleared {
-            let key_prefix_list = self
-                .deleted_prefixes
-                .range(get_interval(key_prefix.clone()))
-                .map(|x| x.to_vec())
-                .collect::<Vec<_>>();
-            for key in key_prefix_list {
-                self.deleted_prefixes.remove(&key);
-            }
-            self.deleted_prefixes.insert(key_prefix);
-        }
->>>>>>> 5d5eaa91 (Implement the scheme for making the total size stored being paid for.)
     }
 
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
@@ -887,49 +865,6 @@ where
         Ok(key_values)
     }
 
-<<<<<<< HEAD
-=======
-    /// Applies the given batch of `crate::common::WriteOperation`.
-    /// ```rust
-    /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
-    /// # use linera_views::key_value_store_view::KeyValueStoreView;
-    /// # use linera_views::batch::Batch;
-    /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
-    ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
-    ///   view.insert(vec![0,1], vec![34]);
-    ///   view.insert(vec![3,4], vec![42]);
-    ///   let mut batch = Batch::new();
-    ///   batch.delete_key_prefix(vec![0]);
-    ///   view.write_batch(batch).await.unwrap();
-    ///   let key_values = view.find_key_values_by_prefix(&[0]).await.unwrap();
-    ///   assert_eq!(key_values, vec![]);
-    /// # })
-    /// ```
-    pub async fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
-        *self.hash.get_mut() = None;
-        for operation in batch.operations {
-            match operation {
-                WriteOperation::Delete { key } => {
-                    if self.was_cleared {
-                        self.updates.remove(&key);
-                    } else {
-                        self.updates.insert(key, Update::Removed);
-                    }
-                }
-                WriteOperation::Put { key, value } => {
-                    self.updates.insert(key, Update::Set(value));
-                }
-                WriteOperation::DeletePrefix { key_prefix } => {
-                    self.delete_prefix(key_prefix);
-                }
-            }
-        }
-        Ok(())
-    }
-
->>>>>>> 5d5eaa91 (Implement the scheme for making the total size stored being paid for.)
     async fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
         let mut hasher = sha3::Sha3_256::default();
         let mut count = 0;

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -3,7 +3,7 @@
 
 use crate::{batch::Batch, common::HasherOutput};
 use async_trait::async_trait;
-use linera_base::crypto::CryptoHash;
+use linera_base::{crypto::CryptoHash, data_types::ArithmeticError};
 pub use linera_views_derive::{
     CryptoHashRootView, CryptoHashView, GraphQLView, HashableView, RootView, View,
 };
@@ -60,6 +60,10 @@ pub enum ViewError {
     /// Input output error.
     #[error("IO error")]
     Io(#[from] std::io::Error),
+
+    /// Arithmetic error
+    #[error("Arithmetic error")]
+    ArithmeticError(#[from] ArithmeticError),
 
     /// An error happened while trying to lock.
     #[error("Failed to lock collection entry: {0:?}")]


### PR DESCRIPTION
## Motivation

In the storage fees, we want to take into account the total used size by the smart contract. This PR implements that and addresses the issue #1228 

## Proposal

The name used is `storage_bytes_stored` which is fairly self-explanatory. The implementation is done via the implemented features in `KeyValueStoreView`. 

## Test Plan

The CI does it.

## Release Plan

No impact right now, but we would like of course to test it.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
