### PR TITLE
Implement progressive fees

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -583,6 +583,7 @@ where
         }
         let balance = self.execution_state.system.balance.get_mut();
         sub_assign_fees(balance, credit)?;
+        sub_assign_fees(balance, policy.messages_price(&messages)?)?;
 
         // Recompute the state hash.
         let state_hash = self.execution_state.crypto_hash().await?;

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -509,7 +509,6 @@ where
         let balance = self.execution_state.system.balance.get_mut();
 
         balance.try_add_assign(credit)?;
-        sub_assign_fees(balance, policy.certificate_price())?;
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
@@ -582,6 +581,7 @@ where
                 .push(u32::try_from(messages.len()).map_err(|_| ArithmeticError::Overflow)?);
         }
         let balance = self.execution_state.system.balance.get_mut();
+        sub_assign_fees(balance, policy.certificate_price())?;
         sub_assign_fees(balance, credit)?;
 
         // Recompute the state hash.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -494,21 +494,6 @@ where
         };
 
         let policy = committee.policy().clone();
-        let credit: Amount = block
-            .incoming_messages
-            .iter()
-            .filter_map(|msg| match &msg.event.message {
-                Message::System(SystemMessage::Credit { account, amount })
-                    if *account == Account::chain(chain_id) =>
-                {
-                    Some(amount)
-                }
-                _ => None,
-            })
-            .sum();
-        let balance = self.execution_state.system.balance.get_mut();
-
-        balance.try_add_assign(credit)?;
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
@@ -582,7 +567,6 @@ where
         }
         let balance = self.execution_state.system.balance.get_mut();
         sub_assign_fees(balance, policy.certificate_price())?;
-        sub_assign_fees(balance, credit)?;
 
         // Recompute the state hash.
         let state_hash = self.execution_state.crypto_hash().await?;

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -510,10 +510,6 @@ where
 
         balance.try_add_assign(credit)?;
         sub_assign_fees(balance, policy.certificate_price())?;
-        sub_assign_fees(
-            balance,
-            policy.storage_bytes_written_price_raw(&block.operations)?,
-        )?;
 
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
@@ -579,6 +575,7 @@ where
             let mut messages_out = self.process_execution_results(context.height, results)
                 .await?;
             let balance = self.execution_state.system.balance.get_mut();
+            sub_assign_fees(balance, policy.storage_bytes_written_price_raw(&operation)?)?;
             sub_assign_fees(balance, policy.messages_price(&messages_out)?)?;
             messages.append(&mut messages_out);
             message_counts

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -512,10 +512,6 @@ where
         sub_assign_fees(balance, policy.certificate_price())?;
         sub_assign_fees(
             balance,
-            policy.storage_bytes_written_price_raw(&block.incoming_messages)?,
-        )?;
-        sub_assign_fees(
-            balance,
             policy.storage_bytes_written_price_raw(&block.operations)?,
         )?;
 
@@ -555,6 +551,7 @@ where
             let mut messages_out = self.process_execution_results(context.height, results)
                 .await?;
             let balance = self.execution_state.system.balance.get_mut();
+            sub_assign_fees(balance, policy.storage_bytes_written_price_raw(&message)?)?;
             sub_assign_fees(balance, policy.messages_price(&messages_out)?)?;
             messages.append(&mut messages_out);
             message_counts

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -126,10 +126,11 @@ pub enum ChainError {
     OwnerWeightError(#[from] WeightedError),
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum ChainExecutionContext {
     Query,
     DescribeApplication,
     IncomingMessage(u32),
     Operation(u32),
+    Certificate,
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1395,15 +1395,17 @@ where
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;
-    assert!(matches!(sender
+    let obtained_error = sender
         .transfer_to_account(
             None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
             UserData(Some(*b"I'm giving away all of my money!")),
         )
-        .await,
-        Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
+        .await;
+    println!("obtained_error={:?}", obtained_error);
+    assert!(matches!(obtained_error,
+                     Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
     ));
     Ok(())
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1403,9 +1403,8 @@ where
             UserData(Some(*b"I'm giving away all of my money!")),
         )
         .await;
-    println!("obtained_error={:?}", obtained_error);
     assert!(matches!(obtained_error,
-                     Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
+                     Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Certificate))
     ));
     Ok(())
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -52,10 +52,10 @@ use std::{io, path::Path, str::FromStr, sync::Arc};
 use thiserror::Error;
 
 /// Substracts an amount from a balance and reports an error if that is impossible
-pub fn sub_assign_fees(balance: &mut Amount, fees: Amount) -> Result<(), PricingError> {
-    Ok(balance
-        .try_sub_assign(fees)
-        .map_err(|_| ArithmeticError::Underflow)?)
+pub fn sub_assign_fees_internal(balance: &mut Amount, fees: Amount) -> Result<(), SystemExecutionError> {
+    let current_balance = balance.clone();
+    let error = SystemExecutionError::InsufficientFunding { current_balance };
+    Ok(balance.try_sub_assign(fees).map_err(|_| error)?)
 }
 
 /// The entries of the runtime related to storage
@@ -128,9 +128,9 @@ impl ResourceTracker {
         let initial_fuel = policy.remaining_fuel(*balance);
         let used_fuel = initial_fuel.saturating_sub(runtime_counts.remaining_fuel);
         self.used_fuel += used_fuel;
-        sub_assign_fees(balance, policy.fuel_price(used_fuel)?)?;
+        sub_assign_fees_internal(balance, policy.fuel_price(used_fuel)?)?;
         // The number of reads
-        sub_assign_fees(
+        sub_assign_fees_internal(
             balance,
             policy.storage_num_reads_price(&runtime_counts.num_reads)?,
         )?;
@@ -139,12 +139,12 @@ impl ResourceTracker {
         let bytes_read = runtime_counts.bytes_read;
         self.maximum_bytes_left_to_read -= bytes_read;
         self.bytes_read += runtime_counts.bytes_read;
-        sub_assign_fees(balance, policy.storage_bytes_read_price(&bytes_read)?)?;
+        sub_assign_fees_internal(balance, policy.storage_bytes_read_price(&bytes_read)?)?;
         // The number of bytes written
         let bytes_written = runtime_counts.bytes_written;
         self.maximum_bytes_left_to_write -= bytes_written;
         self.bytes_written += bytes_written;
-        sub_assign_fees(balance, policy.storage_bytes_written_price(&bytes_written)?)?;
+        sub_assign_fees_internal(balance, policy.storage_bytes_written_price(&bytes_written)?)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

The balance code works by adding the `credit` and then subtracting it which is kind of weird. We change the balance structure so that the fees are added and removed progressively.

## Proposal

The following steps were done:
* First add the fees for messages that were removed by error.
* Process the message costs progressively.
* The certificate costs are subtracted at the very end.
* The sub_assign_fees is split into two codes. This is because fee subtraction could occur in execution but also in chain code.

## Test Plan

The CI should address it.

## Release Plan

No change to the use of the system.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
