### PR TITLE
linera net up --kubernetes initial version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,6 +1055,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.48.5",
 ]
@@ -2805,12 +2806,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc3606fd16aca7989db2f84bb25684d0270c6d6fa1dbcd0025af7b4130523a6"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "kube"
+version = "0.87.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34392aea935145070dcd5b39a6dea689ac6534d7d117461316c3d157b1d0fc3"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.87.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7266548b9269d9fa19022620d706697e64f312fb2ba31b93e6986453fcc82c92"
+dependencies = [
+ "base64 0.21.5",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "jsonpath_lib",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "pin-project",
+ "rustls 0.21.8",
+ "rustls-pemfile",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml 0.9.27",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.7.10",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.87.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8321c315b96b59f59ef6b33f604b84b905ab8f9ff114a4f909d934c520227b1"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http",
+ "k8s-openapi",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -3154,7 +3243,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde-reflection",
- "serde_yaml",
+ "serde_yaml 0.8.26",
  "similar-asserts",
  "structopt",
  "test-strategy",
@@ -3243,6 +3332,8 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "k8s-openapi",
+ "kube",
  "linera-base",
  "linera-chain",
  "linera-core",
@@ -3254,9 +3345,11 @@ dependencies = [
  "matching-engine",
  "once_cell",
  "parse_duration",
+ "pathdiff",
  "prometheus",
  "proptest",
  "rand 0.7.3",
+ "rand 0.8.5",
  "rcgen",
  "reqwest",
  "serde",
@@ -4018,6 +4111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4085,6 +4187,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "peeking_take_while"
@@ -5104,6 +5212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5169,6 +5287,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,6 +5344,7 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -5262,6 +5391,19 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
+dependencies = [
+ "indexmap 2.1.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -6096,6 +6238,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
+ "base64 0.21.5",
  "bitflags 2.4.1",
  "bytes",
  "futures-core",
@@ -6103,9 +6246,11 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6320,6 +6465,12 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ rand = "0.8.5"
 rand07 = { package = "rand", version = "0.7.3" }
 rand_chacha = "0.3.1"
 rand_distr = "0.4.3"
+k8s-openapi = { version = "0.20.0", features = ["v1_28"] }
+pathdiff = "0.2.1"
+kube = "0.87.1"
 rcgen = "0.11.1"
 reqwest = { version = "0.11.14", default-features = false, features = ["rustls-tls"] }
 rocksdb = "0.21.0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,7 +98,6 @@ RUN mv \
     target/"$target"/release/linera-db \
     ./
 
-
 RUN strip linera linera-proxy linera-server linera-db
 
 # Stage 3.5 - Optionally copy binaries instead of using the build
@@ -116,6 +115,7 @@ FROM builder$copy as binaries
 
 # Stage 4 - Setup running environment for container
 FROM debian:latest
+
 ARG environment
 ARG target
 

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -19,6 +19,7 @@ wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
 rocksdb = ["linera-views/rocksdb", "linera-core/rocksdb", "linera-storage/rocksdb"]
 aws = ["linera-views/aws", "linera-core/aws", "linera-storage/aws"]
 scylladb = ["linera-views/scylladb", "linera-core/scylladb", "linera-storage/scylladb"]
+kubernetes = ["dep:k8s-openapi", "dep:kube", "dep:pathdiff"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -37,6 +38,8 @@ file-lock = "2.1.10"
 futures = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
+k8s-openapi = { workspace = true, optional = true }
+kube = { workspace = true, optional = true }
 linera-base = { workspace = true }
 linera-chain = { workspace = true }
 linera-core = { workspace = true }
@@ -46,7 +49,9 @@ linera-storage = { workspace = true }
 linera-views = { workspace = true }
 once_cell = { workspace = true }
 parse_duration = { workspace = true }
+pathdiff = { workspace = true, optional = true }
 prometheus = { workspace = true }
+rand = { workspace = true }
 rand07 = { workspace = true }
 rcgen = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::CommandExt;
+use anyhow::{Context, Result};
+use pathdiff::diff_paths;
+use std::path::PathBuf;
+use tokio::process::Command;
+
+pub struct DockerImage {
+    name: String,
+}
+
+impl DockerImage {
+    pub async fn new(name: String, bin_path: &PathBuf, github_root: &PathBuf) -> Result<Self> {
+        let docker_image = Self { name };
+        docker_image.build(bin_path, github_root).await?;
+        Ok(docker_image)
+    }
+
+    pub fn get_name(&self) -> &String {
+        &self.name
+    }
+
+    async fn build(&self, bin_path: &PathBuf, github_root: &PathBuf) -> Result<()> {
+        let bin_path = diff_paths(bin_path, github_root).context("Getting relative path failed")?;
+        let binaries_arg = format!(
+            "binaries={}",
+            bin_path.to_str().context("Getting str failed")?
+        );
+
+        Command::new("docker")
+            .current_dir(github_root)
+            .arg("build")
+            .args(["-f", "docker/Dockerfile"])
+            .args(["--build-arg", &binaries_arg])
+            .arg(".")
+            .args(["-t", &self.name])
+            .spawn_and_wait_for_stdout()
+            .await?;
+        Ok(())
+    }
+}

--- a/linera-service/src/cli_wrappers/helm.rs
+++ b/linera-service/src/cli_wrappers/helm.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::CommandExt;
+use anyhow::{Context, Result};
+use pathdiff::diff_paths;
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+pub struct HelmRelease {
+    name: String,
+}
+
+impl HelmRelease {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+
+    pub async fn install(
+        &self,
+        configs_dir: &PathBuf,
+        server_config_id: usize,
+        github_root: &Path,
+    ) -> Result<()> {
+        let execution_dir = format!("{}/kubernetes/linera-validator", github_root.display());
+
+        let configs_dir = diff_paths(configs_dir, execution_dir.clone())
+            .context("Getting relative path failed")?;
+        let configs_dir = configs_dir.to_str().expect("Getting str failed");
+
+        Command::new("helm")
+            .current_dir(&execution_dir)
+            .arg("install")
+            .arg(&self.name)
+            .arg(".")
+            .args(["--values", "values-local.yaml"])
+            .arg("--wait")
+            .args(["--set", "installCRDs=true"])
+            .args([
+                "--set",
+                &format!("validator.serverConfig={configs_dir}/server_{server_config_id}.json"),
+            ])
+            .args([
+                "--set",
+                &format!("validator.genesisConfig={configs_dir}/genesis.json"),
+            ])
+            .spawn_and_wait_for_stdout()
+            .await?;
+        Ok(())
+    }
+}

--- a/linera-service/src/cli_wrappers/kind.rs
+++ b/linera-service/src/cli_wrappers/kind.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::CommandExt;
+use anyhow::Result;
+use rand::Rng;
+use tokio::process::Command;
+
+pub struct KindCluster {
+    id: u32,
+}
+
+impl KindCluster {
+    pub async fn new(cluster_id: Option<u32>) -> Result<Self> {
+        let cluster = match cluster_id {
+            Some(id) => Self { id },
+            None => Self {
+                id: Self::get_random_cluster_id(),
+            },
+        };
+
+        cluster.create().await?;
+        Ok(cluster)
+    }
+
+    fn get_random_cluster_id() -> u32 {
+        rand::thread_rng().gen_range(0..99999)
+    }
+
+    async fn create(&self) -> Result<()> {
+        Command::new("kind")
+            .args(["create", "cluster"])
+            .args(["--name", self.id.to_string().as_str()])
+            .spawn_and_wait_for_stdout()
+            .await?;
+        Ok(())
+    }
+
+    pub async fn delete(&self) -> Result<()> {
+        Command::new("kind")
+            .args(["delete", "cluster"])
+            .args(["--name", self.id.to_string().as_str()])
+            .spawn_and_wait_for_stdout()
+            .await?;
+        Ok(())
+    }
+
+    pub async fn load_docker_image(&self, docker_image: &String) -> Result<()> {
+        Command::new("kind")
+            .args(["load", "docker-image", docker_image])
+            .args(["--name", self.id.to_string().as_str()])
+            .spawn_and_wait_for_stdout()
+            .await?;
+        Ok(())
+    }
+}

--- a/linera-service/src/cli_wrappers/kubectl.rs
+++ b/linera-service/src/cli_wrappers/kubectl.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::CommandExt;
+use anyhow::{Context, Result};
+use tokio::process::{Child, Command};
+
+pub struct KubectlInstance {
+    pub port_forward_child: Option<Child>,
+}
+
+impl KubectlInstance {
+    pub fn new(port_forward_child: Option<Child>) -> Self {
+        Self { port_forward_child }
+    }
+
+    pub async fn port_forward(&mut self, pod_name: &str, ports: &str) -> Result<()> {
+        self.port_forward_child = Some(
+            Command::new("kubectl")
+                .arg("port-forward")
+                .arg(pod_name)
+                .arg(ports)
+                .spawn()
+                .context("Port forwarding failed")?,
+        );
+        Ok(())
+    }
+
+    pub async fn get_pods(&mut self) -> Result<String> {
+        Command::new("kubectl")
+            .arg("get")
+            .arg("pods")
+            .spawn_and_wait_for_stdout()
+            .await
+    }
+}

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -182,7 +182,7 @@ impl LineraNetConfig for LocalNetTestingConfig {
 
 #[async_trait]
 impl LineraNet for LocalNet {
-    fn ensure_is_running(&mut self) -> Result<()> {
+    async fn ensure_is_running(&mut self) -> Result<()> {
         for validator in self.running_validators.values_mut() {
             validator.ensure_is_running().context("in local network")?
         }

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -4,8 +4,26 @@
 //! Helper module to call the binaries of `linera-service` with appropriate command-line
 //! arguments.
 
+#[cfg(feature = "kubernetes")]
+/// How to run docker operations
+mod docker;
+#[cfg(feature = "kubernetes")]
+/// How to run helm operations
+mod helm;
+#[cfg(feature = "kubernetes")]
+/// How to run kind operations
+mod kind;
+#[cfg(feature = "kubernetes")]
+/// How to run kubectl operations
+mod kubectl;
+#[cfg(feature = "kubernetes")]
+/// How to run Linera validators locally as a Kubernetes deployment.
+pub mod local_kubernetes_net;
 /// How to run Linera validators locally as native processes.
 pub mod local_net;
+#[cfg(feature = "kubernetes")]
+/// Util functions for the wrappers
+mod util;
 /// How to run a linera wallet and its GraphQL service.
 mod wallet;
 
@@ -25,7 +43,7 @@ pub trait LineraNetConfig {
 /// A running Linera net.
 #[async_trait]
 pub trait LineraNet {
-    fn ensure_is_running(&mut self) -> Result<()>;
+    async fn ensure_is_running(&mut self) -> Result<()>;
 
     fn make_client(&mut self) -> ClientWrapper;
 

--- a/linera-service/src/cli_wrappers/util.rs
+++ b/linera-service/src/cli_wrappers/util.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::util::CommandExt;
+use anyhow::Result;
+use std::path::PathBuf;
+use tokio::process::Command;
+
+pub async fn get_github_root() -> Result<PathBuf> {
+    let github_root = Command::new("git")
+        .arg("rev-parse")
+        .arg("--show-toplevel")
+        .spawn_and_wait_for_stdout()
+        .await?;
+    Ok(PathBuf::from(
+        github_root
+            .strip_suffix('\n')
+            .expect("Stripping suffix should not fail")
+            .to_string(),
+    ))
+}

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -176,7 +176,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
         panic!("Failed to receive new block");
     }
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -263,7 +263,7 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) {
         if response1["chain"]["executionState"]["system"]["balance"].as_str() == Some("6.")
             && response2["chain"]["executionState"]["system"]["balance"].as_str() == Some("4.")
         {
-            net.ensure_is_running().unwrap();
+            net.ensure_is_running().await.unwrap();
             net.terminate().await.unwrap();
             return;
         }
@@ -327,7 +327,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig
 
     node_service2.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -397,7 +397,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
         Amount::from_tokens(3)
     );
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -470,7 +470,7 @@ async fn test_project_publish(database: Database, network: Network) {
         1
     );
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -560,7 +560,7 @@ async fn test_example_publish(database: Database, network: Network) {
         1
     );
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -651,7 +651,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
         Amount::from_tokens(3)
     );
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -706,7 +706,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
         Amount::from_tokens(4)
     );
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -786,7 +786,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
         .await
         .unwrap();
     assert_eq!(client3.query_balance(chain3).await.unwrap(), Amount::ZERO);
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -828,6 +828,6 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetTestingConfig) {
     let result = client.retry_pending_block(Some(chain_id)).await;
     assert!(result.unwrap().is_none());
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -190,7 +190,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) {
 
     node_service.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -237,7 +237,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 
     node_service.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -323,7 +323,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     node_service1.ensure_is_running().unwrap();
     node_service2.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -440,7 +440,7 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
     node_service1.ensure_is_running().unwrap();
     node_service2.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -520,7 +520,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(config: impl LineraNetConfig)
 
     node_service.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -646,7 +646,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
     node_service1.ensure_is_running().unwrap();
     node_service2.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -911,7 +911,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     node_service_a.ensure_is_running().unwrap();
     node_service_b.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }
 
@@ -1231,6 +1231,6 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
     node_service0.ensure_is_running().unwrap();
     node_service1.ensure_is_running().unwrap();
 
-    net.ensure_is_running().unwrap();
+    net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }


### PR DESCRIPTION
## Motivation

We want to replace `build_and_redeploy`, and also set things up to run end to end tests agaist a locally running Kubernetes cluster.

## Proposal

This is an initial version. We don't have number of validators or numbers of shards being respected in this version, this will be done in a follow up PR.

## Test Plan

Ran it:


![Screenshot 2023-11-10 at 11.17.04.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/6ee4028d-a05d-4a33-913b-912fbf41750a.png)


Then ran `sync-balance` against it, and it succeeded.
