### PR TITLE
`rust-toolchain.toml`: bump Rust to latest stable (1.73)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -139,8 +139,12 @@ jobs:
       run: |
         cargo clippy --all-targets --all-features --tests --locked
     - name: Run cargo doc
+      env:
+        # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
+        RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links
+        RUSTFLAGS: -D warnings
       run: |
-        RUSTDOCFLAGS='-D warnings' cargo doc --locked --all-features
+        cargo doc --locked --all-features
     - name: Run cargo check-all-features
       run: |
         cargo check-all-features --all-targets

--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -130,14 +130,12 @@ pub mod tests {
 
         let a_notifier = notifier.clone();
         let handle_a = std::thread::spawn(move || {
-            let chain_a = chain_a;
             for _ in 0..NOTIFICATIONS_A {
                 a_notifier.notify(&chain_a, &());
             }
         });
 
         let handle_b = std::thread::spawn(move || {
-            let chain_b = chain_b;
             for _ in 0..NOTIFICATIONS_B {
                 notifier.notify(&chain_b, &());
             }

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -644,7 +644,7 @@ async fn route_aux(
 #[wasm_bindgen]
 pub async fn route(app: JsValue, path: JsValue, args: JsValue) {
     let path = path.as_string();
-    let args = from_value::<Vec<(String, String)>>(args).unwrap_or(Vec::new());
+    let args = from_value::<Vec<(String, String)>>(args).unwrap_or_default();
     let msg = format!("route: {} {:?}", path.as_deref().unwrap_or("none"), args);
     log_str(&msg);
     let data = from_value::<Data>(app.clone()).expect("cannot parse Vue data");

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -193,7 +193,7 @@ where
 
     /// Registers the handler to an Axum router
     pub fn route(&self, app: Option<Router>) -> Router {
-        let app = app.unwrap_or_else(Router::new);
+        let app = app.unwrap_or_default();
         app.route("/", get(graphiql).post(Self::handler))
             .layer(Extension(self.state.clone().schema()))
             .layer(CorsLayer::permissive())

--- a/linera-service-graphql-client/src/utils.rs
+++ b/linera-service-graphql-client/src/utils.rs
@@ -15,7 +15,7 @@ pub enum Error {
 
 impl From<Option<Vec<graphql_client::Error>>> for Error {
     fn from(val: Option<Vec<graphql_client::Error>>) -> Self {
-        Self::GraphQLError(val.unwrap_or(Vec::new()))
+        Self::GraphQLError(val.unwrap_or_default())
     }
 }
 

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -1616,8 +1616,7 @@ mod tests {
     #[test]
     fn test_serialization_len() {
         for n in [0, 10, 127, 128, 129, 16383, 16384, 20000] {
-            let mut vec = Vec::new();
-            vec.resize(n, 0_u8);
+            let vec = vec![0u8; n];
             let est_size = get_uleb128_size(n) + n;
             let serial_size = serialized_size(&vec).unwrap();
             assert_eq!(est_size, serial_size);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.73.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

I was working on updating GraphQL and I ran into an internal compiler error:

```
thread 'rustc' panicked at 'forcing query with already existing `DepNode`
- query-key: Canonical { value: ParamEnvAnd { param_env: ParamEnv { caller_bounds: [Binder { value: OutlivesPredicate(ReLateBound(DebruijnIndex(1), BoundRegion { var: 0, kind: BrAnon(None) }), ReLateBound(DebruijnIndex(1), BoundRegion { var: 1, kind: BrAnon(None) })), bound_vars: [] }, Binder { value: OutlivesPredicate(ReLateBound(DebruijnIndex(1), BoundRegion { var: 2, kind: BrAnon(None) }), ReLateBound(DebruijnIndex(1), BoundRegion { var: 1, kind: BrAnon(None) })), bound_vars: [] }, Binder { value: OutlivesPredicate(ReLateBound(DebruijnIndex(1), BoundRegion { var: 3, kind: BrAnon(None) }), ReLateBound(DebruijnIndex(1), BoundRegion { var: 1, kind: BrAnon(None) })), bound_vars: [] }, Binder { value: TraitPredicate(<MyMapFilters<K> as async_graphql::InputType>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<MyMapFilters<K> as std::marker::Sized>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<MyMapFilters<K> as std::marker::Sync>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<MyMapFilters<K> as std::marker::Send>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<linera_views::views::ViewError as std::convert::From<<C as linera_views::common::Context>::Error>>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<linera_views::views::ViewError as std::marker::Sized>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<V as async_graphql::OutputType>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<V as std::marker::Sync>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<V as std::marker::Send>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<V as linera_views::views::View<C>>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<K as std::fmt::Debug>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<K as linera_views::common::CustomSerialize>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<K as async_graphql::OutputType>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<K as std::marker::Sync>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<K as std::marker::Send>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<K as async_graphql::InputType>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<C as linera_views::common::Context>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<C as std::marker::Sync>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<C as std::marker::Send>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<V as std::marker::Sized>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<K as std::marker::Sized>, polarity:Positive), bound_vars: [] }, Binder { value: TraitPredicate(<C as std::marker::Sized>, polarity:Positive), bound_vars: [] }, Binder { value: OutlivesPredicate(GQL<linera_views::collection_view::CustomCollectionView<C, K, V>>, ReLateBound(DebruijnIndex(1), BoundRegion { var: 1, kind: BrAnon(None) })), bound_vars: [] }, Binder { value: OutlivesPredicate(C, ReLateBound(DebruijnIndex(1), BoundRegion { var: 1, kind: BrAnon(None) })), bound_vars: [] }, Binder { value: OutlivesPredicate(K, ReLateBound(DebruijnIndex(1), BoundRegion { var: 1, kind: BrAnon(None) })), bound_vars: [] }, Binder { value: OutlivesPredicate(V, ReLateBound(DebruijnIndex(1), BoundRegion { var: 1, kind: BrAnon(None) })), bound_vars: [] }], reveal: UserFacing, constness: NotConst }, value: Normalize { value: [async block@scratch/src/main.rs:72:1: 72:10] } }, max_universe: U0, variables: [CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }, CanonicalVarInfo { kind: Region(U0) }] }
- dep-node: type_op_normalize_ty(aa7d445f457cac26-8028c5c559abc021)', /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/compiler/rustc_query_system/src/dep_graph/graph.rs:351:9
stack backtrace:
   0:     0x7fe7d6112b61 - std::backtrace_rs::backtrace::libunwind::trace::he648b5c8dd376705
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x7fe7d6112b61 - std::backtrace_rs::backtrace::trace_unsynchronized::h5da3e203eef39e9f
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x7fe7d6112b61 - std::sys_common::backtrace::_print_fmt::h8d28d3f20588ae4c
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:65:5
   3:     0x7fe7d6112b61 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hd9a5b0c9c6b058c0
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:44:22
   4:     0x7fe7d617977f - core::fmt::rt::Argument::fmt::h0afc04119f252b53
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/fmt/rt.rs:138:9
   5:     0x7fe7d617977f - core::fmt::write::h50b1b3e73851a6fe
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/fmt/mod.rs:1094:21
   6:     0x7fe7d61054a7 - std::io::Write::write_fmt::h184eaf275e4484f0
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/io/mod.rs:1714:15
   7:     0x7fe7d6112975 - std::sys_common::backtrace::_print::hf58c3a5a25090e71
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:47:5
   8:     0x7fe7d6112975 - std::sys_common::backtrace::print::hb9cf0a7c7f077819
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:34:9
   9:     0x7fe7d6115753 - std::panicking::default_hook::{{closure}}::h066adb2e3f3e2c07
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:269:22
  10:     0x7fe7d61154e4 - std::panicking::default_hook::h277fa2776900ff14
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:288:9
  11:     0x7fe7d946756b - <rustc_driver_impl[10725d833993dc31]::install_ice_hook::{closure#0} as core[f12ae36cc2e1ecf0]::ops::function::FnOnce<(&core[f12ae36cc2e1ecf0]::panic::panic_info::PanicInfo,)>>::call_once::{shim:vtable#0}
  12:     0x7fe7d6115f7e - <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call::h09cad52ea08435f2
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/alloc/src/boxed.rs:2007:9
  13:     0x7fe7d6115f7e - std::panicking::rust_panic_with_hook::hceaf38da6d9db792
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:709:13
  14:     0x7fe7d6115d07 - std::panicking::begin_panic_handler::{{closure}}::h2bce3ed2516af7df
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:597:13
  15:     0x7fe7d6112fc6 - std::sys_common::backtrace::__rust_end_short_backtrace::h090f3faf8f98a395
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys_common/backtrace.rs:151:18
  16:     0x7fe7d6115a52 - rust_begin_unwind
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:593:5
  17:     0x7fe7d61759f3 - core::panicking::panic_fmt::h4ec8274704d163a3
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:67:14
  18:     0x7fe7d8a5da43 - rustc_query_system[5a9d202ec1d2890c]::query::plumbing::try_execute_query::<rustc_query_impl[7f6201a046a7a363]::DynamicConfig<rustc_query_system[5a9d202ec1d2890c]::query::caches::DefaultCache<rustc_middle[4cadb439cfabc8cf]::infer::canonical::Canonical<rustc_middle[4cadb439cfabc8cf]::ty::ParamEnvAnd<rustc_middle[4cadb439cfabc8cf]::traits::query::type_op::Normalize<rustc_middle[4cadb439cfabc8cf]::ty::Ty>>>, rustc_middle[4cadb439cfabc8cf]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[7f6201a046a7a363]::plumbing::QueryCtxt, true>
  19:     0x7fe7d8a5cde3 - rustc_query_impl[7f6201a046a7a363]::query_impl::type_op_normalize_ty::get_query_incr::__rust_end_short_backtrace
  20:     0x7fe7d84aace6 - <rustc_middle[4cadb439cfabc8cf]::ty::ParamEnvAnd<rustc_middle[4cadb439cfabc8cf]::traits::query::type_op::Normalize<rustc_middle[4cadb439cfabc8cf]::ty::Ty>> as rustc_trait_selection[ec0b3e5583b7dbc2]::traits::query::type_op::TypeOp>::fully_perform
  21:     0x7fe7d80cd1d5 - rustc_borrowck[9ba73aa227b2b27]::type_check::free_region_relations::create
  22:     0x7fe7d8094f22 - rustc_borrowck[9ba73aa227b2b27]::type_check::type_check
  23:     0x7fe7d8090984 - rustc_borrowck[9ba73aa227b2b27]::nll::compute_regions
  24:     0x7fe7d8070147 - rustc_borrowck[9ba73aa227b2b27]::do_mir_borrowck
  25:     0x7fe7d806e337 - rustc_borrowck[9ba73aa227b2b27]::mir_borrowck
  26:     0x7fe7d74755de - rustc_query_impl[7f6201a046a7a363]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[7f6201a046a7a363]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[4cadb439cfabc8cf]::query::erase::Erased<[u8; 8usize]>>
  27:     0x7fe7d74755ae - <rustc_query_impl[7f6201a046a7a363]::query_impl::mir_borrowck::dynamic_query::{closure#2} as core[f12ae36cc2e1ecf0]::ops::function::FnOnce<(rustc_middle[4cadb439cfabc8cf]::ty::context::TyCtxt, rustc_span[14af2d27fb997609]::def_id::LocalDefId)>>::call_once
  28:     0x7fe7d819aa86 - rustc_query_system[5a9d202ec1d2890c]::query::plumbing::try_execute_query::<rustc_query_impl[7f6201a046a7a363]::DynamicConfig<rustc_query_system[5a9d202ec1d2890c]::query::caches::VecCache<rustc_span[14af2d27fb997609]::def_id::LocalDefId, rustc_middle[4cadb439cfabc8cf]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[7f6201a046a7a363]::plumbing::QueryCtxt, true>
  29:     0x7fe7d8dc5479 - rustc_query_impl[7f6201a046a7a363]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
  30:     0x7fe7d84c954f - <rustc_borrowck[9ba73aa227b2b27]::type_check::TypeChecker>::prove_closure_bounds
  31:     0x7fe7d84875bd - <rustc_borrowck[9ba73aa227b2b27]::type_check::TypeChecker>::typeck_mir
  32:     0x7fe7d80953dc - rustc_borrowck[9ba73aa227b2b27]::type_check::type_check
  33:     0x7fe7d8090984 - rustc_borrowck[9ba73aa227b2b27]::nll::compute_regions
  34:     0x7fe7d8070147 - rustc_borrowck[9ba73aa227b2b27]::do_mir_borrowck
  35:     0x7fe7d806e337 - rustc_borrowck[9ba73aa227b2b27]::mir_borrowck
  36:     0x7fe7d74755de - rustc_query_impl[7f6201a046a7a363]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[7f6201a046a7a363]::query_impl::mir_borrowck::dynamic_query::{closure#2}::{closure#0}, rustc_middle[4cadb439cfabc8cf]::query::erase::Erased<[u8; 8usize]>>
  37:     0x7fe7d74755ae - <rustc_query_impl[7f6201a046a7a363]::query_impl::mir_borrowck::dynamic_query::{closure#2} as core[f12ae36cc2e1ecf0]::ops::function::FnOnce<(rustc_middle[4cadb439cfabc8cf]::ty::context::TyCtxt, rustc_span[14af2d27fb997609]::def_id::LocalDefId)>>::call_once
  38:     0x7fe7d819aa86 - rustc_query_system[5a9d202ec1d2890c]::query::plumbing::try_execute_query::<rustc_query_impl[7f6201a046a7a363]::DynamicConfig<rustc_query_system[5a9d202ec1d2890c]::query::caches::VecCache<rustc_span[14af2d27fb997609]::def_id::LocalDefId, rustc_middle[4cadb439cfabc8cf]::query::erase::Erased<[u8; 8usize]>>, false, false, false>, rustc_query_impl[7f6201a046a7a363]::plumbing::QueryCtxt, true>
  39:     0x7fe7d8dc5479 - rustc_query_impl[7f6201a046a7a363]::query_impl::mir_borrowck::get_query_incr::__rust_end_short_backtrace
  40:     0x7fe7d882de2e - rustc_data_structures[cf1e21f3f9509cab]::sync::par_for_each_in::<&[rustc_span[14af2d27fb997609]::def_id::LocalDefId], <rustc_middle[4cadb439cfabc8cf]::hir::map::Map>::par_body_owners<rustc_interface[7e6a9899d53a1fe5]::passes::analysis::{closure#1}::{closure#0}>::{closure#0}>
  41:     0x7fe7d882db26 - <rustc_session[c98e5f13e8087e38]::session::Session>::time::<(), rustc_interface[7e6a9899d53a1fe5]::passes::analysis::{closure#1}>
  42:     0x7fe7d882d24e - rustc_interface[7e6a9899d53a1fe5]::passes::analysis
  43:     0x7fe7d887dcfa - rustc_query_impl[7f6201a046a7a363]::plumbing::__rust_begin_short_backtrace::<rustc_query_impl[7f6201a046a7a363]::query_impl::analysis::dynamic_query::{closure#2}::{closure#0}, rustc_middle[4cadb439cfabc8cf]::query::erase::Erased<[u8; 1usize]>>
  44:     0x7fe7d887dce9 - <rustc_query_impl[7f6201a046a7a363]::query_impl::analysis::dynamic_query::{closure#2} as core[f12ae36cc2e1ecf0]::ops::function::FnOnce<(rustc_middle[4cadb439cfabc8cf]::ty::context::TyCtxt, ())>>::call_once
  45:     0x7fe7d8c19d8c - rustc_query_system[5a9d202ec1d2890c]::query::plumbing::try_execute_query::<rustc_query_impl[7f6201a046a7a363]::DynamicConfig<rustc_query_system[5a9d202ec1d2890c]::query::caches::SingleCache<rustc_middle[4cadb439cfabc8cf]::query::erase::Erased<[u8; 1usize]>>, false, false, false>, rustc_query_impl[7f6201a046a7a363]::plumbing::QueryCtxt, true>
  46:     0x7fe7d8c19934 - rustc_query_impl[7f6201a046a7a363]::query_impl::analysis::get_query_incr::__rust_end_short_backtrace
  47:     0x7fe7d892ddf2 - <rustc_interface[7e6a9899d53a1fe5]::queries::QueryResult<&rustc_middle[4cadb439cfabc8cf]::ty::context::GlobalCtxt>>::enter::<core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>, rustc_driver_impl[10725d833993dc31]::run_compiler::{closure#1}::{closure#2}::{closure#4}>
  48:     0x7fe7d892ca97 - <rustc_interface[7e6a9899d53a1fe5]::interface::Compiler>::enter::<rustc_driver_impl[10725d833993dc31]::run_compiler::{closure#1}::{closure#2}, core[f12ae36cc2e1ecf0]::result::Result<core[f12ae36cc2e1ecf0]::option::Option<rustc_interface[7e6a9899d53a1fe5]::queries::Linker>, rustc_span[14af2d27fb997609]::ErrorGuaranteed>>
  49:     0x7fe7d8929cc5 - rustc_span[14af2d27fb997609]::set_source_map::<core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>, rustc_interface[7e6a9899d53a1fe5]::interface::run_compiler<core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>, rustc_driver_impl[10725d833993dc31]::run_compiler::{closure#1}>::{closure#0}::{closure#0}>
  50:     0x7fe7d8929736 - <scoped_tls[a7f541bbfecfca9d]::ScopedKey<rustc_span[14af2d27fb997609]::SessionGlobals>>::set::<rustc_interface[7e6a9899d53a1fe5]::interface::run_compiler<core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>, rustc_driver_impl[10725d833993dc31]::run_compiler::{closure#1}>::{closure#0}, core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>>
  51:     0x7fe7d8928cfc - std[7c7acd4e376d60d3]::sys_common::backtrace::__rust_begin_short_backtrace::<rustc_interface[7e6a9899d53a1fe5]::util::run_in_thread_pool_with_globals<rustc_interface[7e6a9899d53a1fe5]::interface::run_compiler<core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>, rustc_driver_impl[10725d833993dc31]::run_compiler::{closure#1}>::{closure#0}, core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>>
  52:     0x7fe7d8ca1305 - <<std[7c7acd4e376d60d3]::thread::Builder>::spawn_unchecked_<rustc_interface[7e6a9899d53a1fe5]::util::run_in_thread_pool_with_globals<rustc_interface[7e6a9899d53a1fe5]::interface::run_compiler<core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>, rustc_driver_impl[10725d833993dc31]::run_compiler::{closure#1}>::{closure#0}, core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>>::{closure#0}::{closure#0}, core[f12ae36cc2e1ecf0]::result::Result<(), rustc_span[14af2d27fb997609]::ErrorGuaranteed>>::{closure#1} as core[f12ae36cc2e1ecf0]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  53:     0x7fe7d6120435 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::hc0b1022758ecac73
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/alloc/src/boxed.rs:1993:9
  54:     0x7fe7d6120435 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h0c9654ebe7ad657e
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/alloc/src/boxed.rs:1993:9
  55:     0x7fe7d6120435 - std::sys::unix::thread::Thread::new::thread_start::h04c8e9c7d83d3bd5
                               at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/sys/unix/thread.rs:108:17
  56:     0x7fe7d5eb4dd4 - start_thread
  57:     0x7fe7d5f369b0 - __clone3
  58:                0x0 - <unknown>

error: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-compiler&template=ice.md

note: rustc 1.72.0 (5680fa18f 2023-08-23) running on x86_64-unknown-linux-gnu

note: compiler flags: --crate-type bin -C embed-bitcode=no -C debuginfo=2 -C incremental=[REDACTED]

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
#0 [type_op_normalize_ty] normalizing `[async block@scratch/src/main.rs:72:1: 72:10]`
#1 [mir_borrowck] borrow-checking `<impl at scratch/src/main.rs:72:1: 72:10>::resolve_field::{closure#0}`
#2 [mir_borrowck] borrow-checking `<impl at scratch/src/main.rs:72:1: 72:10>::resolve_field`
#3 [analysis] running analysis passes on this crate
end of query stack
```

Thankfully the error does not reoccur in Rust 1.73, which is now the latest stable, and it probably makes sense for us to track stable anyway.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Bump the Rust toolchain version in `rust-toolchain.toml` to 1.73, the latest stable.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

<!-- How to test that the changes are correct. -->

I think that CI should cover it.

## Release Plan

I think this should have no user-visible changes, since we only export stable ABIs that don't change with Rust versions — but if I'm wrong please let me know!

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [Rust 1.73 changelog](https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
