### PR TITLE
Faucet listens for connections of 0.0.0.0 instead of 127.0.0.1

### DIFF
--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -122,7 +122,7 @@ where
 
         info!("GraphiQL IDE: http://localhost:{}", port);
 
-        Server::bind(&SocketAddr::from(([127, 0, 0, 1], port)))
+        Server::bind(&SocketAddr::from(([0, 0, 0, 0], port)))
             .serve(app.into_make_service())
             .await?;
 


### PR DESCRIPTION
## Motivation

We would like the Faucet to accept incoming external connections.

## Proposal

Change the server IP from 127.0.0.1 to 0.0.0.0.

## Test Plan

CI.