### PR TITLE
Add --limit-rate-until to faucet command.

### DIFF
--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -9,7 +9,7 @@ use axum::{http::StatusCode, response, response::IntoResponse, Extension, Router
 use futures::lock::Mutex;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::Amount,
+    data_types::{Amount, Timestamp},
     identifiers::{ChainId, MessageId},
 };
 use linera_core::{
@@ -27,10 +27,17 @@ use tracing::{error, info};
 
 use crate::util;
 
+#[cfg(test)]
+#[path = "unit_tests/faucet.rs"]
+mod tests;
+
 /// The root GraphQL mutation type.
 pub struct MutationRoot<P, S> {
     client: Arc<Mutex<ChainClient<P, S>>>,
     amount: Amount,
+    end_timestamp: Timestamp,
+    start_timestamp: Timestamp,
+    start_balance: Amount,
 }
 
 #[derive(Debug, ThisError)]
@@ -65,8 +72,43 @@ where
 {
     /// Creates a new chain with the given authentication key, and transfers tokens to it.
     async fn claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
-        let ownership = ChainOwnership::single(public_key);
+        self.do_claim(public_key).await
+    }
+}
+
+impl<P, S> MutationRoot<P, S>
+where
+    P: ValidatorNodeProvider + Send + Sync + 'static,
+    S: Store + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
+{
+    async fn do_claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
         let mut client = self.client.lock().await;
+
+        if self.start_timestamp < self.end_timestamp {
+            let local_time = client.storage_client().await.current_time();
+            if local_time < self.end_timestamp {
+                let full_duration = self
+                    .end_timestamp
+                    .saturating_diff_micros(self.start_timestamp);
+                let remaining_duration = self.end_timestamp.saturating_diff_micros(local_time);
+                let balance = client.local_balance().await?;
+                let Ok(remaining_balance) = balance.try_sub(self.amount) else {
+                    return Err(Error::new("The faucet is empty."));
+                };
+                // The tokens unlock linearly, e.g. if 1/3 of the time is left, then 1/3 of the
+                // tokens remain locked, so the remaining balance must be at least 1/3 of the start
+                // balance. In general:
+                // start_balance / full_duration <= remaining_balance / remaining_duration.
+                if Self::multiply(u128::from(self.start_balance), remaining_duration)
+                    > Self::multiply(u128::from(remaining_balance), full_duration)
+                {
+                    return Err(Error::new("Not enough unlocked balance; try again later."));
+                }
+            }
+        }
+
+        let ownership = ChainOwnership::single(public_key);
         let (message_id, certificate) = client.open_chain(ownership, self.amount).await?;
         let chain_id = ChainId::child(message_id);
         Ok(ClaimOutcome {
@@ -77,12 +119,27 @@ where
     }
 }
 
+impl<P, S> MutationRoot<P, S> {
+    /// Multiplies a `u128` with a `u64` and returns the result as a 192-bit number.
+    fn multiply(a: u128, b: u64) -> [u64; 3] {
+        let lower = u128::from(u64::MAX);
+        let b = u128::from(b);
+        let mut a1 = (a >> 64) * b;
+        let a0 = (a & lower) * b;
+        a1 += a0 >> 64;
+        [(a1 >> 64) as u64, (a1 & lower) as u64, (a0 & lower) as u64]
+    }
+}
+
 /// A GraphQL interface to request a new chain with tokens.
 #[derive(Clone)]
 pub struct FaucetService<P, S> {
     client: Arc<Mutex<ChainClient<P, S>>>,
     port: NonZeroU16,
     amount: Amount,
+    end_timestamp: Timestamp,
+    start_timestamp: Timestamp,
+    start_balance: Amount,
 }
 
 impl<P, S> FaucetService<P, S>
@@ -92,24 +149,37 @@ where
     ViewError: From<S::ContextError>,
 {
     /// Creates a new instance of the faucet service.
-    pub fn new(port: NonZeroU16, client: ChainClient<P, S>, amount: Amount) -> Self {
-        Self {
+    pub async fn new(
+        port: NonZeroU16,
+        mut client: ChainClient<P, S>,
+        amount: Amount,
+        end_timestamp: Timestamp,
+    ) -> anyhow::Result<Self> {
+        let start_timestamp = client.storage_client().await.current_time();
+        let start_balance = client.local_balance().await?;
+        Ok(Self {
             client: Arc::new(Mutex::new(client)),
             port,
             amount,
-        }
+            end_timestamp,
+            start_timestamp,
+            start_balance,
+        })
     }
 
     pub fn schema(&self) -> Schema<EmptyFields, MutationRoot<P, S>, EmptySubscription> {
         let mutation_root = MutationRoot {
             client: self.client.clone(),
             amount: self.amount,
+            end_timestamp: self.end_timestamp,
+            start_timestamp: self.start_timestamp,
+            start_balance: self.start_balance,
         };
         Schema::build(EmptyFields, mutation_root, EmptySubscription).finish()
     }
 
     /// Runs the faucet.
-    pub async fn run(self) -> Result<(), anyhow::Error> {
+    pub async fn run(self) -> anyhow::Result<()> {
         let port = self.port.get();
         let index_handler = axum::routing::get(util::graphiql).post(Self::index_handler);
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -967,7 +967,7 @@ enum ClientCommand {
         /// The end timestamp: The faucet will rate-limit the token supply so it runs out of money
         /// no earlier than this.
         #[structopt(long)]
-        end_timestamp: Option<DateTime<Utc>>,
+        limit_rate_until: Option<DateTime<Utc>>,
     },
 
     /// Publish bytecode.
@@ -1634,10 +1634,10 @@ impl Runnable for Job {
                 chain_id,
                 port,
                 amount,
-                end_timestamp,
+                limit_rate_until,
             } => {
                 let chain_client = context.make_chain_client(storage, chain_id);
-                let end_timestamp = end_timestamp
+                let end_timestamp = limit_rate_until
                     .map(|et| {
                         let micros = u64::try_from(et.timestamp_micros())
                             .expect("End timestamp before 1970");

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::MutationRoot;
+use futures::lock::Mutex;
+use linera_base::{
+    crypto::KeyPair,
+    data_types::{Amount, Timestamp},
+    identifiers::ChainDescription,
+};
+use linera_core::client::client_test_utils::{
+    MakeMemoryStoreClient, StoreBuilder as _, TestBuilder,
+};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_faucet_rate_limiting() {
+    let store_builder = MakeMemoryStoreClient::default();
+    let clock = store_builder.clock().clone();
+    clock.set(Timestamp::from(0));
+    let mut builder = TestBuilder::new(store_builder, 4, 1).await.unwrap();
+    let client = builder
+        .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(6))
+        .await
+        .unwrap();
+    let client = Arc::new(Mutex::new(client));
+    let root = MutationRoot {
+        client,
+        amount: Amount::from_tokens(1),
+        end_timestamp: Timestamp::from(6000),
+        start_timestamp: Timestamp::from(0),
+        start_balance: Amount::from_tokens(6),
+    };
+    // The faucet is releasing one token every 1000 microseconds. So at 1000 one claim should
+    // succeed. At 3000, two more should have been unlocked.
+    clock.set(Timestamp::from(999));
+    assert!(root.do_claim(KeyPair::generate().public()).await.is_err());
+    clock.set(Timestamp::from(1000));
+    assert!(root.do_claim(KeyPair::generate().public()).await.is_ok());
+    assert!(root.do_claim(KeyPair::generate().public()).await.is_err());
+    clock.set(Timestamp::from(3000));
+    assert!(root.do_claim(KeyPair::generate().public()).await.is_ok());
+    assert!(root.do_claim(KeyPair::generate().public()).await.is_ok());
+    assert!(root.do_claim(KeyPair::generate().public()).await.is_err());
+}
+
+#[test]
+fn test_multiply() {
+    let mul = MutationRoot::<(), ()>::multiply;
+    assert_eq!(mul((1 << 127) + (1 << 63), 1 << 63), [1 << 62, 1 << 62, 0]);
+    assert_eq!(mul(u128::MAX, u64::MAX), [u64::MAX - 1, u64::MAX, 1]);
+}


### PR DESCRIPTION
## Motivation

A faucet shouldn't give away tokens as quickly as it can serve requests, otherwise someone could quickly claim all of them and empty the faucet.

## Proposal

Add an `--end-timestamp` parameter to `faucet`. The tokens are then released at a constant rate, so that they don't run out before the specified time.

## Test Plan

A client test was added to check the rate limiting logic.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
