### PR TITLE
Use a `RwLock` over the contract system runtime to prevent data races

### DIFF
--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -29,6 +29,7 @@ use crate::{
     MessageContext, OperationContext, QueryContext, RawExecutionResult, ServiceRuntime,
     SessionCallResult, SessionId, UserApplication, WasmRuntime,
 };
+use async_lock::RwLock;
 use async_trait::async_trait;
 use futures::future;
 use std::{path::Path, sync::Arc};
@@ -130,7 +131,7 @@ impl UserApplication for WasmApplication {
         runtime: &dyn ContractRuntime,
         argument: &[u8],
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
-        let (runtime_actor, runtime_requests) = RuntimeActor::new(runtime);
+        let (runtime_actor, runtime_requests) = RuntimeActor::new(RwLock::new(runtime));
 
         let wasm_result_receiver = match self {
             #[cfg(feature = "wasmtime")]
@@ -158,7 +159,7 @@ impl UserApplication for WasmApplication {
         runtime: &dyn ContractRuntime,
         operation: &[u8],
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
-        let (runtime_actor, runtime_requests) = RuntimeActor::new(runtime);
+        let (runtime_actor, runtime_requests) = RuntimeActor::new(RwLock::new(runtime));
 
         let wasm_result_receiver = match self {
             #[cfg(feature = "wasmtime")]
@@ -186,7 +187,7 @@ impl UserApplication for WasmApplication {
         runtime: &dyn ContractRuntime,
         message: &[u8],
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
-        let (runtime_actor, runtime_requests) = RuntimeActor::new(runtime);
+        let (runtime_actor, runtime_requests) = RuntimeActor::new(RwLock::new(runtime));
 
         let wasm_result_receiver = match self {
             #[cfg(feature = "wasmtime")]
@@ -215,7 +216,7 @@ impl UserApplication for WasmApplication {
         argument: &[u8],
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, ExecutionError> {
-        let (runtime_actor, runtime_requests) = RuntimeActor::new(runtime);
+        let (runtime_actor, runtime_requests) = RuntimeActor::new(RwLock::new(runtime));
 
         let wasm_result_receiver = match self {
             #[cfg(feature = "wasmtime")]
@@ -245,7 +246,7 @@ impl UserApplication for WasmApplication {
         argument: &[u8],
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallResult, ExecutionError> {
-        let (runtime_actor, runtime_requests) = RuntimeActor::new(runtime);
+        let (runtime_actor, runtime_requests) = RuntimeActor::new(RwLock::new(runtime));
 
         let wasm_result_receiver = match self {
             #[cfg(feature = "wasmtime")]

--- a/linera-execution/src/wasm/runtime_actor/handlers.rs
+++ b/linera-execution/src/wasm/runtime_actor/handlers.rs
@@ -75,7 +75,7 @@ where
         // value of the called function changes.
         #[allow(clippy::unit_arg)]
         match request {
-            ContractRequest::Base(base_request) => (*self).handle_request(base_request).await?,
+            ContractRequest::Base(base_request) => self.handle_request(base_request).await?,
             ContractRequest::RemainingFuel { response_sender } => {
                 response_sender.respond(self.remaining_fuel())
             }
@@ -134,7 +134,7 @@ where
 {
     async fn handle_request(&self, request: ServiceRequest) -> Result<(), ExecutionError> {
         match request {
-            ServiceRequest::Base(base_request) => (*self).handle_request(base_request).await?,
+            ServiceRequest::Base(base_request) => self.handle_request(base_request).await?,
             ServiceRequest::TryQueryApplication {
                 queried_id,
                 argument,

--- a/linera-execution/src/wasm/runtime_actor/mod.rs
+++ b/linera-execution/src/wasm/runtime_actor/mod.rs
@@ -5,9 +5,13 @@
 
 mod handlers;
 mod requests;
+mod sync_response;
 
 use self::handlers::RequestHandler;
-pub use self::requests::{BaseRequest, ContractRequest, ServiceRequest};
+pub use self::{
+    requests::{BaseRequest, ContractRequest, ServiceRequest},
+    sync_response::{SyncReceiver, SyncSender},
+};
 use crate::{ExecutionError, WasmExecutionError};
 use futures::{
     channel::mpsc,

--- a/linera-execution/src/wasm/runtime_actor/sync_response.rs
+++ b/linera-execution/src/wasm/runtime_actor/sync_response.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types useful for sending synchronous responses from a [`RuntimeActor`]
+
+/// Creates a channel that wraps a [`oneshot`] channel with the [`Sender`] type not implementing
+/// [`Future`][`std::future::Future`].
+///
+/// This forces the channel to be used in a blocking manner.
+pub fn channel<T>() -> (SyncSender<T>, SyncReceiver<T>) {
+    let (sender, receiver) = oneshot::channel();
+
+    (SyncSender(sender), SyncReceiver(receiver))
+}
+
+/// A wrapper around [`oneshot::Sender`] that is connected to a synchronous [`SyncReceiver`].
+pub struct SyncSender<T>(oneshot::Sender<T>);
+
+impl<T> SyncSender<T> {
+    /// Sends a `message` to the synchronous [`SyncReceiver`] endpoint.
+    pub fn send(self, message: T) -> Result<(), oneshot::SendError<T>> {
+        self.0.send(message)
+    }
+}
+
+/// A wrapper around [`oneshot::Receiver`] that is connected to a synchronous [`SyncSender`].
+///
+/// This type does not implement [`Future`], so it can't be used to receive messages
+/// asynchronously.
+pub struct SyncReceiver<T>(oneshot::Receiver<T>);
+
+impl<T> SyncReceiver<T> {
+    /// Blocks until a message from the [`SyncSender`] endpoint is received.
+    pub fn recv(self) -> Result<T, oneshot::RecvError> {
+        self.0.recv()
+    }
+}

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -81,21 +81,19 @@ macro_rules! impl_contract_system_api {
 
             fn load_and_lock(&mut self) -> Result<Option<Vec<u8>>, Self::Error> {
                 self.runtime
-                    .send_request(|response_sender| ContractRequest::TryReadAndLockMyState {
+                    .send_sync_request(|response_sender| ContractRequest::TryReadAndLockMyState {
                         response_sender,
-                    })?
-                    .recv()
-                    .map_err(|oneshot::RecvError| WasmExecutionError::MissingRuntimeResponse.into())
+                    })
+                    .map_err(|error| error.into())
             }
 
             fn store_and_unlock(&mut self, state: &[u8]) -> Result<bool, Self::Error> {
                 self.runtime
-                    .send_request(|response_sender| ContractRequest::SaveAndUnlockMyState {
+                    .send_sync_request(|response_sender| ContractRequest::SaveAndUnlockMyState {
                         state: state.to_owned(),
                         response_sender,
-                    })?
-                    .recv()
-                    .map_err(|oneshot::RecvError| WasmExecutionError::MissingRuntimeResponse.into())
+                    })
+                    .map_err(|error| error.into())
             }
 
             fn lock_new(&mut self) -> Result<Self::Lock, Self::Error> {
@@ -131,16 +129,15 @@ macro_rules! impl_contract_system_api {
                     .collect();
 
                 self.runtime
-                    .send_request(|response_sender| ContractRequest::TryCallApplication {
+                    .send_sync_request(|response_sender| ContractRequest::TryCallApplication {
                         authenticated,
                         callee_id: application.into(),
                         argument: argument.to_owned(),
                         forwarded_sessions,
                         response_sender,
-                    })?
-                    .recv()
+                    })
                     .map(|call_result| call_result.into())
-                    .map_err(|oneshot::RecvError| WasmExecutionError::MissingRuntimeResponse.into())
+                    .map_err(|error| error.into())
             }
 
             fn try_call_session(
@@ -157,16 +154,15 @@ macro_rules! impl_contract_system_api {
                     .collect();
 
                 self.runtime
-                    .send_request(|response_sender| ContractRequest::TryCallSession {
+                    .send_sync_request(|response_sender| ContractRequest::TryCallSession {
                         authenticated,
                         session_id: session.into(),
                         argument: argument.to_owned(),
                         forwarded_sessions,
                         response_sender,
-                    })?
-                    .recv()
+                    })
                     .map(|call_result| call_result.into())
-                    .map_err(|oneshot::RecvError| WasmExecutionError::MissingRuntimeResponse.into())
+                    .map_err(|error| error.into())
             }
 
             fn log(
@@ -599,12 +595,11 @@ macro_rules! impl_view_system_api_for_contract {
                     }
                 }
                 self.runtime
-                    .send_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
+                    .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
                         batch,
                         response_sender,
-                    })?
-                    .recv()
-                    .map_err(|oneshot::RecvError| WasmExecutionError::MissingRuntimeResponse.into())
+                    })
+                    .map_err(|error| error.into())
             }
         }
     };

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -110,12 +110,10 @@ impl ApplicationRuntimeContext for Contract {
         context
             .extra
             .runtime
-            .send_request(|response_sender| ContractRequest::SetRemainingFuel {
+            .send_sync_request(|response_sender| ContractRequest::SetRemainingFuel {
                 remaining_fuel,
                 response_sender,
             })
-            .map_err(|_| ())?
-            .recv()
             .map_err(|_| ())
     }
 }

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -120,12 +120,10 @@ impl ApplicationRuntimeContext for Contract {
         let remaining_fuel = initial_fuel.saturating_sub(consumed_fuel);
 
         runtime
-            .send_request(|response_sender| ContractRequest::SetRemainingFuel {
+            .send_sync_request(|response_sender| ContractRequest::SetRemainingFuel {
                 remaining_fuel,
                 response_sender,
             })
-            .map_err(|_| ())?
-            .recv()
             .map_err(|_| ())
     }
 }

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -89,9 +89,7 @@ impl KeyValueStoreClient for KeyValueStore {
                 }
             }
         }
-        let promise = wit::WriteBatch::new(&list_oper);
-        yield_once().await;
-        promise.wait();
+        wit::write_batch(&list_oper);
         Ok(())
     }
 

--- a/linera-sdk/view_system_api.wit
+++ b/linera-sdk/view_system_api.wit
@@ -19,7 +19,4 @@ variant write-operation {
     put(tuple<list<u8>,list<u8>>),
 }
 
-resource write-batch {
-    static new: func(key: list<write-operation>) -> write-batch
-    wait: func()
-}
+write-batch: func(key: list<write-operation>)


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
It is currently possible to achieve non-deterministic execution of contracts by causing data races when reading and writing to storage. This is undesirable because it would mean certificates could be rejected because some of their transactions execute differently on different validators.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use a `RwLock` from [`async-lock`](https://docs.rs/async-lock/latest/async_lock/struct.RwLock.html) to prevent data races when accessing the contract system API runtime.

However, since the lock is write-preferring, it's also necessary to ensure there is never an attempt to acquire the write lock more than once at any given moment. To achieve this, all system APIs that acquire a write lock need to be blocking (synchronous). To help enforce this new rule, those system APIs were changed to use a new `SyncSender` type for the response channel, in which the connected `SyncReceiver` endpoint can not receive the response asynchronously.

Additionally, the `RuntimeActor::run` method was refactored to remove the usage of `select!`, which randomizes the order it polls the incoming requests channel and the current active requests.

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This changes some system APIs called from the Wasm guest, so:

- Need to bump the major/minor version number in the next release of the crates.

## Links

Closes #925 
<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
