### PR TITLE
Simplify the `from_bytes_opt`.

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -108,14 +108,14 @@ pub fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
 }
 
 pub(crate) fn from_bytes_opt<V: DeserializeOwned, E>(
-    key_opt: Option<Vec<u8>>,
+    key_opt: &Option<Vec<u8>>,
 ) -> Result<Option<V>, E>
 where
     E: From<bcs::Error>,
 {
     match key_opt {
         Some(bytes) => {
-            let value = bcs::from_bytes(&bytes)?;
+            let value = bcs::from_bytes(bytes)?;
             Ok(Some(value))
         }
         None => Ok(None),
@@ -198,7 +198,7 @@ pub trait KeyValueStoreClient {
     where
         Self::Error: From<bcs::Error>,
     {
-        from_bytes_opt(self.read_key_bytes(key).await?)
+        from_bytes_opt(&self.read_key_bytes(key).await?)
     }
 
     /// Reads multiple `keys` and deserializes the results if present.
@@ -211,7 +211,7 @@ pub trait KeyValueStoreClient {
     {
         let mut values = Vec::with_capacity(keys.len());
         for entry in self.read_multi_key_bytes(keys).await? {
-            values.push(from_bytes_opt(entry)?);
+            values.push(from_bytes_opt(&entry)?);
         }
         Ok(values)
     }
@@ -404,7 +404,7 @@ pub trait Context {
     where
         Item: DeserializeOwned,
     {
-        from_bytes_opt(self.read_key_bytes(key).await?)
+        from_bytes_opt(&self.read_key_bytes(key).await?)
     }
 
     /// Reads multiple `keys` and deserializes the results if present.
@@ -417,7 +417,7 @@ pub trait Context {
     {
         let mut values = Vec::with_capacity(keys.len());
         for entry in self.read_multi_key_bytes(keys).await? {
-            values.push(from_bytes_opt(entry)?);
+            values.push(from_bytes_opt(&entry)?);
         }
         Ok(values)
     }

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -52,8 +52,8 @@ where
         let key2 = context.base_tag(KeyTag::Hash as u8);
         let keys = vec![key1, key2];
         let values_bytes = context.read_multi_key_bytes(keys).await?;
-        let stored_count = from_bytes_opt(values_bytes[0].clone())?.unwrap_or_default();
-        let hash = from_bytes_opt(values_bytes[1].clone())?;
+        let stored_count = from_bytes_opt(&values_bytes[0])?.unwrap_or_default();
+        let hash = from_bytes_opt(&values_bytes[1])?;
         Ok(Self {
             context,
             was_cleared: false,

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -54,8 +54,8 @@ where
         let key2 = context.base_tag(KeyTag::Hash as u8);
         let keys = vec![key1, key2];
         let values_bytes = context.read_multi_key_bytes(keys).await?;
-        let stored_indices = from_bytes_opt(values_bytes[0].clone())?.unwrap_or_default();
-        let hash = from_bytes_opt(values_bytes[1].clone())?;
+        let stored_indices = from_bytes_opt(&values_bytes[0])?.unwrap_or_default();
+        let hash = from_bytes_opt(&values_bytes[1])?;
         Ok(Self {
             context,
             stored_indices,

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -46,8 +46,8 @@ where
         let key2 = context.base_tag(KeyTag::Hash as u8);
         let keys = vec![key1, key2];
         let values_bytes = context.read_multi_key_bytes(keys).await?;
-        let stored_value = Box::new(from_bytes_opt(values_bytes[0].clone())?.unwrap_or_default());
-        let hash = from_bytes_opt(values_bytes[1].clone())?;
+        let stored_value = Box::new(from_bytes_opt(&values_bytes[0])?.unwrap_or_default());
+        let hash = from_bytes_opt(&values_bytes[1])?;
         Ok(Self {
             context,
             stored_value,


### PR DESCRIPTION
## Motivation

The `from_bytes_opt` is doing some `clone()` operations which can actually be removed.

## Proposal

Implement the simplification

## Test Plan

The CI.

## Release Plan

Nothing relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
