### PR TITLE
Clean types in `collect()` statements.

### DIFF
--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -303,7 +303,7 @@ impl<'de> Deserialize<'de> for AccountOwner {
             where
                 E: serde::de::Error,
             {
-                let parts: Vec<&str> = value.splitn(2, ':').collect();
+                let parts = value.splitn(2, ':').collect::<Vec<_>>();
                 if parts.len() != 2 {
                     return Err(Error::custom("string does not contain colon"));
                 }

--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -463,9 +463,9 @@ impl Signature {
     {
         let mut msg = Vec::new();
         value.write(&mut msg);
-        let mut messages: Vec<&[u8]> = Vec::new();
-        let mut signatures: Vec<dalek::Signature> = Vec::new();
-        let mut public_keys: Vec<dalek::PublicKey> = Vec::new();
+        let mut messages = Vec::<&[u8]>::new();
+        let mut signatures = Vec::new();
+        let mut public_keys = Vec::new();
         for (addr, sig) in votes.into_iter() {
             messages.push(&msg);
             signatures.push(sig.0);

--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -463,11 +463,11 @@ impl Signature {
     {
         let mut msg = Vec::new();
         value.write(&mut msg);
-        let mut messages = Vec::<&[u8]>::new();
+        let mut messages = Vec::new();
         let mut signatures = Vec::new();
         let mut public_keys = Vec::new();
         for (addr, sig) in votes.into_iter() {
-            messages.push(&msg);
+            messages.push(msg.as_slice());
             signatures.push(sig.0);
             public_keys.push(dalek::PublicKey::from_bytes(&addr.0)?);
         }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -852,13 +852,13 @@ where
                 locations,
             )) = &err
             {
-                let blobs: Vec<HashedValue> = future::join_all(locations.iter().map(|location| {
+                let blobs = future::join_all(locations.iter().map(|location| {
                     LocalNodeClient::<S>::download_blob(nodes.clone(), block.chain_id, *location)
                 }))
                 .await
                 .into_iter()
                 .flatten()
-                .collect();
+                .collect::<Vec<_>>();
                 if !blobs.is_empty() {
                     self.process_certificate(certificate.clone(), blobs).await?;
                 }
@@ -1533,7 +1533,7 @@ where
             ChainError::InactiveChain(self.chain_id)
         );
         let messages = self.pending_messages().await?;
-        let mut owners: Vec<_> = ownership.owners.values().copied().collect();
+        let mut owners = ownership.owners.values().copied().collect::<Vec<_>>();
         owners.extend(
             ownership
                 .super_owners

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -422,7 +422,7 @@ where
     where
         A: ValidatorNode + Send + Sync + 'static + Clone,
     {
-        let futures: Vec<_> = validators
+        let futures = validators
             .into_iter()
             .map(|(name, node)| {
                 let mut client = self.clone();
@@ -432,7 +432,7 @@ where
                         .await
                 }
             })
-            .collect();
+            .collect::<Vec<_>>();
         futures::future::join_all(futures).await;
         let info = self.local_chain_info(chain_id).await?;
         Ok(info)

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -268,7 +268,9 @@ fn direct_credit_message(recipient: ChainId, amount: Amount) -> OutgoingMessage 
 
 /// Creates `count` key pairs and returns them, sorted by the `Owner` created from their public key.
 fn generate_key_pairs(count: usize) -> Vec<KeyPair> {
-    let mut key_pairs: Vec<_> = iter::repeat_with(KeyPair::generate).take(count).collect();
+    let mut key_pairs = iter::repeat_with(KeyPair::generate)
+        .take(count)
+        .collect::<Vec<_>>();
     key_pairs.sort_by_key(|key_pair| Owner::from(key_pair.public()));
     key_pairs
 }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -203,7 +203,7 @@ where
                         return Err(NodeError::InvalidChainInfoResponse);
                     }
                 }
-                let unique_locations: HashSet<_> = locations.iter().cloned().collect();
+                let unique_locations = locations.iter().cloned().collect::<HashSet<_>>();
                 if locations.len() > unique_locations.len() {
                     warn!("locations requested by validator contain duplicates");
                     return Err(NodeError::InvalidChainInfoResponse);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -659,7 +659,7 @@ where
         }
         let blob_hashes: HashSet<_> = blobs.iter().map(|blob| blob.hash()).collect();
         let recent_values = self.recent_values.lock().await;
-        let tasks: Vec<_> = required_locations
+        let tasks = required_locations
             .into_keys()
             .filter(|location| {
                 !recent_values.contains(&location.certificate_hash)
@@ -671,7 +671,7 @@ where
                     .read_value(location.certificate_hash)
                     .map(move |result| (location, result))
             })
-            .collect();
+            .collect::<Vec<_>>();
         let mut locations = vec![];
         for (location, result) in future::join_all(tasks).await {
             match result {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -368,7 +368,7 @@ impl FromStr for Account {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split(':').collect();
+        let parts = s.split(':').collect::<Vec<_>>();
         anyhow::ensure!(
             parts.len() <= 2,
             "Expecting format `chain-id:address` or `chain-id`"

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -273,10 +273,10 @@ impl common::Contract for Contract {
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<Result<ApplicationCallResult, String>, RuntimeError> {
-        let forwarded_sessions: Vec<_> = forwarded_sessions
+        let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)
-            .collect();
+            .collect::<Vec<_>>();
 
         contract::Contract::handle_application_call(
             &self.contract,
@@ -296,10 +296,10 @@ impl common::Contract for Contract {
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<Result<(SessionCallResult, Vec<u8>), String>, RuntimeError> {
-        let forwarded_sessions: Vec<_> = forwarded_sessions
+        let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)
-            .collect();
+            .collect::<Vec<_>>();
 
         contract::Contract::handle_session_call(
             &self.contract,

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -363,10 +363,10 @@ impl common::Contract for Contract {
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<Result<ApplicationCallResult, String>, Trap> {
-        let forwarded_sessions: Vec<_> = forwarded_sessions
+        let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)
-            .collect();
+            .collect::<Vec<_>>();
 
         contract::Contract::handle_application_call(
             &self.contract,
@@ -386,10 +386,10 @@ impl common::Contract for Contract {
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<Result<(SessionCallResult, Vec<u8>), String>, Trap> {
-        let forwarded_sessions: Vec<_> = forwarded_sessions
+        let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)
-            .collect();
+            .collect::<Vec<_>>();
 
         contract::Contract::handle_session_call(
             &self.contract,

--- a/linera-explorer/src/entrypoint.rs
+++ b/linera-explorer/src/entrypoint.rs
@@ -24,17 +24,17 @@ fn forge_arg_type(arg: &Value, non_null: bool) -> Option<String> {
         }
         Some("NON_NULL") => forge_arg_type(&arg["ofType"], true),
         Some("LIST") => {
-            let args: Vec<String> = arg["_input"]
+            let args = arg["_input"]
                 .as_array()
                 .unwrap()
                 .iter()
                 .filter_map(|x| forge_arg_type(x, false))
-                .collect();
+                .collect::<Vec<_>>();
             Some(format!("[{}]", args.join(", ")))
         }
         Some("ENUM") => arg["_input"].as_str().map(|x| x.to_string()),
         Some("INPUT_OBJECT") => {
-            let args: Vec<String> = arg["inputFields"]
+            let args = arg["inputFields"]
                 .as_array()
                 .unwrap()
                 .iter()
@@ -42,7 +42,7 @@ fn forge_arg_type(arg: &Value, non_null: bool) -> Option<String> {
                     let name = x["name"].as_str().unwrap();
                     forge_arg_type(&x["type"], false).map(|arg| format!("{}: {}", name, arg))
                 })
-                .collect();
+                .collect::<Vec<_>>();
             Some(format!("{{{}}}", args.join(", ")))
         }
         _ => None,
@@ -62,7 +62,7 @@ fn forge_arg(arg: &Value) -> Option<String> {
 
 /// Forges query arguments.
 fn forge_args(args: Vec<Value>) -> String {
-    let args: Vec<String> = args.iter().filter_map(forge_arg).collect();
+    let args = args.iter().filter_map(forge_arg).collect::<Vec<_>>();
     if !args.is_empty() {
         format!("({})", args.join(","))
     } else {
@@ -85,14 +85,14 @@ fn forge_response_type(output: &Value, name: Option<&str>, root: bool) -> Option
         ),
         "NON_NULL" | "LIST" => forge_response_type(&output["ofType"], name, root),
         "OBJECT" => {
-            let fields: Vec<String> = output["fields"]
+            let fields = output["fields"]
                 .as_array()
                 .unwrap()
                 .iter()
                 .filter_map(|elt: &Value| {
                     forge_response_type(&elt["type"], elt["name"].as_str(), false)
                 })
-                .collect();
+                .collect::<Vec<_>>();
             if root {
                 Some(format!("{{ {} }}", fields.join(" ")))
             } else {

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -343,12 +343,12 @@ fn fill_type(element: &Value, types: &Vec<Value>) -> Value {
                     match types.iter().find(|elt: &&Value| elt["name"] == name) {
                         None => (),
                         Some(element_definition) => {
-                            let fields: Vec<Value> = element_definition["fields"]
+                            let fields = element_definition["fields"]
                                 .as_array()
                                 .unwrap()
                                 .iter()
                                 .map(|elt| fill_type(elt, types))
-                                .collect();
+                                .collect::<Vec<_>>();
                             object.insert("fields".to_string(), Value::Array(fields));
                         }
                     }
@@ -357,12 +357,12 @@ fn fill_type(element: &Value, types: &Vec<Value>) -> Value {
                     match types.iter().find(|elt: &&Value| elt["name"] == name) {
                         None => (),
                         Some(element_definition) => {
-                            let fields: Vec<Value> = element_definition["inputFields"]
+                            let fields = element_definition["inputFields"]
                                 .as_array()
                                 .unwrap()
                                 .iter()
                                 .map(|elt| fill_type(elt, types))
-                                .collect();
+                                .collect::<Vec<_>>();
                             object.insert("inputFields".to_string(), Value::Array(fields));
                         }
                     }
@@ -371,12 +371,12 @@ fn fill_type(element: &Value, types: &Vec<Value>) -> Value {
                     match types.iter().find(|elt: &&Value| elt["name"] == name) {
                         None => (),
                         Some(element_definition) => {
-                            let values: Vec<Value> = element_definition["enumValues"]
+                            let values = element_definition["enumValues"]
                                 .as_array()
                                 .unwrap()
                                 .iter()
                                 .map(|elt| fill_type(elt, types))
-                                .collect();
+                                .collect::<Vec<_>>();
                             object.insert("enumValues".to_string(), Value::Array(values));
                         }
                     }
@@ -759,7 +759,7 @@ pub async fn start(app: JsValue) {
                 .unwrap();
             let uri = Url::parse(&uri).expect("failed to parse url");
             let pathname = uri.path();
-            let mut args: Vec<(String, String)> = uri.query_pairs().into_owned().collect();
+            let mut args = uri.query_pairs().into_owned().collect::<Vec<_>>();
             args.push(("chain".to_string(), default_chain.to_string()));
             let path = match pathname {
                 "/blocks" => Some("blocks".to_string()),

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -185,7 +185,7 @@ where
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split(':').collect();
+        let parts = s.split(':').collect::<Vec<_>>();
         anyhow::ensure!(
             parts.len() == 3,
             "Expecting format `(tcp|udp|grpc|grpcs):host:port`"

--- a/linera-sdk/src/bin/linera-wasm-test-runner/main.rs
+++ b/linera-sdk/src/bin/linera-wasm-test-runner/main.rs
@@ -61,7 +61,10 @@ async fn main() -> Result<ExitCode> {
     let engine = Engine::new(&engine_config)?;
     let mut linker = Linker::new(&engine);
     let test_module = load_test_module(&options.module_path, &engine)?;
-    let tests: Vec<_> = test_module.exports().filter_map(Test::new).collect();
+    let tests = test_module
+        .exports()
+        .filter_map(Test::new)
+        .collect::<Vec<_>>();
 
     mock_system_api::add_to_linker(&mut linker)?;
 

--- a/linera-sdk/src/contract/system_api/private.rs
+++ b/linera-sdk/src/contract/system_api/private.rs
@@ -74,10 +74,10 @@ pub fn call_application_without_persisting_state(
     argument: &[u8],
     forwarded_sessions: Vec<SessionId>,
 ) -> (Vec<u8>, Vec<SessionId>) {
-    let forwarded_sessions: Vec<_> = forwarded_sessions
+    let forwarded_sessions = forwarded_sessions
         .into_iter()
         .map(wit::SessionId::from)
-        .collect();
+        .collect::<Vec<_>>();
 
     wit::try_call_application(
         authenticated,
@@ -98,10 +98,10 @@ pub fn call_session_without_persisting_state(
     argument: &[u8],
     forwarded_sessions: Vec<SessionId>,
 ) -> (Vec<u8>, Vec<SessionId>) {
-    let forwarded_sessions: Vec<_> = forwarded_sessions
+    let forwarded_sessions = forwarded_sessions
         .into_iter()
         .map(wit::SessionId::from)
-        .collect();
+        .collect::<Vec<_>>();
 
     wit::try_call_session(authenticated, session.into(), argument, &forwarded_sessions).into()
 }

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -186,12 +186,12 @@ impl ActiveChain {
         let cargo_manifest =
             Manifest::from_path(manifest_path).expect("Failed to load Cargo.toml manifest");
 
-        let binaries: Vec<_> = cargo_manifest
+        let binaries = cargo_manifest
             .bin
             .into_iter()
             .filter_map(|binary| binary.name)
             .filter(|name| name.ends_with("service") || name.ends_with("contract"))
-            .collect();
+            .collect::<Vec<_>>();
 
         assert_eq!(
             binaries.len(),

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -170,8 +170,10 @@ mod from {
                 message_counts,
                 state_hash,
             } = val;
-            let messages: Vec<OutgoingMessage> =
-                messages.into_iter().map(OutgoingMessage::from).collect();
+            let messages = messages
+                .into_iter()
+                .map(OutgoingMessage::from)
+                .collect::<Vec<_>>();
             ExecutedBlock {
                 block: block.into(),
                 messages,

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1290,8 +1290,11 @@ impl Runnable for Job {
                 let mut chain_client = context.make_chain_client(storage, chain_id);
                 info!("Starting operation to open a new chain");
                 let time_start = Instant::now();
-                let owners: Vec<_> = if weights.is_empty() {
-                    public_keys.into_iter().zip(iter::repeat(100)).collect()
+                let owners = if weights.is_empty() {
+                    public_keys
+                        .into_iter()
+                        .zip(iter::repeat(100))
+                        .collect::<Vec<_>>()
                 } else if weights.len() != public_keys.len() {
                     bail!(
                         "There are {} public keys but {} weights.",
@@ -1299,7 +1302,7 @@ impl Runnable for Job {
                         weights.len()
                     );
                 } else {
-                    public_keys.into_iter().zip(weights).collect()
+                    public_keys.into_iter().zip(weights).collect::<Vec<_>>()
                 };
                 let multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
                 let ownership = ChainOwnership::multiple(owners, multi_leader_rounds);
@@ -1546,7 +1549,7 @@ impl Runnable for Job {
                 let responses = context
                     .mass_broadcast("block proposals", max_in_flight, proposals)
                     .await;
-                let votes: Vec<_> = responses
+                let votes = responses
                     .into_iter()
                     .filter_map(|message| {
                         deserialize_response(message).and_then(|response| {
@@ -1556,7 +1559,7 @@ impl Runnable for Job {
                             })
                         })
                     })
-                    .collect();
+                    .collect::<Vec<_>>();
                 info!("Received {} valid votes.", votes.len());
 
                 info!("Starting benchmark phase 2 (certified blocks)");

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -303,7 +303,7 @@ where
         multi_leader_rounds: Option<u32>,
         balance: Option<Amount>,
     ) -> Result<ChainId, Error> {
-        let owners: Vec<_> = if let Some(weights) = weights {
+        let owners = if let Some(weights) = weights {
             if weights.len() != public_keys.len() {
                 return Err(Error::new(format!(
                     "There are {} public keys but {} weights.",
@@ -311,9 +311,12 @@ where
                     weights.len()
                 )));
             }
-            public_keys.into_iter().zip(weights).collect()
+            public_keys.into_iter().zip(weights).collect::<Vec<_>>()
         } else {
-            public_keys.into_iter().zip(iter::repeat(100)).collect()
+            public_keys
+                .into_iter()
+                .zip(iter::repeat(100))
+                .collect::<Vec<_>>()
         };
         let multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
         let ownership = ChainOwnership::multiple(owners, multi_leader_rounds);

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -99,10 +99,10 @@ impl KeyValueStoreClient for MemoryClient {
                     map.remove(&key);
                 }
                 WriteOperation::DeletePrefix { key_prefix } => {
-                    let key_list: Vec<Vec<u8>> = map
+                    let key_list = map
                         .range(get_interval(key_prefix))
                         .map(|x| x.0.to_vec())
-                        .collect();
+                        .collect::<Vec<_>>();
                     for key in key_list {
                         map.remove(&key);
                     }

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -56,7 +56,10 @@ async fn run_reads<C: KeyValueStoreClient + Sync>(
             .find_keys_by_prefix(key_prefix)
             .await
             .unwrap();
-        let keys_request: Vec<_> = keys_by_prefix.iterator().map(Result::unwrap).collect();
+        let keys_request = keys_by_prefix
+            .iterator()
+            .map(Result::unwrap)
+            .collect::<Vec<_>>();
         let mut set_key_value1 = HashSet::new();
         let mut keys_request_deriv = Vec::new();
         let key_values_by_prefix = key_value_store

--- a/linera-witty-macros/src/wit_import.rs
+++ b/linera-witty-macros/src/wit_import.rs
@@ -45,11 +45,11 @@ struct FunctionInformation<'input> {
 impl<'input> WitImportGenerator<'input> {
     /// Collects the pieces necessary for code generation from the inputs.
     fn new(trait_definition: &'input ItemTrait, namespace: &'input LitStr) -> Self {
-        let functions: Vec<_> = trait_definition
+        let functions = trait_definition
             .items
             .iter()
             .map(FunctionInformation::from)
-            .collect();
+            .collect::<Vec<_>>();
 
         WitImportGenerator {
             trait_name: &trait_definition.ident,

--- a/scripts/check_copyright_header/src/main.rs
+++ b/scripts/check_copyright_header/src/main.rs
@@ -62,7 +62,7 @@ fn check_file_header(
 }
 
 fn main() -> Result<(), CheckFileHeaderError> {
-    let args: Vec<String> = env::args().collect();
+    let args = env::args().collect::<Vec<_>>();
     let file_path = args.get(1).expect("Usage: FILE");
 
     let file = File::open(file_path).expect("Failed to open file");


### PR DESCRIPTION
## Motivation

The types annotation is something that we want to avoid. In particular for the `collect()` it was put because it was needed. Except that it is not. This PR cleans up that art of the code.

## Proposal

Straightforward given the stated contraints

## Test Plan

CI

## Release Plan

Nothing relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
