### PR TITLE
Save pending block in wallet; add retry command.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -114,6 +114,7 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
         block_hash: Option<CryptoHash>,
         timestamp: Timestamp,
         next_block_height: BlockHeight,
+        pending_block: Option<Block>,
     ) -> ChainClient<ValidatorNodeProvider, StorageClient> {
         let known_key_pairs = known_key_pairs
             .into_iter()
@@ -138,7 +139,7 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
             block_hash,
             timestamp,
             next_block_height,
-            pending_block: None,
+            pending_block,
             cross_chain_delay: self.cross_chain_delay,
             cross_chain_retries: self.cross_chain_retries,
             node_client,
@@ -1203,7 +1204,11 @@ where
         let query = ChainInfoQuery::new(self.chain_id).with_manager_values();
         let response = self.node_client.handle_chain_info_query(query).await?;
         let manager = response.info.manager;
-        let Some(next_round) = manager.next_round() else {
+        let next_round = if let Some(next_round) = manager.next_round() {
+            next_round
+        } else if self.pending_block.is_some() {
+            manager.current_round
+        } else {
             return Err(ChainClientError::BlockProposalError(
                 "Cannot propose a block; there is already a proposal in the current round",
             ));

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1185,7 +1185,7 @@ where
             self.pending_block.is_none() || self.pending_block.as_ref() == Some(&block),
             ChainClientError::BlockProposalError(
                 "Client state has a different pending block; \
-                use the retry-pending-block command to commit that first"
+                use the `linera retry-pending-block` command to commit that first"
             )
         );
         ensure!(
@@ -1240,7 +1240,7 @@ where
         self.node_client
             .handle_block_proposal(proposal.clone())
             .await?;
-        // Remember what we are trying to do, before sending the proposal to the validators.
+        // Remember what we are trying to do before sending the proposal to the validators.
         self.pending_block = Some(block);
         // Send the query to validators.
         let submit_action = CommunicateAction::SubmitBlock(proposal.clone());

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1183,7 +1183,10 @@ where
     async fn propose_block(&mut self, block: Block) -> Result<Certificate, ChainClientError> {
         ensure!(
             self.pending_block.is_none() || self.pending_block.as_ref() == Some(&block),
-            ChainClientError::BlockProposalError("Client state has a different pending block")
+            ChainClientError::BlockProposalError(
+                "Client state has a different pending block; \
+                use the retry-pending-block command to commit that first"
+            )
         );
         ensure!(
             block.height == self.next_block_height,

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -519,6 +519,7 @@ where
             block_hash,
             Timestamp::from(0),
             block_height,
+            None,
         ))
     }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -304,6 +304,10 @@ type MutationRoot {
 	"""
 	processInbox(chainId: ChainId!): [CryptoHash!]!
 	"""
+	Retries the pending block that was unsuccessfully proposed earlier.
+	"""
+	retryPendingBlock(chainId: ChainId!): CryptoHash
+	"""
 	Transfers `amount` units of value from the given owner's account to the recipient.
 	If no owner is given, try to take the units out of the unattributed account.
 	"""

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -76,12 +76,11 @@ where
     }
 
     /// Runs the chain listener.
-    pub fn run<C>(self, context: C, storage: S)
+    pub async fn run<C>(self, context: Arc<Mutex<C>>, storage: S)
     where
         C: ClientContext<P> + Send + 'static,
     {
-        let chain_ids = context.wallet_state().chain_ids();
-        let context = Arc::new(Mutex::new(context));
+        let chain_ids = context.lock().await.wallet_state().chain_ids();
         for chain_id in chain_ids {
             Self::run_with_chain_id(
                 chain_id,

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -13,6 +13,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId, Owner},
 };
+use linera_chain::data_types::Block;
 use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
 use linera_execution::{
     committee::{Committee, ValidatorName, ValidatorState},
@@ -103,6 +104,7 @@ pub struct UserChain {
     pub block_hash: Option<CryptoHash>,
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
+    pub pending_block: Option<Block>,
 }
 
 impl UserChain {
@@ -119,6 +121,7 @@ impl UserChain {
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight::ZERO,
+            pending_block: None,
         }
     }
 
@@ -130,6 +133,7 @@ impl UserChain {
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight::ZERO,
+            pending_block: None,
         }
     }
 }
@@ -232,6 +236,7 @@ impl WalletState {
             block_hash: None,
             timestamp,
             next_block_height: BlockHeight(0),
+            pending_block: None,
         };
         self.insert(user_chain);
         Ok(())
@@ -262,6 +267,7 @@ impl WalletState {
                 block_hash: state.block_hash(),
                 next_block_height: state.next_block_height(),
                 timestamp: state.timestamp(),
+                pending_block: state.pending_block().clone(),
             },
         );
     }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1646,8 +1646,8 @@ impl Runnable for Job {
 
             Service { config, port } => {
                 let default_chain = context.wallet_state.default_chain();
-                let service = NodeService::new(config, port, default_chain, storage);
-                service.run(context).await?;
+                let service = NodeService::new(config, port, default_chain, storage, context);
+                service.run().await?;
             }
 
             Faucet {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -242,6 +242,14 @@ where
         Ok(hashes)
     }
 
+    /// Retries the pending block that was unsuccessfully proposed earlier.
+    async fn retry_pending_block(&self, chain_id: ChainId) -> Result<Option<CryptoHash>, Error> {
+        let mut client = self.clients.try_client_lock(&chain_id).await?;
+        let maybe_certificate = client.retry_pending_block().await?;
+        self.context.lock().await.update_wallet(&mut *client).await;
+        Ok(maybe_certificate.map(|cert| cert.hash()))
+    }
+
     /// Transfers `amount` units of value from the given owner's account to the recipient.
     /// If no owner is given, try to take the units out of the unattributed account.
     async fn transfer(


### PR DESCRIPTION
## Motivation

After unsuccessfully proposing a valid fast block, it is not safe to propose a different block at the same height anymore.

Currently, we don't store the proposed block in the wallet, and there is no command to retry it.

## Proposal

Store the pending block in the wallet, and add a `retry-pending-block` command that will send it to the validators again.

For this to work, all the commands that involve block proposals need to save the wallet even if they fail.

## Test Plan

An end-to-end test was added, where a block proposal fails and is retried.

## Release Plan

- Need to update the developer manual.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
