### PR TITLE
Bumped versions to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "linera-base"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-graphql",
  "bcs",
@@ -2902,7 +2902,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-graphql",
  "async-lock",
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "linera-explorer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3030,7 +3030,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-example"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-graphql-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "graphql_client",
  "linera-base",
@@ -3098,7 +3098,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-plugins"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3116,7 +3116,7 @@ dependencies = [
 
 [[package]]
 name = "linera-rpc"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3157,7 +3157,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-wasm-tests"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3208,7 +3208,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "amm",
  "anyhow",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service-graphql-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "fungible",
  "graphql_client",
@@ -3292,7 +3292,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -3351,7 +3351,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "convert_case 0.6.0",
  "heck 0.4.1",
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "either",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -3529,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-test-modules"
-version = "0.1.0"
+version = "0.6.0"
 dependencies = [
  "wit-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,23 +120,23 @@ wit-bindgen-guest-rust = { version = "0.2.0", package = "linera-wit-bindgen-gues
 wit-bindgen-host-wasmer-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmer-rust" }
 wit-bindgen-host-wasmtime-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmtime-rust" }
 
-linera-base = { version = "0.5.0", path = "./linera-base" }
-linera-chain = { version = "0.5.0", path = "./linera-chain" }
-linera-core = { version = "0.5.0", path = "./linera-core", default-features = false }
-linera-execution = { version = "0.5.0", path = "./linera-execution", default-features = false }
+linera-base = { version = "0.6.0", path = "./linera-base" }
+linera-chain = { version = "0.6.0", path = "./linera-chain" }
+linera-core = { version = "0.6.0", path = "./linera-core", default-features = false }
+linera-execution = { version = "0.6.0", path = "./linera-execution", default-features = false }
 linera-indexer = { path = "./linera-indexer/lib" }
 linera-indexer-example = { path = "./linera-indexer/example" }
 linera-indexer-graphql-client = { path = "./linera-indexer/graphql-client" }
 linera-indexer-plugins = { path = "./linera-indexer/plugins" }
-linera-rpc = { version = "0.5.0", path = "./linera-rpc" }
-linera-storage = { version = "0.5.0", path = "./linera-storage", default-features = false }
-linera-views = { version = "0.5.0", path = "./linera-views", default-features = false }
-linera-views-derive = { version = "0.5.0", path = "./linera-views-derive" }
-linera-witty = { version = "0.5.0", path = "./linera-witty" }
-linera-witty-macros = { version = "0.5.0", path = "./linera-witty-macros" }
-linera-sdk-derive = { version = "0.5.0", path = "./linera-sdk-derive" }
-linera-service = { version = "0.5.0", path = "./linera-service" }
-linera-service-graphql-client = { version = "0.5.0", path = "./linera-service-graphql-client" }
+linera-rpc = { version = "0.6.0", path = "./linera-rpc" }
+linera-storage = { version = "0.6.0", path = "./linera-storage", default-features = false }
+linera-views = { version = "0.6.0", path = "./linera-views", default-features = false }
+linera-views-derive = { version = "0.6.0", path = "./linera-views-derive" }
+linera-witty = { version = "0.6.0", path = "./linera-witty" }
+linera-witty-macros = { version = "0.6.0", path = "./linera-witty-macros" }
+linera-sdk-derive = { version = "0.6.0", path = "./linera-sdk-derive" }
+linera-service = { version = "0.6.0", path = "./linera-service" }
+linera-service-graphql-client = { version = "0.6.0", path = "./linera-service-graphql-client" }
 
 counter = { path = "./examples/counter" }
 meta-counter = { path = "./examples/meta-counter" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1628,7 +1628,7 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "linera-base"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-graphql",
  "bcs",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-graphql",
  "async-lock",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "bcs",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "convert_case 0.6.0",
  "heck 0.4.1",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-base"
-version = "0.5.0"
+version = "0.6.0"
 description = "Base definitions, including cryptography, used by the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-chain"
-version = "0.5.0"
+version = "0.6.0"
 description = "Persistent data and the corresponding logics used by the Linera protocol for chains of blocks, certificates, and cross-chain messaging."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-core"
-version = "0.5.0"
+version = "0.6.0"
 description = "The core Linera protocol, including client and server logic, node synchronization, etc."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-execution"
-version = "0.5.0"
+version = "0.6.0"
 description = "Persistent data and the corresponding logics used by the Linera protocol for runtime and execution of smart contracts / applications."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-explorer/Cargo.toml
+++ b/linera-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-explorer"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Block explorer for the Linera network"
 readme = "README.md"

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer-example"
-version = "0.5.0"
+version = "0.6.0"
 description = "Indexer example."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-indexer/graphql-client/Cargo.toml
+++ b/linera-indexer/graphql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer-graphql-client"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "GraphQL client for the indexer"
 readme = "README.md"

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer"
-version = "0.5.0"
+version = "0.6.0"
 description = "Indexer for Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-indexer/plugins/Cargo.toml
+++ b/linera-indexer/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer-plugins"
-version = "0.5.0"
+version = "0.6.0"
 description = "Indexer plugins."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-rpc"
-version = "0.5.0"
+version = "0.6.0"
 description = "RPC schemas and networking library for the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-sdk-derive/Cargo.toml
+++ b/linera-sdk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk-derive"
-version = "0.5.0"
+version = "0.6.0"
 description = "The procedural macros for the crate `linera-sdk`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk"
-version = "0.5.0"
+version = "0.6.0"
 description = "Library to support developping Linera applications in Rust."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-sdk/wasm-tests/Cargo.toml
+++ b/linera-sdk/wasm-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk-wasm-tests"
-version = "0.1.0"
+version = "0.6.0"
 authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-service-graphql-client"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "A GraphQL client for Linera node service"
 readme = "README.md"

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-service"
-version = "0.5.0"
+version = "0.6.0"
 description = "Executable for clients (aka CLI wallets), proxy (aka validator frontend) and servers of the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-storage"
-version = "0.5.0"
+version = "0.6.0"
 description = "Storage abstractions for the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-views-derive/Cargo.toml
+++ b/linera-views-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-views-derive"
-version = "0.5.0"
+version = "0.6.0"
 description = "The procedural macros for the crate `linera-views`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-views"
-version = "0.5.0"
+version = "0.6.0"
 description = "A library mapping complex data structures onto a key-value store, used by the Linera protocol"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-witty-macros"
-version = "0.5.0"
+version = "0.6.0"
 description = "Procedural macros for generation of WIT compatible host code from Rust code"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-witty"
-version = "0.5.0"
+version = "0.6.0"
 description = "Generation of WIT compatible host code from Rust code"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty/test-modules/Cargo.toml
+++ b/linera-witty/test-modules/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"
 homepage = "https://linera.dev"
 license = "Apache-2.0"
-version = "0.1.0"
+version = "0.6.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Motivation

The update in validator configuration files with the addition of optional TLS for GRPC connections introduced breaking changes.

## Proposal

Bump the minor version.

## Test Plan

CI

## Release Plan

@ma2bd to release on `crates.io` after it's been merged into `main`.
