### PR TITLE
Verify data after initializing the wallet.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -604,6 +604,18 @@ impl ExecutedBlock {
         }
     }
 
+    pub fn message_by_id(&self, message_id: &MessageId) -> Option<&OutgoingMessage> {
+        let MessageId {
+            chain_id,
+            height,
+            index,
+        } = message_id;
+        if self.block.chain_id != *chain_id || self.block.height != *height {
+            return None;
+        }
+        self.messages.get(usize::try_from(*index).ok()?)
+    }
+
     /// Returns the message ID belonging to the `index`th outgoing message in this block.
     fn message_id(&self, index: u32) -> MessageId {
         MessageId {

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -9,7 +9,7 @@ use comfy_table::{
 };
 use file_lock::{FileLock, FileOptions};
 use linera_base::{
-    crypto::{CryptoHash, CryptoRng, KeyPair, PublicKey},
+    crypto::{BcsSignable, CryptoHash, CryptoRng, KeyPair, PublicKey},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId, Owner},
 };
@@ -458,6 +458,7 @@ pub struct GenesisConfig {
 
 impl Import for GenesisConfig {}
 impl Export for GenesisConfig {}
+impl BcsSignable for GenesisConfig {}
 
 impl GenesisConfig {
     pub fn new(

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -2,13 +2,13 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, Context, Error};
+use anyhow::{anyhow, bail, Context, Error};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
 use futures::{lock::Mutex, StreamExt};
 use linera_base::{
-    crypto::{CryptoRng, KeyPair, PublicKey},
+    crypto::{CryptoHash, CryptoRng, KeyPair, PublicKey},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, MessageId, Owner},
 };
@@ -48,6 +48,7 @@ use linera_views::{common::CommonStoreConfig, views::ViewError};
 use rand07::Rng;
 use serde_json::Value;
 use std::{
+    collections::HashMap,
     env, fs, iter,
     num::NonZeroU16,
     path::PathBuf,
@@ -73,7 +74,7 @@ use {
         config::NetworkProtocol, grpc_network::GrpcClient, mass::MassClient, simple_network,
         HandleCertificateRequest, RpcMessage,
     },
-    std::collections::{HashMap, HashSet},
+    std::collections::HashSet,
     tracing::{error, trace},
 };
 
@@ -1850,6 +1851,7 @@ impl Runnable for Job {
 
             Wallet(WalletCommand::Init {
                 faucet: Some(faucet_url),
+                with_other_chains,
                 ..
             }) => {
                 info!("Requesting a new chain from the faucet.");
@@ -1863,11 +1865,16 @@ impl Runnable for Job {
                 Self::assign_new_chain_to_key(
                     outcome.chain_id,
                     outcome.message_id,
-                    storage,
+                    storage.clone(),
                     public_key,
                     &mut context,
                 )
                 .await?;
+                let admin_id = context.wallet_state.genesis_admin_chain();
+                let chains = with_other_chains
+                    .into_iter()
+                    .chain([admin_id, outcome.chain_id]);
+                Self::print_peg_certificate_hash(storage, chains, &context).await?;
                 context.wallet_state.set_default_chain(outcome.chain_id)?;
                 context.save_wallet();
             }
@@ -1940,6 +1947,69 @@ impl Job {
             .wallet_state
             .assign_new_chain_to_key(public_key, chain_id, executed_block.block.timestamp)
             .context("could not assign the new chain")?;
+        Ok(())
+    }
+
+    /// Prints a warning message to explain that the wallet has been initialized using data from
+    /// untrusted nodes, and gives instructions to verify that we are connected to the right
+    /// network.
+    async fn print_peg_certificate_hash<S>(
+        storage: S,
+        chain_ids: impl IntoIterator<Item = ChainId>,
+        context: &ClientContext,
+    ) -> anyhow::Result<()>
+    where
+        S: Store + Clone + Send + Sync + 'static,
+        ViewError: From<S::ContextError>,
+    {
+        let mut chains = HashMap::new();
+        for chain_id in chain_ids {
+            if chains.contains_key(&chain_id) {
+                continue;
+            }
+            chains.insert(chain_id, storage.load_chain(chain_id).await?);
+        }
+        // Find a chain with the latest known epoch, preferably the admin chain.
+        let (peg_chain_id, _) = chains
+            .iter()
+            .filter_map(|(chain_id, chain)| {
+                let epoch = (*chain.execution_state.system.epoch.get())?;
+                let is_admin = Some(*chain_id) == *chain.execution_state.system.admin_id.get();
+                Some((*chain_id, (epoch, is_admin)))
+            })
+            .max_by_key(|(_, epoch)| *epoch)
+            .context("no active chain found")?;
+        let peg_chain = chains.remove(&peg_chain_id).unwrap();
+        // These are the still-trusted committees. Every chain tip should be signed by one of them.
+        let committees = peg_chain.execution_state.system.committees.get();
+        for (chain_id, chain) in &chains {
+            let Some(hash) = chain.tip_state.get().block_hash else {
+                continue; // This chain was created based on the genesis config.
+            };
+            let certificate = storage.read_certificate(hash).await?;
+            let committee = committees
+                .get(&certificate.value().epoch())
+                .ok_or_else(|| anyhow!("tip of chain {chain_id} is outdated."))?;
+            certificate.check(committee)?;
+        }
+        // This proves that once we have verified that the peg chain's tip is a block in the real
+        // network, we can be confident that all downloaded chains are.
+        let config_hash = CryptoHash::new(context.wallet_state.genesis_config());
+        let maybe_epoch = peg_chain.execution_state.system.epoch.get();
+        let epoch = maybe_epoch.context("missing epoch in peg chain")?.0;
+        warn!(
+            "Initialized wallet based on data provided by untrusted nodes. \
+            Please verify that the following is correct by comparing with a trusted user \
+            who is already connected to the network, and that {epoch} is the current epoch:\n\
+            genesis config hash: {config_hash}"
+        );
+        if let Some(peg_hash) = peg_chain.tip_state.get().block_hash {
+            warn!(
+                "In addition, verify that the following certificate exists in the real network:\n\
+                certificate hash: {peg_hash}\n\
+                chain ID:         {peg_chain_id}"
+            );
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

The faucet, or even the genesis validators, after a while, shouldn't be considered to be trusted. (No single entity should be, and _former_ validators shouldn't be either.)

## Proposal

Verify that the new chain was actually created and assigned to the user.

Print a warning with instructions for the user to verify the downloaded data

## Test Plan

The faucet end-to-end test exercises this code.

It's not clear that the added code and CI costs are worth having tests feeding a client different kinds of garbage data.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
