### PR TITLE
Rename now to local_time.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -332,7 +332,7 @@ where
         timestamp: Timestamp,
         messages: Vec<OutgoingMessage>,
         certificate_hash: CryptoHash,
-        now: Timestamp,
+        local_time: Timestamp,
     ) -> Result<(), ChainError> {
         let chain_id = self.chain_id();
         ensure!(
@@ -381,7 +381,7 @@ where
                         height,
                         index,
                     };
-                    self.execute_immediate_message(message_id, &message, timestamp, now)
+                    self.execute_immediate_message(message_id, &message, timestamp, local_time)
                         .await?;
                 }
             }
@@ -429,7 +429,7 @@ where
         message_id: MessageId,
         message: &Message,
         timestamp: Timestamp,
-        now: Timestamp,
+        local_time: Timestamp,
     ) -> Result<(), ChainError> {
         if let Message::System(SystemMessage::OpenChain {
             ownership,
@@ -456,7 +456,7 @@ where
             self.manager.get_mut().reset(
                 self.execution_state.system.ownership.get(),
                 BlockHeight(0),
-                now,
+                local_time,
             )?;
         }
         Ok(())
@@ -501,7 +501,7 @@ where
     pub async fn execute_block(
         &mut self,
         block: &Block,
-        now: Timestamp,
+        local_time: Timestamp,
     ) -> Result<BlockExecutionOutcome, ChainError> {
         let start_time = Instant::now();
 
@@ -642,7 +642,7 @@ where
         self.manager.get_mut().reset(
             self.execution_state.system.ownership.get(),
             block.height.try_add_one()?,
-            now,
+            local_time,
         )?;
 
         // Log Prometheus metrics

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1346,12 +1346,12 @@ where
     /// This will usually be the current time according to the local clock, but may be slightly
     /// ahead to make sure it's not earlier than the incoming messages or the previous block.
     async fn next_timestamp(&self, incoming_messages: &[IncomingMessage]) -> Timestamp {
-        let now = self.storage_client().await.current_time();
+        let local_time = self.storage_client().await.current_time();
         incoming_messages
             .iter()
             .map(|msg| msg.event.timestamp)
             .max()
-            .map_or(now, |timestamp| timestamp.max(now))
+            .map_or(local_time, |timestamp| timestamp.max(local_time))
             .max(self.timestamp)
     }
 


### PR DESCRIPTION
## Motivation

The current timestamp is called `now` in several places in the code. This is a bit ambiguous—is it the local time or the current block's timestamp?

## Proposal

Rename `now` to `local_time`.

## Test Plan

No logic changed.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
