### PR TITLE
Upgrade `syn` to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,7 +3190,7 @@ version = "0.6.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3357,7 +3357,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3524,7 +3524,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ sha3 = "0.10.8"
 similar-asserts = "1.5.0"
 static_assertions = "1.1.0"
 structopt = "0.3.26"
-syn = "1.0.109"
+syn = "2.0.39"
 tempfile = "3.8.1"
 test-case = "3.2.1"
 test-log = { version = "0.2.13", default-features = false, features = ["trace"] }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -229,7 +229,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -240,7 +240,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -810,7 +810,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -827,7 +827,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -896,7 +896,7 @@ checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1070,7 +1070,7 @@ dependencies = [
  "darling 0.20.1",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1243,7 +1243,7 @@ checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1765,7 +1765,7 @@ version = "0.6.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1824,7 +1824,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2345,7 +2345,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2929,7 +2929,7 @@ checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3209,7 +3209,7 @@ checksum = "f66edd6b6cd810743c0c71e1d085e92b01ce6a72782032e3f794c8284fe4bcdd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3250,7 +3250,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3299,7 +3299,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3388,7 +3388,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -4311,7 +4311,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -40,11 +40,15 @@ fn get_type_field(field: syn::Field) -> Option<syn::Ident> {
 fn custom_attribute(attributes: &[Attribute], key: &str) -> Option<LitStr> {
     attributes
         .iter()
-        .filter(|attribute| attribute.path.is_ident("view"))
+        .filter(|attribute| attribute.path().is_ident("view"))
         .filter_map(|attribute| match attribute.parse_args() {
             Ok(MetaNameValue {
                 path,
-                lit: Lit::Str(value),
+                value:
+                    syn::Expr::Lit(syn::ExprLit {
+                        lit: Lit::Str(value),
+                        ..
+                    }),
                 ..
             }) => path.is_ident(key).then_some(value),
             _ => panic!(

--- a/linera-witty-macros/src/util.rs
+++ b/linera-witty-macros/src/util.rs
@@ -82,8 +82,12 @@ impl AttributeParameters {
             .iter()
             .find(|pair| pair.path.is_ident(name))
             .map(|pair| {
-                let Lit::Str(lit_str) = &pair.lit else {
-                    abort!(&pair.lit, "Expected a string literal");
+                let syn::Expr::Lit(syn::ExprLit {
+                    lit: Lit::Str(lit_str),
+                    ..
+                }) = &pair.value
+                else {
+                    abort!(&pair.value, "Expected a string literal");
                 };
 
                 lit_str.value()

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -8,14 +8,14 @@ use proc_macro2::{Span, TokenStream};
 use proc_macro_error::abort;
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
-    spanned::Spanned, FnArg, GenericArgument, GenericParam, Ident, ImplItem, ImplItemMethod,
-    LitStr, PatType, Path, PathArguments, PathSegment, ReturnType, Signature, Token, Type,
-    TypePath, TypeReference,
+    spanned::Spanned, FnArg, GenericArgument, GenericParam, Ident, ImplItem, ImplItemFn, LitStr,
+    PatType, Path, PathArguments, PathSegment, ReturnType, Signature, Token, Type, TypePath,
+    TypeReference,
 };
 
 /// Pieces of information extracted from a function's definition.
 pub struct FunctionInformation<'input> {
-    function: &'input ImplItemMethod,
+    function: &'input ImplItemFn,
     wit_name: String,
     is_reentrant: bool,
     parameter_bindings: TokenStream,
@@ -28,7 +28,7 @@ impl<'input> FunctionInformation<'input> {
     /// [`FunctionInformation`] instance.
     pub fn from_item(item: &'input ImplItem, caller_type_parameter: Option<&'input Ident>) -> Self {
         match item {
-            ImplItem::Method(function) => FunctionInformation::new(function, caller_type_parameter),
+            ImplItem::Fn(function) => FunctionInformation::new(function, caller_type_parameter),
             ImplItem::Const(const_item) => abort!(
                 const_item.ident,
                 "Const items are not supported in exported types"
@@ -47,7 +47,7 @@ impl<'input> FunctionInformation<'input> {
 
     /// Parses a function definition and collects pieces of information into a
     /// [`FunctionInformation`] instance.
-    pub fn new(function: &'input ImplItemMethod, caller_type: Option<&'input Ident>) -> Self {
+    pub fn new(function: &'input ImplItemFn, caller_type: Option<&'input Ident>) -> Self {
         let wit_name = function.sig.ident.to_string().to_kebab_case();
         let is_reentrant = Self::is_reentrant(&function.sig)
             || Self::uses_caller_parameter(&function.sig, caller_type);

--- a/linera-witty-macros/src/wit_import.rs
+++ b/linera-witty-macros/src/wit_import.rs
@@ -9,9 +9,7 @@ use proc_macro2::{Span, TokenStream};
 use proc_macro_error::abort;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use std::collections::HashSet;
-use syn::{
-    spanned::Spanned, FnArg, Ident, ItemTrait, LitStr, ReturnType, TraitItem, TraitItemMethod,
-};
+use syn::{spanned::Spanned, FnArg, Ident, ItemTrait, LitStr, ReturnType, TraitItem, TraitItemFn};
 
 /// Returns the code generated for calling imported Wasm functions.
 ///
@@ -34,7 +32,7 @@ pub struct WitImportGenerator<'input> {
 
 /// Pieces of information extracted from a function's definition.
 struct FunctionInformation<'input> {
-    function: &'input TraitItemMethod,
+    function: &'input TraitItemFn,
     parameter_definitions: TokenStream,
     parameter_bindings: TokenStream,
     return_type: TokenStream,
@@ -215,7 +213,7 @@ impl<'input> WitImportGenerator<'input> {
 impl<'input> FunctionInformation<'input> {
     /// Extracts the necessary information from the `function` and stores it in a new
     /// [`FunctionInformation`] instance.
-    pub fn new(function: &'input TraitItemMethod) -> Self {
+    pub fn new(function: &'input TraitItemFn) -> Self {
         let (parameter_definitions, parameter_bindings, parameter_types) =
             Self::parse_parameters(function.sig.inputs.iter());
 
@@ -291,7 +289,7 @@ impl<'input> FunctionInformation<'input> {
 impl<'input> From<&'input TraitItem> for FunctionInformation<'input> {
     fn from(item: &'input TraitItem) -> Self {
         match item {
-            TraitItem::Method(function) => FunctionInformation::new(function),
+            TraitItem::Fn(function) => FunctionInformation::new(function),
             TraitItem::Const(const_item) => abort!(
                 const_item.ident,
                 "Const items are not supported in imported traits"


### PR DESCRIPTION
## Motivation

`syn` has released a new major version.  The upgrade isn't particularly painful, and it allows us to use crates that depend on the newer `syn` (such as `prettyplease` for prettifying code, e.g. for https://github.com/linera-io/linera-protocol/pull/1237#discussion_r1395301520).

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Upgrade `syn` to 2.0.39.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Build and run CI tests.

<!-- How to test that the changes are correct. -->

## Release Plan

This change should be invisible to consumers.

## Links

- https://github.com/linera-io/linera-protocol/pull/1237
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
