### PR TITLE
Codify linting toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -102,11 +102,11 @@ jobs:
       run: >
         find linera-* -name '*.rs' -a -not -wholename '*/target/*' -print0
         | xargs -0 -L1 ./scripts/target/release/check_copyright_header
+    - name: Put lint toolchain file in place
+      run: |
+        ln -sf rust-toolchain.lint.toml rust-toolchain.toml
     - uses: Twey/setup-rust-toolchain@v1
-      with:
-        toolchain: nightly-2023-10-22
-        target: wasm32-unknown-unknown
-        components: clippy rustfmt
+      working-directory: toolchains/lint
     - name: Install cargo-machete
       run: |
         cargo install cargo-machete --locked

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697723726,
-        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "lastModified": 1699781429,
+        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1697940838,
-        "narHash": "sha256-eyk92QqAoRNC0V99KOcKcBZjLPixxNBS0PRc4KlSQVs=",
+        "lastModified": 1700100993,
+        "narHash": "sha256-Zc//DbR3eMGajG09iQUMTO/Tc/fdUYmTAzXYdxx5MKw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a3e829c06eadf848f13d109c7648570ce37ebccd",
+        "rev": "b7a041430733fccaa1ffc3724bb9454289d0f701",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1697388351,
-        "narHash": "sha256-63N2eBpKaziIy4R44vjpUu8Nz5fCJY7okKrkixvDQmY=",
+        "lastModified": 1699786194,
+        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "aae39f64f5ecbe89792d05eacea5cb241891292a",
+        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,12 +26,10 @@
           pkg-config
           nodejs
         ];
-        rustToolchain = (pkgs.rust-bin.fromRustupToolchainFile
-          ./rust-toolchain.toml);
-        rustPlatform = pkgs.makeRustPlatform {
-          rustc = rustToolchain;
-          cargo = rustToolchain;
-        };
+        rustBuildToolchain = (pkgs.rust-bin.fromRustupToolchainFile
+          ./toolchains/build/rust-toolchain.toml);
+        rustLintToolchain = (pkgs.rust-bin.fromRustupToolchainFile
+          ./toolchains/lint/rust-toolchain.toml);
       in {
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
@@ -45,15 +43,19 @@
           ];
           shellHook = ''
             # For rust-analyzer 'hover' tooltips to work.
-            export RUST_SRC_PATH=${rustToolchain.availableComponents.rust-src}
+            export RUST_SRC_PATH=${rustBuildToolchain.availableComponents.rust-src}
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib
             export PATH=$PWD/target/release:~/.cargo/bin:$PATH
           '';
           buildInputs = nonRustDeps;
           nativeBuildInputs = with pkgs; [
-            rustToolchain
+            rustBuildToolchain
             rust-analyzer
           ];
+        };
+
+        devShells.lint = pkgs.mkShell {
+          nativeBuildInputs = [ rustLintToolchain ];
         };
 
         # Add your auto-formatters here.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,1 @@
-[toolchain]
-channel = "1.73.0"
-components = [ "clippy", "rustfmt", "rust-src" ]
-targets = [ "wasm32-unknown-unknown" ]
-profile = "minimal"
+toolchains/build/rust-toolchain.toml

--- a/toolchains/build/rust-toolchain.toml
+++ b/toolchains/build/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.73.0"
+components = [ "clippy", "rustfmt", "rust-src" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"

--- a/toolchains/lint/rust-toolchain.toml
+++ b/toolchains/lint/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-10-23"
+components = [ "clippy", "rustfmt" ]
+profile = "minimal"


### PR DESCRIPTION
## Motivation

It is unfortunate that our linting toolchain is only specified in the GitHub actions, as this requires local developers to keep their local nightly updated to match that file.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

This PR moves the specification of our linting toolchain out of the GitHub actions into a dedicated toolchain file.  Different toolchains are stored in `toolchains/{name}/rust-toolchain.toml`, which should make it possible to select between them in CI by running the action from that directory.  Eventually this will no longer be necessary, as `rustup` [is planning to add support for multiple toolchain files](https://github.com/rust-lang/rustup/issues/2686).

We also add a new `devShell` to the Nix flake that references the linting toolchain file, allowing `nix develop .#lint` to drop the developer into a shell suitable for running our CI lints.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

These changes should be invisible to the user.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- https://github.com/rust-lang/rustup/issues/2686 will allow us to simplify the toolchain structure, as well as add a `rustup ensure` command to replace the (deprecated) behaviour of `rustup show` that is currently relied upon by the action. 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
