### PR TITLE
Add a network name to the genesis config.

### DIFF
--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -454,6 +454,7 @@ pub struct GenesisConfig {
     pub timestamp: Timestamp,
     pub chains: Vec<(PublicKey, Amount)>,
     pub policy: ResourceControlPolicy,
+    pub network_name: String,
 }
 
 impl Import for GenesisConfig {}
@@ -466,6 +467,7 @@ impl GenesisConfig {
         admin_id: ChainId,
         timestamp: Timestamp,
         policy: ResourceControlPolicy,
+        network_name: String,
     ) -> Self {
         Self {
             committee,
@@ -473,6 +475,7 @@ impl GenesisConfig {
             timestamp,
             chains: Vec::new(),
             policy,
+            network_name,
         }
     }
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -941,6 +941,10 @@ enum ClientCommand {
         /// TESTING ONLY.
         #[structopt(long)]
         testing_prng_seed: Option<u64>,
+
+        /// A unique name to identify this network.
+        #[structopt(long)]
+        network_name: Option<String>,
     },
 
     /// Watch the network for notifications.
@@ -2042,6 +2046,7 @@ async fn main() -> Result<(), anyhow::Error> {
             maximum_bytes_written_per_block,
             messages_price,
             testing_prng_seed,
+            network_name,
         } => {
             let committee_config = CommitteeConfig::read(committee_config_path)
                 .expect("Unable to read committee config file");
@@ -2071,8 +2076,12 @@ async fn main() -> Result<(), anyhow::Error> {
                 })
                 .unwrap_or_else(Timestamp::now);
             let admin_id = ChainId::root(*admin_root);
+            let network_name = network_name.clone().unwrap_or_else(|| {
+                // Default: e.g. "linera-test-2023-11-14T23:13:20"
+                format!("linera-test-{}", Utc::now().naive_utc().format("%FT%T"))
+            });
             let mut genesis_config =
-                GenesisConfig::new(committee_config, admin_id, timestamp, policy);
+                GenesisConfig::new(committee_config, admin_id, timestamp, policy, network_name);
             let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
             let mut chains = vec![];
             for i in 0..*num {


### PR DESCRIPTION
## Motivation

We want to identify and distinguish different networks, like devnet vs. testnet vs. mainnet.

## Proposal

Add a network name to the genesis config.

## Test Plan

This is not being used for anything yet.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
