### PR TITLE
CI: add timeouts and reduce CPU costs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -52,19 +52,19 @@ jobs:
         publish_branch: gh-pages
         publish_dir: ./target/doc
 
-  docsrs:
-    runs-on: ubuntu-latest-16-cores
+  # TODO(#802): Fix this job.
+  # docsrs:
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v3
-    - uses: Twey/setup-rust-toolchain@v1
-    - name: Checkout docs.rs tool repository
-      run: |
-        cd ${{ runner.temp }}
-        git clone https://github.com/rust-lang/docs.rs docsrs
-        cd docsrs
-        git submodule update --init
-    # TODO(#802): Fix this.
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - uses: Twey/setup-rust-toolchain@v1
+  #   - name: Checkout docs.rs tool repository
+  #     run: |
+  #       cd ${{ runner.temp }}
+  #       git clone https://github.com/rust-lang/docs.rs docsrs
+  #       cd docsrs
+  #       git submodule update --init
     # - name: Generate standalone packages
     #   run: |
     #     for crate in $LINERA_CRATES; do

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -49,7 +49,7 @@ jobs:
         cargo build --locked --release --target wasm32-unknown-unknown
     - name: Build
       run: |
-        cargo build --locked --release --features aws
+        cargo build --locked --features aws
     - name: Setup local DynamoDB instance
       run: |
         docker run --rm -d --name local-dynamodb -p 8000:8000/tcp amazon/dynamodb-local
@@ -60,4 +60,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: test
         LOCALSTACK_ENDPOINT: http://localhost:8000
       run: |
-        cargo test --locked --release --features aws -- dynamo
+        cargo test --locked --features aws -- dynamo

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -32,8 +32,10 @@ permissions:
 
 jobs:
 
-  build:
+  test:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 30
+
     steps:
     - uses: actions/checkout@v3
     - uses: Twey/setup-rust-toolchain@v1

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -47,7 +47,7 @@ jobs:
         cargo build --locked --release --target wasm32-unknown-unknown
     - name: Build
       run: |
-        cargo build --locked --features aws
+        cargo build --locked --release --features aws
     - name: Setup local DynamoDB instance
       run: |
         docker run --rm -d --name local-dynamodb -p 8000:8000/tcp amazon/dynamodb-local
@@ -58,4 +58,4 @@ jobs:
         AWS_SECRET_ACCESS_KEY: test
         LOCALSTACK_ENDPOINT: http://localhost:8000
       run: |
-        cargo test --locked --features aws -- dynamo
+        cargo test --locked --release --features aws -- dynamo

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -32,7 +32,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -33,6 +33,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 30
+
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -30,6 +30,7 @@ jobs:
 
   local-kind-deployment-integration-test:
     runs-on: ubuntu-latest-16-cores
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
 
   local-kind-deployment-integration-test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,6 +34,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
         cargo test -p linera-witty --features wasmer,wasmtime
 
   lint:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -32,8 +32,10 @@ permissions:
 
 jobs:
 
-  build:
+  test:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 30
+
     steps:
     - uses: actions/checkout@v3
     - uses: Twey/setup-rust-toolchain@v1

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -49,10 +49,10 @@ jobs:
         cargo build --locked --release --target wasm32-unknown-unknown
     - name: Build
       run: |
-        cargo build --locked --release --features scylladb
+        cargo build --locked --features scylladb
     - name: Setup local ScyllaDB instance
       run: |
         docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla
     - name: Run ScyllaDB tests
       run: |
-        cargo test --locked --release --features scylladb -- scylla
+        cargo test --locked --features scylladb -- scylla

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -47,10 +47,10 @@ jobs:
         cargo build --locked --release --target wasm32-unknown-unknown
     - name: Build
       run: |
-        cargo build --locked --features scylladb
+        cargo build --locked --release --features scylladb
     - name: Setup local ScyllaDB instance
       run: |
         docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla
     - name: Run ScyllaDB tests
       run: |
-        cargo test --locked --features scylladb -- scylla
+        cargo test --locked --release --features scylladb -- scylla


### PR DESCRIPTION
## Motivation

When a test deadlocks, this currently costs 360 minutes of a 16-core machine.

## Proposal

* Add timeouts for test jobs
* Reduce the number of cores for certain jobs

Note that the default `ubuntu-latest` has 2 cores and is free for opensource projects (up to a limit).
Otherwise, github charges per minute per core.

## Test Plan

CI