### PR TITLE
Print more useful info on build_and_redeploy

### DIFF
--- a/kubernetes/linera-validator/build_and_redeploy.sh
+++ b/kubernetes/linera-validator/build_and_redeploy.sh
@@ -141,8 +141,12 @@ kubectl get pods
 echo -e "\nServices:"
 kubectl get svc
 
-docker rm linera-test-local || true
-docker run -d --name linera-test-local "$docker_image"
+echo -e "\nMake sure the terminal you'll run the linera client from has these exports:"
+echo 'export LINERA_WALLET=/tmp/wallet.json'
+echo 'export LINERA_STORAGE="rocksdb:/tmp/linera.db"'
+
+echo -e "\nTo access Prometheus, you need to port forward yourself, that won't be done here. Run:"
+echo -e "kubectl port-forward prometheus-linera-core-kube-prometheu-prometheus-0 9090"
 
 # Get the Grafana pod name
 grafana_pod_name=$(kubectl get pods | grep grafana | awk '{ print $1 }')


### PR DESCRIPTION
## Motivation

Having the exports prints are still useful, because we have `linera net up` and `build_and_redeploy`, which tell you to point to different wallets and storage.
So if you use `linera net up`, then go back to using `build_and_redeploy`, and you don't know you have to export the `/tmp` wallet and storage, connection to your validator will fail, and if you don't know this you'll be confused :)
Having prometheus info is useful and we should've added a while back.

## Proposal

Add the proposed prints

## Test Plan

Run `build_and_redeploy`, saw the prints
