### PR TITLE
Split WasmApplication into WasmContract and WasmService

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -12,6 +12,8 @@ mod outbox;
 pub mod test;
 
 pub use chain::ChainStateView;
+pub use manager::{ChainManager, ChainManagerInfo, Outcome as ChainManagerOutcome};
+
 use data_types::{Event, Origin};
 use linera_base::{
     crypto::CryptoError,
@@ -20,7 +22,6 @@ use linera_base::{
 };
 use linera_execution::{policy::PricingError, ExecutionError};
 use linera_views::views::ViewError;
-pub use manager::{ChainManager, ChainManagerInfo, Outcome as ChainManagerOutcome};
 use rand_distr::WeightedError;
 use thiserror::Error;
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -30,8 +30,7 @@ use linera_execution::{
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
     GenericApplicationId, Message, Operation, OperationContext, ResourceTracker,
-    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmApplication,
-    WasmRuntime,
+    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmContract, WasmRuntime,
 };
 use linera_storage::{MemoryStoreClient, Store};
 use linera_views::views::{CryptoHashView, ViewError};
@@ -117,14 +116,7 @@ where
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
     let contract_bytecode = Bytecode::load_from_file(contract_path).await?;
     let service_bytecode = Bytecode::load_from_file(service_path).await?;
-    let application = Arc::new(
-        WasmApplication::new(
-            contract_bytecode.clone(),
-            service_bytecode.clone(),
-            wasm_runtime,
-        )
-        .await?,
-    );
+    let contract = Arc::new(WasmContract::new(contract_bytecode.clone(), wasm_runtime).await?);
 
     // Publish some bytecode.
     let publish_operation = SystemOperation::PublishBytecode {
@@ -378,7 +370,7 @@ where
     let mut creator_state = ExecutionStateView::from_system_state(creator_system_state).await;
     creator_state
         .simulate_initialization(
-            application,
+            contract,
             application_description,
             initial_value_bytes.clone(),
         )

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    policy::ResourceControlPolicy,
+    resources::{ResourceTracker, RuntimeLimits},
     runtime::{ApplicationStatus, ExecutionRuntime, SessionManager},
     system::SystemExecutionStateView,
     ContractRuntime, ExecutionError, ExecutionResult, ExecutionRuntimeContext, Message,
     MessageContext, Operation, OperationContext, Query, QueryContext, RawExecutionResult,
-    RawOutgoingMessage, ResourceControlPolicy, ResourceTracker, Response, RuntimeLimits,
-    SystemMessage, UserApplicationDescription, UserApplicationId,
+    RawOutgoingMessage, Response, SystemMessage, UserApplicationDescription, UserApplicationId,
 };
 use linera_base::{
     ensure,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -57,7 +57,7 @@ use thiserror::Error;
 /// An implementation of [`UserContract`]
 pub type UserContractCode = Arc<dyn UserContract + Send + Sync + 'static>;
 
-/// An implementation of [`ServiceApplication`]
+/// An implementation of [`UserService`].
 pub type UserServiceCode = Arc<dyn UserService + Send + Sync + 'static>;
 
 #[derive(Error, Debug)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -30,7 +30,7 @@ pub use system::{
 ))]
 pub use wasm::test as wasm_test;
 #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
-pub use wasm::{WasmApplication, WasmExecutionError};
+pub use wasm::{WasmContract, WasmExecutionError, WasmService};
 #[cfg(any(test, feature = "test"))]
 pub use {applications::ApplicationRegistry, system::SystemExecutionState};
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -9,10 +9,10 @@ mod execution;
 mod graphql;
 mod ownership;
 pub mod policy;
+mod resources;
 mod runtime;
 pub mod system;
 mod wasm;
-use crate::policy::{PricingError, ResourceControlPolicy};
 
 pub use applications::{
     ApplicationRegistryView, BytecodeLocation, GenericApplicationId, UserApplicationDescription,
@@ -20,6 +20,7 @@ pub use applications::{
 };
 pub use execution::ExecutionStateView;
 pub use ownership::ChainOwnership;
+pub use resources::ResourceTracker;
 pub use system::{
     SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,
     SystemResponse,
@@ -34,6 +35,7 @@ pub use wasm::{WasmContract, WasmExecutionError, WasmService};
 #[cfg(any(test, feature = "test"))]
 pub use {applications::ApplicationRegistry, system::SystemExecutionState};
 
+use crate::policy::PricingError;
 use async_graphql::SimpleObject;
 use async_trait::async_trait;
 use custom_debug_derive::Debug;
@@ -47,139 +49,10 @@ use linera_base::{
     identifiers::{BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner, SessionId},
 };
 use linera_views::{batch::Batch, views::ViewError};
+use resources::RuntimeCounts;
 use serde::{Deserialize, Serialize};
 use std::{io, path::Path, str::FromStr, sync::Arc};
 use thiserror::Error;
-
-/// The entries of the runtime related to storage
-#[derive(Copy, Debug, Clone)]
-pub struct RuntimeLimits {
-    /// maximum_budget for reading
-    pub max_budget_num_reads: u64,
-    /// maximum budget of bytes read
-    pub max_budget_bytes_read: u64,
-    /// maximum budget of bytes written
-    pub max_budget_bytes_written: u64,
-    /// The maximum size of read allowed per block
-    pub maximum_bytes_left_to_read: u64,
-    /// The maximum size of write allowed per block
-    pub maximum_bytes_left_to_write: u64,
-}
-
-/// The entries of the runtime related to storage
-#[derive(Copy, Debug, Clone)]
-pub struct ResourceTracker {
-    /// The used fuel in the computation
-    pub used_fuel: u64,
-    /// The number of reads in the computation
-    pub num_reads: u64,
-    /// The total number of bytes read
-    pub bytes_read: u64,
-    /// The total number of bytes written
-    pub bytes_written: u64,
-    /// The maximum size of read that remains available for use
-    pub maximum_bytes_left_to_read: u64,
-    /// The maximum size of write that remains available for use
-    pub maximum_bytes_left_to_write: u64,
-}
-
-#[cfg(any(test, feature = "test"))]
-impl Default for ResourceTracker {
-    fn default() -> Self {
-        ResourceTracker {
-            used_fuel: 0,
-            num_reads: 0,
-            bytes_read: 0,
-            bytes_written: 0,
-            maximum_bytes_left_to_read: u64::MAX / 2,
-            maximum_bytes_left_to_write: u64::MAX / 2,
-        }
-    }
-}
-
-impl Default for RuntimeLimits {
-    fn default() -> Self {
-        RuntimeLimits {
-            max_budget_num_reads: u64::MAX / 2,
-            max_budget_bytes_read: u64::MAX / 2,
-            max_budget_bytes_written: u64::MAX / 2,
-            maximum_bytes_left_to_read: u64::MAX / 2,
-            maximum_bytes_left_to_write: u64::MAX / 2,
-        }
-    }
-}
-
-impl ResourceTracker {
-    /// Subtracts an amount from a balance and reports an error if that is impossible
-    fn sub_assign_fees(balance: &mut Amount, fees: Amount) -> Result<(), SystemExecutionError> {
-        balance
-            .try_sub_assign(fees)
-            .map_err(|_| SystemExecutionError::InsufficientFunding {
-                current_balance: *balance,
-            })
-    }
-
-    /// Updates the limits for the maximum and updates the balance.
-    pub fn update_limits(
-        &mut self,
-        balance: &mut Amount,
-        policy: &ResourceControlPolicy,
-        runtime_counts: RuntimeCounts,
-    ) -> Result<(), ExecutionError> {
-        // The fuel being used
-        let initial_fuel = policy.remaining_fuel(*balance);
-        let used_fuel = initial_fuel.saturating_sub(runtime_counts.remaining_fuel);
-        self.used_fuel += used_fuel;
-        Self::sub_assign_fees(balance, policy.fuel_price(used_fuel)?)?;
-        // The number of reads
-        Self::sub_assign_fees(
-            balance,
-            policy.storage_num_reads_price(&runtime_counts.num_reads)?,
-        )?;
-        self.num_reads += runtime_counts.num_reads;
-        // The number of bytes read
-        let bytes_read = runtime_counts.bytes_read;
-        self.maximum_bytes_left_to_read -= bytes_read;
-        self.bytes_read += runtime_counts.bytes_read;
-        Self::sub_assign_fees(balance, policy.storage_bytes_read_price(&bytes_read)?)?;
-        // The number of bytes written
-        let bytes_written = runtime_counts.bytes_written;
-        self.maximum_bytes_left_to_write -= bytes_written;
-        self.bytes_written += bytes_written;
-        Self::sub_assign_fees(balance, policy.storage_bytes_written_price(&bytes_written)?)?;
-        Ok(())
-    }
-
-    /// Obtain the limits for the running of the system
-    pub fn limits(&self, policy: &ResourceControlPolicy, balance: &Amount) -> RuntimeLimits {
-        let max_budget_num_reads =
-            u64::try_from(balance.saturating_div(policy.storage_num_reads)).unwrap_or(u64::MAX);
-        let max_budget_bytes_read =
-            u64::try_from(balance.saturating_div(policy.storage_bytes_read)).unwrap_or(u64::MAX);
-        let max_budget_bytes_written =
-            u64::try_from(balance.saturating_div(policy.storage_bytes_read)).unwrap_or(u64::MAX);
-        RuntimeLimits {
-            max_budget_num_reads,
-            max_budget_bytes_read,
-            max_budget_bytes_written,
-            maximum_bytes_left_to_read: self.maximum_bytes_left_to_read,
-            maximum_bytes_left_to_write: self.maximum_bytes_left_to_write,
-        }
-    }
-}
-
-/// The entries of the runtime related to fuel and storage
-#[derive(Copy, Debug, Clone)]
-pub struct RuntimeCounts {
-    /// The remaining fuel available
-    pub remaining_fuel: u64,
-    /// The number of read operations
-    pub num_reads: u64,
-    /// The bytes that have been read
-    pub bytes_read: u64,
-    /// The bytes that have been written
-    pub bytes_written: u64,
-}
 
 /// An implementation of [`UserContract`]
 pub type UserContractCode = Arc<dyn UserContract + Send + Sync + 'static>;

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -11,11 +11,11 @@ use linera_base::data_types::Amount;
 /// The entries of the runtime related to storage
 #[derive(Copy, Debug, Clone)]
 pub struct RuntimeLimits {
-    /// maximum_budget for reading
+    /// The maximum read requests per block
     pub max_budget_num_reads: u64,
-    /// maximum budget of bytes read
+    /// The maximum number of bytes that can be read per block
     pub max_budget_bytes_read: u64,
-    /// maximum budget of bytes written
+    /// The maximum number of bytes that can be written per block
     pub max_budget_bytes_written: u64,
     /// The maximum size of read allowed per block
     pub maximum_bytes_left_to_read: u64,

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -1,0 +1,139 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module tracks the resources used during the execution of a transaction.
+
+use crate::{policy::ResourceControlPolicy, system::SystemExecutionError, ExecutionError};
+
+use custom_debug_derive::Debug;
+use linera_base::data_types::Amount;
+
+/// The entries of the runtime related to storage
+#[derive(Copy, Debug, Clone)]
+pub struct RuntimeLimits {
+    /// maximum_budget for reading
+    pub max_budget_num_reads: u64,
+    /// maximum budget of bytes read
+    pub max_budget_bytes_read: u64,
+    /// maximum budget of bytes written
+    pub max_budget_bytes_written: u64,
+    /// The maximum size of read allowed per block
+    pub maximum_bytes_left_to_read: u64,
+    /// The maximum size of write allowed per block
+    pub maximum_bytes_left_to_write: u64,
+}
+
+/// The entries of the runtime related to storage
+#[derive(Copy, Debug, Clone)]
+pub struct ResourceTracker {
+    /// The used fuel in the computation
+    pub used_fuel: u64,
+    /// The number of reads in the computation
+    pub num_reads: u64,
+    /// The total number of bytes read
+    pub bytes_read: u64,
+    /// The total number of bytes written
+    pub bytes_written: u64,
+    /// The maximum size of read that remains available for use
+    pub maximum_bytes_left_to_read: u64,
+    /// The maximum size of write that remains available for use
+    pub maximum_bytes_left_to_write: u64,
+}
+
+#[cfg(any(test, feature = "test"))]
+impl Default for ResourceTracker {
+    fn default() -> Self {
+        ResourceTracker {
+            used_fuel: 0,
+            num_reads: 0,
+            bytes_read: 0,
+            bytes_written: 0,
+            maximum_bytes_left_to_read: u64::MAX / 2,
+            maximum_bytes_left_to_write: u64::MAX / 2,
+        }
+    }
+}
+
+impl Default for RuntimeLimits {
+    fn default() -> Self {
+        RuntimeLimits {
+            max_budget_num_reads: u64::MAX / 2,
+            max_budget_bytes_read: u64::MAX / 2,
+            max_budget_bytes_written: u64::MAX / 2,
+            maximum_bytes_left_to_read: u64::MAX / 2,
+            maximum_bytes_left_to_write: u64::MAX / 2,
+        }
+    }
+}
+
+impl ResourceTracker {
+    /// Subtracts an amount from a balance and reports an error if that is impossible
+    fn sub_assign_fees(balance: &mut Amount, fees: Amount) -> Result<(), SystemExecutionError> {
+        balance
+            .try_sub_assign(fees)
+            .map_err(|_| SystemExecutionError::InsufficientFunding {
+                current_balance: *balance,
+            })
+    }
+
+    /// Updates the limits for the maximum and updates the balance.
+    pub fn update_limits(
+        &mut self,
+        balance: &mut Amount,
+        policy: &ResourceControlPolicy,
+        runtime_counts: RuntimeCounts,
+    ) -> Result<(), ExecutionError> {
+        // The fuel being used
+        let initial_fuel = policy.remaining_fuel(*balance);
+        let used_fuel = initial_fuel.saturating_sub(runtime_counts.remaining_fuel);
+        self.used_fuel += used_fuel;
+        Self::sub_assign_fees(balance, policy.fuel_price(used_fuel)?)?;
+        // The number of reads
+        Self::sub_assign_fees(
+            balance,
+            policy.storage_num_reads_price(&runtime_counts.num_reads)?,
+        )?;
+        self.num_reads += runtime_counts.num_reads;
+        // The number of bytes read
+        let bytes_read = runtime_counts.bytes_read;
+        self.maximum_bytes_left_to_read -= bytes_read;
+        self.bytes_read += runtime_counts.bytes_read;
+        Self::sub_assign_fees(balance, policy.storage_bytes_read_price(&bytes_read)?)?;
+        // The number of bytes written
+        let bytes_written = runtime_counts.bytes_written;
+        self.maximum_bytes_left_to_write -= bytes_written;
+        self.bytes_written += bytes_written;
+        Self::sub_assign_fees(balance, policy.storage_bytes_written_price(&bytes_written)?)?;
+        Ok(())
+    }
+
+    /// Obtain the limits for the running of the system
+    pub fn limits(&self, policy: &ResourceControlPolicy, balance: &Amount) -> RuntimeLimits {
+        let max_budget_num_reads =
+            u64::try_from(balance.saturating_div(policy.storage_num_reads)).unwrap_or(u64::MAX);
+        let max_budget_bytes_read =
+            u64::try_from(balance.saturating_div(policy.storage_bytes_read)).unwrap_or(u64::MAX);
+        let max_budget_bytes_written =
+            u64::try_from(balance.saturating_div(policy.storage_bytes_read)).unwrap_or(u64::MAX);
+        RuntimeLimits {
+            max_budget_num_reads,
+            max_budget_bytes_read,
+            max_budget_bytes_written,
+            maximum_bytes_left_to_read: self.maximum_bytes_left_to_read,
+            maximum_bytes_left_to_write: self.maximum_bytes_left_to_write,
+        }
+    }
+}
+
+/// The entries of the runtime related to fuel and storage
+#[derive(Copy, Debug, Clone)]
+pub struct RuntimeCounts {
+    /// The remaining fuel available
+    pub remaining_fuel: u64,
+    /// The number of read operations
+    pub num_reads: u64,
+    /// The bytes that have been read
+    pub bytes_read: u64,
+    /// The bytes that have been written
+    pub bytes_written: u64,
+}

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -33,7 +33,7 @@ use std::{
 };
 
 /// Runtime data tracked during the execution of a transaction.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ExecutionRuntime<'a, C, const WRITABLE: bool> {
     /// The current chain ID.
     chain_id: ChainId,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -38,28 +38,28 @@ pub(crate) struct ExecutionRuntime<'a, C, const WRITABLE: bool> {
     /// The current chain ID.
     chain_id: ChainId,
     /// The current stack of application descriptions.
-    applications: Arc<Mutex<&'a mut Vec<ApplicationStatus>>>,
+    applications: Mutex<&'a mut Vec<ApplicationStatus>>,
     /// The storage view on the execution state.
-    execution_state: Arc<Mutex<&'a mut ExecutionStateView<C>>>,
+    execution_state: Mutex<&'a mut ExecutionStateView<C>>,
     /// All the sessions and their IDs.
-    session_manager: Arc<Mutex<&'a mut SessionManager>>,
+    session_manager: Mutex<&'a mut SessionManager>,
     /// Track active (i.e. locked) applications for which re-entrancy is disallowed.
-    active_simple_user_states: Arc<Mutex<ActiveSimpleUserStates<C>>>,
+    active_simple_user_states: Mutex<ActiveSimpleUserStates<C>>,
     /// Track active (i.e. locked) applications for which re-entrancy is disallowed.
-    active_view_user_states: Arc<Mutex<ActiveViewUserStates<C>>>,
+    active_view_user_states: Mutex<ActiveViewUserStates<C>>,
     /// Track active (i.e. locked) sessions for which re-entrancy is disallowed.
-    active_sessions: Arc<Mutex<ActiveSessions>>,
+    active_sessions: Mutex<ActiveSessions>,
     /// Accumulate the externally visible results (e.g. cross-chain messages) of applications.
-    execution_results: Arc<Mutex<&'a mut Vec<ExecutionResult>>>,
+    execution_results: Mutex<&'a mut Vec<ExecutionResult>>,
 
     /// The amount of fuel available for executing the application.
-    remaining_fuel: Arc<AtomicU64>,
+    remaining_fuel: AtomicU64,
     /// The number of reads
-    num_reads: Arc<AtomicU64>,
+    num_reads: AtomicU64,
     /// the total size being read
-    bytes_read: Arc<AtomicU64>,
+    bytes_read: AtomicU64,
     /// The total size being written
-    bytes_written: Arc<AtomicU64>,
+    bytes_written: AtomicU64,
     /// The runtime limits
     runtime_limits: RuntimeLimits,
 }
@@ -115,17 +115,17 @@ where
     ) -> Self {
         assert_eq!(chain_id, execution_state.context().extra().chain_id());
         Self {
-            applications: Arc::new(Mutex::new(applications)),
-            execution_state: Arc::new(Mutex::new(execution_state)),
-            session_manager: Arc::new(Mutex::new(session_manager)),
-            active_simple_user_states: Arc::default(),
-            active_view_user_states: Arc::default(),
-            active_sessions: Arc::default(),
-            execution_results: Arc::new(Mutex::new(execution_results)),
-            remaining_fuel: Arc::new(AtomicU64::new(fuel)),
-            num_reads: Arc::new(AtomicU64::new(0)),
-            bytes_read: Arc::new(AtomicU64::new(0)),
-            bytes_written: Arc::new(AtomicU64::new(0)),
+            applications: Mutex::new(applications),
+            execution_state: Mutex::new(execution_state),
+            session_manager: Mutex::new(session_manager),
+            active_simple_user_states: Mutex::default(),
+            active_view_user_states: Mutex::default(),
+            active_sessions: Mutex::default(),
+            execution_results: Mutex::new(execution_results),
+            remaining_fuel: AtomicU64::new(fuel),
+            num_reads: AtomicU64::new(0),
+            bytes_read: AtomicU64::new(0),
+            bytes_written: AtomicU64::new(0),
             runtime_limits,
             chain_id,
         }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -114,10 +114,6 @@ where
         runtime_limits: RuntimeLimits,
     ) -> Self {
         assert_eq!(chain_id, execution_state.context().extra().chain_id());
-        let remaining_fuel = Arc::new(AtomicU64::new(fuel));
-        let num_reads = Arc::new(AtomicU64::new(0));
-        let bytes_read = Arc::new(AtomicU64::new(0));
-        let bytes_written = Arc::new(AtomicU64::new(0));
         Self {
             applications: Arc::new(Mutex::new(applications)),
             execution_state: Arc::new(Mutex::new(execution_state)),
@@ -126,10 +122,10 @@ where
             active_view_user_states: Arc::default(),
             active_sessions: Arc::default(),
             execution_results: Arc::new(Mutex::new(execution_results)),
-            remaining_fuel,
-            num_reads,
-            bytes_read,
-            bytes_written,
+            remaining_fuel: Arc::new(AtomicU64::new(fuel)),
+            num_reads: Arc::new(AtomicU64::new(0)),
+            bytes_read: Arc::new(AtomicU64::new(0)),
+            bytes_written: Arc::new(AtomicU64::new(0)),
             runtime_limits,
             chain_id,
         }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -35,16 +35,6 @@ use std::{
 /// Runtime data tracked during the execution of a transaction.
 #[derive(Debug, Clone)]
 pub(crate) struct ExecutionRuntime<'a, C, const WRITABLE: bool> {
-    /// The amount of fuel available for executing the application.
-    remaining_fuel: Arc<AtomicU64>,
-    /// The number of reads
-    num_reads: Arc<AtomicU64>,
-    /// the total size being read
-    bytes_read: Arc<AtomicU64>,
-    /// The total size being written
-    bytes_written: Arc<AtomicU64>,
-    /// The runtime limits
-    runtime_limits: RuntimeLimits,
     /// The current chain ID.
     chain_id: ChainId,
     /// The current stack of application descriptions.
@@ -61,6 +51,17 @@ pub(crate) struct ExecutionRuntime<'a, C, const WRITABLE: bool> {
     active_sessions: Arc<Mutex<ActiveSessions>>,
     /// Accumulate the externally visible results (e.g. cross-chain messages) of applications.
     execution_results: Arc<Mutex<&'a mut Vec<ExecutionResult>>>,
+
+    /// The amount of fuel available for executing the application.
+    remaining_fuel: Arc<AtomicU64>,
+    /// The number of reads
+    num_reads: Arc<AtomicU64>,
+    /// the total size being read
+    bytes_read: Arc<AtomicU64>,
+    /// The total size being written
+    bytes_written: Arc<AtomicU64>,
+    /// The runtime limits
+    runtime_limits: RuntimeLimits,
 }
 
 /// The runtime status of an application.
@@ -118,12 +119,6 @@ where
         let bytes_read = Arc::new(AtomicU64::new(0));
         let bytes_written = Arc::new(AtomicU64::new(0));
         Self {
-            remaining_fuel,
-            num_reads,
-            bytes_read,
-            bytes_written,
-            runtime_limits,
-            chain_id,
             applications: Arc::new(Mutex::new(applications)),
             execution_state: Arc::new(Mutex::new(execution_state)),
             session_manager: Arc::new(Mutex::new(session_manager)),
@@ -131,6 +126,12 @@ where
             active_view_user_states: Arc::default(),
             active_sessions: Arc::default(),
             execution_results: Arc::new(Mutex::new(execution_results)),
+            remaining_fuel,
+            num_reads,
+            bytes_read,
+            bytes_written,
+            runtime_limits,
+            chain_id,
         }
     }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    execution::ExecutionStateView, BaseRuntime, CallResult, ContractRuntime, ExecutionError,
-    ExecutionResult, ExecutionRuntimeContext, RuntimeCounts, RuntimeLimits, ServiceRuntime,
-    SessionId, UserApplicationDescription, UserApplicationId, UserContractCode, UserServiceCode,
+    execution::ExecutionStateView,
+    resources::{RuntimeCounts, RuntimeLimits},
+    BaseRuntime, CallResult, ContractRuntime, ExecutionError, ExecutionResult,
+    ExecutionRuntimeContext, ServiceRuntime, SessionId, UserApplicationDescription,
+    UserApplicationId, UserContractCode, UserServiceCode,
 };
 use async_lock::{Mutex, MutexGuard, MutexGuardArc, RwLockWriteGuardArc};
 use async_trait::async_trait;

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -27,7 +27,7 @@ use self::{runtime_actor::RuntimeActor, sanitizer::sanitize};
 use crate::{
     ApplicationCallResult, Bytecode, CalleeContext, ContractRuntime, ExecutionError,
     MessageContext, OperationContext, QueryContext, RawExecutionResult, ServiceRuntime,
-    SessionCallResult, SessionId, UserApplication, WasmRuntime,
+    SessionCallResult, SessionId, UserContract, UserService, WasmRuntime,
 };
 use async_lock::RwLock;
 use async_trait::async_trait;
@@ -124,7 +124,7 @@ pub enum WasmExecutionError {
 }
 
 #[async_trait]
-impl UserApplication for WasmApplication {
+impl UserContract for WasmApplication {
     async fn initialize(
         &self,
         context: &OperationContext,
@@ -270,7 +270,10 @@ impl UserApplication for WasmApplication {
         *session_state = updated_session_state;
         Ok(result)
     }
+}
 
+#[async_trait]
+impl UserService for WasmApplication {
     async fn handle_query(
         &self,
         context: &QueryContext,

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -39,15 +39,15 @@ use super::{
     ApplicationCallResult, SessionCallResult, WasmApplication, WasmExecutionError,
 };
 use crate::{
-    Bytecode, CalleeContext, ContractRuntime, ExecutionError, MessageContext, OperationContext,
-    QueryContext, RawExecutionResult, ServiceRuntime,
+    Bytecode, CalleeContext, ExecutionError, MessageContext, OperationContext, QueryContext,
+    RawExecutionResult,
 };
 use bytes::Bytes;
 use futures::channel::mpsc;
 use linera_base::identifiers::SessionId;
 use linera_views::batch::Batch;
 use once_cell::sync::Lazy;
-use std::{marker::PhantomData, mem, sync::Arc};
+use std::{marker::PhantomData, sync::Arc};
 use tokio::sync::Mutex;
 use wasmer::{
     imports, wasmparser::Operator, CompilerConfig, Engine, EngineBuilder, Instance, Module,
@@ -319,40 +319,6 @@ impl common::Service for Service {
         argument: Vec<u8>,
     ) -> Result<Result<Vec<u8>, String>, RuntimeError> {
         service::Service::handle_query(&self.service, store, context.into(), &argument)
-    }
-}
-
-/// Unsafe trait to artificially transmute a type in order to extend its lifetime.
-///
-/// # Safety
-///
-/// It is the caller's responsibility to ensure that the resulting [`WithoutLifetime`] type is not
-/// in use after the original lifetime expires.
-pub unsafe trait RemoveLifetime {
-    type WithoutLifetime: 'static;
-
-    /// Removes the lifetime artificially.
-    ///
-    /// # Safety
-    ///
-    /// It is the caller's responsibility to ensure that the resulting [`WithoutLifetime`] type is not
-    /// in use after the original lifetime expires.
-    unsafe fn remove_lifetime(self) -> Self::WithoutLifetime;
-}
-
-unsafe impl<'runtime> RemoveLifetime for &'runtime dyn ContractRuntime {
-    type WithoutLifetime = &'static dyn ContractRuntime;
-
-    unsafe fn remove_lifetime(self) -> Self::WithoutLifetime {
-        unsafe { mem::transmute(self) }
-    }
-}
-
-unsafe impl<'runtime> RemoveLifetime for &'runtime dyn ServiceRuntime {
-    type WithoutLifetime = &'static dyn ServiceRuntime;
-
-    unsafe fn remove_lifetime(self) -> Self::WithoutLifetime {
-        unsafe { mem::transmute(self) }
     }
 }
 

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -151,13 +151,13 @@ impl WasmContract {
         contract_bytecode: Bytecode,
     ) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
-        let contract = contract_cache
+        let module = contract_cache
             .get_or_insert_with(contract_bytecode, |bytecode| {
                 Module::new(&CONTRACT_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadContractModule)?;
 
-        Ok(WasmContract::Wasmtime { contract })
+        Ok(WasmContract::Wasmtime { module })
     }
 
     /// Prepares a runtime instance to call into the Wasm contract.
@@ -195,13 +195,13 @@ impl WasmService {
     /// Creates a new [`WasmService`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
-        let service = service_cache
+        let module = service_cache
             .get_or_insert_with(service_bytecode, |bytecode| {
                 Module::new(&SERVICE_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;
 
-        Ok(WasmService::Wasmtime { service })
+        Ok(WasmService::Wasmtime { module })
     }
 
     /// Prepares a runtime instance to call into the Wasm service.

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -40,7 +40,7 @@ use super::{
     common::{self, ApplicationRuntimeContext, WasmRuntimeContext},
     module_cache::ModuleCache,
     runtime_actor::{BaseRequest, ContractRequest, SendRequestExt, ServiceRequest},
-    WasmApplication, WasmExecutionError,
+    WasmContract, WasmExecutionError, WasmService,
 };
 use crate::{
     ApplicationCallResult, Bytecode, CalleeContext, ExecutionError, MessageContext,
@@ -145,11 +145,10 @@ impl ApplicationRuntimeContext for Service {
     }
 }
 
-impl WasmApplication {
-    /// Creates a new [`WasmApplication`] using Wasmtime with the provided bytecodes.
+impl WasmContract {
+    /// Creates a new [`WasmContract`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(
         contract_bytecode: Bytecode,
-        service_bytecode: Bytecode,
     ) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
         let contract = contract_cache
@@ -158,14 +157,7 @@ impl WasmApplication {
             })
             .map_err(WasmExecutionError::LoadContractModule)?;
 
-        let mut service_cache = SERVICE_CACHE.lock().await;
-        let service = service_cache
-            .get_or_insert_with(service_bytecode, |bytecode| {
-                Module::new(&SERVICE_ENGINE, bytecode)
-            })
-            .map_err(WasmExecutionError::LoadServiceModule)?;
-
-        Ok(WasmApplication::Wasmtime { contract, service })
+        Ok(WasmContract::Wasmtime { contract })
     }
 
     /// Prepares a runtime instance to call into the Wasm contract.
@@ -196,6 +188,20 @@ impl WasmApplication {
             store,
             extra: (),
         })
+    }
+}
+
+impl WasmService {
+    /// Creates a new [`WasmService`] using Wasmtime with the provided bytecodes.
+    pub async fn new_with_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
+        let mut service_cache = SERVICE_CACHE.lock().await;
+        let service = service_cache
+            .get_or_insert_with(service_bytecode, |bytecode| {
+                Module::new(&SERVICE_ENGINE, bytecode)
+            })
+            .map_err(WasmExecutionError::LoadServiceModule)?;
+
+        Ok(WasmService::Wasmtime { service })
     }
 
     /// Prepares a runtime instance to call into the Wasm service.

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -68,7 +68,7 @@ struct TestApplication {
 }
 
 #[async_trait]
-impl UserApplication for TestApplication {
+impl UserContract for TestApplication {
     /// Nothing needs to be done during initialization.
     async fn initialize(
         &self,
@@ -170,7 +170,10 @@ impl UserApplication for TestApplication {
             close_session: true,
         })
     }
+}
 
+#[async_trait]
+impl UserService for TestApplication {
     /// Returns the application state.
     async fn handle_query(
         &self,
@@ -203,7 +206,11 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         .await?;
     view.context()
         .extra()
-        .user_applications()
+        .user_contracts()
+        .insert(app_id, Arc::new(TestApplication { owner }));
+    view.context()
+        .extra()
+        .user_services()
         .insert(app_id, Arc::new(TestApplication { owner }));
 
     let context = OperationContext {
@@ -276,7 +283,7 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         .await?;
     view.context()
         .extra()
-        .user_applications()
+        .user_contracts()
         .insert(app_id, Arc::new(TestApplication { owner }));
 
     let context = OperationContext {

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -56,7 +56,18 @@ async fn test_fuel_for_counter_wasm_application(
     .await?;
     view.context()
         .extra
-        .user_applications()
+        .user_contracts()
+        .insert(app_id, Arc::new(application));
+
+    let application = WasmApplication::from_files(
+        "tests/fixtures/counter_contract.wasm",
+        "tests/fixtures/counter_service.wasm",
+        wasm_runtime,
+    )
+    .await?;
+    view.context()
+        .extra
+        .user_services()
         .insert(app_id, Arc::new(application));
 
     let app_id = app_id.with_abi::<CounterAbi>();

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -14,7 +14,8 @@ use linera_base::{
 use linera_execution::{
     policy::ResourceControlPolicy, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView,
     Operation, OperationContext, Query, QueryContext, RawExecutionResult, ResourceTracker,
-    Response, SystemExecutionState, TestExecutionRuntimeContext, WasmApplication, WasmRuntime,
+    Response, SystemExecutionState, TestExecutionRuntimeContext, WasmContract, WasmRuntime,
+    WasmService,
 };
 use linera_views::{memory::MemoryContext, views::View};
 use serde_json::json;
@@ -48,27 +49,19 @@ async fn test_fuel_for_counter_wasm_application(
         .register_application(app_desc.clone())
         .await?;
 
-    let application = WasmApplication::from_files(
-        "tests/fixtures/counter_contract.wasm",
-        "tests/fixtures/counter_service.wasm",
-        wasm_runtime,
-    )
-    .await?;
+    let contract =
+        WasmContract::from_file("tests/fixtures/counter_contract.wasm", wasm_runtime).await?;
     view.context()
         .extra
         .user_contracts()
-        .insert(app_id, Arc::new(application));
+        .insert(app_id, Arc::new(contract));
 
-    let application = WasmApplication::from_files(
-        "tests/fixtures/counter_contract.wasm",
-        "tests/fixtures/counter_service.wasm",
-        wasm_runtime,
-    )
-    .await?;
+    let service =
+        WasmService::from_file("tests/fixtures/counter_service.wasm", wasm_runtime).await?;
     view.context()
         .extra
         .user_services()
-        .insert(app_id, Arc::new(application));
+        .insert(app_id, Arc::new(service));
 
     let app_id = app_id.with_abi::<CounterAbi>();
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -88,7 +88,7 @@ pub static WRITE_CERTIFICATE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 
 #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
-use linera_execution::{Operation, SystemOperation, WasmApplication};
+use linera_execution::{Operation, SystemOperation, WasmContract, WasmService};
 
 /// Communicate with a persistent storage using the "views" abstraction.
 #[async_trait]
@@ -250,11 +250,9 @@ pub trait Store: Sized {
         let index = usize::try_from(bytecode_location.operation_index)
             .map_err(|_| linera_base::data_types::ArithmeticError::Overflow)?;
         match operations.get(index) {
-            Some(Operation::System(SystemOperation::PublishBytecode { contract, service })) => {
-                Ok(Arc::new(
-                    WasmApplication::new(contract.clone(), service.clone(), wasm_runtime).await?,
-                ))
-            }
+            Some(Operation::System(SystemOperation::PublishBytecode { contract, .. })) => Ok(
+                Arc::new(WasmContract::new(contract.clone(), wasm_runtime).await?),
+            ),
             _ => Err(ExecutionError::InvalidBytecodeId(*bytecode_id)),
         }
     }
@@ -306,11 +304,9 @@ pub trait Store: Sized {
         let index = usize::try_from(bytecode_location.operation_index)
             .map_err(|_| linera_base::data_types::ArithmeticError::Overflow)?;
         match operations.get(index) {
-            Some(Operation::System(SystemOperation::PublishBytecode { contract, service })) => {
-                Ok(Arc::new(
-                    WasmApplication::new(contract.clone(), service.clone(), wasm_runtime).await?,
-                ))
-            }
+            Some(Operation::System(SystemOperation::PublishBytecode { service, .. })) => Ok(
+                Arc::new(WasmService::new(service.clone(), wasm_runtime).await?),
+            ),
             _ => Err(ExecutionError::InvalidBytecodeId(*bytecode_id)),
         }
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -36,8 +36,8 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    ChainOwnership, ExecutionError, ExecutionRuntimeContext, UserApplicationCode,
-    UserApplicationDescription, UserApplicationId, WasmRuntime,
+    ChainOwnership, ExecutionError, ExecutionRuntimeContext, UserApplicationDescription,
+    UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime,
 };
 use linera_views::{
     batch::Batch,
@@ -219,10 +219,10 @@ pub trait Store: Sized {
     /// Creates a [`linera-sdk::UserApplication`] instance using the bytecode in storage referenced
     /// by the `application_description`.
     #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
-    async fn load_application(
+    async fn load_contract(
         &self,
         application_description: &UserApplicationDescription,
-    ) -> Result<UserApplicationCode, ExecutionError> {
+    ) -> Result<UserContractCode, ExecutionError> {
         let Some(wasm_runtime) = self.wasm_runtime() else {
             panic!("A Wasm runtime is required to load user applications.");
         };
@@ -261,10 +261,66 @@ pub trait Store: Sized {
 
     #[cfg(not(any(feature = "wasmer", feature = "wasmtime")))]
     #[allow(clippy::diverging_sub_expression)]
-    async fn load_application(
+    async fn load_contract(
         &self,
         _application_description: &UserApplicationDescription,
-    ) -> Result<UserApplicationCode, ExecutionError> {
+    ) -> Result<UserContractCode, ExecutionError> {
+        panic!(
+            "A Wasm runtime is required to load user applications. \
+            Please enable the `wasmer` or the `wasmtime` feature flags \
+            when compiling `linera-storage`."
+        );
+    }
+
+    /// Creates a [`linera-sdk::UserContract`] instance using the bytecode in storage referenced
+    /// by the `application_description`.
+    #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+    async fn load_service(
+        &self,
+        application_description: &UserApplicationDescription,
+    ) -> Result<UserServiceCode, ExecutionError> {
+        let Some(wasm_runtime) = self.wasm_runtime() else {
+            panic!("A Wasm runtime is required to load user applications.");
+        };
+        let UserApplicationDescription {
+            bytecode_id,
+            bytecode_location,
+            ..
+        } = application_description;
+        let value = self
+            .read_value(bytecode_location.certificate_hash)
+            .await
+            .map_err(|error| match error {
+                ViewError::NotFound(_) => ExecutionError::ApplicationBytecodeNotFound(Box::new(
+                    application_description.clone(),
+                )),
+                _ => error.into(),
+            })?
+            .into_inner();
+        let operations = match value {
+            CertificateValue::ConfirmedBlock { executed_block, .. } => {
+                executed_block.block.operations
+            }
+            _ => return Err(ExecutionError::InvalidBytecodeId(*bytecode_id)),
+        };
+        let index = usize::try_from(bytecode_location.operation_index)
+            .map_err(|_| linera_base::data_types::ArithmeticError::Overflow)?;
+        match operations.get(index) {
+            Some(Operation::System(SystemOperation::PublishBytecode { contract, service })) => {
+                Ok(Arc::new(
+                    WasmApplication::new(contract.clone(), service.clone(), wasm_runtime).await?,
+                ))
+            }
+            _ => Err(ExecutionError::InvalidBytecodeId(*bytecode_id)),
+        }
+    }
+
+    #[cfg(not(any(feature = "wasmer", feature = "wasmtime")))]
+    #[allow(clippy::diverging_sub_expression)]
+    async fn load_service(
+        &self,
+        _application_description: &UserApplicationDescription,
+    ) -> Result<UserServiceCode, ExecutionError> {
         panic!(
             "A Wasm runtime is required to load user applications. \
             Please enable the `wasmer` or the `wasmtime` feature flags \
@@ -277,8 +333,21 @@ pub trait Store: Sized {
 pub struct DbStoreInner<Client> {
     client: Client,
     guards: ChainGuards,
-    user_applications: Arc<DashMap<UserApplicationId, UserApplicationCode>>,
+    user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
+    user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
     wasm_runtime: Option<WasmRuntime>,
+}
+
+impl<Client> DbStoreInner<Client> {
+    fn new(client: Client, wasm_runtime: Option<WasmRuntime>) -> Self {
+        Self {
+            client,
+            guards: ChainGuards::default(),
+            user_contracts: Arc::new(DashMap::new()),
+            user_services: Arc::new(DashMap::new()),
+            wasm_runtime,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -368,7 +437,8 @@ where
         let runtime_context = ChainRuntimeContext {
             store: self.clone(),
             chain_id,
-            user_applications: self.client.user_applications.clone(),
+            user_contracts: self.client.user_contracts.clone(),
+            user_services: self.client.user_services.clone(),
             chain_guard: Some(Arc::new(guard)),
         };
         let client = self.client.client.clone();
@@ -509,7 +579,8 @@ where
 pub struct ChainRuntimeContext<StoreClient> {
     store: StoreClient,
     pub chain_id: ChainId,
-    pub user_applications: Arc<DashMap<UserApplicationId, UserApplicationCode>>,
+    pub user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
+    pub user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
     pub chain_guard: Option<Arc<ChainGuard>>,
 }
 
@@ -522,20 +593,38 @@ where
         self.chain_id
     }
 
-    fn user_applications(&self) -> &Arc<DashMap<UserApplicationId, UserApplicationCode>> {
-        &self.user_applications
+    fn user_contracts(&self) -> &Arc<DashMap<UserApplicationId, UserContractCode>> {
+        &self.user_contracts
     }
 
-    async fn get_user_application(
+    fn user_services(&self) -> &Arc<DashMap<UserApplicationId, UserServiceCode>> {
+        &self.user_services
+    }
+
+    async fn get_user_contract(
         &self,
         description: &UserApplicationDescription,
-    ) -> Result<UserApplicationCode, ExecutionError> {
-        match self.user_applications.entry(description.into()) {
+    ) -> Result<UserContractCode, ExecutionError> {
+        match self.user_contracts.entry(description.into()) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),
             Entry::Vacant(entry) => {
-                let application = self.store.load_application(description).await?;
-                entry.insert(application.clone());
-                Ok(application)
+                let contract = self.store.load_contract(description).await?;
+                entry.insert(contract.clone());
+                Ok(contract)
+            }
+        }
+    }
+
+    async fn get_user_service(
+        &self,
+        description: &UserApplicationDescription,
+    ) -> Result<UserServiceCode, ExecutionError> {
+        match self.user_services.entry(description.into()) {
+            Entry::Occupied(entry) => Ok(entry.get().clone()),
+            Entry::Vacant(entry) => {
+                let service = self.store.load_service(description).await?;
+                entry.insert(service.clone());
+                Ok(service)
             }
         }
     }

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{chain_guards::ChainGuards, DbStore, DbStoreInner};
+use crate::{DbStore, DbStoreInner};
 use linera_execution::WasmRuntime;
 use linera_views::memory::{create_memory_client_stream_queries, MemoryClient};
 use std::sync::Arc;
@@ -9,14 +9,9 @@ use std::sync::Arc;
 type MemoryStore = DbStoreInner<MemoryClient>;
 
 impl MemoryStore {
-    pub fn new(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize) -> Self {
+    pub fn make(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize) -> Self {
         let client = create_memory_client_stream_queries(max_stream_queries);
-        Self {
-            client,
-            guards: ChainGuards::default(),
-            user_applications: Arc::default(),
-            wasm_runtime,
-        }
+        Self::new(client, wasm_runtime)
     }
 }
 
@@ -34,7 +29,7 @@ impl MemoryStoreClient<crate::TestClock> {
 impl<C> MemoryStoreClient<C> {
     pub fn new(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize, clock: C) -> Self {
         Self {
-            client: Arc::new(MemoryStore::new(wasm_runtime, max_stream_queries)),
+            client: Arc::new(MemoryStore::make(wasm_runtime, max_stream_queries)),
             clock,
         }
     }


### PR DESCRIPTION
## Motivation

* Code cleanups
* Validators shouldn't have to load Wasm services

## Proposal

* split UserApplication trait into UserContract + UserService
* split WasmApplication trait into WasmContract and WasmService
* remove Arc in ExecutionRuntime
* minor code improvements

## Test Plan

CI