### PR TITLE
Codify lint toolchain, Mk.II

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,6 @@ permissions:
   contents: read
 
 jobs:
-
   test:
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 45
@@ -103,11 +102,10 @@ jobs:
       run: >
         find linera-* -name '*.rs' -a -not -wholename '*/target/*' -print0
         | xargs -0 -L1 ./scripts/target/release/check_copyright_header
+    - name: Put lint toolchain file in place
+      run: |
+        ln -sf toolchains/lint/rust-toolchain.toml
     - uses: Twey/setup-rust-toolchain@v1
-      with:
-        toolchain: nightly-2023-10-22
-        target: wasm32-unknown-unknown
-        components: clippy rustfmt
     - name: Install cargo-machete
       run: |
         cargo install cargo-machete --locked
@@ -126,7 +124,7 @@ jobs:
         cargo install cargo-sort --locked
     - name: Check formatting
       run: |
-        cargo +nightly-2023-10-22 fmt -- --check
+        cargo fmt -- --check
     - name: Check for unused dependencies
       run: |
         cargo machete
@@ -161,3 +159,7 @@ jobs:
       run: |
         cd examples
         cargo sort -c -w
+    - name: Restore `rust-toolchain.toml` file
+      if: '!cancelled()'
+      run: |
+        ln -sf toolchains/build/rust-toolchain.toml

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1697723726,
-        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "lastModified": 1699781429,
+        "narHash": "sha256-UYefjidASiLORAjIvVsUHG6WBtRhM67kTjEY4XfZOFs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "rev": "e44462d6021bfe23dfb24b775cc7c390844f773d",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1696019113,
-        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
         "type": "github"
       },
       "original": {
@@ -117,11 +117,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1697940838,
-        "narHash": "sha256-eyk92QqAoRNC0V99KOcKcBZjLPixxNBS0PRc4KlSQVs=",
+        "lastModified": 1700100993,
+        "narHash": "sha256-Zc//DbR3eMGajG09iQUMTO/Tc/fdUYmTAzXYdxx5MKw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a3e829c06eadf848f13d109c7648570ce37ebccd",
+        "rev": "b7a041430733fccaa1ffc3724bb9454289d0f701",
         "type": "github"
       },
       "original": {
@@ -165,11 +165,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1697388351,
-        "narHash": "sha256-63N2eBpKaziIy4R44vjpUu8Nz5fCJY7okKrkixvDQmY=",
+        "lastModified": 1699786194,
+        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "aae39f64f5ecbe89792d05eacea5cb241891292a",
+        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,12 +26,10 @@
           pkg-config
           nodejs
         ];
-        rustToolchain = (pkgs.rust-bin.fromRustupToolchainFile
-          ./rust-toolchain.toml);
-        rustPlatform = pkgs.makeRustPlatform {
-          rustc = rustToolchain;
-          cargo = rustToolchain;
-        };
+        rustBuildToolchain = (pkgs.rust-bin.fromRustupToolchainFile
+          ./toolchains/build/rust-toolchain.toml);
+        rustLintToolchain = (pkgs.rust-bin.fromRustupToolchainFile
+          ./toolchains/lint/rust-toolchain.toml);
       in {
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
@@ -45,15 +43,19 @@
           ];
           shellHook = ''
             # For rust-analyzer 'hover' tooltips to work.
-            export RUST_SRC_PATH=${rustToolchain.availableComponents.rust-src}
+            export RUST_SRC_PATH=${rustBuildToolchain.availableComponents.rust-src}
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib
             export PATH=$PWD/target/release:~/.cargo/bin:$PATH
           '';
           buildInputs = nonRustDeps;
           nativeBuildInputs = with pkgs; [
-            rustToolchain
+            rustBuildToolchain
             rust-analyzer
           ];
+        };
+
+        devShells.lint = pkgs.mkShell {
+          nativeBuildInputs = [ rustLintToolchain ];
         };
 
         # Add your auto-formatters here.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -204,7 +204,7 @@ impl CrossChainRequest {
             CrossChainRequest::UpdateRecipient { height_map, .. } => {
                 height_map.iter().any(|(_, heights)| {
                     debug_assert!(heights.windows(2).all(|w| w[0] <= w[1]));
-                    matches!(heights.get(0), Some(h) if *h <= height)
+                    matches!(heights.first(), Some(h) if *h <= height)
                 })
             }
             _ => false,

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -278,7 +278,7 @@ async fn chains(app: &JsValue, node: &str) -> Result<ChainId> {
         .serialize(&SER)
         .expect("failed to serialize ChainIds");
     setf(app, "chains", &chains_js);
-    Ok(chains.default.unwrap_or_else(|| match chains.list.get(0) {
+    Ok(chains.default.unwrap_or_else(|| match chains.list.first() {
         None => ChainId::from(ChainDescription::Root(0)),
         Some(chain_id) => *chain_id,
     }))

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -73,7 +73,7 @@ fn context_and_constraints(
         context = Type::Path(TypePath {
             qself: None,
             path: template_vect
-                .get(0)
+                .first()
                 .expect("failed to find the first generic parameter")
                 .clone()
                 .into(),
@@ -126,7 +126,7 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
         clear_quotes.push(quote! { self.#name.clear(); });
     }
     let first_name_quote = name_quotes
-        .get(0)
+        .first()
         .expect("list of names should be non-empty");
 
     let increment_counter = if root {

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -295,8 +295,7 @@ where
         if count == 0 {
             return Ok(Vec::new());
         }
-        let mut values = Vec::new();
-        values.reserve(count);
+        let mut values = Vec::with_capacity(count);
         if !self.was_cleared {
             let stored_remainder = self.stored_count();
             let start = self.stored_indices.end - stored_remainder;
@@ -336,8 +335,7 @@ where
         if count == 0 {
             return Ok(Vec::new());
         }
-        let mut values = Vec::new();
-        values.reserve(count);
+        let mut values = Vec::with_capacity(count);
         let new_back_len = self.new_back_values.len();
         if count <= new_back_len || self.was_cleared {
             values.extend(

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -1041,8 +1041,14 @@ async fn compute_hash_view_iter<R: RngCore>(rng: &mut R, n: usize, k: usize) {
             .push(compute_hash_ordered_view(rng, &mut store3, key_value_vector.clone()).await);
     }
     for i in 1..n_iter {
-        assert_eq!(unord1_hashes.first().unwrap(), unord1_hashes.get(i).unwrap());
-        assert_eq!(unord2_hashes.first().unwrap(), unord2_hashes.get(i).unwrap());
+        assert_eq!(
+            unord1_hashes.first().unwrap(),
+            unord1_hashes.get(i).unwrap(),
+        );
+        assert_eq!(
+            unord2_hashes.first().unwrap(),
+            unord2_hashes.get(i).unwrap(),
+        );
         assert_eq!(ord_hashes.first().unwrap(), ord_hashes.get(i).unwrap());
     }
 }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -1041,9 +1041,9 @@ async fn compute_hash_view_iter<R: RngCore>(rng: &mut R, n: usize, k: usize) {
             .push(compute_hash_ordered_view(rng, &mut store3, key_value_vector.clone()).await);
     }
     for i in 1..n_iter {
-        assert_eq!(unord1_hashes.get(0).unwrap(), unord1_hashes.get(i).unwrap());
-        assert_eq!(unord2_hashes.get(0).unwrap(), unord2_hashes.get(i).unwrap());
-        assert_eq!(ord_hashes.get(0).unwrap(), ord_hashes.get(i).unwrap());
+        assert_eq!(unord1_hashes.first().unwrap(), unord1_hashes.get(i).unwrap());
+        assert_eq!(unord2_hashes.first().unwrap(), unord2_hashes.get(i).unwrap());
+        assert_eq!(ord_hashes.first().unwrap(), ord_hashes.get(i).unwrap());
     }
 }
 

--- a/toolchains/build/rust-toolchain.toml
+++ b/toolchains/build/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "1.73.0"
+components = [ "clippy", "rustfmt", "rust-src" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"

--- a/toolchains/lint/rust-toolchain.toml
+++ b/toolchains/lint/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2023-10-23"
+components = [ "clippy", "rustfmt" ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"


### PR DESCRIPTION
Re-implement https://github.com/linera-io/linera-protocol/pull/1251 without using `working-directory`, which is apparently forbidden in combination with `uses`.