### PR TITLE
Add timeouts for reqwest clients

### DIFF
--- a/linera-explorer/src/entrypoint.rs
+++ b/linera-explorer/src/entrypoint.rs
@@ -3,6 +3,7 @@
 
 use super::js_utils::{getf, js_to_json, setf, SER};
 
+use crate::reqwest_client;
 use serde::Serialize;
 use serde_json::Value;
 use serde_wasm_bindgen::from_value;
@@ -129,7 +130,7 @@ pub async fn query(app: JsValue, query: JsValue, kind: String) {
     let response = forge_response(&query_json["type"]);
     let body =
         serde_json::json!({ "query": format!("{} {{{} {}}}", kind, input, response) }).to_string();
-    let client = reqwest::Client::new();
+    let client = reqwest_client();
     match client.post(&link).body(body).send().await {
         Err(e) => setf(&app, "errors", &JsValue::from_str(&e.to_string())),
         Ok(response) => match response.text().await {

--- a/linera-explorer/src/graphql.rs
+++ b/linera-explorer/src/graphql.rs
@@ -3,9 +3,10 @@
 
 use anyhow::Result;
 use serde_json::Value;
+use crate::reqwest_client;
 
 pub async fn introspection(url: &str) -> Result<Value> {
-    let client = reqwest::Client::new();
+    let client = reqwest_client();
     let graphql_query =
         "query { \
            __schema { \

--- a/linera-explorer/src/graphql.rs
+++ b/linera-explorer/src/graphql.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::reqwest_client;
 use anyhow::Result;
 use serde_json::Value;
-use crate::reqwest_client;
 
 pub async fn introspection(url: &str) -> Result<Value> {
     let client = reqwest_client();

--- a/linera-explorer/src/lib.rs
+++ b/linera-explorer/src/lib.rs
@@ -40,7 +40,7 @@ use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_wasm_bindgen::from_value;
-use std::{str::FromStr, time::Duration};
+use std::str::FromStr;
 use url::Url;
 use uuid::Uuid;
 use wasm_bindgen::prelude::*;
@@ -48,13 +48,10 @@ use wasm_bindgen_futures::spawn_local;
 use ws_stream_wasm::*;
 
 static WEBSOCKET: OnceCell<WsMeta> = OnceCell::new();
-static DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(crate) fn reqwest_client() -> reqwest::Client {
-    reqwest::ClientBuilder::new()
-        .timeout(DEFAULT_TIMEOUT)
-        .build()
-        .unwrap()
+    // timeouts cannot be enforced when compiling to wasm-js.
+    reqwest::ClientBuilder::new().build().unwrap()
 }
 
 /// Page enum containing info for each page.


### PR DESCRIPTION
## Motivation

Asynchronous `reqwest::Client` do not have timeouts be default resulting in tests which can hang indefinitely.

## Proposal

Add a timeout of 30 seconds to all `reqwest::Client`.

## Test Plan

CI should catch regressions.
