### PR TITLE
Fix deadlock in `ChainListener`

### DIFF
--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -197,8 +197,8 @@ where
                 }
             }
             tracker.insert(notification);
-            let mut context_guard = context.lock().await;
-            context_guard.update_wallet(&mut *client.lock().await).await;
+            let mut client_guard = client.lock().await;
+            context.lock().await.update_wallet(&mut *client_guard).await;
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `end_to_end_queries` test would sometimes hang due to a deadlock.

## Root Cause Analysis

Two locks are shared between the `NodeService` and the `ChainListener`, one for a chain client and one for the `ClientContext`. In most places, the chain client lock is acquired before the context lock. However, there was one place where the context lock was acquired before the chain client lock.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Always acquire the chain client lock before the context lock.

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
