### PR TITLE
Add `--tokio-threads` option to command line tools

### DIFF
--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -12,6 +12,10 @@ struct DatabaseToolOptions {
     /// Subcommands. Acceptable values are run and generate.
     #[structopt(subcommand)]
     command: DatabaseToolCommand,
+
+    /// The number of Tokio worker threads to use.
+    #[structopt(long)]
+    tokio_threads: Option<usize>,
 }
 
 #[derive(StructOpt)]
@@ -120,8 +124,7 @@ async fn evaluate_options(options: DatabaseToolOptions) -> Result<i32, anyhow::E
     Ok(0)
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let env_filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();
@@ -131,7 +134,26 @@ async fn main() {
         .init();
 
     let options = DatabaseToolOptions::from_args();
-    let error_code = match evaluate_options(options).await {
+
+    let mut runtime = if options.tokio_threads == Some(1) {
+        tokio::runtime::Builder::new_current_thread()
+    } else {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+
+        if let Some(threads) = options.tokio_threads {
+            builder.worker_threads(threads);
+        }
+
+        builder
+    };
+
+    let result = runtime
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime")
+        .block_on(evaluate_options(options));
+
+    let error_code = match result {
         Ok(code) => code,
         Err(msg) => {
             tracing::error!("Error is {:?}", msg);

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -666,6 +666,10 @@ struct ClientOptions {
     /// messages have been delivered.
     #[structopt(long)]
     wait_for_outgoing_messages: bool,
+
+    /// The number of Tokio worker threads to use.
+    #[structopt(long)]
+    tokio_threads: Option<usize>,
 }
 
 impl ClientOptions {
@@ -2135,8 +2139,7 @@ async fn net_up(
     Ok(())
 }
 
-#[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
+fn main() -> Result<(), anyhow::Error> {
     let env_filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();
@@ -2146,6 +2149,26 @@ async fn main() -> Result<(), anyhow::Error> {
         .init();
     let options = ClientOptions::init()?;
 
+    let mut runtime = if options.tokio_threads == Some(1) {
+        tokio::runtime::Builder::new_current_thread()
+    } else {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+
+        if let Some(threads) = options.tokio_threads {
+            builder.worker_threads(threads);
+        }
+
+        builder
+    };
+
+    runtime
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime")
+        .block_on(run(options))
+}
+
+async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
     match &options.command {
         ClientCommand::CreateGenesisConfig {
             committee_config_path,

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -38,6 +38,10 @@ pub struct ProxyOptions {
     /// Timeout for receiving responses (us)
     #[structopt(long, default_value = "4000000")]
     recv_timeout_us: u64,
+
+    /// The number of Tokio worker threads to use.
+    #[structopt(long)]
+    tokio_threads: Option<usize>,
 }
 
 /// A Linera Proxy, either gRPC or over 'Simple Transport', meaning TCP or UDP.
@@ -182,8 +186,7 @@ impl SimpleProxy {
     }
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let env_filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();
@@ -192,6 +195,23 @@ async fn main() -> Result<()> {
         .with_env_filter(env_filter)
         .init();
 
-    let proxy = Proxy::from_options(ProxyOptions::from_args()).await?;
-    proxy.run().await
+    let options = ProxyOptions::from_args();
+
+    let mut runtime = if options.tokio_threads == Some(1) {
+        tokio::runtime::Builder::new_current_thread()
+    } else {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+
+        if let Some(threads) = options.tokio_threads {
+            builder.worker_threads(threads);
+        }
+
+        builder
+    };
+
+    runtime
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime")
+        .block_on(async move { Proxy::from_options(options).await?.run().await })
 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -219,6 +219,10 @@ struct ServerOptions {
     /// Subcommands. Acceptable values are run and generate.
     #[structopt(subcommand)]
     command: ServerCommand,
+
+    /// The number of Tokio worker threads to use.
+    #[structopt(long)]
+    tokio_threads: Option<usize>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize)]
@@ -382,8 +386,7 @@ fn parse_duration(s: &str) -> Result<u64, parse_duration::parse::Error> {
         .unwrap_or(u64::MAX))
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let env_filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();
@@ -394,6 +397,26 @@ async fn main() {
 
     let options = ServerOptions::from_args();
 
+    let mut runtime = if options.tokio_threads == Some(1) {
+        tokio::runtime::Builder::new_current_thread()
+    } else {
+        let mut builder = tokio::runtime::Builder::new_multi_thread();
+
+        if let Some(threads) = options.tokio_threads {
+            builder.worker_threads(threads);
+        }
+
+        builder
+    };
+
+    runtime
+        .enable_all()
+        .build()
+        .expect("Failed to create Tokio runtime")
+        .block_on(run(options))
+}
+
+async fn run(options: ServerOptions) {
     match options.command {
         ServerCommand::Run {
             server_config_path,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When investigating deadlocks and hangs, it is sometimes useful to run the binaries with Tokio using a single worker thread. This limits parallelism while still being concurrent, and is especially helpful to determine if there are blocking calls that can lead to deadlocks.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add a `--tokio-threads` command line option to all binaries in `linera-service` (except the `linera-schema-export` binary).

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
