### PR TITLE
Use impl LineraNetConfig instead of LocalNetTestingConfig on end to end tests

### DIFF
--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -38,6 +38,9 @@ pub trait LineraNetConfig {
     type Net: LineraNet + Sized + Send + Sync + 'static;
 
     async fn instantiate(self) -> Result<(Self::Net, ClientWrapper)>;
+
+    #[cfg(any(test, feature = "test"))]
+    fn get_network(&self) -> Network;
 }
 
 /// A running Linera net.
@@ -48,6 +51,23 @@ pub trait LineraNet {
     fn make_client(&mut self) -> ClientWrapper;
 
     async fn terminate(mut self) -> Result<()>;
+
+    #[cfg(any(test, feature = "test"))]
+    async fn terminate_server(&mut self, i: usize, j: usize) -> Result<()>;
+
+    #[cfg(any(test, feature = "test"))]
+    async fn start_server(&mut self, i: usize, j: usize) -> Result<()>;
+
+    #[cfg(any(test, feature = "test"))]
+    async fn generate_validator_config(&mut self, i: usize) -> Result<()>;
+
+    async fn start_validator(&mut self, i: usize) -> Result<()>;
+
+    #[cfg(any(test, feature = "test"))]
+    fn validator_name(&self, i: usize) -> Option<&String>;
+
+    #[cfg(any(test, feature = "test"))]
+    fn remove_validator(&mut self, i: usize) -> Result<()>;
 }
 
 /// Network protocol in use outside and inside a Linera net.

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -41,9 +41,9 @@ async fn test_resolve_binary() {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Simple) ; "scylladb_simple"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Simple) ; "aws_simple"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
+async fn test_end_to_end_reconfiguration(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
-    let network = config.network;
+    let network = config.get_network();
     let (mut net, client) = config.instantiate().await.unwrap();
 
     let client_2 = net.make_client();
@@ -275,7 +275,7 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig) {
+async fn test_end_to_end_retry_notification_stream(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client1) = config.instantiate().await.unwrap();
@@ -794,7 +794,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_retry_pending_block(config: LocalNetTestingConfig) {
+async fn test_end_to_end_retry_pending_block(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     // Create runner and client.
     let (mut net, client) = config.instantiate().await.unwrap();


### PR DESCRIPTION
## Motivation

We need to use `impl LineraNetConfig` everywhere as we'll have more derived types of it that need to pass the end to end tests

## Proposal

Changing specific implementations to use `impl LineraNetConfig` instead. I'm not doing all the implementations on this PR as the code won't be used, so doing it in the next one where I actually attempt to pass the end to end tests

## Test Plan

CI

