### PR TITLE
Properly cleanup if something fails on linera net up --kubernetes

### DIFF
--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -94,7 +94,7 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
     // launching network, service and indexer
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
-    let (net, client) = config.instantiate().await.unwrap();
+    let (mut net, client) = config.instantiate().await.unwrap();
     let mut node_service = client.run_node_service(None).await.unwrap();
     let mut indexer = run_indexer(&client.tmp_dir).await;
 

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -50,7 +50,7 @@ async fn transfer(client: &reqwest::Client, url: &str, from: ChainId, to: ChainI
 async fn test_end_to_end_queries(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
-    let (net, client) = config.instantiate().await.unwrap();
+    let (mut net, client) = config.instantiate().await.unwrap();
 
     let node_chains = {
         let wallet = client.get_wallet().unwrap();

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -79,12 +79,12 @@ impl Validator {
         }
     }
 
-    async fn terminate(mut self) -> Result<()> {
+    async fn terminate(&mut self) -> Result<()> {
         self.proxy
             .kill()
             .await
             .context("terminating validator proxy")?;
-        for mut server in self.servers {
+        for server in &mut self.servers {
             server
                 .kill()
                 .await
@@ -203,8 +203,8 @@ impl LineraNet for LocalNet {
         client
     }
 
-    async fn terminate(mut self) -> Result<()> {
-        for (_, validator) in self.running_validators {
+    async fn terminate(&mut self) -> Result<()> {
+        for validator in self.running_validators.values_mut() {
             validator.terminate().await.context("in local network")?
         }
         Ok(())

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -47,7 +47,7 @@ pub trait LineraNet {
 
     fn make_client(&mut self) -> ClientWrapper;
 
-    async fn terminate(mut self) -> Result<()>;
+    async fn terminate(&mut self) -> Result<()>;
 }
 
 /// Network protocol in use outside and inside a Linera net.


### PR DESCRIPTION
## Motivation

Right now, if something goes wrong when initializing the cluster, those kind clusters created will just linger there, as well as everything else

## Proposal

Let's make sure that if there's an error, we'll clean things up properly

## Test Plan

In the case of failure, we're now cleaning things up: https://gist.github.com/andresilva91/1f180b5e38480652cc96f25f9a623254
