### PR TITLE
Increase Helm Install timeout to 10m

### DIFF
--- a/kubernetes/linera-validator/build_and_redeploy.sh
+++ b/kubernetes/linera-validator/build_and_redeploy.sh
@@ -125,6 +125,7 @@ if [ -n "$cloud_mode" ]; then
         --values values-local-with-cloud-build.yaml \
         --wait \
         --set installCRDs=true \
+        --timeout 10m \
         --set validator.serverConfig=working/server_1.json \
         --set validator.genesisConfig=working/genesis.json
 else
@@ -132,6 +133,7 @@ else
         --values values-local.yaml \
         --wait \
         --set installCRDs=true \
+        --timeout 10m \
         --set validator.serverConfig=working/server_1.json \
         --set validator.genesisConfig=working/genesis.json
 fi

--- a/linera-service/src/cli_wrappers/helm.rs
+++ b/linera-service/src/cli_wrappers/helm.rs
@@ -45,6 +45,7 @@ impl HelmRelease {
             ])
             .args(["--set", &format!("numShards={num_shards}")])
             .args(["--kube-context", &format!("kind-{}", cluster_id)])
+            .args(["--timeout", "10m"])
             .spawn_and_wait_for_stdout()
             .await?;
         Ok(())


### PR DESCRIPTION
## Motivation

With the new init container for ScyllaDB, sometimes we're exceeding the default 5m timeout

## Proposal

Increase the timeout to 10m to make sure we always succeed in initializing the clusters

## Test Plan

Ran locally, was gonna fail, but didn't with the increased timeout

