### PR TITLE
Renamings related to KeyValueStore

### DIFF
--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -35,20 +35,20 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStorage, linera_views::rocks_db::create_rocks_db_common_config,
-    linera_views::rocks_db::RocksDbKvStoreConfig, tokio::sync::Semaphore,
+    linera_views::rocks_db::RocksDbStoreConfig, tokio::sync::Semaphore,
 };
 
 #[cfg(feature = "aws")]
 use {
     linera_storage::DynamoDbStorage,
-    linera_views::dynamo_db::DynamoDbKvStoreConfig,
+    linera_views::dynamo_db::DynamoDbStoreConfig,
     linera_views::dynamo_db::{create_dynamo_db_common_config, LocalStackTestContext},
 };
 
 #[cfg(feature = "scylladb")]
 use {
     linera_storage::ScyllaDbStorage, linera_views::scylla_db::create_scylla_db_common_config,
-    linera_views::scylla_db::ScyllaDbKvStoreConfig,
+    linera_views::scylla_db::ScyllaDbStoreConfig,
 };
 
 #[cfg(any(feature = "aws", feature = "scylladb"))]
@@ -659,7 +659,7 @@ impl StorageBuilder for MakeRocksDbStorage {
         let path_buf = dir.path().to_path_buf();
         self.temp_dirs.push(dir);
         let common_config = create_rocks_db_common_config();
-        let store_config = RocksDbKvStoreConfig {
+        let store_config = RocksDbStoreConfig {
             path_buf,
             common_config,
         };
@@ -710,7 +710,7 @@ impl StorageBuilder for MakeDynamoDbStorage {
         let table = format!("{}_{}", table, self.instance_counter);
         let table_name = table.parse()?;
         let common_config = create_dynamo_db_common_config();
-        let store_config = DynamoDbKvStoreConfig {
+        let store_config = DynamoDbStoreConfig {
             config,
             table_name,
             common_config,
@@ -774,7 +774,7 @@ impl StorageBuilder for MakeScyllaDbStorage {
         let table_name = get_table_name();
         let table_name = format!("{}_{}", table_name, self.instance_counter);
         let common_config = create_scylla_db_common_config();
-        let store_config = ScyllaDbKvStoreConfig {
+        let store_config = ScyllaDbStoreConfig {
             uri: self.uri.clone(),
             table_name,
             common_config,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -36,7 +36,7 @@ use linera_execution::{
 };
 use linera_storage::{DbStorage, MemoryStorage, Storage, TestClock};
 use linera_views::{
-    common::KeyValueStoreClient,
+    common::KeyValueStore,
     memory::TEST_MEMORY_MAX_STREAM_QUERIES,
     value_splitting::DatabaseConsistencyError,
     views::{CryptoHashView, ViewError},
@@ -450,9 +450,9 @@ async fn test_scylla_db_handle_block_proposal_ticks() {
 
 async fn run_test_handle_block_proposal_ticks<C>(storage: DbStorage<C, TestClock>)
 where
-    C: KeyValueStoreClient + Clone + Send + Sync + 'static,
-    ViewError: From<<C as KeyValueStoreClient>::Error>,
-    <C as KeyValueStoreClient>::Error:
+    C: KeyValueStore + Clone + Send + Sync + 'static,
+    ViewError: From<<C as KeyValueStore>::Error>,
+    <C as KeyValueStore>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     let key_pair = KeyPair::generate();
@@ -3420,9 +3420,9 @@ async fn test_scylla_db_leader_timeouts() {
 
 async fn run_test_leader_timeouts<C>(storage: DbStorage<C, TestClock>)
 where
-    C: KeyValueStoreClient + Clone + Send + Sync + 'static,
-    ViewError: From<<C as KeyValueStoreClient>::Error>,
-    <C as KeyValueStoreClient>::Error:
+    C: KeyValueStore + Clone + Send + Sync + 'static,
+    ViewError: From<<C as KeyValueStore>::Error>,
+    <C as KeyValueStore>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     let chain_id = ChainId::root(0);
@@ -3646,9 +3646,9 @@ async fn test_scylla_db_round_types() {
 
 async fn run_test_round_types<C>(storage: DbStorage<C, TestClock>)
 where
-    C: KeyValueStoreClient + Clone + Send + Sync + 'static,
-    ViewError: From<<C as KeyValueStoreClient>::Error>,
-    <C as KeyValueStoreClient>::Error:
+    C: KeyValueStore + Clone + Send + Sync + 'static,
+    ViewError: From<<C as KeyValueStore>::Error>,
+    <C as KeyValueStore>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     let chain_id = ChainId::root(0);

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -14,7 +14,7 @@ use axum::{extract::Extension, routing::get, Router};
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
 use linera_chain::data_types::HashedValue;
 use linera_views::{
-    common::{Context, ContextFromDb, KeyValueStore},
+    common::{Context, ContextFromStore, KeyValueStore},
     map_view::MapView,
     register_view::RegisterView,
     set_view::SetView,
@@ -36,11 +36,11 @@ pub struct StateView<C> {
 #[derive(Clone)]
 pub struct State<C>(Arc<Mutex<StateView<C>>>);
 
-type StateSchema<DB> = Schema<State<ContextFromDb<(), DB>>, EmptyMutation, EmptySubscription>;
+type StateSchema<S> = Schema<State<ContextFromStore<(), S>>, EmptyMutation, EmptySubscription>;
 
-pub struct Indexer<DB> {
-    pub state: State<ContextFromDb<(), DB>>,
-    pub plugins: BTreeMap<String, Box<dyn Plugin<DB>>>,
+pub struct Indexer<S> {
+    pub state: State<ContextFromStore<(), S>>,
+    pub plugins: BTreeMap<String, Box<dyn Plugin<S>>>,
 }
 
 pub enum IndexerCommand {
@@ -54,20 +54,20 @@ enum LatestBlock {
     StartHeight(BlockHeight),
 }
 
-impl<DB> Indexer<DB>
+impl<S> Indexer<S>
 where
-    DB: KeyValueStore + Clone + Send + Sync + 'static,
-    DB::Error: From<bcs::Error>
+    S: KeyValueStore + Clone + Send + Sync + 'static,
+    S::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send
         + Sync
         + std::error::Error
         + 'static,
-    ViewError: From<DB::Error>,
+    ViewError: From<S::Error>,
 {
     /// Loads the indexer using a database backend with an `indexer` prefix.
-    pub async fn load(store: DB) -> Result<Self, IndexerError> {
-        let context = ContextFromDb::create(store.clone(), "indexer".as_bytes().to_vec(), ())
+    pub async fn load(store: S) -> Result<Self, IndexerError> {
+        let context = ContextFromStore::create(store.clone(), "indexer".as_bytes().to_vec(), ())
             .await
             .map_err(|e| IndexerError::ViewError(e.into()))?;
         let state = State(Arc::new(Mutex::new(StateView::load(context).await?)));
@@ -81,7 +81,7 @@ where
     /// the indexer.
     pub async fn process_value(
         &self,
-        state: &mut StateView<ContextFromDb<(), DB>>,
+        state: &mut StateView<ContextFromStore<(), S>>,
         value: &HashedValue,
     ) -> Result<(), IndexerError> {
         for plugin in self.plugins.values() {
@@ -176,7 +176,7 @@ where
     /// Registers a new plugin in the indexer
     pub async fn add_plugin(
         &mut self,
-        plugin: impl Plugin<DB> + 'static,
+        plugin: impl Plugin<S> + 'static,
     ) -> Result<(), IndexerError> {
         let name = plugin.name();
         self.plugins
@@ -187,7 +187,7 @@ where
     }
 
     /// Handles queries made to the root of the indexer
-    async fn handler(schema: Extension<StateSchema<DB>>, req: GraphQLRequest) -> GraphQLResponse {
+    async fn handler(schema: Extension<StateSchema<S>>, req: GraphQLRequest) -> GraphQLResponse {
         schema.execute(req.into_inner()).await.into()
     }
 

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -14,7 +14,7 @@ use axum::{extract::Extension, routing::get, Router};
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
 use linera_chain::data_types::HashedValue;
 use linera_views::{
-    common::{Context, ContextFromDb, KeyValueStoreClient},
+    common::{Context, ContextFromDb, KeyValueStore},
     map_view::MapView,
     register_view::RegisterView,
     set_view::SetView,
@@ -56,7 +56,7 @@ enum LatestBlock {
 
 impl<DB> Indexer<DB>
 where
-    DB: KeyValueStoreClient + Clone + Send + Sync + 'static,
+    DB: KeyValueStore + Clone + Send + Sync + 'static,
     DB::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -8,7 +8,7 @@ use async_graphql::{EmptyMutation, EmptySubscription, ObjectType, Schema};
 use axum::Router;
 use linera_chain::data_types::HashedValue;
 use linera_views::{
-    common::{ContextFromDb, KeyValueStoreClient},
+    common::{ContextFromDb, KeyValueStore},
     views::{View, ViewError},
 };
 use std::sync::Arc;
@@ -17,7 +17,7 @@ use tokio::sync::Mutex;
 #[async_trait::async_trait]
 pub trait Plugin<DB>: Send + Sync
 where
-    DB: KeyValueStoreClient + Clone + Send + Sync + 'static,
+    DB: KeyValueStore + Clone + Send + Sync + 'static,
     DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<DB::Error>,
 {
@@ -74,7 +74,7 @@ pub async fn load<DB, V: View<ContextFromDb<(), DB>>>(
     name: &str,
 ) -> Result<Arc<Mutex<V>>, IndexerError>
 where
-    DB: KeyValueStoreClient + Clone + Send + Sync + 'static,
+    DB: KeyValueStore + Clone + Send + Sync + 'static,
     DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<DB::Error>,
 {

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -8,18 +8,18 @@ use async_graphql::{EmptyMutation, EmptySubscription, ObjectType, Schema};
 use axum::Router;
 use linera_chain::data_types::HashedValue;
 use linera_views::{
-    common::{ContextFromDb, KeyValueStore},
+    common::{ContextFromStore, KeyValueStore},
     views::{View, ViewError},
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
 #[async_trait::async_trait]
-pub trait Plugin<DB>: Send + Sync
+pub trait Plugin<S>: Send + Sync
 where
-    DB: KeyValueStore + Clone + Send + Sync + 'static,
-    DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<DB::Error>,
+    S: KeyValueStore + Clone + Send + Sync + 'static,
+    S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
+    ViewError: From<S::Error>,
 {
     /// Gets the name of the plugin
     fn name(&self) -> String
@@ -27,7 +27,7 @@ where
         Self: Sized;
 
     /// Loads the plugin from a store
-    async fn load(store: DB) -> Result<Self, IndexerError>
+    async fn load(store: S) -> Result<Self, IndexerError>
     where
         Self: Sized;
 
@@ -69,16 +69,16 @@ pub fn route<Q: async_graphql::ObjectType + 'static>(
     .layer(tower_http::cors::CorsLayer::permissive())
 }
 
-pub async fn load<DB, V: View<ContextFromDb<(), DB>>>(
-    store: DB,
+pub async fn load<S, V: View<ContextFromStore<(), S>>>(
+    store: S,
     name: &str,
 ) -> Result<Arc<Mutex<V>>, IndexerError>
 where
-    DB: KeyValueStore + Clone + Send + Sync + 'static,
-    DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<DB::Error>,
+    S: KeyValueStore + Clone + Send + Sync + 'static,
+    S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
+    ViewError: From<S::Error>,
 {
-    let context = ContextFromDb::create(store, name.as_bytes().to_vec(), ())
+    let context = ContextFromStore::create(store, name.as_bytes().to_vec(), ())
         .await
         .map_err(|e| IndexerError::ViewError(e.into()))?;
     let plugin = V::load(context).await?;

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use linera_views::{
     common::CommonStoreConfig,
-    rocks_db::{RocksDbClient, RocksDbKvStoreConfig},
+    rocks_db::{RocksDbClient, RocksDbStoreConfig},
 };
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -38,7 +38,7 @@ impl RocksDbRunner {
             max_stream_queries: config.client.max_stream_queries,
             cache_size: config.client.cache_size,
         };
-        let store_config = RocksDbKvStoreConfig {
+        let store_config = RocksDbStoreConfig {
             path_buf: config.client.storage.as_path().to_path_buf(),
             common_config,
         };

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use linera_views::{
     common::CommonStoreConfig,
-    rocks_db::{RocksDbClient, RocksDbStoreConfig},
+    rocks_db::{RocksDbStore, RocksDbStoreConfig},
 };
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -28,7 +28,7 @@ pub struct RocksDbConfig {
     cache_size: usize,
 }
 
-pub type RocksDbRunner = Runner<RocksDbClient, RocksDbConfig>;
+pub type RocksDbRunner = Runner<RocksDbStore, RocksDbConfig>;
 
 impl RocksDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
@@ -42,7 +42,7 @@ impl RocksDbRunner {
             path_buf: config.client.storage.as_path().to_path_buf(),
             common_config,
         };
-        let store = RocksDbClient::initialize(store_config).await?;
+        let store = RocksDbStore::initialize(store_config).await?;
         Self::new(config, store).await
     }
 }

--- a/linera-indexer/lib/src/runner.rs
+++ b/linera-indexer/lib/src/runner.rs
@@ -7,7 +7,7 @@ use crate::{common::IndexerError, indexer::Indexer, plugin::Plugin, service::Lis
 use axum::Server;
 use linera_base::identifiers::ChainId;
 use linera_views::{
-    common::KeyValueStoreClient, value_splitting::DatabaseConsistencyError, views::ViewError,
+    common::KeyValueStore, value_splitting::DatabaseConsistencyError, views::ViewError,
 };
 use structopt::{StructOpt, StructOptInternal};
 use tokio::select;
@@ -47,7 +47,7 @@ impl<DB, Config> Runner<DB, Config>
 where
     Self: Send,
     Config: Clone + std::fmt::Debug + Send + Sync + StructOptInternal,
-    DB: KeyValueStoreClient + Clone + Send + Sync + 'static,
+    DB: KeyValueStore + Clone + Send + Sync + 'static,
     DB::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use linera_views::{
     common::CommonStoreConfig,
-    scylla_db::{ScyllaDbClient, ScyllaDbKvStoreConfig},
+    scylla_db::{ScyllaDbClient, ScyllaDbStoreConfig},
 };
 use structopt::StructOpt;
 
@@ -39,7 +39,7 @@ impl ScyllaDbRunner {
             max_stream_queries: config.client.max_stream_queries,
             cache_size: config.client.cache_size,
         };
-        let store_config = ScyllaDbKvStoreConfig {
+        let store_config = ScyllaDbStoreConfig {
             uri: config.client.uri.clone(),
             table_name: config.client.table.clone(),
             common_config,

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use linera_views::{
     common::CommonStoreConfig,
-    scylla_db::{ScyllaDbClient, ScyllaDbStoreConfig},
+    scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
 };
 use structopt::StructOpt;
 
@@ -29,7 +29,7 @@ pub struct ScyllaDbConfig {
     cache_size: usize,
 }
 
-pub type ScyllaDbRunner = Runner<ScyllaDbClient, ScyllaDbConfig>;
+pub type ScyllaDbRunner = Runner<ScyllaDbStore, ScyllaDbConfig>;
 
 impl ScyllaDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
@@ -44,7 +44,7 @@ impl ScyllaDbRunner {
             table_name: config.client.table.clone(),
             common_config,
         };
-        let (store, _) = ScyllaDbClient::new(store_config).await?;
+        let (store, _) = ScyllaDbStore::new(store_config).await?;
         Self::new(config, store).await
     }
 }

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -19,7 +19,7 @@ use linera_chain::data_types::HashedValue;
 use linera_core::worker::Reason;
 use linera_service_graphql_client::{block, chains, notifications, Block, Chains, Notifications};
 use linera_views::{
-    common::KeyValueStoreClient, value_splitting::DatabaseConsistencyError, views::ViewError,
+    common::KeyValueStore, value_splitting::DatabaseConsistencyError, views::ViewError,
 };
 use std::time::Duration;
 use structopt::StructOpt;
@@ -129,7 +129,7 @@ impl Listener {
         chain_id: ChainId,
     ) -> Result<ChainId, IndexerError>
     where
-        DB: KeyValueStoreClient + Clone + Send + Sync + 'static,
+        DB: KeyValueStore + Clone + Send + Sync + 'static,
         DB::Error: From<bcs::Error>
             + From<DatabaseConsistencyError>
             + Send

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -11,7 +11,7 @@ use linera_indexer::{
     plugin::{load, route, sdl, Plugin},
 };
 use linera_views::{
-    common::{Context, ContextFromDb, KeyValueStore},
+    common::{Context, ContextFromStore, KeyValueStore},
     map_view::MapView,
     views::{RootView, ViewError},
 };
@@ -109,17 +109,17 @@ static NAME: &str = "operations";
 
 /// Implements `Plugin`
 #[async_trait::async_trait]
-impl<DB> Plugin<DB> for OperationsPlugin<ContextFromDb<(), DB>>
+impl<S> Plugin<S> for OperationsPlugin<ContextFromStore<(), S>>
 where
-    DB: KeyValueStore + Clone + Send + Sync + 'static,
-    DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<DB::Error>,
+    S: KeyValueStore + Clone + Send + Sync + 'static,
+    S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
+    ViewError: From<S::Error>,
 {
     fn name(&self) -> String {
         NAME.to_string()
     }
 
-    async fn load(store: DB) -> Result<Self, IndexerError>
+    async fn load(store: S) -> Result<Self, IndexerError>
     where
         Self: Sized,
     {

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -11,7 +11,7 @@ use linera_indexer::{
     plugin::{load, route, sdl, Plugin},
 };
 use linera_views::{
-    common::{Context, ContextFromDb, KeyValueStoreClient},
+    common::{Context, ContextFromDb, KeyValueStore},
     map_view::MapView,
     views::{RootView, ViewError},
 };
@@ -111,7 +111,7 @@ static NAME: &str = "operations";
 #[async_trait::async_trait]
 impl<DB> Plugin<DB> for OperationsPlugin<ContextFromDb<(), DB>>
 where
-    DB: KeyValueStoreClient + Clone + Send + Sync + 'static,
+    DB: KeyValueStore + Clone + Send + Sync + 'static,
     DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<DB::Error>,
 {

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -18,7 +18,7 @@ use linera_views::{
 /// That key length is decreased by 4 due to the use of a value splitting.
 /// Then the `KeyValueStore` needs to handle some base_key and so we
 /// reduce to 900. Depending on the size, the error can occur in system_api
-/// or in the KeyValueStoreView.
+/// or in the `KeyValueStoreView`.
 const MAX_KEY_SIZE: usize = 900;
 
 /// A type to interface with the key value storage provided to applications.

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use linera_base::ensure;
 use linera_views::{
     batch::{Batch, WriteOperation},
-    common::{ContextFromDb, KeyValueStore},
+    common::{ContextFromStore, KeyValueStore},
     views::ViewError,
 };
 
@@ -23,9 +23,9 @@ const MAX_KEY_SIZE: usize = 900;
 
 /// A type to interface with the key value storage provided to applications.
 #[derive(Default, Clone)]
-pub struct KeyValueWasm;
+pub struct WasmStore;
 
-impl KeyValueWasm {
+impl WasmStore {
     async fn find_keys_by_prefix_load(&self, key_prefix: &[u8]) -> Vec<Vec<u8>> {
         let promise = wit::FindKeys::new(key_prefix);
         yield_once().await;
@@ -40,8 +40,8 @@ impl KeyValueWasm {
 }
 
 #[async_trait]
-impl KeyValueStore for KeyValueWasm {
-    // The KeyValueWasm of the system_api does not have limits
+impl KeyValueStore for WasmStore {
+    // The WasmStore of the system_api does not have limits
     // on the size of its values.
     const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
@@ -126,4 +126,4 @@ impl KeyValueStore for KeyValueWasm {
 
 /// Implementation of [`linera_views::common::Context`] to be used for data storage
 /// by Linera applications.
-pub type ViewStorageContext = ContextFromDb<(), KeyValueWasm>;
+pub type ViewStorageContext = ContextFromStore<(), WasmStore>;

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -16,7 +16,7 @@ use linera_views::{
 /// We need to have a maximum key size that handles all possible underlying
 /// sizes. The constraint so far is DynamoDb which has a key length of 1024.
 /// That key length is decreased by 4 due to the use of a value splitting.
-/// Then the KeyValueStore needs to handle some base_key and so we
+/// Then the `KeyValueStore` needs to handle some base_key and so we
 /// reduce to 900. Depending on the size, the error can occur in system_api
 /// or in the KeyValueStoreView.
 const MAX_KEY_SIZE: usize = 900;

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -9,23 +9,23 @@ use async_trait::async_trait;
 use linera_base::ensure;
 use linera_views::{
     batch::{Batch, WriteOperation},
-    common::{ContextFromDb, KeyValueStoreClient},
+    common::{ContextFromDb, KeyValueStore},
     views::ViewError,
 };
 
 /// We need to have a maximum key size that handles all possible underlying
 /// sizes. The constraint so far is DynamoDb which has a key length of 1024.
 /// That key length is decreased by 4 due to the use of a value splitting.
-/// Then the KeyValueStoreClient needs to handle some base_key and so we
+/// Then the KeyValueStore needs to handle some base_key and so we
 /// reduce to 900. Depending on the size, the error can occur in system_api
 /// or in the KeyValueStoreView.
 const MAX_KEY_SIZE: usize = 900;
 
 /// A type to interface with the key value storage provided to applications.
 #[derive(Default, Clone)]
-pub struct KeyValueStore;
+pub struct KeyValueWasm;
 
-impl KeyValueStore {
+impl KeyValueWasm {
     async fn find_keys_by_prefix_load(&self, key_prefix: &[u8]) -> Vec<Vec<u8>> {
         let promise = wit::FindKeys::new(key_prefix);
         yield_once().await;
@@ -40,8 +40,8 @@ impl KeyValueStore {
 }
 
 #[async_trait]
-impl KeyValueStoreClient for KeyValueStore {
-    // The KeyValueStoreClient of the system_api does not have limits
+impl KeyValueStore for KeyValueWasm {
+    // The KeyValueWasm of the system_api does not have limits
     // on the size of its values.
     const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
@@ -126,4 +126,4 @@ impl KeyValueStoreClient for KeyValueStore {
 
 /// Implementation of [`linera_views::common::Context`] to be used for data storage
 /// by Linera applications.
-pub type ViewStorageContext = ContextFromDb<(), KeyValueStore>;
+pub type ViewStorageContext = ContextFromDb<(), KeyValueWasm>;

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -23,9 +23,9 @@ const MAX_KEY_SIZE: usize = 900;
 
 /// A type to interface with the key value storage provided to applications.
 #[derive(Default, Clone)]
-pub struct WasmStore;
+pub struct AppStateStore;
 
-impl WasmStore {
+impl AppStateStore {
     async fn find_keys_by_prefix_load(&self, key_prefix: &[u8]) -> Vec<Vec<u8>> {
         let promise = wit::FindKeys::new(key_prefix);
         yield_once().await;
@@ -40,8 +40,8 @@ impl WasmStore {
 }
 
 #[async_trait]
-impl KeyValueStore for WasmStore {
-    // The WasmStore of the system_api does not have limits
+impl KeyValueStore for AppStateStore {
+    // The AppStateStore of the system_api does not have limits
     // on the size of its values.
     const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
@@ -126,4 +126,4 @@ impl KeyValueStore for WasmStore {
 
 /// Implementation of [`linera_views::common::Context`] to be used for data storage
 /// by Linera applications.
-pub type ViewStorageContext = ContextFromStore<(), WasmStore>;
+pub type ViewStorageContext = ContextFromStore<(), AppStateStore>;

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -13,7 +13,7 @@ use tracing::error;
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStorage,
-    linera_views::rocks_db::{RocksDbClient, RocksDbStoreConfig},
+    linera_views::rocks_db::{RocksDbStore, RocksDbStoreConfig},
     std::path::PathBuf,
 };
 
@@ -234,7 +234,7 @@ impl StoreConfig {
             }),
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb(config) => {
-                RocksDbClient::delete_all(config).await?;
+                RocksDbStore::delete_all(config).await?;
                 Ok(())
             }
             #[cfg(feature = "aws")]
@@ -259,7 +259,7 @@ impl StoreConfig {
             }),
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb(config) => {
-                RocksDbClient::delete_single(config).await?;
+                RocksDbStore::delete_single(config).await?;
                 Ok(())
             }
             #[cfg(feature = "aws")]
@@ -283,7 +283,7 @@ impl StoreConfig {
                 error: "existence not make sense for memory storage".to_string(),
             }),
             #[cfg(feature = "rocksdb")]
-            StoreConfig::RocksDb(config) => Ok(RocksDbClient::test_existence(config).await?),
+            StoreConfig::RocksDb(config) => Ok(RocksDbStore::test_existence(config).await?),
             #[cfg(feature = "aws")]
             StoreConfig::DynamoDb(config) => Ok(DynamoDbClient::test_existence(config).await?),
             #[cfg(feature = "scylladb")]
@@ -300,7 +300,7 @@ impl StoreConfig {
             }),
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb(config) => {
-                RocksDbClient::initialize(config).await?;
+                RocksDbStore::initialize(config).await?;
                 Ok(())
             }
             #[cfg(feature = "aws")]
@@ -431,7 +431,7 @@ pub async fn test_existence_storage(config: StoreConfig) -> Result<bool, anyhow:
             bail!("The initialization should not be called for memory");
         }
         #[cfg(feature = "rocksdb")]
-        StoreConfig::RocksDb(config) => Ok(RocksDbClient::test_existence(config).await?),
+        StoreConfig::RocksDb(config) => Ok(RocksDbStore::test_existence(config).await?),
         #[cfg(feature = "aws")]
         StoreConfig::DynamoDb(config) => Ok(DynamoDbClient::test_existence(config).await?),
         #[cfg(feature = "scylladb")]

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -27,7 +27,7 @@ use {
 use {
     anyhow::Context,
     linera_storage::ScyllaDbStorage,
-    linera_views::scylla_db::{ScyllaDbClient, ScyllaDbStoreConfig},
+    linera_views::scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
     std::num::NonZeroU16,
     tracing::debug,
 };
@@ -244,7 +244,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config) => {
-                ScyllaDbClient::delete_all(config).await?;
+                ScyllaDbStore::delete_all(config).await?;
                 Ok(())
             }
         }
@@ -269,7 +269,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config) => {
-                ScyllaDbClient::delete_single(config).await?;
+                ScyllaDbStore::delete_single(config).await?;
                 Ok(())
             }
         }
@@ -287,7 +287,7 @@ impl StoreConfig {
             #[cfg(feature = "aws")]
             StoreConfig::DynamoDb(config) => Ok(DynamoDbStore::test_existence(config).await?),
             #[cfg(feature = "scylladb")]
-            StoreConfig::ScyllaDb(config) => Ok(ScyllaDbClient::test_existence(config).await?),
+            StoreConfig::ScyllaDb(config) => Ok(ScyllaDbStore::test_existence(config).await?),
         }
     }
 
@@ -310,7 +310,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config) => {
-                ScyllaDbClient::initialize(config).await?;
+                ScyllaDbStore::initialize(config).await?;
                 Ok(())
             }
         }
@@ -335,7 +335,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config) => {
-                let tables = ScyllaDbClient::list_tables(config).await?;
+                let tables = ScyllaDbStore::list_tables(config).await?;
                 Ok(tables)
             }
         }
@@ -435,7 +435,7 @@ pub async fn test_existence_storage(config: StoreConfig) -> Result<bool, anyhow:
         #[cfg(feature = "aws")]
         StoreConfig::DynamoDb(config) => Ok(DynamoDbStore::test_existence(config).await?),
         #[cfg(feature = "scylladb")]
-        StoreConfig::ScyllaDb(config) => Ok(ScyllaDbClient::test_existence(config).await?),
+        StoreConfig::ScyllaDb(config) => Ok(ScyllaDbStore::test_existence(config).await?),
     }
 }
 

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -20,7 +20,7 @@ use {
 #[cfg(feature = "aws")]
 use {
     linera_storage::DynamoDbStorage,
-    linera_views::dynamo_db::{get_config, DynamoDbClient, DynamoDbStoreConfig, TableName},
+    linera_views::dynamo_db::{get_config, DynamoDbStore, DynamoDbStoreConfig, TableName},
 };
 
 #[cfg(feature = "scylladb")]
@@ -239,7 +239,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "aws")]
             StoreConfig::DynamoDb(config) => {
-                DynamoDbClient::delete_all(config).await?;
+                DynamoDbStore::delete_all(config).await?;
                 Ok(())
             }
             #[cfg(feature = "scylladb")]
@@ -264,7 +264,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "aws")]
             StoreConfig::DynamoDb(config) => {
-                DynamoDbClient::delete_single(config).await?;
+                DynamoDbStore::delete_single(config).await?;
                 Ok(())
             }
             #[cfg(feature = "scylladb")]
@@ -285,7 +285,7 @@ impl StoreConfig {
             #[cfg(feature = "rocksdb")]
             StoreConfig::RocksDb(config) => Ok(RocksDbStore::test_existence(config).await?),
             #[cfg(feature = "aws")]
-            StoreConfig::DynamoDb(config) => Ok(DynamoDbClient::test_existence(config).await?),
+            StoreConfig::DynamoDb(config) => Ok(DynamoDbStore::test_existence(config).await?),
             #[cfg(feature = "scylladb")]
             StoreConfig::ScyllaDb(config) => Ok(ScyllaDbClient::test_existence(config).await?),
         }
@@ -305,7 +305,7 @@ impl StoreConfig {
             }
             #[cfg(feature = "aws")]
             StoreConfig::DynamoDb(config) => {
-                DynamoDbClient::initialize(config).await?;
+                DynamoDbStore::initialize(config).await?;
                 Ok(())
             }
             #[cfg(feature = "scylladb")]
@@ -330,7 +330,7 @@ impl StoreConfig {
             }),
             #[cfg(feature = "aws")]
             StoreConfig::DynamoDb(config) => {
-                let tables = DynamoDbClient::list_tables(config).await?;
+                let tables = DynamoDbStore::list_tables(config).await?;
                 Ok(tables)
             }
             #[cfg(feature = "scylladb")]
@@ -433,7 +433,7 @@ pub async fn test_existence_storage(config: StoreConfig) -> Result<bool, anyhow:
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config) => Ok(RocksDbStore::test_existence(config).await?),
         #[cfg(feature = "aws")]
-        StoreConfig::DynamoDb(config) => Ok(DynamoDbClient::test_existence(config).await?),
+        StoreConfig::DynamoDb(config) => Ok(DynamoDbStore::test_existence(config).await?),
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config) => Ok(ScyllaDbClient::test_existence(config).await?),
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -12,7 +12,7 @@ use linera_chain::{
 use linera_execution::{UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime};
 use linera_views::{
     batch::Batch,
-    common::{ContextFromDb, KeyValueStore},
+    common::{ContextFromStore, KeyValueStore},
     value_splitting::DatabaseConsistencyError,
     views::{View, ViewError},
 };
@@ -153,7 +153,7 @@ where
     <Client as KeyValueStore>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
-    type Context = ContextFromDb<ChainRuntimeContext<Self>, Client>;
+    type Context = ContextFromStore<ChainRuntimeContext<Self>, Client>;
     type ContextError = <Client as KeyValueStore>::Error;
 
     fn current_time(&self) -> Timestamp {
@@ -175,7 +175,7 @@ where
         };
         let client = self.client.client.clone();
         let base_key = bcs::to_bytes(&BaseKey::ChainState(chain_id))?;
-        let context = ContextFromDb::create(client, base_key, runtime_context).await?;
+        let context = ContextFromStore::create(client, base_key, runtime_context).await?;
         ChainStateView::load(context).await
     }
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -12,7 +12,7 @@ use linera_chain::{
 use linera_execution::{UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime};
 use linera_views::{
     batch::Batch,
-    common::{ContextFromDb, KeyValueStoreClient},
+    common::{ContextFromDb, KeyValueStore},
     value_splitting::DatabaseConsistencyError,
     views::{View, ViewError},
 };
@@ -61,7 +61,7 @@ pub static WRITE_CERTIFICATE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("Counter creation should not fail")
 });
 
-/// A storage implemented from a [`KeyValueStoreClient`]
+/// A storage implemented from a [`KeyValueStore`]
 pub struct DbStorageInner<Client> {
     client: Client,
     pub(crate) guards: ChainGuards,
@@ -147,14 +147,14 @@ impl TestClock {
 #[async_trait]
 impl<Client, C> Storage for DbStorage<Client, C>
 where
-    Client: KeyValueStoreClient + Clone + Send + Sync + 'static,
+    Client: KeyValueStore + Clone + Send + Sync + 'static,
     C: Clock + Clone + Send + Sync + 'static,
-    ViewError: From<<Client as KeyValueStoreClient>::Error>,
-    <Client as KeyValueStoreClient>::Error:
+    ViewError: From<<Client as KeyValueStore>::Error>,
+    <Client as KeyValueStore>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     type Context = ContextFromDb<ChainRuntimeContext<Self>, Client>;
-    type ContextError = <Client as KeyValueStoreClient>::Error;
+    type ContextError = <Client as KeyValueStore>::Error;
 
     fn current_time(&self) -> Timestamp {
         self.clock.current_time()
@@ -265,10 +265,10 @@ where
 
 impl<Client, C> DbStorage<Client, C>
 where
-    Client: KeyValueStoreClient + Clone + Send + Sync + 'static,
+    Client: KeyValueStore + Clone + Send + Sync + 'static,
     C: Clock,
-    ViewError: From<<Client as KeyValueStoreClient>::Error>,
-    <Client as KeyValueStoreClient>::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
+    ViewError: From<<Client as KeyValueStore>::Error>,
+    <Client as KeyValueStore>::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
 {
     fn add_value_to_batch(&self, value: &HashedValue, batch: &mut Batch) -> Result<(), ViewError> {
         WRITE_VALUE_COUNTER.with_label_values(&[]).inc();

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    dynamo_db::{DynamoDbClient, DynamoDbContextError, DynamoDbStoreConfig},
+    dynamo_db::{DynamoDbStore, DynamoDbContextError, DynamoDbStoreConfig},
 };
 use std::sync::Arc;
 
@@ -22,7 +22,7 @@ use {
 #[path = "unit_tests/dynamo_db.rs"]
 mod tests;
 
-type DynamoDbStorageInner = DbStorageInner<DynamoDbClient>;
+type DynamoDbStorageInner = DbStorageInner<DynamoDbStore>;
 
 impl DynamoDbStorageInner {
     #[cfg(any(test, feature = "test"))]
@@ -30,8 +30,8 @@ impl DynamoDbStorageInner {
         store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (client, table_status) = DynamoDbClient::new_for_testing(store_config).await?;
-        let storage = Self::new(client, wasm_runtime);
+        let (store, table_status) = DynamoDbStore::new_for_testing(store_config).await?;
+        let storage = Self::new(store, wasm_runtime);
         Ok((storage, table_status))
     }
 
@@ -39,8 +39,8 @@ impl DynamoDbStorageInner {
         store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, DynamoDbContextError> {
-        let client = DynamoDbClient::initialize(store_config).await?;
-        let storage = Self::new(client, wasm_runtime);
+        let store = DynamoDbStore::initialize(store_config).await?;
+        let storage = Self::new(store, wasm_runtime);
         Ok(storage)
     }
 
@@ -48,13 +48,13 @@ impl DynamoDbStorageInner {
         store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
-        let (client, table_status) = DynamoDbClient::new(store_config).await?;
-        let storage = Self::new(client, wasm_runtime);
+        let (store, table_status) = DynamoDbStore::new(store_config).await?;
+        let storage = Self::new(store, wasm_runtime);
         Ok((storage, table_status))
     }
 }
 
-pub type DynamoDbStorage<C> = DbStorage<DynamoDbClient, C>;
+pub type DynamoDbStorage<C> = DbStorage<DynamoDbStore, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl DynamoDbStorage<TestClock> {

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    dynamo_db::{DynamoDbStore, DynamoDbContextError, DynamoDbStoreConfig},
+    dynamo_db::{DynamoDbContextError, DynamoDbStore, DynamoDbStoreConfig},
 };
 use std::sync::Arc;
 

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    dynamo_db::{DynamoDbClient, DynamoDbContextError, DynamoDbKvStoreConfig},
+    dynamo_db::{DynamoDbClient, DynamoDbContextError, DynamoDbStoreConfig},
 };
 use std::sync::Arc;
 
@@ -27,7 +27,7 @@ type DynamoDbStorageInner = DbStorageInner<DynamoDbClient>;
 impl DynamoDbStorageInner {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let (client, table_status) = DynamoDbClient::new_for_testing(store_config).await?;
@@ -36,7 +36,7 @@ impl DynamoDbStorageInner {
     }
 
     async fn initialize(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, DynamoDbContextError> {
         let client = DynamoDbClient::initialize(store_config).await?;
@@ -45,7 +45,7 @@ impl DynamoDbStorageInner {
     }
 
     async fn make(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let (client, table_status) = DynamoDbClient::new(store_config).await?;
@@ -63,7 +63,7 @@ impl DynamoDbStorage<TestClock> {
         let table_name = table.parse().expect("Invalid table name");
         let localstack = LocalStackTestContext::new().await.expect("localstack");
         let common_config = create_dynamo_db_common_config();
-        let store_config = DynamoDbKvStoreConfig {
+        let store_config = DynamoDbStoreConfig {
             config: localstack.dynamo_db_config(),
             table_name,
             common_config,
@@ -76,7 +76,7 @@ impl DynamoDbStorage<TestClock> {
     }
 
     pub async fn new_for_testing(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
@@ -92,7 +92,7 @@ impl DynamoDbStorage<TestClock> {
 
 impl DynamoDbStorage<WallClock> {
     pub async fn initialize(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, DynamoDbContextError> {
         let storage = DynamoDbStorageInner::initialize(store_config, wasm_runtime).await?;
@@ -104,7 +104,7 @@ impl DynamoDbStorage<WallClock> {
     }
 
     pub async fn new(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let (storage, table_status) =

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -10,8 +10,8 @@ type MemoryStorageInner = DbStorageInner<MemoryStore>;
 
 impl MemoryStorageInner {
     pub fn make(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize) -> Self {
-        let client = create_memory_store_stream_queries(max_stream_queries);
-        Self::new(client, wasm_runtime)
+        let store = create_memory_store_stream_queries(max_stream_queries);
+        Self::new(store, wasm_runtime)
     }
 }
 

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -3,19 +3,19 @@
 
 use crate::db_storage::{DbStorage, DbStorageInner};
 use linera_execution::WasmRuntime;
-use linera_views::memory::{create_memory_client_stream_queries, MemoryClient};
+use linera_views::memory::{create_memory_store_stream_queries, MemoryStore};
 use std::sync::Arc;
 
-type MemoryStorageInner = DbStorageInner<MemoryClient>;
+type MemoryStorageInner = DbStorageInner<MemoryStore>;
 
 impl MemoryStorageInner {
     pub fn make(wasm_runtime: Option<WasmRuntime>, max_stream_queries: usize) -> Self {
-        let client = create_memory_client_stream_queries(max_stream_queries);
+        let client = create_memory_store_stream_queries(max_stream_queries);
         Self::new(client, wasm_runtime)
     }
 }
 
-pub type MemoryStorage<C> = DbStorage<MemoryClient, C>;
+pub type MemoryStorage<C> = DbStorage<MemoryStore, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl MemoryStorage<crate::TestClock> {

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    rocks_db::{RocksDbClient, RocksDbContextError, RocksDbStoreConfig},
+    rocks_db::{RocksDbStore, RocksDbContextError, RocksDbStoreConfig},
 };
 use std::sync::Arc;
 
@@ -19,7 +19,7 @@ use {
 #[path = "unit_tests/rocks_db.rs"]
 mod tests;
 
-type RocksDbStorageInner = DbStorageInner<RocksDbClient>;
+type RocksDbStorageInner = DbStorageInner<RocksDbStore>;
 
 impl RocksDbStorageInner {
     #[cfg(any(test, feature = "test"))]
@@ -27,7 +27,7 @@ impl RocksDbStorageInner {
         store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
-        let (client, table_status) = RocksDbClient::new_for_testing(store_config).await?;
+        let (client, table_status) = RocksDbStore::new_for_testing(store_config).await?;
         let storage = Self::new(client, wasm_runtime);
         Ok((storage, table_status))
     }
@@ -36,7 +36,7 @@ impl RocksDbStorageInner {
         store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, RocksDbContextError> {
-        let client = RocksDbClient::initialize(store_config).await?;
+        let client = RocksDbStore::initialize(store_config).await?;
         let storage = Self::new(client, wasm_runtime);
         Ok(storage)
     }
@@ -45,13 +45,13 @@ impl RocksDbStorageInner {
         store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
-        let (client, table_status) = RocksDbClient::new(store_config).await?;
+        let (client, table_status) = RocksDbStore::new(store_config).await?;
         let storage = Self::new(client, wasm_runtime);
         Ok((storage, table_status))
     }
 }
 
-pub type RocksDbStorage<C> = DbStorage<RocksDbClient, C>;
+pub type RocksDbStorage<C> = DbStorage<RocksDbStore, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl RocksDbStorage<TestClock> {

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -36,8 +36,8 @@ impl RocksDbStorageInner {
         store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, RocksDbContextError> {
-        let client = RocksDbStore::initialize(store_config).await?;
-        let storage = Self::new(client, wasm_runtime);
+        let store = RocksDbStore::initialize(store_config).await?;
+        let storage = Self::new(store, wasm_runtime);
         Ok(storage)
     }
 

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    rocks_db::{RocksDbClient, RocksDbContextError, RocksDbKvStoreConfig},
+    rocks_db::{RocksDbClient, RocksDbContextError, RocksDbStoreConfig},
 };
 use std::sync::Arc;
 
@@ -24,7 +24,7 @@ type RocksDbStorageInner = DbStorageInner<RocksDbClient>;
 impl RocksDbStorageInner {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
         let (client, table_status) = RocksDbClient::new_for_testing(store_config).await?;
@@ -33,7 +33,7 @@ impl RocksDbStorageInner {
     }
 
     async fn initialize(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, RocksDbContextError> {
         let client = RocksDbClient::initialize(store_config).await?;
@@ -42,7 +42,7 @@ impl RocksDbStorageInner {
     }
 
     async fn make(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
         let (client, table_status) = RocksDbClient::new(store_config).await?;
@@ -59,7 +59,7 @@ impl RocksDbStorage<TestClock> {
         let dir = TempDir::new().unwrap();
         let path_buf = dir.path().to_path_buf();
         let common_config = create_rocks_db_common_config();
-        let store_config = RocksDbKvStoreConfig {
+        let store_config = RocksDbStoreConfig {
             path_buf,
             common_config,
         };
@@ -71,7 +71,7 @@ impl RocksDbStorage<TestClock> {
     }
 
     pub async fn new_for_testing(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
@@ -87,7 +87,7 @@ impl RocksDbStorage<TestClock> {
 
 impl RocksDbStorage<WallClock> {
     pub async fn initialize(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, RocksDbContextError> {
         let storage = RocksDbStorageInner::initialize(store_config, wasm_runtime).await?;
@@ -99,7 +99,7 @@ impl RocksDbStorage<WallClock> {
     }
 
     pub async fn new(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), RocksDbContextError> {
         let (storage, table_status) = RocksDbStorageInner::make(store_config, wasm_runtime).await?;

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    rocks_db::{RocksDbStore, RocksDbContextError, RocksDbStoreConfig},
+    rocks_db::{RocksDbContextError, RocksDbStore, RocksDbStoreConfig},
 };
 use std::sync::Arc;
 

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    scylla_db::{ScyllaDbStore, ScyllaDbContextError, ScyllaDbStoreConfig},
+    scylla_db::{ScyllaDbContextError, ScyllaDbStore, ScyllaDbStoreConfig},
 };
 use std::sync::Arc;
 

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    scylla_db::{ScyllaDbClient, ScyllaDbContextError, ScyllaDbStoreConfig},
+    scylla_db::{ScyllaDbStore, ScyllaDbContextError, ScyllaDbStoreConfig},
 };
 use std::sync::Arc;
 
@@ -19,7 +19,7 @@ use {
 #[path = "unit_tests/scylla_db.rs"]
 mod tests;
 
-type ScyllaDbStorageInner = DbStorageInner<ScyllaDbClient>;
+type ScyllaDbStorageInner = DbStorageInner<ScyllaDbStore>;
 
 impl ScyllaDbStorageInner {
     #[cfg(any(test, feature = "test"))]
@@ -27,8 +27,8 @@ impl ScyllaDbStorageInner {
         store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
-        let (client, table_status) = ScyllaDbClient::new_for_testing(store_config).await?;
-        let storage = Self::new(client, wasm_runtime);
+        let (store, table_status) = ScyllaDbStore::new_for_testing(store_config).await?;
+        let storage = Self::new(store, wasm_runtime);
         Ok((storage, table_status))
     }
 
@@ -36,8 +36,8 @@ impl ScyllaDbStorageInner {
         store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, ScyllaDbContextError> {
-        let client = ScyllaDbClient::initialize(store_config).await?;
-        let storage = Self::new(client, wasm_runtime);
+        let store = ScyllaDbStore::initialize(store_config).await?;
+        let storage = Self::new(store, wasm_runtime);
         Ok(storage)
     }
 
@@ -45,13 +45,13 @@ impl ScyllaDbStorageInner {
         store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
-        let (client, table_status) = ScyllaDbClient::new(store_config).await?;
-        let storage = Self::new(client, wasm_runtime);
+        let (store, table_status) = ScyllaDbStore::new(store_config).await?;
+        let storage = Self::new(store, wasm_runtime);
         Ok((storage, table_status))
     }
 }
 
-pub type ScyllaDbStorage<C> = DbStorage<ScyllaDbClient, C>;
+pub type ScyllaDbStorage<C> = DbStorage<ScyllaDbStore, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl ScyllaDbStorage<TestClock> {

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -5,7 +5,7 @@ use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
 use linera_execution::WasmRuntime;
 use linera_views::{
     common::TableStatus,
-    scylla_db::{ScyllaDbClient, ScyllaDbContextError, ScyllaDbKvStoreConfig},
+    scylla_db::{ScyllaDbClient, ScyllaDbContextError, ScyllaDbStoreConfig},
 };
 use std::sync::Arc;
 
@@ -24,7 +24,7 @@ type ScyllaDbStorageInner = DbStorageInner<ScyllaDbClient>;
 impl ScyllaDbStorageInner {
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let (client, table_status) = ScyllaDbClient::new_for_testing(store_config).await?;
@@ -33,7 +33,7 @@ impl ScyllaDbStorageInner {
     }
 
     async fn initialize(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, ScyllaDbContextError> {
         let client = ScyllaDbClient::initialize(store_config).await?;
@@ -42,7 +42,7 @@ impl ScyllaDbStorageInner {
     }
 
     async fn make(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let (client, table_status) = ScyllaDbClient::new(store_config).await?;
@@ -59,7 +59,7 @@ impl ScyllaDbStorage<TestClock> {
         let uri = "localhost:9042".to_string();
         let table_name = get_table_name();
         let common_config = create_scylla_db_common_config();
-        let store_config = ScyllaDbKvStoreConfig {
+        let store_config = ScyllaDbStoreConfig {
             uri,
             table_name,
             common_config,
@@ -72,7 +72,7 @@ impl ScyllaDbStorage<TestClock> {
     }
 
     pub async fn new_for_testing(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
@@ -88,7 +88,7 @@ impl ScyllaDbStorage<TestClock> {
 
 impl ScyllaDbStorage<WallClock> {
     pub async fn initialize(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<Self, ScyllaDbContextError> {
         let storage = ScyllaDbStorageInner::initialize(store_config, wasm_runtime).await?;
@@ -100,7 +100,7 @@ impl ScyllaDbStorage<WallClock> {
     }
 
     pub async fn new(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
         wasm_runtime: Option<WasmRuntime>,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let (storage, table_status) =

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -9,9 +9,10 @@ We have designed a `KeyValueStore` trait that represents the basic functionaliti
 of a key-value store whose keys are `Vec<u8>` and whose values are `Vec<u8>`.
 
 We provide an implementation of the trait `KeyValueStore` for the following key-value stores:
-* `MemoryClient` is using the memory (and uses internally a simple B-Tree map).
+* `MemoryStore` is using the memory (and uses internally a simple B-Tree map).
 * `RocksDbStore` is a disk-based key-value store
 * `DynamoDbStore` is the AWS-based DynamoDB service.
+* `ScyllaDbStore` is a cloud based Cassandra compatible database.
 
 The trait `KeyValueStore` was designed so that more storage solutions can be easily added in the future.
 

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -10,7 +10,7 @@ of a key-value store whose keys are `Vec<u8>` and whose values are `Vec<u8>`.
 
 We provide an implementation of the trait `KeyValueStore` for the following key-value stores:
 * `MemoryClient` is using the memory (and uses internally a simple B-Tree map).
-* `RocksDbClient` is a disk-based key-value store
+* `RocksDbStore` is a disk-based key-value store
 * `DynamoDbClient` is the AWS-based DynamoDB service.
 
 The trait `KeyValueStore` was designed so that more storage solutions can be easily added in the future.

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -16,7 +16,7 @@ We provide an implementation of the trait `KeyValueStore` for the following key-
 The trait `KeyValueStore` was designed so that more storage solutions can be easily added in the future.
 
 The `KeyValueStore` trait is also implemented for several internal constructions of clients:
-* The `LruCachingKeyValueClient<K>` client implements the Least Recently Used (LRU)
+* The `LruCachingKeyValueStore<K>` client implements the Least Recently Used (LRU)
 caching of reads into the client.
 * The `ViewContainer<C>` client implements a key-value store client from a context.
 * The `ValueSplittingKeyValueStore<K>` implements a client for which the

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -5,21 +5,21 @@ For an overview, see `README.md`.
 
 ## Key Value Store Clients
 
-We have designed a `KeyValueStoreClient` trait that represents the basic functionalities
+We have designed a `KeyValueStore` trait that represents the basic functionalities
 of a key-value store whose keys are `Vec<u8>` and whose values are `Vec<u8>`.
 
-We provide an implementation of the trait `KeyValueStoreClient` for the following key-value stores:
+We provide an implementation of the trait `KeyValueStore` for the following key-value stores:
 * `MemoryClient` is using the memory (and uses internally a simple B-Tree map).
 * `RocksDbClient` is a disk-based key-value store
 * `DynamoDbClient` is the AWS-based DynamoDB service.
 
-The trait `KeyValueStoreClient` was designed so that more storage solutions can be easily added in the future.
+The trait `KeyValueStore` was designed so that more storage solutions can be easily added in the future.
 
-The `KeyValueStoreClient` trait is also implemented for several internal constructions of clients:
+The `KeyValueStore` trait is also implemented for several internal constructions of clients:
 * The `LruCachingKeyValueClient<K>` client implements the Least Recently Used (LRU)
 caching of reads into the client.
 * The `ViewContainer<C>` client implements a key-value store client from a context.
-* The `ValueSplittingKeyValueStoreClient<K>` implements a client for which the
+* The `ValueSplittingKeyValueStore<K>` implements a client for which the
 size of the values is unbounded, on top of another client for which it is bounded.
 (Some databases have strict limitations on the value size.)
 
@@ -41,7 +41,7 @@ we have a view or any other object then we have a `base_key` associated with it 
 with no other objects. A view is associated to many keys, all of whom share the same
 `base_key` as prefix.
 This leads us to introduce a trait `Context` that can be implemented with a specific
-`KeyValueStoreClient` client and a `base_key`.
+`KeyValueStore` client and a `base_key`.
 
 Another issue to consider is that we do not want to just store the values, but we
 also need to accommodate other features:
@@ -66,7 +66,7 @@ If the user is using a single view then for whatever `base_key` is chosen, the s
 created will be prefix-free. If several views are created then their base keys must be
 chosen to be prefix-free so that the whole set of keys is prefix-free.
 
-## API of the `KeyValueStoreClient`
+## API of the `KeyValueStore`
 
 The design of the key-value store client is done in the following way:
 * We can put a `(key, value)` and delete a `key`.
@@ -97,7 +97,7 @@ the block entries would be processed after accessing the database the next time.
 ## Splitting large values across keys
 
 Some key-value store clients limit the size of the values (named `MAX_VALUE_SIZE`
-in the code). `ValueSplittingKeyValueStoreClient` is a wrapper that accepts values
+in the code). `ValueSplittingKeyValueStore` is a wrapper that accepts values
 of any size. Internally, it splits them into smaller pieces and stores them
 using a wrapped, possibly size-limited, client.
 

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -17,10 +17,10 @@ We provide an implementation of the trait `KeyValueStore` for the following key-
 The trait `KeyValueStore` was designed so that more storage solutions can be easily added in the future.
 
 The `KeyValueStore` trait is also implemented for several internal constructions of clients:
-* The `LruCachingKeyValueStore<K>` client implements the Least Recently Used (LRU)
+* The `LruCachingStore<K>` client implements the Least Recently Used (LRU)
 caching of reads into the client.
 * The `ViewContainer<C>` client implements a key-value store client from a context.
-* The `ValueSplittingKeyValueStore<K>` implements a client for which the
+* The `ValueSplittingStore<K>` implements a client for which the
 size of the values is unbounded, on top of another client for which it is bounded.
 (Some databases have strict limitations on the value size.)
 
@@ -98,7 +98,7 @@ the block entries would be processed after accessing the database the next time.
 ## Splitting large values across keys
 
 Some key-value store clients limit the size of the values (named `MAX_VALUE_SIZE`
-in the code). `ValueSplittingKeyValueStore` is a wrapper that accepts values
+in the code). `ValueSplittingStore` is a wrapper that accepts values
 of any size. Internally, it splits them into smaller pieces and stores them
 using a wrapped, possibly size-limited, client.
 

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -11,7 +11,7 @@ of a key-value store whose keys are `Vec<u8>` and whose values are `Vec<u8>`.
 We provide an implementation of the trait `KeyValueStore` for the following key-value stores:
 * `MemoryClient` is using the memory (and uses internally a simple B-Tree map).
 * `RocksDbStore` is a disk-based key-value store
-* `DynamoDbClient` is the AWS-based DynamoDB service.
+* `DynamoDbStore` is the AWS-based DynamoDB service.
 
 The trait `KeyValueStore` was designed so that more storage solutions can be easily added in the future.
 

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -16,9 +16,10 @@ See `DESIGN.md` for more details.
 The databases supported are of the NoSQL variety and they are key-value stores.
 
 We provide support for the following databases:
-* `MemoryClient` is using the memory
+* `MemoryStore` is using the memory
 * `RocksDbStore` is a disk-based key-value store
 * `DynamoDbStore` is the AWS-based DynamoDB service.
+* `ScyllaDbStore` is a cloud based Cassandra compatible database.
 
 The corresponding type in the code is the `KeyValueStore`.
 A context is the combination of a client and a path (named `base_key` which is

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -18,7 +18,7 @@ The databases supported are of the NoSQL variety and they are key-value stores.
 We provide support for the following databases:
 * `MemoryClient` is using the memory
 * `RocksDbStore` is a disk-based key-value store
-* `DynamoDbClient` is the AWS-based DynamoDB service.
+* `DynamoDbStore` is the AWS-based DynamoDB service.
 
 The corresponding type in the code is the `KeyValueStore`.
 A context is the combination of a client and a path (named `base_key` which is

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -17,7 +17,7 @@ The databases supported are of the NoSQL variety and they are key-value stores.
 
 We provide support for the following databases:
 * `MemoryClient` is using the memory
-* `RocksDbClient` is a disk-based key-value store
+* `RocksDbStore` is a disk-based key-value store
 * `DynamoDbClient` is the AWS-based DynamoDB service.
 
 The corresponding type in the code is the `KeyValueStore`.

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -20,7 +20,7 @@ We provide support for the following databases:
 * `RocksDbClient` is a disk-based key-value store
 * `DynamoDbClient` is the AWS-based DynamoDB service.
 
-The corresponding type in the code is the `KeyValueStoreClient`.
+The corresponding type in the code is the `KeyValueStore`.
 A context is the combination of a client and a path (named `base_key` which is
 of type `Vec<u8>`).
 
@@ -45,7 +45,7 @@ The following views implement the `View` trait:
 * `SetView` implements a set with keys.
 * `CollectionView` implements a map whose values are views themselves.
 * `ReentrantCollectionView` implements a map for which different keys can be accessed independently.
-* `ViewContainer<C>` implements a `KeyValueStoreClient` and is used internally.
+* `ViewContainer<C>` implements a `KeyValueStore` and is used internally.
 
 The `LogView` can be seen as an analog of `VecDeque` while `MapView` is an analog of `BTreeMap`.
 

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -3,11 +3,11 @@
 
 //! This provides several functionalities for the handling of data.
 //! The most important traits are:
-//! * [`KeyValueStoreClient`][trait1] which manages the access to a database and is clonable. It has a minimal interface
+//! * [`KeyValueStore`][trait1] which manages the access to a database and is clonable. It has a minimal interface
 //! * [`Context`][trait2] which provides access to a database plus a `base_key` and some extra type `E` which is carried along
 //! and has no impact on the running of the system. There is also a bunch of other helper functions.
 //!
-//! [trait1]: common::KeyValueStoreClient
+//! [trait1]: common::KeyValueStore
 //! [trait2]: common::Context
 
 use crate::{batch::Batch, views::ViewError};
@@ -41,12 +41,12 @@ pub(crate) enum Update<T> {
     Set(T),
 }
 
-/// Status of a table at the creation time of a [`KeyValueStoreClient`] instance.
+/// Status of a table at the creation time of a [`KeyValueStore`] instance.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TableStatus {
-    /// Table was created during the construction of the [`KeyValueStoreClient`] instance.
+    /// Table was created during the construction of the [`KeyValueStore`] instance.
     New,
-    /// Table already existed when the [`KeyValueStoreClient`] instance was created.
+    /// Table already existed when the [`KeyValueStore`] instance was created.
     Existing,
 }
 
@@ -261,7 +261,7 @@ pub trait KeyValueIterable<Error> {
 
 /// Low-level, asynchronous key-value operations. Useful for storage APIs not based on views.
 #[async_trait]
-pub trait KeyValueStoreClient {
+pub trait KeyValueStore {
     /// The maximal size of values that can be stored.
     const MAX_VALUE_SIZE: usize;
 
@@ -539,7 +539,7 @@ pub trait Context {
 }
 
 /// Implementation of the [`Context`] trait on top of a DB client implementing
-/// [`KeyValueStoreClient`].
+/// [`KeyValueStore`].
 #[derive(Debug, Default, Clone)]
 pub struct ContextFromDb<E, DB> {
     /// The DB client that is shared between views.
@@ -553,7 +553,7 @@ pub struct ContextFromDb<E, DB> {
 impl<E, DB> ContextFromDb<E, DB>
 where
     E: Clone + Send + Sync,
-    DB: KeyValueStoreClient + Clone + Send + Sync,
+    DB: KeyValueStore + Clone + Send + Sync,
     DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<DB::Error>,
 {
@@ -601,7 +601,7 @@ where
 impl<E, DB> Context for ContextFromDb<E, DB>
 where
     E: Clone + Send + Sync,
-    DB: KeyValueStoreClient + Clone + Send + Sync,
+    DB: KeyValueStore + Clone + Send + Sync,
     DB::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<DB::Error>,
 {

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -7,7 +7,7 @@ use crate::{
         CommonStoreConfig, ContextFromDb, KeyIterable, KeyValueIterable, KeyValueStore,
         TableStatus, MIN_VIEW_TAG,
     },
-    lru_caching::LruCachingKeyValueClient,
+    lru_caching::LruCachingKeyValueStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingKeyValueStore},
 };
 use async_lock::{Semaphore, SemaphoreGuard};
@@ -1181,7 +1181,7 @@ impl KeyValueStore for DynamoDbStoreInternal {
 /// A shared DB client for DynamoDb implementing LruCaching
 #[derive(Clone)]
 pub struct DynamoDbStore {
-    store: LruCachingKeyValueClient<ValueSplittingKeyValueStore<DynamoDbStoreInternal>>,
+    store: LruCachingKeyValueStore<ValueSplittingKeyValueStore<DynamoDbStoreInternal>>,
 }
 
 #[async_trait]
@@ -1240,7 +1240,7 @@ impl DynamoDbStore {
         let (store, table_status) = DynamoDbStoreInternal::new_for_testing(store_config).await?;
         let store = ValueSplittingKeyValueStore::new(store);
         let store = Self {
-            store: LruCachingKeyValueClient::new(store, cache_size),
+            store: LruCachingKeyValueStore::new(store, cache_size),
         };
         Ok((store, table_status))
     }
@@ -1253,7 +1253,7 @@ impl DynamoDbStore {
         let store = DynamoDbStoreInternal::initialize(store_config).await?;
         let store = ValueSplittingKeyValueStore::new(store);
         let store = Self {
-            store: LruCachingKeyValueClient::new(store, cache_size),
+            store: LruCachingKeyValueStore::new(store, cache_size),
         };
         Ok(store)
     }
@@ -1294,7 +1294,7 @@ impl DynamoDbStore {
         let (store, table_name) = DynamoDbStoreInternal::new(store_config).await?;
         let store = ValueSplittingKeyValueStore::new(store);
         let store = Self {
-            store: LruCachingKeyValueClient::new(store, cache_size),
+            store: LruCachingKeyValueStore::new(store, cache_size),
         };
         Ok((store, table_name))
     }

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -554,7 +554,7 @@ impl DeletePrefixExpander for DynamoDbClientInternal {
 
 /// The initial configuration of the system
 #[derive(Debug)]
-pub struct DynamoDbKvStoreConfig {
+pub struct DynamoDbStoreConfig {
     /// The AWS configuration
     pub config: Config,
     /// The table_name used
@@ -656,7 +656,7 @@ impl DynamoDbClientInternal {
     /// Creates a new [`DynamoDbClientInternal`] instance from scratch using the provided `config` parameters.
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         if Self::test_table_existence(&client, &store_config.table_name).await? {
@@ -680,27 +680,27 @@ impl DynamoDbClientInternal {
 
     /// Testing the existence of a table
     pub async fn test_existence(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<bool, DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         Self::test_table_existence(&client, &store_config.table_name).await
     }
 
-    async fn delete_all(store_config: DynamoDbKvStoreConfig) -> Result<(), DynamoDbContextError> {
+    async fn delete_all(store_config: DynamoDbStoreConfig) -> Result<(), DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         clear_tables(&client).await?;
         Ok(())
     }
 
     async fn list_tables(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<Vec<String>, DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         list_tables_from_client(&client).await
     }
 
     async fn delete_single(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<(), DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         client
@@ -713,7 +713,7 @@ impl DynamoDbClientInternal {
 
     /// Creates a new [`DynamoDbClientInternal`] instance using the provided `config` parameters.
     pub async fn new(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         let stop_if_table_exists = false;
@@ -730,7 +730,7 @@ impl DynamoDbClientInternal {
 
     /// Initializes a RocksDB database from a specified path.
     pub async fn initialize(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<Self, DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         let stop_if_table_exists = false;
@@ -1234,7 +1234,7 @@ impl DynamoDbClient {
     /// Creates a `DynamoDbClient` from scratch with an LRU cache
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (client, table_status) = DynamoDbClientInternal::new_for_testing(store_config).await?;
@@ -1247,7 +1247,7 @@ impl DynamoDbClient {
 
     /// Initializes a `DynamoDbClient`.
     pub async fn initialize(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<Self, DynamoDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let client = DynamoDbClientInternal::initialize(store_config).await?;
@@ -1260,35 +1260,35 @@ impl DynamoDbClient {
 
     /// Deletes all the tables from the database
     pub async fn test_existence(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<bool, DynamoDbContextError> {
         DynamoDbClientInternal::test_existence(store_config).await
     }
 
     /// List all the tables of the database
     pub async fn list_tables(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<Vec<String>, DynamoDbContextError> {
         DynamoDbClientInternal::list_tables(store_config).await
     }
 
     /// Deletes all the tables from the database
     pub async fn delete_all(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<(), DynamoDbContextError> {
         DynamoDbClientInternal::delete_all(store_config).await
     }
 
     /// Deletes a single table from the database
     pub async fn delete_single(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<(), DynamoDbContextError> {
         DynamoDbClientInternal::delete_single(store_config).await
     }
 
     /// Creates a `DynamoDbClient` with an LRU cache
     pub async fn new(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (client, table_name) = DynamoDbClientInternal::new(store_config).await?;
@@ -1312,7 +1312,7 @@ where
     /// Creates a new [`DynamoDbContext`] instance from scratch from the given AWS configuration.
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         base_key: Vec<u8>,
         extra: E,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
@@ -1327,7 +1327,7 @@ where
 
     /// Creates a new [`DynamoDbContext`] instance from the given AWS configuration.
     pub async fn new(
-        store_config: DynamoDbKvStoreConfig,
+        store_config: DynamoDbStoreConfig,
         base_key: Vec<u8>,
         extra: E,
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
@@ -1573,7 +1573,7 @@ pub async fn create_dynamo_db_test_client() -> DynamoDbClient {
     let table_name = table.parse().expect("Invalid table name");
     let use_localstack = true;
     let config = get_config(use_localstack).await.expect("config");
-    let store_config = DynamoDbKvStoreConfig {
+    let store_config = DynamoDbStoreConfig {
         config,
         table_name,
         common_config,

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -7,8 +7,8 @@ use crate::{
         CommonStoreConfig, ContextFromStore, KeyIterable, KeyValueIterable, KeyValueStore,
         TableStatus, MIN_VIEW_TAG,
     },
-    lru_caching::LruCachingKeyValueStore,
-    value_splitting::{DatabaseConsistencyError, ValueSplittingKeyValueStore},
+    lru_caching::LruCachingStore,
+    value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
 };
 use async_lock::{Semaphore, SemaphoreGuard};
 use async_trait::async_trait;
@@ -1179,7 +1179,7 @@ impl KeyValueStore for DynamoDbStoreInternal {
 /// A shared DB client for DynamoDb implementing LruCaching
 #[derive(Clone)]
 pub struct DynamoDbStore {
-    store: LruCachingKeyValueStore<ValueSplittingKeyValueStore<DynamoDbStoreInternal>>,
+    store: LruCachingStore<ValueSplittingStore<DynamoDbStoreInternal>>,
 }
 
 #[async_trait]
@@ -1236,10 +1236,9 @@ impl DynamoDbStore {
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (store, table_status) = DynamoDbStoreInternal::new_for_testing(store_config).await?;
-        let store = ValueSplittingKeyValueStore::new(store);
-        let store = Self {
-            store: LruCachingKeyValueStore::new(store, cache_size),
-        };
+        let store = ValueSplittingStore::new(store);
+        let store = LruCachingStore::new(store, cache_size);
+        let store = Self { store };
         Ok((store, table_status))
     }
 
@@ -1249,10 +1248,9 @@ impl DynamoDbStore {
     ) -> Result<Self, DynamoDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let store = DynamoDbStoreInternal::initialize(store_config).await?;
-        let store = ValueSplittingKeyValueStore::new(store);
-        let store = Self {
-            store: LruCachingKeyValueStore::new(store, cache_size),
-        };
+        let store = ValueSplittingStore::new(store);
+        let store = LruCachingStore::new(store, cache_size);
+        let store = Self { store };
         Ok(store)
     }
 
@@ -1288,10 +1286,9 @@ impl DynamoDbStore {
     ) -> Result<(Self, TableStatus), DynamoDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (store, table_name) = DynamoDbStoreInternal::new(store_config).await?;
-        let store = ValueSplittingKeyValueStore::new(store);
-        let store = Self {
-            store: LruCachingKeyValueStore::new(store, cache_size),
-        };
+        let store = ValueSplittingStore::new(store);
+        let store = LruCachingStore::new(store, cache_size);
+        let store = Self { store };
         Ok((store, table_name))
     }
 }

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -699,9 +699,7 @@ impl DynamoDbStoreInternal {
         list_tables_from_client(&client).await
     }
 
-    async fn delete_single(
-        store_config: DynamoDbStoreConfig,
-    ) -> Result<(), DynamoDbContextError> {
+    async fn delete_single(store_config: DynamoDbStoreConfig) -> Result<(), DynamoDbContextError> {
         let client = Client::from_conf(store_config.config);
         client
             .delete_table()
@@ -1273,9 +1271,7 @@ impl DynamoDbStore {
     }
 
     /// Deletes all the tables from the database
-    pub async fn delete_all(
-        store_config: DynamoDbStoreConfig,
-    ) -> Result<(), DynamoDbContextError> {
+    pub async fn delete_all(store_config: DynamoDbStoreConfig) -> Result<(), DynamoDbContextError> {
         DynamoDbStoreInternal::delete_all(store_config).await
     }
 

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -21,7 +21,7 @@ use std::{
 
 #[cfg(any(test, feature = "test"))]
 use {
-    crate::common::{ContextFromDb, KeyValueStore},
+    crate::common::{ContextFromStore, KeyValueStore},
     crate::memory::{MemoryContext, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
     async_lock::{MutexGuardArc, RwLock},
     std::sync::Arc,
@@ -837,7 +837,7 @@ where
 
 /// A context that stores all values in memory.
 #[cfg(any(test, feature = "test"))]
-pub type KeyValueStoreMemoryContext<E> = ContextFromDb<E, ViewContainer<MemoryContext<()>>>;
+pub type KeyValueStoreMemoryContext<E> = ContextFromStore<E, ViewContainer<MemoryContext<()>>>;
 
 #[cfg(any(test, feature = "test"))]
 impl<E> KeyValueStoreMemoryContext<E> {
@@ -848,11 +848,7 @@ impl<E> KeyValueStoreMemoryContext<E> {
         extra: E,
     ) -> Result<Self, ViewError> {
         let context = MemoryContext::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES, ());
-        let key_value_store_view = ViewContainer::new(context).await?;
-        Ok(Self {
-            db: key_value_store_view,
-            base_key,
-            extra,
-        })
+        let store = ViewContainer::new(context).await?;
+        Ok(Self { store, base_key, extra })
     }
 }

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -21,15 +21,15 @@ use std::{
 
 #[cfg(any(test, feature = "test"))]
 use {
-    crate::common::{ContextFromDb, KeyValueStoreClient},
+    crate::common::{ContextFromDb, KeyValueStore},
     crate::memory::{MemoryContext, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
     async_lock::{MutexGuardArc, RwLock},
     std::sync::Arc,
 };
 
 /// We implement two types:
-/// 1) The first type KeyValueStoreView implements View and the function of KeyValueStoreClient
-/// (though not KeyValueStoreClient).
+/// 1) The first type KeyValueStoreView implements View and the function of KeyValueStore
+/// (though not KeyValueStore).
 ///
 /// 2) The second type ViewContainer encapsulates KeyValueStoreView and provides the following functionalities:
 /// * The Clone trait
@@ -46,7 +46,7 @@ enum KeyTag {
     Hash,
 }
 
-/// A view that represents the functions of KeyValueStoreClient (though not KeyValueStoreClient).
+/// A view that represents the functions of KeyValueStore (though not KeyValueStore).
 ///
 /// Comment on the data set:
 /// In order to work, the view needs to store the updates and deleted_prefixes.
@@ -766,7 +766,7 @@ pub struct ViewContainer<C> {
 
 #[cfg(any(test, feature = "test"))]
 #[async_trait]
-impl<C> KeyValueStoreClient for ViewContainer<C>
+impl<C> KeyValueStore for ViewContainer<C>
 where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -849,6 +849,10 @@ impl<E> KeyValueStoreMemoryContext<E> {
     ) -> Result<Self, ViewError> {
         let context = MemoryContext::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES, ());
         let store = ViewContainer::new(context).await?;
-        Ok(Self { store, base_key, extra })
+        Ok(Self {
+            store,
+            base_key,
+            extra,
+        })
     }
 }

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -19,7 +19,7 @@
 //! We provide support for the following databases:
 //! * `MemoryClient` is using the memory
 //! * `RocksDbStore` is a disk-based key-value store
-//! * `DynamoDbClient` is the AWS-based DynamoDB service.
+//! * `DynamoDbStore` is the AWS-based DynamoDB service.
 //!
 //! The corresponding type in the code is the `KeyValueStore`.
 //! A context is the combination of a client and a path (named `base_key` which is

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -21,7 +21,7 @@
 //! * `RocksDbClient` is a disk-based key-value store
 //! * `DynamoDbClient` is the AWS-based DynamoDB service.
 //!
-//! The corresponding type in the code is the `KeyValueStoreClient`.
+//! The corresponding type in the code is the `KeyValueStore`.
 //! A context is the combination of a client and a path (named `base_key` which is
 //! of type `Vec<u8>`).
 //!
@@ -46,7 +46,7 @@
 //! * `SetView` implements a set with keys.
 //! * `CollectionView` implements a map whose values are views themselves.
 //! * `ReentrantCollectionView` implements a map for which different keys can be accessed independently.
-//! * `ViewContainer<C>` implements a `KeyValueStoreClient` and is used internally.
+//! * `ViewContainer<C>` implements a `KeyValueStore` and is used internally.
 //!
 //! The `LogView` can be seen as an analog of `VecDeque` while `MapView` is an analog of `BTreeMap`.
 
@@ -55,7 +55,7 @@
 /// The definition of the batches for writing in the database.
 pub mod batch;
 
-/// The definitions used for the `KeyValueStoreClient` and `Context`.
+/// The definitions used for the `KeyValueStore` and `Context`.
 pub mod common;
 
 /// The code for handling big values by splitting them into several small ones.

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -17,9 +17,10 @@
 //! The databases supported are of the NoSQL variety and they are key-value stores.
 //!
 //! We provide support for the following databases:
-//! * `MemoryClient` is using the memory
+//! * `MemoryStore` is using the memory
 //! * `RocksDbStore` is a disk-based key-value store
 //! * `DynamoDbStore` is the AWS-based DynamoDB service.
+//! * `ScyllaDbStore` is a cloud based Cassandra compatible database.
 //!
 //! The corresponding type in the code is the `KeyValueStore`.
 //! A context is the combination of a client and a path (named `base_key` which is

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! We provide support for the following databases:
 //! * `MemoryClient` is using the memory
-//! * `RocksDbClient` is a disk-based key-value store
+//! * `RocksDbStore` is a disk-based key-value store
 //! * `DynamoDbClient` is the AWS-based DynamoDB service.
 //!
 //! The corresponding type in the code is the `KeyValueStore`.

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -86,14 +86,14 @@ impl<'a> LruPrefixCache {
 
 /// We take a client, a maximum size and build a LRU-based system.
 #[derive(Clone)]
-pub struct LruCachingKeyValueStore<K> {
+pub struct LruCachingStore<K> {
     /// The inner client that is called by the LRU cache one
     pub client: K,
     lru_read_values: Option<Arc<Mutex<LruPrefixCache>>>,
 }
 
 #[async_trait]
-impl<K> KeyValueStore for LruCachingKeyValueStore<K>
+impl<K> KeyValueStore for LruCachingStore<K>
 where
     K: KeyValueStore + Send + Sync,
 {
@@ -210,7 +210,7 @@ where
     }
 }
 
-impl<K> LruCachingKeyValueStore<K>
+impl<K> LruCachingStore<K>
 where
     K: KeyValueStore,
 {
@@ -233,7 +233,7 @@ where
 
 /// A context that stores all values in memory.
 #[cfg(any(test, feature = "test"))]
-pub type LruCachingMemoryContext<E> = ContextFromStore<E, LruCachingKeyValueStore<MemoryStore>>;
+pub type LruCachingMemoryContext<E> = ContextFromStore<E, LruCachingStore<MemoryStore>>;
 
 #[cfg(any(test, feature = "test"))]
 impl<E> LruCachingMemoryContext<E> {
@@ -245,7 +245,7 @@ impl<E> LruCachingMemoryContext<E> {
         n: usize,
     ) -> Result<Self, ViewError> {
         let store = MemoryStore::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES);
-        let store = LruCachingKeyValueStore::new(store, n);
+        let store = LruCachingStore::new(store, n);
         Ok(Self {
             store,
             base_key,

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -246,6 +246,10 @@ impl<E> LruCachingMemoryContext<E> {
     ) -> Result<Self, ViewError> {
         let store = MemoryStore::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES);
         let store = LruCachingKeyValueStore::new(store, n);
-        Ok(Self { store, base_key, extra })
+        Ok(Self {
+            store,
+            base_key,
+            extra,
+        })
     }
 }

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -6,7 +6,7 @@ pub const TEST_CACHE_SIZE: usize = 1000;
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_interval, KeyValueStoreClient},
+    common::{get_interval, KeyValueStore},
 };
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -93,9 +93,9 @@ pub struct LruCachingKeyValueClient<K> {
 }
 
 #[async_trait]
-impl<K> KeyValueStoreClient for LruCachingKeyValueClient<K>
+impl<K> KeyValueStore for LruCachingKeyValueClient<K>
 where
-    K: KeyValueStoreClient + Send + Sync,
+    K: KeyValueStore + Send + Sync,
 {
     // The LRU cache does not change the underlying client's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
@@ -212,7 +212,7 @@ where
 
 impl<K> LruCachingKeyValueClient<K>
 where
-    K: KeyValueStoreClient,
+    K: KeyValueStore,
 {
     /// Creates a new key-value store client that implements an LRU cache.
     pub fn new(client: K, max_size: usize) -> Self {

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -19,7 +19,7 @@ use std::{
 #[cfg(any(test, feature = "test"))]
 use {
     crate::common::ContextFromDb,
-    crate::memory::{MemoryClient, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
+    crate::memory::{MemoryStore, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
     crate::views::ViewError,
     async_lock::MutexGuardArc,
 };
@@ -233,7 +233,7 @@ where
 
 /// A context that stores all values in memory.
 #[cfg(any(test, feature = "test"))]
-pub type LruCachingMemoryContext<E> = ContextFromDb<E, LruCachingKeyValueStore<MemoryClient>>;
+pub type LruCachingMemoryContext<E> = ContextFromDb<E, LruCachingKeyValueStore<MemoryStore>>;
 
 #[cfg(any(test, feature = "test"))]
 impl<E> LruCachingMemoryContext<E> {
@@ -244,7 +244,7 @@ impl<E> LruCachingMemoryContext<E> {
         extra: E,
         n: usize,
     ) -> Result<Self, ViewError> {
-        let store = MemoryClient::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES);
+        let store = MemoryStore::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES);
         let store = LruCachingKeyValueStore::new(store, n);
         Ok(Self {
             db: store,

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -18,7 +18,7 @@ use std::{
 
 #[cfg(any(test, feature = "test"))]
 use {
-    crate::common::ContextFromDb,
+    crate::common::ContextFromStore,
     crate::memory::{MemoryStore, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
     crate::views::ViewError,
     async_lock::MutexGuardArc,
@@ -233,7 +233,7 @@ where
 
 /// A context that stores all values in memory.
 #[cfg(any(test, feature = "test"))]
-pub type LruCachingMemoryContext<E> = ContextFromDb<E, LruCachingKeyValueStore<MemoryStore>>;
+pub type LruCachingMemoryContext<E> = ContextFromStore<E, LruCachingKeyValueStore<MemoryStore>>;
 
 #[cfg(any(test, feature = "test"))]
 impl<E> LruCachingMemoryContext<E> {
@@ -246,10 +246,6 @@ impl<E> LruCachingMemoryContext<E> {
     ) -> Result<Self, ViewError> {
         let store = MemoryStore::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES);
         let store = LruCachingKeyValueStore::new(store, n);
-        Ok(Self {
-            db: store,
-            base_key,
-            extra,
-        })
+        Ok(Self { store, base_key, extra })
     }
 }

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 
 /// The initial configuration of the system
 #[derive(Debug)]
-pub struct MemoryKvStoreConfig {
+pub struct MemoryStoreConfig {
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,
 }

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_interval, CommonStoreConfig, ContextFromDb, KeyValueStoreClient},
+    common::{get_interval, CommonStoreConfig, ContextFromDb, KeyValueStore},
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
 };
@@ -34,7 +34,7 @@ pub struct MemoryClient {
 }
 
 #[async_trait]
-impl KeyValueStoreClient for MemoryClient {
+impl KeyValueStore for MemoryClient {
     const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -28,13 +28,13 @@ pub type MemoryStoreMap = BTreeMap<Vec<u8>, Vec<u8>>;
 
 /// A virtual DB client where data are persisted in memory.
 #[derive(Clone)]
-pub struct MemoryClient {
+pub struct MemoryStore {
     map: Arc<RwLock<MutexGuardArc<MemoryStoreMap>>>,
     max_stream_queries: usize,
 }
 
 #[async_trait]
-impl KeyValueStore for MemoryClient {
+impl KeyValueStore for MemoryStore {
     const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Error = MemoryContextError;
@@ -118,11 +118,11 @@ impl KeyValueStore for MemoryClient {
     }
 }
 
-impl MemoryClient {
-    /// constructor of MemoryClient
+impl MemoryStore {
+    /// constructor of MemoryStore
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, max_stream_queries: usize) -> Self {
         let map = Arc::new(RwLock::new(guard));
-        MemoryClient {
+        MemoryStore {
             map,
             max_stream_queries,
         }
@@ -130,12 +130,12 @@ impl MemoryClient {
 }
 
 /// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type MemoryContext<E> = ContextFromDb<E, MemoryClient>;
+pub type MemoryContext<E> = ContextFromDb<E, MemoryStore>;
 
 impl<E> MemoryContext<E> {
     /// Creates a [`MemoryContext`].
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, max_stream_queries: usize, extra: E) -> Self {
-        let db = MemoryClient::new(guard, max_stream_queries);
+        let db = MemoryStore::new(guard, max_stream_queries);
         let base_key = Vec::new();
         Self {
             db,
@@ -157,17 +157,17 @@ pub fn create_memory_context() -> MemoryContext<()> {
 }
 
 /// Creates a test memory client for working.
-pub fn create_memory_client_stream_queries(max_stream_queries: usize) -> MemoryClient {
+pub fn create_memory_store_stream_queries(max_stream_queries: usize) -> MemoryStore {
     let state = Arc::new(Mutex::new(BTreeMap::new()));
     let guard = state
         .try_lock_arc()
         .expect("We should acquire the lock just after creating the object");
-    MemoryClient::new(guard, max_stream_queries)
+    MemoryStore::new(guard, max_stream_queries)
 }
 
-/// Creates a test memory client for working.
-pub fn create_memory_client() -> MemoryClient {
-    create_memory_client_stream_queries(TEST_MEMORY_MAX_STREAM_QUERIES)
+/// Creates a test memory store for working.
+pub fn create_memory_store() -> MemoryStore {
+    create_memory_store_stream_queries(TEST_MEMORY_MAX_STREAM_QUERIES)
 }
 
 /// The error type for [`MemoryContext`].
@@ -177,8 +177,8 @@ pub enum MemoryContextError {
     #[error("BCS error: {0}")]
     Bcs(#[from] bcs::Error),
 
-    /// The value is too large for the MemoryClient
-    #[error("The value is too large for the MemoryClient")]
+    /// The value is too large for the MemoryStore
+    #[error("The value is too large for the MemoryStore")]
     TooLargeValue,
 
     /// The database is not consistent

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_interval, CommonStoreConfig, ContextFromDb, KeyValueStore},
+    common::{get_interval, CommonStoreConfig, ContextFromStore, KeyValueStore},
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
 };
@@ -130,18 +130,14 @@ impl MemoryStore {
 }
 
 /// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type MemoryContext<E> = ContextFromDb<E, MemoryStore>;
+pub type MemoryContext<E> = ContextFromStore<E, MemoryStore>;
 
 impl<E> MemoryContext<E> {
     /// Creates a [`MemoryContext`].
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, max_stream_queries: usize, extra: E) -> Self {
-        let db = MemoryStore::new(guard, max_stream_queries);
+        let store = MemoryStore::new(guard, max_stream_queries);
         let base_key = Vec::new();
-        Self {
-            db,
-            base_key,
-            extra,
-        }
+        Self { store, base_key, extra }
     }
 }
 

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -137,7 +137,11 @@ impl<E> MemoryContext<E> {
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, max_stream_queries: usize, extra: E) -> Self {
         let store = MemoryStore::new(guard, max_stream_queries);
         let base_key = Vec::new();
-        Self { store, base_key, extra }
+        Self {
+            store,
+            base_key,
+            extra,
+        }
     }
 }
 

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{get_upper_bound, CommonStoreConfig, ContextFromDb, KeyValueStore, TableStatus},
-    lru_caching::LruCachingKeyValueClient,
+    lru_caching::LruCachingKeyValueStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingKeyValueStore},
 };
 use async_trait::async_trait;
@@ -208,7 +208,7 @@ impl KeyValueStore for RocksDbStoreInternal {
 /// A shared DB client for RocksDB implementing LruCaching
 #[derive(Clone)]
 pub struct RocksDbStore {
-    store: LruCachingKeyValueClient<ValueSplittingKeyValueStore<RocksDbStoreInternal>>,
+    store: LruCachingKeyValueStore<ValueSplittingKeyValueStore<RocksDbStoreInternal>>,
 }
 
 impl RocksDbStore {
@@ -309,7 +309,7 @@ impl RocksDbStore {
         };
         let store = ValueSplittingKeyValueStore::new(store);
         let store = Self {
-            store: LruCachingKeyValueClient::new(store, cache_size),
+            store: LruCachingKeyValueStore::new(store, cache_size),
         };
         Ok((store, table_status))
     }

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_upper_bound, CommonStoreConfig, ContextFromDb, KeyValueStore, TableStatus},
+    common::{get_upper_bound, CommonStoreConfig, ContextFromStore, KeyValueStore, TableStatus},
     lru_caching::LruCachingKeyValueStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingKeyValueStore},
 };
@@ -340,7 +340,7 @@ pub async fn create_rocks_db_test_store() -> RocksDbStore {
 }
 
 /// An implementation of [`crate::common::Context`] based on RocksDB
-pub type RocksDbContext<E> = ContextFromDb<E, RocksDbStore>;
+pub type RocksDbContext<E> = ContextFromStore<E, RocksDbStore>;
 
 #[async_trait]
 impl KeyValueStore for RocksDbStore {
@@ -390,12 +390,8 @@ impl KeyValueStore for RocksDbStore {
 
 impl<E: Clone + Send + Sync> RocksDbContext<E> {
     /// Creates a [`RocksDbContext`].
-    pub fn new(db: RocksDbStore, base_key: Vec<u8>, extra: E) -> Self {
-        Self {
-            db,
-            base_key,
-            extra,
-        }
+    pub fn new(store: RocksDbStore, base_key: Vec<u8>, extra: E) -> Self {
+        Self { store, base_key, extra }
     }
 }
 

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -4,8 +4,8 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{get_upper_bound, CommonStoreConfig, ContextFromStore, KeyValueStore, TableStatus},
-    lru_caching::LruCachingKeyValueStore,
-    value_splitting::{DatabaseConsistencyError, ValueSplittingKeyValueStore},
+    lru_caching::LruCachingStore,
+    value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
 };
 use async_trait::async_trait;
 use linera_base::ensure;
@@ -208,7 +208,7 @@ impl KeyValueStore for RocksDbStoreInternal {
 /// A shared DB client for RocksDB implementing LruCaching
 #[derive(Clone)]
 pub struct RocksDbStore {
-    store: LruCachingKeyValueStore<ValueSplittingKeyValueStore<RocksDbStoreInternal>>,
+    store: LruCachingStore<ValueSplittingStore<RocksDbStoreInternal>>,
 }
 
 impl RocksDbStore {
@@ -305,10 +305,9 @@ impl RocksDbStore {
             db: Arc::new(db),
             max_stream_queries,
         };
-        let store = ValueSplittingKeyValueStore::new(store);
-        let store = Self {
-            store: LruCachingKeyValueStore::new(store, cache_size),
-        };
+        let store = ValueSplittingStore::new(store);
+        let store = LruCachingStore::new(store, cache_size);
+        let store = Self { store };
         Ok((store, table_status))
     }
 }

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -391,7 +391,11 @@ impl KeyValueStore for RocksDbStore {
 impl<E: Clone + Send + Sync> RocksDbContext<E> {
     /// Creates a [`RocksDbContext`].
     pub fn new(store: RocksDbStore, base_key: Vec<u8>, extra: E) -> Self {
-        Self { store, base_key, extra }
+        Self {
+            store,
+            base_key,
+            extra,
+        }
     }
 }
 

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -263,9 +263,7 @@ impl RocksDbStore {
     }
 
     /// Initializes a RocksDB database from a specified path.
-    pub async fn initialize(
-        store_config: RocksDbStoreConfig,
-    ) -> Result<Self, RocksDbContextError> {
+    pub async fn initialize(store_config: RocksDbStoreConfig) -> Result<Self, RocksDbContextError> {
         let create_if_missing = true;
         let (client, table_status) = Self::new_internal(store_config, create_if_missing).await?;
         if table_status == TableStatus::Existing {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -43,7 +43,7 @@ pub struct RocksDbClientInternal {
 
 /// The initial configuration of the system
 #[derive(Clone, Debug)]
-pub struct RocksDbKvStoreConfig {
+pub struct RocksDbStoreConfig {
     /// The AWS configuration
     pub path_buf: PathBuf,
     /// The common configuration of the key value store
@@ -214,7 +214,7 @@ pub struct RocksDbClient {
 impl RocksDbClient {
     /// Returns whether a table already exists.
     pub async fn test_existence(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
     ) -> Result<bool, RocksDbContextError> {
         let options = rocksdb::Options::default();
         let result = DB::open(&options, store_config.path_buf.clone());
@@ -230,7 +230,7 @@ impl RocksDbClient {
     /// Creates a RocksDB database for unit tests from a specified path.
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
     ) -> Result<(RocksDbClient, TableStatus), RocksDbContextError> {
         let path = store_config.path_buf.as_path();
         fs::remove_dir_all(path)?;
@@ -239,7 +239,7 @@ impl RocksDbClient {
     }
 
     /// Creates all RocksDB databases
-    pub async fn delete_all(store_config: RocksDbKvStoreConfig) -> Result<(), RocksDbContextError> {
+    pub async fn delete_all(store_config: RocksDbStoreConfig) -> Result<(), RocksDbContextError> {
         let path = store_config.path_buf.as_path();
         fs::remove_dir_all(path)?;
         Ok(())
@@ -247,7 +247,7 @@ impl RocksDbClient {
 
     /// Creates all RocksDB databases
     pub async fn delete_single(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
     ) -> Result<(), RocksDbContextError> {
         let path = store_config.path_buf.as_path();
         fs::remove_dir_all(path)?;
@@ -256,7 +256,7 @@ impl RocksDbClient {
 
     /// Creates a RocksDB database from a specified path.
     pub async fn new(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
     ) -> Result<(RocksDbClient, TableStatus), RocksDbContextError> {
         let create_if_missing = false;
         Self::new_internal(store_config, create_if_missing).await
@@ -264,7 +264,7 @@ impl RocksDbClient {
 
     /// Initializes a RocksDB database from a specified path.
     pub async fn initialize(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
     ) -> Result<Self, RocksDbContextError> {
         let create_if_missing = true;
         let (client, table_status) = Self::new_internal(store_config, create_if_missing).await?;
@@ -276,7 +276,7 @@ impl RocksDbClient {
 
     /// Creates a RocksDB database from a specified path.
     async fn new_internal(
-        store_config: RocksDbKvStoreConfig,
+        store_config: RocksDbStoreConfig,
         create_if_missing: bool,
     ) -> Result<(RocksDbClient, TableStatus), RocksDbContextError> {
         let kv_name = format!(
@@ -331,7 +331,7 @@ pub async fn create_rocks_db_test_client() -> RocksDbClient {
     let dir = TempDir::new().unwrap();
     let path_buf = dir.path().to_path_buf();
     let common_config = create_rocks_db_common_config();
-    let store_config = RocksDbKvStoreConfig {
+    let store_config = RocksDbStoreConfig {
         path_buf,
         common_config,
     };

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -768,7 +768,11 @@ pub type ScyllaDbContext<E> = ContextFromStore<E, ScyllaDbStore>;
 impl<E: Clone + Send + Sync> ScyllaDbContext<E> {
     /// Creates a [`ScyllaDbContext`].
     pub fn new(store: ScyllaDbStore, base_key: Vec<u8>, extra: E) -> Self {
-        Self { store, base_key, extra }
+        Self {
+            store,
+            base_key,
+            extra,
+        }
     }
 }
 

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -21,7 +21,7 @@ use crate::{lru_caching::TEST_CACHE_SIZE, test_utils::get_table_name};
 use crate::{
     batch::{Batch, DeletePrefixExpander},
     common::{
-        get_upper_bound_option, CommonStoreConfig, ContextFromDb, KeyValueStore, TableStatus,
+        get_upper_bound_option, CommonStoreConfig, ContextFromStore, KeyValueStore, TableStatus,
     },
     lru_caching::LruCachingKeyValueStore,
     value_splitting::DatabaseConsistencyError,
@@ -763,16 +763,12 @@ pub async fn create_scylla_db_test_store() -> ScyllaDbStore {
 }
 
 /// An implementation of [`crate::common::Context`] based on ScyllaDB
-pub type ScyllaDbContext<E> = ContextFromDb<E, ScyllaDbStore>;
+pub type ScyllaDbContext<E> = ContextFromStore<E, ScyllaDbStore>;
 
 impl<E: Clone + Send + Sync> ScyllaDbContext<E> {
     /// Creates a [`ScyllaDbContext`].
-    pub fn new(db: ScyllaDbStore, base_key: Vec<u8>, extra: E) -> Self {
-        Self {
-            db,
-            base_key,
-            extra,
-        }
+    pub fn new(store: ScyllaDbStore, base_key: Vec<u8>, extra: E) -> Self {
+        Self { store, base_key, extra }
     }
 }
 

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -539,9 +539,7 @@ impl ScyllaDbStoreInternal {
         Ok(())
     }
 
-    async fn delete_single(
-        store_config: ScyllaDbStoreConfig,
-    ) -> Result<(), ScyllaDbContextError> {
+    async fn delete_single(store_config: ScyllaDbStoreConfig) -> Result<(), ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
             .build()
@@ -707,9 +705,7 @@ impl ScyllaDbStore {
     }
 
     /// Delete all the tables of a database
-    pub async fn delete_all(
-        store_config: ScyllaDbStoreConfig,
-    ) -> Result<(), ScyllaDbContextError> {
+    pub async fn delete_all(store_config: ScyllaDbStoreConfig) -> Result<(), ScyllaDbContextError> {
         ScyllaDbStoreInternal::delete_all(store_config).await
     }
 

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -23,7 +23,7 @@ use crate::{
     common::{
         get_upper_bound_option, CommonStoreConfig, ContextFromDb, KeyValueStore, TableStatus,
     },
-    lru_caching::LruCachingKeyValueClient,
+    lru_caching::LruCachingKeyValueStore,
     value_splitting::DatabaseConsistencyError,
 };
 use async_lock::{Semaphore, SemaphoreGuard};
@@ -613,7 +613,7 @@ impl ScyllaDbStoreInternal {
 /// A shared DB store for ScyllaDB implementing LruCaching
 #[derive(Clone)]
 pub struct ScyllaDbStore {
-    store: LruCachingKeyValueClient<ScyllaDbStoreInternal>,
+    store: LruCachingKeyValueStore<ScyllaDbStoreInternal>,
 }
 
 /// The type for building a new ScyllaDb Key Value Store
@@ -683,7 +683,7 @@ impl ScyllaDbStore {
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (store, table_status) = ScyllaDbStoreInternal::new_for_testing(store_config).await?;
-        let store = LruCachingKeyValueClient::new(store, cache_size);
+        let store = LruCachingKeyValueStore::new(store, cache_size);
         let store = ScyllaDbStore { store };
         Ok((store, table_status))
     }
@@ -694,7 +694,7 @@ impl ScyllaDbStore {
     ) -> Result<Self, ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let store = ScyllaDbStoreInternal::initialize(store_config).await?;
-        let store = LruCachingKeyValueClient::new(store, cache_size);
+        let store = LruCachingKeyValueStore::new(store, cache_size);
         let store = ScyllaDbStore { store };
         Ok(store)
     }
@@ -733,7 +733,7 @@ impl ScyllaDbStore {
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (store, table_status) = ScyllaDbStoreInternal::new(store_config).await?;
-        let store = LruCachingKeyValueClient::new(store, cache_size);
+        let store = LruCachingKeyValueStore::new(store, cache_size);
         let store = ScyllaDbStore { store };
         Ok((store, table_status))
     }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -23,7 +23,7 @@ use crate::{
     common::{
         get_upper_bound_option, CommonStoreConfig, ContextFromStore, KeyValueStore, TableStatus,
     },
-    lru_caching::LruCachingKeyValueStore,
+    lru_caching::LruCachingStore,
     value_splitting::DatabaseConsistencyError,
 };
 use async_lock::{Semaphore, SemaphoreGuard};
@@ -611,7 +611,7 @@ impl ScyllaDbStoreInternal {
 /// A shared DB store for ScyllaDB implementing LruCaching
 #[derive(Clone)]
 pub struct ScyllaDbStore {
-    store: LruCachingKeyValueStore<ScyllaDbStoreInternal>,
+    store: LruCachingStore<ScyllaDbStoreInternal>,
 }
 
 /// The type for building a new ScyllaDb Key Value Store
@@ -681,7 +681,7 @@ impl ScyllaDbStore {
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (store, table_status) = ScyllaDbStoreInternal::new_for_testing(store_config).await?;
-        let store = LruCachingKeyValueStore::new(store, cache_size);
+        let store = LruCachingStore::new(store, cache_size);
         let store = ScyllaDbStore { store };
         Ok((store, table_status))
     }
@@ -692,7 +692,7 @@ impl ScyllaDbStore {
     ) -> Result<Self, ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let store = ScyllaDbStoreInternal::initialize(store_config).await?;
-        let store = LruCachingKeyValueStore::new(store, cache_size);
+        let store = LruCachingStore::new(store, cache_size);
         let store = ScyllaDbStore { store };
         Ok(store)
     }
@@ -729,7 +729,7 @@ impl ScyllaDbStore {
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (store, table_status) = ScyllaDbStoreInternal::new(store_config).await?;
-        let store = LruCachingKeyValueStore::new(store, cache_size);
+        let store = LruCachingStore::new(store, cache_size);
         let store = ScyllaDbStore { store };
         Ok((store, table_status))
     }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -358,7 +358,7 @@ impl ScyllaDbClientInternal {
 
     /// Tests if a table is present in the database or not
     pub async fn test_existence(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<bool, ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
@@ -468,7 +468,7 @@ impl ScyllaDbClientInternal {
 
     #[cfg(any(test, feature = "test"))]
     async fn new_for_testing(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
@@ -489,7 +489,7 @@ impl ScyllaDbClientInternal {
         .await
     }
 
-    async fn initialize(store_config: ScyllaDbKvStoreConfig) -> Result<Self, ScyllaDbContextError> {
+    async fn initialize(store_config: ScyllaDbStoreConfig) -> Result<Self, ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
             .build()
@@ -510,7 +510,7 @@ impl ScyllaDbClientInternal {
     }
 
     async fn list_tables(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<Vec<String>, ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
@@ -529,7 +529,7 @@ impl ScyllaDbClientInternal {
         Ok(tables)
     }
 
-    async fn delete_all(store_config: ScyllaDbKvStoreConfig) -> Result<(), ScyllaDbContextError> {
+    async fn delete_all(store_config: ScyllaDbStoreConfig) -> Result<(), ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
             .build()
@@ -540,7 +540,7 @@ impl ScyllaDbClientInternal {
     }
 
     async fn delete_single(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<(), ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
@@ -552,7 +552,7 @@ impl ScyllaDbClientInternal {
     }
 
     async fn new(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let session = SessionBuilder::new()
             .known_node(store_config.uri.as_str())
@@ -571,7 +571,7 @@ impl ScyllaDbClientInternal {
 
     async fn new_internal(
         session: Session,
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
         stop_if_table_exists: bool,
         create_if_missing: bool,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
@@ -618,7 +618,7 @@ pub struct ScyllaDbClient {
 
 /// The type for building a new ScyllaDb Key Value Store Client
 #[derive(Debug)]
-pub struct ScyllaDbKvStoreConfig {
+pub struct ScyllaDbStoreConfig {
     /// The url to which the requests have to be sent
     pub uri: String,
     /// The name of the table that we create
@@ -679,7 +679,7 @@ impl ScyllaDbClient {
     /// Creates a [`ScyllaDbClient`] from the input parameters.
     #[cfg(any(test, feature = "test"))]
     pub async fn new_for_testing(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (client, table_status) = ScyllaDbClientInternal::new_for_testing(store_config).await?;
@@ -690,7 +690,7 @@ impl ScyllaDbClient {
 
     /// Creates a [`ScyllaDbClient`] from the input parameters.
     pub async fn initialize(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<Self, ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let client = ScyllaDbClientInternal::initialize(store_config).await?;
@@ -701,35 +701,35 @@ impl ScyllaDbClient {
 
     /// Delete all the tables of a database
     pub async fn test_existence(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<bool, ScyllaDbContextError> {
         ScyllaDbClientInternal::test_existence(store_config).await
     }
 
     /// Delete all the tables of a database
     pub async fn delete_all(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<(), ScyllaDbContextError> {
         ScyllaDbClientInternal::delete_all(store_config).await
     }
 
     /// Delete all the tables of a database
     pub async fn list_tables(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<Vec<String>, ScyllaDbContextError> {
         ScyllaDbClientInternal::list_tables(store_config).await
     }
 
     /// Deletes a single table from the database
     pub async fn delete_single(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<(), ScyllaDbContextError> {
         ScyllaDbClientInternal::delete_single(store_config).await
     }
 
     /// Creates a [`ScyllaDbClient`] from the input parameters.
     pub async fn new(
-        store_config: ScyllaDbKvStoreConfig,
+        store_config: ScyllaDbStoreConfig,
     ) -> Result<(Self, TableStatus), ScyllaDbContextError> {
         let cache_size = store_config.common_config.cache_size;
         let (client, table_status) = ScyllaDbClientInternal::new(store_config).await?;
@@ -755,7 +755,7 @@ pub async fn create_scylla_db_test_client() -> ScyllaDbClient {
     let uri = "localhost:9042".to_string();
     let table_name = get_table_name();
     let common_config = create_scylla_db_common_config();
-    let store_config = ScyllaDbKvStoreConfig {
+    let store_config = ScyllaDbStoreConfig {
         uri,
         table_name,
         common_config,

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! This provides a KeyValueStoreClient for the ScyllaDB database.
+//! This provides a KeyValueStore for the ScyllaDB database.
 //! The code is functional but some aspects are missing.
 //!
 //! The current connection is done via a Session and a corresponding
@@ -9,10 +9,10 @@
 //! concurrent queries is controlled by max_concurrent_queries.
 //!
 //! We thus implement the
-//! * [`KeyValueStoreClient`][trait1] for a database access.
+//! * [`KeyValueStore`][trait1] for a database access.
 //! * [`Context`][trait2] for the context.
 //!
-//! [trait1]: common::KeyValueStoreClient
+//! [trait1]: common::KeyValueStore
 //! [trait2]: common::Context
 
 #[cfg(any(test, feature = "test"))]
@@ -21,7 +21,7 @@ use crate::{lru_caching::TEST_CACHE_SIZE, test_utils::get_table_name};
 use crate::{
     batch::{Batch, DeletePrefixExpander},
     common::{
-        get_upper_bound_option, CommonStoreConfig, ContextFromDb, KeyValueStoreClient, TableStatus,
+        get_upper_bound_option, CommonStoreConfig, ContextFromDb, KeyValueStore, TableStatus,
     },
     lru_caching::LruCachingKeyValueClient,
     value_splitting::DatabaseConsistencyError,
@@ -113,7 +113,7 @@ impl From<ScyllaDbContextError> for crate::views::ViewError {
 }
 
 #[async_trait]
-impl KeyValueStoreClient for ScyllaDbClientInternal {
+impl KeyValueStore for ScyllaDbClientInternal {
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Error = ScyllaDbContextError;
@@ -628,12 +628,12 @@ pub struct ScyllaDbStoreConfig {
 }
 
 #[async_trait]
-impl KeyValueStoreClient for ScyllaDbClient {
+impl KeyValueStore for ScyllaDbClient {
     const MAX_VALUE_SIZE: usize = ScyllaDbClientInternal::MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = ScyllaDbClientInternal::MAX_KEY_SIZE;
-    type Error = <ScyllaDbClientInternal as KeyValueStoreClient>::Error;
-    type Keys = <ScyllaDbClientInternal as KeyValueStoreClient>::Keys;
-    type KeyValues = <ScyllaDbClientInternal as KeyValueStoreClient>::KeyValues;
+    type Error = <ScyllaDbClientInternal as KeyValueStore>::Error;
+    type Keys = <ScyllaDbClientInternal as KeyValueStore>::Keys;
+    type KeyValues = <ScyllaDbClientInternal as KeyValueStore>::KeyValues;
 
     fn max_stream_queries(&self) -> usize {
         self.client.max_stream_queries()

--- a/linera-views/src/unit_tests/dynamo_db_context_tests.rs
+++ b/linera-views/src/unit_tests/dynamo_db_context_tests.rs
@@ -4,7 +4,7 @@
 use super::{DynamoDbContext, TableName, TableStatus};
 use crate::dynamo_db::{
     clear_tables, create_dynamo_db_common_config, list_tables_from_client, DynamoDbContextError,
-    DynamoDbKvStoreConfig, LocalStackTestContext,
+    DynamoDbStoreConfig, LocalStackTestContext,
 };
 use anyhow::Error;
 
@@ -13,7 +13,7 @@ async fn get_table_status(
     table_name: &TableName,
 ) -> Result<TableStatus, DynamoDbContextError> {
     let common_config = create_dynamo_db_common_config();
-    let store_config = DynamoDbKvStoreConfig {
+    let store_config = DynamoDbStoreConfig {
         config: localstack.dynamo_db_config(),
         table_name: table_name.clone(),
         common_config,

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -14,14 +14,14 @@ use std::collections::VecDeque;
 #[cfg(feature = "rocksdb")]
 use {
     crate::rocks_db::create_rocks_db_common_config,
-    crate::rocks_db::RocksDbKvStoreConfig,
+    crate::rocks_db::RocksDbStoreConfig,
     crate::rocks_db::{RocksDbClient, RocksDbContext},
     tempfile::TempDir,
 };
 
 #[cfg(feature = "aws")]
 use crate::{
-    dynamo_db::DynamoDbKvStoreConfig,
+    dynamo_db::DynamoDbStoreConfig,
     dynamo_db::LocalStackTestContext,
     dynamo_db::{create_dynamo_db_common_config, DynamoDbContext},
     test_utils::get_table_name,
@@ -223,7 +223,7 @@ impl TestContextFactory for RocksDbContextFactory {
         let directory = TempDir::new()?;
         let common_config = create_rocks_db_common_config();
         let path_buf = directory.path().to_path_buf();
-        let store_config = RocksDbKvStoreConfig {
+        let store_config = RocksDbStoreConfig {
             path_buf,
             common_config,
         };
@@ -262,7 +262,7 @@ impl TestContextFactory for DynamoDbContextFactory {
         self.table_counter += 1;
         let common_config = create_dynamo_db_common_config();
         let dummy_key_prefix = vec![0];
-        let store_config = DynamoDbKvStoreConfig {
+        let store_config = DynamoDbStoreConfig {
             config,
             table_name,
             common_config,

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -15,7 +15,7 @@ use std::collections::VecDeque;
 use {
     crate::rocks_db::create_rocks_db_common_config,
     crate::rocks_db::RocksDbStoreConfig,
-    crate::rocks_db::{RocksDbClient, RocksDbContext},
+    crate::rocks_db::{RocksDbStore, RocksDbContext},
     tempfile::TempDir,
 };
 
@@ -227,10 +227,10 @@ impl TestContextFactory for RocksDbContextFactory {
             path_buf,
             common_config,
         };
-        let (client, _) = RocksDbClient::new_for_testing(store_config)
+        let (store, _) = RocksDbStore::new_for_testing(store_config)
             .await
-            .expect("client");
-        let context = RocksDbContext::new(client, vec![], ());
+            .expect("store");
+        let context = RocksDbContext::new(store, vec![], ());
 
         self.temporary_directories.push(directory);
 

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -15,7 +15,7 @@ use std::collections::VecDeque;
 use {
     crate::rocks_db::create_rocks_db_common_config,
     crate::rocks_db::RocksDbStoreConfig,
-    crate::rocks_db::{RocksDbStore, RocksDbContext},
+    crate::rocks_db::{RocksDbContext, RocksDbStore},
     tempfile::TempDir,
 };
 

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 #[cfg(feature = "scylladb")]
-use crate::{scylla_db::create_scylla_db_test_client, scylla_db::ScyllaDbContext};
+use crate::{scylla_db::create_scylla_db_test_store, scylla_db::ScyllaDbContext};
 
 #[tokio::test]
 async fn test_queue_operations_with_memory_context() -> Result<(), anyhow::Error> {
@@ -286,9 +286,9 @@ impl TestContextFactory for ScyllaDbContextFactory {
     type Context = ScyllaDbContext<()>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        let client = create_scylla_db_test_client().await;
-        let table_name = client.get_table_name().await;
-        let context = ScyllaDbContext::new(client, vec![], ());
+        let store = create_scylla_db_test_store().await;
+        let table_name = store.get_table_name().await;
+        let context = ScyllaDbContext::new(store, vec![], ());
 
         self.table_names.push(table_name);
 

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -406,7 +406,11 @@ impl<E> TestMemoryContext<E> {
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
         let store = TestMemoryStore::new(guard);
         let base_key = Vec::new();
-        Self { store, base_key, extra }
+        Self {
+            store,
+            base_key,
+            extra,
+        }
     }
 }
 
@@ -438,7 +442,11 @@ impl<E> TestMemoryContextInternal<E> {
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
         let store = TestMemoryStoreInternal::new(guard);
         let base_key = Vec::new();
-        Self { store, base_key, extra }
+        Self {
+            store,
+            base_key,
+            extra,
+        }
     }
 }
 

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{ContextFromDb, KeyIterable, KeyValueIterable, KeyValueStore},
+    common::{ContextFromStore, KeyIterable, KeyValueIterable, KeyValueStore},
     memory::{MemoryContextError, MemoryStore, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
 };
 use async_lock::{Mutex, MutexGuardArc};
@@ -399,18 +399,14 @@ impl TestMemoryStore {
 }
 
 /// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type TestMemoryContext<E> = ContextFromDb<E, TestMemoryStore>;
+pub type TestMemoryContext<E> = ContextFromStore<E, TestMemoryStore>;
 
 impl<E> TestMemoryContext<E> {
     /// Creates a [`TestMemoryContext`].
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
-        let db = TestMemoryStore::new(guard);
+        let store = TestMemoryStore::new(guard);
         let base_key = Vec::new();
-        Self {
-            db,
-            base_key,
-            extra,
-        }
+        Self { store, base_key, extra }
     }
 }
 
@@ -435,18 +431,14 @@ pub fn create_test_memory_store() -> TestMemoryStore {
 }
 
 /// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type TestMemoryContextInternal<E> = ContextFromDb<E, TestMemoryStoreInternal>;
+pub type TestMemoryContextInternal<E> = ContextFromStore<E, TestMemoryStoreInternal>;
 
 impl<E> TestMemoryContextInternal<E> {
     /// Creates a [`TestMemoryContextInternal`].
     pub fn new(guard: MutexGuardArc<MemoryStoreMap>, extra: E) -> Self {
-        let db = TestMemoryStoreInternal::new(guard);
+        let store = TestMemoryStoreInternal::new(guard);
         let base_key = Vec::new();
-        Self {
-            db,
-            base_key,
-            extra,
-        }
+        Self { store, base_key, extra }
     }
 }
 

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{ContextFromDb, KeyIterable, KeyValueIterable, KeyValueStore},
-    memory::{MemoryStore, MemoryContextError, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
+    memory::{MemoryContextError, MemoryStore, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
 };
 use async_lock::{Mutex, MutexGuardArc};
 use async_trait::async_trait;
@@ -142,12 +142,7 @@ where
 
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
         let mut keys = Vec::new();
-        for big_key in self
-            .store
-            .find_keys_by_prefix(key_prefix)
-            .await?
-            .iterator()
-        {
+        for big_key in self.store.find_keys_by_prefix(key_prefix).await?.iterator() {
             let big_key = big_key?;
             let len = big_key.len();
             if Self::read_index_from_key(big_key)? == 0 {
@@ -479,8 +474,7 @@ mod tests {
         batch::Batch,
         common::KeyValueStore,
         value_splitting::{
-            create_test_memory_store_internal, TestMemoryStoreInternal,
-            ValueSplittingKeyValueStore,
+            create_test_memory_store_internal, TestMemoryStoreInternal, ValueSplittingKeyValueStore,
         },
     };
     use rand::{Rng, SeedableRng};

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -16,7 +16,7 @@ use rand::{Rng, RngCore, SeedableRng};
 use std::collections::{BTreeMap, HashSet};
 
 #[cfg(feature = "rocksdb")]
-use linera_views::rocks_db::create_rocks_db_test_client;
+use linera_views::rocks_db::create_rocks_db_test_store;
 
 #[cfg(feature = "aws")]
 use linera_views::dynamo_db::create_dynamo_db_test_client;
@@ -170,7 +170,7 @@ async fn test_reads_memory() {
 #[tokio::test]
 async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_rocks_db_test_client().await;
+        let key_value_store = create_rocks_db_test_store().await;
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -369,7 +369,7 @@ async fn test_key_value_store_view_memory_writes_from_blank() {
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_rocks_db_writes_from_blank() {
-    let key_value_store = create_rocks_db_test_client().await;
+    let key_value_store = create_rocks_db_test_store().await;
     run_writes_from_blank(&key_value_store).await;
 }
 
@@ -461,7 +461,7 @@ async fn test_memory_big_write_read() {
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_rocks_db_big_write_read() {
-    let key_value_store = create_rocks_db_test_client().await;
+    let key_value_store = create_rocks_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
@@ -596,7 +596,7 @@ async fn test_memory_writes_from_state() {
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_rocks_db_writes_from_state() {
-    let key_value_store = create_rocks_db_test_client().await;
+    let key_value_store = create_rocks_db_test_store().await;
     run_writes_from_state(&key_value_store).await;
 }
 

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -401,9 +401,9 @@ async fn test_big_value_read_write() {
         let mut batch = Batch::new();
         let key = vec![43, 23, 56];
         batch.put_key_value(key.clone(), &test_string).unwrap();
-        context.db.write_batch(batch, &[]).await.unwrap();
+        context.store.write_batch(batch, &[]).await.unwrap();
         let read_string = context
-            .db
+            .store
             .read_value::<String>(&key)
             .await
             .unwrap()

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -5,12 +5,12 @@ use linera_views::{
     batch::{Batch, WriteOperation},
     common::{KeyIterable, KeyValueIterable, KeyValueStore},
     key_value_store_view::ViewContainer,
-    memory::{create_memory_client, create_memory_context},
+    memory::{create_memory_store, create_memory_context},
     test_utils::{
         get_random_byte_vector, get_random_key_prefix, get_random_key_values_prefix,
         get_small_key_space,
     },
-    value_splitting::create_test_memory_client,
+    value_splitting::create_test_memory_store,
 };
 use rand::{Rng, RngCore, SeedableRng};
 use std::collections::{BTreeMap, HashSet};
@@ -153,7 +153,7 @@ fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {
 #[tokio::test]
 async fn test_reads_test_memory() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_test_memory_client();
+        let key_value_store = create_test_memory_store();
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -161,7 +161,7 @@ async fn test_reads_test_memory() {
 #[tokio::test]
 async fn test_reads_memory() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_memory_client();
+        let key_value_store = create_memory_store();
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -204,7 +204,7 @@ async fn test_reads_key_value_store_view_memory() {
 
 #[tokio::test]
 async fn test_reads_memory_specific() {
-    let key_value_store = create_memory_client();
+    let key_value_store = create_memory_store();
     let key_values = vec![
         (vec![0, 1, 255], Vec::new()),
         (vec![0, 1, 255, 37], Vec::new()),
@@ -349,13 +349,13 @@ async fn run_writes_from_blank<C: KeyValueStore + Sync>(key_value_store: &C) {
 
 #[tokio::test]
 async fn test_test_memory_writes_from_blank() {
-    let key_value_store = create_test_memory_client();
+    let key_value_store = create_test_memory_store();
     run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
 async fn test_memory_writes_from_blank() {
-    let key_value_store = create_memory_client();
+    let key_value_store = create_memory_store();
     run_writes_from_blank(&key_value_store).await;
 }
 
@@ -450,7 +450,7 @@ async fn test_scylla_db_big_write_read() {
 
 #[tokio::test]
 async fn test_memory_big_write_read() {
-    let key_value_store = create_memory_client();
+    let key_value_store = create_memory_store();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
@@ -589,7 +589,7 @@ async fn run_writes_from_state<C: KeyValueStore + Sync>(key_value_store: &C) {
 
 #[tokio::test]
 async fn test_memory_writes_from_state() {
-    let key_value_store = create_memory_client();
+    let key_value_store = create_memory_store();
     run_writes_from_state(&key_value_store).await;
 }
 

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, HashSet};
 use linera_views::rocks_db::create_rocks_db_test_store;
 
 #[cfg(feature = "aws")]
-use linera_views::dynamo_db::create_dynamo_db_test_client;
+use linera_views::dynamo_db::create_dynamo_db_test_store;
 
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::create_scylla_db_test_client;
@@ -179,7 +179,7 @@ async fn test_reads_rocks_db() {
 #[tokio::test]
 async fn test_reads_dynamodb() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_dynamo_db_test_client().await;
+        let key_value_store = create_dynamo_db_test_store().await;
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -376,7 +376,7 @@ async fn test_rocks_db_writes_from_blank() {
 #[cfg(feature = "aws")]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_blank() {
-    let key_value_store = create_dynamo_db_test_client().await;
+    let key_value_store = create_dynamo_db_test_store().await;
     run_writes_from_blank(&key_value_store).await;
 }
 
@@ -470,7 +470,7 @@ async fn test_rocks_db_big_write_read() {
 #[cfg(feature = "aws")]
 #[tokio::test]
 async fn test_dynamo_db_big_write_read() {
-    let key_value_store = create_dynamo_db_test_client().await;
+    let key_value_store = create_dynamo_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
@@ -603,7 +603,7 @@ async fn test_rocks_db_writes_from_state() {
 #[cfg(feature = "aws")]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_state() {
-    let key_value_store = create_dynamo_db_test_client().await;
+    let key_value_store = create_dynamo_db_test_store().await;
     run_writes_from_state(&key_value_store).await;
 }
 

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -5,7 +5,7 @@ use linera_views::{
     batch::{Batch, WriteOperation},
     common::{KeyIterable, KeyValueIterable, KeyValueStore},
     key_value_store_view::ViewContainer,
-    memory::{create_memory_store, create_memory_context},
+    memory::{create_memory_context, create_memory_store},
     test_utils::{
         get_random_byte_vector, get_random_key_prefix, get_random_key_values_prefix,
         get_small_key_space,

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -22,7 +22,7 @@ use linera_views::rocks_db::create_rocks_db_test_store;
 use linera_views::dynamo_db::create_dynamo_db_test_store;
 
 #[cfg(feature = "scylladb")]
-use linera_views::scylla_db::create_scylla_db_test_client;
+use linera_views::scylla_db::create_scylla_db_test_store;
 
 /// This test starts with a collection of key/values being inserted into the code
 /// which is then followed by a number of reading tests. The functionalities being
@@ -188,7 +188,7 @@ async fn test_reads_dynamodb() {
 #[tokio::test]
 async fn test_reads_scylla_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_scylla_db_test_client().await;
+        let key_value_store = create_scylla_db_test_store().await;
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -383,7 +383,7 @@ async fn test_dynamo_db_writes_from_blank() {
 #[cfg(feature = "scylladb")]
 #[tokio::test]
 async fn test_scylla_db_writes_from_blank() {
-    let key_value_store = create_scylla_db_test_client().await;
+    let key_value_store = create_scylla_db_test_store().await;
     run_writes_from_blank(&key_value_store).await;
 }
 
@@ -442,7 +442,7 @@ async fn run_big_write_read<C: KeyValueStore + Sync>(
 #[cfg(feature = "scylladb")]
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {
-    let key_value_store = create_scylla_db_test_client().await;
+    let key_value_store = create_scylla_db_test_store().await;
     let value_sizes = vec![1000, 200000, 5000000];
     let target_size = 14000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
@@ -610,6 +610,6 @@ async fn test_dynamo_db_writes_from_state() {
 #[cfg(feature = "scylladb")]
 #[tokio::test]
 async fn test_scylla_db_writes_from_state() {
-    let key_value_store = create_scylla_db_test_client().await;
+    let key_value_store = create_scylla_db_test_store().await;
     run_writes_from_state(&key_value_store).await;
 }

--- a/linera-views/tests/operations_tests.rs
+++ b/linera-views/tests/operations_tests.rs
@@ -3,7 +3,7 @@
 
 use linera_views::{
     batch::{Batch, WriteOperation},
-    common::{KeyIterable, KeyValueIterable, KeyValueStoreClient},
+    common::{KeyIterable, KeyValueIterable, KeyValueStore},
     key_value_store_view::ViewContainer,
     memory::{create_memory_client, create_memory_context},
     test_utils::{
@@ -32,7 +32,7 @@ use linera_views::scylla_db::create_scylla_db_test_client;
 /// * `find_keys_by_prefix` / `find_key_values_by_prefix`
 /// * The ordering of keys returned by `find_keys_by_prefix` and `find_key_values_by_prefix`
 #[cfg(test)]
-async fn run_reads<C: KeyValueStoreClient + Sync>(
+async fn run_reads<C: KeyValueStore + Sync>(
     key_value_store: C,
     key_values: Vec<(Vec<u8>, Vec<u8>)>,
 ) {
@@ -296,7 +296,7 @@ fn realize_batch(batch: &Batch) -> BTreeMap<Vec<u8>, Vec<u8>> {
 }
 
 #[cfg(test)]
-async fn read_key_values_prefix<C: KeyValueStoreClient + Sync>(
+async fn read_key_values_prefix<C: KeyValueStore + Sync>(
     key_value_store: &C,
     key_prefix: &[u8],
 ) -> BTreeMap<Vec<u8>, Vec<u8>> {
@@ -316,7 +316,7 @@ async fn read_key_values_prefix<C: KeyValueStoreClient + Sync>(
 }
 
 #[cfg(test)]
-async fn run_test_batch_from_blank<C: KeyValueStoreClient + Sync>(
+async fn run_test_batch_from_blank<C: KeyValueStore + Sync>(
     key_value_store: &C,
     key_prefix: Vec<u8>,
     batch: Batch,
@@ -329,7 +329,7 @@ async fn run_test_batch_from_blank<C: KeyValueStoreClient + Sync>(
 }
 
 #[cfg(test)]
-async fn run_writes_from_blank<C: KeyValueStoreClient + Sync>(key_value_store: &C) {
+async fn run_writes_from_blank<C: KeyValueStore + Sync>(key_value_store: &C) {
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     let n_oper = 1000;
     let batch_size = 500;
@@ -414,12 +414,12 @@ async fn test_big_value_read_write() {
 
 // DynamoDb has limits at 1M (for pagination), 4M (for write)
 // Let us go right past them at 20M of data with writing and then
-// reading it. And 20M is not huge by any mean. All KeyValueStoreClient
+// reading it. And 20M is not huge by any mean. All KeyValueStore
 // must handle that.
 //
 // The size of the value vary as each size has its own issues.
 #[cfg(test)]
-async fn run_big_write_read<C: KeyValueStoreClient + Sync>(
+async fn run_big_write_read<C: KeyValueStore + Sync>(
     key_value_store: C,
     target_size: usize,
     value_sizes: Vec<usize>,
@@ -480,7 +480,7 @@ async fn test_dynamo_db_big_write_read() {
 type StateBatch = (Vec<(Vec<u8>, Vec<u8>)>, Batch);
 
 #[cfg(test)]
-async fn run_test_batch_from_state<C: KeyValueStoreClient + Sync>(
+async fn run_test_batch_from_state<C: KeyValueStore + Sync>(
     key_value_store: &C,
     key_prefix: Vec<u8>,
     state_and_batch: StateBatch,
@@ -575,7 +575,7 @@ fn generate_specific_state_batch(key_prefix: &[u8], option: usize) -> StateBatch
 }
 
 #[cfg(test)]
-async fn run_writes_from_state<C: KeyValueStoreClient + Sync>(key_value_store: &C) {
+async fn run_writes_from_state<C: KeyValueStore + Sync>(key_value_store: &C) {
     for option in 0..7 {
         let key_prefix = if option == 6 {
             vec![255, 255, 255]

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 #[cfg(feature = "rocksdb")]
-use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbStore, RocksDbContext};
+use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbContext, RocksDbStore};
 
 #[cfg(feature = "aws")]
 use linera_views::{
@@ -44,7 +44,7 @@ use linera_views::{
 };
 
 #[cfg(feature = "scylladb")]
-use linera_views::scylla_db::{create_scylla_db_test_store, ScyllaDbStore, ScyllaDbContext};
+use linera_views::scylla_db::{create_scylla_db_test_store, ScyllaDbContext, ScyllaDbStore};
 
 #[cfg(any(feature = "aws", feature = "rocksdb", feature = "scylladb"))]
 use std::collections::BTreeSet;

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -39,7 +39,7 @@ use linera_views::rocks_db::{create_rocks_db_test_client, RocksDbClient, RocksDb
 #[cfg(feature = "aws")]
 use linera_views::{
     common::CommonStoreConfig, dynamo_db::create_dynamo_db_common_config,
-    dynamo_db::DynamoDbContext, dynamo_db::DynamoDbKvStoreConfig, dynamo_db::LocalStackTestContext,
+    dynamo_db::DynamoDbContext, dynamo_db::DynamoDbStoreConfig, dynamo_db::LocalStackTestContext,
     dynamo_db::TableName, test_utils::get_table_name,
 };
 
@@ -253,7 +253,7 @@ impl StateStore for DynamoDbTestStore {
         // TODO(#643): Actually acquire a lock.
         tracing::trace!("Acquiring lock on {:?}", id);
         let base_key = bcs::to_bytes(&id)?;
-        let store_config = DynamoDbKvStoreConfig {
+        let store_config = DynamoDbStoreConfig {
             config: self.localstack.dynamo_db_config(),
             table_name: self.table_name.clone(),
             common_config: self.common_config.clone(),

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -34,7 +34,7 @@ use std::{
 };
 
 #[cfg(feature = "rocksdb")]
-use linera_views::rocks_db::{create_rocks_db_test_client, RocksDbClient, RocksDbContext};
+use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbStore, RocksDbContext};
 
 #[cfg(feature = "aws")]
 use linera_views::{
@@ -160,7 +160,7 @@ impl StateStore for LruMemoryStore {
 
 #[cfg(feature = "rocksdb")]
 pub struct RocksDbTestStore {
-    client: RocksDbClient,
+    store: RocksDbStore,
     accessed_chains: BTreeSet<usize>,
 }
 
@@ -170,10 +170,10 @@ impl StateStore for RocksDbTestStore {
     type Context = RocksDbContext<usize>;
 
     async fn new() -> Self {
-        let client = create_rocks_db_test_client().await;
+        let store = create_rocks_db_test_store().await;
         let accessed_chains = BTreeSet::new();
         RocksDbTestStore {
-            client,
+            store,
             accessed_chains,
         }
     }
@@ -183,7 +183,7 @@ impl StateStore for RocksDbTestStore {
         // TODO(#643): Actually acquire a lock.
         tracing::trace!("Acquiring lock on {:?}", id);
         let base_key = bcs::to_bytes(&id)?;
-        let context = RocksDbContext::new(self.client.clone(), base_key, id);
+        let context = RocksDbContext::new(self.store.clone(), base_key, id);
         StateView::load(context).await
     }
 }


### PR DESCRIPTION
## Motivation

To better reflect the purpose of the code, we have renamed several traits

## Proposal

The following renames were done:
* rename `KeyValueStoreClient` to `KeyValueStore`.
* rename `*KvStore* `to `*Store*`  (all stores are key-value stores anyway)
* rename `*Client` to `*Store`
* Renaming of `ContextFromDb` to `ContextFromStore` which is clearer.
* rename the `client` to `store` accordingly.

## Test Plan

The CI should take care of it.

## Release Plan

Some typos in the documentation were identified in the process and this impacts the release.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
