### PR TITLE
Create a custom `AsyncMutex` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,6 +2985,7 @@ name = "linera-base"
 version = "0.6.0"
 dependencies = [
  "async-graphql",
+ "async-lock",
  "bcs",
  "chrono",
  "custom_debug_derive",
@@ -3000,6 +3001,7 @@ dependencies = [
  "sha3",
  "test-strategy",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1631,6 +1631,7 @@ name = "linera-base"
 version = "0.6.0"
 dependencies = [
  "async-graphql",
+ "async-lock",
  "bcs",
  "chrono",
  "ed25519-dalek",
@@ -1644,6 +1645,7 @@ dependencies = [
  "sha3",
  "test-strategy",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -11,10 +11,12 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
+locks = ["async-lock", "tracing"]
 test = ["test-strategy", "proptest"]
 
 [dependencies]
 async-graphql = { workspace = true }
+async-lock = { workspace = true, optional = true }
 bcs = { workspace = true }
 ed25519-dalek = { workspace = true }
 generic-array = { workspace = true }
@@ -26,6 +28,7 @@ serde_bytes = { workspace = true }
 sha3 = { workspace = true }
 test-strategy = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tracing = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { workspace = true }

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -10,6 +10,8 @@ pub mod crypto;
 pub mod data_types;
 mod graphql;
 pub mod identifiers;
+#[cfg(feature = "locks")]
+pub mod locks;
 
 pub use graphql::BcsHexParseError;
 #[doc(hidden)]

--- a/linera-base/src/locks.rs
+++ b/linera-base/src/locks.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Custom synchronization locks with embedded logging.
+
+use async_lock::{Mutex, MutexGuard};
+use std::{
+    any::type_name,
+    fmt::{self, Debug, Formatter},
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
+
+/// A mutex to be used in asynchronous tasks.
+pub struct AsyncMutex<T> {
+    name: Arc<str>,
+    lock: Arc<Mutex<T>>,
+}
+
+impl<T> AsyncMutex<T> {
+    /// Create a new [`AsyncMutex`] with the provided `name` to guard `data`.
+    pub fn new(name: impl Into<String>, data: T) -> Self {
+        AsyncMutex {
+            name: name.into().into(),
+            lock: Arc::new(Mutex::new(data)),
+        }
+    }
+
+    /// Locks the [`AsyncMutex`] and returns an [`AsyncMutexGuard`] to access the underlying data.
+    pub async fn lock(&self) -> AsyncMutexGuard<'_, T> {
+        let name = self.name.clone();
+        tracing::trace!(name = %self.name, "Locking");
+        let guard = self.lock.lock().await;
+        tracing::trace!(name = %self.name, "Locked");
+        AsyncMutexGuard { name, guard }
+    }
+}
+
+impl<T> Clone for AsyncMutex<T> {
+    fn clone(&self) -> Self {
+        AsyncMutex {
+            name: self.name.clone(),
+            lock: self.lock.clone(),
+        }
+    }
+}
+
+impl<T> Debug for AsyncMutex<T> {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        formatter
+            .debug_struct("AsyncMutex")
+            .field("name", &self.name)
+            .field("lock", &format_args!("Arc<Mutex<{}>>", type_name::<T>()))
+            .finish()
+    }
+}
+
+/// A guard that unlocks its respective [`AsyncMutex`] when dropped.
+pub struct AsyncMutexGuard<'guard, T> {
+    name: Arc<str>,
+    guard: MutexGuard<'guard, T>,
+}
+
+impl<T> Drop for AsyncMutexGuard<'_, T> {
+    fn drop(&mut self) {
+        tracing::trace!(name = %self.name, "Unlocking");
+    }
+}
+
+impl<'guard, T> Deref for AsyncMutexGuard<'guard, T> {
+    type Target = MutexGuard<'guard, T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.guard
+    }
+}
+
+impl<'guard, T> DerefMut for AsyncMutexGuard<'guard, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.guard
+    }
+}

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -29,7 +29,7 @@ async-trait = { workspace = true }
 bcs = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
-linera-base = { workspace = true }
+linera-base = { workspace = true, features = ["locks"] }
 linera-chain = { workspace = true }
 linera-execution = { workspace = true }
 linera-storage = { workspace = true }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -15,7 +15,6 @@ use crate::{
 use futures::{
     channel::oneshot,
     future,
-    lock::Mutex,
     stream::{self, FuturesUnordered, StreamExt},
 };
 use linera_base::{
@@ -24,6 +23,7 @@ use linera_base::{
     data_types::{Amount, ArithmeticError, BlockHeight, Timestamp},
     ensure,
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    locks::AsyncMutex,
 };
 use linera_chain::{
     data_types::{
@@ -484,7 +484,7 @@ where
     }
 
     async fn local_chain_info(
-        this: Arc<Mutex<Self>>,
+        this: AsyncMutex<Self>,
         chain_id: ChainId,
         local_node: &mut LocalNodeClient<S>,
     ) -> Option<ChainInfo> {
@@ -499,7 +499,7 @@ where
     }
 
     async fn local_next_block_height(
-        this: Arc<Mutex<Self>>,
+        this: AsyncMutex<Self>,
         chain_id: ChainId,
         local_node: &mut LocalNodeClient<S>,
     ) -> Option<BlockHeight> {
@@ -508,7 +508,7 @@ where
     }
 
     async fn process_notification<A>(
-        this: Arc<Mutex<Self>>,
+        this: AsyncMutex<Self>,
         name: ValidatorName,
         node: A,
         mut local_node: LocalNodeClient<S>,
@@ -587,7 +587,7 @@ where
 
     /// Spawns a thread that listens to notifications about the current chain from all validators,
     /// and synchronizes the local state accordingly.
-    pub async fn listen(this: Arc<Mutex<Self>>) -> Result<(), ChainClientError>
+    pub async fn listen(this: AsyncMutex<Self>) -> Result<(), ChainClientError>
     where
         P: Send + 'static,
     {
@@ -609,7 +609,7 @@ where
     }
 
     async fn update_streams(
-        this: &Arc<Mutex<Self>>,
+        this: &AsyncMutex<Self>,
         senders: &mut HashMap<ValidatorName, oneshot::Sender<()>>,
     ) -> Result<(), ChainClientError>
     where
@@ -1019,7 +1019,7 @@ where
     /// This is similar to `find_received_certificates` but for only one validator.
     /// We also don't try to synchronize the admin chain.
     pub async fn find_received_certificates_from_validator<A>(
-        this: Arc<Mutex<Self>>,
+        this: AsyncMutex<Self>,
         name: ValidatorName,
         node: A,
     ) -> Result<(), ChainClientError>

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -8,10 +8,11 @@ use crate::{
     notifier::Notifier,
     worker::{Notification, ValidatorWorker, WorkerError, WorkerState},
 };
-use futures::{future, lock::Mutex};
+use futures::future;
 use linera_base::{
     data_types::{ArithmeticError, BlockHeight},
     identifiers::{ChainId, MessageId},
+    locks::AsyncMutex,
 };
 use linera_chain::data_types::{
     Block, BlockProposal, Certificate, ExecutedBlock, HashedValue, LiteCertificate,
@@ -36,7 +37,7 @@ pub struct LocalNode<S> {
 /// A client to a local node.
 #[derive(Clone)]
 pub struct LocalNodeClient<S> {
-    node: Arc<Mutex<LocalNode<S>>>,
+    node: AsyncMutex<LocalNode<S>>,
 }
 
 /// Error type for the operations on a local node.
@@ -144,7 +145,7 @@ impl<S> LocalNodeClient<S> {
     pub fn new(state: WorkerState<S>, notifier: Arc<Notifier<Notification>>) -> Self {
         let node = LocalNode { state, notifier };
         Self {
-            node: Arc::new(Mutex::new(node)),
+            node: AsyncMutex::new("LocalNode", node),
         }
     }
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -15,11 +15,12 @@ use crate::{
     updater::CommunicationError,
     worker::{Notification, Reason, WorkerError},
 };
-use futures::{lock::Mutex, StreamExt};
+use futures::StreamExt;
 use linera_base::{
     crypto::*,
     data_types::*,
     identifiers::{ChainDescription, ChainId, MessageId, Owner},
+    locks::AsyncMutex,
 };
 use linera_chain::{
     data_types::{CertificateValue, Event, ExecutedBlock},
@@ -34,7 +35,6 @@ use linera_execution::{
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use std::sync::Arc;
 use test_log::test;
 
 #[cfg(feature = "rocksdb")]
@@ -86,7 +86,7 @@ where
     let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
-    let sender = Arc::new(Mutex::new(sender));
+    let sender = AsyncMutex::new("sender", sender);
     // Listen to the notifications on the sender chain.
     let mut notifications = sender.lock().await.subscribe().await?;
     ChainClient::listen(sender.clone()).await?;

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -40,7 +40,7 @@ hex = { workspace = true }
 http = { workspace = true }
 k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
-linera-base = { workspace = true }
+linera-base = { workspace = true, features = ["locks"] }
 linera-chain = { workspace = true }
 linera-core = { workspace = true }
 linera-execution = { workspace = true }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -3,7 +3,7 @@
 
 use crate::{config::WalletState, node_service::ChainClients};
 use async_trait::async_trait;
-use futures::{lock::Mutex, StreamExt};
+use futures::StreamExt;
 use linera_base::{
     crypto::KeyPair,
     data_types::Timestamp,
@@ -19,7 +19,7 @@ use linera_core::{
 use linera_execution::{Message, SystemMessage};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use std::{collections::btree_map, sync::Arc, time::Duration};
+use std::{collections::btree_map, time::Duration};
 use structopt::StructOpt;
 use tracing::{error, info, warn};
 
@@ -130,7 +130,7 @@ where
                 return Ok(());
             };
             let client = context_guard.make_chain_client(storage.clone(), chain_id);
-            let client = Arc::new(Mutex::new(client));
+            let client = AsyncMutex::new(format!("ChainClient({chain_id})"), client);
             entry.insert(client.clone());
             client
         };

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -8,6 +8,7 @@ use linera_base::{
     crypto::KeyPair,
     data_types::Timestamp,
     identifiers::{ChainId, Destination},
+    locks::AsyncMutex,
 };
 use linera_chain::data_types::OutgoingMessage;
 use linera_core::{
@@ -75,7 +76,7 @@ where
     }
 
     /// Runs the chain listener.
-    pub async fn run<C>(self, context: Arc<Mutex<C>>, storage: S)
+    pub async fn run<C>(self, context: AsyncMutex<C>, storage: S)
     where
         C: ClientContext<P> + Send + 'static,
     {
@@ -94,7 +95,7 @@ where
     fn run_with_chain_id<C>(
         chain_id: ChainId,
         clients: ChainClients<P, S>,
-        context: Arc<Mutex<C>>,
+        context: AsyncMutex<C>,
         storage: S,
         config: ChainListenerConfig,
     ) where
@@ -112,7 +113,7 @@ where
     async fn run_client_stream<C>(
         chain_id: ChainId,
         clients: ChainClients<P, S>,
-        context: Arc<Mutex<C>>,
+        context: AsyncMutex<C>,
         storage: S,
         config: ChainListenerConfig,
     ) -> Result<(), anyhow::Error>

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -6,11 +6,12 @@ use anyhow::{anyhow, bail, Context, Error};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use colored::Colorize;
-use futures::{lock::Mutex, StreamExt};
+use futures::StreamExt;
 use linera_base::{
     crypto::{CryptoHash, CryptoRng, KeyPair, PublicKey},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, MessageId, Owner},
+    locks::AsyncMutex,
 };
 use linera_chain::data_types::{Certificate, CertificateValue, ExecutedBlock};
 use linera_core::{
@@ -1658,7 +1659,7 @@ impl Runnable for Job {
                 let chain_id = chain_client.chain_id();
                 info!("Watching for notifications for chain {:?}", chain_id);
                 let mut notification_stream = chain_client.subscribe().await?;
-                ChainClient::listen(Arc::new(Mutex::new(chain_client))).await?;
+                ChainClient::listen(AsyncMutex::new("Watch ChainClient", chain_client)).await?;
                 while let Some(notification) = notification_stream.next().await {
                     if raw {
                         println!("{}", serde_json::to_string(&notification)?);

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -20,6 +20,7 @@ use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
     data_types::Amount,
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner},
+    locks::AsyncMutex,
     BcsHexParseError,
 };
 use linera_chain::{data_types::HashedValue, ChainStateView};
@@ -105,7 +106,7 @@ pub struct SubscriptionRoot<P, S> {
 /// Our root GraphQL mutation type.
 pub struct MutationRoot<P, S, C> {
     clients: ChainClients<P, S>,
-    context: Arc<Mutex<C>>,
+    context: AsyncMutex<C>,
 }
 
 #[derive(Debug, ThisError)]
@@ -684,7 +685,7 @@ pub struct NodeService<P, S, C> {
     port: NonZeroU16,
     default_chain: Option<ChainId>,
     storage: S,
-    context: Arc<Mutex<C>>,
+    context: AsyncMutex<C>,
 }
 
 impl<P, S: Clone, C> Clone for NodeService<P, S, C> {
@@ -721,7 +722,7 @@ where
             port,
             default_chain,
             storage,
-            context: Arc::new(Mutex::new(context)),
+            context: AsyncMutex::new("NodeService's ClientContext", context),
         }
     }
 

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = { workspace = true }
 bcs = { workspace = true }
 dashmap = { workspace = true }
 futures = { workspace = true }
-linera-base = { workspace = true }
+linera-base = { workspace = true, features = ["locks"] }
 linera-chain = { workspace = true }
 linera-execution = { workspace = true }
 linera-views = { workspace = true, features = ["metrics"] }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
We have encountered some deadlocks before (e.g., #1266 and #1173) and they are particularly hard to debug. Being able to see when locks are attempting to lock, successfully acquiring the lock and releasing the lock is often very useful.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a custom `AsyncMutex` type that replaces `Arc<{tokio::sync,futures::lock}::Mutex<T>>` and prints `tracing` log messages for lock events.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactoring, all existing tests should pass and (TODO) some new unit tests where added for the new types.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

This is a part of #1213, but does _not_ close it. A future PR should add the ability to select (at compile time) which crate should be used internally for providing the `Mutex` type.
<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
