### PR TITLE
Implement the support of `stored_size` for `KeyValueStoreView`.

### DIFF
--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -144,6 +144,7 @@ where
                 }
             }
         }
+        self.sizes.flush(batch)?;
         let hash = *self.hash.get_mut();
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
@@ -152,6 +153,11 @@ where
                 Some(hash) => batch.put_key_value(key, &hash)?,
             }
             self.stored_hash = hash;
+        }
+        if self.stored_total_size != self.total_size {
+            let key = self.context.base_tag(KeyTag::TotalSize as u8);
+            batch.put_key_value(key, &self.total_size)?;
+            self.stored_total_size = self.total_size;
         }
         Ok(())
     }

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -73,9 +73,9 @@ pub struct KeyValueStoreView<C> {
     context: C,
     was_cleared: bool,
     updates: BTreeMap<Vec<u8>, Update<Vec<u8>>>,
-    stored_total_size: (u64,u64),
-    total_size: (u64,u64),
-    sizes: ByteMapView<C, (u64,u64)>,
+    stored_total_size: (u64, u64),
+    total_size: (u64, u64),
+    sizes: ByteMapView<C, (u64, u64)>,
     deleted_prefixes: BTreeSet<Vec<u8>>,
     stored_hash: Option<HasherOutput>,
     hash: Mutex<Option<HasherOutput>>,
@@ -170,7 +170,7 @@ where
         self.was_cleared = true;
         self.updates.clear();
         self.deleted_prefixes.clear();
-        self.total_size = (0,0);
+        self.total_size = (0, 0);
         self.sizes.clear();
         *self.hash.get_mut() = None;
     }
@@ -198,7 +198,7 @@ where
     ///   assert_eq!(total_size, (0,0));
     /// # })
     /// ```
-    pub fn total_size(&self) -> (u64,u64) {
+    pub fn total_size(&self) -> (u64, u64) {
         self.total_size
     }
 
@@ -438,7 +438,7 @@ where
     ///   assert_eq!(key_values, vec![vec![0,1],vec![0,2]]);
     /// # })
     /// ```
-    pub async fn index_values(&self) -> Result<Vec<(Vec<u8>,Vec<u8>)>, ViewError> {
+    pub async fn index_values(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
         let mut index_values = Vec::new();
         self.for_each_index_value(|index, value| {
             index_values.push((index.to_vec(), value.to_vec()));
@@ -616,7 +616,7 @@ where
                         self.updates.remove(&key);
                     }
                     let key_values = self.sizes.key_values_by_prefix(key_prefix.clone()).await?;
-                    for (key,value) in key_values {
+                    for (key, value) in key_values {
                         self.total_size.0 -= value.0;
                         self.total_size.1 -= value.1;
                         self.sizes.remove(key);

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -538,17 +538,14 @@ where
     /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]).await.unwrap();
-    ///   view.remove(vec![0,1]);
+    ///   view.remove(vec![0,1]).await.unwrap();
     ///   assert_eq!(view.get(&[0,1]).await.unwrap(), None);
     /// # })
     /// ```
-    pub fn remove(&mut self, index: Vec<u8>) {
-        *self.hash.get_mut() = None;
-        if self.was_cleared {
-            self.updates.remove(&index);
-        } else {
-            self.updates.insert(index, Update::Removed);
-        }
+    pub async fn remove(&mut self, index: Vec<u8>) -> Result<(), ViewError> {
+        let mut batch = Batch::new();
+        batch.delete_key(index);
+        self.write_batch(batch).await
     }
 
     /// Deletes a key_prefix.

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -73,6 +73,7 @@ pub struct KeyValueStoreView<C> {
     context: C,
     was_cleared: bool,
     updates: BTreeMap<Vec<u8>, Update<Vec<u8>>>,
+    stored_total_size: u64,
     total_size: u64,
     sizes: MapView<C, Vec<u8>, u64>,
     deleted_prefixes: BTreeSet<Vec<u8>>,
@@ -102,6 +103,7 @@ where
             context,
             was_cleared: false,
             updates: BTreeMap::new(),
+            stored_total_size: total_size,
             total_size,
             sizes,
             deleted_prefixes: BTreeSet::new(),
@@ -114,6 +116,8 @@ where
         self.was_cleared = false;
         self.updates.clear();
         self.deleted_prefixes.clear();
+        self.total_size = self.stored_total_size;
+        self.sizes.rollback();
         *self.hash.get_mut() = self.stored_hash;
     }
 
@@ -160,6 +164,8 @@ where
         self.was_cleared = true;
         self.updates.clear();
         self.deleted_prefixes.clear();
+        self.total_size = 0;
+        self.sizes.clear();
         *self.hash.get_mut() = None;
     }
 }

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -186,7 +186,7 @@ where
         C::MAX_KEY_SIZE - 1 - prefix_len
     }
 
-    /// Getting the total size that will be used when stored
+    /// Getting the total sizes that will be used for keys and values when stored
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::create_memory_context;
@@ -448,7 +448,7 @@ where
         Ok(index_values)
     }
 
-    /// Returns the list of indices and values in lexicographic order.
+    /// Returns the number of entries.
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::create_memory_context;

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -113,7 +113,7 @@ where
     /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
-    ///   assert_eq!(set.contains(vec![0,1]).await.unwrap(), true);
+    ///   assert_eq!(set.contains(&[0,1]).await.unwrap(), true);
     /// # })
     /// ```
     pub fn insert(&mut self, short_key: Vec<u8>) {
@@ -129,7 +129,7 @@ where
     /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.remove(vec![0,1]);
-    ///   assert_eq!(set.contains(vec![0,1]).await.unwrap(), false);
+    ///   assert_eq!(set.contains(&[0,1]).await.unwrap(), false);
     /// # })
     /// ```
     pub fn remove(&mut self, short_key: Vec<u8>) {
@@ -160,12 +160,12 @@ where
     /// # let context = create_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
-    ///   assert_eq!(set.contains(vec![34]).await.unwrap(), false);
-    ///   assert_eq!(set.contains(vec![0,1]).await.unwrap(), true);
+    ///   assert_eq!(set.contains(&[34]).await.unwrap(), false);
+    ///   assert_eq!(set.contains(&[0,1]).await.unwrap(), true);
     /// # })
     /// ```
-    pub async fn contains(&self, short_key: Vec<u8>) -> Result<bool, ViewError> {
-        if let Some(update) = self.updates.get(&short_key) {
+    pub async fn contains(&self, short_key: &[u8]) -> Result<bool, ViewError> {
+        if let Some(update) = self.updates.get(short_key) {
             let value = match update {
                 Update::Removed => false,
                 Update::Set(()) => true,
@@ -175,7 +175,7 @@ where
         if self.was_cleared {
             return Ok(false);
         }
-        let key = self.context.base_tag_index(KeyTag::Index as u8, &short_key);
+        let key = self.context.base_tag_index(KeyTag::Index as u8, short_key);
         match self.context.read_value_bytes(&key).await? {
             None => Ok(false),
             Some(_) => Ok(true),
@@ -474,7 +474,7 @@ where
         Q: Serialize + ?Sized,
     {
         let short_key = C::derive_short_key(index)?;
-        self.set.contains(short_key).await
+        self.set.contains(&short_key).await
     }
 }
 
@@ -715,7 +715,7 @@ where
         Q: CustomSerialize + ?Sized,
     {
         let short_key = index.to_custom_bytes()?;
-        self.set.contains(short_key).await
+        self.set.contains(&short_key).await
     }
 }
 

--- a/linera-views/tests/key_value_store_view.rs
+++ b/linera-views/tests/key_value_store_view.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_views::{
+    key_value_store_view::KeyValueStoreView,
+    memory::create_memory_context,
+    views::{CryptoHashRootView, RootView, View},
+};
+use rand::{distributions::Uniform, Rng, SeedableRng};
+use std::collections::BTreeMap;
+
+#[derive(CryptoHashRootView)]
+pub struct StateView<C> {
+    pub store: KeyValueStoreView<C>,
+}
+
+fn remove_by_prefix<V>(map: &mut BTreeMap<Vec<u8>, V>, key_prefix: Vec<u8>) {
+    map.retain(|key, _| !key.starts_with(&key_prefix));
+}
+
+fn total_size(vec: &Vec<(Vec<u8>,Vec<u8>)>) -> u64 {
+    let mut total_size = 0;
+    for (key, value) in vec {
+        total_size += key.len() + value.len();
+    }
+    total_size as u64
+}
+
+#[tokio::test]
+async fn key_value_store_view_mutability_check() {
+    let context = create_memory_context();
+    let mut rng = rand::rngs::StdRng::seed_from_u64(2);
+    let mut state_map = BTreeMap::new();
+    let n = 20;
+    for _ in 0..n {
+        let mut view = StateView::load(context.clone()).await.unwrap();
+        let save = rng.gen::<bool>();
+        let read_state = view.store.index_values().await.unwrap();
+        let state_vec = state_map.clone().into_iter().collect::<Vec<_>>();
+        assert_eq!(state_vec, read_state);
+        assert_eq!(total_size(&state_vec), view.store.total_size());
+        //
+        let count_oper = rng.gen_range(0..25);
+        let mut new_state_map = state_map.clone();
+        let mut new_state_vec = state_vec.clone();
+        for _ in 0..count_oper {
+            let choice = rng.gen_range(0..5);
+            let count = view.store.count().await.unwrap();
+            if choice == 0 {
+                // inserting random stuff
+                let n_ins = rng.gen_range(0..10);
+                for _ in 0..n_ins {
+                    let len = rng.gen_range(1..6);
+                    let key = rng
+                        .clone()
+                        .sample_iter(Uniform::from(0..4))
+                        .take(len)
+                        .collect::<Vec<_>>();
+                    let value = key.clone();
+                    view.store.insert(key.clone(), value.clone()).await.unwrap();
+                    new_state_map.insert(key, value);
+                }
+            }
+            if choice == 1 && count > 0 {
+                // deleting some entries
+                let n_remove = rng.gen_range(0..count);
+                for _ in 0..n_remove {
+                    let pos = rng.gen_range(0..count);
+                    let vec = new_state_vec[pos].clone();
+                    view.store.remove(vec.0.clone()).await.unwrap();
+                    new_state_map.remove(&vec.0);
+                }
+            }
+            if choice == 2 && count > 0 {
+                // deleting a prefix
+                let val = rng.gen_range(0..5) as u8;
+                let key_prefix = vec![val];
+                view.store.remove_by_prefix(key_prefix.clone()).await.unwrap();
+                remove_by_prefix(&mut new_state_map, key_prefix);
+            }
+            if choice == 3 {
+                // Doing the clearing
+                view.clear();
+                new_state_map.clear();
+            }
+            if choice == 4 {
+                // Doing the rollback
+                view.rollback();
+                new_state_map = state_map.clone();
+            }
+            new_state_vec = new_state_map.clone().into_iter().collect();
+            let new_key_values = view.store.index_values().await.unwrap();
+            assert_eq!(new_state_vec, new_key_values);
+            assert_eq!(total_size(&new_state_vec), view.store.total_size());
+        }
+        if save {
+            state_map = new_state_map.clone();
+            view.save().await.unwrap();
+        }
+    }
+}

--- a/linera-views/tests/key_value_store_view.rs
+++ b/linera-views/tests/key_value_store_view.rs
@@ -42,6 +42,8 @@ async fn key_value_store_view_mutability() {
         let read_state = view.store.index_values().await.unwrap();
         let state_vec = state_map.clone().into_iter().collect::<Vec<_>>();
         assert_eq!(state_vec, read_state);
+        println!("A: total_size(&state_vec)={}", total_size(&state_vec));
+        println!("A: view.store.total_size()={}", view.store.total_size());
         assert_eq!(total_size(&state_vec), view.store.total_size());
         //
         let count_oper = rng.gen_range(0..25);
@@ -80,7 +82,7 @@ async fn key_value_store_view_mutability() {
                     assert_eq!(total_size(&new_state_vec), view.store.total_size());
                 }
             }
-            if choice == 1 && count > 0 && false {
+            if choice == 1 && count > 0 {
                 // deleting some entries
                 let n_remove = rng.gen_range(0..count);
                 for _ in 0..n_remove {
@@ -98,7 +100,7 @@ async fn key_value_store_view_mutability() {
                 view.store.remove_by_prefix(key_prefix.clone()).await.unwrap();
                 remove_by_prefix(&mut new_state_map, key_prefix);
             }
-            if choice == 3 && false {
+            if choice == 3 {
                 // Doing the clearing
                 view.clear();
                 new_state_map.clear();
@@ -108,9 +110,12 @@ async fn key_value_store_view_mutability() {
                 view.rollback();
                 new_state_map = state_map.clone();
             }
+            println!("save={}", save);
             new_state_vec = new_state_map.clone().into_iter().collect();
             let new_key_values = view.store.index_values().await.unwrap();
             assert_eq!(new_state_vec, new_key_values);
+            println!("B: total_size(&new_state_vec)={}", total_size(&new_state_vec));
+            println!("B: view.store.total_size()={}", view.store.total_size());
             assert_eq!(total_size(&new_state_vec), view.store.total_size());
             let all_keys_vec = all_keys.clone().into_iter().collect::<Vec<_>>();
             let tests_multi_get = view.store.multi_get(all_keys_vec).await.unwrap();
@@ -119,10 +124,8 @@ async fn key_value_store_view_mutability() {
                 let test_map = new_state_map.contains_key(&key);
                 let test_view = view.store.get(&key).await.unwrap().is_some();
                 let test_multi_get = tests_multi_get[i].is_some();
-                if test_map != test_view || test_map != test_multi_get {
-                    println!("key={:?} test_map={}, test_view={} test_multi_get={}", key, test_map, test_view, test_multi_get);
-                    assert!(false);
-                }
+                assert_eq!(test_map, test_view);
+                assert_eq!(test_map, test_multi_get);
             }
         }
         if save {

--- a/linera-views/tests/key_value_store_view.rs
+++ b/linera-views/tests/key_value_store_view.rs
@@ -19,12 +19,14 @@ fn remove_by_prefix<V: Debug>(map: &mut BTreeMap<Vec<u8>, V>, key_prefix: Vec<u8
     map.retain(|key, _| !key.starts_with(&key_prefix));
 }
 
-fn total_size(vec: &Vec<(Vec<u8>,Vec<u8>)>) -> u64 {
-    let mut total_size = 0;
+fn total_size(vec: &Vec<(Vec<u8>,Vec<u8>)>) -> (u64, u64) {
+    let mut total_key_size = 0;
+    let mut total_value_size = 0;
     for (key, value) in vec {
-        total_size += key.len() + value.len();
+        total_key_size += key.len();
+        total_value_size += value.len();
     }
-    total_size as u64
+    (total_key_size as u64, total_value_size as u64)
 }
 
 #[tokio::test]
@@ -45,13 +47,13 @@ async fn key_value_store_view_mutability() {
         let count_oper = rng.gen_range(0..25);
         let mut new_state_map = state_map.clone();
         let mut new_state_vec = state_vec.clone();
-        for i_oper in 0..count_oper {
+        for _ in 0..count_oper {
             let choice = rng.gen_range(0..5);
             let count = view.store.count().await.unwrap();
             if choice == 0 {
                 // inserting random stuff
                 let n_ins = rng.gen_range(0..10);
-                for u in 0..n_ins {
+                for _ in 0..n_ins {
                     let len = rng.gen_range(1..6);
                     let key = rng
                         .clone()

--- a/linera-views/tests/key_value_store_view.rs
+++ b/linera-views/tests/key_value_store_view.rs
@@ -7,8 +7,10 @@ use linera_views::{
     views::{CryptoHashRootView, RootView, View},
 };
 use rand::{distributions::Uniform, Rng, SeedableRng};
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Debug;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
 
 #[derive(CryptoHashRootView)]
 pub struct StateView<C> {
@@ -19,7 +21,7 @@ fn remove_by_prefix<V: Debug>(map: &mut BTreeMap<Vec<u8>, V>, key_prefix: Vec<u8
     map.retain(|key, _| !key.starts_with(&key_prefix));
 }
 
-fn total_size(vec: &Vec<(Vec<u8>,Vec<u8>)>) -> (u64, u64) {
+fn total_size(vec: &Vec<(Vec<u8>, Vec<u8>)>) -> (u64, u64) {
     let mut total_key_size = 0;
     let mut total_value_size = 0;
     for (key, value) in vec {
@@ -85,7 +87,10 @@ async fn key_value_store_view_mutability() {
                 // deleting a prefix
                 let val = rng.gen_range(0..5) as u8;
                 let key_prefix = vec![val];
-                view.store.remove_by_prefix(key_prefix.clone()).await.unwrap();
+                view.store
+                    .remove_by_prefix(key_prefix.clone())
+                    .await
+                    .unwrap();
                 remove_by_prefix(&mut new_state_map, key_prefix);
             }
             if choice == 3 {

--- a/linera-views/tests/key_value_store_view.rs
+++ b/linera-views/tests/key_value_store_view.rs
@@ -93,7 +93,7 @@ async fn key_value_store_view_mutability() {
                 view.clear();
                 new_state_map.clear();
             }
-            if choice == 4 && false {
+            if choice == 4 {
                 // Doing the rollback
                 view.rollback();
                 new_state_map = state_map.clone();

--- a/linera-views/tests/key_value_store_view.rs
+++ b/linera-views/tests/key_value_store_view.rs
@@ -41,6 +41,8 @@ async fn key_value_store_view_mutability() {
         let save = rng.gen::<bool>();
         let read_state = view.store.index_values().await.unwrap();
         let state_vec = state_map.clone().into_iter().collect::<Vec<_>>();
+        println!("read_state={:?}", read_state);
+        println!("state_vec={:?}", state_vec);
         assert_eq!(state_vec, read_state);
         println!("A: total_size(&state_vec)={}", total_size(&state_vec));
         println!("A: view.store.total_size()={}", view.store.total_size());
@@ -49,10 +51,10 @@ async fn key_value_store_view_mutability() {
         let count_oper = rng.gen_range(0..25);
         let mut new_state_map = state_map.clone();
         let mut new_state_vec = state_vec.clone();
-        for _ in 0..count_oper {
+        for i_oper in 0..count_oper {
             let choice = rng.gen_range(0..5);
             let count = view.store.count().await.unwrap();
-            println!("choice={} count={}", choice, count);
+            println!("{} / {}  choice={} count={}", i_oper, count_oper, choice, count);
             if choice == 0 {
                 // inserting random stuff
                 let n_ins = rng.gen_range(0..10);
@@ -112,6 +114,7 @@ async fn key_value_store_view_mutability() {
             }
             println!("save={}", save);
             new_state_vec = new_state_map.clone().into_iter().collect();
+            println!("|new_state_vec|={} |new_state_map|={}", new_state_vec.len(), new_state_map.len());
             let new_key_values = view.store.index_values().await.unwrap();
             assert_eq!(new_state_vec, new_key_values);
             println!("B: total_size(&new_state_vec)={}", total_size(&new_state_vec));

--- a/linera-views/tests/map_view_tests.rs
+++ b/linera-views/tests/map_view_tests.rs
@@ -18,7 +18,7 @@ fn remove_by_prefix<V>(map: &mut BTreeMap<Vec<u8>, V>, key_prefix: Vec<u8>) {
     map.retain(|key, _| !key.starts_with(&key_prefix));
 }
 
-async fn map_view_mutability<R: RngCore + Clone>(rng: &mut R) {
+async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) {
     let context = create_memory_context();
     let mut state_map = BTreeMap::new();
     let mut all_keys = BTreeSet::new();
@@ -105,9 +105,9 @@ async fn map_view_mutability<R: RngCore + Clone>(rng: &mut R) {
 }
 
 #[tokio::test]
-async fn map_view_mutability_iter() {
+async fn map_view_mutability() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     for _ in 0..10 {
-        map_view_mutability(&mut rng).await;
+        run_map_view_mutability(&mut rng).await;
     }
 }

--- a/linera-views/tests/map_view_tests.rs
+++ b/linera-views/tests/map_view_tests.rs
@@ -6,9 +6,8 @@ use linera_views::{
     memory::create_memory_context,
     views::{CryptoHashRootView, RootView, View},
 };
-use rand::{distributions::Uniform, Rng, SeedableRng};
+use rand::{distributions::Uniform, Rng, RngCore, SeedableRng};
 use std::collections::{BTreeMap, BTreeSet};
-use rand::RngCore;
 
 #[derive(CryptoHashRootView)]
 pub struct StateView<C> {

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -1093,7 +1093,10 @@ async fn check_hash_memoization_persistence<S>(
             view.queue.push_back(pair1_first_u8 as u64);
             view.map.insert(&str0, pair1_first_u8 as usize).unwrap();
             view.map.insert(&str1, pair0_first_u8 as usize).unwrap();
-            view.key_value_store.insert(pair.0.clone(), pair.1.clone()).await.unwrap();
+            view.key_value_store
+                .insert(pair.0.clone(), pair.1.clone())
+                .await
+                .unwrap();
             if choice == 0 {
                 view.rollback();
                 let hash_new = view.hash().await.unwrap();

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -979,7 +979,7 @@ where
             Delete { key } => {
                 let key_str = format!("{:?}", &key);
                 view.map.remove(&key_str).unwrap();
-                view.key_value_store.remove(key);
+                view.key_value_store.remove(key).await.unwrap();
             }
             DeletePrefix { key_prefix: _ } => {}
         }

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -934,7 +934,7 @@ where
         let key_str = format!("{:?}", &key);
         let value_usize = (*value.first().unwrap()) as usize;
         view.map.insert(&key_str, value_usize).unwrap();
-        view.key_value_store.insert(key, value);
+        view.key_value_store.insert(key, value).await.unwrap();
         {
             let subview = view.collection.load_entry_mut(&key_str).await.unwrap();
             subview.push(value_usize as u32);
@@ -970,7 +970,7 @@ where
                 tmp += first_value_u64;
                 view.x1.set(tmp);
                 view.map.insert(&key_str, first_value_usize).unwrap();
-                view.key_value_store.insert(key, value);
+                view.key_value_store.insert(key, value).await.unwrap();
                 {
                     let subview = view.collection.load_entry_mut(&key_str).await.unwrap();
                     subview.push(first_value as u32);
@@ -1093,7 +1093,7 @@ async fn check_hash_memoization_persistence<S>(
             view.queue.push_back(pair1_first_u8 as u64);
             view.map.insert(&str0, pair1_first_u8 as usize).unwrap();
             view.map.insert(&str1, pair0_first_u8 as usize).unwrap();
-            view.key_value_store.insert(pair.0.clone(), pair.1.clone());
+            view.key_value_store.insert(pair.0.clone(), pair.1.clone()).await.unwrap();
             if choice == 0 {
                 view.rollback();
                 let hash_new = view.hash().await.unwrap();


### PR DESCRIPTION
## Motivation

For the purpose of storage fees, we need to keep track of the total size stored.
This PR should address #1263.

## Proposal

The following decision were done:
* The key size and the value sizes are tracked separately. However, instead of having this tracked separately, we track a pair (u64,u64) along.
* The tests for `MapView` were reinforced in view of the detected problems that led to PR #1284.
* Random checks were implemented for `KeyValueStoreView` that led to the detection of aforementioned bugs.
* Instead of reinventing the wheel, the `ByteMapView` was used.
* The `insert`, `remove` and `remove_by_prefix` functions are left. However, they are calling the `write_batch`and so become `async`. But it was better to keep the functionality.
* Change the `get` functions in `ByteMapView` and `KeyValueStoreView` so that they take a `&[u8]` as argument.

## Test Plan

The CI should address it with the random tests.

## Release Plan

No change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
