### PR TITLE
Remove retry loops when sending certificates

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -33,9 +33,8 @@ pub type NotificationStream = Pin<Box<dyn Stream<Item = Notification> + Send>>;
 #[derive(Debug, Default, Clone, Copy)]
 pub enum CrossChainMessageDelivery {
     #[default]
-    Default,
-    DoNotWaitForOutgoingMessages,
-    WaitForOutgoingMessages,
+    NonBlocking,
+    Blocking,
 }
 
 /// How to communicate with a validator node.
@@ -168,12 +167,19 @@ pub enum NodeError {
 }
 
 impl CrossChainMessageDelivery {
-    pub fn should_wait_for_outgoing_messages(self, default: bool) -> bool {
+    pub fn new(wait_for_outgoing_messages: bool) -> Self {
+        if wait_for_outgoing_messages {
+            CrossChainMessageDelivery::Blocking
+        } else {
+            CrossChainMessageDelivery::NonBlocking
+        }
+    }
+
+    pub fn wait_for_outgoing_messages(self) -> bool {
         use CrossChainMessageDelivery::*;
         match self {
-            Default => default,
-            DoNotWaitForOutgoingMessages => false,
-            WaitForOutgoingMessages => true,
+            NonBlocking => false,
+            Blocking => true,
         }
     }
 }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -149,24 +149,6 @@ pub enum NodeError {
     #[error("The received chain info response is invalid")]
     InvalidChainInfoResponse,
 
-    #[error(
-        "Failed to submit block proposal: chain {chain_id:?} was still inactive \
-         after validator synchronization and {retries} retries"
-    )]
-    ProposedBlockToInactiveChain { chain_id: ChainId, retries: usize },
-
-    #[error(
-        "Failed to submit block proposal: chain {chain_id:?} was still missing messages \
-         after validator synchronization and {retries} retries"
-    )]
-    ProposedBlockWithLaggingMessages { chain_id: ChainId, retries: usize },
-
-    #[error(
-        "Failed to submit block proposal: chain {chain_id:?} was still missing application bytecodes \
-         after validator synchronization and {retries} retries"
-    )]
-    ProposedBlockWithLaggingBytecode { chain_id: ChainId, retries: usize },
-
     // Networking errors.
     // TODO(#258): These errors should be defined in linera-rpc.
     #[error("Cannot deserialize")]

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::{ChainClient, ValidatorNodeProvider},
+    client::{ChainClient, ChainClientBuilder, ValidatorNodeProvider},
     data_types::*,
-    node::{NodeError, NotificationStream, ValidatorNode},
+    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
     notifier::Notifier,
     worker::{Notification, ValidatorWorker, WorkerState},
 };
@@ -54,8 +54,6 @@ use {
 #[cfg(any(feature = "aws", feature = "scylladb"))]
 use linera_views::test_utils::get_table_name;
 
-use super::ChainClientBuilder;
-
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum FaultType {
     Honest,
@@ -100,6 +98,7 @@ where
     async fn handle_lite_certificate(
         &mut self,
         certificate: LiteCertificate<'_>,
+        _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let certificate = certificate.cloned();
         self.spawn_and_receive(move |validator, sender| {
@@ -112,6 +111,7 @@ where
         &mut self,
         certificate: Certificate,
         blobs: Vec<HashedValue>,
+        _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
             validator.do_handle_certificate(certificate, blobs, sender)

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -512,8 +512,7 @@ where
             .await;
         self.chain_client_storages.push(storage.clone());
         let provider = self.validator_clients.iter().cloned().collect();
-        let cross_chain_delay = std::time::Duration::from_millis(500);
-        let builder = ChainClientBuilder::new(provider, 10, cross_chain_delay, 10);
+        let builder = ChainClientBuilder::new(provider, 10);
         Ok(builder.build(
             chain_id,
             vec![key_pair],

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -512,7 +512,7 @@ where
             .await;
         self.chain_client_storages.push(storage.clone());
         let provider = self.validator_clients.iter().cloned().collect();
-        let builder = ChainClientBuilder::new(provider, 10);
+        let builder = ChainClientBuilder::new(provider, 10, CrossChainMessageDelivery::NonBlocking);
         Ok(builder.build(
             chain_id,
             vec![key_pair],

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -11,7 +11,10 @@ use crate::{
         ChainClient, ChainClientError, CommunicateAction,
     },
     local_node::LocalNodeError,
-    node::NodeError::{self, ClientIoError},
+    node::{
+        CrossChainMessageDelivery,
+        NodeError::{self, ClientIoError},
+    },
     updater::CommunicationError,
     worker::{Notification, Reason, WorkerError},
 };
@@ -1318,7 +1321,10 @@ where
         .communicate_chain_updates(
             &builder.initial_committee,
             client1.chain_id,
-            CommunicateAction::AdvanceToNextBlockHeight(client1.next_block_height),
+            CommunicateAction::AdvanceToNextBlockHeight {
+                height: client1.next_block_height,
+                delivery: CrossChainMessageDelivery::Default,
+            },
         )
         .await
         .unwrap();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1323,7 +1323,7 @@ where
             client1.chain_id,
             CommunicateAction::AdvanceToNextBlockHeight {
                 height: client1.next_block_height,
-                delivery: CrossChainMessageDelivery::Default,
+                delivery: CrossChainMessageDelivery::NonBlocking,
             },
         )
         .await

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -277,20 +277,15 @@ where
         // Figure out which certificates this validator is missing.
         let query = ChainInfoQuery::new(chain_id);
         let initial_block_height = match self.node.handle_chain_info_query(query).await {
-            Ok(response) if response.info.description.is_some() => {
+            Ok(response) => {
                 response.check(self.name)?;
                 response.info.next_block_height
             }
-            Ok(response) => {
-                response.check(self.name)?;
-                BlockHeight::ZERO
-            }
-            Err(e) => {
+            Err(error) => {
                 error!(
-                    "Failed to query validator {:?} about missing blocks for chain {:?}: {}",
-                    self.name, chain_id, e
+                    name = ?self.name, ?chain_id, %error, "Failed to query validator about missing blocks"
                 );
-                return Err(e);
+                return Err(error);
             }
         };
         // Obtain the missing blocks and the manager state from the local node.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -55,8 +55,6 @@ pub struct ValidatorUpdater<A, S> {
     pub name: ValidatorName,
     pub node: A,
     pub storage: S,
-    pub delay: Duration,
-    pub retries: usize,
 }
 
 /// An error result for [`communicate_with_quorum`].

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -38,7 +38,7 @@ use grpc::{
 use linera_base::identifiers::ChainId;
 use linera_chain::data_types;
 use linera_core::{
-    node::{NodeError, NotificationStream, ValidatorNode},
+    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
     worker::{NetworkActions, Notification, ValidatorWorker, WorkerError, WorkerState},
 };
 use linera_storage::Storage;
@@ -712,10 +712,13 @@ impl ValidatorNode for GrpcClient {
     async fn handle_lite_certificate(
         &mut self,
         certificate: data_types::LiteCertificate<'_>,
+        delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let wait_for_outgoing_messages =
+            delivery.should_wait_for_outgoing_messages(self.wait_for_outgoing_messages);
         let request = HandleLiteCertificateRequest {
             certificate,
-            wait_for_outgoing_messages: self.wait_for_outgoing_messages,
+            wait_for_outgoing_messages,
         };
         client_delegate!(self, handle_lite_certificate, request)
     }
@@ -725,11 +728,14 @@ impl ValidatorNode for GrpcClient {
         &mut self,
         certificate: data_types::Certificate,
         blobs: Vec<data_types::HashedValue>,
+        delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
+        let wait_for_outgoing_messages =
+            delivery.should_wait_for_outgoing_messages(self.wait_for_outgoing_messages);
         let request = HandleCertificateRequest {
             certificate,
             blobs,
-            wait_for_outgoing_messages: self.wait_for_outgoing_messages,
+            wait_for_outgoing_messages,
         };
         client_delegate!(self, handle_certificate, request)
     }

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -585,7 +585,6 @@ pub struct GrpcClient {
     client: ValidatorNodeClient<Channel>,
     notification_retry_delay: Duration,
     notification_retries: u32,
-    wait_for_outgoing_messages: bool,
 }
 
 impl GrpcClient {
@@ -604,7 +603,6 @@ impl GrpcClient {
             client,
             notification_retry_delay: options.notification_retry_delay,
             notification_retries: options.notification_retries,
-            wait_for_outgoing_messages: options.wait_for_outgoing_messages,
         })
     }
 
@@ -714,8 +712,7 @@ impl ValidatorNode for GrpcClient {
         certificate: data_types::LiteCertificate<'_>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        let wait_for_outgoing_messages =
-            delivery.should_wait_for_outgoing_messages(self.wait_for_outgoing_messages);
+        let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleLiteCertificateRequest {
             certificate,
             wait_for_outgoing_messages,
@@ -730,8 +727,7 @@ impl ValidatorNode for GrpcClient {
         blobs: Vec<data_types::HashedValue>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        let wait_for_outgoing_messages =
-            delivery.should_wait_for_outgoing_messages(self.wait_for_outgoing_messages);
+        let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
             blobs,

--- a/linera-rpc/src/node_provider.rs
+++ b/linera-rpc/src/node_provider.rs
@@ -52,7 +52,6 @@ pub struct NodeOptions {
     pub recv_timeout: Duration,
     pub notification_retry_delay: Duration,
     pub notification_retries: u32,
-    pub wait_for_outgoing_messages: bool,
 }
 
 #[derive(Copy, Clone)]
@@ -104,12 +103,7 @@ impl ValidatorNodeProvider for SimpleNodeProvider {
             }
         })?;
 
-        let client = SimpleClient::new(
-            network,
-            self.0.send_timeout,
-            self.0.recv_timeout,
-            self.0.wait_for_outgoing_messages,
-        );
+        let client = SimpleClient::new(network, self.0.send_timeout, self.0.recv_timeout);
 
         Ok(client)
     }

--- a/linera-rpc/src/simple_network.rs
+++ b/linera-rpc/src/simple_network.rs
@@ -344,7 +344,6 @@ pub struct SimpleClient {
     network: ValidatorPublicNetworkPreConfig<TransportProtocol>,
     send_timeout: Duration,
     recv_timeout: Duration,
-    wait_for_outgoing_messages: bool,
 }
 
 impl SimpleClient {
@@ -352,13 +351,11 @@ impl SimpleClient {
         network: ValidatorPublicNetworkPreConfig<TransportProtocol>,
         send_timeout: Duration,
         recv_timeout: Duration,
-        wait_for_outgoing_messages: bool,
     ) -> Self {
         Self {
             network,
             send_timeout,
             recv_timeout,
-            wait_for_outgoing_messages,
         }
     }
 
@@ -417,8 +414,7 @@ impl ValidatorNode for SimpleClient {
         certificate: LiteCertificate<'_>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let wait_for_outgoing_messages =
-            delivery.should_wait_for_outgoing_messages(self.wait_for_outgoing_messages);
+        let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleLiteCertificateRequest {
             certificate: certificate.cloned(),
             wait_for_outgoing_messages,
@@ -433,8 +429,7 @@ impl ValidatorNode for SimpleClient {
         blobs: Vec<HashedValue>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
-        let wait_for_outgoing_messages =
-            delivery.should_wait_for_outgoing_messages(self.wait_for_outgoing_messages);
+        let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
             blobs,

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -485,44 +485,26 @@ NodeError:
     11:
       InvalidChainInfoResponse: UNIT
     12:
-      ProposedBlockToInactiveChain:
-        STRUCT:
-          - chain_id:
-              TYPENAME: ChainId
-          - retries: U64
-    13:
-      ProposedBlockWithLaggingMessages:
-        STRUCT:
-          - chain_id:
-              TYPENAME: ChainId
-          - retries: U64
-    14:
-      ProposedBlockWithLaggingBytecode:
-        STRUCT:
-          - chain_id:
-              TYPENAME: ChainId
-          - retries: U64
-    15:
       InvalidDecoding: UNIT
-    16:
+    13:
       UnexpectedMessage: UNIT
-    17:
+    14:
       GrpcError:
         STRUCT:
           - error: STR
-    18:
+    15:
       ClientIoError:
         STRUCT:
           - error: STR
-    19:
+    16:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    20:
+    17:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    21:
+    18:
       SubscriptionFailed:
         STRUCT:
           - status: STR

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -17,7 +17,7 @@ use linera_core::{
     client::{ChainClient, ChainClientBuilder},
     data_types::ChainInfoQuery,
     local_node::LocalNodeClient,
-    node::ValidatorNodeProvider,
+    node::{CrossChainMessageDelivery, ValidatorNodeProvider},
     notifier::Notifier,
     worker::WorkerState,
 };
@@ -86,7 +86,6 @@ struct ClientContext {
     recv_timeout: Duration,
     notification_retry_delay: Duration,
     notification_retries: u32,
-    wait_for_outgoing_messages: bool,
     prng: Box<dyn CryptoRng>,
 }
 
@@ -167,11 +166,11 @@ impl ClientContext {
             recv_timeout,
             notification_retry_delay,
             notification_retries: options.notification_retries,
-            wait_for_outgoing_messages: options.wait_for_outgoing_messages,
         };
         let node_provider = NodeProvider::new(node_options);
+        let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
         let chain_client_builder =
-            ChainClientBuilder::new(node_provider, options.max_pending_messages);
+            ChainClientBuilder::new(node_provider, options.max_pending_messages, delivery);
         ClientContext {
             chain_client_builder,
             wallet_state,
@@ -179,7 +178,6 @@ impl ClientContext {
             recv_timeout,
             notification_retry_delay,
             notification_retries: options.notification_retries,
-            wait_for_outgoing_messages: options.wait_for_outgoing_messages,
             prng,
         }
     }
@@ -278,7 +276,6 @@ impl ClientContext {
             recv_timeout: self.recv_timeout,
             notification_retry_delay: self.notification_retry_delay,
             notification_retries: self.notification_retries,
-            wait_for_outgoing_messages: self.wait_for_outgoing_messages,
         }
     }
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -159,7 +159,6 @@ impl ClientContext {
     fn configure(options: &ClientOptions, wallet_state: WalletState) -> Self {
         let send_timeout = Duration::from_micros(options.send_timeout_us);
         let recv_timeout = Duration::from_micros(options.recv_timeout_us);
-        let cross_chain_delay = Duration::from_micros(options.cross_chain_delay_ms);
         let notification_retry_delay = Duration::from_micros(options.notification_retry_delay_us);
         let prng = wallet_state.make_prng();
 
@@ -171,12 +170,8 @@ impl ClientContext {
             wait_for_outgoing_messages: options.wait_for_outgoing_messages,
         };
         let node_provider = NodeProvider::new(node_options);
-        let chain_client_builder = ChainClientBuilder::new(
-            node_provider,
-            options.max_pending_messages,
-            cross_chain_delay,
-            options.cross_chain_retries,
-        );
+        let chain_client_builder =
+            ChainClientBuilder::new(node_provider, options.max_pending_messages);
         ClientContext {
             chain_client_builder,
             wallet_state,
@@ -622,13 +617,6 @@ struct ClientOptions {
     /// Timeout for receiving responses (us)
     #[structopt(long, default_value = "4000000")]
     recv_timeout_us: u64,
-
-    /// Time between attempts while waiting on cross-chain updates (ms)
-    #[structopt(long, default_value = "4000")]
-    cross_chain_delay_ms: u64,
-
-    #[structopt(long, default_value = "10")]
-    cross_chain_retries: usize,
 
     #[structopt(long, default_value = "10")]
     max_pending_messages: usize,

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -7,7 +7,10 @@ use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCert
 use linera_core::{
     client::ChainClient,
     data_types::{ChainInfoQuery, ChainInfoResponse},
-    node::{NodeError, NotificationStream, ValidatorNode, ValidatorNodeProvider},
+    node::{
+        CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
+        ValidatorNodeProvider,
+    },
 };
 use linera_execution::committee::Committee;
 use linera_service::{
@@ -34,6 +37,7 @@ impl ValidatorNode for DummyValidatorNode {
     async fn handle_lite_certificate(
         &mut self,
         _: LiteCertificate<'_>,
+        _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
@@ -42,6 +46,7 @@ impl ValidatorNode for DummyValidatorNode {
         &mut self,
         _: Certificate,
         _: Vec<HashedValue>,
+        _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }


### PR DESCRIPTION
## Motivation

Continue simplify the client code after #1220 and #1283

## Proposal

* Define enum `CrossChainMessageDelivery` to allow forcing `wait_for_outgoing_messages = true` for individual certificate uploads
* Use it when needed, notably when uploading certificates corresponding to received messages

## Test Plan

CI

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
Some CLI options are removed
