### PR TITLE
Wait for Scylladb initialization instead of failing

### DIFF
--- a/docker/server-init.sh
+++ b/docker/server-init.sh
@@ -1,14 +1,25 @@
 #!/bin/sh
 
-./linera-db check_existence --storage "scylladb:tcp:scylladb.default.svc.cluster.local:9042"
-status=$?
+while true; do
+  ./linera-db check_existence --storage "scylladb:tcp:scylladb.default.svc.cluster.local:9042"
+  status=$?
 
-if [ $status -eq 0 ]; then
-  exit 0
-elif [ $status -eq 1 ]; then
-  ./linera-server initialize \
-    --storage scylladb:tcp:scylladb.default.svc.cluster.local:9042 \
-    --genesis /config/genesis.json || exit 1;
-else
-  exit $status
-fi
+  if [ $status -eq 0 ]; then
+    echo "Database already exists, no need to initialize."
+    exit 0
+  elif [ $status -eq 1 ]; then
+    echo "Database does not exist, attempting to initialize..."
+    if ./linera-server initialize \
+      --storage scylladb:tcp:scylladb.default.svc.cluster.local:9042 \
+      --genesis /config/genesis.json; then
+      echo "Initialization successful."
+      exit 0
+    else
+      echo "Initialization failed, retrying in 5 seconds..."
+      sleep 5
+    fi
+  else
+    echo "An unexpected error occurred (status: $status), retrying in 5 seconds..."
+    sleep 5
+  fi
+done

--- a/kubernetes/linera-validator/templates/server.yaml
+++ b/kubernetes/linera-validator/templates/server.yaml
@@ -31,6 +31,20 @@ spec:
     spec:
       serviceAccountName: linera-admin
       terminationGracePeriodSeconds: 10
+      initContainers:
+        - name: linera-server-initializer
+          image: {{ .Values.lineraImage }}
+          imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
+          command: ["./server-init.sh"]
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.logLevel }}
+            - name: RUST_BACKTRACE
+              value: "1"
+          volumeMounts:
+            - name: config
+              mountPath: "/config"
+              readOnly: true
       containers:
         - name: linera-server
           image: {{ .Values.lineraImage }}
@@ -51,20 +65,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          volumeMounts:
-            - name: config
-              mountPath: "/config"
-              readOnly: true
-      initContainers:
-        - name: linera-server-initializer
-          image: {{ .Values.lineraImage }}
-          imagePullPolicy: {{ .Values.lineraImagePullPolicy }}
-          command: ["./server-init.sh"]
-          env:
-            - name: RUST_LOG
-              value: {{ .Values.logLevel }}
-            - name: RUST_BACKTRACE
-              value: "1"
           volumeMounts:
             - name: config
               mountPath: "/config"


### PR DESCRIPTION
## Motivation

Right now when we're trying to initialize the shards, we check for ScyllaDB and just fail if it's not ready. That makes Kubernetes go into a `CrashLoopBackoff`, which is an exponential backoff, which will make us wait much more than we need.

## Proposal

Change the script to wait for the initialization instead of failing

## Test Plan

Started clusters locally, a few seconds after ScyllaDB is `Running`, the shards also start being initialized. Initialization felt a lot faster

