### PR TITLE
Removal of the "delete" and "write_delete".

### DIFF
--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-2.snap
@@ -17,19 +17,5 @@ impl linera_views::views::RootView<CustomContext> for TestView {
         self.context().write_batch(batch).await?;
         Ok(())
     }
-    async fn write_delete(self) -> Result<(), linera_views::views::ViewError> {
-        use linera_views::{common::Context, batch::Batch, views::View};
-        let context = self.context().clone();
-        let batch = Batch::build(move |batch| {
-                Box::pin(async move {
-                    self.register.delete(batch);
-                    self.collection.delete(batch);
-                    Ok(())
-                })
-            })
-            .await?;
-        context.write_batch(batch).await?;
-        Ok(())
-    }
 }
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-3.snap
@@ -17,19 +17,5 @@ impl linera_views::views::RootView<custom::path::to::ContextType> for TestView {
         self.context().write_batch(batch).await?;
         Ok(())
     }
-    async fn write_delete(self) -> Result<(), linera_views::views::ViewError> {
-        use linera_views::{common::Context, batch::Batch, views::View};
-        let context = self.context().clone();
-        let batch = Batch::build(move |batch| {
-                Box::pin(async move {
-                    self.register.delete(batch);
-                    self.collection.delete(batch);
-                    Ok(())
-                })
-            })
-            .await?;
-        context.write_batch(batch).await?;
-        Ok(())
-    }
 }
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-4.snap
@@ -17,19 +17,5 @@ impl linera_views::views::RootView<custom::GenericContext<T>> for TestView {
         self.context().write_batch(batch).await?;
         Ok(())
     }
-    async fn write_delete(self) -> Result<(), linera_views::views::ViewError> {
-        use linera_views::{common::Context, batch::Batch, views::View};
-        let context = self.context().clone();
-        let batch = Batch::build(move |batch| {
-                Box::pin(async move {
-                    self.register.delete(batch);
-                    self.collection.delete(batch);
-                    Ok(())
-                })
-            })
-            .await?;
-        context.write_batch(batch).await?;
-        Ok(())
-    }
 }
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code.snap
@@ -21,19 +21,5 @@ where
         self.context().write_batch(batch).await?;
         Ok(())
     }
-    async fn write_delete(self) -> Result<(), linera_views::views::ViewError> {
-        use linera_views::{common::Context, batch::Batch, views::View};
-        let context = self.context().clone();
-        let batch = Batch::build(move |batch| {
-                Box::pin(async move {
-                    self.register.delete(batch);
-                    self.collection.delete(batch);
-                    Ok(())
-                })
-            })
-            .await?;
-        context.write_batch(batch).await?;
-        Ok(())
-    }
 }
 

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -130,10 +130,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.was_cleared = true;
         self.updates.get_mut().clear();
@@ -575,10 +571,6 @@ where
         self.collection.flush(batch)
     }
 
-    fn delete(self, batch: &mut Batch) {
-        self.collection.delete(batch)
-    }
-
     fn clear(&mut self) {
         self.collection.clear()
     }
@@ -885,10 +877,6 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
         self.collection.flush(batch)
-    }
-
-    fn delete(self, batch: &mut Batch) {
-        self.collection.delete(batch)
     }
 
     fn clear(&mut self) {

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -74,10 +74,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        self.inner.delete(batch);
-    }
-
     fn clear(&mut self) {
         self.inner.clear();
         *self.hash.get_mut() = None;

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -185,10 +185,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.was_cleared = true;
         self.updates.clear();

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -102,10 +102,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.was_cleared = true;
         self.new_values.clear();

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -121,10 +121,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.was_cleared = true;
         self.updates.clear();
@@ -806,10 +802,6 @@ where
         self.map.flush(batch)
     }
 
-    fn delete(self, batch: &mut Batch) {
-        self.map.delete(batch)
-    }
-
     fn clear(&mut self) {
         self.map.clear()
     }
@@ -1185,10 +1177,6 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
         self.map.flush(batch)
-    }
-
-    fn delete(self, batch: &mut Batch) {
-        self.map.delete(batch)
     }
 
     fn clear(&mut self) {

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -119,10 +119,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.was_cleared = true;
         self.new_back_values.clear();

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -121,10 +121,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.was_cleared = true;
         self.updates.get_mut().clear();
@@ -726,10 +722,6 @@ where
         self.collection.flush(batch)
     }
 
-    fn delete(self, batch: &mut Batch) {
-        self.collection.delete(batch)
-    }
-
     fn clear(&mut self) {
         self.collection.clear()
     }
@@ -1085,10 +1077,6 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
         self.collection.flush(batch)
-    }
-
-    fn delete(self, batch: &mut Batch) {
-        self.collection.delete(batch)
     }
 
     fn clear(&mut self) {

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -80,10 +80,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.update = Some(Box::default());
         *self.hash.get_mut() = None;

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -89,10 +89,6 @@ where
         Ok(())
     }
 
-    fn delete(self, batch: &mut Batch) {
-        batch.delete_key_prefix(self.context.base_key());
-    }
-
     fn clear(&mut self) {
         self.was_cleared = true;
         self.updates.clear();
@@ -386,10 +382,6 @@ where
         self.set.flush(batch)
     }
 
-    fn delete(self, batch: &mut Batch) {
-        self.set.delete(batch)
-    }
-
     fn clear(&mut self) {
         self.set.clear()
     }
@@ -623,10 +615,6 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
         self.set.flush(batch)
-    }
-
-    fn delete(self, batch: &mut Batch) {
-        self.set.delete(batch)
     }
 
     fn clear(&mut self) {

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -38,12 +38,6 @@ pub trait View<C>: Sized {
     /// changes in the `batch` variable first. If the view is dropped without calling `flush`, staged
     /// changes are simply lost.
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError>;
-
-    /// Instead of persisting changes, clears all the data that belong to this view and its
-    /// subviews. Crash-resistant storage implementations are expected to accumulate the
-    /// desired changes into the `batch` variable first.
-    /// No data/metadata at all is left after deletion. The view is consumed by `delete`.
-    fn delete(self, batch: &mut Batch);
 }
 
 /// Main error type for the crate.
@@ -166,9 +160,6 @@ impl Hasher for sha3::Sha3_256 {
 pub trait RootView<C>: View<C> {
     /// Saves the root view to the database context
     async fn save(&mut self) -> Result<(), ViewError>;
-
-    /// Deletes the root view to the database context
-    async fn write_delete(self) -> Result<(), ViewError>;
 }
 
 /// A [`View`] that also supports crypto hash

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -654,7 +654,6 @@ where
             assert_eq!(view.queue.front().await.unwrap(), None);
             assert_eq!(view.queue.count(), 0);
         }
-        view.write_delete().await.unwrap();
     }
     staged_hash
 }
@@ -665,8 +664,7 @@ async fn test_views_in_lru_memory_param(config: &TestConfig) {
     let mut store = LruMemoryStore::new().await;
     test_store(&mut store, config).await;
     assert_eq!(store.states.len(), 1);
-    let entry = store.states.get(&1).unwrap().clone();
-    assert!(entry.lock().await.is_empty());
+    store.states.get(&1).unwrap();
 }
 
 #[tokio::test]
@@ -682,8 +680,7 @@ async fn test_views_in_memory_param(config: &TestConfig) {
     let mut store = MemoryTestStore::new().await;
     test_store(&mut store, config).await;
     assert_eq!(store.states.len(), 1);
-    let entry = store.states.get(&1).unwrap().clone();
-    assert!(entry.lock().await.is_empty());
+    store.states.get(&1).unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

The `delete` function has been removed from the view code following Issue 1289.

## Proposal

The code for `delete` and `write_delete` is eliminated.
The `write_delete` was used only for the tests and it is removed there as well since after all
if we remove the delete, we could remove the usage as well.

## Test Plan

The CI

## Release Plan

The documentation has to be updated with respect to that aspect.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
