### PR TITLE
Improvement to the `stored_size` code.

### DIFF
--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -94,7 +94,6 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
         if self.was_cleared {
-            self.was_cleared = false;
             batch.delete_key_prefix(self.context.base_key());
             for (index, update) in mem::take(self.updates.get_mut()) {
                 if let Update::Set(mut view) = update {
@@ -119,7 +118,11 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        if self.stored_hash != hash {
+        // In tne admittedly rare scenarion that we do a clear
+        // and stored_hash = hash, we need to update the
+        // hash, otherwise, we will recompute it while this
+        // can be avoided.
+        if self.stored_hash != hash || self.was_cleared {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),
@@ -127,6 +130,7 @@ where
             }
             self.stored_hash = hash;
         }
+        self.was_cleared = false;
         Ok(())
     }
 

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -118,7 +118,7 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In tne admittedly rare scenarion that we do a clear
+        // In the scenario where we do a clear
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -168,7 +168,11 @@ where
         }
         self.sizes.flush(batch)?;
         let hash = *self.hash.get_mut();
-        if self.stored_hash != hash {
+        // In tne admittedly rare scenarion that we do a clear
+        // and stored_hash = hash, we need to update the
+        // hash, otherwise, we will recompute it while this
+        // can be avoided.
+        if self.stored_hash != hash || self.was_cleared {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -74,6 +74,7 @@ impl SizeData {
             .ok_or(ViewError::ArithmeticError(ArithmeticError::Overflow))?;
         Ok(())
     }
+
     /// Subtract a size to the existing SizeData
     pub fn sub_assign(&mut self, size: SizeData) {
         self.key -= size.key;

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -621,7 +621,7 @@ where
                     ensure!(key.len() <= max_key_size, ViewError::KeyTooLong);
                     if let Some(value) = self.sizes.get(&key).await? {
                         let entry_size = SizeData {
-                            key: key.len() as u32,
+                            key: u32::try_from(key.len()).map_err(|_| ArithmeticError::Overflow)?,
                             value,
                         };
                         self.total_size.sub_assign(entry_size);

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -176,6 +176,9 @@ where
             }
             self.stored_hash = hash;
         }
+        // We could have the scenario where was_cleared is called but
+        // stored_total_size = total_size. If the test for was_cleared
+        // were absent then we would be a size of 0 down the line.
         if self.stored_total_size != self.total_size || self.was_cleared {
             let key = self.context.base_tag(KeyTag::TotalSize as u8);
             batch.put_key_value(key, &self.total_size)?;

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -88,7 +88,7 @@ where
             self.new_values.clear();
         }
         let hash = *self.hash.get_mut();
-        // In tne admittedly rare scenarion that we do a clear
+        // In the scenario where we do a clear
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -71,11 +71,9 @@ where
     }
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
-        if self.was_cleared {
-            if self.stored_count > 0 {
-                batch.delete_key_prefix(self.context.base_key());
-                self.stored_count = 0;
-            }
+        if self.was_cleared && self.stored_count > 0 {
+            batch.delete_key_prefix(self.context.base_key());
+            self.stored_count = 0;
         }
         if !self.new_values.is_empty() {
             for value in &self.new_values {

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -72,7 +72,6 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
         if self.was_cleared {
-            self.was_cleared = false;
             if self.stored_count > 0 {
                 batch.delete_key_prefix(self.context.base_key());
                 self.stored_count = 0;
@@ -91,7 +90,11 @@ where
             self.new_values.clear();
         }
         let hash = *self.hash.get_mut();
-        if self.stored_hash != hash {
+        // In tne admittedly rare scenarion that we do a clear
+        // and stored_hash = hash, we need to update the
+        // hash, otherwise, we will recompute it while this
+        // can be avoided.
+        if self.stored_hash != hash || self.was_cleared {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),
@@ -99,6 +102,7 @@ where
             }
             self.stored_hash = hash;
         }
+        self.was_cleared = false;
         Ok(())
     }
 

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -88,7 +88,6 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
         if self.was_cleared {
-            self.was_cleared = false;
             batch.delete_key_prefix(self.context.base_key());
             for (index, update) in mem::take(&mut self.updates) {
                 if let Update::Set(value) = update {
@@ -110,7 +109,11 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        if self.stored_hash != hash {
+        // In tne admittedly rare scenarion that we do a clear
+        // and stored_hash = hash, we need to update the
+        // hash, otherwise, we will recompute it while this
+        // can be avoided.
+        if self.stored_hash != hash || self.was_cleared {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),
@@ -118,6 +121,7 @@ where
             }
             self.stored_hash = hash;
         }
+        self.was_cleared = false;
         Ok(())
     }
 

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -109,7 +109,7 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In tne admittedly rare scenarion that we do a clear
+        // In the scenario where we do a clear
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -106,9 +106,12 @@ where
             batch.put_key_value(key, &self.stored_indices)?;
         }
         self.front_delete_count = 0;
-        self.was_cleared = false;
         let hash = *self.hash.get_mut();
-        if self.stored_hash != hash {
+        // In tne admittedly rare scenarion that we do a clear
+        // and stored_hash = hash, we need to update the
+        // hash, otherwise, we will recompute it while this
+        // can be avoided.
+        if self.stored_hash != hash || self.was_cleared {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),
@@ -116,6 +119,7 @@ where
             }
             self.stored_hash = hash;
         }
+        self.was_cleared = false;
         Ok(())
     }
 

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -107,7 +107,7 @@ where
         }
         self.front_delete_count = 0;
         let hash = *self.hash.get_mut();
-        // In tne admittedly rare scenarion that we do a clear
+        // In the scenario where we do a clear
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -109,7 +109,7 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In tne admittedly rare scenarion that we do a clear
+        // In the scenario where we do a clear
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -77,7 +77,7 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In tne admittedly rare scenarion that we do a clear
+        // In the scenario where we do a clear
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -3,7 +3,7 @@
 
 use crate::{batch::Batch, common::HasherOutput};
 use async_trait::async_trait;
-use linera_base::crypto::CryptoHash;
+use linera_base::{crypto::CryptoHash, data_types::ArithmeticError};
 pub use linera_views_derive::{
     CryptoHashRootView, CryptoHashView, GraphQLView, HashableView, RootView, View,
 };
@@ -60,6 +60,10 @@ pub enum ViewError {
     /// Input output error.
     #[error("IO error")]
     Io(#[from] std::io::Error),
+
+    /// Arithmetic error
+    #[error("Arithmetic error")]
+    ArithmeticError(#[from] ArithmeticError),
 
     /// An error happened while trying to lock.
     #[error("Failed to lock collection entry: {0:?}")]


### PR DESCRIPTION
## Motivation

The merging of the PR #1287 was actually done a little bit prematurely, so this PR actually
do after merge corrections.

## Proposal

The following is done:
* Add documentation for the subtle `|| self.was_cleared` for the `total_size`.
* Do the same trick for the hash.
* Replace the `ByteMapView<SizeData>` by `ByteMapView<u32>` which takes less space.
* Add the check of overflow for the `add_assign`.

## Test Plan

The CI does it.

## Release Plan

That should not change anything.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
