### PR TITLE
`linera-views`: Add local guard newtypes

### DIFF
--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -8,7 +8,7 @@ use crate::{
     ExecutionRuntimeContext, ServiceRuntime, SessionId, UserApplicationDescription,
     UserApplicationId, UserContractCode, UserServiceCode,
 };
-use async_lock::{Mutex, MutexGuard, MutexGuardArc, RwLockWriteGuardArc};
+use async_lock::{Mutex, MutexGuard, MutexGuardArc};
 use async_trait::async_trait;
 use custom_debug_derive::Debug;
 use linera_base::{
@@ -20,6 +20,7 @@ use linera_views::{
     batch::Batch,
     common::Context,
     key_value_store_view::KeyValueStoreView,
+    reentrant_collection_view,
     register_view::RegisterView,
     views::{View, ViewError},
 };
@@ -78,9 +79,11 @@ pub(crate) struct ApplicationStatus {
 }
 
 type ActiveViewUserStates<C> =
-    BTreeMap<UserApplicationId, RwLockWriteGuardArc<KeyValueStoreView<C>>>;
-type ActiveSimpleUserStates<C> =
-    BTreeMap<UserApplicationId, RwLockWriteGuardArc<RegisterView<C, Vec<u8>>>>;
+    BTreeMap<UserApplicationId, reentrant_collection_view::WriteGuardedView<KeyValueStoreView<C>>>;
+type ActiveSimpleUserStates<C> = BTreeMap<
+    UserApplicationId,
+    reentrant_collection_view::WriteGuardedView<RegisterView<C, Vec<u8>>>,
+>;
 type ActiveSessions = BTreeMap<SessionId, MutexGuardArc<SessionState>>;
 
 #[derive(Debug, Clone, Default)]

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -406,7 +406,7 @@ fn generate_graphql_code_for_field(
 
             let (guard, lifetime) = match view_name.as_str() {
                 "ReentrantCollectionView" | "ReentrantCustomCollectionView" => (
-                    quote!(linera_views::async_lock::RwLockReadGuardArc),
+                    quote!(linera_views::reentrant_collection_view::ReadGuardedView),
                     quote!(),
                 ),
                 "CollectionView" | "CustomCollectionView" => (


### PR DESCRIPTION
Adds a local `ReadGuardedView` and `WriteGuardedView` for `ReentrantCollectionView` to parallel that of `CollectionView`.

This is currently just an `async_lock::RwLock{Read,Write}GuardArc` inside, but rather than expose that foreign type, this change lets us expose only our own types — and, importantly, implement traits on them.

## Motivation

https://github.com/linera-io/linera-protocol/pull/1280 requires implementing `async_graphql::OutputType` for our lock types.  Unfortunately, since the locks are remote types, we can't implement traits on them.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

In non-reëntrant collections, types `ReadGuardedView` and `WriteGuardedView` already exist.  This PR extends that to the reëntrant case by adding parallel `Read`- and `WriteGuardedView` types for `CollectionView`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI is sufficient.

<!-- How to test that the changes are correct. -->

## Release Plan

This PR changes the API of `linera-views`, which is an external-facing library.  As such it requires a version bump.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
