### PR TITLE
`linera-sdk`: surface GraphQL errors in failure output

### DIFF
--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -499,8 +499,16 @@ impl ActiveChain {
     where
         Abi: ServiceAbi<Query = async_graphql::Request, QueryResponse = async_graphql::Response>,
     {
-        self.query(application_id, query.into())
-            .await
+        let query = query.into();
+        let query_str = query.query.clone();
+        let response = self.query(application_id, query).await;
+        if !response.errors.is_empty() {
+            panic!(
+                "GraphQL query:\n{}\nyielded errors:\n{:#?}",
+                query_str, response.errors
+            );
+        }
+        response
             .data
             .into_json()
             .expect("Unexpected non-JSON query response")


### PR DESCRIPTION
## Motivation

GraphQL errors in tests are currently not surfaced, and as a result `Null` is returned when something goes wrong with no indication as to what happened.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Panic if the response from the GraphQL query includes errors, making sure to include the errors and the offending query in the output.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

This affects only tests, so no version bump is required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
