### PR TITLE
`linera-views`: Generalize API in `map_view`

### DIFF
--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -1275,7 +1275,7 @@ where
     pub async fn get<Q>(&self, index: &Q) -> Result<Option<V>, ViewError>
     where
         I: Borrow<Q>,
-        Q: Serialize + ?Sized + CustomSerialize,
+        Q: ?Sized + CustomSerialize,
     {
         let short_key = index.to_custom_bytes()?;
         self.map.get(&short_key).await
@@ -1298,7 +1298,7 @@ where
     pub async fn get_mut<Q>(&mut self, index: &Q) -> Result<Option<&mut V>, ViewError>
     where
         I: Borrow<Q>,
-        Q: Serialize + ?Sized + CustomSerialize,
+        Q: ?Sized + CustomSerialize,
     {
         let short_key = index.to_custom_bytes()?;
         self.map.get_mut(short_key).await


### PR DESCRIPTION
`CustomMapView` doesn't need a `Serialize` constraint on its keys, as it uses `CustomSerialize` anyway.

`BytesMapView` doesn't need to own the key in its parameters, and requiring it introduces additional copies.

## Motivation

https://github.com/linera-io/linera-protocol/pull/1280 needs the API for `MapView` to be slightly more general than it is.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Remove some unused constraints on code in `linera_views::map_view`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

This is a fully backwards-compatible change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
