### PR TITLE
Address two bugs with the handling of prefixes

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -254,7 +254,7 @@ fn insert_key_prefix_test1() {
     set.insert(vec![0, 4]);
 
     insert_key_prefix(&mut set, vec![0, 4, 5]);
-    let keys = set.iter().map(|x| x.clone()).collect::<Vec<_>>();
+    let keys = set.iter().cloned().collect::<Vec<_>>();
     assert_eq!(keys, vec![vec![0, 4]]);
 }
 

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_interval, get_upper_bound, Context, GreatestLowerBoundIterator, HasherOutput,
+        get_interval, get_upper_bound, insert_key_prefix, Context, GreatestLowerBoundIterator, HasherOutput,
         KeyIterable, KeyValueIterable, Update, MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
@@ -682,15 +682,7 @@ where
                     }
                     self.sizes.remove_by_prefix(key_prefix.clone());
                     if !self.was_cleared {
-                        let key_prefix_list = self
-                            .deleted_prefixes
-                            .range(get_interval(key_prefix.clone()))
-                            .map(|x| x.to_vec())
-                            .collect::<Vec<_>>();
-                        for key in key_prefix_list {
-                            self.deleted_prefixes.remove(&key);
-                        }
-                        self.deleted_prefixes.insert(key_prefix);
+                        insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
                     }
                 }
             }

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -4,8 +4,9 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_interval, get_upper_bound, insert_key_prefix, Context, GreatestLowerBoundIterator, HasherOutput,
-        KeyIterable, KeyValueIterable, Update, MIN_VIEW_TAG,
+        get_interval, get_upper_bound, insert_key_prefix, is_index_absent, Context,
+        GreatestLowerBoundIterator, HasherOutput, KeyIterable, KeyValueIterable, Update,
+        MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
     views::{HashableView, Hasher, View, ViewError},
@@ -547,9 +548,7 @@ where
         if self.was_cleared {
             return Ok(None);
         }
-        let iter = self.deleted_prefixes.iter();
-        let mut lower_bound = GreatestLowerBoundIterator::new(0, iter);
-        if !lower_bound.is_index_absent(index) {
+        if !is_index_absent(&self.deleted_prefixes, index) {
             return Ok(None);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
@@ -587,9 +586,7 @@ where
                 result.push(value);
             } else {
                 result.push(None);
-                let iter = self.deleted_prefixes.iter();
-                let mut lower_bound = GreatestLowerBoundIterator::new(0, iter);
-                if lower_bound.is_index_absent(&index) {
+                if is_index_absent(&self.deleted_prefixes, &index) {
                     missed_indices.push(i);
                     let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
                     vector_query.push(key);

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -19,7 +19,7 @@
 use crate::{
     batch::Batch,
     common::{
-        get_interval, Context, CustomSerialize, GreatestLowerBoundIterator, HasherOutput,
+        get_interval, insert_key_prefix, Context, CustomSerialize, GreatestLowerBoundIterator, HasherOutput,
         KeyIterable, KeyValueIterable, Update, MIN_VIEW_TAG,
     },
     views::{HashableView, Hasher, View, ViewError},
@@ -201,15 +201,7 @@ where
             self.updates.remove(&key);
         }
         if !self.was_cleared {
-            let key_prefix_list = self
-                .deleted_prefixes
-                .range(get_interval(key_prefix.clone()))
-                .map(|x| x.to_vec())
-                .collect::<Vec<_>>();
-            for key in key_prefix_list {
-                self.deleted_prefixes.remove(&key);
-            }
-            self.deleted_prefixes.insert(key_prefix);
+            insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
         }
     }
 

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -19,8 +19,9 @@
 use crate::{
     batch::Batch,
     common::{
-        get_interval, insert_key_prefix, Context, CustomSerialize, GreatestLowerBoundIterator, HasherOutput,
-        KeyIterable, KeyValueIterable, Update, MIN_VIEW_TAG,
+        get_interval, insert_key_prefix, is_index_absent, Context, CustomSerialize,
+        GreatestLowerBoundIterator, HasherOutput, KeyIterable, KeyValueIterable, Update,
+        MIN_VIEW_TAG,
     },
     views::{HashableView, Hasher, View, ViewError},
 };
@@ -240,9 +241,7 @@ where
         if self.was_cleared {
             return Ok(None);
         }
-        let iter = self.deleted_prefixes.iter();
-        let mut lower_bound = GreatestLowerBoundIterator::new(0, iter);
-        if !lower_bound.is_index_absent(short_key) {
+        if !is_index_absent(&self.deleted_prefixes, short_key) {
             return Ok(None);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, short_key);

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -326,7 +326,7 @@ where
         let mut lower_bound = GreatestLowerBoundIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
-        if !self.was_cleared {
+        if !self.was_cleared && is_index_absent(&self.deleted_prefixes, &prefix) {
             let base = self.context.base_tag_index(KeyTag::Index as u8, &prefix);
             for index in self.context.find_keys_by_prefix(&base).await?.iterator() {
                 let index = index?;
@@ -521,7 +521,7 @@ where
         let mut lower_bound = GreatestLowerBoundIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
-        if !self.was_cleared {
+        if !self.was_cleared && is_index_absent(&self.deleted_prefixes, &prefix) {
             let base = self.context.base_tag_index(KeyTag::Index as u8, &prefix);
             for entry in self
                 .context


### PR DESCRIPTION
## Motivation

While implementing the `delete=clear+save` we saw a number of problems. Here are the ones for prefixes

## Proposal

Two bugs were addressed:
* One when we insert a prefix bug it is already matched by existing prefixes.
* One in `MapView` where a prefix has been deleted and the `for_each_key_*` is used for the same prefix. Then we need to remove the prefix from consideration.

## Test Plan

The CI and a better check.

## Release Plan

None.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
