### PR TITLE
Support custom user data in host functions exported with Witty

### DIFF
--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -212,7 +212,7 @@ impl<'input> FunctionInformation<'input> {
     /// Generates the code to export a host function using a mock Wasm instance for testing.
     #[cfg(feature = "mock-instance")]
     pub fn generate_for_mock_instance(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
-        let caller = quote! { linera_witty::MockInstance };
+        let caller = quote! { linera_witty::MockInstance<()> };
         let input_to_guest_parameters = quote! { input };
         let guest_results_to_output = quote! { guest_results };
         let output_results_trait = quote! { linera_witty::MockResults };

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -167,7 +167,7 @@ impl<'input> FunctionInformation<'input> {
     #[cfg(feature = "wasmer")]
     pub fn generate_for_wasmer(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
         let caller = quote! {
-            linera_witty::wasmer::FunctionEnvMut<'_, linera_witty::wasmer::InstanceSlot>
+            linera_witty::wasmer::FunctionEnvMut<'_, linera_witty::wasmer::InstanceSlot<()>>
         };
         let input_to_guest_parameters = quote! {
             linera_witty::wasmer::WasmerParameters::from_wasmer(input)

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -165,10 +165,12 @@ impl<'input> FunctionInformation<'input> {
 
     /// Generates the code to export a host function using the Wasmer runtime.
     #[cfg(feature = "wasmer")]
-    pub fn generate_for_wasmer(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
-        let caller = quote! {
-            linera_witty::wasmer::FunctionEnvMut<'_, linera_witty::wasmer::InstanceSlot<()>>
-        };
+    pub fn generate_for_wasmer(
+        &self,
+        namespace: &LitStr,
+        type_name: &Ident,
+        caller: &TokenStream,
+    ) -> TokenStream {
         let input_to_guest_parameters = quote! {
             linera_witty::wasmer::WasmerParameters::from_wasmer(input)
         };
@@ -189,8 +191,12 @@ impl<'input> FunctionInformation<'input> {
 
     /// Generates the code to export a host function using the Wasmtime runtime.
     #[cfg(feature = "wasmtime")]
-    pub fn generate_for_wasmtime(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
-        let caller = quote! { linera_witty::wasmtime::Caller<'_, ()> };
+    pub fn generate_for_wasmtime(
+        &self,
+        namespace: &LitStr,
+        type_name: &Ident,
+        caller: &TokenStream,
+    ) -> TokenStream {
         let input_to_guest_parameters = quote! {
             linera_witty::wasmtime::WasmtimeParameters::from_wasmtime(input)
         };
@@ -211,8 +217,12 @@ impl<'input> FunctionInformation<'input> {
 
     /// Generates the code to export a host function using a mock Wasm instance for testing.
     #[cfg(feature = "mock-instance")]
-    pub fn generate_for_mock_instance(&self, namespace: &LitStr, type_name: &Ident) -> TokenStream {
-        let caller = quote! { linera_witty::MockInstance<()> };
+    pub fn generate_for_mock_instance(
+        &self,
+        namespace: &LitStr,
+        type_name: &Ident,
+        caller: &TokenStream,
+    ) -> TokenStream {
         let input_to_guest_parameters = quote! { input };
         let guest_results_to_output = quote! { guest_results };
         let output_results_trait = quote! { linera_witty::MockResults };
@@ -232,7 +242,7 @@ impl<'input> FunctionInformation<'input> {
         &self,
         namespace: &LitStr,
         type_name: &Ident,
-        caller: TokenStream,
+        caller: &TokenStream,
         input_to_guest_parameters: TokenStream,
         guest_results_to_output: TokenStream,
         output_results_trait: TokenStream,

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -91,7 +91,7 @@ impl<'input> WitExportGenerator<'input> {
         {
             let export_target = quote! { linera_witty::wasmer::InstanceBuilder };
             let target_caller_type = quote! {
-                linera_witty::wasmer::FunctionEnvMut<'_, linera_witty::wasmer::InstanceSlot>
+                linera_witty::wasmer::FunctionEnvMut<'_, linera_witty::wasmer::InstanceSlot<()>>
             };
             let exported_functions = self
                 .functions

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -209,6 +209,16 @@ enum CallerTypeParameter<'input> {
 impl<'input> CallerTypeParameter<'input> {
     /// Parses a type's [`Generics`] to determine if a caller type parameter should be used.
     pub fn new(generics: &'input Generics) -> Self {
+        let caller_type_parameter = Self::extract_caller_type_parameter(generics);
+
+        match caller_type_parameter {
+            None => CallerTypeParameter::NotPresent,
+            Some(caller) => CallerTypeParameter::WithoutUserData(caller),
+        }
+    }
+
+    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
+    fn extract_caller_type_parameter(generics: &'input Generics) -> Option<&'input Ident> {
         if generics.type_params().count() > 1 {
             abort!(
                 generics.params,
@@ -217,10 +227,10 @@ impl<'input> CallerTypeParameter<'input> {
             );
         }
 
-        match generics.type_params().next() {
-            None => CallerTypeParameter::NotPresent,
-            Some(parameter) => CallerTypeParameter::WithoutUserData(&parameter.ident),
-        }
+        generics
+            .type_params()
+            .next()
+            .map(|parameter| &parameter.ident)
     }
 
     /// Returns the [`Ident`]ifier of the generic type parameter used for the caller.

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -12,8 +12,10 @@ use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
 use syn::{
-    punctuated::Punctuated, token::Paren, Generics, Ident, ItemImpl, LitStr, Type, TypePath,
-    TypeTuple,
+    punctuated::Punctuated, token::Paren, AngleBracketedGenericArguments, AssocType,
+    GenericArgument, Generics, Ident, ItemImpl, LitStr, PathArguments, PathSegment, PredicateType,
+    Token, TraitBound, TraitBoundModifier, Type, TypeParamBound, TypePath, TypeTuple, WhereClause,
+    WherePredicate,
 };
 
 /// Returns the code generated for exporting host functions to guest Wasm instances.
@@ -206,16 +208,26 @@ pub fn type_name(implementation: &ItemImpl) -> &Ident {
 enum CallerTypeParameter<'input> {
     NotPresent,
     WithoutUserData(&'input Ident),
+    WithUserData {
+        caller: &'input Ident,
+        user_data: &'input Type,
+    },
 }
 
 impl<'input> CallerTypeParameter<'input> {
     /// Parses a type's [`Generics`] to determine if a caller type parameter should be used.
     pub fn new(generics: &'input Generics) -> Self {
         let caller_type_parameter = Self::extract_caller_type_parameter(generics);
+        let user_data_type =
+            caller_type_parameter.and_then(|caller| Self::extract_user_data_type(generics, caller));
 
-        match caller_type_parameter {
-            None => CallerTypeParameter::NotPresent,
-            Some(caller) => CallerTypeParameter::WithoutUserData(caller),
+        match (caller_type_parameter, user_data_type) {
+            (None, None) => CallerTypeParameter::NotPresent,
+            (Some(caller), None) => CallerTypeParameter::WithoutUserData(caller),
+            (Some(caller), Some(user_data)) => {
+                CallerTypeParameter::WithUserData { caller, user_data }
+            }
+            (None, Some(_)) => unreachable!("Missing caller type parameter"),
         }
     }
 
@@ -235,11 +247,124 @@ impl<'input> CallerTypeParameter<'input> {
             .map(|parameter| &parameter.ident)
     }
 
+    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
+    fn extract_user_data_type(
+        generics: &'input Generics,
+        caller_parameter: &Ident,
+    ) -> Option<&'input Type> {
+        Self::extract_caller_bounds(generics.where_clause.as_ref()?, caller_parameter)?
+            .filter_map(Self::extract_caller_bound_path)
+            .filter_map(Self::extract_caller_bound_arguments)
+            .filter_map(Self::extract_caller_user_data_type_argument)
+            .next()
+    }
+
+    /// Extracts the type bounds inside a `where` clause specific to the generic
+    /// `caller_parameter`.
+    fn extract_caller_bounds(
+        where_clause: &'input WhereClause,
+        caller_parameter: &Ident,
+    ) -> Option<impl Iterator<Item = &'input TypeParamBound> + 'input> {
+        where_clause
+            .predicates
+            .iter()
+            .filter_map(|predicate| match predicate {
+                WherePredicate::Type(PredicateType {
+                    bounded_ty: Type::Path(TypePath { qself: None, path }),
+                    bounds,
+                    ..
+                }) if path.is_ident(caller_parameter) => Some(bounds.iter()),
+                _ => None,
+            })
+            .next()
+    }
+
+    /// Extracts the path from a trait `bound`.
+    fn extract_caller_bound_path(
+        bound: &'input TypeParamBound,
+    ) -> Option<impl Iterator<Item = &'input PathSegment> + 'input> {
+        match bound {
+            TypeParamBound::Trait(TraitBound {
+                paren_token: None,
+                modifier: TraitBoundModifier::None,
+                lifetimes: None,
+                path,
+            }) => Some(path.segments.iter()),
+            _ => None,
+        }
+    }
+
+    /// Extracts the generic arguments inside the caller parameter path's `segments`.
+    fn extract_caller_bound_arguments(
+        segments: impl Iterator<Item = &'input PathSegment>,
+    ) -> Option<&'input Punctuated<GenericArgument, Token![,]>> {
+        let mut segments = segments.peekable();
+
+        if matches!(
+            segments.peek(),
+            Some(PathSegment { ident, arguments: PathArguments::None })
+                if ident == "linera_witty",
+        ) {
+            segments.next();
+        }
+
+        match segments.next()? {
+            PathSegment {
+                ident,
+                arguments:
+                    PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                        colon2_token: None,
+                        args,
+                        ..
+                    }),
+            } if ident == "Instance" => {
+                if segments.next().is_some() {
+                    return None;
+                }
+
+                Some(args)
+            }
+            _ => None,
+        }
+    }
+
+    /// Extracts the custom user data [`Type`] from the caller bound's generic `arguments`.
+    fn extract_caller_user_data_type_argument(
+        arguments: &'input Punctuated<GenericArgument, Token![,]>,
+    ) -> Option<&'input Type> {
+        if arguments.len() != 1 {
+            abort!(
+                arguments,
+                "Caller type parameter should have a user data type. \
+                E.g. `Caller: linera_witty::Instance<UserData = CustomData>`"
+            );
+        }
+
+        match arguments
+            .iter()
+            .next()
+            .expect("Missing argument in arguments list")
+        {
+            GenericArgument::AssocType(AssocType {
+                ident,
+                generics: None,
+                ty: user_data,
+                ..
+            }) if ident == "UserData" => Some(user_data),
+            _ => abort!(
+                arguments,
+                "Caller type parameter should have a user data type. \
+                E.g. `Caller: linera_witty::Instance<UserData = CustomData>`"
+            ),
+        }
+    }
+
     /// Returns the [`Ident`]ifier of the generic type parameter used for the caller.
     pub fn caller(&self) -> Option<&'input Ident> {
         match self {
             CallerTypeParameter::NotPresent => None,
             CallerTypeParameter::WithoutUserData(caller) => Some(caller),
+            CallerTypeParameter::WithUserData { caller, .. } => Some(caller),
         }
     }
 
@@ -248,6 +373,7 @@ impl<'input> CallerTypeParameter<'input> {
         match self {
             CallerTypeParameter::NotPresent => None,
             CallerTypeParameter::WithoutUserData(_) => None,
+            CallerTypeParameter::WithUserData { user_data, .. } => Some(user_data),
         }
     }
 }

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -89,7 +89,7 @@ impl<'input> WitExportGenerator<'input> {
     fn generate_for_wasmer(&mut self) -> Option<TokenStream> {
         #[cfg(feature = "wasmer")]
         {
-            let export_target = quote! { linera_witty::wasmer::InstanceBuilder };
+            let export_target = quote! { linera_witty::wasmer::InstanceBuilder<()> };
             let target_caller_type = quote! {
                 linera_witty::wasmer::FunctionEnvMut<'_, linera_witty::wasmer::InstanceSlot<()>>
             };

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -129,8 +129,8 @@ impl<'input> WitExportGenerator<'input> {
     fn generate_for_mock_instance(&mut self) -> Option<TokenStream> {
         #[cfg(feature = "mock-instance")]
         {
-            let export_target = quote! { linera_witty::MockInstance };
-            let target_caller_type = quote! { linera_witty::MockInstance };
+            let export_target = quote! { linera_witty::MockInstance<()> };
+            let target_caller_type = quote! { linera_witty::MockInstance<()> };
             let exported_functions = self.functions.iter().map(|function| {
                 function.generate_for_mock_instance(self.namespace, self.type_name)
             });

--- a/linera-witty/src/runtime/borrowed_instance.rs
+++ b/linera-witty/src/runtime/borrowed_instance.rs
@@ -18,9 +18,18 @@ where
     I: Instance,
 {
     type Runtime = I::Runtime;
+    type UserData = I::UserData;
+    type UserDataReference<'a> = I::UserDataReference<'a>
+    where
+        Self::UserData: 'a,
+        Self: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<<Self::Runtime as Runtime>::Export> {
         I::load_export(*self, name)
+    }
+
+    fn user_data(&self) -> Self::UserDataReference<'_> {
+        I::user_data(*self)
     }
 }
 

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -37,14 +37,14 @@ pub type FunctionHandler<UserData> =
 /// A fake Wasm instance.
 ///
 /// Only contains exports for the memory and the canonical ABI allocation functions.
-pub struct MockInstance<UserData = ()> {
+pub struct MockInstance<UserData> {
     memory: Arc<Mutex<Vec<u8>>>,
     exported_functions: HashMap<String, FunctionHandler<UserData>>,
     imported_functions: HashMap<String, FunctionHandler<UserData>>,
     user_data: Arc<Mutex<UserData>>,
 }
 
-impl Default for MockInstance {
+impl Default for MockInstance<()> {
     fn default() -> Self {
         let memory = Arc::new(Mutex::new(Vec::new()));
 

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -175,7 +175,8 @@ impl<UserData> Instance for MockInstance<UserData> {
     }
 }
 
-impl<Parameters, Results> InstanceWithFunction<Parameters, Results> for MockInstance
+impl<Parameters, Results, UserData> InstanceWithFunction<Parameters, Results>
+    for MockInstance<UserData>
 where
     Parameters: FlatLayout + 'static,
     Results: FlatLayout + 'static,

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -49,13 +49,31 @@ where
     UserData: Default,
 {
     fn default() -> Self {
+        MockInstance::new(UserData::default())
+    }
+}
+
+impl<UserData> Clone for MockInstance<UserData> {
+    fn clone(&self) -> Self {
+        MockInstance {
+            memory: self.memory.clone(),
+            exported_functions: self.exported_functions.clone(),
+            imported_functions: self.imported_functions.clone(),
+            user_data: self.user_data.clone(),
+        }
+    }
+}
+
+impl<UserData> MockInstance<UserData> {
+    /// Creates a new [`MockInstance`] using the provided `user_data`.
+    pub fn new(user_data: UserData) -> Self {
         let memory = Arc::new(Mutex::new(Vec::new()));
 
         MockInstance {
             memory: memory.clone(),
             exported_functions: HashMap::new(),
             imported_functions: HashMap::new(),
-            user_data: Arc::new(Mutex::new(UserData::default())),
+            user_data: Arc::new(Mutex::new(user_data)),
         }
         .with_exported_function("cabi_free", |_, _: HList![i32]| Ok(hlist![]))
         .with_exported_function(
@@ -84,20 +102,6 @@ where
             },
         )
     }
-}
-
-impl<UserData> Clone for MockInstance<UserData> {
-    fn clone(&self) -> Self {
-        MockInstance {
-            memory: self.memory.clone(),
-            exported_functions: self.exported_functions.clone(),
-            imported_functions: self.imported_functions.clone(),
-            user_data: self.user_data.clone(),
-        }
-    }
-}
-
-impl<UserData> MockInstance<UserData> {
     /// Adds a mock exported function to this [`MockInstance`].
     ///
     /// The `handler` will be called whenever the exported function is called.

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -44,7 +44,10 @@ pub struct MockInstance<UserData> {
     user_data: Arc<Mutex<UserData>>,
 }
 
-impl Default for MockInstance<()> {
+impl<UserData> Default for MockInstance<UserData>
+where
+    UserData: Default,
+{
     fn default() -> Self {
         let memory = Arc::new(Mutex::new(Vec::new()));
 
@@ -52,7 +55,7 @@ impl Default for MockInstance<()> {
             memory: memory.clone(),
             exported_functions: HashMap::new(),
             imported_functions: HashMap::new(),
-            user_data: Arc::new(Mutex::new(())),
+            user_data: Arc::new(Mutex::new(UserData::default())),
         }
         .with_exported_function("cabi_free", |_, _: HList![i32]| Ok(hlist![]))
         .with_exported_function(

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -31,16 +31,16 @@ impl Runtime for MockRuntime {
 }
 
 /// A closure for handling calls to mocked functions.
-pub type FunctionHandler =
-    Arc<dyn Fn(MockInstance, Box<dyn Any>) -> Result<Box<dyn Any>, RuntimeError>>;
+pub type FunctionHandler<UserData> =
+    Arc<dyn Fn(MockInstance<UserData>, Box<dyn Any>) -> Result<Box<dyn Any>, RuntimeError>>;
 
 /// A fake Wasm instance.
 ///
 /// Only contains exports for the memory and the canonical ABI allocation functions.
 pub struct MockInstance<UserData = ()> {
     memory: Arc<Mutex<Vec<u8>>>,
-    exported_functions: HashMap<String, FunctionHandler>,
-    imported_functions: HashMap<String, FunctionHandler>,
+    exported_functions: HashMap<String, FunctionHandler<UserData>>,
+    imported_functions: HashMap<String, FunctionHandler<UserData>>,
     user_data: Arc<Mutex<UserData>>,
 }
 

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -259,9 +259,10 @@ impl<UserData> InstanceWithMemory for MockInstance<UserData> {
     }
 }
 
-impl<Handler, Parameters, Results> ExportFunction<Handler, Parameters, Results> for MockInstance
+impl<Handler, Parameters, Results, UserData> ExportFunction<Handler, Parameters, Results>
+    for MockInstance<UserData>
 where
-    Handler: Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
+    Handler: Fn(MockInstance<UserData>, Parameters) -> Result<Results, RuntimeError> + 'static,
     Parameters: 'static,
     Results: 'static,
 {

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -94,7 +94,7 @@ impl<UserData> Clone for MockInstance<UserData> {
     }
 }
 
-impl MockInstance {
+impl<UserData> MockInstance<UserData> {
     /// Adds a mock exported function to this [`MockInstance`].
     ///
     /// The `handler` will be called whenever the exported function is called.
@@ -106,7 +106,7 @@ impl MockInstance {
     where
         Parameters: 'static,
         Results: 'static,
-        Handler: Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
+        Handler: Fn(MockInstance<UserData>, Parameters) -> Result<Results, RuntimeError> + 'static,
     {
         self.add_exported_function(name, handler);
         self
@@ -123,7 +123,7 @@ impl MockInstance {
     where
         Parameters: 'static,
         Results: 'static,
-        Handler: Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
+        Handler: Fn(MockInstance<UserData>, Parameters) -> Result<Results, RuntimeError> + 'static,
     {
         self.exported_functions.insert(
             name.into(),

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -38,10 +38,11 @@ pub type FunctionHandler =
 ///
 /// Only contains exports for the memory and the canonical ABI allocation functions.
 #[derive(Clone)]
-pub struct MockInstance {
+pub struct MockInstance<UserData = ()> {
     memory: Arc<Mutex<Vec<u8>>>,
     exported_functions: HashMap<String, FunctionHandler>,
     imported_functions: HashMap<String, FunctionHandler>,
+    user_data: Arc<Mutex<UserData>>,
 }
 
 impl Default for MockInstance {
@@ -52,6 +53,7 @@ impl Default for MockInstance {
             memory: memory.clone(),
             exported_functions: HashMap::new(),
             imported_functions: HashMap::new(),
+            user_data: Arc::new(Mutex::new(())),
         }
         .with_exported_function("cabi_free", |_, _: HList![i32]| Ok(hlist![]))
         .with_exported_function(

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -208,10 +208,10 @@ where
     }
 }
 
-impl RuntimeMemory<MockInstance> for Arc<Mutex<Vec<u8>>> {
+impl<UserData> RuntimeMemory<MockInstance<UserData>> for Arc<Mutex<Vec<u8>>> {
     fn read<'instance>(
         &self,
-        instance: &'instance MockInstance,
+        instance: &'instance MockInstance<UserData>,
         location: GuestPointer,
         length: u32,
     ) -> Result<Cow<'instance, [u8]>, RuntimeError> {
@@ -228,7 +228,7 @@ impl RuntimeMemory<MockInstance> for Arc<Mutex<Vec<u8>>> {
 
     fn write(
         &mut self,
-        instance: &mut MockInstance,
+        instance: &mut MockInstance<UserData>,
         location: GuestPointer,
         bytes: &[u8],
     ) -> Result<(), RuntimeError> {

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -163,7 +163,7 @@ impl MockInstance {
     }
 }
 
-impl Instance for MockInstance {
+impl<UserData> Instance for MockInstance<UserData> {
     type Runtime = MockRuntime;
 
     fn load_export(&mut self, name: &str) -> Option<String> {

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -37,7 +37,6 @@ pub type FunctionHandler =
 /// A fake Wasm instance.
 ///
 /// Only contains exports for the memory and the canonical ABI allocation functions.
-#[derive(Clone)]
 pub struct MockInstance<UserData = ()> {
     memory: Arc<Mutex<Vec<u8>>>,
     exported_functions: HashMap<String, FunctionHandler>,
@@ -81,6 +80,17 @@ impl Default for MockInstance {
                 Ok(hlist![address.0 as i32])
             },
         )
+    }
+}
+
+impl<UserData> Clone for MockInstance<UserData> {
+    fn clone(&self) -> Self {
+        MockInstance {
+            memory: self.memory.clone(),
+            exported_functions: self.exported_functions.clone(),
+            imported_functions: self.imported_functions.clone(),
+            user_data: self.user_data.clone(),
+        }
     }
 }
 

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -246,7 +246,7 @@ impl<UserData> RuntimeMemory<MockInstance<UserData>> for Arc<Mutex<Vec<u8>>> {
     }
 }
 
-impl InstanceWithMemory for MockInstance {
+impl<UserData> InstanceWithMemory for MockInstance<UserData> {
     fn memory_from_export(
         &self,
         export: String,

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -6,6 +6,7 @@
 use super::{memory::Memory, RuntimeError};
 use crate::memory_layout::FlatLayout;
 use frunk::HList;
+use std::ops::Deref;
 
 /// A Wasm runtime.
 ///
@@ -23,8 +24,20 @@ pub trait Instance: Sized {
     /// The runtime this instance is running in.
     type Runtime: Runtime;
 
+    /// Custom user data stored in the instance.
+    type UserData;
+
+    /// A reference to the custom user data stored in the instance.
+    type UserDataReference<'a>: Deref<Target = Self::UserData>
+    where
+        Self::UserData: 'a,
+        Self: 'a;
+
     /// Loads an export from the guest module.
     fn load_export(&mut self, name: &str) -> Option<<Self::Runtime as Runtime>::Export>;
+
+    /// Returns a reference to the custom user data stored in this instance.
+    fn user_data(&self) -> Self::UserDataReference<'_>;
 }
 
 /// How a runtime supports a function signature.

--- a/linera-witty/src/runtime/wasmer/export_function.rs
+++ b/linera-witty/src/runtime/wasmer/export_function.rs
@@ -21,7 +21,7 @@ macro_rules! export_function {
             HandlerError: Error + Send + Sync + 'static,
             Handler:
                 Fn(
-                    FunctionEnvMut<'_, InstanceSlot>,
+                    FunctionEnvMut<'_, InstanceSlot<()>>,
                     ($( $types, )*),
                 ) -> Result<FlatResult, HandlerError>
                 + Send
@@ -40,7 +40,7 @@ macro_rules! export_function {
                     self,
                     &environment,
                     move |
-                        environment: FunctionEnvMut<'_, InstanceSlot>,
+                        environment: FunctionEnvMut<'_, InstanceSlot<()>>,
                         $( $names: $types ),*
                     | -> Result<FlatResult, wasmer::RuntimeError> {
                         handler(environment, ($( $names, )*))

--- a/linera-witty/src/runtime/wasmer/export_function.rs
+++ b/linera-witty/src/runtime/wasmer/export_function.rs
@@ -14,7 +14,7 @@ use wasmer::{FromToNativeWasmType, Function, FunctionEnvMut, WasmTypeList};
 macro_rules! export_function {
     ($( $names:ident: $types:ident ),*) => {
         impl<Handler, HandlerError, $( $types, )* FlatResult>
-            ExportFunction<Handler, ($( $types, )*), FlatResult> for InstanceBuilder
+            ExportFunction<Handler, ($( $types, )*), FlatResult> for InstanceBuilder<()>
         where
             $( $types: FromToNativeWasmType, )*
             FlatResult: MaybeFlatType + WasmTypeList,

--- a/linera-witty/src/runtime/wasmer/function.rs
+++ b/linera-witty/src/runtime/wasmer/function.rs
@@ -17,7 +17,7 @@ use wasmer::{AsStoreRef, Extern, FromToNativeWasmType, TypedFunction};
 /// the [`EntrypointInstance`] and [`ReentrantInstance`] types.
 macro_rules! impl_instance_with_function {
     ($( $names:ident : $types:ident ),*) => {
-        impl_instance_with_function_for!(EntrypointInstance, $( $names: $types ),*);
+        impl_instance_with_function_for!(EntrypointInstance<()>, $( $names: $types ),*);
         impl_instance_with_function_for!(ReentrantInstance<'_, ()>, $( $names: $types ),*);
     };
 }

--- a/linera-witty/src/runtime/wasmer/function.rs
+++ b/linera-witty/src/runtime/wasmer/function.rs
@@ -18,7 +18,7 @@ use wasmer::{AsStoreRef, Extern, FromToNativeWasmType, TypedFunction};
 macro_rules! impl_instance_with_function {
     ($( $names:ident : $types:ident ),*) => {
         impl_instance_with_function_for!(EntrypointInstance, $( $names: $types ),*);
-        impl_instance_with_function_for!(ReentrantInstance<'_>, $( $names: $types ),*);
+        impl_instance_with_function_for!(ReentrantInstance<'_, ()>, $( $names: $types ),*);
     };
 }
 

--- a/linera-witty/src/runtime/wasmer/function.rs
+++ b/linera-witty/src/runtime/wasmer/function.rs
@@ -17,8 +17,8 @@ use wasmer::{AsStoreRef, Extern, FromToNativeWasmType, TypedFunction};
 /// the [`EntrypointInstance`] and [`ReentrantInstance`] types.
 macro_rules! impl_instance_with_function {
     ($( $names:ident : $types:ident ),*) => {
-        impl_instance_with_function_for!(EntrypointInstance<()>, $( $names: $types ),*);
-        impl_instance_with_function_for!(ReentrantInstance<'_, ()>, $( $names: $types ),*);
+        impl_instance_with_function_for!(EntrypointInstance<UserData>, $( $names: $types ),*);
+        impl_instance_with_function_for!(ReentrantInstance<'_, UserData>, $( $names: $types ),*);
     };
 }
 
@@ -26,11 +26,12 @@ macro_rules! impl_instance_with_function {
 /// the provided `instance` type.
 macro_rules! impl_instance_with_function_for {
     ($instance:ty, $( $names:ident : $types:ident ),*) => {
-        impl<$( $types, )* Results> InstanceWithFunction<HList![$( $types ),*], Results>
+        impl<$( $types, )* Results, UserData> InstanceWithFunction<HList![$( $types ),*], Results>
             for $instance
         where
             $( $types: FlatType + FromToNativeWasmType, )*
             Results: FlatLayout + WasmerResults,
+            UserData: Send + 'static,
         {
             type Function = TypedFunction<
                 <HList![$( $types ),*] as WasmerParameters>::ImportParameters,

--- a/linera-witty/src/runtime/wasmer/memory.rs
+++ b/linera-witty/src/runtime/wasmer/memory.rs
@@ -51,4 +51,4 @@ macro_rules! impl_memory_traits {
 }
 
 impl_memory_traits!(EntrypointInstance);
-impl_memory_traits!(ReentrantInstance<'_>);
+impl_memory_traits!(ReentrantInstance<'_, ()>);

--- a/linera-witty/src/runtime/wasmer/memory.rs
+++ b/linera-witty/src/runtime/wasmer/memory.rs
@@ -50,5 +50,5 @@ macro_rules! impl_memory_traits {
     };
 }
 
-impl_memory_traits!(EntrypointInstance);
+impl_memory_traits!(EntrypointInstance<()>);
 impl_memory_traits!(ReentrantInstance<'_, ()>);

--- a/linera-witty/src/runtime/wasmer/memory.rs
+++ b/linera-witty/src/runtime/wasmer/memory.rs
@@ -10,7 +10,10 @@ use wasmer::{Extern, Memory};
 
 macro_rules! impl_memory_traits {
     ($instance:ty) => {
-        impl InstanceWithMemory for $instance {
+        impl<UserData> InstanceWithMemory for $instance
+        where
+            UserData: Send + 'static,
+        {
             fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
                 Ok(match export {
                     Extern::Memory(memory) => Some(memory),
@@ -19,7 +22,10 @@ macro_rules! impl_memory_traits {
             }
         }
 
-        impl RuntimeMemory<$instance> for Memory {
+        impl<UserData> RuntimeMemory<$instance> for Memory
+        where
+            UserData: Send + 'static,
+        {
             fn read<'instance>(
                 &self,
                 instance: &'instance $instance,
@@ -50,5 +56,5 @@ macro_rules! impl_memory_traits {
     };
 }
 
-impl_memory_traits!(EntrypointInstance<()>);
-impl_memory_traits!(ReentrantInstance<'_, ()>);
+impl_memory_traits!(EntrypointInstance<UserData>);
+impl_memory_traits!(ReentrantInstance<'_, UserData>);

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -66,7 +66,7 @@ impl InstanceBuilder {
     pub fn instantiate(
         mut self,
         module: &Module,
-    ) -> Result<EntrypointInstance, InstantiationError> {
+    ) -> Result<EntrypointInstance<()>, InstantiationError> {
         let instance = wasmer::Instance::new(&mut self.store, module, &self.imports)?;
 
         *self
@@ -99,18 +99,18 @@ impl AsStoreMut for InstanceBuilder {
 }
 
 /// Necessary data for implementing an entrypoint [`Instance`].
-pub struct EntrypointInstance {
+pub struct EntrypointInstance<UserData> {
     store: Store,
-    instance: InstanceSlot<()>,
+    instance: InstanceSlot<UserData>,
 }
 
-impl AsStoreRef for EntrypointInstance {
+impl<UserData> AsStoreRef for EntrypointInstance<UserData> {
     fn as_store_ref(&self) -> StoreRef<'_> {
         self.store.as_store_ref()
     }
 }
 
-impl AsStoreMut for EntrypointInstance {
+impl<UserData> AsStoreMut for EntrypointInstance<UserData> {
     fn as_store_mut(&mut self) -> StoreMut<'_> {
         self.store.as_store_mut()
     }
@@ -120,7 +120,7 @@ impl AsStoreMut for EntrypointInstance {
     }
 }
 
-impl Instance for EntrypointInstance {
+impl<UserData> Instance for EntrypointInstance<UserData> {
     type Runtime = Wasmer;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -141,7 +141,6 @@ impl Instance for ReentrantInstance<'_> {
 }
 
 /// A slot to store a [`wasmer::Instance`] in a way that can be shared with reentrant calls.
-#[derive(Clone)]
 pub struct InstanceSlot<UserData> {
     instance: Arc<Mutex<Option<wasmer::Instance>>>,
     user_data: Arc<Mutex<UserData>>,
@@ -170,5 +169,14 @@ impl<UserData> InstanceSlot<UserData> {
             .exports
             .get_extern(name)
             .cloned()
+    }
+}
+
+impl<UserData> Clone for InstanceSlot<UserData> {
+    fn clone(&self) -> Self {
+        InstanceSlot {
+            instance: self.instance.clone(),
+            user_data: self.user_data.clone(),
+        }
     }
 }

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -130,9 +130,12 @@ impl Instance for EntrypointInstance {
 
 /// Alias for the [`Instance`] implementation made available inside host functions called by the
 /// guest.
-pub type ReentrantInstance<'a> = FunctionEnvMut<'a, InstanceSlot<()>>;
+pub type ReentrantInstance<'a, UserData> = FunctionEnvMut<'a, InstanceSlot<UserData>>;
 
-impl Instance for ReentrantInstance<'_> {
+impl<UserData> Instance for ReentrantInstance<'_, UserData>
+where
+    UserData: Send + 'static,
+{
     type Runtime = Wasmer;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {

--- a/linera-witty/src/runtime/wasmtime/function.rs
+++ b/linera-witty/src/runtime/wasmtime/function.rs
@@ -12,7 +12,7 @@ use wasmtime::{AsContext, AsContextMut, Extern, TypedFunc};
 /// Implements [`InstanceWithFunction`] for the Wasmtime [`Instance`] implementations.
 macro_rules! impl_instance_with_function {
     ($instance:ty) => {
-        impl<Parameters, Results> InstanceWithFunction<Parameters, Results> for $instance
+        impl<Parameters, Results, UserData> InstanceWithFunction<Parameters, Results> for $instance
         where
             Parameters: FlatLayout + WasmtimeParameters,
             Results: FlatLayout + WasmtimeResults,
@@ -45,5 +45,5 @@ macro_rules! impl_instance_with_function {
     };
 }
 
-impl_instance_with_function!(EntrypointInstance);
-impl_instance_with_function!(ReentrantInstance<'_>);
+impl_instance_with_function!(EntrypointInstance<UserData>);
+impl_instance_with_function!(ReentrantInstance<'_, UserData>);

--- a/linera-witty/src/runtime/wasmtime/memory.rs
+++ b/linera-witty/src/runtime/wasmtime/memory.rs
@@ -10,7 +10,7 @@ use wasmtime::{Extern, Memory};
 
 macro_rules! impl_memory_traits {
     ($instance:ty) => {
-        impl InstanceWithMemory for $instance {
+        impl<UserData> InstanceWithMemory for $instance {
             fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
                 Ok(match export {
                     Extern::Memory(memory) => Some(memory),
@@ -19,7 +19,7 @@ macro_rules! impl_memory_traits {
             }
         }
 
-        impl RuntimeMemory<$instance> for Memory {
+        impl<UserData> RuntimeMemory<$instance> for Memory {
             fn read<'instance>(
                 &self,
                 instance: &'instance $instance,
@@ -49,5 +49,5 @@ macro_rules! impl_memory_traits {
     };
 }
 
-impl_memory_traits!(EntrypointInstance);
-impl_memory_traits!(ReentrantInstance<'_>);
+impl_memory_traits!(EntrypointInstance<UserData>);
+impl_memory_traits!(ReentrantInstance<'_, UserData>);

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -63,7 +63,7 @@ impl<UserData> Instance for EntrypointInstance<UserData> {
 /// guest.
 pub type ReentrantInstance<'a, UserData = ()> = Caller<'a, UserData>;
 
-impl Instance for Caller<'_, ()> {
+impl<UserData> Instance for Caller<'_, UserData> {
     type Runtime = Wasmtime;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -24,7 +24,7 @@ impl Runtime for Wasmtime {
 }
 
 /// Necessary data for implementing an entrypoint [`Instance`].
-pub struct EntrypointInstance<UserData = ()> {
+pub struct EntrypointInstance<UserData> {
     instance: wasmtime::Instance,
     store: Store<UserData>,
 }
@@ -61,7 +61,7 @@ impl<UserData> Instance for EntrypointInstance<UserData> {
 
 /// Alias for the [`Instance`] implementation made available inside host functions called by the
 /// guest.
-pub type ReentrantInstance<'a, UserData = ()> = Caller<'a, UserData>;
+pub type ReentrantInstance<'a, UserData> = Caller<'a, UserData>;
 
 impl<UserData> Instance for Caller<'_, UserData> {
     type Runtime = Wasmtime;

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -24,15 +24,15 @@ impl Runtime for Wasmtime {
 }
 
 /// Necessary data for implementing an entrypoint [`Instance`].
-pub struct EntrypointInstance {
+pub struct EntrypointInstance<UserData = ()> {
     instance: wasmtime::Instance,
-    store: Store<()>,
+    store: Store<UserData>,
 }
 
-impl EntrypointInstance {
+impl<UserData> EntrypointInstance<UserData> {
     /// Creates a new [`EntrypointInstance`] with the guest module
     /// [`Instance`][`wasmtime::Instance`] and [`Store`].
-    pub fn new(instance: wasmtime::Instance, store: Store<()>) -> Self {
+    pub fn new(instance: wasmtime::Instance, store: Store<UserData>) -> Self {
         EntrypointInstance { instance, store }
     }
 }

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -61,7 +61,7 @@ impl<UserData> Instance for EntrypointInstance<UserData> {
 
 /// Alias for the [`Instance`] implementation made available inside host functions called by the
 /// guest.
-pub type ReentrantInstance<'a> = Caller<'a, ()>;
+pub type ReentrantInstance<'a, UserData = ()> = Caller<'a, UserData>;
 
 impl Instance for Caller<'_, ()> {
     type Runtime = Wasmtime;

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -37,16 +37,16 @@ impl<UserData> EntrypointInstance<UserData> {
     }
 }
 
-impl AsContext for EntrypointInstance {
-    type Data = ();
+impl<UserData> AsContext for EntrypointInstance<UserData> {
+    type Data = UserData;
 
-    fn as_context(&self) -> StoreContext<()> {
+    fn as_context(&self) -> StoreContext<UserData> {
         self.store.as_context()
     }
 }
 
-impl AsContextMut for EntrypointInstance {
-    fn as_context_mut(&mut self) -> StoreContextMut<()> {
+impl<UserData> AsContextMut for EntrypointInstance<UserData> {
+    fn as_context_mut(&mut self) -> StoreContextMut<UserData> {
         self.store.as_context_mut()
     }
 }

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -53,9 +53,18 @@ impl<UserData> AsContextMut for EntrypointInstance<UserData> {
 
 impl<UserData> Instance for EntrypointInstance<UserData> {
     type Runtime = Wasmtime;
+    type UserData = UserData;
+    type UserDataReference<'a> = &'a UserData
+    where
+        Self: 'a,
+        UserData: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         self.instance.get_export(&mut self.store, name)
+    }
+
+    fn user_data(&self) -> Self::UserDataReference<'_> {
+        self.store.data()
     }
 }
 
@@ -65,8 +74,17 @@ pub type ReentrantInstance<'a, UserData> = Caller<'a, UserData>;
 
 impl<UserData> Instance for Caller<'_, UserData> {
     type Runtime = Wasmtime;
+    type UserData = UserData;
+    type UserDataReference<'a> = &'a UserData
+    where
+        Self: 'a,
+        UserData: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         Caller::get_export(self, name)
+    }
+
+    fn user_data(&self) -> Self::UserDataReference<'_> {
+        Caller::data(self)
     }
 }

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -51,7 +51,7 @@ impl<UserData> AsContextMut for EntrypointInstance<UserData> {
     }
 }
 
-impl Instance for EntrypointInstance {
+impl<UserData> Instance for EntrypointInstance<UserData> {
     type Runtime = Wasmtime;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {

--- a/linera-witty/src/type_traits/implementations/tests.rs
+++ b/linera-witty/src/type_traits/implementations/tests.rs
@@ -129,7 +129,7 @@ fn test_memory_roundtrip<T>(input: T, memory_data: &[u8])
 where
     T: Debug + Eq + WitLoad + WitStore,
 {
-    let mut instance = MockInstance::default();
+    let mut instance = MockInstance::<()>::default();
     let mut memory = instance.memory().unwrap();
     let length = memory_data.len() as u32;
 
@@ -150,7 +150,7 @@ where
     T: Debug + Eq + WitLoad + WitStore,
     <T::Layout as Layout>::Flat: Debug + Eq,
 {
-    let mut instance = MockInstance::default();
+    let mut instance = MockInstance::<()>::default();
     let mut memory = instance.memory().unwrap();
 
     let lowered_layout = input.lower(&mut memory).unwrap();

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -51,7 +51,7 @@ pub struct WasmtimeInstanceFactory;
 #[cfg(feature = "wasmtime")]
 impl TestInstanceFactory for WasmtimeInstanceFactory {
     type Builder = ::wasmtime::Linker<()>;
-    type Instance = wasmtime::EntrypointInstance;
+    type Instance = wasmtime::EntrypointInstance<()>;
     type Caller<'caller> = ::wasmtime::Caller<'caller, ()>;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -118,9 +118,9 @@ pub struct MockInstanceFactory {
 }
 
 impl TestInstanceFactory for MockInstanceFactory {
-    type Builder = MockInstance;
-    type Instance = MockInstance;
-    type Caller<'caller> = MockInstance;
+    type Builder = MockInstance<()>;
+    type Instance = MockInstance<()>;
+    type Caller<'caller> = MockInstance<()>;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance
     where
@@ -156,7 +156,7 @@ impl TestInstanceFactory for MockInstanceFactory {
 
 impl MockInstanceFactory {
     /// Mock the exported functions from the "export-simple-function" module.
-    fn export_simple_function(&mut self, instance: &mut MockInstance) {
+    fn export_simple_function(&mut self, instance: &mut MockInstance<()>) {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/simple-function#simple",
@@ -166,7 +166,7 @@ impl MockInstanceFactory {
     }
 
     /// Mock the exported functions from the "export-getters" module.
-    fn export_getters(&mut self, instance: &mut MockInstance) {
+    fn export_getters(&mut self, instance: &mut MockInstance<()>) {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/getters#get-true",
@@ -242,7 +242,7 @@ impl MockInstanceFactory {
     }
 
     /// Mock the exported functions from the "export-setters" module.
-    fn export_setters(&mut self, instance: &mut MockInstance) {
+    fn export_setters(&mut self, instance: &mut MockInstance<()>) {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/setters#set-bool",
@@ -345,7 +345,7 @@ impl MockInstanceFactory {
     }
 
     /// Mock the exported functions from the "operations" module.
-    fn export_operations(&mut self, instance: &mut MockInstance) {
+    fn export_operations(&mut self, instance: &mut MockInstance<()>) {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/operations#and-bool",
@@ -417,7 +417,7 @@ impl MockInstanceFactory {
     }
 
     /// Mock calling the imported function in the "import-simple-function" module.
-    fn import_simple_function(&mut self, instance: &mut MockInstance) {
+    fn import_simple_function(&mut self, instance: &mut MockInstance<()>) {
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/entrypoint#entrypoint",
@@ -433,8 +433,8 @@ impl MockInstanceFactory {
     }
 
     /// Mock calling the imported functions in the "import-getters" module.
-    fn import_getters(&mut self, instance: &mut MockInstance) {
-        fn check_getter<Value>(caller: &MockInstance, name: &str, expected_value: Value)
+    fn import_getters(&mut self, instance: &mut MockInstance<()>) {
+        fn check_getter<Value>(caller: &MockInstance<()>, name: &str, expected_value: Value)
         where
             Value: Debug + PartialEq + WitLoad + 'static,
         {
@@ -473,8 +473,8 @@ impl MockInstanceFactory {
     }
 
     /// Mock calling the imported functions in the "import-setters" module.
-    fn import_setters(&mut self, instance: &mut MockInstance) {
-        fn send_to_setter<Value>(caller: &MockInstance, name: &str, value: Value)
+    fn import_setters(&mut self, instance: &mut MockInstance<()>) {
+        fn send_to_setter<Value>(caller: &MockInstance<()>, name: &str, value: Value)
         where
             Value: WitStore + 'static,
             Value::Layout: Add<HList![]>,
@@ -514,9 +514,9 @@ impl MockInstanceFactory {
     }
 
     /// Mock calling the imported functions in the "import-operations".
-    fn import_operations(&mut self, instance: &mut MockInstance) {
+    fn import_operations(&mut self, instance: &mut MockInstance<()>) {
         fn check_operation<Value>(
-            caller: &MockInstance,
+            caller: &MockInstance<()>,
             name: &str,
             operands: impl WitStore + 'static,
             expected_result: Value,
@@ -573,31 +573,31 @@ impl MockInstanceFactory {
     }
 
     /// Mock the behavior of the "reentrancy-simple-function" module.
-    fn reentrancy_simple_function(&mut self, instance: &mut MockInstance) {
+    fn reentrancy_simple_function(&mut self, instance: &mut MockInstance<()>) {
         self.import_simple_function(instance);
         self.export_simple_function(instance);
     }
 
     /// Mock the behavior of the "reentrancy-getters" module.
-    fn reentrancy_getters(&mut self, instance: &mut MockInstance) {
+    fn reentrancy_getters(&mut self, instance: &mut MockInstance<()>) {
         self.import_getters(instance);
         self.export_getters(instance);
     }
 
     /// Mock the behavior of the "reentrancy-setters" module.
-    fn reentrancy_setters(&mut self, instance: &mut MockInstance) {
+    fn reentrancy_setters(&mut self, instance: &mut MockInstance<()>) {
         self.import_setters(instance);
         self.export_setters(instance);
     }
 
     /// Mock the behavior of the "reentrancy-operations" module.
-    fn reentrancy_operations(&mut self, instance: &mut MockInstance) {
+    fn reentrancy_operations(&mut self, instance: &mut MockInstance<()>) {
         self.import_operations(instance);
         self.export_operations(instance);
     }
 
     /// Mock the behavior of the "reentrancy-global-state" module.
-    fn reentrancy_global_state(&mut self, instance: &mut MockInstance) {
+    fn reentrancy_global_state(&mut self, instance: &mut MockInstance<()>) {
         let global_state_for_entrypoint = Arc::new(AtomicU32::new(0));
         let global_state_for_getter = global_state_for_entrypoint.clone();
 
@@ -637,9 +637,9 @@ impl MockInstanceFactory {
     /// added to the current list of deferred assertions, to be checked when the test finishes.
     fn mock_exported_function<Parameters, Results>(
         &mut self,
-        instance: &mut MockInstance,
+        instance: &mut MockInstance<()>,
         name: &str,
-        handler: impl Fn(MockInstance, Parameters) -> Result<Results, RuntimeError> + 'static,
+        handler: impl Fn(MockInstance<()>, Parameters) -> Result<Results, RuntimeError> + 'static,
         expected_calls: usize,
     ) where
         Parameters: 'static,

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -85,7 +85,7 @@ pub struct WasmerInstanceFactory;
 
 #[cfg(feature = "wasmer")]
 impl TestInstanceFactory for WasmerInstanceFactory {
-    type Builder = wasmer::InstanceBuilder;
+    type Builder = wasmer::InstanceBuilder<()>;
     type Instance = wasmer::EntrypointInstance<()>;
     type Caller<'caller> = ::wasmer::FunctionEnvMut<'caller, wasmer::InstanceSlot<()>>;
 
@@ -100,7 +100,7 @@ impl TestInstanceFactory for WasmerInstanceFactory {
         )
         .expect("Failed to load module");
 
-        let mut builder = wasmer::InstanceBuilder::new(engine);
+        let mut builder = wasmer::InstanceBuilder::new(engine, ());
 
         ExportedFunctions::export_to(&mut builder)
             .expect("Failed to export functions to Wasmer instance builder");

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -86,7 +86,7 @@ pub struct WasmerInstanceFactory;
 #[cfg(feature = "wasmer")]
 impl TestInstanceFactory for WasmerInstanceFactory {
     type Builder = wasmer::InstanceBuilder;
-    type Instance = wasmer::EntrypointInstance;
+    type Instance = wasmer::EntrypointInstance<()>;
     type Caller<'caller> = ::wasmer::FunctionEnvMut<'caller, wasmer::InstanceSlot<()>>;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -87,7 +87,7 @@ pub struct WasmerInstanceFactory;
 impl TestInstanceFactory for WasmerInstanceFactory {
     type Builder = wasmer::InstanceBuilder;
     type Instance = wasmer::EntrypointInstance;
-    type Caller<'caller> = ::wasmer::FunctionEnvMut<'caller, wasmer::InstanceSlot>;
+    type Caller<'caller> = ::wasmer::FunctionEnvMut<'caller, wasmer::InstanceSlot<()>>;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance
     where

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -51,8 +51,8 @@ impl ExportedSimpleFunction {
 /// The host function is called from the guest, and calls the guest back through a function with
 /// the same name.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -149,8 +149,8 @@ where
 /// The host functions are called from the guest, and they return values obtained by calling back
 /// the guest through functions with the same names.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -241,8 +241,8 @@ where
 /// The host functions are called from the guest, and they forward the arguments back to the guest
 /// by calling guest functions with the same names.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -333,8 +333,8 @@ where
 /// The host functions are called from the guest, and they call the guest back through functions
 /// with the same names, forwarding the arguments and retrieving the final results.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -380,8 +380,8 @@ impl ExportedGlobalState {
 ///
 /// The final value returned from the guest must match the initial value the host sent in.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_global_state<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -32,8 +32,8 @@ impl SimpleFunction {
 
 /// Test exporting a simple function without parameters or return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -105,8 +105,8 @@ impl Getters {
 
 /// Test exporting functions with return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -175,8 +175,8 @@ impl Setters {
 
 /// Test exporting functions with parameters.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -244,8 +244,8 @@ impl Operations {
 
 /// Test exporting functions with multiple parameters and return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -23,9 +23,9 @@ trait SimpleFunction {
 }
 
 /// Test importing a simple function without parameters or return values.
-#[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -58,9 +58,9 @@ trait Getters {
 }
 
 /// Test importing functions with return values.
-#[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -163,9 +163,9 @@ trait Setters {
 }
 
 /// Test importing functions with parameters.
-#[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -229,9 +229,9 @@ trait Operations {
 }
 
 /// Test importing functions with multiple parameters and return values.
-#[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory; "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory; "with Wasmtime"))]
+#[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
+#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -176,7 +176,7 @@ fn test_load_from_memory<T>(input: &[u8], expected: T)
 where
     T: Debug + Eq + WitLoad,
 {
-    let mut instance = MockInstance::default();
+    let mut instance = MockInstance::<()>::default();
     let mut memory = instance.memory().unwrap();
 
     let address = memory.allocate(input.len() as u32).unwrap();
@@ -192,7 +192,7 @@ fn test_lift_from_flat_layout<T>(input: <T::Layout as Layout>::Flat, expected: T
 where
     T: Debug + Eq + WitLoad,
 {
-    let mut instance = MockInstance::default();
+    let mut instance = MockInstance::<()>::default();
     let memory = instance.memory().unwrap();
 
     assert_eq!(T::lift_from(input, &memory).unwrap(), expected);

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -218,7 +218,7 @@ fn test_store_in_memory<T>(data: &T, expected: &[u8])
 where
     T: WitStore,
 {
-    let mut instance = MockInstance::default();
+    let mut instance = MockInstance::<()>::default();
     let mut memory = instance.memory().unwrap();
 
     let length = expected.len() as u32;
@@ -236,7 +236,7 @@ where
     T: WitStore,
     <T::Layout as Layout>::Flat: Debug + Eq,
 {
-    let mut instance = MockInstance::default();
+    let mut instance = MockInstance::<()>::default();
     let mut memory = instance.memory().unwrap();
 
     assert_eq!(data.lower(&mut memory).unwrap(), expected);


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When exporting host functions for Wasm guests to call, the handlers might need access to custom data that's outside the Wasm guest.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add a `UserData` generic type parameter to the Wasm instance implementations. Also add a `UserData` associated type to the `Instance`, allowing the `wit_export` procedural macro to discover the user data type to use based on it.

## Test Plan

<!-- How to test that the changes are correct. -->
A unit test was added to cover using the custom user data.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
