### PR TITLE
Add proxy-internal service to Kubernetes

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -17,6 +17,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  name: proxy-internal
+  labels:
+    app: proxy-internal
+spec:
+  ports:
+    - port: 20100
+      name: linera-port-int
+      targetPort: 20100
+  selector:
+    app: proxy
+  type: NodePort
+
+---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,6 +57,8 @@ spec:
           ports:
             - containerPort: {{ .Values.proxyPort }}
               name: linera-port
+            - containerPort: 20100
+              name: linera-port-int
           command: ["./linera-proxy"]
           args: ["/config/server.json"]
           env:


### PR DESCRIPTION
## Motivation

This service will be needed so that the internal port of the validators work properly

## Proposal

Add the service

## Test Plan

This was tested by running the e2e tests locally with Kubernetes

