### PR TITLE
Fix k8s-local config hosts

### DIFF
--- a/configuration/k8s-local/validator_1.toml
+++ b/configuration/k8s-local/validator_1.toml
@@ -1,9 +1,9 @@
 server_config_path = "server_1.json"
 host = "127.0.0.1"
 port = 19100
-metrics_host = "validator-1"
+metrics_host = "proxy-internal.default.svc.cluster.local"
 metrics_port = 21100
-internal_host = "validator-1"
+internal_host = "proxy-internal.default.svc.cluster.local"
 internal_port = 20100
 [external_protocol]
 Grpc = "ClearText"


### PR DESCRIPTION
## Motivation

This was a bug that we found while trying to run e2e tests with Kubernetes. This will break notifications when we deploy things with anything that uses this config, like `build_and_redeploy` for example

## Proposal

Fix the config

## Test Plan

Run and make sure notifications work

