### PR TITLE
Use std::process::Command instead on wrappers

### DIFF
--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::CommandExt;
 use anyhow::{Context, Result};
 use pathdiff::diff_paths;
 use std::path::PathBuf;
@@ -12,32 +11,31 @@ pub struct DockerImage {
 }
 
 impl DockerImage {
-    pub async fn new(name: String, bin_path: &PathBuf, github_root: &PathBuf) -> Result<Self> {
-        let docker_image = Self { name };
-        docker_image.build(bin_path, github_root).await?;
-        Ok(docker_image)
-    }
-
     pub fn name(&self) -> &String {
         &self.name
     }
 
-    async fn build(&self, bin_path: &PathBuf, github_root: &PathBuf) -> Result<()> {
+    pub async fn build(name: String, bin_path: &PathBuf, github_root: &PathBuf) -> Result<Self> {
+        let docker_image = Self { name: name.clone() };
         let bin_path = diff_paths(bin_path, github_root).context("Getting relative path failed")?;
         let binaries_arg = format!(
             "binaries={}",
             bin_path.to_str().context("Getting str failed")?
         );
 
-        Command::new("docker")
+        let status = Command::new("docker")
             .current_dir(github_root)
             .arg("build")
             .args(["-f", "docker/Dockerfile"])
             .args(["--build-arg", &binaries_arg])
             .arg(".")
-            .args(["-t", &self.name])
-            .spawn_and_wait_for_stdout()
+            .args(["-t", &name])
+            .status()
             .await?;
-        Ok(())
+
+        if !status.success() {
+            return Err(anyhow::anyhow!("Error Docker building image {}", name,));
+        }
+        Ok(docker_image)
     }
 }

--- a/linera-service/src/cli_wrappers/helm.rs
+++ b/linera-service/src/cli_wrappers/helm.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::CommandExt;
 use anyhow::{Context, Result};
 use pathdiff::diff_paths;
 use std::path::{Path, PathBuf};
@@ -24,7 +23,7 @@ impl HelmRelease {
             .context("Getting relative path failed")?;
         let configs_dir = configs_dir.to_str().expect("Getting str failed");
 
-        Command::new("helm")
+        let status = Command::new("helm")
             .current_dir(&execution_dir)
             .arg("install")
             .arg(&name)
@@ -43,8 +42,17 @@ impl HelmRelease {
             .args(["--set", &format!("numShards={num_shards}")])
             .args(["--kube-context", &format!("kind-{}", cluster_id)])
             .args(["--timeout", "10m"])
-            .spawn_and_wait_for_stdout()
+            .status()
             .await?;
+
+        if !status.success() {
+            return Err(anyhow::anyhow!(
+                "Error Helm installing release {} on cluster {}",
+                name,
+                cluster_id
+            ));
+        }
+
         Ok(())
     }
 }

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -177,7 +177,9 @@ impl LineraNet for LocalKubernetesNet {
 
             Err(errors
                 .into_iter()
-                .fold(anyhow!("{err_str} occurred"), |acc, e| acc.context(e)))
+                .fold(anyhow!("{err_str} occurred"), |acc, e: anyhow::Error| {
+                    acc.context(e)
+                }))
         }
     }
 }
@@ -285,7 +287,7 @@ impl LocalKubernetesNet {
 
         let github_root = get_github_root().await?;
         // Build Docker image
-        let docker_image = DockerImage::new(
+        let docker_image = DockerImage::build(
             String::from("linera-test:latest"),
             binaries_path,
             &github_root,
@@ -353,13 +355,11 @@ impl LocalKubernetesNet {
                     .expect("Getting validator pod name should not fail");
 
                 let local_port = 19100 + i;
-                kubectl_instance
-                    .port_forward(
-                        validator_pod_name,
-                        &format!("{local_port}:{local_port}"),
-                        cluster_id,
-                    )
-                    .await?;
+                kubectl_instance.port_forward(
+                    validator_pod_name,
+                    &format!("{local_port}:{local_port}"),
+                    cluster_id,
+                )?;
 
                 Result::<(), anyhow::Error>::Ok(())
             };


### PR DESCRIPTION
## Motivation

Depending on where we're running this (what runtime), using the tokio one can make these calls hang. So it's better to use `std::process::Command` directly instead

## Proposal

Use `std::process::Command`

## Test Plan

Run from e2e tests, make sure they don't hang

