### PR TITLE
Pass one e2e and one wasm e2e test with Kubernetes

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
 
-  local-kind-deployment-integration-test:
+  kind-deployment-integration-test:
     runs-on: ubuntu-latest
 
     steps:
@@ -47,16 +47,6 @@ jobs:
           strip target/release/linera-proxy
           strip target/release/linera-server
           strip target/release/linera-db
-      - name: Install Kind
-        run: |
-          curl -sL -o /tmp/kind https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-amd64
-          chmod +x /tmp/kind
-          mv /tmp/kind /usr/local/bin/
-      - name: Install Kubectl
-        run: |
-          curl -sL -o /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.24.1/bin/linux/amd64/kubectl
-          chmod +x /tmp/kubectl
-          mv /tmp/kubectl /usr/local/bin/
         # Build the docker image copying the already built binaries
       - name: Build Docker and deploy locally with Kind
         run: |
@@ -90,3 +80,29 @@ jobs:
         if: always()
         run: |
           kind delete cluster
+
+  kind-deployment-e2e-tests:
+    runs-on: ubuntu-latest-16-cores
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: Twey/setup-rust-toolchain@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build client binary
+        run: |
+          cargo build --release --locked --bin linera --bin linera-proxy --bin linera-server --bin linera-db --features scylladb,rocksdb,kubernetes
+          strip target/release/linera
+          strip target/release/linera-proxy
+          strip target/release/linera-server
+          strip target/release/linera-db
+      - name: Run Wasm e2e test
+        run: |
+          cargo test --locked -p linera-service --features scylladb,kubernetes --test wasm_end_to_end_tests -- test_wasm_end_to_end_amm
+      - name: Run e2e test
+        run: |
+          cargo test --locked -p linera-service --features scylladb,kubernetes --test end_to_end_tests -- test_end_to_end_multiple_wallets

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -8,6 +8,8 @@ mod common;
 
 use common::INTEGRATION_TEST_GUARD;
 use linera_base::{data_types::Amount, identifiers::ChainId};
+#[cfg(feature = "kubernetes")]
+use linera_service::cli_wrappers::local_kubernetes_net::LocalKubernetesNetTestingConfig;
 use linera_service::{
     cli_wrappers::{
         local_net::{Database, LocalNet, LocalNetConfig, LocalNetTestingConfig},
@@ -334,9 +336,10 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig
     net.terminate().await.unwrap();
 }
 
-#[cfg_attr(feature = "rocksdb", test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
-#[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
-#[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(all(feature = "rocksdb", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
+#[cfg_attr(all(feature = "scylladb", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(all(feature = "aws", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(LocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_scylladb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -11,6 +11,8 @@ use linera_base::{
     data_types::{Amount, Timestamp},
     identifiers::ChainId,
 };
+#[cfg(feature = "kubernetes")]
+use linera_service::cli_wrappers::local_kubernetes_net::LocalKubernetesNetTestingConfig;
 use linera_service::cli_wrappers::{
     local_net::{Database, LocalNetTestingConfig},
     ApplicationWrapper, ClientWrapper, LineraNet, LineraNetConfig, Network,
@@ -923,9 +925,10 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     net.terminate().await.unwrap();
 }
 
-#[cfg_attr(feature = "rocksdb", test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
-#[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
-#[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(all(feature = "rocksdb", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
+#[cfg_attr(all(feature = "scylladb", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(all(feature = "aws", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(LocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_scylladb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
     use amm::{AmmAbi, Parameters};


### PR DESCRIPTION
## Motivation

We need to pass all e2e and wasm e2e tests with the local Kubernetes deployment

## Proposal

They all pass, but right now is not feasible to have all tests creating one cluster each in parallel in CI, so doing just one test of each for now

## Test Plan

Run the tests against the local Kubernetes deployment, they pass

