### PR TITLE
Register `#[witty_specialize_with]` attribute

### DIFF
--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -27,7 +27,7 @@ use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
 ///
 /// All fields in the type must also implement `WitType`.
 #[proc_macro_error]
-#[proc_macro_derive(WitType, attributes(witty))]
+#[proc_macro_derive(WitType, attributes(witty_specialize_with))]
 pub fn derive_wit_type(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
 
@@ -53,7 +53,7 @@ pub fn derive_wit_type(input: TokenStream) -> TokenStream {
 ///
 /// All fields in the type must also implement `WitLoad`.
 #[proc_macro_error]
-#[proc_macro_derive(WitLoad)]
+#[proc_macro_derive(WitLoad, attributes(witty_specialize_with))]
 pub fn derive_wit_load(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
 
@@ -79,7 +79,7 @@ pub fn derive_wit_load(input: TokenStream) -> TokenStream {
 ///
 /// All fields in the type must also implement `WitStore`.
 #[proc_macro_error]
-#[proc_macro_derive(WitStore)]
+#[proc_macro_derive(WitStore, attributes(witty_specialize_with))]
 pub fn derive_wit_store(input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as DeriveInput);
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
PR #1294 added support for a new `#[witty_specialize_with]` attribute that generates code for generic types with some predefined specializations. However, using the attribute did not work because the compiler complained of an unrecognized attribute.

Unfortunately the tests didn't capture the error because the tests did not run the procedural macro directly, running only the internal implementation instead (skipping the compiler).

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Properly register the attribute so that it can be used in real-world scenarios.

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
