### PR TITLE
Use more suitable tokio Command functions

### DIFF
--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -1,28 +1,24 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::CommandExt;
 use anyhow::{Context, Result};
 use pathdiff::diff_paths;
 use std::path::PathBuf;
 use tokio::process::Command;
+
+use crate::util::CommandExt;
 
 pub struct DockerImage {
     name: String,
 }
 
 impl DockerImage {
-    pub async fn new(name: String, bin_path: &PathBuf, github_root: &PathBuf) -> Result<Self> {
-        let docker_image = Self { name };
-        docker_image.build(bin_path, github_root).await?;
-        Ok(docker_image)
-    }
-
     pub fn name(&self) -> &String {
         &self.name
     }
 
-    async fn build(&self, bin_path: &PathBuf, github_root: &PathBuf) -> Result<()> {
+    pub async fn build(name: String, bin_path: &PathBuf, github_root: &PathBuf) -> Result<Self> {
+        let docker_image = Self { name: name.clone() };
         let bin_path = diff_paths(bin_path, github_root).context("Getting relative path failed")?;
         let binaries_arg = format!(
             "binaries={}",
@@ -35,9 +31,10 @@ impl DockerImage {
             .args(["-f", "docker/Dockerfile"])
             .args(["--build-arg", &binaries_arg])
             .arg(".")
-            .args(["-t", &self.name])
-            .spawn_and_wait_for_stdout()
+            .args(["-t", &name])
+            .spawn_and_wait()
             .await?;
-        Ok(())
+
+        Ok(docker_image)
     }
 }

--- a/linera-service/src/cli_wrappers/helm.rs
+++ b/linera-service/src/cli_wrappers/helm.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::CommandExt;
 use anyhow::{Context, Result};
 use pathdiff::diff_paths;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
+
+use crate::util::CommandExt;
 
 pub struct HelmRelease;
 
@@ -43,8 +44,7 @@ impl HelmRelease {
             .args(["--set", &format!("numShards={num_shards}")])
             .args(["--kube-context", &format!("kind-{}", cluster_id)])
             .args(["--timeout", "10m"])
-            .spawn_and_wait_for_stdout()
-            .await?;
-        Ok(())
+            .spawn_and_wait()
+            .await
     }
 }

--- a/linera-service/src/cli_wrappers/kind.rs
+++ b/linera-service/src/cli_wrappers/kind.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::CommandExt;
 use anyhow::Result;
 use rand::Rng;
 use tokio::process::Command;
+
+use crate::util::CommandExt;
 
 #[derive(Clone)]
 pub struct KindCluster {
@@ -24,8 +25,9 @@ impl KindCluster {
         Command::new("kind")
             .args(["create", "cluster"])
             .args(["--name", cluster.id().to_string().as_str()])
-            .spawn_and_wait_for_stdout()
+            .spawn_and_wait()
             .await?;
+
         Ok(cluster)
     }
 
@@ -36,18 +38,16 @@ impl KindCluster {
     pub async fn delete(&self) -> Result<()> {
         Command::new("kind")
             .args(["delete", "cluster"])
-            .args(["--name", self.id.to_string().as_str()])
-            .spawn_and_wait_for_stdout()
-            .await?;
-        Ok(())
+            .args(["--name", &self.id.to_string()])
+            .spawn_and_wait()
+            .await
     }
 
     pub async fn load_docker_image(&self, docker_image: &String) -> Result<()> {
         Command::new("kind")
             .args(["load", "docker-image", docker_image])
             .args(["--name", self.id.to_string().as_str()])
-            .spawn_and_wait_for_stdout()
-            .await?;
-        Ok(())
+            .spawn_and_wait()
+            .await
     }
 }

--- a/linera-service/src/cli_wrappers/kubectl.rs
+++ b/linera-service/src/cli_wrappers/kubectl.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::CommandExt;
 use anyhow::{Context, Result};
 use tokio::process::{Child, Command};
+
+use crate::util::CommandExt;
 
 pub struct KubectlInstance {
     pub port_forward_children: Vec<Child>,
@@ -16,12 +17,7 @@ impl KubectlInstance {
         }
     }
 
-    pub async fn port_forward(
-        &mut self,
-        pod_name: &str,
-        ports: &str,
-        cluster_id: u32,
-    ) -> Result<()> {
+    pub fn port_forward(&mut self, pod_name: &str, ports: &str, cluster_id: u32) -> Result<()> {
         let port_forward_child = Command::new("kubectl")
             .arg("port-forward")
             .arg(pod_name)
@@ -35,11 +31,13 @@ impl KubectlInstance {
     }
 
     pub async fn get_pods(&mut self, cluster_id: u32) -> Result<String> {
-        Command::new("kubectl")
+        let output = Command::new("kubectl")
             .arg("get")
             .arg("pods")
             .args(["--context", &format!("kind-{}", cluster_id)])
             .spawn_and_wait_for_stdout()
-            .await
+            .await?;
+
+        Ok(String::from_utf8_lossy(output.as_bytes()).to_string())
     }
 }


### PR DESCRIPTION
## Motivation

We don't always need the output. Also, for `kind delete` that gets called on drop, we shouldn't mess with stdout/stderr at all, because it can hang waiting on a buffer flush that never happens, because the tokio runtime is already shutting down.

## Proposal

Call more suitable methods

## Test Plan

Tested running e2e tests with Kubernetes

