### PR TITLE
Fix Witty specialization inside tuple types

### DIFF
--- a/linera-witty-macros/src/util/specialization.rs
+++ b/linera-witty-macros/src/util/specialization.rs
@@ -23,7 +23,7 @@ use syn::{
     DataStruct, DataUnion, DeriveInput, Field, Fields, GenericArgument, GenericParam, Generics,
     Ident, MacroDelimiter, Meta, MetaList, Path, PathArguments, PredicateType, QSelf, ReturnType,
     Token, Type, TypeArray, TypeBareFn, TypeGroup, TypeImplTrait, TypeParamBound, TypeParen,
-    TypePath, TypePtr, TypeReference, TypeSlice, WhereClause, WherePredicate,
+    TypePath, TypePtr, TypeReference, TypeSlice, TypeTuple, WhereClause, WherePredicate,
 };
 
 /// Collected specializations to apply before deriving a trait for a type.
@@ -311,6 +311,11 @@ impl Specialization {
                     self.change_types_in_type(ty);
                 }
                 self.change_types_in_path(path);
+            }
+            Type::Tuple(TypeTuple { elems, .. }) => {
+                for element in elems {
+                    self.change_types_in_type(element);
+                }
             }
             _ => {}
         }

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -168,6 +168,11 @@ impl<UserData> MockInstance<UserData> {
 
         Results::lift_from(flat_results, &self.clone().memory()?)
     }
+
+    /// Returns a copy of the current memory contents.
+    pub fn memory_contents(&self) -> Vec<u8> {
+        self.memory.lock().unwrap().clone()
+    }
 }
 
 impl<UserData> Instance for MockInstance<UserData> {

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -49,3 +49,12 @@ pub enum Enum {
     LargeVariantWithLooseAlignment(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8),
     SmallerVariantWithStrictAlignment { inner: u64 },
 }
+
+/// A generic struct with some specialized fields.
+#[derive(Clone, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
+#[witty_specialize_with(A = u8, B = i16)]
+pub struct SpecializedGenericStruct<A, B> {
+    pub first: A,
+    pub second: B,
+    pub both: Vec<(A, B)>,
+}

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -7,8 +7,8 @@
 mod types;
 
 use self::types::{
-    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding,
-    TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericStruct,
+    TupleWithPadding, TupleWithoutPadding,
 };
 use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, WitLoad};
 use std::fmt::Debug;
@@ -174,6 +174,29 @@ fn test_enum_type() {
         ],
         &expected,
         &[],
+    );
+}
+
+/// Check that a generic type with a specialization request is properly loaded from memory and
+/// lifted from its flat layout.
+#[test]
+fn test_specialized_generic_struct() {
+    let expected = SpecializedGenericStruct {
+        first: 254_u8,
+        second: -10_i16,
+        both: vec![(1, -1), (2, -2)],
+    };
+
+    test_load_from_memory(
+        &[
+            254, 0, 246, 255, 12, 0, 0, 0, 2, 0, 0, 0, 1, 0, 255, 255, 2, 0, 254, 255,
+        ],
+        &expected,
+    );
+    test_lift_from_flat_layout(
+        hlist![0x0000_00fe_i32, -10_i32, 0_i32, 2_i32,],
+        &expected,
+        &[1, 0, 255, 255, 2, 0, 254, 255],
     );
 }
 

--- a/linera-witty/tests/wit_load.rs
+++ b/linera-witty/tests/wit_load.rs
@@ -16,11 +16,11 @@ use std::fmt::Debug;
 /// Check that a wrapper type is properly loaded from memory and lifted from its flat layout.
 #[test]
 fn test_simple_bool_wrapper() {
-    test_load_from_memory(&[1], SimpleWrapper(true));
-    test_load_from_memory(&[0], SimpleWrapper(false));
+    test_load_from_memory(&[1], &SimpleWrapper(true));
+    test_load_from_memory(&[0], &SimpleWrapper(false));
 
-    test_lift_from_flat_layout(hlist![1], SimpleWrapper(true));
-    test_lift_from_flat_layout(hlist![0], SimpleWrapper(false));
+    test_lift_from_flat_layout(hlist![1], &SimpleWrapper(true));
+    test_lift_from_flat_layout(hlist![0], &SimpleWrapper(false));
 }
 
 /// Check that a type with multiple fields ordered in a way that doesn't require any padding is
@@ -29,10 +29,10 @@ fn test_simple_bool_wrapper() {
 fn test_tuple_struct_without_padding() {
     let expected = TupleWithoutPadding(0x0807_0605_0403_0201_u64, 0x0c0b_0a09_i32, 0x0e0d_i16);
 
-    test_load_from_memory(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], expected);
+    test_load_from_memory(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], &expected);
     test_lift_from_flat_layout(
         hlist![0x0807_0605_0403_0201_i64, 0x0c0b_0a09_i32, 0x0000_0e0d_i32],
-        expected,
+        &expected,
     );
 }
 
@@ -44,11 +44,11 @@ fn test_tuple_struct_with_padding() {
 
     test_load_from_memory(
         &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        expected,
+        &expected,
     );
     test_lift_from_flat_layout(
         hlist![0x0000_0201_i32, 0x0807_0605_i32, 0x100f_0e0d_0c0b_0a09_i64],
-        expected,
+        &expected,
     );
 }
 
@@ -67,7 +67,7 @@ fn test_named_struct_with_double_padding() {
         &[
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         ],
-        expected,
+        &expected,
     );
     test_lift_from_flat_layout(
         hlist![
@@ -76,7 +76,7 @@ fn test_named_struct_with_double_padding() {
             0x0000_0009_i32,
             0x1817_1615_1413_1211_i64,
         ],
-        expected,
+        &expected,
     );
 }
 
@@ -102,7 +102,7 @@ fn test_nested_types() {
             25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
             47, 48, 49, 50, 51, 52, 53, 54, 55, 56,
         ],
-        expected,
+        &expected,
     );
     test_lift_from_flat_layout(
         hlist![
@@ -114,7 +114,7 @@ fn test_nested_types() {
             0x302f_2e2d_2c2b_2a29_i64,
             0x3837_3635_3433_3231_i64,
         ],
-        expected,
+        &expected,
     );
 }
 
@@ -126,22 +126,22 @@ fn test_enum_type() {
 
     test_load_from_memory(
         &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
-        expected,
+        &expected,
     );
     test_lift_from_flat_layout(
         hlist![0_i32, 0_i64, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32, 0_i32],
-        expected,
+        &expected,
     );
 
     let expected = Enum::LargeVariantWithLooseAlignment(7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
 
     test_load_from_memory(
         &[1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        expected,
+        &expected,
     );
     test_lift_from_flat_layout(
         hlist![1_i32, 7_i64, 8_i32, 9_i32, 10_i32, 11_i32, 12_i32, 13_i32, 14_i32, 15_i32, 16_i32],
-        expected,
+        &expected,
     );
 
     let expected = Enum::SmallerVariantWithStrictAlignment {
@@ -150,7 +150,7 @@ fn test_enum_type() {
 
     test_load_from_memory(
         &[2, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-        expected,
+        &expected,
     );
     test_lift_from_flat_layout(
         hlist![
@@ -166,13 +166,13 @@ fn test_enum_type() {
             0_i32,
             0_i32
         ],
-        expected,
+        &expected,
     );
 }
 
 /// Tests that the type `T` can be loaded from an `input` sequence of bytes in memory and that it
 /// matches the `expected` value.
-fn test_load_from_memory<T>(input: &[u8], expected: T)
+fn test_load_from_memory<T>(input: &[u8], expected: &T)
 where
     T: Debug + Eq + WitLoad,
 {
@@ -183,17 +183,17 @@ where
 
     memory.write(address, input).unwrap();
 
-    assert_eq!(T::load(&memory, address).unwrap(), expected);
+    assert_eq!(&T::load(&memory, address).unwrap(), expected);
 }
 
 /// Tests that the type `T` can be lifted from an `input` flat layout and that it matches the
 /// `expected` value.
-fn test_lift_from_flat_layout<T>(input: <T::Layout as Layout>::Flat, expected: T)
+fn test_lift_from_flat_layout<T>(input: <T::Layout as Layout>::Flat, expected: &T)
 where
     T: Debug + Eq + WitLoad,
 {
     let mut instance = MockInstance::<()>::default();
     let memory = instance.memory().unwrap();
 
-    assert_eq!(T::lift_from(input, &memory).unwrap(), expected);
+    assert_eq!(&T::lift_from(input, &memory).unwrap(), expected);
 }

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -7,8 +7,8 @@
 mod types;
 
 use self::types::{
-    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, TupleWithPadding,
-    TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericStruct,
+    TupleWithPadding, TupleWithoutPadding,
 };
 use linera_witty::{HList, Layout, WitType};
 
@@ -75,4 +75,18 @@ fn test_enum_type() {
     assert_eq!(Enum::SIZE, 18);
     assert_eq!(<Enum as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Enum as WitType>::Layout as Layout>::Flat::LEN, 11);
+}
+
+/// Check the memory size and layout derived for a specialized generic `struct` type.
+#[test]
+fn test_specialized_generic_struct() {
+    assert_eq!(SpecializedGenericStruct::SIZE, 12);
+    assert_eq!(
+        <SpecializedGenericStruct<u8, i16> as WitType>::Layout::ALIGNMENT,
+        4
+    );
+    assert_eq!(
+        <<SpecializedGenericStruct<u8, i16> as WitType>::Layout as Layout>::Flat::LEN,
+        4
+    );
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
PR #1294 allowed specializing generic types before deriving Witty traits, and while writing some tests for #1318 I realized that there was a bug in supporting specialization of types inside tuples. Tuples were simply not specialized.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Specialize tuple types.

## Test Plan

<!-- How to test that the changes are correct. -->
Adds some unit tests that cover both #1318 and this fix.

## Release Plan

Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
