### PR TITLE
Reintroduction of `delete=clear + save`.

### DIFF
--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -119,10 +119,6 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In the scenario where we do a clear
-        // and stored_hash = hash, we need to update the
-        // hash, otherwise, we will recompute it while this
-        // can be avoided.
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
@@ -307,6 +303,7 @@ where
     pub fn remove_entry(&mut self, short_key: Vec<u8>) {
         *self.hash.get_mut() = None;
         if self.delete_storage_first {
+            // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
             self.updates.get_mut().remove(&short_key);
         } else {
             self.updates.get_mut().insert(short_key, Update::Removed);

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -206,9 +206,12 @@ where
         // stored_total_size = total_size. If the test for was_cleared
         // were absent then we would be a size of 0 down the line.
         if self.stored_total_size != self.total_size || self.was_cleared {
-            let key = self.context.base_tag(KeyTag::TotalSize as u8);
-            batch.put_key_value(key, &self.total_size)?;
-            self.stored_total_size = self.total_size;
+            // If the value is 0 and it is cleared then no need to save total_size
+            if self.total_size.sum() > 0 || !self.was_cleared {
+                let key = self.context.base_tag(KeyTag::TotalSize as u8);
+                batch.put_key_value(key, &self.total_size)?;
+                self.stored_total_size = self.total_size;
+            }
         }
         self.was_cleared = false;
         Ok(())

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -192,10 +192,6 @@ where
         }
         self.sizes.flush(batch)?;
         let hash = *self.hash.get_mut();
-        // In the scenario where we do a clear
-        // and stored_hash = hash, we need to update the
-        // hash, otherwise, we will recompute it while this
-        // can be avoided.
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
@@ -664,6 +660,7 @@ where
                     }
                     self.sizes.remove(key.clone());
                     if self.delete_storage_first {
+                        // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
                         self.updates.remove(&key);
                     } else {
                         self.updates.insert(key, Update::Removed);

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -573,7 +573,7 @@ where
             };
             return Ok(test);
         }
-        if self.was_cleared {
+        if self.delete_storage_first {
             return Ok(false);
         }
         if contains_key(&self.deleted_prefixes, index) {

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -29,7 +29,7 @@ enum KeyTag {
 #[derive(Debug)]
 pub struct LogView<C, T> {
     context: C,
-    was_cleared: bool,
+    delete_storage_first: bool,
     stored_count: usize,
     new_values: Vec<T>,
     stored_hash: Option<HasherOutput>,
@@ -56,7 +56,7 @@ where
         let hash = from_bytes_opt(&values_bytes[1])?;
         Ok(Self {
             context,
-            was_cleared: false,
+            delete_storage_first: false,
             stored_count,
             new_values: Vec::new(),
             stored_hash: hash,
@@ -65,13 +65,13 @@ where
     }
 
     fn rollback(&mut self) {
-        self.was_cleared = false;
+        self.delete_storage_first = false;
         self.new_values.clear();
         *self.hash.get_mut() = self.stored_hash;
     }
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
-        if self.was_cleared && self.stored_count > 0 {
+        if self.delete_storage_first && self.stored_count > 0 {
             batch.delete_key_prefix(self.context.base_key());
             self.stored_count = 0;
         }
@@ -92,7 +92,7 @@ where
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.
-        if self.stored_hash != hash || self.was_cleared {
+        if self.stored_hash != hash || self.delete_storage_first {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),
@@ -100,12 +100,12 @@ where
             }
             self.stored_hash = hash;
         }
-        self.was_cleared = false;
+        self.delete_storage_first = false;
         Ok(())
     }
 
     fn clear(&mut self) {
-        self.was_cleared = true;
+        self.delete_storage_first = true;
         self.new_values.clear();
         *self.hash.get_mut() = None;
     }
@@ -145,7 +145,7 @@ where
     /// # })
     /// ```
     pub fn count(&self) -> usize {
-        if self.was_cleared {
+        if self.delete_storage_first {
             self.new_values.len()
         } else {
             self.stored_count + self.new_values.len()
@@ -177,7 +177,7 @@ where
     /// # })
     /// ```
     pub async fn get(&self, index: usize) -> Result<Option<T>, ViewError> {
-        let value = if self.was_cleared {
+        let value = if self.delete_storage_first {
             self.new_values.get(index).cloned()
         } else if index < self.stored_count {
             let key = self.context.derive_tag_key(KeyTag::Index as u8, &index)?;
@@ -203,7 +203,7 @@ where
     /// ```
     pub async fn multi_get(&self, indices: Vec<usize>) -> Result<Vec<Option<T>>, ViewError> {
         let mut result = Vec::new();
-        if self.was_cleared {
+        if self.delete_storage_first {
             for index in indices {
                 result.push(self.new_values.get(index).cloned());
             }
@@ -265,7 +265,7 @@ where
     where
         R: RangeBounds<usize>,
     {
-        let effective_stored_count = if self.was_cleared {
+        let effective_stored_count = if self.delete_storage_first {
             0
         } else {
             self.stored_count

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -48,7 +48,7 @@ enum KeyTag {
 #[derive(Debug)]
 pub struct ByteMapView<C, V> {
     context: C,
-    was_cleared: bool,
+    delete_storage_first: bool,
     updates: BTreeMap<Vec<u8>, Update<V>>,
     deleted_prefixes: BTreeSet<Vec<u8>>,
     stored_hash: Option<HasherOutput>,
@@ -71,7 +71,7 @@ where
         let hash = context.read_value(&key).await?;
         Ok(Self {
             context,
-            was_cleared: false,
+            delete_storage_first: false,
             updates: BTreeMap::new(),
             deleted_prefixes: BTreeSet::new(),
             stored_hash: hash,
@@ -80,14 +80,14 @@ where
     }
 
     fn rollback(&mut self) {
-        self.was_cleared = false;
+        self.delete_storage_first = false;
         self.updates.clear();
         self.deleted_prefixes.clear();
         *self.hash.get_mut() = self.stored_hash;
     }
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
-        if self.was_cleared {
+        if self.delete_storage_first {
             batch.delete_key_prefix(self.context.base_key());
             for (index, update) in mem::take(&mut self.updates) {
                 if let Update::Set(value) = update {
@@ -95,6 +95,7 @@ where
                     batch.put_key_value(key, &value)?;
                 }
             }
+            self.stored_hash = None;
         } else {
             for index in mem::take(&mut self.deleted_prefixes) {
                 let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
@@ -113,7 +114,7 @@ where
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.
-        if self.stored_hash != hash || self.was_cleared {
+        if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),
@@ -121,12 +122,12 @@ where
             }
             self.stored_hash = hash;
         }
-        self.was_cleared = false;
+        self.delete_storage_first = false;
         Ok(())
     }
 
     fn clear(&mut self) {
-        self.was_cleared = true;
+        self.delete_storage_first = true;
         self.updates.clear();
         self.deleted_prefixes.clear();
         *self.hash.get_mut() = None;
@@ -169,7 +170,7 @@ where
     /// ```
     pub fn remove(&mut self, short_key: Vec<u8>) {
         *self.hash.get_mut() = None;
-        if self.was_cleared {
+        if self.delete_storage_first {
             self.updates.remove(&short_key);
         } else {
             self.updates.insert(short_key, Update::Removed);
@@ -200,7 +201,7 @@ where
         for key in key_list {
             self.updates.remove(&key);
         }
-        if !self.was_cleared {
+        if !self.delete_storage_first {
             insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
         }
     }
@@ -237,7 +238,7 @@ where
             };
             return Ok(value);
         }
-        if self.was_cleared {
+        if self.delete_storage_first {
             return Ok(None);
         }
         if contains_key(&self.deleted_prefixes, short_key) {
@@ -249,7 +250,7 @@ where
 
     /// Loads the value in updates if that is at all possible.
     async fn load_value(&mut self, short_key: &[u8]) -> Result<(), ViewError> {
-        if !self.was_cleared && !self.updates.contains_key(short_key) {
+        if !self.delete_storage_first && !self.updates.contains_key(short_key) {
             let key = self.context.base_tag_index(KeyTag::Index as u8, short_key);
             let value = self.context.read_value(&key).await?;
             if let Some(value) = value {
@@ -324,7 +325,7 @@ where
         let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
-        if !self.was_cleared && !contains_key(&self.deleted_prefixes, &prefix) {
+        if !self.delete_storage_first && !contains_key(&self.deleted_prefixes, &prefix) {
             let base = self.context.base_tag_index(KeyTag::Index as u8, &prefix);
             for index in self.context.find_keys_by_prefix(&base).await?.iterator() {
                 let index = index?;
@@ -519,7 +520,7 @@ where
         let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
-        if !self.was_cleared && !contains_key(&self.deleted_prefixes, &prefix) {
+        if !self.delete_storage_first && !contains_key(&self.deleted_prefixes, &prefix) {
             let base = self.context.base_tag_index(KeyTag::Index as u8, &prefix);
             for entry in self
                 .context
@@ -701,7 +702,7 @@ where
         use std::collections::btree_map::Entry;
 
         let update = match self.updates.entry(short_key.clone()) {
-            Entry::Vacant(e) if self.was_cleared => e.insert(Update::Set(V::default())),
+            Entry::Vacant(e) if self.delete_storage_first => e.insert(Update::Set(V::default())),
             Entry::Vacant(e) => {
                 let key = self.context.base_tag_index(KeyTag::Index as u8, &short_key);
                 let value = self.context.read_value(&key).await?.unwrap_or_default();

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -110,10 +110,6 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In the scenario where we do a clear
-        // and stored_hash = hash, we need to update the
-        // hash, otherwise, we will recompute it while this
-        // can be avoided.
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
@@ -171,6 +167,7 @@ where
     pub fn remove(&mut self, short_key: Vec<u8>) {
         *self.hash.get_mut() = None;
         if self.delete_storage_first {
+            // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
             self.updates.remove(&short_key);
         } else {
             self.updates.insert(short_key, Update::Removed);

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -100,7 +100,7 @@ where
             }
             self.new_back_values.clear();
         }
-        if !self.was_cleared || self.stored_indices.len() > 0 {
+        if !self.was_cleared || !self.stored_indices.is_empty() {
             let key = self.context.base_tag(KeyTag::Store as u8);
             batch.put_key_value(key, &self.stored_indices)?;
         }

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -107,10 +107,6 @@ where
         }
         self.front_delete_count = 0;
         let hash = *self.hash.get_mut();
-        // In the scenario where we do a clear
-        // and stored_hash = hash, we need to update the
-        // hash, otherwise, we will recompute it while this
-        // can be avoided.
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -138,10 +138,6 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In the scenario where we do a clear
-        // and stored_hash = hash, we need to update the
-        // hash, otherwise, we will recompute it while this
-        // can be avoided.
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
@@ -307,6 +303,7 @@ where
     pub fn remove_entry(&mut self, short_key: Vec<u8>) {
         *self.hash.get_mut() = None;
         if self.delete_storage_first {
+            // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
             self.updates.get_mut().remove(&short_key);
         } else {
             self.updates.get_mut().insert(short_key, Update::Removed);

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -94,7 +94,7 @@ where
 
     fn clear(&mut self) {
         self.delete_storage_first = true;
-        self.update = Some(Box::default());
+        self.update = None;
         *self.hash.get_mut() = None;
     }
 }

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -76,10 +76,6 @@ where
             self.stored_value = value;
         }
         let hash = *self.hash.get_mut();
-        // In the scenario where we do a clear
-        // and stored_hash = hash, we need to update the
-        // hash, otherwise, we will recompute it while this
-        // can be avoided.
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
@@ -94,7 +90,7 @@ where
 
     fn clear(&mut self) {
         self.delete_storage_first = true;
-        self.update = None;
+        self.update = Some(Box::default());
         *self.hash.get_mut() = None;
     }
 }

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -78,10 +78,6 @@ where
             }
         }
         let hash = *self.hash.get_mut();
-        // In the scenario where we do a clear
-        // and stored_hash = hash, we need to update the
-        // hash, otherwise, we will recompute it while this
-        // can be avoided.
         if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
@@ -136,6 +132,7 @@ where
     pub fn remove(&mut self, short_key: Vec<u8>) {
         *self.hash.get_mut() = None;
         if self.delete_storage_first {
+            // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
             self.updates.remove(&short_key);
         } else {
             self.updates.insert(short_key, Update::Removed);

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -24,7 +24,7 @@ enum KeyTag {
 #[derive(Debug)]
 pub struct ByteSetView<C> {
     context: C,
-    was_cleared: bool,
+    delete_storage_first: bool,
     updates: BTreeMap<Vec<u8>, Update<()>>,
     stored_hash: Option<HasherOutput>,
     hash: Mutex<Option<HasherOutput>>,
@@ -45,7 +45,7 @@ where
         let hash = context.read_value(&key).await?;
         Ok(Self {
             context,
-            was_cleared: false,
+            delete_storage_first: false,
             updates: BTreeMap::new(),
             stored_hash: hash,
             hash: Mutex::new(hash),
@@ -53,13 +53,13 @@ where
     }
 
     fn rollback(&mut self) {
-        self.was_cleared = false;
+        self.delete_storage_first = false;
         self.updates.clear();
         *self.hash.get_mut() = self.stored_hash;
     }
 
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
-        if self.was_cleared {
+        if self.delete_storage_first {
             batch.delete_key_prefix(self.context.base_key());
             for (index, update) in mem::take(&mut self.updates) {
                 if let Update::Set(_) = update {
@@ -67,6 +67,7 @@ where
                     batch.put_key_value_bytes(key, Vec::new());
                 }
             }
+            self.stored_hash = None;
         } else {
             for (index, update) in mem::take(&mut self.updates) {
                 let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
@@ -81,7 +82,7 @@ where
         // and stored_hash = hash, we need to update the
         // hash, otherwise, we will recompute it while this
         // can be avoided.
-        if self.stored_hash != hash || self.was_cleared {
+        if self.stored_hash != hash {
             let key = self.context.base_tag(KeyTag::Hash as u8);
             match hash {
                 None => batch.delete_key(key),
@@ -89,12 +90,12 @@ where
             }
             self.stored_hash = hash;
         }
-        self.was_cleared = false;
+        self.delete_storage_first = false;
         Ok(())
     }
 
     fn clear(&mut self) {
-        self.was_cleared = true;
+        self.delete_storage_first = true;
         self.updates.clear();
         *self.hash.get_mut() = None;
     }
@@ -134,7 +135,7 @@ where
     /// ```
     pub fn remove(&mut self, short_key: Vec<u8>) {
         *self.hash.get_mut() = None;
-        if self.was_cleared {
+        if self.delete_storage_first {
             self.updates.remove(&short_key);
         } else {
             self.updates.insert(short_key, Update::Removed);
@@ -172,7 +173,7 @@ where
             };
             return Ok(value);
         }
-        if self.was_cleared {
+        if self.delete_storage_first {
             return Ok(false);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, short_key);
@@ -236,7 +237,7 @@ where
     {
         let mut updates = self.updates.iter();
         let mut update = updates.next();
-        if !self.was_cleared {
+        if !self.delete_storage_first {
             let base = self.context.base_tag(KeyTag::Index as u8);
             for index in self.context.find_keys_by_prefix(&base).await?.iterator() {
                 let index = index?;

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -26,9 +26,8 @@ pub trait View<C>: Sized {
     /// Discards all pending changes. After that `flush` should have no effect to storage.
     fn rollback(&mut self);
 
-    /// Clears the view. That can be seen as resetting to default. In the case of a RegisterView
-    /// this means setting the value to T::default(). For LogView, QueueView, this leaves
-    /// the range data to be left in the database.
+    /// Clears the view. That can be seen as resetting to default. If the clear is followed
+    /// by a flush then all the relevant data is removed on the storage.
     fn clear(&mut self);
 
     /// Persists changes to storage. This leaves the view still usable and is essentially neutral to the

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -654,6 +654,8 @@ where
             assert_eq!(view.queue.front().await.unwrap(), None);
             assert_eq!(view.queue.count(), 0);
         }
+        view.clear();
+        view.save().await.unwrap();
     }
     staged_hash
 }
@@ -664,7 +666,8 @@ async fn test_views_in_lru_memory_param(config: &TestConfig) {
     let mut store = LruMemoryStore::new().await;
     test_store(&mut store, config).await;
     assert_eq!(store.states.len(), 1);
-    store.states.get(&1).unwrap();
+    let entry = store.states.get(&1).unwrap().clone();
+    assert!(entry.lock().await.is_empty());
 }
 
 #[tokio::test]
@@ -680,7 +683,8 @@ async fn test_views_in_memory_param(config: &TestConfig) {
     let mut store = MemoryTestStore::new().await;
     test_store(&mut store, config).await;
     assert_eq!(store.states.len(), 1);
-    store.states.get(&1).unwrap();
+    let entry = store.states.get(&1).unwrap().clone();
+    assert!(entry.lock().await.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

We recently eliminated the `delete` and `write_delete` because they were essentially not used and actually
we could do instead a `clear + save`.
It turns out that having that `delete=clear + save` was not so easy and required changing some code in the flush of the views.
That PR is not critical, but I think it keeps us honest to have it working as expected and so I think it is important long term.

## Proposal

The corrections were done for the following views:
* `QueueView`
* `KeyValueStoreView`
* `RegisterView`.
The idea is that if we do a clear and then the flush then nothing should be left.

Corresponding changes were done in the tests that in fact revert previous changes.

## Test Plan

That CI test should do the trick and was not so easy to get correct.

## Release Plan

The fact that the `flush + save` does not leave anything is I think significant and it should be inserted into the documentation.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
