### PR TITLE
Fix support for nested `enum`s in Witty

### DIFF
--- a/linera-witty/src/memory_layout/element.rs
+++ b/linera-witty/src/memory_layout/element.rs
@@ -59,26 +59,9 @@ where
 {
 }
 
-impl<R> LayoutElement for Either<(), R>
-where
-    R: LayoutElement,
-{
-    const ALIGNMENT: u32 = R::ALIGNMENT;
-    const IS_EMPTY: bool = R::IS_EMPTY;
-
-    type Flat = R::Flat;
-
-    fn flatten(self) -> Self::Flat {
-        match self {
-            Either::Left(()) => <R::Flat as Default>::default(),
-            Either::Right(value) => value.flatten(),
-        }
-    }
-}
-
 impl<L, R> LayoutElement for Either<L, R>
 where
-    L: SimpleType,
+    L: LayoutElement,
     R: LayoutElement,
     Either<L::Flat, R::Flat>: JoinFlatTypes,
 {

--- a/linera-witty/tests/common/types.rs
+++ b/linera-witty/tests/common/types.rs
@@ -58,3 +58,13 @@ pub struct SpecializedGenericStruct<A, B> {
     pub second: B,
     pub both: Vec<(A, B)>,
 }
+
+/// A generic enum with some specialized fields.
+#[derive(Clone, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
+#[witty_specialize_with(A = Option<bool>)]
+#[witty_specialize_with(B = u32)]
+pub enum SpecializedGenericEnum<A, B> {
+    None,
+    First(A),
+    MaybeSecond { maybe: Option<B> },
+}

--- a/linera-witty/tests/wit_store.rs
+++ b/linera-witty/tests/wit_store.rs
@@ -7,8 +7,8 @@
 mod types;
 
 use self::types::{
-    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericStruct,
-    TupleWithPadding, TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
+    SpecializedGenericStruct, TupleWithPadding, TupleWithoutPadding,
 };
 use linera_witty::{hlist, InstanceWithMemory, Layout, MockInstance, WitStore};
 use std::fmt::Debug;
@@ -251,6 +251,101 @@ fn test_specialized_generic_struct() {
         &data,
         hlist![0x0000_00c8_i32, -200_i32, 0x0000_0000_i32, 0x0000_0004_i32],
         &expected_heap,
+    );
+}
+
+/// Check that a generic enum with a specialization request type's variants are properly stored in
+/// memory and lowered into its flat layout.
+#[test]
+fn test_specialized_generic_enum_type() {
+    let data = SpecializedGenericEnum::None;
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ],
+        &[],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0000_0000_i32, 0x0000_0000_i32, 0x0000_0000_i32],
+        &[],
+    );
+
+    let data = SpecializedGenericEnum::First(None);
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ],
+        &[],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0000_0001_i32, 0x0000_0000_i32, 0x0000_0000_i32],
+        &[],
+    );
+
+    let data = SpecializedGenericEnum::First(Some(false));
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ],
+        &[],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0000_0001_i32, 0x0000_0001_i32, 0x0000_0000_i32],
+        &[],
+    );
+
+    let data = SpecializedGenericEnum::First(Some(true));
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x01, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ],
+        &[],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0000_0001_i32, 0x0000_0001_i32, 0x0000_0001_i32],
+        &[],
+    );
+
+    let data = SpecializedGenericEnum::MaybeSecond { maybe: None };
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ],
+        &[],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0000_0002_i32, 0x0000_0000_i32, 0x0000_0000_i32],
+        &[],
+    );
+
+    let data = SpecializedGenericEnum::MaybeSecond { maybe: Some(9) };
+
+    test_store_in_memory(
+        &data,
+        &[
+            0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00,
+        ],
+        &[],
+    );
+    test_lower_to_flat_layout(
+        &data,
+        hlist![0x0000_0002_i32, 0x0000_0001_i32, 0x0000_0009_i32],
+        &[],
     );
 }
 

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -7,8 +7,8 @@
 mod types;
 
 use self::types::{
-    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericStruct,
-    TupleWithPadding, TupleWithoutPadding,
+    Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
+    SpecializedGenericStruct, TupleWithPadding, TupleWithoutPadding,
 };
 use linera_witty::{HList, Layout, WitType};
 
@@ -88,5 +88,19 @@ fn test_specialized_generic_struct() {
     assert_eq!(
         <<SpecializedGenericStruct<u8, i16> as WitType>::Layout as Layout>::Flat::LEN,
         4
+    );
+}
+
+/// Check the memory size and layout derived for a specialized generic `enum` type.
+#[test]
+fn test_specialized_generic_enum_type() {
+    assert_eq!(SpecializedGenericEnum::SIZE, 12);
+    assert_eq!(
+        <SpecializedGenericEnum<Option<bool>, u32> as WitType>::Layout::ALIGNMENT,
+        4
+    );
+    assert_eq!(
+        <<SpecializedGenericEnum<Option<bool>, u32> as WitType>::Layout as Layout>::Flat::LEN,
+        3
     );
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Compilation fails with the derived Witty traits for `enum`s that have fields that are also `enum`s. This is caused by the flat layout having an incorrect assumption that variants always have a primitive type in the first option.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Remove the assumption, deriving `LayoutElement` without requiring the first choice to be a `PrimitiveType`.

## Test Plan

<!-- How to test that the changes are correct. -->
Adds a test that covers specialization of generic `enum`s with nested `enum` fields.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
