### PR TITLE
Remove total from message limit warning.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -340,8 +340,7 @@ where
         for message in requested_pending_messages {
             if pending_messages.len() >= self.max_pending_messages {
                 tracing::warn!(
-                    "Limiting block from {} to {} incoming messages",
-                    pending_messages.len(),
+                    "Limiting block to {} incoming messages",
                     self.max_pending_messages
                 );
                 break;


### PR DESCRIPTION
## Motivation

We always print

```
WARN linera_core::client: Limiting block from 10 to 10 incoming messages at the same time
```

even if there are more than 10 pending messages. Counting them would be inaccurate, or involve filtering redundant `RegisterApplications` messages from the messages we're not even including.

## Proposal

Remove the total from the warning.

## Test Plan

Only a log message changed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
