### PR TITLE
Support directly testing the existence of keys without downloading the key.

### DIFF
--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -60,6 +60,13 @@ impl KeyValueStore for AppStateStore {
         Ok(promise.wait())
     }
 
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+        ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
+        let promise = wit::ReadValueBytes::new(key);
+        yield_once().await;
+        Ok(promise.wait().is_some())
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -60,7 +60,7 @@ impl KeyValueStore for AppStateStore {
         Ok(promise.wait())
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
         ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
         let promise = wit::ReadValueBytes::new(key);
         yield_once().await;

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -61,10 +61,7 @@ impl KeyValueStore for AppStateStore {
     }
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
-        ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
-        let promise = wit::ReadValueBytes::new(key);
-        yield_once().await;
-        Ok(promise.wait().is_some())
+        Ok(self.read_value_bytes(key).await?.is_some())
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -283,6 +283,9 @@ pub trait KeyValueStore {
     /// Retrieves a `Vec<u8>` from the database using the provided `key`.
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
+    /// Test whether a key exists in the database
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error>;
+
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(
         &self,
@@ -436,6 +439,9 @@ pub trait Context {
     /// Retrieves a `Vec<u8>` from the database using the provided `key` prefixed by the current
     /// context.
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Test whether a key exists in the database
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(
@@ -626,6 +632,10 @@ where
 
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         log_time_async(self.store.read_value_bytes(key), "read_value_bytes").await
+    }
+
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+        log_time_async(self.store.test_existence_value(key), "test_existence_value").await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -284,7 +284,7 @@ pub trait KeyValueStore {
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Test whether a key exists in the database
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error>;
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(
@@ -441,7 +441,7 @@ pub trait Context {
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Test whether a key exists in the database
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error>;
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(
@@ -634,8 +634,8 @@ where
         log_time_async(self.store.read_value_bytes(key), "read_value_bytes").await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
-        log_time_async(self.store.test_existence_value(key), "test_existence_value").await
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
+        log_time_async(self.store.contains_key(key), "contains_key").await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -831,7 +831,7 @@ impl DynamoDbStoreInternal {
         }
     }
 
-    async fn test_existence_value_general(
+    async fn contains_key_general(
         &self,
         key_db: HashMap<String, AttributeValue>,
     ) -> Result<bool, DynamoDbContextError> {
@@ -1140,10 +1140,10 @@ impl KeyValueStore for DynamoDbStoreInternal {
         self.read_value_bytes_general(key_db).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, DynamoDbContextError> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, DynamoDbContextError> {
         ensure!(key.len() <= MAX_KEY_SIZE, DynamoDbContextError::KeyTooLong);
         let key_db = build_key(key.to_vec());
-        self.test_existence_value_general(key_db).await
+        self.contains_key_general(key_db).await
     }
 
     async fn read_multi_values_bytes(
@@ -1221,8 +1221,8 @@ impl KeyValueStore for DynamoDbStore {
         self.store.read_value_bytes(key).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, DynamoDbContextError> {
-        self.store.test_existence_value(key).await
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, DynamoDbContextError> {
+        self.store.contains_key(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -841,13 +841,11 @@ impl DynamoDbStoreInternal {
             .get_item()
             .table_name(self.table.as_ref())
             .set_key(Some(key_db))
+            .projection_expression(PARTITION_ATTRIBUTE)
             .send()
             .await?;
 
-        Ok(match response.item {
-            Some(_) => true,
-            None => false,
-        })
+        Ok(response.item.is_some())
     }
 
     async fn write_single_key_value(

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -538,9 +538,7 @@ where
     /// # })
     /// ```
     pub async fn get(&self, index: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
-        if index.len() > self.max_key_size() {
-            return Err(ViewError::KeyTooLong);
-        }
+        ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let value = match update {
                 Update::Removed => None,
@@ -574,9 +572,7 @@ where
     /// # })
     /// ```
     pub async fn test_existence(&self, index: &[u8]) -> Result<bool, ViewError> {
-        if index.len() > self.max_key_size() {
-            return Err(ViewError::KeyTooLong);
-        }
+        ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let test = match update {
                 Update::Removed => false,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -567,11 +567,11 @@ where
     /// # let context = create_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]).await.unwrap();
-    ///   assert!(view.test_existence(&[0,1]).await.unwrap());
-    ///   assert!(!view.test_existence(&[0,2]).await.unwrap());
+    ///   assert!(view.contains_key(&[0,1]).await.unwrap());
+    ///   assert!(!view.contains_key(&[0,2]).await.unwrap());
     /// # })
     /// ```
-    pub async fn test_existence(&self, index: &[u8]) -> Result<bool, ViewError> {
+    pub async fn contains_key(&self, index: &[u8]) -> Result<bool, ViewError> {
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let test = match update {
@@ -589,7 +589,7 @@ where
             return Ok(false);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
-        Ok(self.context.test_existence_value(&key).await?)
+        Ok(self.context.contains_key(&key).await?)
     }
 
     /// Obtains the values of a range of indices
@@ -1011,9 +1011,9 @@ where
         view.get(key).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, ViewError> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, ViewError> {
         let view = self.view.read().await;
-        view.test_existence(key).await
+        view.contains_key(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -558,7 +558,7 @@ where
         Ok(self.context.read_value_bytes(&key).await?)
     }
 
-    /// Obtains the value at the given index, if any.
+    /// Test whether a view contains a specific index.
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::create_memory_context;

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -128,10 +128,10 @@ where
         }
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
         match &self.lru_read_values {
             None => {
-                return self.client.test_existence_value(key).await;
+                return self.client.contains_key(key).await;
             }
             Some(lru_read_values) => {
                 // First inquiring in the read_value_bytes LRU
@@ -140,7 +140,7 @@ where
                     return Ok(value.is_some());
                 }
                 drop(lru_read_values_container);
-                self.client.test_existence_value(key).await
+                self.client.contains_key(key).await
             }
         }
     }

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -50,6 +50,11 @@ impl KeyValueStore for MemoryStore {
         Ok(map.get(key).cloned())
     }
 
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
+        let map = self.map.read().await;
+        Ok(map.get(key).is_some())
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -52,7 +52,7 @@ impl KeyValueStore for MemoryStore {
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
         let map = self.map.read().await;
-        Ok(map.get(key).is_some())
+        Ok(map.contains_key(key))
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -50,7 +50,7 @@ impl KeyValueStore for MemoryStore {
         Ok(map.get(key).cloned())
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
         let map = self.map.read().await;
         Ok(map.get(key).is_some())
     }

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -69,6 +69,11 @@ impl KeyValueStore for RocksDbStoreInternal {
         Ok(tokio::task::spawn_blocking(move || client.db.get(&key)).await??)
     }
 
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, RocksDbContextError> {
+        let value = self.read_value_bytes(key).await?;
+        Ok(value.is_some())
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -355,6 +360,10 @@ impl KeyValueStore for RocksDbStore {
 
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, RocksDbContextError> {
         self.store.read_value_bytes(key).await
+    }
+
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, RocksDbContextError> {
+        self.store.test_existence_value(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -69,7 +69,7 @@ impl KeyValueStore for RocksDbStoreInternal {
         Ok(tokio::task::spawn_blocking(move || client.db.get(&key)).await??)
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, RocksDbContextError> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, RocksDbContextError> {
         let value = self.read_value_bytes(key).await?;
         Ok(value.is_some())
     }
@@ -362,8 +362,8 @@ impl KeyValueStore for RocksDbStore {
         self.store.read_value_bytes(key).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, RocksDbContextError> {
-        self.store.test_existence_value(key).await
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, RocksDbContextError> {
+        self.store.contains_key(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -72,8 +72,12 @@ impl KeyValueStore for RocksDbStoreInternal {
     async fn contains_key(&self, key: &[u8]) -> Result<bool, RocksDbContextError> {
         ensure!(key.len() <= MAX_KEY_SIZE, RocksDbContextError::KeyTooLong);
         let client = self.clone();
-        let key = key.to_vec();
-        Ok(tokio::task::spawn_blocking(move || client.db.key_may_exist(&key)).await?)
+        let key_copy = key.to_vec();
+        let test = tokio::task::spawn_blocking(move || client.db.key_may_exist(&key_copy)).await?;
+        if !test {
+            return Ok(false);
+        }
+        Ok(self.read_value_bytes(&key).await?.is_some())
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -130,10 +130,10 @@ impl KeyValueStore for ScyllaDbStoreInternal {
         Self::read_value_internal(store, key.to_vec()).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
-        Self::test_existence_value_internal(store, key.to_vec()).await
+        Self::contains_key_internal(store, key.to_vec()).await
     }
 
     async fn read_multi_values_bytes(
@@ -215,7 +215,7 @@ impl ScyllaDbStoreInternal {
         Ok(None)
     }
 
-    async fn test_existence_value_internal(
+    async fn contains_key_internal(
         store: &ScyllaDbStorePair,
         key: Vec<u8>,
     ) -> Result<bool, ScyllaDbContextError> {
@@ -669,8 +669,8 @@ impl KeyValueStore for ScyllaDbStore {
         self.store.read_value_bytes(key).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
-        self.store.test_existence_value(key).await
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
+        self.store.contains_key(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -130,6 +130,12 @@ impl KeyValueStore for ScyllaDbStoreInternal {
         Self::read_value_internal(store, key.to_vec()).await
     }
 
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+        let store = self.store.deref();
+        let _guard = self.acquire().await;
+        Self::test_existence_value_internal(store, key.to_vec()).await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -207,6 +213,28 @@ impl ScyllaDbStoreInternal {
             }
         }
         Ok(None)
+    }
+
+    async fn test_existence_value_internal(
+        store: &ScyllaDbStorePair,
+        key: Vec<u8>,
+    ) -> Result<bool, ScyllaDbContextError> {
+        ensure!(key.len() <= MAX_KEY_SIZE, ScyllaDbContextError::KeyTooLong);
+        let session = &store.0;
+        let table_name = &store.1;
+        // Read the value of a key
+        let values = (key,);
+        let query = format!(
+            "SELECT dummy FROM kv.{} WHERE dummy = 0 AND k = ? ALLOW FILTERING",
+            table_name
+        );
+        let rows = session.query(query, values).await?;
+        if let Some(rows) = rows.rows {
+            if let Some(_row) = rows.into_typed::<(Vec<u8>,)>().next() {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     async fn write_batch_internal(
@@ -639,6 +667,10 @@ impl KeyValueStore for ScyllaDbStore {
 
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         self.store.read_value_bytes(key).await
+    }
+
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+        self.store.test_existence_value(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -87,10 +87,10 @@ where
         Ok(Some(big_value))
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
         let mut big_key = key.to_vec();
         big_key.extend(&[0, 0, 0, 0]);
-        self.store.test_existence_value(&big_key).await
+        self.store.contains_key(&big_key).await
     }
 
     async fn read_multi_values_bytes(
@@ -301,8 +301,8 @@ impl KeyValueStore for TestMemoryStoreInternal {
         self.store.read_value_bytes(key).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
-        self.store.test_existence_value(key).await
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
+        self.store.contains_key(key).await
     }
 
     async fn read_multi_values_bytes(
@@ -369,8 +369,8 @@ impl KeyValueStore for TestMemoryStore {
         self.store.read_value_bytes(key).await
     }
 
-    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
-        self.store.test_existence_value(key).await
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
+        self.store.contains_key(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -87,6 +87,12 @@ where
         Ok(Some(big_value))
     }
 
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, Self::Error> {
+        let mut big_key = key.to_vec();
+        big_key.extend(&[0, 0, 0, 0]);
+        self.store.test_existence_value(&big_key).await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -295,6 +301,10 @@ impl KeyValueStore for TestMemoryStoreInternal {
         self.store.read_value_bytes(key).await
     }
 
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
+        self.store.test_existence_value(key).await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -357,6 +367,10 @@ impl KeyValueStore for TestMemoryStore {
 
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryContextError> {
         self.store.read_value_bytes(key).await
+    }
+
+    async fn test_existence_value(&self, key: &[u8]) -> Result<bool, MemoryContextError> {
+        self.store.test_existence_value(key).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -102,7 +102,7 @@ async fn run_reads<S: KeyValueStore + Sync>(store: S, key_values: Vec<(Vec<u8>, 
         }
         let mut test_exists = Vec::new();
         for key in &keys {
-            test_exists.push(store.test_existence_value(key).await.unwrap());
+            test_exists.push(store.contains_key(key).await.unwrap());
         }
         let values_read = store.read_multi_values_bytes(keys).await.unwrap();
         assert_eq!(values, values_read);


### PR DESCRIPTION
## Motivation

Sometimes we want to test the existence of a key without downloading the full value.

## Proposal

The following was done:
* The `KeyValueStore` trait was extended appropriately.
* For `DynamoDb` and `ScyllaDb` some code directly using the facility of the database was coded. This was not possible for `RocksDb`.
* For `ValueSplitting` that was straightforward to do and immediately gain.
* For `LruCaching` we use the cache for the key/value but we could conceivably have added code for the caching of the test existence.
* For `AppStore` we have not yet coded the passing of those tests and instead use the read.
So, there is possibility of further PR depending on the outcome of the discussion here.

## Test Plan

The CI was extended appropriately.

## Release Plan

The manual might have to be changed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
