### PR TITLE
Box chain manager info fields

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -443,9 +443,10 @@ where
     /// multi-owner chain, we pick one identity for which we know the private key.
     pub async fn identity(&mut self) -> Result<Owner, ChainClientError> {
         let manager = self.chain_info().await?.manager;
-        if !manager.ownership.is_active() {
-            return Err(LocalNodeError::InactiveChain(self.chain_id).into());
-        }
+        ensure!(
+            manager.ownership.is_active(),
+            LocalNodeError::InactiveChain(self.chain_id)
+        );
         let mut identities = manager
             .ownership
             .owners
@@ -963,7 +964,7 @@ where
         // Now we should have a complete view of all committees in the system.
         let (committees, max_epoch) = self.known_committees().await?;
         // Proceed to downloading received certificates.
-        let trackers = self.received_certificate_trackers.clone();
+        let trackers = &self.received_certificate_trackers;
         let result = communicate_with_quorum(
             &nodes,
             &local_committee,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -477,7 +477,7 @@ where
         if let Some(proposal) = info.manager.requested_proposed {
             if proposal.content.block.chain_id == chain_id {
                 let owner = proposal.owner;
-                if let Err(error) = self.handle_block_proposal(proposal).await {
+                if let Err(error) = self.handle_block_proposal(*proposal).await {
                     tracing::warn!("Skipping proposal from {}: {}", owner, error);
                 }
             }
@@ -485,7 +485,7 @@ where
         if let Some(cert) = info.manager.requested_locked {
             if cert.value().is_validated() && cert.value().chain_id() == chain_id {
                 let hash = cert.hash();
-                if let Err(error) = self.handle_certificate(cert, vec![]).await {
+                if let Err(error) = self.handle_certificate(*cert, vec![]).await {
                     tracing::warn!("Skipping certificate {}: {}", hash, error);
                 }
             }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3546,7 +3546,10 @@ where
         .handle_chain_info_query(query_values.clone())
         .await
         .unwrap();
-    assert_eq!(response.info.manager.requested_locked, Some(certificate1));
+    assert_eq!(
+        response.info.manager.requested_locked,
+        Some(Box::new(certificate1))
+    );
 
     // Proposing block2 now would fail.
     let proposal = block2
@@ -3568,7 +3571,10 @@ where
         .handle_chain_info_query(query_values.clone())
         .await
         .unwrap();
-    assert_eq!(response.info.manager.requested_locked, Some(certificate2));
+    assert_eq!(
+        response.info.manager.requested_locked,
+        Some(Box::new(certificate2))
+    );
     let vote = response.info.manager.pending.as_ref().unwrap();
     assert_eq!(vote.value, lite_value2);
     assert_eq!(vote.round, Round::SingleLeader(5));
@@ -3613,7 +3619,10 @@ where
         .await
         .unwrap();
     let (response, _) = worker.handle_chain_info_query(query_values).await.unwrap();
-    assert_eq!(response.info.manager.requested_locked, Some(certificate));
+    assert_eq!(
+        response.info.manager.requested_locked,
+        Some(Box::new(certificate))
+    );
 }
 
 #[test(tokio::test)]


### PR DESCRIPTION
## Motivation

The `ChainManagerInfo` is large, and makes stack overflows more likely. Changes like https://github.com/linera-io/linera-protocol/pull/1305 trigger them in some scenarios.

~Also, some people were seeing compiler panics with Rust 1.73.0.~

## Proposal

Box some fields in `ChainManagerInfo` ~and upgrade Rust to version 1.74.0~.

## Test Plan

No logic was changed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
