### PR TITLE
Increased ingress connection timeouts

### DIFF
--- a/kubernetes/linera-validator/templates/ingress.yaml
+++ b/kubernetes/linera-validator/templates/ingress.yaml
@@ -23,4 +23,14 @@ metadata:
 spec:
   domains:
     - {{ .Values.validatorDomainName }}
+
+---
+
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: proxy-backend-config
+spec:
+  timeoutSec: 2147483647  # Maximum possible value
+
 {{- end }}

--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     cloud.google.com/app-protocols: '{"linera-port":"HTTP2"}'
+    cloud.google.com/backend-config: '{"default": "proxy-backend-config"}'
   name: proxy
   labels:
     app: proxy


### PR DESCRIPTION
## Motivation

The GKE Ingress was killing connections after the 30 second default. 

This meant that idle notification streams were being killed and had to be re-established.

## Proposal

Set the idle connection timeout to the largest possible value. 

This is a temporary measure. Longer term we may want to implement a health-check or heartbeat protocol to keep idle connection alive instead.