### PR TITLE
Add a ticker symbol to the fungible example.

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -428,10 +428,14 @@ impl Amm {
     async fn balance(&mut self, owner: &AccountOwner, token_idx: u32) -> Result<Amount, AmmError> {
         let balance = fungible::ApplicationCall::Balance { owner: *owner };
         let token = Self::fungible_id(token_idx).expect("failed to get the token");
-        Ok(self
+        match self
             .call_application(true, token, &balance, vec![])
             .await?
-            .0)
+            .0
+        {
+            fungible::FungibleResponse::Balance(balance) => Ok(balance),
+            response => Err(AmmError::UnexpectedFungibleResponse(response)),
+        }
     }
 
     async fn receive_from_account(

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -1,7 +1,7 @@
 use std::convert::Infallible;
 
 use async_graphql::{scalar, Request, Response};
-use fungible::AccountOwner;
+use fungible::{AccountOwner, FungibleResponse};
 use linera_sdk::{
     base::{Amount, ArithmeticError, ContractAbi, ServiceAbi},
     views::ViewError,
@@ -141,4 +141,8 @@ pub enum AmmError {
 
     #[error(transparent)]
     Infallible(#[from] Infallible),
+
+    /// Unexpected response from fungible token application.
+    #[error("Unexpected response from fungible token application: {0:?}")]
+    UnexpectedFungibleResponse(FungibleResponse),
 }

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -114,7 +114,8 @@ with 100 of them and another with 200 of them:
 ```bash
 APP_ID_0=$(linera --with-wallet 0 project publish-and-create \
            examples/fungible \
-           --json-argument '{ "accounts": { "User:'$OWNER_0'": "100", "User:'$OWNER_1'": "200" } }')
+           --json-argument '{ "accounts": { "User:'$OWNER_0'": "100", "User:'$OWNER_1'": "200" } }' \
+           --json-parameters "{ \"ticker_symbol\": \"FUN\" }")
 
 # Wait for it to fully complete
 sleep 8

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -120,7 +120,8 @@ with 100 of them and another with 200 of them:
 ```bash
 APP_ID_0=$(linera --with-wallet 0 project publish-and-create \
            examples/fungible \
-           --json-argument '{ "accounts": { "User:'$OWNER_0'": "100", "User:'$OWNER_1'": "200" } }')
+           --json-argument '{ "accounts": { "User:'$OWNER_0'": "100", "User:'$OWNER_1'": "200" } }' \
+           --json-parameters "{ \"ticker_symbol\": \"FUN\" }")
 
 # Wait for it to fully complete
 sleep 8

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -107,6 +107,7 @@ APP_ID=$(linera create-application $BYTECODE_ID \
     --json-argument "{ \"accounts\": {
         \"User:$OWNER_1\": \"100.\"
     } }" \
+    --json-parameters "{ \"ticker_symbol\": \"FUN\" }" \
 )
 ```
 

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -5,7 +5,9 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use fungible::{Account, AccountOwner, FungibleTokenAbi, InitialStateBuilder, Operation};
+use fungible::{
+    Account, AccountOwner, FungibleTokenAbi, InitialStateBuilder, Operation, Parameters,
+};
 use linera_sdk::{base::Amount, test::TestValidator};
 
 /// Test transferring tokens across microchains.
@@ -23,10 +25,11 @@ async fn test_cross_chain_transfer() {
     let sender_account = AccountOwner::from(sender_chain.public_key());
 
     let initial_state = InitialStateBuilder::default().with_account(sender_account, initial_amount);
+    let params = Parameters::new("FUN");
     let application_id = sender_chain
         .create_application::<fungible::FungibleTokenAbi>(
             bytecode_id,
-            (),
+            params,
             initial_state.build(),
             vec![],
         )

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -464,8 +464,9 @@ where
 
     let accounts = BTreeMap::from_iter([(sender_owner, Amount::from_tokens(1_000_000))]);
     let state = fungible::InitialState { accounts };
+    let params = fungible::Parameters::new("FUN");
     let (application_id, _cert) = sender
-        .create_application(bytecode_id, &(), &state, vec![])
+        .create_application(bytecode_id, &params, &state, vec![])
         .await?;
 
     // Make a transfer using the fungible app.

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -63,8 +63,9 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
     let state = InitialState {
         accounts: BTreeMap::new(),
     };
+    let params = fungible::Parameters::new("FUN");
     let application_id = client
-        .publish_and_create::<FungibleTokenAbi>(contract, service, &(), &state, &[], None)
+        .publish_and_create::<FungibleTokenAbi>(contract, service, &params, &state, &[], None)
         .await
         .unwrap();
 

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -365,8 +365,9 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
     let state = InitialState { accounts };
     // Setting up the application and verifying
     let (contract, service) = client1.build_example("fungible").await.unwrap();
+    let params = fungible::Parameters::new("FUN");
     let application_id = client1
-        .publish_and_create::<FungibleTokenAbi>(contract, service, &(), &state, &[], None)
+        .publish_and_create::<FungibleTokenAbi>(contract, service, &params, &state, &[], None)
         .await
         .unwrap();
 
@@ -483,8 +484,9 @@ async fn test_wasm_end_to_end_same_wallet_fungible(config: impl LineraNetConfig)
     let state = InitialState { accounts };
     // Setting up the application and verifying
     let (contract, service) = client1.build_example("fungible").await.unwrap();
+    let params = fungible::Parameters::new("FUN");
     let application_id = client1
-        .publish_and_create::<FungibleTokenAbi>(contract, service, &(), &state, &[], None)
+        .publish_and_create::<FungibleTokenAbi>(contract, service, &params, &state, &[], None)
         .await
         .unwrap();
 
@@ -562,11 +564,12 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
 
     // Setting up the application fungible
     let (contract_fungible, service_fungible) = client1.build_example("fungible").await.unwrap();
+    let params = fungible::Parameters::new("FUN");
     let application_id_fungible = client1
         .publish_and_create::<FungibleTokenAbi>(
             contract_fungible,
             service_fungible,
-            &(),
+            &params,
             &state_fungible,
             &[],
             None,
@@ -706,22 +709,24 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     };
 
     // Setting up the application fungible on chain_a and chain_b
+    let params0 = fungible::Parameters::new("ZERO");
     let token0 = client_a
         .publish_and_create::<FungibleTokenAbi>(
             contract_fungible_a,
             service_fungible_a,
-            &(),
+            &params0,
             &state_fungible0,
             &[],
             None,
         )
         .await
         .unwrap();
+    let params1 = fungible::Parameters::new("ONE");
     let token1 = client_b
         .publish_and_create::<FungibleTokenAbi>(
             contract_fungible_b,
             service_fungible_b,
-            &(),
+            &params1,
             &state_fungible1,
             &[],
             None,
@@ -989,21 +994,23 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
         .await
         .unwrap();
 
+    let params0 = fungible::Parameters::new("ZERO");
     let token0 = node_service_admin
         .create_application::<FungibleTokenAbi>(
             &chain_admin,
             &fungible_bytecode_id,
-            &(),
+            &params0,
             &state_fungible0,
             &[],
         )
         .await
         .unwrap();
+    let params1 = fungible::Parameters::new("ONE");
     let token1 = node_service_admin
         .create_application::<FungibleTokenAbi>(
             &chain_admin,
             &fungible_bytecode_id,
-            &(),
+            &params1,
             &state_fungible1,
             &[],
         )


### PR DESCRIPTION
## Motivation

It's difficult to recognize fungible tokens based on their application ID.

## Proposal

Add a "ticker symbol" parameter.

## Test Plan

The READMEs were updated, and I tried running them even with an added temporary assertion in the fungible `initialize` implementation. (No need to commit that assertion, because https://github.com/linera-io/linera-protocol/issues/1332 will do that for all apps.)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
