### PR TITLE
Fix panic on user application errors

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -216,8 +216,8 @@ where
                 contract.execute_message(context, runtime_sender, message)
             }
         });
-        let runtime_result = dbg!(runtime_actor.run().await);
-        let call_result = dbg!(call_result_future.await?);
+        let runtime_result = runtime_actor.run().await;
+        let call_result = call_result_future.await?;
 
         // TODO(#989): Make user errors fail blocks again.
         let mut result = match (runtime_result, call_result) {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -536,11 +536,13 @@ where
         let value_future = tokio::task::spawn_blocking(move || {
             code.handle_query(query_context, runtime_sender, argument)
         });
-        runtime_actor.run().await?;
-        let value = value_future.await??;
-
+        // TODO(#989): Simplify after message failures are not ignored.
+        let runtime_result = runtime_actor.run().await;
+        let value = value_future.await;
         self.applications_mut().pop();
-        Ok(value)
+
+        runtime_result?;
+        value?
     }
 }
 
@@ -683,10 +685,13 @@ where
                 forwarded_sessions,
             )
         });
-        runtime_actor.run().await?;
-        let raw_result = raw_result_future.await??;
-
+        // TODO(#989): Simplify after message failures are not ignored.
+        let runtime_result = runtime_actor.run().await;
+        let raw_result = raw_result_future.await;
         self.applications_mut().pop();
+        runtime_result?;
+        let raw_result = raw_result??;
+
         // Interpret the results of the call.
         self.execution_results_mut().push(ExecutionResult::User(
             callee_id,
@@ -749,10 +754,13 @@ where
                 forwarded_sessions,
             )
         });
-        runtime_actor.run().await?;
-        let (raw_result, session_state) = raw_result_future.await??;
-
+        // TODO(#989): Simplify after message failures are not ignored.
+        let runtime_result = runtime_actor.run().await;
+        let raw_result = raw_result_future.await;
         self.applications_mut().pop();
+        runtime_result?;
+        let (raw_result, session_state) = raw_result??;
+
         // Interpret the results of the call.
         if raw_result.close_session {
             // Terminate the session.

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -9,6 +9,7 @@ use self::utils::create_dummy_user_application_description;
 use linera_base::{
     crypto::PublicKey,
     data_types::BlockHeight,
+    ensure,
     identifiers::{ChainDescription, ChainId, Owner, SessionId},
 };
 use linera_execution::{
@@ -76,6 +77,7 @@ struct TestApplication {
 enum TestOperation {
     Completely,
     LeakingSession,
+    FailingCrossApplicationCall,
 }
 
 impl UserContract for TestApplication {
@@ -173,6 +175,10 @@ impl UserContract for TestApplication {
     ) -> Result<ApplicationCallResult, ExecutionError> {
         assert_eq!(argument.len(), 1);
         assert_eq!(context.authenticated_signer, Some(self.owner));
+        ensure!(
+            argument[0] != TestOperation::FailingCrossApplicationCall as u8,
+            ExecutionError::UserError("Cross-application call failed".to_owned())
+        );
         Ok(ApplicationCallResult {
             create_sessions: vec![vec![1]],
             ..ApplicationCallResult::default()
@@ -338,5 +344,65 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
         .await;
 
     assert!(matches!(result, Err(ExecutionError::SessionWasNotClosed)));
+    Ok(())
+}
+
+/// Tests if user application errors when handling cross-application calls are handled correctly.
+///
+/// Sends an operation to the [`TestApplication`] requesting it to fail a cross-application call.
+/// It is then forwarded to the reentrant call, where the cross-application call handler fails and
+/// the execution error should be handled correctly.
+#[tokio::test]
+async fn test_cross_application_error() -> anyhow::Result<()> {
+    let owner = Owner::from(PublicKey::debug(0));
+    let mut state = SystemExecutionState::default();
+    state.description = Some(ChainDescription::Root(0));
+    let mut view =
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
+            .await;
+    let app_desc = create_dummy_user_application_description();
+    let app_id = view
+        .system
+        .registry
+        .register_application(app_desc.clone())
+        .await?;
+    view.context()
+        .extra()
+        .user_contracts()
+        .insert(app_id, Arc::new(TestApplication { owner }));
+    view.context()
+        .extra()
+        .user_services()
+        .insert(app_id, Arc::new(TestApplication { owner }));
+
+    let context = OperationContext {
+        chain_id: ChainId::root(0),
+        height: BlockHeight(0),
+        index: 0,
+        authenticated_signer: Some(owner),
+        next_message_index: 0,
+    };
+    let mut tracker = ResourceTracker::default();
+    let policy = ResourceControlPolicy::default();
+    let result = view
+        .execute_operation(
+            context,
+            Operation::User {
+                application_id: app_id,
+                bytes: vec![TestOperation::FailingCrossApplicationCall as u8],
+            },
+            &policy,
+            &mut tracker,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        vec![ExecutionResult::User(
+            app_id,
+            RawExecutionResult::default().with_authenticated_signer(Some(owner))
+        ),]
+    );
+
     Ok(())
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -120,7 +120,7 @@ impl UserContract for TestApplication {
         let call_result = runtime_sender.try_call_application(
             /* authenticated */ true,
             app_id,
-            vec![],
+            operation.clone(),
             vec![],
         )?;
         assert_eq!(call_result.value, Vec::<u8>::new());
@@ -143,8 +143,9 @@ impl UserContract for TestApplication {
         &self,
         context: MessageContext,
         mut runtime_sender: ContractRuntimeSender,
-        _message: Vec<u8>,
+        message: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
+        assert_eq!(message.len(), 1);
         // Who we are.
         assert_eq!(context.authenticated_signer, Some(self.owner));
         let app_id = runtime_sender.application_id()?;
@@ -154,7 +155,7 @@ impl UserContract for TestApplication {
         runtime_sender.try_call_application(
             /* authenticated */ true,
             app_id,
-            vec![],
+            message,
             vec![],
         )?;
         runtime_sender.unlock()?;
@@ -167,9 +168,10 @@ impl UserContract for TestApplication {
         &self,
         context: CalleeContext,
         _runtime_sender: ContractRuntimeSender,
-        _argument: Vec<u8>,
+        argument: Vec<u8>,
         _forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, ExecutionError> {
+        assert_eq!(argument.len(), 1);
         assert_eq!(context.authenticated_signer, Some(self.owner));
         Ok(ApplicationCallResult {
             create_sessions: vec![vec![1]],


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
It's currently possible to cause a `panic` inside validator shards by returning custom errors from applications. This happens because an assertion is triggered due to a bug introduced recently. The bug happens because the runtime application call stack is not updated when ignoring user errors.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Always update the application call stack before checking for errors.

## Test Plan

<!-- How to test that the changes are correct. -->
A unit test was added for the scenario where an application returns a custom user error. Execution should finish successfully.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

Closes #1344