### PR TITLE
Create new runtime interface for the contract execution thread

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,9 +6,9 @@ use crate::{
     resources::{ResourceTracker, RuntimeLimits},
     runtime::{ApplicationStatus, ExecutionRuntime, SessionManager},
     system::SystemExecutionStateView,
-    ContractRuntime, ExecutionError, ExecutionResult, ExecutionRuntimeContext, Message,
-    MessageContext, Operation, OperationContext, Query, QueryContext, RawExecutionResult,
-    RawOutgoingMessage, Response, SystemMessage, UserApplicationDescription, UserApplicationId,
+    ExecutionError, ExecutionResult, ExecutionRuntimeContext, Message, MessageContext, Operation,
+    OperationContext, Query, QueryContext, RawExecutionResult, RawOutgoingMessage, Response,
+    SystemMessage, UserApplicationDescription, UserApplicationId,
 };
 use linera_base::{
     ensure,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -77,6 +77,10 @@ pub enum ExecutionError {
     WasmError(#[from] WasmExecutionError),
     #[error(transparent)]
     JoinError(#[from] tokio::task::JoinError),
+    #[error("Host future was polled after it had finished")]
+    PolledTwice,
+    #[error("Attempt to use a system API to write to read-only storage")]
+    WriteAttemptToReadOnlyStorage,
 
     #[error("A session is still opened at the end of a transaction")]
     SessionWasNotClosed,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -297,7 +297,7 @@ pub trait BaseRuntime: Send + Sync {
     fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError>;
 
     // TODO(#1152): remove
-    /// Reads the application state (new).
+    /// Reads the application state.
     fn try_read_my_state(&mut self) -> Result<Vec<u8>, ExecutionError> {
         let promise = self.try_read_my_state_new()?;
         self.try_read_my_state_wait(&promise)
@@ -368,7 +368,7 @@ pub trait BaseRuntime: Send + Sync {
         promise: &Self::FindKeysByPrefix,
     ) -> Result<Vec<Vec<u8>>, ExecutionError>;
 
-    /// Reads the data from the key/values having a specific prefix (wait).
+    /// Reads the data from the key/values having a specific prefix.
     #[cfg(feature = "test")]
     #[allow(clippy::type_complexity)]
     fn find_key_values_by_prefix(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -50,7 +50,6 @@ use linera_base::{
     identifiers::{BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner, SessionId},
 };
 use linera_views::{batch::Batch, views::ViewError};
-use resources::RuntimeCounts;
 use runtime_actor::{ContractRuntimeSender, ServiceRuntimeSender};
 use serde::{Deserialize, Serialize};
 use std::{io, path::Path, str::FromStr, sync::Arc};
@@ -274,55 +273,140 @@ pub struct QueryContext {
     pub chain_id: ChainId,
 }
 
-#[async_trait]
 pub trait BaseRuntime: Send + Sync {
+    type Read;
+    type Lock;
+    type Unlock;
+    type ReadValueBytes;
+    type FindKeysByPrefix;
+    type FindKeyValuesByPrefix;
+
     /// The current chain id.
-    fn chain_id(&self) -> ChainId;
+    fn chain_id(&mut self) -> Result<ChainId, ExecutionError>;
 
     /// The current application id.
-    fn application_id(&self) -> UserApplicationId;
+    fn application_id(&mut self) -> Result<UserApplicationId, ExecutionError>;
 
     /// The current application parameters.
-    fn application_parameters(&self) -> Vec<u8>;
+    fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError>;
 
     /// Reads the system balance.
-    fn read_system_balance(&self) -> Amount;
+    fn read_system_balance(&mut self) -> Result<Amount, ExecutionError>;
 
     /// Reads the system timestamp.
-    fn read_system_timestamp(&self) -> Timestamp;
+    fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError>;
 
-    /// Reads the application state.
-    async fn try_read_my_state(&self) -> Result<Vec<u8>, ExecutionError>;
+    // TODO(#1152): remove
+    /// Reads the application state (new).
+    fn try_read_my_state(&mut self) -> Result<Vec<u8>, ExecutionError> {
+        let promise = self.try_read_my_state_new()?;
+        self.try_read_my_state_wait(&promise)
+    }
+
+    // TODO(#1152): remove
+    /// Reads the application state (new).
+    fn try_read_my_state_new(&mut self) -> Result<Self::Read, ExecutionError>;
+
+    // TODO(#1152): remove
+    /// Reads the application state (wait).
+    fn try_read_my_state_wait(&mut self, promise: &Self::Read) -> Result<Vec<u8>, ExecutionError>;
 
     /// Locks the view user state and prevents further reading/loading
-    async fn lock_view_user_state(&self) -> Result<(), ExecutionError>;
+    #[cfg(feature = "test")]
+    fn lock(&mut self) -> Result<(), ExecutionError> {
+        let promise = self.lock_new()?;
+        self.lock_wait(&promise)
+    }
+
+    /// Locks the view user state and prevents further reading/loading (new)
+    fn lock_new(&mut self) -> Result<Self::Lock, ExecutionError>;
+
+    /// Locks the view user state and prevents further reading/loading (wait)
+    fn lock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError>;
 
     /// Unlocks the view user state and allows reading/loading again
-    async fn unlock_view_user_state(&self) -> Result<(), ExecutionError>;
+    #[cfg(feature = "test")]
+    fn unlock(&mut self) -> Result<(), ExecutionError> {
+        let promise = self.unlock_new()?;
+        self.unlock_wait(&promise)
+    }
 
-    /// Reads the key from the KV store
-    async fn read_value_bytes(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError>;
+    /// Unlocks the view user state and allows reading/loading again (new)
+    fn unlock_new(&mut self) -> Result<Self::Unlock, ExecutionError>;
 
-    /// Reads the data from the keys having a specific prefix.
-    async fn find_keys_by_prefix(
-        &self,
+    /// Unlocks the view user state and allows reading/loading again (wait)
+    fn unlock_wait(&mut self, promise: &Self::Unlock) -> Result<(), ExecutionError>;
+
+    /// Reads the key from the key-value store
+    #[cfg(feature = "test")]
+    fn read_value_bytes(&mut self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
+        let promise = self.read_value_bytes_new(key)?;
+        self.read_value_bytes_wait(&promise)
+    }
+
+    /// Reads the key from the key-value store (new)
+    fn read_value_bytes_new(
+        &mut self,
+        key: Vec<u8>,
+    ) -> Result<Self::ReadValueBytes, ExecutionError>;
+
+    /// Reads the key from the key-value store (wait)
+    fn read_value_bytes_wait(
+        &mut self,
+        promise: &Self::ReadValueBytes,
+    ) -> Result<Option<Vec<u8>>, ExecutionError>;
+
+    /// Reads the data from the keys having a specific prefix (new).
+    fn find_keys_by_prefix_new(
+        &mut self,
         key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeysByPrefix, ExecutionError>;
+
+    /// Reads the data from the keys having a specific prefix (wait).
+    fn find_keys_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeysByPrefix,
     ) -> Result<Vec<Vec<u8>>, ExecutionError>;
 
-    /// Reads the data from the key/values having a specific prefix.
-    async fn find_key_values_by_prefix(
-        &self,
+    /// Reads the data from the key/values having a specific prefix (wait).
+    #[cfg(feature = "test")]
+    #[allow(clippy::type_complexity)]
+    fn find_key_values_by_prefix(
+        &mut self,
         key_prefix: Vec<u8>,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
+        let promise = self.find_key_values_by_prefix_new(key_prefix)?;
+        self.find_key_values_by_prefix_wait(&promise)
+    }
+
+    /// Reads the data from the key/values having a specific prefix (new).
+    fn find_key_values_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError>;
+
+    /// Reads the data from the key/values having a specific prefix (wait).
+    #[allow(clippy::type_complexity)]
+    fn find_key_values_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeyValuesByPrefix,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError>;
 }
 
-#[async_trait]
 pub trait ServiceRuntime: BaseRuntime {
-    /// Queries another application.
-    async fn try_query_application(
-        &self,
+    type TryQueryApplication;
+
+    /// Queries another application (new).
+    fn try_query_application_new(
+        &mut self,
         queried_id: UserApplicationId,
         argument: Vec<u8>,
+    ) -> Result<Self::TryQueryApplication, ExecutionError>;
+
+    /// Queries another application (wait).
+    fn try_query_application_wait(
+        &mut self,
+        promise: &Self::TryQueryApplication,
     ) -> Result<Vec<u8>, ExecutionError>;
 }
 
@@ -334,33 +418,28 @@ pub struct CallResult {
     pub sessions: Vec<SessionId>,
 }
 
-#[async_trait]
 pub trait ContractRuntime: BaseRuntime {
     /// Returns the amount of execution fuel remaining before execution is aborted.
-    fn remaining_fuel(&self) -> u64;
-
-    /// Returns the remaining fuel as well as the storage related information on the state
-    fn runtime_counts(&self) -> RuntimeCounts;
+    fn remaining_fuel(&mut self) -> Result<u64, ExecutionError>;
 
     /// Sets the amount of execution fuel remaining before execution is aborted.
-    fn set_remaining_fuel(&self, remaining_fuel: u64);
+    fn set_remaining_fuel(&mut self, remaining_fuel: u64) -> Result<(), ExecutionError>;
 
+    // TODO(#1152): remove
     /// Reads the application state and prevents further reading/loading until the state is saved.
-    async fn try_read_and_lock_my_state(&self) -> Result<Vec<u8>, ExecutionError>;
+    fn try_read_and_lock_my_state(&mut self) -> Result<Option<Vec<u8>>, ExecutionError>;
 
+    // TODO(#1152): remove
     /// Saves the application state and allows reading/loading the state again.
-    fn save_and_unlock_my_state(&self, state: Vec<u8>) -> Result<(), ExecutionError>;
+    fn save_and_unlock_my_state(&mut self, state: Vec<u8>) -> Result<bool, ExecutionError>;
 
-    /// Allows reading/loading the state again (without saving anything).
-    fn unlock_my_state(&self);
-
-    /// Writes the batch and then unlock
-    async fn write_batch_and_unlock(&self, batch: Batch) -> Result<(), ExecutionError>;
+    /// Writes the batch and then unlock.
+    fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError>;
 
     /// Calls another application. Forwarded sessions will now be visible to
     /// `callee_id` (but not to the caller any more).
-    async fn try_call_application(
-        &self,
+    fn try_call_application(
+        &mut self,
         authenticated: bool,
         callee_id: UserApplicationId,
         argument: Vec<u8>,
@@ -369,8 +448,8 @@ pub trait ContractRuntime: BaseRuntime {
 
     /// Calls into a session that is in our scope. Forwarded sessions will be visible to
     /// the application that runs `session_id`.
-    async fn try_call_session(
-        &self,
+    fn try_call_session(
+        &mut self,
         authenticated: bool,
         session_id: SessionId,
         argument: Vec<u8>,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -228,7 +228,10 @@ where
     where
         Self: ContractRuntime,
     {
-        RuntimeActor::new(async_lock::RwLock::new(self))
+        let (sender, receiver) = futures::channel::mpsc::unbounded();
+        let actor = RuntimeActor::new(async_lock::RwLock::new(self), receiver);
+        let sender = ContractRuntimeSender::new(sender);
+        (actor, sender)
     }
 
     pub(crate) fn service_runtime_actor(
@@ -237,7 +240,10 @@ where
     where
         Self: ServiceRuntime,
     {
-        RuntimeActor::new(self)
+        let (sender, receiver) = futures::channel::mpsc::unbounded();
+        let actor = RuntimeActor::new(self, receiver);
+        let sender = ServiceRuntimeSender::new(sender);
+        (actor, sender)
     }
 
     fn forward_sessions(

--- a/linera-execution/src/runtime_actor/mod.rs
+++ b/linera-execution/src/runtime_actor/mod.rs
@@ -122,8 +122,9 @@ where
     }
 }
 
-/// Extension trait to help with receiving oneshot responses.
+/// Extension trait to help with receiving responses with a [`oneshot::Receiver`].
 pub trait ReceiverExt<T> {
+    /// Receives a response `T`, or returns an [`ExecutionError`] if the sender endpoint is closed.
     fn recv_response(self) -> Result<T, ExecutionError>;
 }
 

--- a/linera-execution/src/runtime_actor/mod.rs
+++ b/linera-execution/src/runtime_actor/mod.rs
@@ -28,19 +28,18 @@ pub struct RuntimeActor<Runtime, Request> {
     requests: mpsc::UnboundedReceiver<Request>,
 }
 
+impl<Runtime, Request> RuntimeActor<Runtime, Request> {
+    /// Creates a new [`RuntimeActor`] using the provided `Runtime` to handle `Request`s.
+    pub fn new(runtime: Runtime, requests: mpsc::UnboundedReceiver<Request>) -> Self {
+        Self { runtime, requests }
+    }
+}
+
 impl<Runtime, Request> RuntimeActor<Runtime, Request>
 where
     Runtime: RequestHandler<Request>,
     Request: std::fmt::Debug,
 {
-    /// Creates a new [`RuntimeActor`] using the provided `Runtime` to handle `Request`s.
-    ///
-    /// Returns the new [`RuntimeActor`] so that it can be executed later with the
-    /// [`RuntimeActor::run`] method and the endpoint to send `Request`s to the actor.
-    pub fn new(runtime: Runtime, requests: mpsc::UnboundedReceiver<Request>) -> Self {
-        Self { runtime, requests }
-    }
-
     /// Runs the [`RuntimeActor`], handling `Request`s until all the sender endpoints are closed.
     pub async fn run(self) -> Result<(), ExecutionError> {
         let runtime = self.runtime;

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -5,7 +5,7 @@ use crate::{
     runtime_actor::{
         BaseRequest, ContractRequest, ReceiverExt, ServiceRequest, UnboundedSenderExt,
     },
-    CallResult, ExecutionError,
+    BaseRuntime, CallResult, ContractRuntime, ExecutionError, ServiceRuntime,
 };
 use futures::channel::mpsc;
 use linera_base::{
@@ -14,15 +14,6 @@ use linera_base::{
 };
 use linera_views::batch::Batch;
 use std::sync::Mutex;
-
-pub type Load = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
-pub type Lock = Mutex<Option<oneshot::Receiver<()>>>;
-pub type Unlock = Mutex<Option<oneshot::Receiver<()>>>;
-pub type TryQueryApplication = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
-
-pub type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
-pub type FindKeys = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
-pub type FindKeyValues = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
 
 /// Wrapper around a sender to a runtime actor.
 pub struct RuntimeSender<Request> {
@@ -47,8 +38,15 @@ impl<Request> Clone for RuntimeSender<Request> {
     }
 }
 
-impl ContractRuntimeSender {
-    pub fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+impl BaseRuntime for ContractRuntimeSender {
+    type Read = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
+    type Lock = Mutex<Option<oneshot::Receiver<()>>>;
+    type Unlock = Mutex<Option<oneshot::Receiver<()>>>;
+    type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
+    type FindKeysByPrefix = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
+    type FindKeyValuesByPrefix = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
+
+    fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ChainId { response_sender })
@@ -56,7 +54,7 @@ impl ContractRuntimeSender {
             .recv_response()
     }
 
-    pub fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
+    fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
@@ -64,7 +62,7 @@ impl ContractRuntimeSender {
             .recv_response()
     }
 
-    pub fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
+    fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ApplicationParameters { response_sender })
@@ -72,7 +70,7 @@ impl ContractRuntimeSender {
             .recv_response()
     }
 
-    pub fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
+    fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
@@ -80,7 +78,7 @@ impl ContractRuntimeSender {
             .recv_response()
     }
 
-    pub fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
+    fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
@@ -88,47 +86,15 @@ impl ContractRuntimeSender {
             .recv_response()
     }
 
-    pub fn try_read_my_state(&mut self) -> Result<Vec<u8>, ExecutionError> {
-        self.inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::TryReadMyState { response_sender })
-            })?
-            .recv_response()
-    }
-
-    pub fn try_read_and_lock_my_state(&mut self) -> Result<Option<Vec<u8>>, ExecutionError> {
-        self.inner
-            .send_sync_request(|response_sender| ContractRequest::TryReadAndLockMyState {
-                response_sender,
-            })
-    }
-
-    pub fn save_and_unlock_my_state(&mut self, state: Vec<u8>) -> Result<bool, ExecutionError> {
-        self.inner
-            .send_sync_request(|response_sender| ContractRequest::SaveAndUnlockMyState {
-                state,
-                response_sender,
-            })
-    }
-
-    #[cfg(feature = "test")]
-    pub fn lock(&mut self) -> Result<(), ExecutionError> {
-        self.inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
-            })?
-            .recv_response()
-    }
-
-    pub fn lock_new(&mut self) -> Result<Lock, ExecutionError> {
-        Ok(std::sync::Mutex::new(Some(self.inner.send_request(
+    fn try_read_my_state_new(&mut self) -> Result<Self::Read, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
             |response_sender| {
-                ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
+                ContractRequest::Base(BaseRequest::TryReadMyState { response_sender })
             },
         )?)))
     }
 
-    pub fn lock_wait(&mut self, promise: &Lock) -> Result<(), ExecutionError> {
+    fn try_read_my_state_wait(&mut self, promise: &Self::Read) -> Result<Vec<u8>, ExecutionError> {
         let receiver = promise
             .try_lock()
             .expect("Unexpected reentrant locking of `oneshot::Receiver`")
@@ -137,7 +103,137 @@ impl ContractRuntimeSender {
         receiver.recv_response()
     }
 
-    pub fn try_call_application(
+    fn lock_new(&mut self) -> Result<Self::Lock, ExecutionError> {
+        Ok(std::sync::Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
+            },
+        )?)))
+    }
+
+    fn lock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    fn unlock_new(&mut self) -> Result<Self::Unlock, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
+            },
+        )?)))
+    }
+
+    fn unlock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    fn read_value_bytes_new(
+        &mut self,
+        key: Vec<u8>,
+    ) -> Result<Self::ReadValueBytes, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::ReadValueBytes {
+                    key,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    fn read_value_bytes_wait(
+        &mut self,
+        promise: &Self::ReadValueBytes,
+    ) -> Result<Option<Vec<u8>>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    fn find_keys_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeysByPrefix, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::FindKeysByPrefix {
+                    key_prefix,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    fn find_keys_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeysByPrefix,
+    ) -> Result<Vec<Vec<u8>>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    fn find_key_values_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::FindKeyValuesByPrefix {
+                    key_prefix,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn find_key_values_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeyValuesByPrefix,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+}
+
+impl ContractRuntime for ContractRuntimeSender {
+    fn try_read_and_lock_my_state(&mut self) -> Result<Option<Vec<u8>>, ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::TryReadAndLockMyState {
+                response_sender,
+            })
+    }
+
+    fn save_and_unlock_my_state(&mut self, state: Vec<u8>) -> Result<bool, ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::SaveAndUnlockMyState {
+                state,
+                response_sender,
+            })
+    }
+
+    fn try_call_application(
         &mut self,
         authenticated: bool,
         callee_id: ApplicationId,
@@ -154,7 +250,7 @@ impl ContractRuntimeSender {
             })
     }
 
-    pub fn try_call_session(
+    fn try_call_session(
         &mut self,
         authenticated: bool,
         session_id: SessionId,
@@ -171,89 +267,7 @@ impl ContractRuntimeSender {
             })
     }
 
-    #[cfg(feature = "test")]
-    pub fn read_value_bytes(&mut self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
-        self.inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::ReadValueBytes {
-                    key,
-                    response_sender,
-                })
-            })?
-            .recv_response()
-    }
-
-    pub fn read_value_bytes_new(&mut self, key: Vec<u8>) -> Result<ReadValueBytes, ExecutionError> {
-        Ok(Mutex::new(Some(self.inner.send_request(
-            |response_sender| {
-                ContractRequest::Base(BaseRequest::ReadValueBytes {
-                    key,
-                    response_sender,
-                })
-            },
-        )?)))
-    }
-
-    pub fn read_value_bytes_wait(
-        &mut self,
-        promise: &ReadValueBytes,
-    ) -> Result<Option<Vec<u8>>, ExecutionError> {
-        let receiver = promise
-            .try_lock()
-            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-            .take()
-            .ok_or_else(|| ExecutionError::PolledTwice)?;
-        receiver.recv_response()
-    }
-
-    pub fn find_keys_new(&mut self, key_prefix: Vec<u8>) -> Result<FindKeys, ExecutionError> {
-        Ok(Mutex::new(Some(self.inner.send_request(
-            |response_sender| {
-                ContractRequest::Base(BaseRequest::FindKeysByPrefix {
-                    key_prefix,
-                    response_sender,
-                })
-            },
-        )?)))
-    }
-
-    pub fn find_keys_wait(&mut self, promise: &FindKeys) -> Result<Vec<Vec<u8>>, ExecutionError> {
-        let receiver = promise
-            .try_lock()
-            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-            .take()
-            .ok_or_else(|| ExecutionError::PolledTwice)?;
-        receiver.recv_response()
-    }
-
-    pub fn find_key_values_new(
-        &mut self,
-        key_prefix: Vec<u8>,
-    ) -> Result<FindKeyValues, ExecutionError> {
-        Ok(Mutex::new(Some(self.inner.send_request(
-            |response_sender| {
-                ContractRequest::Base(BaseRequest::FindKeyValuesByPrefix {
-                    key_prefix,
-                    response_sender,
-                })
-            },
-        )?)))
-    }
-
-    #[allow(clippy::type_complexity)]
-    pub fn find_key_values_wait(
-        &mut self,
-        promise: &FindKeyValues,
-    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
-        let receiver = promise
-            .try_lock()
-            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-            .take()
-            .ok_or_else(|| ExecutionError::PolledTwice)?;
-        receiver.recv_response()
-    }
-
-    pub fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError> {
+    fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError> {
         self.inner
             .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
                 batch,
@@ -261,13 +275,13 @@ impl ContractRuntimeSender {
             })
     }
 
-    pub fn remaining_fuel(&mut self) -> Result<u64, ExecutionError> {
+    fn remaining_fuel(&mut self) -> Result<u64, ExecutionError> {
         self.inner
             .send_request(|response_sender| ContractRequest::RemainingFuel { response_sender })?
             .recv_response()
     }
 
-    pub fn set_remaining_fuel(&mut self, remaining_fuel: u64) -> Result<(), ExecutionError> {
+    fn set_remaining_fuel(&mut self, remaining_fuel: u64) -> Result<(), ExecutionError> {
         self.inner
             .send_sync_request(|response_sender| ContractRequest::SetRemainingFuel {
                 remaining_fuel,
@@ -276,8 +290,15 @@ impl ContractRuntimeSender {
     }
 }
 
-impl ServiceRuntimeSender {
-    pub fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+impl BaseRuntime for ServiceRuntimeSender {
+    type Read = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
+    type Lock = Mutex<Option<oneshot::Receiver<()>>>;
+    type Unlock = Mutex<Option<oneshot::Receiver<()>>>;
+    type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
+    type FindKeysByPrefix = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
+    type FindKeyValuesByPrefix = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
+
+    fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::ChainId { response_sender })
@@ -285,7 +306,7 @@ impl ServiceRuntimeSender {
             .recv_response()
     }
 
-    pub fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
+    fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::ApplicationId { response_sender })
@@ -293,7 +314,7 @@ impl ServiceRuntimeSender {
             .recv_response()
     }
 
-    pub fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
+    fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::ApplicationParameters { response_sender })
@@ -301,7 +322,7 @@ impl ServiceRuntimeSender {
             .recv_response()
     }
 
-    pub fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
+    fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
@@ -309,7 +330,7 @@ impl ServiceRuntimeSender {
             .recv_response()
     }
 
-    pub fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
+    fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
@@ -317,39 +338,31 @@ impl ServiceRuntimeSender {
             .recv_response()
     }
 
-    pub fn try_read_my_state_new(&mut self) -> Result<Load, ExecutionError> {
+    fn try_read_my_state_new(&mut self) -> Result<Self::Read, ExecutionError> {
         Ok(Mutex::new(Some(self.inner.send_request(
             |response_sender| ServiceRequest::Base(BaseRequest::TryReadMyState { response_sender }),
         )?)))
     }
 
-    pub fn try_read_my_state_wait(
-        &mut self,
-        promise: &Load,
-    ) -> Result<Result<Vec<u8>, String>, ExecutionError> {
+    fn try_read_my_state_wait(&mut self, promise: &Self::Read) -> Result<Vec<u8>, ExecutionError> {
         let receiver = promise
             .try_lock()
             .expect("Unexpected reentrant locking of `oneshot::Receiver`")
             .take()
             .ok_or_else(|| ExecutionError::PolledTwice)?;
-        receiver
-            .recv_response()
-            // TODO(#1153): remove
-            .map(Ok)
+        receiver.recv_response()
     }
 
     #[cfg(feature = "test")]
-    pub fn lock(&mut self) -> Result<Result<(), String>, ExecutionError> {
+    fn lock(&mut self) -> Result<(), ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
             })?
             .recv_response()
-            // TODO(#1153): remove
-            .map(Ok)
     }
 
-    pub fn lock_new(&mut self) -> Result<Lock, ExecutionError> {
+    fn lock_new(&mut self) -> Result<Self::Lock, ExecutionError> {
         Ok(Mutex::new(Some(self.inner.send_request(
             |response_sender| {
                 ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
@@ -357,20 +370,17 @@ impl ServiceRuntimeSender {
         )?)))
     }
 
-    pub fn lock_wait(&mut self, promise: &Lock) -> Result<Result<(), String>, ExecutionError> {
+    fn lock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError> {
         let receiver = promise
             .try_lock()
             .expect("Unexpected reentrant locking of `oneshot::Receiver`")
             .take()
             .ok_or_else(|| ExecutionError::PolledTwice)?;
-        receiver
-            .recv_response()
-            // TODO(#1153): remove
-            .map(Ok)
+        receiver.recv_response()
     }
 
     #[cfg(feature = "test")]
-    pub fn unlock(&mut self) -> Result<(), ExecutionError> {
+    fn unlock(&mut self) -> Result<(), ExecutionError> {
         self.inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
@@ -378,7 +388,7 @@ impl ServiceRuntimeSender {
             .recv_response()
     }
 
-    pub fn unlock_new(&mut self) -> Result<Unlock, ExecutionError> {
+    fn unlock_new(&mut self) -> Result<Self::Unlock, ExecutionError> {
         Ok(Mutex::new(Some(self.inner.send_request(
             |response_sender| {
                 ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
@@ -386,60 +396,19 @@ impl ServiceRuntimeSender {
         )?)))
     }
 
-    pub fn unlock_wait(&mut self, promise: &Lock) -> Result<Result<(), String>, ExecutionError> {
+    fn unlock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError> {
         let receiver = promise
             .try_lock()
             .expect("Unexpected reentrant locking of `oneshot::Receiver`")
             .take()
             .ok_or_else(|| ExecutionError::PolledTwice)?;
-        receiver
-            .recv_response()
-            // TODO(#1153): remove
-            .map(Ok)
+        receiver.recv_response()
     }
 
-    pub fn try_query_application_new(
+    fn read_value_bytes_new(
         &mut self,
-        queried_id: ApplicationId,
-        argument: Vec<u8>,
-    ) -> Result<TryQueryApplication, ExecutionError> {
-        Ok(Mutex::new(Some(self.inner.send_request(
-            move |response_sender| ServiceRequest::TryQueryApplication {
-                queried_id,
-                argument,
-                response_sender,
-            },
-        )?)))
-    }
-
-    pub fn try_query_application_wait(
-        &mut self,
-        promise: &TryQueryApplication,
-    ) -> Result<Result<Vec<u8>, String>, ExecutionError> {
-        let receiver = promise
-            .try_lock()
-            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-            .take()
-            .ok_or_else(|| ExecutionError::PolledTwice)?;
-        receiver
-            .recv_response()
-            // TODO(#1153): remove
-            .map(Ok)
-    }
-
-    #[cfg(feature = "test")]
-    pub fn read_value_bytes(&mut self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
-        self.inner
-            .send_request(|response_sender| {
-                ServiceRequest::Base(BaseRequest::ReadValueBytes {
-                    key,
-                    response_sender,
-                })
-            })?
-            .recv_response()
-    }
-
-    pub fn read_value_bytes_new(&mut self, key: Vec<u8>) -> Result<ReadValueBytes, ExecutionError> {
+        key: Vec<u8>,
+    ) -> Result<Self::ReadValueBytes, ExecutionError> {
         Ok(Mutex::new(Some(self.inner.send_request(
             |response_sender| {
                 ServiceRequest::Base(BaseRequest::ReadValueBytes {
@@ -450,9 +419,9 @@ impl ServiceRuntimeSender {
         )?)))
     }
 
-    pub fn read_value_bytes_wait(
+    fn read_value_bytes_wait(
         &mut self,
-        promise: &ReadValueBytes,
+        promise: &Self::ReadValueBytes,
     ) -> Result<Option<Vec<u8>>, ExecutionError> {
         let receiver = promise
             .try_lock()
@@ -462,7 +431,10 @@ impl ServiceRuntimeSender {
         receiver.recv_response()
     }
 
-    pub fn find_keys_new(&mut self, key_prefix: Vec<u8>) -> Result<FindKeys, ExecutionError> {
+    fn find_keys_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeysByPrefix, ExecutionError> {
         Ok(Mutex::new(Some(self.inner.send_request(
             |response_sender| {
                 ServiceRequest::Base(BaseRequest::FindKeysByPrefix {
@@ -473,7 +445,10 @@ impl ServiceRuntimeSender {
         )?)))
     }
 
-    pub fn find_keys_wait(&mut self, promise: &FindKeys) -> Result<Vec<Vec<u8>>, ExecutionError> {
+    fn find_keys_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeysByPrefix,
+    ) -> Result<Vec<Vec<u8>>, ExecutionError> {
         let receiver = promise
             .try_lock()
             .expect("Unexpected reentrant locking of `oneshot::Receiver`")
@@ -482,10 +457,10 @@ impl ServiceRuntimeSender {
         receiver.recv_response()
     }
 
-    pub fn find_key_values_new(
+    fn find_key_values_by_prefix_new(
         &mut self,
         key_prefix: Vec<u8>,
-    ) -> Result<FindKeyValues, ExecutionError> {
+    ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError> {
         Ok(Mutex::new(Some(self.inner.send_request(
             |response_sender| {
                 ServiceRequest::Base(BaseRequest::FindKeyValuesByPrefix {
@@ -497,9 +472,9 @@ impl ServiceRuntimeSender {
     }
 
     #[allow(clippy::type_complexity)]
-    pub fn find_key_values_wait(
+    fn find_key_values_by_prefix_wait(
         &mut self,
-        promise: &FindKeyValues,
+        promise: &Self::FindKeyValuesByPrefix,
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
         let receiver = promise
             .try_lock()
@@ -508,8 +483,34 @@ impl ServiceRuntimeSender {
             .ok_or_else(|| ExecutionError::PolledTwice)?;
         receiver.recv_response()
     }
+}
 
-    pub fn write_batch_and_unlock(&mut self, _batch: Batch) -> Result<(), ExecutionError> {
-        Err(ExecutionError::WriteAttemptToReadOnlyStorage)
+impl ServiceRuntime for ServiceRuntimeSender {
+    type TryQueryApplication = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
+
+    fn try_query_application_new(
+        &mut self,
+        queried_id: ApplicationId,
+        argument: Vec<u8>,
+    ) -> Result<Self::TryQueryApplication, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            move |response_sender| ServiceRequest::TryQueryApplication {
+                queried_id,
+                argument,
+                response_sender,
+            },
+        )?)))
+    }
+
+    fn try_query_application_wait(
+        &mut self,
+        promise: &Self::TryQueryApplication,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
     }
 }

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-
+/// Helper implementations to proxy requests through to [`RuntimeActor`][`super::RuntimeActor`]s.
 use crate::{
     runtime_actor::{
         BaseRequest, ContractRequest, ReceiverExt, ServiceRequest, UnboundedSenderExt,
@@ -128,7 +128,7 @@ impl BaseRuntime for ContractRuntimeSender {
         )?)))
     }
 
-    fn unlock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError> {
+    fn unlock_wait(&mut self, promise: &Self::Unlock) -> Result<(), ExecutionError> {
         let receiver = promise
             .try_lock()
             .expect("Unexpected reentrant locking of `oneshot::Receiver`")
@@ -396,7 +396,7 @@ impl BaseRuntime for ServiceRuntimeSender {
         )?)))
     }
 
-    fn unlock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError> {
+    fn unlock_wait(&mut self, promise: &Self::Unlock) -> Result<(), ExecutionError> {
         let receiver = promise
             .try_lock()
             .expect("Unexpected reentrant locking of `oneshot::Receiver`")

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Helper implementations to proxy requests through to [`RuntimeActor`][`super::RuntimeActor`]s.
+//! Helper implementations to proxy requests through to [`RuntimeActor`][`super::RuntimeActor`]s.
 
 use crate::{
     runtime_actor::{

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -261,13 +261,13 @@ impl ContractRuntimeSender {
             })
     }
 
-    pub fn remaining_fuel(&self) -> Result<u64, ExecutionError> {
+    pub fn remaining_fuel(&mut self) -> Result<u64, ExecutionError> {
         self.inner
             .send_request(|response_sender| ContractRequest::RemainingFuel { response_sender })?
             .recv_response()
     }
 
-    pub fn set_remaining_fuel(&self, remaining_fuel: u64) -> Result<(), ExecutionError> {
+    pub fn set_remaining_fuel(&mut self, remaining_fuel: u64) -> Result<(), ExecutionError> {
         self.inner
             .send_sync_request(|response_sender| ContractRequest::SetRemainingFuel {
                 remaining_fuel,

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
+
 /// Helper implementations to proxy requests through to [`RuntimeActor`][`super::RuntimeActor`]s.
+
 use crate::{
     runtime_actor::{
         BaseRequest, ContractRequest, ReceiverExt, ServiceRequest, UnboundedSenderExt,

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -1,31 +1,515 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::runtime_actor::{ContractRequest, ServiceRequest};
+use crate::{
+    runtime_actor::{
+        BaseRequest, ContractRequest, ReceiverExt, ServiceRequest, UnboundedSenderExt,
+    },
+    CallResult, ExecutionError,
+};
 use futures::channel::mpsc;
+use linera_base::{
+    data_types::{Amount, Timestamp},
+    identifiers::{ApplicationId, ChainId, SessionId},
+};
+use linera_views::batch::Batch;
+use std::sync::Mutex;
 
-/// Gives access to the contract system API.
-#[derive(Clone)]
-pub struct ContractRuntimeSender {
-    pub inner: mpsc::UnboundedSender<ContractRequest>,
+pub type Load = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
+pub type Lock = Mutex<Option<oneshot::Receiver<()>>>;
+pub type Unlock = Mutex<Option<oneshot::Receiver<()>>>;
+pub type TryQueryApplication = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
+
+pub type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
+pub type FindKeys = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
+pub type FindKeyValues = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
+
+/// Wrapper around a sender to a runtime actor.
+pub struct RuntimeSender<Request> {
+    inner: mpsc::UnboundedSender<Request>,
 }
 
-impl ContractRuntimeSender {
+pub type ContractRuntimeSender = RuntimeSender<ContractRequest>;
+pub type ServiceRuntimeSender = RuntimeSender<ServiceRequest>;
+
+impl<Request> RuntimeSender<Request> {
     /// Creates a new [`ContractRuntimeSender`] instance.
-    pub fn new(inner: mpsc::UnboundedSender<ContractRequest>) -> Self {
+    pub(crate) fn new(inner: mpsc::UnboundedSender<Request>) -> Self {
         Self { inner }
     }
 }
 
-/// Gives access to the service system API.
-#[derive(Clone)]
-pub struct ServiceRuntimeSender {
-    pub inner: mpsc::UnboundedSender<ServiceRequest>,
+impl<Request> Clone for RuntimeSender<Request> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl ContractRuntimeSender {
+    pub fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::ChainId { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::ApplicationParameters { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn try_read_my_state(&mut self) -> Result<Vec<u8>, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::TryReadMyState { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn try_read_and_lock_my_state(&mut self) -> Result<Option<Vec<u8>>, ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::TryReadAndLockMyState {
+                response_sender,
+            })
+    }
+
+    pub fn save_and_unlock_my_state(&mut self, state: Vec<u8>) -> Result<bool, ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::SaveAndUnlockMyState {
+                state,
+                response_sender,
+            })
+    }
+
+    #[cfg(feature = "test")]
+    pub fn lock(&mut self) -> Result<(), ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn lock_new(&mut self) -> Result<Lock, ExecutionError> {
+        Ok(std::sync::Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
+            },
+        )?)))
+    }
+
+    pub fn lock_wait(&mut self, promise: &Lock) -> Result<(), ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    pub fn try_call_application(
+        &mut self,
+        authenticated: bool,
+        callee_id: ApplicationId,
+        argument: Vec<u8>,
+        forwarded_sessions: Vec<SessionId>,
+    ) -> Result<CallResult, ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::TryCallApplication {
+                authenticated,
+                callee_id,
+                argument,
+                forwarded_sessions,
+                response_sender,
+            })
+    }
+
+    pub fn try_call_session(
+        &mut self,
+        authenticated: bool,
+        session_id: SessionId,
+        argument: Vec<u8>,
+        forwarded_sessions: Vec<SessionId>,
+    ) -> Result<CallResult, ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::TryCallSession {
+                authenticated,
+                session_id,
+                argument,
+                forwarded_sessions,
+                response_sender,
+            })
+    }
+
+    #[cfg(feature = "test")]
+    pub fn read_value_bytes(&mut self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ContractRequest::Base(BaseRequest::ReadValueBytes {
+                    key,
+                    response_sender,
+                })
+            })?
+            .recv_response()
+    }
+
+    pub fn read_value_bytes_new(&mut self, key: Vec<u8>) -> Result<ReadValueBytes, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::ReadValueBytes {
+                    key,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    pub fn read_value_bytes_wait(
+        &mut self,
+        promise: &ReadValueBytes,
+    ) -> Result<Option<Vec<u8>>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    pub fn find_keys_new(&mut self, key_prefix: Vec<u8>) -> Result<FindKeys, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::FindKeysByPrefix {
+                    key_prefix,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    pub fn find_keys_wait(&mut self, promise: &FindKeys) -> Result<Vec<Vec<u8>>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    pub fn find_key_values_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<FindKeyValues, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ContractRequest::Base(BaseRequest::FindKeyValuesByPrefix {
+                    key_prefix,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn find_key_values_wait(
+        &mut self,
+        promise: &FindKeyValues,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    pub fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
+                batch,
+                response_sender,
+            })
+    }
+
+    pub fn remaining_fuel(&self) -> Result<u64, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| ContractRequest::RemainingFuel { response_sender })?
+            .recv_response()
+    }
+
+    pub fn set_remaining_fuel(&self, remaining_fuel: u64) -> Result<(), ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::SetRemainingFuel {
+                remaining_fuel,
+                response_sender,
+            })
+    }
 }
 
 impl ServiceRuntimeSender {
-    /// Creates a new [`ServiceRuntimeSender`] instance.
-    pub fn new(inner: mpsc::UnboundedSender<ServiceRequest>) -> Self {
-        Self { inner }
+    pub fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::ChainId { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn application_id(&mut self) -> Result<ApplicationId, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::ApplicationId { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::ApplicationParameters { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn try_read_my_state_new(&mut self) -> Result<Load, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| ServiceRequest::Base(BaseRequest::TryReadMyState { response_sender }),
+        )?)))
+    }
+
+    pub fn try_read_my_state_wait(
+        &mut self,
+        promise: &Load,
+    ) -> Result<Result<Vec<u8>, String>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver
+            .recv_response()
+            // TODO(#1153): remove
+            .map(Ok)
+    }
+
+    #[cfg(feature = "test")]
+    pub fn lock(&mut self) -> Result<Result<(), String>, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
+            })?
+            .recv_response()
+            // TODO(#1153): remove
+            .map(Ok)
+    }
+
+    pub fn lock_new(&mut self) -> Result<Lock, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
+            },
+        )?)))
+    }
+
+    pub fn lock_wait(&mut self, promise: &Lock) -> Result<Result<(), String>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver
+            .recv_response()
+            // TODO(#1153): remove
+            .map(Ok)
+    }
+
+    #[cfg(feature = "test")]
+    pub fn unlock(&mut self) -> Result<(), ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
+            })?
+            .recv_response()
+    }
+
+    pub fn unlock_new(&mut self) -> Result<Unlock, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
+            },
+        )?)))
+    }
+
+    pub fn unlock_wait(&mut self, promise: &Lock) -> Result<Result<(), String>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver
+            .recv_response()
+            // TODO(#1153): remove
+            .map(Ok)
+    }
+
+    pub fn try_query_application_new(
+        &mut self,
+        queried_id: ApplicationId,
+        argument: Vec<u8>,
+    ) -> Result<TryQueryApplication, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            move |response_sender| ServiceRequest::TryQueryApplication {
+                queried_id,
+                argument,
+                response_sender,
+            },
+        )?)))
+    }
+
+    pub fn try_query_application_wait(
+        &mut self,
+        promise: &TryQueryApplication,
+    ) -> Result<Result<Vec<u8>, String>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver
+            .recv_response()
+            // TODO(#1153): remove
+            .map(Ok)
+    }
+
+    #[cfg(feature = "test")]
+    pub fn read_value_bytes(&mut self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
+        self.inner
+            .send_request(|response_sender| {
+                ServiceRequest::Base(BaseRequest::ReadValueBytes {
+                    key,
+                    response_sender,
+                })
+            })?
+            .recv_response()
+    }
+
+    pub fn read_value_bytes_new(&mut self, key: Vec<u8>) -> Result<ReadValueBytes, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ServiceRequest::Base(BaseRequest::ReadValueBytes {
+                    key,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    pub fn read_value_bytes_wait(
+        &mut self,
+        promise: &ReadValueBytes,
+    ) -> Result<Option<Vec<u8>>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    pub fn find_keys_new(&mut self, key_prefix: Vec<u8>) -> Result<FindKeys, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ServiceRequest::Base(BaseRequest::FindKeysByPrefix {
+                    key_prefix,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    pub fn find_keys_wait(&mut self, promise: &FindKeys) -> Result<Vec<Vec<u8>>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    pub fn find_key_values_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<FindKeyValues, ExecutionError> {
+        Ok(Mutex::new(Some(self.inner.send_request(
+            |response_sender| {
+                ServiceRequest::Base(BaseRequest::FindKeyValuesByPrefix {
+                    key_prefix,
+                    response_sender,
+                })
+            },
+        )?)))
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn find_key_values_wait(
+        &mut self,
+        promise: &FindKeyValues,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
+        let receiver = promise
+            .try_lock()
+            .expect("Unexpected reentrant locking of `oneshot::Receiver`")
+            .take()
+            .ok_or_else(|| ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    pub fn write_batch_and_unlock(&mut self, _batch: Batch) -> Result<(), ExecutionError> {
+        Err(ExecutionError::WriteAttemptToReadOnlyStorage)
     }
 }

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::runtime_actor::{ContractRequest, ServiceRequest};
+use futures::channel::mpsc;
+
+/// Gives access to the contract system API.
+#[derive(Clone)]
+pub struct ContractRuntimeSender {
+    pub inner: mpsc::UnboundedSender<ContractRequest>,
+}
+
+impl ContractRuntimeSender {
+    /// Creates a new [`ContractRuntimeSender`] instance.
+    pub fn new(inner: mpsc::UnboundedSender<ContractRequest>) -> Self {
+        Self { inner }
+    }
+}
+
+/// Gives access to the service system API.
+#[derive(Clone)]
+pub struct ServiceRuntimeSender {
+    pub inner: mpsc::UnboundedSender<ServiceRequest>,
+}
+
+impl ServiceRuntimeSender {
+    /// Creates a new [`ServiceRuntimeSender`] instance.
+    pub fn new(inner: mpsc::UnboundedSender<ServiceRequest>) -> Self {
+        Self { inner }
+    }
+}

--- a/linera-execution/src/runtime_actor/tests.rs
+++ b/linera-execution/src/runtime_actor/tests.rs
@@ -11,8 +11,8 @@ use std::mem;
 /// Test if sending a message to a dropped [`RuntimeActor`] doesn't cause a panic.
 #[test]
 fn test_sending_message_to_dropped_runtime_actor_doesnt_panic() {
-    let (actor, sender) = RuntimeActor::new(());
-
+    let (sender, receiver) = futures::channel::mpsc::unbounded();
+    let actor = RuntimeActor::new((), receiver);
     mem::drop(actor);
 
     assert!(matches!(

--- a/linera-execution/src/runtime_actor/tests.rs
+++ b/linera-execution/src/runtime_actor/tests.rs
@@ -3,7 +3,7 @@
 
 //! Unit tests for the [`RuntimeActor`].
 
-use super::{RequestHandler, RuntimeActor, SendRequestExt};
+use super::{RequestHandler, RuntimeActor, UnboundedSenderExt};
 use crate::ExecutionError;
 use async_trait::async_trait;
 use std::mem;

--- a/linera-execution/src/wasm/common.rs
+++ b/linera-execution/src/wasm/common.rs
@@ -108,16 +108,6 @@ where
 {
     /// Calls the guest Wasm module's implementation of
     /// [`UserApplication::initialize`][`linera_execution::UserApplication::initialize`].
-    ///
-    /// This method returns a [`Future`][`std::future::Future`], and is equivalent to
-    ///
-    /// ```ignore
-    /// pub async fn initialize(
-    ///     mut self,
-    ///     context: &OperationContext,
-    ///     argument: &[u8],
-    /// ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>
-    /// ```
     pub fn initialize(
         self,
         context: OperationContext,
@@ -130,16 +120,6 @@ where
 
     /// Calls the guest Wasm module's implementation of
     /// [`UserApplication::execute_operation`][`linera_execution::UserApplication::execute_operation`].
-    ///
-    /// This method returns a [`Future`][`std::future::Future`], and is equivalent to
-    ///
-    /// ```ignore
-    /// pub async fn execute_operation(
-    ///     mut self,
-    ///     context: &OperationContext,
-    ///     operation: &[u8],
-    /// ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>
-    /// ```
     pub fn execute_operation(
         self,
         context: OperationContext,
@@ -152,16 +132,6 @@ where
 
     /// Calls the guest Wasm module's implementation of
     /// [`UserApplication::execute_message`][`linera_execution::UserApplication::execute_message`].
-    ///
-    /// This method returns a [`Future`][`std::future::Future`], and is equivalent to
-    ///
-    /// ```ignore
-    /// pub async fn execute_message(
-    ///     mut self,
-    ///     context: &MessageContext,
-    ///     message: &[u8],
-    /// ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>
-    /// ```
     pub fn execute_message(
         self,
         context: MessageContext,
@@ -174,17 +144,6 @@ where
 
     /// Calls the guest Wasm module's implementation of
     /// [`UserApplication::handle_application_call`][`linera_execution::UserApplication::handle_application_call`].
-    ///
-    /// This method returns a [`Future`][`std::future::Future`], and is equivalent to
-    ///
-    /// ```ignore
-    /// pub async fn handle_application_call(
-    ///     mut self,
-    ///     context: &CalleeContext,
-    ///     argument: &[u8],
-    ///     forwarded_sessions: Vec<SessionId>,
-    /// ) -> Result<ApplicationCallResult, ExecutionError>
-    /// ```
     pub fn handle_application_call(
         self,
         context: CalleeContext,
@@ -198,17 +157,6 @@ where
 
     /// Calls the guest Wasm module's implementation of
     /// [`UserApplication::handle_session_call`][`linera_execution::UserApplication::handle_session_call`].
-    ///
-    /// This method returns a [`Future`][`std::future::Future`], and is equivalent to
-    ///
-    /// ```ignore
-    /// pub async fn handle_session_call(
-    ///     mut self,
-    ///     context: &CalleeContext,
-    ///     session_state: &[u8],
-    ///     argument: &[u8],
-    ///     forwarded_sessions: Vec<SessionId>,
-    /// ) -> Result<(SessionCallResult, Vec<u8>), ExecutionError>
     /// ```
     pub fn handle_session_call(
         self,
@@ -235,16 +183,6 @@ where
 {
     /// Calls the guest Wasm module's implementation of
     /// [`UserApplication::handle_query`][`linera_execution::UserApplication::handle_query`].
-    ///
-    /// This method returns a [`Future`][`std::future::Future`], and is equivalent to
-    ///
-    /// ```ignore
-    /// pub async fn handle_query(
-    ///     mut self,
-    ///     context: &QueryContext,
-    ///     argument: &[u8],
-    /// ) -> Result<Vec<u8>, ExecutionError>
-    /// ```
     pub fn handle_query(
         self,
         context: QueryContext,

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -143,12 +143,6 @@ pub enum WasmExecutionError {
     #[cfg(feature = "wasmtime")]
     #[error("Failed to execute Wasm module (Wasmtime)")]
     ExecuteModuleInWasmtime(#[from] ::wasmtime::Trap),
-    #[error("Attempt to use a system API to write to read-only storage")]
-    WriteAttemptToReadOnlyStorage,
-    #[error("Host future was polled after it had finished")]
-    PolledTwice,
-    #[error("Execution of guest future was aborted")]
-    Aborted,
 }
 
 impl UserContract for WasmContract {

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -16,7 +16,7 @@ macro_rules! impl_contract_system_api {
             }
 
             fn chain_id(&mut self) -> Result<contract_system_api::ChainId, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ContractRequest::Base(BaseRequest::ChainId { response_sender })
                     })?
@@ -28,7 +28,7 @@ macro_rules! impl_contract_system_api {
             fn application_id(
                 &mut self,
             ) -> Result<contract_system_api::ApplicationId, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
                     })?
@@ -38,7 +38,7 @@ macro_rules! impl_contract_system_api {
             }
 
             fn application_parameters(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ContractRequest::Base(BaseRequest::ApplicationParameters {
                             response_sender,
@@ -49,7 +49,7 @@ macro_rules! impl_contract_system_api {
             }
 
             fn read_system_balance(&mut self) -> Result<contract_system_api::Amount, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ContractRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
                     })?
@@ -61,7 +61,7 @@ macro_rules! impl_contract_system_api {
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<contract_system_api::Timestamp, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ContractRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
                     })?
@@ -71,7 +71,7 @@ macro_rules! impl_contract_system_api {
             }
 
             fn load(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ContractRequest::Base(BaseRequest::TryReadMyState { response_sender })
                     })?
@@ -80,7 +80,7 @@ macro_rules! impl_contract_system_api {
             }
 
             fn load_and_lock(&mut self) -> Result<Option<Vec<u8>>, Self::Error> {
-                self.runtime
+                self.inner
                     .send_sync_request(|response_sender| ContractRequest::TryReadAndLockMyState {
                         response_sender,
                     })
@@ -88,7 +88,7 @@ macro_rules! impl_contract_system_api {
             }
 
             fn store_and_unlock(&mut self, state: &[u8]) -> Result<bool, Self::Error> {
-                self.runtime
+                self.inner
                     .send_sync_request(|response_sender| ContractRequest::SaveAndUnlockMyState {
                         state: state.to_owned(),
                         response_sender,
@@ -97,7 +97,7 @@ macro_rules! impl_contract_system_api {
             }
 
             fn lock_new(&mut self) -> Result<Self::Lock, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
                     },
@@ -128,7 +128,7 @@ macro_rules! impl_contract_system_api {
                     .map(SessionId::from)
                     .collect();
 
-                self.runtime
+                self.inner
                     .send_sync_request(|response_sender| ContractRequest::TryCallApplication {
                         authenticated,
                         callee_id: application.into(),
@@ -153,7 +153,7 @@ macro_rules! impl_contract_system_api {
                     .map(SessionId::from)
                     .collect();
 
-                self.runtime
+                self.inner
                     .send_sync_request(|response_sender| ContractRequest::TryCallSession {
                         authenticated,
                         session_id: session.into(),
@@ -201,7 +201,7 @@ macro_rules! impl_service_system_api {
             }
 
             fn chain_id(&mut self) -> Result<service_system_api::ChainId, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ServiceRequest::Base(BaseRequest::ChainId { response_sender })
                     })?
@@ -211,7 +211,7 @@ macro_rules! impl_service_system_api {
             }
 
             fn application_id(&mut self) -> Result<service_system_api::ApplicationId, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ServiceRequest::Base(BaseRequest::ApplicationId { response_sender })
                     })?
@@ -221,7 +221,7 @@ macro_rules! impl_service_system_api {
             }
 
             fn application_parameters(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ServiceRequest::Base(BaseRequest::ApplicationParameters { response_sender })
                     })?
@@ -230,7 +230,7 @@ macro_rules! impl_service_system_api {
             }
 
             fn read_system_balance(&mut self) -> Result<service_system_api::Amount, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ServiceRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
                     })?
@@ -242,7 +242,7 @@ macro_rules! impl_service_system_api {
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<service_system_api::Timestamp, Self::Error> {
-                self.runtime
+                self.inner
                     .send_request(|response_sender| {
                         ServiceRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
                     })?
@@ -252,7 +252,7 @@ macro_rules! impl_service_system_api {
             }
 
             fn load_new(&mut self) -> Result<Self::Load, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ServiceRequest::Base(BaseRequest::TryReadMyState { response_sender })
                     },
@@ -275,7 +275,7 @@ macro_rules! impl_service_system_api {
             }
 
             fn lock_new(&mut self) -> Result<Self::Lock, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
                     },
@@ -298,7 +298,7 @@ macro_rules! impl_service_system_api {
             }
 
             fn unlock_new(&mut self) -> Result<Self::Unlock, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
                     },
@@ -327,7 +327,7 @@ macro_rules! impl_service_system_api {
             ) -> Result<Self::TryQueryApplication, Self::Error> {
                 let argument = Vec::from(argument);
 
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| ServiceRequest::TryQueryApplication {
                         queried_id: application.into(),
                         argument: argument.to_owned(),
@@ -391,7 +391,7 @@ macro_rules! impl_view_system_api_for_service {
                 &mut self,
                 key: &[u8],
             ) -> Result<Self::ReadValueBytes, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ServiceRequest::Base(BaseRequest::ReadValueBytes {
                             key: key.to_owned(),
@@ -416,7 +416,7 @@ macro_rules! impl_view_system_api_for_service {
             }
 
             fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ServiceRequest::Base(BaseRequest::FindKeysByPrefix {
                             key_prefix: key_prefix.to_owned(),
@@ -444,7 +444,7 @@ macro_rules! impl_view_system_api_for_service {
                 &mut self,
                 key_prefix: &[u8],
             ) -> Result<Self::FindKeyValues, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ServiceRequest::Base(BaseRequest::FindKeyValuesByPrefix {
                             key_prefix: key_prefix.to_owned(),
@@ -499,7 +499,7 @@ macro_rules! impl_view_system_api_for_contract {
                 &mut self,
                 key: &[u8],
             ) -> Result<Self::ReadValueBytes, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ContractRequest::Base(BaseRequest::ReadValueBytes {
                             key: key.to_owned(),
@@ -524,7 +524,7 @@ macro_rules! impl_view_system_api_for_contract {
             }
 
             fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ContractRequest::Base(BaseRequest::FindKeysByPrefix {
                             key_prefix: key_prefix.to_owned(),
@@ -552,7 +552,7 @@ macro_rules! impl_view_system_api_for_contract {
                 &mut self,
                 key_prefix: &[u8],
             ) -> Result<Self::FindKeyValues, Self::Error> {
-                Ok(Mutex::new(Some(self.runtime.send_request(
+                Ok(Mutex::new(Some(self.inner.send_request(
                     |response_sender| {
                         ContractRequest::Base(BaseRequest::FindKeyValuesByPrefix {
                             key_prefix: key_prefix.to_owned(),
@@ -594,7 +594,7 @@ macro_rules! impl_view_system_api_for_contract {
                         }
                     }
                 }
-                self.runtime
+                self.inner
                     .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
                         batch,
                         response_sender,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -9,110 +9,59 @@ macro_rules! impl_contract_system_api {
         impl contract_system_api::ContractSystemApi for $contract_system_api {
             type Error = ExecutionError;
 
-            type Lock = Mutex<Option<oneshot::Receiver<()>>>;
+            type Lock = crate::runtime_actor::senders::Lock;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
             }
 
             fn chain_id(&mut self) -> Result<contract_system_api::ChainId, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ContractRequest::Base(BaseRequest::ChainId { response_sender })
-                    })?
-                    .recv()
-                    .map(|chain_id| chain_id.into())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.chain_id().map(|chain_id| chain_id.into())
             }
 
             fn application_id(
                 &mut self,
             ) -> Result<contract_system_api::ApplicationId, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
-                    })?
-                    .recv()
+                self.application_id()
                     .map(|application_id| application_id.into())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
             }
 
             fn application_parameters(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ContractRequest::Base(BaseRequest::ApplicationParameters {
-                            response_sender,
-                        })
-                    })?
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.application_parameters()
             }
 
             fn read_system_balance(&mut self) -> Result<contract_system_api::Amount, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ContractRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
-                    })?
-                    .recv()
-                    .map(|balance| balance.into())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.read_system_balance().map(|balance| balance.into())
             }
 
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<contract_system_api::Timestamp, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ContractRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
-                    })?
-                    .recv()
+                self.read_system_timestamp()
                     .map(|timestamp| timestamp.micros())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
             }
 
+            // TODO(#1152): the wit name is wrong
             fn load(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ContractRequest::Base(BaseRequest::TryReadMyState { response_sender })
-                    })?
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.try_read_my_state()
             }
 
+            // TODO(#1152): the wit name is wrong
             fn load_and_lock(&mut self) -> Result<Option<Vec<u8>>, Self::Error> {
-                self.inner
-                    .send_sync_request(|response_sender| ContractRequest::TryReadAndLockMyState {
-                        response_sender,
-                    })
-                    .map_err(|error| error.into())
+                self.try_read_and_lock_my_state()
             }
 
+            // TODO(#1152): the wit name is wrong
             fn store_and_unlock(&mut self, state: &[u8]) -> Result<bool, Self::Error> {
-                self.inner
-                    .send_sync_request(|response_sender| ContractRequest::SaveAndUnlockMyState {
-                        state: state.to_owned(),
-                        response_sender,
-                    })
-                    .map_err(|error| error.into())
+                self.save_and_unlock_my_state(state.to_vec())
             }
 
             fn lock_new(&mut self) -> Result<Self::Lock, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
-                    },
-                )?)))
+                self.lock_new()
             }
 
             fn lock_wait(&mut self, promise: &Self::Lock) -> Result<(), Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.lock_wait(promise)
             }
 
             fn try_call_application(
@@ -128,16 +77,13 @@ macro_rules! impl_contract_system_api {
                     .map(SessionId::from)
                     .collect();
 
-                self.inner
-                    .send_sync_request(|response_sender| ContractRequest::TryCallApplication {
-                        authenticated,
-                        callee_id: application.into(),
-                        argument: argument.to_owned(),
-                        forwarded_sessions,
-                        response_sender,
-                    })
-                    .map(|call_result| call_result.into())
-                    .map_err(|error| error.into())
+                self.try_call_application(
+                    authenticated,
+                    application.into(),
+                    argument.to_vec(),
+                    forwarded_sessions,
+                )
+                .map(|call_result| call_result.into())
             }
 
             fn try_call_session(
@@ -153,16 +99,13 @@ macro_rules! impl_contract_system_api {
                     .map(SessionId::from)
                     .collect();
 
-                self.inner
-                    .send_sync_request(|response_sender| ContractRequest::TryCallSession {
-                        authenticated,
-                        session_id: session.into(),
-                        argument: argument.to_owned(),
-                        forwarded_sessions,
-                        response_sender,
-                    })
-                    .map(|call_result| call_result.into())
-                    .map_err(|error| error.into())
+                self.try_call_session(
+                    authenticated,
+                    session.into(),
+                    argument.to_vec(),
+                    forwarded_sessions,
+                )
+                .map(|call_result| call_result.into())
             }
 
             fn log(
@@ -191,133 +134,72 @@ macro_rules! impl_service_system_api {
         impl service_system_api::ServiceSystemApi for $service_system_api {
             type Error = ExecutionError;
 
-            type Load = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
-            type Lock = Mutex<Option<oneshot::Receiver<()>>>;
-            type Unlock = Mutex<Option<oneshot::Receiver<()>>>;
-            type TryQueryApplication = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
+            type Load = crate::runtime_actor::senders::Load;
+            type Lock = crate::runtime_actor::senders::Lock;
+            type Unlock = crate::runtime_actor::senders::Unlock;
+            type TryQueryApplication = crate::runtime_actor::senders::TryQueryApplication;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
             }
 
             fn chain_id(&mut self) -> Result<service_system_api::ChainId, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ServiceRequest::Base(BaseRequest::ChainId { response_sender })
-                    })?
-                    .recv()
-                    .map(|chain_id| chain_id.into())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.chain_id().map(|chain_id| chain_id.into())
             }
 
             fn application_id(&mut self) -> Result<service_system_api::ApplicationId, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ServiceRequest::Base(BaseRequest::ApplicationId { response_sender })
-                    })?
-                    .recv()
+                self.application_id()
                     .map(|application_id| application_id.into())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
             }
 
             fn application_parameters(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ServiceRequest::Base(BaseRequest::ApplicationParameters { response_sender })
-                    })?
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.application_parameters()
             }
 
             fn read_system_balance(&mut self) -> Result<service_system_api::Amount, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ServiceRequest::Base(BaseRequest::ReadSystemBalance { response_sender })
-                    })?
-                    .recv()
-                    .map(|balance| balance.into())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.read_system_balance().map(|balance| balance.into())
             }
 
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<service_system_api::Timestamp, Self::Error> {
-                self.inner
-                    .send_request(|response_sender| {
-                        ServiceRequest::Base(BaseRequest::ReadSystemTimestamp { response_sender })
-                    })?
-                    .recv()
+                self.read_system_timestamp()
                     .map(|timestamp| timestamp.micros())
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
             }
 
+            // TODO(#1152): the wit name is wrong
             fn load_new(&mut self) -> Result<Self::Load, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ServiceRequest::Base(BaseRequest::TryReadMyState { response_sender })
-                    },
-                )?)))
+                self.try_read_my_state_new()
             }
 
+            // TODO(#1152): the wit name is wrong
             fn load_wait(
                 &mut self,
                 promise: &Self::Load,
             ) -> Result<Result<Vec<u8>, String>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map(Ok)
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.try_read_my_state_wait(promise)
             }
 
             fn lock_new(&mut self) -> Result<Self::Lock, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
-                    },
-                )?)))
+                self.lock_new()
             }
 
             fn lock_wait(
                 &mut self,
                 promise: &Self::Lock,
             ) -> Result<Result<(), String>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map(Ok)
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.lock_wait(promise)
             }
 
             fn unlock_new(&mut self) -> Result<Self::Unlock, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
-                    },
-                )?)))
+                self.unlock_new()
             }
 
             fn unlock_wait(
                 &mut self,
                 promise: &Self::Lock,
             ) -> Result<Result<(), String>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map(Ok)
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.unlock_wait(promise)
             }
 
             fn try_query_application_new(
@@ -325,30 +207,14 @@ macro_rules! impl_service_system_api {
                 application: service_system_api::ApplicationId,
                 argument: &[u8],
             ) -> Result<Self::TryQueryApplication, Self::Error> {
-                let argument = Vec::from(argument);
-
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| ServiceRequest::TryQueryApplication {
-                        queried_id: application.into(),
-                        argument: argument.to_owned(),
-                        response_sender,
-                    },
-                )?)))
+                self.try_query_application_new(application.into(), argument.to_vec())
             }
 
             fn try_query_application_wait(
                 &mut self,
                 promise: &Self::TryQueryApplication,
             ) -> Result<Result<Vec<u8>, String>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map(Ok)
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.try_query_application_wait(promise)
             }
 
             fn log(
@@ -379,9 +245,9 @@ macro_rules! impl_view_system_api_for_service {
         impl view_system_api::ViewSystemApi for $view_system_api {
             type Error = ExecutionError;
 
-            type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
-            type FindKeys = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
-            type FindKeyValues = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
+            type ReadValueBytes = crate::runtime_actor::senders::ReadValueBytes;
+            type FindKeys = crate::runtime_actor::senders::FindKeys;
+            type FindKeyValues = crate::runtime_actor::senders::FindKeyValues;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
@@ -391,88 +257,47 @@ macro_rules! impl_view_system_api_for_service {
                 &mut self,
                 key: &[u8],
             ) -> Result<Self::ReadValueBytes, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ServiceRequest::Base(BaseRequest::ReadValueBytes {
-                            key: key.to_owned(),
-                            response_sender,
-                        })
-                    },
-                )?)))
+                self.read_value_bytes_new(key.to_vec())
             }
 
             fn read_value_bytes_wait(
                 &mut self,
                 promise: &Self::ReadValueBytes,
             ) -> Result<Option<Vec<u8>>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.read_value_bytes_wait(promise)
             }
 
             fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ServiceRequest::Base(BaseRequest::FindKeysByPrefix {
-                            key_prefix: key_prefix.to_owned(),
-                            response_sender,
-                        })
-                    },
-                )?)))
+                self.find_keys_new(key_prefix.to_vec())
             }
 
             fn find_keys_wait(
                 &mut self,
                 promise: &Self::FindKeys,
             ) -> Result<Vec<Vec<u8>>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.find_keys_wait(promise)
             }
 
             fn find_key_values_new(
                 &mut self,
                 key_prefix: &[u8],
             ) -> Result<Self::FindKeyValues, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ServiceRequest::Base(BaseRequest::FindKeyValuesByPrefix {
-                            key_prefix: key_prefix.to_owned(),
-                            response_sender,
-                        })
-                    },
-                )?)))
+                self.find_key_values_new(key_prefix.to_vec())
             }
 
             fn find_key_values_wait(
                 &mut self,
                 promise: &Self::FindKeyValues,
             ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.find_key_values_wait(promise)
             }
 
             fn write_batch(
                 &mut self,
-                _list_oper: Vec<view_system_api::WriteOperation>,
+                _operations: Vec<view_system_api::WriteOperation>,
             ) -> Result<(), Self::Error> {
-                Err(WasmExecutionError::WriteAttemptToReadOnlyStorage.into())
+                // Not calling the runtime to save time.
+                Err(ExecutionError::WriteAttemptToReadOnlyStorage)
             }
         }
     };
@@ -487,9 +312,9 @@ macro_rules! impl_view_system_api_for_contract {
         impl view_system_api::ViewSystemApi for $view_system_api {
             type Error = ExecutionError;
 
-            type ReadValueBytes = Mutex<Option<oneshot::Receiver<Option<Vec<u8>>>>>;
-            type FindKeys = Mutex<Option<oneshot::Receiver<Vec<Vec<u8>>>>>;
-            type FindKeyValues = Mutex<Option<oneshot::Receiver<Vec<(Vec<u8>, Vec<u8>)>>>>;
+            type ReadValueBytes = crate::runtime_actor::senders::ReadValueBytes;
+            type FindKeys = crate::runtime_actor::senders::FindKeys;
+            type FindKeyValues = crate::runtime_actor::senders::FindKeyValues;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
@@ -499,107 +324,61 @@ macro_rules! impl_view_system_api_for_contract {
                 &mut self,
                 key: &[u8],
             ) -> Result<Self::ReadValueBytes, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ContractRequest::Base(BaseRequest::ReadValueBytes {
-                            key: key.to_owned(),
-                            response_sender,
-                        })
-                    },
-                )?)))
+                self.read_value_bytes_new(key.to_vec())
             }
 
             fn read_value_bytes_wait(
                 &mut self,
                 promise: &Self::ReadValueBytes,
             ) -> Result<Option<Vec<u8>>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.read_value_bytes_wait(promise)
             }
 
             fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ContractRequest::Base(BaseRequest::FindKeysByPrefix {
-                            key_prefix: key_prefix.to_owned(),
-                            response_sender,
-                        })
-                    },
-                )?)))
+                self.find_keys_new(key_prefix.to_vec())
             }
 
             fn find_keys_wait(
                 &mut self,
                 promise: &Self::FindKeys,
             ) -> Result<Vec<Vec<u8>>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.find_keys_wait(promise)
             }
 
             fn find_key_values_new(
                 &mut self,
                 key_prefix: &[u8],
             ) -> Result<Self::FindKeyValues, Self::Error> {
-                Ok(Mutex::new(Some(self.inner.send_request(
-                    |response_sender| {
-                        ContractRequest::Base(BaseRequest::FindKeyValuesByPrefix {
-                            key_prefix: key_prefix.to_owned(),
-                            response_sender,
-                        })
-                    },
-                )?)))
+                self.find_key_values_new(key_prefix.to_vec())
             }
 
             fn find_key_values_wait(
                 &mut self,
                 promise: &Self::FindKeyValues,
             ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
-                let receiver = promise
-                    .try_lock()
-                    .expect("Unexpected reentrant locking of `oneshot::Receiver`")
-                    .take()
-                    .ok_or_else(|| WasmExecutionError::PolledTwice)?;
-                receiver
-                    .recv()
-                    .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)
+                self.find_key_values_wait(promise)
             }
 
+            // TODO: the wit name is wrong
             fn write_batch(
                 &mut self,
-                list_oper: Vec<view_system_api::WriteOperation>,
+                operations: Vec<view_system_api::WriteOperation>,
             ) -> Result<(), Self::Error> {
                 let mut batch = Batch::new();
-                for x in list_oper {
-                    match x {
+                for operation in operations {
+                    match operation {
                         view_system_api::WriteOperation::Delete(key) => {
                             batch.delete_key(key.to_vec())
                         }
                         view_system_api::WriteOperation::Deleteprefix(key_prefix) => {
                             batch.delete_key_prefix(key_prefix.to_vec())
                         }
-                        view_system_api::WriteOperation::Put(key_value) => {
-                            batch.put_key_value_bytes(key_value.0.to_vec(), key_value.1.to_vec())
+                        view_system_api::WriteOperation::Put((key, value)) => {
+                            batch.put_key_value_bytes(key.to_vec(), value.to_vec())
                         }
                     }
                 }
-                self.inner
-                    .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
-                        batch,
-                        response_sender,
-                    })
-                    .map_err(|error| error.into())
+                self.write_batch_and_unlock(batch)
             }
         }
     };

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -9,59 +9,57 @@ macro_rules! impl_contract_system_api {
         impl contract_system_api::ContractSystemApi for $contract_system_api {
             type Error = ExecutionError;
 
-            type Lock = crate::runtime_actor::senders::Lock;
+            type Lock = <Self as BaseRuntime>::Lock;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
             }
 
             fn chain_id(&mut self) -> Result<contract_system_api::ChainId, Self::Error> {
-                self.chain_id().map(|chain_id| chain_id.into())
+                BaseRuntime::chain_id(self).map(|chain_id| chain_id.into())
             }
 
             fn application_id(
                 &mut self,
             ) -> Result<contract_system_api::ApplicationId, Self::Error> {
-                self.application_id()
-                    .map(|application_id| application_id.into())
+                BaseRuntime::application_id(self).map(|application_id| application_id.into())
             }
 
             fn application_parameters(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.application_parameters()
+                BaseRuntime::application_parameters(self)
             }
 
             fn read_system_balance(&mut self) -> Result<contract_system_api::Amount, Self::Error> {
-                self.read_system_balance().map(|balance| balance.into())
+                BaseRuntime::read_system_balance(self).map(|balance| balance.into())
             }
 
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<contract_system_api::Timestamp, Self::Error> {
-                self.read_system_timestamp()
-                    .map(|timestamp| timestamp.micros())
+                BaseRuntime::read_system_timestamp(self).map(|timestamp| timestamp.micros())
             }
 
-            // TODO(#1152): the wit name is wrong
+            // TODO(#1152): remove
             fn load(&mut self) -> Result<Vec<u8>, Self::Error> {
                 self.try_read_my_state()
             }
 
-            // TODO(#1152): the wit name is wrong
+            // TODO(#1152): remove
             fn load_and_lock(&mut self) -> Result<Option<Vec<u8>>, Self::Error> {
                 self.try_read_and_lock_my_state()
             }
 
-            // TODO(#1152): the wit name is wrong
+            // TODO(#1152): remove
             fn store_and_unlock(&mut self, state: &[u8]) -> Result<bool, Self::Error> {
                 self.save_and_unlock_my_state(state.to_vec())
             }
 
             fn lock_new(&mut self) -> Result<Self::Lock, Self::Error> {
-                self.lock_new()
+                BaseRuntime::lock_new(self)
             }
 
             fn lock_wait(&mut self, promise: &Self::Lock) -> Result<(), Self::Error> {
-                self.lock_wait(promise)
+                BaseRuntime::lock_wait(self, promise)
             }
 
             fn try_call_application(
@@ -77,7 +75,8 @@ macro_rules! impl_contract_system_api {
                     .map(SessionId::from)
                     .collect();
 
-                self.try_call_application(
+                ContractRuntime::try_call_application(
+                    self,
                     authenticated,
                     application.into(),
                     argument.to_vec(),
@@ -99,7 +98,8 @@ macro_rules! impl_contract_system_api {
                     .map(SessionId::from)
                     .collect();
 
-                self.try_call_session(
+                ContractRuntime::try_call_session(
+                    self,
                     authenticated,
                     session.into(),
                     argument.to_vec(),
@@ -134,72 +134,76 @@ macro_rules! impl_service_system_api {
         impl service_system_api::ServiceSystemApi for $service_system_api {
             type Error = ExecutionError;
 
-            type Load = crate::runtime_actor::senders::Load;
-            type Lock = crate::runtime_actor::senders::Lock;
-            type Unlock = crate::runtime_actor::senders::Unlock;
-            type TryQueryApplication = crate::runtime_actor::senders::TryQueryApplication;
+            type Load = <Self as BaseRuntime>::Read;
+            type Lock = <Self as BaseRuntime>::Lock;
+            type Unlock = <Self as BaseRuntime>::Unlock;
+            type TryQueryApplication = <Self as ServiceRuntime>::TryQueryApplication;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
             }
 
             fn chain_id(&mut self) -> Result<service_system_api::ChainId, Self::Error> {
-                self.chain_id().map(|chain_id| chain_id.into())
+                BaseRuntime::chain_id(self).map(|chain_id| chain_id.into())
             }
 
             fn application_id(&mut self) -> Result<service_system_api::ApplicationId, Self::Error> {
-                self.application_id()
-                    .map(|application_id| application_id.into())
+                BaseRuntime::application_id(self).map(|application_id| application_id.into())
             }
 
             fn application_parameters(&mut self) -> Result<Vec<u8>, Self::Error> {
-                self.application_parameters()
+                BaseRuntime::application_parameters(self)
             }
 
             fn read_system_balance(&mut self) -> Result<service_system_api::Amount, Self::Error> {
-                self.read_system_balance().map(|balance| balance.into())
+                BaseRuntime::read_system_balance(self).map(|balance| balance.into())
             }
 
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<service_system_api::Timestamp, Self::Error> {
-                self.read_system_timestamp()
-                    .map(|timestamp| timestamp.micros())
+                BaseRuntime::read_system_timestamp(self).map(|timestamp| timestamp.micros())
             }
 
-            // TODO(#1152): the wit name is wrong
+            // TODO(#1152): remove
             fn load_new(&mut self) -> Result<Self::Load, Self::Error> {
                 self.try_read_my_state_new()
             }
 
-            // TODO(#1152): the wit name is wrong
+            // TODO(#1152): remove
             fn load_wait(
                 &mut self,
                 promise: &Self::Load,
             ) -> Result<Result<Vec<u8>, String>, Self::Error> {
                 self.try_read_my_state_wait(promise)
+                    // TODO(#1153): remove
+                    .map(Ok)
             }
 
             fn lock_new(&mut self) -> Result<Self::Lock, Self::Error> {
-                self.lock_new()
+                BaseRuntime::lock_new(self)
             }
 
             fn lock_wait(
                 &mut self,
                 promise: &Self::Lock,
             ) -> Result<Result<(), String>, Self::Error> {
-                self.lock_wait(promise)
+                BaseRuntime::lock_wait(self, promise)
+                    // TODO(#1153): remove
+                    .map(Ok)
             }
 
             fn unlock_new(&mut self) -> Result<Self::Unlock, Self::Error> {
-                self.unlock_new()
+                BaseRuntime::unlock_new(self)
             }
 
             fn unlock_wait(
                 &mut self,
                 promise: &Self::Lock,
             ) -> Result<Result<(), String>, Self::Error> {
-                self.unlock_wait(promise)
+                BaseRuntime::unlock_wait(self, promise)
+                    // TODO(#1153): remove
+                    .map(Ok)
             }
 
             fn try_query_application_new(
@@ -207,14 +211,20 @@ macro_rules! impl_service_system_api {
                 application: service_system_api::ApplicationId,
                 argument: &[u8],
             ) -> Result<Self::TryQueryApplication, Self::Error> {
-                self.try_query_application_new(application.into(), argument.to_vec())
+                ServiceRuntime::try_query_application_new(
+                    self,
+                    application.into(),
+                    argument.to_vec(),
+                )
             }
 
             fn try_query_application_wait(
                 &mut self,
                 promise: &Self::TryQueryApplication,
             ) -> Result<Result<Vec<u8>, String>, Self::Error> {
-                self.try_query_application_wait(promise)
+                ServiceRuntime::try_query_application_wait(self, promise)
+                    // TODO(#1153): remove
+                    .map(Ok)
             }
 
             fn log(
@@ -245,9 +255,9 @@ macro_rules! impl_view_system_api_for_service {
         impl view_system_api::ViewSystemApi for $view_system_api {
             type Error = ExecutionError;
 
-            type ReadValueBytes = crate::runtime_actor::senders::ReadValueBytes;
-            type FindKeys = crate::runtime_actor::senders::FindKeys;
-            type FindKeyValues = crate::runtime_actor::senders::FindKeyValues;
+            type ReadValueBytes = <Self as BaseRuntime>::ReadValueBytes;
+            type FindKeys = <Self as BaseRuntime>::FindKeysByPrefix;
+            type FindKeyValues = <Self as BaseRuntime>::FindKeyValuesByPrefix;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
@@ -257,39 +267,39 @@ macro_rules! impl_view_system_api_for_service {
                 &mut self,
                 key: &[u8],
             ) -> Result<Self::ReadValueBytes, Self::Error> {
-                self.read_value_bytes_new(key.to_vec())
+                BaseRuntime::read_value_bytes_new(self, key.to_vec())
             }
 
             fn read_value_bytes_wait(
                 &mut self,
                 promise: &Self::ReadValueBytes,
             ) -> Result<Option<Vec<u8>>, Self::Error> {
-                self.read_value_bytes_wait(promise)
+                BaseRuntime::read_value_bytes_wait(self, promise)
             }
 
             fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
-                self.find_keys_new(key_prefix.to_vec())
+                self.find_keys_by_prefix_new(key_prefix.to_vec())
             }
 
             fn find_keys_wait(
                 &mut self,
                 promise: &Self::FindKeys,
             ) -> Result<Vec<Vec<u8>>, Self::Error> {
-                self.find_keys_wait(promise)
+                self.find_keys_by_prefix_wait(promise)
             }
 
             fn find_key_values_new(
                 &mut self,
                 key_prefix: &[u8],
             ) -> Result<Self::FindKeyValues, Self::Error> {
-                self.find_key_values_new(key_prefix.to_vec())
+                self.find_key_values_by_prefix_new(key_prefix.to_vec())
             }
 
             fn find_key_values_wait(
                 &mut self,
                 promise: &Self::FindKeyValues,
             ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
-                self.find_key_values_wait(promise)
+                self.find_key_values_by_prefix_wait(promise)
             }
 
             fn write_batch(
@@ -312,9 +322,9 @@ macro_rules! impl_view_system_api_for_contract {
         impl view_system_api::ViewSystemApi for $view_system_api {
             type Error = ExecutionError;
 
-            type ReadValueBytes = crate::runtime_actor::senders::ReadValueBytes;
-            type FindKeys = crate::runtime_actor::senders::FindKeys;
-            type FindKeyValues = crate::runtime_actor::senders::FindKeyValues;
+            type ReadValueBytes = <Self as BaseRuntime>::ReadValueBytes;
+            type FindKeys = <Self as BaseRuntime>::FindKeysByPrefix;
+            type FindKeyValues = <Self as BaseRuntime>::FindKeyValuesByPrefix;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
@@ -324,42 +334,42 @@ macro_rules! impl_view_system_api_for_contract {
                 &mut self,
                 key: &[u8],
             ) -> Result<Self::ReadValueBytes, Self::Error> {
-                self.read_value_bytes_new(key.to_vec())
+                BaseRuntime::read_value_bytes_new(self, key.to_vec())
             }
 
             fn read_value_bytes_wait(
                 &mut self,
                 promise: &Self::ReadValueBytes,
             ) -> Result<Option<Vec<u8>>, Self::Error> {
-                self.read_value_bytes_wait(promise)
+                BaseRuntime::read_value_bytes_wait(self, promise)
             }
 
             fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
-                self.find_keys_new(key_prefix.to_vec())
+                self.find_keys_by_prefix_new(key_prefix.to_vec())
             }
 
             fn find_keys_wait(
                 &mut self,
                 promise: &Self::FindKeys,
             ) -> Result<Vec<Vec<u8>>, Self::Error> {
-                self.find_keys_wait(promise)
+                self.find_keys_by_prefix_wait(promise)
             }
 
             fn find_key_values_new(
                 &mut self,
                 key_prefix: &[u8],
             ) -> Result<Self::FindKeyValues, Self::Error> {
-                self.find_key_values_new(key_prefix.to_vec())
+                self.find_key_values_by_prefix_new(key_prefix.to_vec())
             }
 
             fn find_key_values_wait(
                 &mut self,
                 promise: &Self::FindKeyValues,
             ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
-                self.find_key_values_wait(promise)
+                self.find_key_values_by_prefix_wait(promise)
             }
 
-            // TODO: the wit name is wrong
+            // TODO(#1153): the wit name is wrong
             fn write_batch(
                 &mut self,
                 operations: Vec<view_system_api::WriteOperation>,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -199,7 +199,7 @@ macro_rules! impl_service_system_api {
 
             fn unlock_wait(
                 &mut self,
-                promise: &Self::Lock,
+                promise: &Self::Unlock,
             ) -> Result<Result<(), String>, Self::Error> {
                 BaseRuntime::unlock_wait(self, promise)
                     // TODO(#1153): remove

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -39,8 +39,8 @@ use super::{
 };
 use crate::{
     runtime_actor::{BaseRequest, ContractRequest, SendRequestExt, ServiceRequest},
-    Bytecode, CalleeContext, ExecutionError, MessageContext, OperationContext, QueryContext,
-    RawExecutionResult,
+    Bytecode, CalleeContext, ContractRuntimeSender, ExecutionError, MessageContext,
+    OperationContext, QueryContext, RawExecutionResult, ServiceRuntimeSender,
 };
 use bytes::Bytes;
 use futures::channel::mpsc;
@@ -152,16 +152,14 @@ impl WasmContract {
     pub fn prepare_contract_runtime_with_wasmer(
         contract_engine: &Engine,
         contract_module: &Module,
-        runtime: mpsc::UnboundedSender<ContractRequest>,
+        runtime_sender: ContractRuntimeSender,
     ) -> Result<WasmRuntimeContext<Contract>, WasmExecutionError> {
         let mut store = Store::new(contract_engine);
         let mut imports = imports! {};
-        let contract_system_api = ContractSystemApi::new(runtime.clone());
-        let view_system_api = ContractViewSystemApi::new(runtime.clone());
         let system_api_setup =
-            contract_system_api::add_to_imports(&mut store, &mut imports, contract_system_api);
+            contract_system_api::add_to_imports(&mut store, &mut imports, runtime_sender.clone());
         let views_api_setup =
-            view_system_api::add_to_imports(&mut store, &mut imports, view_system_api);
+            view_system_api::add_to_imports(&mut store, &mut imports, runtime_sender.clone());
         let (contract, instance) =
             contract::Contract::instantiate(&mut store, contract_module, &mut imports)
                 .map_err(WasmExecutionError::LoadContractModule)?;
@@ -173,7 +171,10 @@ impl WasmContract {
         Ok(WasmRuntimeContext {
             application,
             store,
-            extra: WasmerContractExtra { runtime, instance },
+            extra: WasmerContractExtra {
+                runtime: runtime_sender.inner,
+                instance,
+            },
         })
     }
 
@@ -212,16 +213,14 @@ impl WasmService {
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare_service_runtime_with_wasmer(
         service_module: &Module,
-        runtime: mpsc::UnboundedSender<ServiceRequest>,
+        runtime_sender: ServiceRuntimeSender,
     ) -> Result<WasmRuntimeContext<Service>, WasmExecutionError> {
         let mut store = Store::new(&*SERVICE_ENGINE);
         let mut imports = imports! {};
-        let service_system_api = ServiceSystemApi::new(runtime.clone());
-        let view_system_api = ServiceViewSystemApi::new(runtime);
         let system_api_setup =
-            service_system_api::add_to_imports(&mut store, &mut imports, service_system_api);
+            service_system_api::add_to_imports(&mut store, &mut imports, runtime_sender.clone());
         let views_api_setup =
-            view_system_api::add_to_imports(&mut store, &mut imports, view_system_api);
+            view_system_api::add_to_imports(&mut store, &mut imports, runtime_sender);
         let (service, instance) =
             service::Service::instantiate(&mut store, service_module, &mut imports)
                 .map_err(WasmExecutionError::LoadServiceModule)?;
@@ -327,64 +326,10 @@ impl common::Service for Service {
     }
 }
 
-/// Implementation to forward contract system calls from the guest Wasm module to the host
-/// implementation.
-pub struct ContractSystemApi {
-    runtime: mpsc::UnboundedSender<ContractRequest>,
-}
-
-impl ContractSystemApi {
-    /// Creates a new [`ContractSystemApi`] instance.
-    pub fn new(runtime: mpsc::UnboundedSender<ContractRequest>) -> Self {
-        ContractSystemApi { runtime }
-    }
-}
-
-impl_contract_system_api!(ContractSystemApi, wasmer::RuntimeError);
-
-/// Implementation to forward service system calls from the guest Wasm module to the host
-/// implementation.
-pub struct ServiceSystemApi {
-    runtime: mpsc::UnboundedSender<ServiceRequest>,
-}
-
-impl ServiceSystemApi {
-    /// Creates a new [`ServiceSystemApi`] instance.
-    pub fn new(runtime: mpsc::UnboundedSender<ServiceRequest>) -> Self {
-        ServiceSystemApi { runtime }
-    }
-}
-
-impl_service_system_api!(ServiceSystemApi, wasmer::RuntimeError);
-
-/// Implementation to forward view system calls from the contract guest Wasm module to the host
-/// implementation.
-pub struct ContractViewSystemApi {
-    runtime: mpsc::UnboundedSender<ContractRequest>,
-}
-
-impl ContractViewSystemApi {
-    /// Creates a new [`ContractViewSystemApi`] instance.
-    pub fn new(runtime: mpsc::UnboundedSender<ContractRequest>) -> Self {
-        ContractViewSystemApi { runtime }
-    }
-}
-
-/// Implementation to forward view system calls from the guest WASM module to the host
-/// implementation.
-pub struct ServiceViewSystemApi {
-    runtime: mpsc::UnboundedSender<ServiceRequest>,
-}
-
-impl ServiceViewSystemApi {
-    /// Creates a new [`ServiceViewSystemApi`] instance.
-    pub fn new(runtime: mpsc::UnboundedSender<ServiceRequest>) -> Self {
-        ServiceViewSystemApi { runtime }
-    }
-}
-
-impl_view_system_api_for_contract!(ContractViewSystemApi, wasmer::RuntimeError);
-impl_view_system_api_for_service!(ServiceViewSystemApi, wasmer::RuntimeError);
+impl_contract_system_api!(ContractRuntimeSender, wasmer::RuntimeError);
+impl_service_system_api!(ServiceRuntimeSender, wasmer::RuntimeError);
+impl_view_system_api_for_contract!(ContractRuntimeSender, wasmer::RuntimeError);
+impl_view_system_api_for_service!(ServiceRuntimeSender, wasmer::RuntimeError);
 
 /// Extra parameters necessary when cleaning up after contract execution.
 pub struct WasmerContractExtra {

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -38,8 +38,9 @@ use super::{
     ApplicationCallResult, SessionCallResult, WasmContract, WasmExecutionError, WasmService,
 };
 use crate::{
-    Bytecode, CalleeContext, ContractRuntimeSender, ExecutionError, MessageContext,
-    OperationContext, QueryContext, RawExecutionResult, ServiceRuntimeSender,
+    BaseRuntime, Bytecode, CalleeContext, ContractRuntime, ContractRuntimeSender, ExecutionError,
+    MessageContext, OperationContext, QueryContext, RawExecutionResult, ServiceRuntime,
+    ServiceRuntimeSender,
 };
 use bytes::Bytes;
 use linera_base::identifiers::SessionId;

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -86,7 +86,7 @@ impl ApplicationRuntimeContext for Contract {
     type Extra = ();
 
     fn configure_initial_fuel(context: &mut WasmRuntimeContext<Self>) -> Result<(), Self::Error> {
-        let runtime_sender = &context.store.data().system_api;
+        let runtime_sender = &mut context.store.data_mut().system_api;
         let fuel = runtime_sender.remaining_fuel()?;
 
         context
@@ -98,12 +98,12 @@ impl ApplicationRuntimeContext for Contract {
     }
 
     fn persist_remaining_fuel(context: &mut WasmRuntimeContext<Self>) -> Result<(), Self::Error> {
-        let runtime_sender = &context.store.data().system_api;
-        let initial_fuel = runtime_sender.remaining_fuel()?;
         let consumed_fuel = context
             .store
             .fuel_consumed()
             .expect("Failed to read consumed fuel");
+        let runtime_sender = &mut context.store.data_mut().system_api;
+        let initial_fuel = runtime_sender.remaining_fuel()?;
         let remaining_fuel = initial_fuel.saturating_sub(consumed_fuel);
 
         runtime_sender.set_remaining_fuel(remaining_fuel)?;

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -42,9 +42,9 @@ use super::{
     WasmContract, WasmExecutionError, WasmService,
 };
 use crate::{
-    ApplicationCallResult, Bytecode, CalleeContext, ContractRuntimeSender, ExecutionError,
-    MessageContext, OperationContext, QueryContext, RawExecutionResult, ServiceRuntimeSender,
-    SessionCallResult, SessionId,
+    ApplicationCallResult, BaseRuntime, Bytecode, CalleeContext, ContractRuntime,
+    ContractRuntimeSender, ExecutionError, MessageContext, OperationContext, QueryContext,
+    RawExecutionResult, ServiceRuntime, ServiceRuntimeSender, SessionCallResult, SessionId,
 };
 use linera_views::batch::Batch;
 use once_cell::sync::Lazy;

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -98,6 +98,7 @@ impl UserContract for TestApplication {
         // Who we are.
         assert_eq!(context.authenticated_signer, Some(self.owner));
         let app_id = runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
             })?
@@ -107,6 +108,7 @@ impl UserContract for TestApplication {
         // Modify our state.
         let chosen_key = vec![0];
         runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
             })?
@@ -114,6 +116,7 @@ impl UserContract for TestApplication {
             .unwrap();
 
         let state = runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ReadValueBytes {
                     key: chosen_key.clone(),
@@ -129,6 +132,7 @@ impl UserContract for TestApplication {
         batch.put_key_value_bytes(chosen_key, state);
 
         runtime_sender
+            .inner
             .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
                 batch,
                 response_sender,
@@ -136,7 +140,7 @@ impl UserContract for TestApplication {
             .expect("State is locked at the start of the operation");
 
         // Call ourselves after the state => ok.
-        let call_result = runtime_sender.send_sync_request(|response_sender| {
+        let call_result = runtime_sender.inner.send_sync_request(|response_sender| {
             ContractRequest::TryCallApplication {
                 authenticated: true,
                 callee_id: app_id,
@@ -150,7 +154,7 @@ impl UserContract for TestApplication {
         if !operation.is_empty() {
             // Call the session to close it.
             let session_id = call_result.sessions[0];
-            runtime_sender.send_sync_request(|response_sender| {
+            runtime_sender.inner.send_sync_request(|response_sender| {
                 ContractRequest::TryCallSession {
                     authenticated: false,
                     session_id,
@@ -173,6 +177,7 @@ impl UserContract for TestApplication {
         // Who we are.
         assert_eq!(context.authenticated_signer, Some(self.owner));
         let app_id = runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
             })?
@@ -180,6 +185,7 @@ impl UserContract for TestApplication {
             .unwrap();
 
         runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
             })?
@@ -187,7 +193,7 @@ impl UserContract for TestApplication {
             .unwrap();
 
         // Call ourselves while the state is locked => not ok.
-        runtime_sender.send_sync_request(|response_sender| {
+        runtime_sender.inner.send_sync_request(|response_sender| {
             ContractRequest::TryCallApplication {
                 authenticated: true,
                 callee_id: app_id,
@@ -198,6 +204,7 @@ impl UserContract for TestApplication {
         })?;
 
         runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ContractRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
             })?
@@ -252,6 +259,7 @@ impl UserService for TestApplication {
         let chosen_key = vec![0];
 
         runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
             })?
@@ -259,6 +267,7 @@ impl UserService for TestApplication {
             .unwrap();
 
         let state = runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::ReadValueBytes {
                     key: chosen_key,
@@ -271,6 +280,7 @@ impl UserService for TestApplication {
         let state = state.unwrap_or_default();
 
         runtime_sender
+            .inner
             .send_request(|response_sender| {
                 ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
             })?

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -196,7 +196,7 @@ impl UserService for TestApplication {
         _argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let chosen_key = vec![0];
-        runtime_sender.lock()?.ok();
+        runtime_sender.lock()?;
 
         let state = runtime_sender
             .read_value_bytes(chosen_key)?

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -148,6 +148,7 @@ impl UserContract for TestApplication {
             vec![],
             vec![],
         )?;
+        runtime_sender.unlock()?;
 
         Ok(RawExecutionResult::default())
     }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -13,10 +13,7 @@ use linera_base::{
 };
 use linera_execution::{
     policy::ResourceControlPolicy,
-    runtime_actor::{
-        BaseRequest, ContractRequest, ContractRuntimeSender, SendRequestExt, ServiceRequest,
-        ServiceRuntimeSender,
-    },
+    runtime_actor::{ContractRuntimeSender, ServiceRuntimeSender},
     *,
 };
 use linera_views::{batch::Batch, common::Context, memory::MemoryContext, views::View};
@@ -92,77 +89,42 @@ impl UserContract for TestApplication {
     fn execute_operation(
         &self,
         context: OperationContext,
-        runtime_sender: ContractRuntimeSender,
+        mut runtime_sender: ContractRuntimeSender,
         operation: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
         // Who we are.
         assert_eq!(context.authenticated_signer, Some(self.owner));
-        let app_id = runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
-            })?
-            .recv()
-            .unwrap();
+        let app_id = runtime_sender.application_id()?;
 
         // Modify our state.
         let chosen_key = vec![0];
-        runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
-            })?
-            .recv()
-            .unwrap();
-
-        let state = runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::ReadValueBytes {
-                    key: chosen_key.clone(),
-                    response_sender,
-                })
-            })?
-            .recv()
-            .unwrap();
-
-        let mut state = state.unwrap_or_default();
+        runtime_sender.lock()?;
+        let mut state = runtime_sender
+            .read_value_bytes(chosen_key.clone())?
+            .unwrap_or_default();
         state.extend(operation.clone());
         let mut batch = Batch::new();
         batch.put_key_value_bytes(chosen_key, state);
+        runtime_sender.write_batch_and_unlock(batch)?;
 
-        runtime_sender
-            .inner
-            .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
-                batch,
-                response_sender,
-            })
-            .expect("State is locked at the start of the operation");
-
-        // Call ourselves after the state => ok.
-        let call_result = runtime_sender.inner.send_sync_request(|response_sender| {
-            ContractRequest::TryCallApplication {
-                authenticated: true,
-                callee_id: app_id,
-                argument: vec![],
-                forwarded_sessions: vec![],
-                response_sender,
-            }
-        })?;
+        // Call ourselves after unlocking the state => ok.
+        let call_result = runtime_sender.try_call_application(
+            /* authenticated */ true,
+            app_id,
+            vec![],
+            vec![],
+        )?;
         assert_eq!(call_result.value, Vec::<u8>::new());
         assert_eq!(call_result.sessions.len(), 1);
         if !operation.is_empty() {
             // Call the session to close it.
             let session_id = call_result.sessions[0];
-            runtime_sender.inner.send_sync_request(|response_sender| {
-                ContractRequest::TryCallSession {
-                    authenticated: false,
-                    session_id,
-                    argument: vec![],
-                    forwarded_sessions: vec![],
-                    response_sender,
-                }
-            })?;
+            runtime_sender.try_call_session(
+                /* authenticated */ false,
+                session_id,
+                vec![],
+                vec![],
+            )?;
         }
         Ok(RawExecutionResult::default())
     }
@@ -171,45 +133,22 @@ impl UserContract for TestApplication {
     fn execute_message(
         &self,
         context: MessageContext,
-        runtime_sender: ContractRuntimeSender,
+        mut runtime_sender: ContractRuntimeSender,
         _message: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError> {
         // Who we are.
         assert_eq!(context.authenticated_signer, Some(self.owner));
-        let app_id = runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::ApplicationId { response_sender })
-            })?
-            .recv()
-            .unwrap();
-
-        runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::LockViewUserState { response_sender })
-            })?
-            .recv()
-            .unwrap();
+        let app_id = runtime_sender.application_id()?;
+        runtime_sender.lock()?;
 
         // Call ourselves while the state is locked => not ok.
-        runtime_sender.inner.send_sync_request(|response_sender| {
-            ContractRequest::TryCallApplication {
-                authenticated: true,
-                callee_id: app_id,
-                argument: vec![],
-                forwarded_sessions: vec![],
-                response_sender,
-            }
-        })?;
+        runtime_sender.try_call_application(
+            /* authenticated */ true,
+            app_id,
+            vec![],
+            vec![],
+        )?;
 
-        runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ContractRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
-            })?
-            .recv()
-            .unwrap();
         Ok(RawExecutionResult::default())
     }
 
@@ -253,39 +192,17 @@ impl UserService for TestApplication {
     fn handle_query(
         &self,
         _context: QueryContext,
-        runtime_sender: ServiceRuntimeSender,
+        mut runtime_sender: ServiceRuntimeSender,
         _argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let chosen_key = vec![0];
-
-        runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ServiceRequest::Base(BaseRequest::LockViewUserState { response_sender })
-            })?
-            .recv()
-            .unwrap();
+        runtime_sender.lock()?.ok();
 
         let state = runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ServiceRequest::Base(BaseRequest::ReadValueBytes {
-                    key: chosen_key,
-                    response_sender,
-                })
-            })?
-            .recv()
-            .unwrap();
+            .read_value_bytes(chosen_key)?
+            .unwrap_or_default();
 
-        let state = state.unwrap_or_default();
-
-        runtime_sender
-            .inner
-            .send_request(|response_sender| {
-                ServiceRequest::Base(BaseRequest::UnlockViewUserState { response_sender })
-            })?
-            .recv()
-            .unwrap();
+        runtime_sender.unlock()?;
 
         Ok(state)
     }


### PR DESCRIPTION
## Motivation

Next step after #1351 in order to run contracts on a single thread (https://github.com/linera-io/linera-protocol/issues/1193)

## Proposal

* Create an abstract interface that hides the actor channel.
* Remove the previous trait (now an internal interface)

We stop short of making the `UserContract` and `UserService` traits generic w.r.t. an implementation of the new interface (i.e. using a generic type to replace `{Contract,Service}RuntimeSender`). This is not blocking me right now and can be done later if needed.

## Test Plan

CI