### PR TITLE
Upgrade Rust to version 1.74.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,1 @@
-[toolchain]
-channel = "1.73.0"
-components = [ "clippy", "rustfmt", "rust-src" ]
-targets = [ "wasm32-unknown-unknown" ]
-profile = "minimal"
+toolchains/build/rust-toolchain.toml

--- a/toolchains/build/rust-toolchain.toml
+++ b/toolchains/build/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.74.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

I saw a few compiler panics with 1.73.0, but not with the new version so far.

## Proposal

Upgrade!

Also, make `rust-toolchain.toml` a symbolic link to deduplicate the version number.

## Test Plan

No logic has changed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
