### PR TITLE
Persist Grafana dashboards

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera-general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera-general.json
@@ -1,0 +1,232 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "disableTextWrap": false,
+          "editorMode": "builder",
+          "expr": "rate(block_execution_latency_bucket{service=\"shards\"}[$__rate_interval])",
+          "fullMetaSearch": false,
+          "includeNullMetadata": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A",
+          "useBackend": false
+        }
+      ],
+      "title": "Block Execution Latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "description": "Shard and proxy panics",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 1,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "10.1.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "builder",
+          "expr": "{app=\"shards\"} |= `panic`",
+          "queryType": "range",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "builder",
+          "expr": "{app=\"proxy\"} |= `panic`",
+          "hide": false,
+          "queryType": "range",
+          "refId": "B"
+        }
+      ],
+      "title": "Panics",
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "2024-01-03T14:32:01.797Z",
+    "to": "2024-01-03T15:54:46.957Z"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Linera General",
+  "uid": "d1c10f4e-acbf-4cb9-9abd-bade0adcbd12",
+  "version": 1,
+  "weekStart": ""
+}

--- a/kubernetes/linera-validator/templates/config.yaml
+++ b/kubernetes/linera-validator/templates/config.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: validator-config
 data:
-  serverConfig: {{ .Files.Get .Values.validator.serverConfig | quote |indent 4 }}
+  serverConfig: {{ .Files.Get .Values.validator.serverConfig | quote | indent 4 }}
   genesisConfig: {{ .Files.Get .Values.validator.genesisConfig | quote | indent 4 }}

--- a/kubernetes/linera-validator/templates/grafana-dashboards-config.yaml
+++ b/kubernetes/linera-validator/templates/grafana-dashboards-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-config
+  labels:
+    grafana_dashboard: "1"
+data:
+  # If adding another dashboard here doesn't work, we should rename this ConfigMap to
+  # linera-general-dashboard-config, and create one ConfigMap per dashboard (that seems
+  # to be what's actually recommended by the docs)
+  linera-general.json: {{ .Files.Get "grafana-dashboards/linera-general.json" | quote | indent 4 }}

--- a/kubernetes/linera-validator/values-local.yaml
+++ b/kubernetes/linera-validator/values-local.yaml
@@ -21,6 +21,18 @@ loki-stack:
       clients:
         - url: http://linera-core-loki:3100/loki/api/v1/push
 
+# Prometheus/Grafana
+kube-prometheus-stack:
+  grafana:
+    sidecar:
+      dashboards:
+        enabled: true
+        label: grafana_dashboard
+        labelValue: "1"
+    persistence:
+      enabled: true
+      size: 1Gi
+
 # Environment
 environment: "kind"
 


### PR DESCRIPTION
## Motivation

We'll have some dashboards that will contain different data that we're interested in monitoring. To do that we need a way of defining and persisting Grafana dashboards.

## Proposal

Create dashboards in Grafana, export the JSON, add it to our codebase and make sure that JSON gets imported when Grafana is initialized

Infra side PR: https://github.com/linera-io/linera-infra/pull/20

## Test Plan

Deployed locally, saw that the imported dashboard was there

