### PR TITLE
Ensure the faucet chain doesn't have super owners.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -298,7 +298,7 @@ where
     }
 
     /// Obtains the basic `ChainInfo` data for the local chain.
-    async fn chain_info(&mut self) -> Result<ChainInfo, LocalNodeError> {
+    pub async fn chain_info(&mut self) -> Result<ChainInfo, LocalNodeError> {
         let query = ChainInfoQuery::new(self.chain_id);
         let response = self.node_client.handle_chain_info_query(query).await?;
         Ok(response.info)

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -685,6 +685,32 @@ impl NodeService {
         bytecode_str.parse().context("could not parse bytecode ID")
     }
 
+    pub async fn change_multiple_owners(
+        &self,
+        chain_id: ChainId,
+        new_public_keys: Vec<PublicKey>,
+        new_weights: Vec<u64>,
+        multi_leader_rounds: u32,
+    ) -> Result<CryptoHash> {
+        let query = format!(
+            "mutation {{ changeMultipleOwners(\
+                chainId: {}, \
+                newPublicKeys: {}, \
+                newWeights: {}, \
+                multiLeaderRounds: {}\
+            ) }}",
+            chain_id.to_value(),
+            new_public_keys.to_value(),
+            new_weights.to_value(),
+            multi_leader_rounds,
+        );
+        let data = self.query_node(query).await?;
+        let hash_str = data["changeMultipleOwners"]
+            .as_str()
+            .context("certificate hash not found")?;
+        hash_str.parse().context("could not parse certificate hash")
+    }
+
     pub async fn query_node(&self, query: impl AsRef<str>) -> Result<Value> {
         let n_try = 30;
         let query = query.as_ref();

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -168,6 +168,11 @@ where
         end_timestamp: Timestamp,
         genesis_config: Arc<GenesisConfig>,
     ) -> anyhow::Result<Self> {
+        let info = client.chain_info().await?;
+        anyhow::ensure!(
+            info.manager.ownership.super_owners.is_empty(),
+            "The faucet chain must not have super owners."
+        );
         let start_timestamp = client.storage_client().await.current_time();
         let start_balance = client.local_balance().await?;
         Ok(Self {


### PR DESCRIPTION
## Motivation

The faucet will sometimes spawn multiple tasks in parallel that each try to commit a block. If it tries fast blocks it will conflict with itself and break the chain.

## Proposal

Ensure on initialization that the faucet chain does not have a super owner.

## Test Plan

Extended the faucet end-to-end test.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
