### PR TITLE
Moving build-image.yaml to linera-infra

### DIFF
--- a/build-image.yaml
+++ b/build-image.yaml
@@ -1,6 +1,0 @@
-steps:
-- name: 'docker:latest'
-  entrypoint: 'docker'
-  args: [ 'build', '-t', 'us-docker.pkg.dev/linera-io-dev/linera-docker-repo/linera-test-local:latest', '-f', 'docker/Dockerfile', '.' ]
-images:
-- 'us-docker.pkg.dev/linera-io-dev/linera-docker-repo/linera-test-local:latest'


### PR DESCRIPTION
## Motivation

We want to keep the infra related stuff outside this repo

## Proposal

Moving `build-image.yaml` to `linera-infra`

## Test Plan

Will test in the `linera-infra` PR

