### PR TITLE
`flake.nix`: use a prebuilt `rocksdb` to speed compilation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,10 +21,11 @@
           clang
           libclang.lib
           libiconv
+          nodejs
           openssl
           protobuf
           pkg-config
-          nodejs
+          rocksdb
         ];
         rustBuildToolchain = (pkgs.rust-bin.fromRustupToolchainFile
           ./toolchains/build/rust-toolchain.toml);
@@ -46,6 +47,7 @@
             export RUST_SRC_PATH=${rustBuildToolchain.availableComponents.rust-src}
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib
             export PATH=$PWD/target/debug:~/.cargo/bin:$PATH
+            export ROCKSDB_LIB_DIR=${pkgs.rocksdb}/lib
           '';
           buildInputs = nonRustDeps;
           nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
## Motivation

`librocksdb-sys` is very slow to build because it builds `rocksdb` from source.  This [used to be necessary](https://github.com/jsgf/rocksdb-sys) due to an allocator mismatch, but [newer `rocksdb`](https://github.com/rust-rocksdb/rust-rocksdb) no longer mentions it, and seems to work fine without any special handling.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Pull in `rocksdb` as a build dependency in our Nix environment, and set an environment variable `ROCKSDB_LIB_DIR` that instructs `librocksdb-sys` on where to find it.

This won't help people building without Nix, but serves as a template for them to set up their own manual solutions (e.g. by imperatively `apt-get install`ing `rocksdb` and either adding `export ROCKSDB_LIB_DIR=/usr/lib` to `~/.bashrc` or similar or adding it to your project [`direnv`](https://direnv.net/) environment).

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Build in the proposed environment.

<!-- How to test that the changes are correct. -->

## Release Plan

Invisible to users.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
