### PR TITLE
Validate application parameters inside `initialize` of every example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,6 +3314,7 @@ dependencies = [
  "linera-sdk",
  "linera-views",
  "log",
+ "serde_json",
  "webassembly-test",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ wasmer-middlewares = "=3.1.1"
 wasmer-vm = { version = "=3.1.1" }
 wasmparser = "0.101.1"
 wasmtime = "1.0"
+webassembly-test = "0.1.0"
 wit-bindgen-guest-rust = { version = "0.2.0", package = "linera-wit-bindgen-guest-rust" }
 wit-bindgen-host-wasmer-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmer-rust" }
 wit-bindgen-host-wasmtime-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmtime-rust" }
@@ -134,6 +135,7 @@ linera-indexer-example = { path = "./linera-indexer/example" }
 linera-indexer-graphql-client = { path = "./linera-indexer/graphql-client" }
 linera-indexer-plugins = { path = "./linera-indexer/plugins" }
 linera-rpc = { version = "0.6.0", path = "./linera-rpc" }
+linera-sdk = { version = "0.6.0", path = "./linera-sdk" }
 linera-storage = { version = "0.6.0", path = "./linera-storage", default-features = false }
 linera-views = { version = "0.6.0", path = "./linera-views", default-features = false }
 linera-views-derive = { version = "0.6.0", path = "./linera-views-derive" }

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -31,6 +31,9 @@ impl Contract for Amm {
         _context: &OperationContext,
         _argument: (),
     ) -> Result<ExecutionResult<Self::Message>, AmmError> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         Ok(ExecutionResult::default())
     }
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -107,6 +107,7 @@ mod tests {
     use futures::FutureExt;
     use linera_sdk::{
         base::{BlockHeight, ChainId, MessageId},
+        test::mock_application_parameters,
         ApplicationCallResult, CalleeContext, Contract, ExecutionResult, MessageContext,
         OperationContext,
     };
@@ -183,6 +184,8 @@ mod tests {
 
     fn create_and_initialize_counter(initial_value: u64) -> Counter {
         let mut counter = Counter::default();
+
+        mock_application_parameters(&());
 
         let result = counter
             .initialize(&dummy_operation_context(), initial_value)

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -30,7 +30,11 @@ impl Contract for Counter {
         _context: &OperationContext,
         value: u64,
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         self.value = value;
+
         Ok(ExecutionResult::default())
     }
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -35,6 +35,9 @@ impl Contract for CrowdFunding {
         _context: &OperationContext,
         argument: InitializationArgument,
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         self.initialization_argument.set(Some(argument));
 
         ensure!(

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -36,6 +36,9 @@ impl Contract for FungibleToken {
         context: &OperationContext,
         mut state: Self::InitializationArgument,
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         // If initial accounts are empty, creator gets 1M tokens to act like a faucet.
         if state.accounts.is_empty() {
             if let Some(owner) = context.authenticated_signer {
@@ -46,6 +49,7 @@ impl Contract for FungibleToken {
             }
         }
         self.initialize_accounts(state).await;
+
         Ok(ExecutionResult::default())
     }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -45,6 +45,9 @@ impl Contract for MatchingEngine {
         _context: &OperationContext,
         _argument: (),
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         Ok(ExecutionResult::default())
     }
 

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -36,6 +36,9 @@ impl Contract for MetaCounter {
         context: &OperationContext,
         _argument: (),
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         Self::counter_id()?;
         // Send a no-op message to ourselves. This is only for testing contracts that send messages
         // on initialization. Since the value is 0 it does not change the counter value.

--- a/examples/reentrant-counter/src/contract.rs
+++ b/examples/reentrant-counter/src/contract.rs
@@ -30,7 +30,11 @@ impl Contract for ReentrantCounter {
         _context: &OperationContext,
         value: u64,
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         self.value.set(value);
+
         Ok(ExecutionResult::default())
     }
 

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -38,6 +38,9 @@ impl Contract for Social {
         _context: &OperationContext,
         _argument: (),
     ) -> Result<ExecutionResult<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+
         Ok(ExecutionResult::default())
     }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -318,9 +318,10 @@ where
     // Create an application.
     let initial_value = 10_u64;
     let initial_value_bytes = serde_json::to_vec(&initial_value)?;
+    let parameters_bytes = serde_json::to_vec(&())?;
     let create_operation = SystemOperation::CreateApplication {
         bytecode_id,
-        parameters: vec![],
+        parameters: parameters_bytes.clone(),
         initialization_argument: initial_value_bytes.clone(),
         required_application_ids: vec![],
     };
@@ -337,7 +338,7 @@ where
         bytecode_location,
         creation: application_id.creation,
         required_application_ids: vec![],
-        parameters: vec![],
+        parameters: parameters_bytes,
     };
     let publish_admin_channel = ChannelFullName {
         application_id: GenericApplicationId::System,

--- a/linera-sdk/src/test/integration/mock_stubs.rs
+++ b/linera-sdk/src/test/integration/mock_stubs.rs
@@ -13,6 +13,7 @@ use linera_base::{
     identifiers::{ApplicationId, ChainId},
 };
 use linera_views::memory::MemoryContext;
+use serde::Serialize;
 
 /// A helpful error message to explain why the mock API isn't available.
 const ERROR_MESSAGE: &str =
@@ -34,7 +35,7 @@ pub fn mock_application_id(_application_id: impl Into<Option<ApplicationId>>) {
 }
 
 /// Sets the mocked application parameters.
-pub fn mock_application_parameters(_application_parameters: impl Into<Option<Vec<u8>>>) {
+pub fn mock_application_parameters(_application_parameters: &impl Serialize) {
     unreachable!("{ERROR_MESSAGE}");
 }
 

--- a/linera-sdk/src/test/unit/mod.rs
+++ b/linera-sdk/src/test/unit/mod.rs
@@ -27,6 +27,7 @@ use linera_views::{
     common::Context,
     memory::MemoryContext,
 };
+use serde::Serialize;
 
 static mut MOCK_CHAIN_ID: Option<ChainId> = None;
 static mut MOCK_APPLICATION_ID: Option<ApplicationId> = None;
@@ -52,8 +53,11 @@ pub fn mock_application_id(application_id: impl Into<Option<ApplicationId>>) {
 }
 
 /// Sets the mocked application parameters.
-pub fn mock_application_parameters(application_parameters: impl Into<Option<Vec<u8>>>) {
-    unsafe { MOCK_APPLICATION_PARAMETERS = application_parameters.into() };
+pub fn mock_application_parameters(application_parameters: &impl Serialize) {
+    let serialized_parameters = serde_json::to_vec(application_parameters)
+        .expect("Failed to serialize mock application parameters");
+
+    unsafe { MOCK_APPLICATION_PARAMETERS = Some(serialized_parameters) };
 }
 
 /// Sets the mocked system balance.

--- a/linera-sdk/wasm-tests/Cargo.toml
+++ b/linera-sdk/wasm-tests/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 
 [dev-dependencies]
-async-trait = "0.1.74"
-bcs = "0.1.6"
-futures = "0.3.29"
-linera-sdk = { path = "..", features = ["test"] }
-linera-views = { path = "../../linera-views" }
-log = "0.4.20"
-serde_json = "1.0.107"
-webassembly-test = "0.1.0"
+async-trait = { workspace = true }
+bcs = { workspace = true }
+futures = { workspace = true }
+linera-sdk = { workspace = true, features = ["test"] }
+linera-views = { workspace = true }
+log = { workspace = true }
+serde_json = { workspace = true }
+webassembly-test = { workspace = true }

--- a/linera-sdk/wasm-tests/Cargo.toml
+++ b/linera-sdk/wasm-tests/Cargo.toml
@@ -11,4 +11,5 @@ futures = "0.3.29"
 linera-sdk = { path = "..", features = ["test"] }
 linera-views = { path = "../../linera-views" }
 log = "0.4.20"
+serde_json = "1.0.107"
 webassembly-test = "0.1.0"

--- a/linera-sdk/wasm-tests/src/lib.rs
+++ b/linera-sdk/wasm-tests/src/lib.rs
@@ -65,15 +65,18 @@ fn mock_application_id() {
 fn mock_application_parameters() {
     let parameters = vec![0, 1, 2, 3, 4, 5, 6];
 
-    test::mock_application_parameters(parameters.clone());
+    test::mock_application_parameters(&parameters);
+
+    let serialized_parameters =
+        serde_json::to_vec(&parameters).expect("Failed to serialize parameters");
 
     assert_eq!(
         contract::system_api::private::current_application_parameters(),
-        parameters
+        serialized_parameters
     );
     assert_eq!(
         service::system_api::private::current_application_parameters(),
-        parameters
+        serialized_parameters
     );
 }
 


### PR DESCRIPTION
Ensure all examples validate their parameters inside `initialize`, to prevent an application to be created with parameters that can't be deserialized.

This is supposed to be a new recommendation for developers, so the examples should show it as a best practice.

## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
It's currently possible to create an application that is bricked because its parameters are invalid and can't be deserialized.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create the best practice of validating the application parameters inside the contract's `initialize` method. This ensures that the application creation fails if the parameters are invalid.

All examples were updated to include this new best practice.

## Test Plan

<!-- How to test that the changes are correct. -->
The Counter unit tests were updated to configure the mock application parameters. A unit test for the failure scenario could not be written, because it would require unit tests that panic (#1372).

## Release Plan

Nothing is needed, but since the SDK was tweaked the updated `mock_application_parameters` is only available for other application developers in the next SDK release.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
