### PR TITLE
Fix MatchingEngineApp::get_account_info.

### DIFF
--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -86,11 +86,12 @@ impl MatchingEngineApp {
         account_owner: &fungible::AccountOwner,
     ) -> Vec<matching_engine::OrderId> {
         let query = format!(
-            "accountInfo(accountOwner: {}) {{ orders }}",
+            "accountInfo {{ entry(key: {}) {{ value {{ orders }} }} }}",
             account_owner.to_value()
         );
         let response_body = self.0.query(query).await.unwrap();
-        serde_json::from_value(response_body["accountInfo"]["orders"].clone()).unwrap()
+        serde_json::from_value(response_body["accountInfo"]["entry"]["value"]["orders"].clone())
+            .unwrap()
     }
 
     async fn order(&self, order: matching_engine::Order) -> Value {


### PR DESCRIPTION
## Motivation

The matching engine end-to-end test now fails because of an invalid GraphQL query, _in addition_ to https://github.com/linera-io/linera-protocol/issues/1159.

## Proposal

Fix the GraphQL query.

## Test Plan

The test is `#[ignore]`d, but increasing the timeouts as described in https://github.com/linera-io/linera-protocol/issues/1159, together with this fix, makes it pass for me again.

## Links

- https://github.com/linera-io/linera-protocol/issues/1159
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
