### PR TITLE
Append environment arguments before the sub-command arguments

### DIFF
--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -385,10 +385,10 @@ impl LocalNet {
             let mut i_try = 0;
             loop {
                 let mut command = self.command_for_binary("linera-server").await?;
-                command.arg("initialize");
                 if let Ok(var) = env::var(SERVER_ENV) {
                     command.args(var.split_whitespace());
                 }
+                command.arg("initialize");
                 let result = command
                     .args(["--storage", &storage])
                     .args(["--genesis", "genesis.json"])
@@ -412,10 +412,10 @@ impl LocalNet {
         }
 
         let mut command = self.command_for_binary("linera-server").await?;
-        command.arg("run");
         if let Ok(var) = env::var(SERVER_ENV) {
             command.args(var.split_whitespace());
         }
+        command.arg("run");
         let child = command
             .args(["--storage", &storage])
             .args(["--server", &format!("server_{}.json", i)])


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Running `LINERA_SERVER_PARAMS="--tokio-threads=1"` currently fails because the argument is appended to the end of the command line, and that means it ends up included in the arguments of the sub-command instead of being part of the global arguments.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Append the `LINERA_SERVER_PARAMS` before the sub-command, so that it's not included in the sub-command's arguments.

## Test Plan

<!-- How to test that the changes are correct. -->
Tested manually by running the end-to-end tests with the `LINERA_SERVER_PARAMS="--tokio-threads=1"` and adding a `panic!("{:?}", options.tokio_threads);` line to `server.rs`'s `main`.

## Release Plan

Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
