### PR TITLE
Make make_client async

### DIFF
--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -90,7 +90,8 @@ impl LineraNetConfig for LocalKubernetesNetConfig {
             self.num_initial_validators,
             self.num_shards,
         )?;
-        let client = net.make_client();
+
+        let client = net.make_client().await;
         ensure!(
             self.num_initial_validators > 0,
             "There should be at least one initial validator"
@@ -98,6 +99,7 @@ impl LineraNetConfig for LocalKubernetesNetConfig {
         net.generate_initial_validator_config().await.unwrap();
         client.create_genesis_config().await.unwrap();
         net.run().await.unwrap();
+
         Ok((net, client))
     }
 }
@@ -133,7 +135,7 @@ impl LineraNetConfig for LocalKubernetesNetTestingConfig {
             num_validators,
             num_shards,
         )?;
-        let client = net.make_client();
+        let client = net.make_client().await;
         if num_validators > 0 {
             net.generate_initial_validator_config().await.unwrap();
             client.create_genesis_config().await.unwrap();
@@ -184,7 +186,7 @@ impl LineraNet for LocalKubernetesNet {
         Ok(())
     }
 
-    fn make_client(&mut self) -> ClientWrapper {
+    async fn make_client(&mut self) -> ClientWrapper {
         let client = ClientWrapper::new(
             self.tmp_dir.clone(),
             self.network,

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -136,7 +136,7 @@ impl LineraNetConfig for LocalNetConfig {
             self.num_initial_validators,
             self.num_shards,
         )?;
-        let client = net.make_client();
+        let client = net.make_client().await;
         ensure!(
             self.num_initial_validators > 0,
             "There should be at least one initial validator"
@@ -170,7 +170,7 @@ impl LineraNetConfig for LocalNetTestingConfig {
             num_validators,
             num_shards,
         )?;
-        let client = net.make_client();
+        let client = net.make_client().await;
         if num_validators > 0 {
             net.generate_initial_validator_config().await.unwrap();
             client.create_genesis_config().await.unwrap();
@@ -189,7 +189,7 @@ impl LineraNet for LocalNet {
         Ok(())
     }
 
-    fn make_client(&mut self) -> ClientWrapper {
+    async fn make_client(&mut self) -> ClientWrapper {
         let client = ClientWrapper::new(
             self.tmp_dir.clone(),
             self.network,

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -45,7 +45,7 @@ pub trait LineraNetConfig {
 pub trait LineraNet {
     async fn ensure_is_running(&mut self) -> Result<()>;
 
-    fn make_client(&mut self) -> ClientWrapper;
+    async fn make_client(&mut self) -> ClientWrapper;
 
     async fn terminate(&mut self) -> Result<()>;
 }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -2138,7 +2138,7 @@ async fn net_up(
     // Create the extra wallets.
     if let Some(extra_wallets) = *extra_wallets {
         for wallet in 1..=extra_wallets {
-            let extra_wallet = net.make_client();
+            let extra_wallet = net.make_client().await;
             extra_wallet.wallet_init(&[], None).await?;
             let unassigned_key = extra_wallet.keygen().await?;
             let new_chain_msg_id = client1

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -51,7 +51,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
     let network = config.network;
     let (mut net, client) = config.instantiate().await.unwrap();
 
-    let client_2 = net.make_client();
+    let client_2 = net.make_client().await;
     client_2.wallet_init(&[], None).await.unwrap();
     let chain_1 = client.get_wallet().unwrap().default_chain().unwrap();
 
@@ -285,7 +285,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     let chain = ChainId::root(0);
     let mut height = 0;
     client2.wallet_init(&[chain], None).await.unwrap();
@@ -347,7 +347,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
     // Create net and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     client2.wallet_init(&[], None).await.unwrap();
 
     // Get some chain owned by Client 1.
@@ -580,7 +580,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
@@ -671,7 +671,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
@@ -726,7 +726,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -743,7 +743,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     let message_id = outcome.message_id;
 
     // Use the faucet directly to initialize client 3.
-    let client3 = net.make_client();
+    let client3 = net.make_client().await;
     let outcome = client3.wallet_init(&[], Some(&faucet.url())).await.unwrap();
     let chain3 = outcome.unwrap().chain_id;
     assert_eq!(

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -258,7 +258,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -349,7 +349,7 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -549,7 +549,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client();
+    let client2 = net.make_client().await;
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -677,8 +677,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
 
     let (mut net, client_admin) = config.instantiate().await.unwrap();
 
-    let client_a = net.make_client();
-    let client_b = net.make_client();
+    let client_a = net.make_client().await;
+    let client_b = net.make_client().await;
 
     client_a.wallet_init(&[], None).await.unwrap();
     client_b.wallet_init(&[], None).await.unwrap();
@@ -943,8 +943,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
 
     let (mut net, client_admin) = config.instantiate().await.unwrap();
 
-    let client0 = net.make_client();
-    let client1 = net.make_client();
+    let client0 = net.make_client().await;
+    let client1 = net.make_client().await;
     client0.wallet_init(&[], None).await.unwrap();
     client1.wallet_init(&[], None).await.unwrap();
 


### PR DESCRIPTION
## Motivation

The implementation for the shared local kubernetes cluster will require us to lock a `futures::lock::Mutex` from inside `make_client`

## Proposal

Making `make_client` async here to avoid too many changes in one PR

## Test Plan

CI

