### PR TITLE
Add initial_balance parameter to open_and_assign

### DIFF
--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -2142,7 +2142,7 @@ async fn net_up(
             extra_wallet.wallet_init(&[], None).await?;
             let unassigned_key = extra_wallet.keygen().await?;
             let new_chain_msg_id = client1
-                .open_chain(default_chain, Some(unassigned_key))
+                .open_chain(default_chain, Some(unassigned_key), Amount::ZERO)
                 .await?
                 .0;
             extra_wallet

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -57,7 +57,10 @@ async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
 
     let (node_service_2, chain_2) = match network {
         Network::Grpc => {
-            let chain_2 = client.open_and_assign(&client_2).await.unwrap();
+            let chain_2 = client
+                .open_and_assign(&client_2, Amount::ZERO)
+                .await
+                .unwrap();
             let node_service_2 = client_2.run_node_service(8081).await.unwrap();
             (Some(node_service_2), chain_2)
         }
@@ -109,7 +112,10 @@ async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
     }
 
     // Create derived chain
-    let (_, chain_3) = client.open_chain(chain_1, None).await.unwrap();
+    let (_, chain_3) = client
+        .open_chain(chain_1, None, Amount::ZERO)
+        .await
+        .unwrap();
 
     // Inspect state of derived chain
     assert!(client.is_chain_present_in_wallet(chain_3).await);
@@ -357,7 +363,10 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
     let client2_key = client2.keygen().await.unwrap();
 
     // Open chain on behalf of Client 2.
-    let (message_id, chain2) = client1.open_chain(chain1, Some(client2_key)).await.unwrap();
+    let (message_id, chain2) = client1
+        .open_chain(chain1, Some(client2_key), Amount::ZERO)
+        .await
+        .unwrap();
 
     // Assign chain2 to client2_key.
     assert_eq!(
@@ -680,9 +689,18 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let client2_key = client2.keygen().await.unwrap();
 
     // Open a great-grandchild chain on behalf of client 2.
-    let (_, grandparent) = client1.open_chain(chain1, None).await.unwrap();
-    let (_, parent) = client1.open_chain(grandparent, None).await.unwrap();
-    let (message_id, chain2) = client1.open_chain(parent, Some(client2_key)).await.unwrap();
+    let (_, grandparent) = client1
+        .open_chain(chain1, None, Amount::ZERO)
+        .await
+        .unwrap();
+    let (_, parent) = client1
+        .open_chain(grandparent, None, Amount::ZERO)
+        .await
+        .unwrap();
+    let (message_id, chain2) = client1
+        .open_chain(parent, Some(client2_key), Amount::ZERO)
+        .await
+        .unwrap();
     client2.assign(client2_key, message_id).await.unwrap();
 
     // Transfer 6 units from Chain 1 to Chain 2.

--- a/linera-service/tests/wasm_end_to_end_tests.rs
+++ b/linera-service/tests/wasm_end_to_end_tests.rs
@@ -262,7 +262,10 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&client2).await.unwrap();
+    let chain2 = client1
+        .open_and_assign(&client2, Amount::ZERO)
+        .await
+        .unwrap();
     let (contract, service) = client1.build_example("social").await.unwrap();
     let bytecode_id = client1
         .publish_bytecode(contract, service, None)
@@ -353,7 +356,10 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&client2).await.unwrap();
+    let chain2 = client1
+        .open_and_assign(&client2, Amount::ZERO)
+        .await
+        .unwrap();
 
     // The players
     let account_owner1 = get_fungible_account_owner(&client1);
@@ -553,7 +559,10 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
     client2.wallet_init(&[], None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
-    let chain2 = client1.open_and_assign(&client2).await.unwrap();
+    let chain2 = client1
+        .open_and_assign(&client2, Amount::ZERO)
+        .await
+        .unwrap();
 
     // The players
     let account_owner1 = get_fungible_account_owner(&client1); // operator
@@ -692,8 +701,14 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
         client_admin.build_example("matching-engine").await.unwrap();
 
     let chain_admin = client_admin.get_wallet().unwrap().default_chain().unwrap();
-    let chain_a = client_admin.open_and_assign(&client_a).await.unwrap();
-    let chain_b = client_admin.open_and_assign(&client_b).await.unwrap();
+    let chain_a = client_admin
+        .open_and_assign(&client_a, Amount::ZERO)
+        .await
+        .unwrap();
+    let chain_b = client_admin
+        .open_and_assign(&client_b, Amount::ZERO)
+        .await
+        .unwrap();
 
     // The players
     let owner_admin = get_fungible_account_owner(&client_admin);
@@ -956,8 +971,14 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
     let chain_admin = client_admin.get_wallet().unwrap().default_chain().unwrap();
 
     // User chains
-    let chain0 = client_admin.open_and_assign(&client0).await.unwrap();
-    let chain1 = client_admin.open_and_assign(&client1).await.unwrap();
+    let chain0 = client_admin
+        .open_and_assign(&client0, Amount::ZERO)
+        .await
+        .unwrap();
+    let chain1 = client_admin
+        .open_and_assign(&client1, Amount::ZERO)
+        .await
+        .unwrap();
 
     // Admin user
     let owner_admin = get_fungible_account_owner(&client_admin);


### PR DESCRIPTION
## Motivation

Open chain can receive an initial balance parameter, but we're currently not using it

## Proposal

As we're gonna use this in the shared local kubernetes cluster wasm e2e tests PR, doing this change here so we don't have too many changes in one PR

## Test Plan

CI

