### PR TITLE
Add initial_funding parameter to create_genesis_config

### DIFF
--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -21,6 +21,7 @@ use kube::{
     api::{Api, ListParams},
     Client,
 };
+use linera_base::data_types::Amount;
 use std::{fs, path::PathBuf, sync::Arc};
 use tempfile::{tempdir, TempDir};
 use tokio::process::Command;
@@ -97,7 +98,10 @@ impl LineraNetConfig for LocalKubernetesNetConfig {
             "There should be at least one initial validator"
         );
         net.generate_initial_validator_config().await.unwrap();
-        client.create_genesis_config().await.unwrap();
+        client
+            .create_genesis_config(Amount::from_tokens(10))
+            .await
+            .unwrap();
         net.run().await.unwrap();
 
         Ok((net, client))
@@ -138,7 +142,10 @@ impl LineraNetConfig for LocalKubernetesNetTestingConfig {
         let client = net.make_client().await;
         if num_validators > 0 {
             net.generate_initial_validator_config().await.unwrap();
-            client.create_genesis_config().await.unwrap();
+            client
+                .create_genesis_config(Amount::from_tokens(10))
+                .await
+                .unwrap();
             net.run().await.unwrap();
         }
         Ok((net, client))

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use async_trait::async_trait;
+use linera_base::data_types::Amount;
 use std::{
     collections::{BTreeMap, HashSet},
     env, fs,
@@ -142,7 +143,10 @@ impl LineraNetConfig for LocalNetConfig {
             "There should be at least one initial validator"
         );
         net.generate_initial_validator_config().await.unwrap();
-        client.create_genesis_config().await.unwrap();
+        client
+            .create_genesis_config(Amount::from_tokens(10))
+            .await
+            .unwrap();
         net.run().await.unwrap();
         Ok((net, client))
     }
@@ -173,7 +177,10 @@ impl LineraNetConfig for LocalNetTestingConfig {
         let client = net.make_client().await;
         if num_validators > 0 {
             net.generate_initial_validator_config().await.unwrap();
-            client.create_genesis_config().await.unwrap();
+            client
+                .create_genesis_config(Amount::from_tokens(10))
+                .await
+                .unwrap();
             net.run().await.unwrap();
         }
         Ok((net, client))

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -145,11 +145,11 @@ impl ClientWrapper {
     }
 
     /// Runs `linera create-genesis-config`.
-    pub async fn create_genesis_config(&self) -> Result<()> {
+    pub async fn create_genesis_config(&self, initial_funding: Amount) -> Result<()> {
         let mut command = self.command().await?;
         command
             .args(["create-genesis-config", "10"])
-            .args(["--initial-funding", "10"])
+            .args(["--initial-funding", &initial_funding.to_string()])
             .args(["--committee", "committee.json"])
             .args(["--genesis", "genesis.json"]);
         if let Some(seed) = self.testing_prng_seed {


### PR DESCRIPTION
## Motivation

For passing all wasm e2e tests with the shared local kubernetes, we need to have a higher initial funding when creating the genesis config

## Proposal

Implementing that missing functionality

## Test Plan

CI

