### PR TITLE
Pass all Wasm e2e tests with Shared Kubernetes cluster

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -47,8 +47,28 @@ jobs:
           strip target/release/linera-server
           strip target/release/linera-db
       - name: Run Wasm e2e test
-        run: |
-          cargo test --locked -p linera-service --features scylladb,kubernetes --test wasm_end_to_end_tests -- test_wasm_end_to_end_amm
+        uses: nick-fields/retry@v2
+        with:
+          # Port forwarding sometimes dies, which makes all requests timeout
+          # Which is why we need retries
+          max_attempts: 5
+          timeout_minutes: 45
+          command: kind get clusters | xargs -I {} kind delete cluster --name {} && cargo test --locked -p linera-service --features scylladb,kubernetes --test wasm_end_to_end_tests -- kubernetes
+      - name: Destroy the kind clusters from Wasm e2e
+        if: always()
+        shell: bash
+        run: >-
+          kind get clusters | xargs -I {} kind delete cluster --name {}
       - name: Run e2e test
-        run: |
-          cargo test --locked -p linera-service --features scylladb,kubernetes --test end_to_end_tests -- test_end_to_end_multiple_wallets
+        uses: nick-fields/retry@v2
+        with:
+          # Port forwarding sometimes dies, which makes all requests timeout
+          # Which is why we need retries
+          max_attempts: 5
+          timeout_minutes: 45
+          command: kind get clusters | xargs -I {} kind delete cluster --name {} && cargo test --locked -p linera-service --features scylladb,kubernetes --test end_to_end_tests -- test_end_to_end_multiple_wallets::kubernetes
+      - name: Destroy the kind clusters from e2e
+        if: always()
+        shell: bash
+        run: >-
+          kind get clusters | xargs -I {} kind delete cluster --name {}

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -9,7 +9,7 @@ mod common;
 use common::INTEGRATION_TEST_GUARD;
 use linera_base::{data_types::Amount, identifiers::ChainId};
 #[cfg(feature = "kubernetes")]
-use linera_service::cli_wrappers::local_kubernetes_net::LocalKubernetesNetTestingConfig;
+use linera_service::cli_wrappers::local_kubernetes_net::SharedLocalKubernetesNetTestingConfig;
 use linera_service::{
     cli_wrappers::{
         local_net::{Database, LocalNet, LocalNetConfig, LocalNetTestingConfig},
@@ -342,10 +342,10 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig
     net.terminate().await.unwrap();
 }
 
-#[cfg_attr(all(feature = "rocksdb", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
-#[cfg_attr(all(feature = "scylladb", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
-#[cfg_attr(all(feature = "aws", not(feature = "kubernetes")), test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
-#[cfg_attr(feature = "kubernetes", test_case(LocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_scylladb_grpc"))]
+#[cfg_attr(feature = "rocksdb", test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;


### PR DESCRIPTION
## Motivation

We need to share the same Kubernetes cluster when running the e2e tests, because the initialization time is too high and we would use a lot more resources in CI

## Proposal

Implemented a shared kubernetes cluster that replaces the existing testing one. Will try e2e tests next, and if they all pass I'll merge the two files in a following PR

## Test Plan

CI

