### PR TITLE
Rename `GreatestLowerBoundIterator` to `SuffixClosedSetIterator`

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -130,7 +130,7 @@ where
 /// entry such that `x <= val` for the lexicographic order. If none exists then None is
 /// returned. The function calls have to be done with increasing `val`.
 ///
-/// The function call `contains_key(val)` tests whether there exists a prefix p in the
+/// The function call `find_key(val)` tests whether there exists a prefix p in the
 /// set of vectors such that p is a prefix of val.
 pub(crate) struct SuffixClosedSetIterator<'a, I> {
     prefix_len: usize,
@@ -171,7 +171,7 @@ where
         }
     }
 
-    pub(crate) fn contains_key(&mut self, index: &[u8]) -> bool {
+    pub(crate) fn find_key(&mut self, index: &[u8]) -> bool {
         let lower_bound = self.find_lower_bound(index);
         match lower_bound {
             None => false,
@@ -183,7 +183,7 @@ where
 pub(crate) fn contains_key(prefixes: &BTreeSet<Vec<u8>>, key: &[u8]) -> bool {
     let iter = prefixes.iter();
     let mut suffix_closed_set = SuffixClosedSetIterator::new(0, iter);
-    suffix_closed_set.contains_key(key)
+    suffix_closed_set.find_key(key)
 }
 
 pub(crate) fn insert_key_prefix(prefixes: &mut BTreeSet<Vec<u8>>, prefix: Vec<u8>) {
@@ -234,33 +234,33 @@ fn suffix_closed_set_test1_the_lower_bound() {
 }
 
 #[test]
-fn suffix_closed_set_test2_contains_key() {
+fn suffix_closed_set_test2_find_key() {
     let mut set = BTreeSet::<Vec<u8>>::new();
     set.insert(vec![4]);
     set.insert(vec![0, 3]);
     set.insert(vec![5]);
 
     let mut suffix_closed_set = SuffixClosedSetIterator::new(0, set.iter());
-    assert!(!suffix_closed_set.contains_key(&[0]));
-    assert!(suffix_closed_set.contains_key(&[0, 3]));
-    assert!(suffix_closed_set.contains_key(&[0, 3, 4]));
-    assert!(!suffix_closed_set.contains_key(&[1]));
-    assert!(suffix_closed_set.contains_key(&[4]));
+    assert!(!suffix_closed_set.find_key(&[0]));
+    assert!(suffix_closed_set.find_key(&[0, 3]));
+    assert!(suffix_closed_set.find_key(&[0, 3, 4]));
+    assert!(!suffix_closed_set.find_key(&[1]));
+    assert!(suffix_closed_set.find_key(&[4]));
 }
 
 #[test]
-fn suffix_closed_set_test3_contains_key_prefix_len() {
+fn suffix_closed_set_test3_find_key_prefix_len() {
     let mut set = BTreeSet::<Vec<u8>>::new();
     set.insert(vec![0, 4]);
     set.insert(vec![0, 3]);
     set.insert(vec![0, 0, 1]);
 
     let mut suffix_closed_set = SuffixClosedSetIterator::new(1, set.iter());
-    assert!(!suffix_closed_set.contains_key(&[0]));
-    assert!(suffix_closed_set.contains_key(&[0, 1]));
-    assert!(suffix_closed_set.contains_key(&[0, 1, 4]));
-    assert!(suffix_closed_set.contains_key(&[3]));
-    assert!(!suffix_closed_set.contains_key(&[5]));
+    assert!(!suffix_closed_set.find_key(&[0]));
+    assert!(suffix_closed_set.find_key(&[0, 1]));
+    assert!(suffix_closed_set.find_key(&[0, 1, 4]));
+    assert!(suffix_closed_set.find_key(&[3]));
+    assert!(!suffix_closed_set.find_key(&[5]));
 }
 
 #[test]

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -211,11 +211,26 @@ fn suffix_closed_set_test1_the_lower_bound() {
 
     let mut suffix_closed_set = SuffixClosedSet::new(0, set.iter());
     assert_eq!(suffix_closed_set.get_lower_bound(&[3]), None);
-    assert_eq!(suffix_closed_set.get_lower_bound(&[15]), Some(vec!(10)).as_ref());
-    assert_eq!(suffix_closed_set.get_lower_bound(&[17]), Some(vec!(10)).as_ref());
-    assert_eq!(suffix_closed_set.get_lower_bound(&[25]), Some(vec!(24)).as_ref());
-    assert_eq!(suffix_closed_set.get_lower_bound(&[27]), Some(vec!(24)).as_ref());
-    assert_eq!(suffix_closed_set.get_lower_bound(&[42]), Some(vec!(40)).as_ref());
+    assert_eq!(
+        suffix_closed_set.get_lower_bound(&[15]),
+        Some(vec!(10)).as_ref()
+    );
+    assert_eq!(
+        suffix_closed_set.get_lower_bound(&[17]),
+        Some(vec!(10)).as_ref()
+    );
+    assert_eq!(
+        suffix_closed_set.get_lower_bound(&[25]),
+        Some(vec!(24)).as_ref()
+    );
+    assert_eq!(
+        suffix_closed_set.get_lower_bound(&[27]),
+        Some(vec!(24)).as_ref()
+    );
+    assert_eq!(
+        suffix_closed_set.get_lower_bound(&[42]),
+        Some(vec!(40)).as_ref()
+    );
 }
 
 #[test]

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -123,23 +123,23 @@ where
     }
 }
 
-/// `GreatestLowerBoundIterator` iterates over the entries of a container ordered
+/// `SuffixClosedSet` iterates over the entries of a container ordered
 /// lexicographically.
 ///
 /// The function call `get_lower_bound(val)` returns a `Some(x)` where `x` is the highest
-/// entry such that `x <= val`. If none exists then None is returned. The function calls
-/// have to be done with increasing `val`.
+/// entry such that `x <= val` for the lexicographic order. If none exists then None is
+/// returned. The function calls have to be done with increasing `val`.
 ///
 /// The function calls `is_index_absent(val)` tests whether there exist a prefix p in the
 /// set of vectors such that p is a prefix of val.
-pub(crate) struct GreatestLowerBoundIterator<'a, IT> {
+pub(crate) struct SuffixClosedSet<'a, IT> {
     prefix_len: usize,
     prec1: Option<&'a Vec<u8>>,
     prec2: Option<&'a Vec<u8>>,
     iter: IT,
 }
 
-impl<'a, IT> GreatestLowerBoundIterator<'a, IT>
+impl<'a, IT> SuffixClosedSet<'a, IT>
 where
     IT: Iterator<Item = &'a Vec<u8>>,
 {
@@ -182,8 +182,8 @@ where
 
 pub(crate) fn is_index_absent(prefixes: &BTreeSet<Vec<u8>>, key: &[u8]) -> bool {
     let iter = prefixes.iter();
-    let mut lower_bound = GreatestLowerBoundIterator::new(0, iter);
-    lower_bound.is_index_absent(key)
+    let mut suffix_closed_set = SuffixClosedSet::new(0, iter);
+    suffix_closed_set.is_index_absent(key)
 }
 
 pub(crate) fn insert_key_prefix(prefixes: &mut BTreeSet<Vec<u8>>, prefix: Vec<u8>) {
@@ -200,7 +200,7 @@ pub(crate) fn insert_key_prefix(prefixes: &mut BTreeSet<Vec<u8>>, prefix: Vec<u8
 }
 
 #[test]
-fn lower_bound_test1_the_lower_bound() {
+fn suffix_closed_set_test1_the_lower_bound() {
     let mut set = BTreeSet::<Vec<u8>>::new();
     set.insert(vec![4]);
     set.insert(vec![7]);
@@ -209,43 +209,43 @@ fn lower_bound_test1_the_lower_bound() {
     set.insert(vec![24]);
     set.insert(vec![40]);
 
-    let mut lower_bound = GreatestLowerBoundIterator::new(0, set.iter());
-    assert_eq!(lower_bound.get_lower_bound(&[3]), None);
-    assert_eq!(lower_bound.get_lower_bound(&[15]), Some(vec!(10)).as_ref());
-    assert_eq!(lower_bound.get_lower_bound(&[17]), Some(vec!(10)).as_ref());
-    assert_eq!(lower_bound.get_lower_bound(&[25]), Some(vec!(24)).as_ref());
-    assert_eq!(lower_bound.get_lower_bound(&[27]), Some(vec!(24)).as_ref());
-    assert_eq!(lower_bound.get_lower_bound(&[42]), Some(vec!(40)).as_ref());
+    let mut suffix_closed_set = SuffixClosedSet::new(0, set.iter());
+    assert_eq!(suffix_closed_set.get_lower_bound(&[3]), None);
+    assert_eq!(suffix_closed_set.get_lower_bound(&[15]), Some(vec!(10)).as_ref());
+    assert_eq!(suffix_closed_set.get_lower_bound(&[17]), Some(vec!(10)).as_ref());
+    assert_eq!(suffix_closed_set.get_lower_bound(&[25]), Some(vec!(24)).as_ref());
+    assert_eq!(suffix_closed_set.get_lower_bound(&[27]), Some(vec!(24)).as_ref());
+    assert_eq!(suffix_closed_set.get_lower_bound(&[42]), Some(vec!(40)).as_ref());
 }
 
 #[test]
-fn lower_bound_test2_is_index_absent() {
+fn suffix_closed_set_test2_is_index_absent() {
     let mut set = BTreeSet::<Vec<u8>>::new();
     set.insert(vec![4]);
     set.insert(vec![0, 3]);
     set.insert(vec![5]);
 
-    let mut lower_bound = GreatestLowerBoundIterator::new(0, set.iter());
-    assert!(lower_bound.is_index_absent(&[0]));
-    assert!(!lower_bound.is_index_absent(&[0, 3]));
-    assert!(!lower_bound.is_index_absent(&[0, 3, 4]));
-    assert!(lower_bound.is_index_absent(&[1]));
-    assert!(!lower_bound.is_index_absent(&[4]));
+    let mut suffix_closed_set = SuffixClosedSet::new(0, set.iter());
+    assert!(suffix_closed_set.is_index_absent(&[0]));
+    assert!(!suffix_closed_set.is_index_absent(&[0, 3]));
+    assert!(!suffix_closed_set.is_index_absent(&[0, 3, 4]));
+    assert!(suffix_closed_set.is_index_absent(&[1]));
+    assert!(!suffix_closed_set.is_index_absent(&[4]));
 }
 
 #[test]
-fn lower_bound_test3_is_index_absent_prefix_len() {
+fn suffix_closed_set_test3_is_index_absent_prefix_len() {
     let mut set = BTreeSet::<Vec<u8>>::new();
     set.insert(vec![0, 4]);
     set.insert(vec![0, 3]);
     set.insert(vec![0, 0, 1]);
 
-    let mut lower_bound = GreatestLowerBoundIterator::new(1, set.iter());
-    assert!(lower_bound.is_index_absent(&[0]));
-    assert!(!lower_bound.is_index_absent(&[0, 1]));
-    assert!(!lower_bound.is_index_absent(&[0, 1, 4]));
-    assert!(!lower_bound.is_index_absent(&[3]));
-    assert!(lower_bound.is_index_absent(&[5]));
+    let mut suffix_closed_set = SuffixClosedSet::new(1, set.iter());
+    assert!(suffix_closed_set.is_index_absent(&[0]));
+    assert!(!suffix_closed_set.is_index_absent(&[0, 1]));
+    assert!(!suffix_closed_set.is_index_absent(&[0, 1, 4]));
+    assert!(!suffix_closed_set.is_index_absent(&[3]));
+    assert!(suffix_closed_set.is_index_absent(&[5]));
 }
 
 #[test]

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -4,9 +4,8 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_interval, get_upper_bound, insert_key_prefix, contains_key, Context,
-        SuffixClosedSet, HasherOutput, KeyIterable, KeyValueIterable, Update,
-        MIN_VIEW_TAG,
+        contains_key, get_interval, get_upper_bound, insert_key_prefix, Context, HasherOutput,
+        KeyIterable, KeyValueIterable, SuffixClosedSet, Update, MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
     views::{HashableView, Hasher, View, ViewError},

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -5,7 +5,7 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::{
         contains_key, get_interval, get_upper_bound, insert_key_prefix, Context, HasherOutput,
-        KeyIterable, KeyValueIterable, SuffixClosedSet, Update, MIN_VIEW_TAG,
+        KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
     views::{HashableView, Hasher, View, ViewError},
@@ -277,7 +277,7 @@ where
         let key_prefix = self.context.base_tag(KeyTag::Index as u8);
         let mut updates = self.updates.iter();
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSet::new(0, self.deleted_prefixes.iter());
+        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
         if !self.was_cleared {
             for index in self
                 .context
@@ -376,7 +376,7 @@ where
         let key_prefix = self.context.base_tag(KeyTag::Index as u8);
         let mut updates = self.updates.iter();
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSet::new(0, self.deleted_prefixes.iter());
+        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
         if !self.was_cleared {
             for entry in self
                 .context
@@ -578,7 +578,7 @@ where
             return Ok(false);
         }
         let iter = self.deleted_prefixes.iter();
-        let mut suffix_closed_set = SuffixClosedSet::new(0, iter);
+        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, iter);
         if suffix_closed_set.contains_key(index) {
             return Ok(false);
         }
@@ -801,7 +801,7 @@ where
             .updates
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSet::new(0, self.deleted_prefixes.iter());
+        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
         if !self.was_cleared {
             for key in self
                 .context
@@ -874,7 +874,7 @@ where
             .updates
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSet::new(0, self.deleted_prefixes.iter());
+        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
         if !self.was_cleared {
             for entry in self
                 .context

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_interval, get_upper_bound, insert_key_prefix, is_index_absent, Context,
+        get_interval, get_upper_bound, insert_key_prefix, contains_key, Context,
         SuffixClosedSet, HasherOutput, KeyIterable, KeyValueIterable, Update,
         MIN_VIEW_TAG,
     },
@@ -301,7 +301,7 @@ where
                             }
                         }
                         _ => {
-                            if suffix_closed_set.is_index_absent(index) && !f(index)? {
+                            if !suffix_closed_set.contains_key(index) && !f(index)? {
                                 return Ok(());
                             }
                             break;
@@ -400,7 +400,7 @@ where
                             }
                         }
                         _ => {
-                            if suffix_closed_set.is_index_absent(index) && !f(index, index_val)? {
+                            if !suffix_closed_set.contains_key(index) && !f(index, index_val)? {
                                 return Ok(());
                             }
                             break;
@@ -546,7 +546,7 @@ where
         if self.was_cleared {
             return Ok(None);
         }
-        if !is_index_absent(&self.deleted_prefixes, index) {
+        if contains_key(&self.deleted_prefixes, index) {
             return Ok(None);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
@@ -580,7 +580,7 @@ where
         }
         let iter = self.deleted_prefixes.iter();
         let mut suffix_closed_set = SuffixClosedSet::new(0, iter);
-        if !suffix_closed_set.is_index_absent(index) {
+        if suffix_closed_set.contains_key(index) {
             return Ok(false);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
@@ -618,7 +618,7 @@ where
                 result.push(value);
             } else {
                 result.push(None);
-                if is_index_absent(&self.deleted_prefixes, &index) {
+                if !contains_key(&self.deleted_prefixes, &index) {
                     missed_indices.push(i);
                     let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
                     vector_query.push(key);
@@ -825,7 +825,7 @@ where
                         _ => {
                             let mut key_with_prefix = key_prefix.to_vec();
                             key_with_prefix.extend_from_slice(key);
-                            if suffix_closed_set.is_index_absent(&key_with_prefix) {
+                            if !suffix_closed_set.contains_key(&key_with_prefix) {
                                 keys.push(key.to_vec());
                             }
                             break;
@@ -899,7 +899,7 @@ where
                         _ => {
                             let mut key_with_prefix = key_prefix.to_vec();
                             key_with_prefix.extend_from_slice(&key);
-                            if suffix_closed_set.is_index_absent(&key_with_prefix) {
+                            if !suffix_closed_set.contains_key(&key_with_prefix) {
                                 key_values.push((key, value));
                             }
                             break;

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -300,7 +300,7 @@ where
                             }
                         }
                         _ => {
-                            if !suffix_closed_set.contains_key(index) && !f(index)? {
+                            if !suffix_closed_set.find_key(index) && !f(index)? {
                                 return Ok(());
                             }
                             break;
@@ -399,7 +399,7 @@ where
                             }
                         }
                         _ => {
-                            if !suffix_closed_set.contains_key(index) && !f(index, index_val)? {
+                            if !suffix_closed_set.find_key(index) && !f(index, index_val)? {
                                 return Ok(());
                             }
                             break;
@@ -577,9 +577,7 @@ where
         if self.was_cleared {
             return Ok(false);
         }
-        let iter = self.deleted_prefixes.iter();
-        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, iter);
-        if suffix_closed_set.contains_key(index) {
+        if contains_key(&self.deleted_prefixes, index) {
             return Ok(false);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
@@ -824,7 +822,7 @@ where
                         _ => {
                             let mut key_with_prefix = key_prefix.to_vec();
                             key_with_prefix.extend_from_slice(key);
-                            if !suffix_closed_set.contains_key(&key_with_prefix) {
+                            if !suffix_closed_set.find_key(&key_with_prefix) {
                                 keys.push(key.to_vec());
                             }
                             break;
@@ -898,7 +896,7 @@ where
                         _ => {
                             let mut key_with_prefix = key_prefix.to_vec();
                             key_with_prefix.extend_from_slice(&key);
-                            if !suffix_closed_set.contains_key(&key_with_prefix) {
+                            if !suffix_closed_set.find_key(&key_with_prefix) {
                                 key_values.push((key, value));
                             }
                             break;

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -20,7 +20,7 @@ use crate::{
     batch::Batch,
     common::{
         get_interval, insert_key_prefix, is_index_absent, Context, CustomSerialize,
-        GreatestLowerBoundIterator, HasherOutput, KeyIterable, KeyValueIterable, Update,
+        SuffixClosedSet, HasherOutput, KeyIterable, KeyValueIterable, Update,
         MIN_VIEW_TAG,
     },
     views::{HashableView, Hasher, View, ViewError},
@@ -322,7 +322,7 @@ where
     {
         let prefix_len = prefix.len();
         let iter = self.deleted_prefixes.range(get_interval(prefix.clone()));
-        let mut lower_bound = GreatestLowerBoundIterator::new(prefix_len, iter);
+        let mut suffix_closed_set = SuffixClosedSet::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
         if !self.was_cleared && is_index_absent(&self.deleted_prefixes, &prefix) {
@@ -343,7 +343,7 @@ where
                             }
                         }
                         _ => {
-                            if lower_bound.is_index_absent(index) && !f(index)? {
+                            if suffix_closed_set.is_index_absent(index) && !f(index)? {
                                 return Ok(());
                             }
                             break;
@@ -517,7 +517,7 @@ where
     {
         let prefix_len = prefix.len();
         let iter = self.deleted_prefixes.range(get_interval(prefix.clone()));
-        let mut lower_bound = GreatestLowerBoundIterator::new(prefix_len, iter);
+        let mut suffix_closed_set = SuffixClosedSet::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
         if !self.was_cleared && is_index_absent(&self.deleted_prefixes, &prefix) {
@@ -544,7 +544,7 @@ where
                             }
                         }
                         _ => {
-                            if lower_bound.is_index_absent(index) && !f(index, bytes)? {
+                            if suffix_closed_set.is_index_absent(index) && !f(index, bytes)? {
                                 return Ok(());
                             }
                             break;

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -19,9 +19,8 @@
 use crate::{
     batch::Batch,
     common::{
-        get_interval, insert_key_prefix, contains_key, Context, CustomSerialize,
-        SuffixClosedSet, HasherOutput, KeyIterable, KeyValueIterable, Update,
-        MIN_VIEW_TAG,
+        contains_key, get_interval, insert_key_prefix, Context, CustomSerialize, HasherOutput,
+        KeyIterable, KeyValueIterable, SuffixClosedSet, Update, MIN_VIEW_TAG,
     },
     views::{HashableView, Hasher, View, ViewError},
 };

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -20,7 +20,7 @@ use crate::{
     batch::Batch,
     common::{
         contains_key, get_interval, insert_key_prefix, Context, CustomSerialize, HasherOutput,
-        KeyIterable, KeyValueIterable, SuffixClosedSet, Update, MIN_VIEW_TAG,
+        KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
     },
     views::{HashableView, Hasher, View, ViewError},
 };
@@ -321,7 +321,7 @@ where
     {
         let prefix_len = prefix.len();
         let iter = self.deleted_prefixes.range(get_interval(prefix.clone()));
-        let mut suffix_closed_set = SuffixClosedSet::new(prefix_len, iter);
+        let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
         if !self.was_cleared && !contains_key(&self.deleted_prefixes, &prefix) {
@@ -516,7 +516,7 @@ where
     {
         let prefix_len = prefix.len();
         let iter = self.deleted_prefixes.range(get_interval(prefix.clone()));
-        let mut suffix_closed_set = SuffixClosedSet::new(prefix_len, iter);
+        let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
         if !self.was_cleared && !contains_key(&self.deleted_prefixes, &prefix) {

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -342,7 +342,7 @@ where
                             }
                         }
                         _ => {
-                            if !suffix_closed_set.contains_key(index) && !f(index)? {
+                            if !suffix_closed_set.find_key(index) && !f(index)? {
                                 return Ok(());
                             }
                             break;
@@ -543,7 +543,7 @@ where
                             }
                         }
                         _ => {
-                            if !suffix_closed_set.contains_key(index) && !f(index, bytes)? {
+                            if !suffix_closed_set.find_key(index) && !f(index, bytes)? {
                                 return Ok(());
                             }
                             break;


### PR DESCRIPTION
## Motivation

The terminology `GreatestLowerBoundIterator` is not great and `SuffixClosedSetIterator` is a better name.

## Proposal

We did that renaming and also renamed `is_index_absent` into `contains_key`.

## Test Plan

The CI.

## Release Plan

Nothing changes.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
