### PR TITLE
Add a faucet endpoint to return the current list of validators.

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -82,13 +82,20 @@ pub trait ValidatorNodeProvider {
     where
         I: FromIterator<(ValidatorName, Self::Node)>,
     {
-        committee
-            .validators()
-            .iter()
-            .map(|(name, validator)| {
-                let node = self.make_node(&validator.network_address)?;
-                Ok((*name, node))
-            })
+        self.make_nodes_from_list(committee.validator_addresses())
+    }
+
+    fn make_nodes_from_list<I, A>(
+        &self,
+        validators: impl IntoIterator<Item = (ValidatorName, A)>,
+    ) -> Result<I, NodeError>
+    where
+        I: FromIterator<(ValidatorName, Self::Node)>,
+        A: AsRef<str>,
+    {
+        validators
+            .into_iter()
+            .map(|(name, address)| Ok((name, self.make_node(address.as_ref())?)))
             .collect()
     }
 }

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -350,6 +350,12 @@ impl Committee {
         &self.validators
     }
 
+    pub fn validator_addresses(&self) -> impl Iterator<Item = (ValidatorName, &str)> {
+        self.validators
+            .iter()
+            .map(|(name, validator)| (*name, &*validator.network_address))
+    }
+
     pub fn total_votes(&self) -> u64 {
         self.total_votes
     }


### PR DESCRIPTION
## Motivation

The genesis config is not enough for a client to join the network in general: The current validators could be different and the genesis validators already offline.

## Proposal

Add a `currentValidators` endpoint.

## Test Plan

The faucet end-to-end test tests this: `wallet init` now requests the current list of validators.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/1361.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
