### PR TITLE
Speed up `find_received_certificates`.

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -164,6 +164,9 @@ pub enum NodeError {
     SubscriptionError { transport: String },
     #[error("Failed to subscribe; tonic status: {status}")]
     SubscriptionFailed { status: String },
+
+    #[error("Failed to make a chain info query on the local node: {error}")]
+    LocalNodeQuery { error: String },
 }
 
 impl CrossChainMessageDelivery {

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -508,6 +508,10 @@ NodeError:
       SubscriptionFailed:
         STRUCT:
           - status: STR
+    19:
+      LocalNodeQuery:
+        STRUCT:
+          - error: STR
 Operation:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

`ChainClient::find_received_certificates` downloads all certificates received by the chain from every validator every time e.g. the `sync-balance` command is executed.

## Proposal

Look them up locally before downloading any certificates. Don't download what we already have.

## Test Plan

I tried it out and it took less than 1 instead of 27 seconds to run `sync-balance`.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
