### PR TITLE
Introduce `contains_hash` for the `Storage`

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -666,9 +666,8 @@ where
                     && !blob_hashes.contains(&location.certificate_hash)
             })
             .map(|location| {
-                // TODO(#515): Don't read the value just to check existence.
                 self.storage
-                    .contains_hash(location.certificate_hash)
+                    .contains_value(location.certificate_hash)
                     .map(move |result| (location, result))
             })
             .collect::<Vec<_>>();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -668,15 +668,15 @@ where
             .map(|location| {
                 // TODO(#515): Don't read the value just to check existence.
                 self.storage
-                    .read_value(location.certificate_hash)
+                    .contains_hash(location.certificate_hash)
                     .map(move |result| (location, result))
             })
             .collect::<Vec<_>>();
         let mut locations = vec![];
         for (location, result) in future::join_all(tasks).await {
             match result {
-                Ok(_value) => {} // Value is not missing.
-                Err(ViewError::NotFound(_)) => locations.push(location),
+                Ok(true) => {}
+                Ok(false) => locations.push(location),
                 Err(err) => Err(err)?,
             }
         }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -80,6 +80,9 @@ pub trait Storage: Sized {
     where
         ViewError: From<Self::ContextError>;
 
+    /// Tests whether the hash is contained in the storage
+    async fn contains_hash(&self, hash: CryptoHash) -> Result<bool, ViewError>;
+
     /// Reads the value with the given hash.
     async fn read_value(&self, hash: CryptoHash) -> Result<HashedValue, ViewError>;
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -80,8 +80,8 @@ pub trait Storage: Sized {
     where
         ViewError: From<Self::ContextError>;
 
-    /// Tests whether the hash is contained in the storage
-    async fn contains_hash(&self, hash: CryptoHash) -> Result<bool, ViewError>;
+    /// Tests existence of a value with the given hash.
+    async fn contains_value(&self, hash: CryptoHash) -> Result<bool, ViewError>;
 
     /// Reads the value with the given hash.
     async fn read_value(&self, hash: CryptoHash) -> Result<HashedValue, ViewError>;
@@ -98,6 +98,9 @@ pub trait Storage: Sized {
 
     /// Writes several values
     async fn write_values(&self, values: &[HashedValue]) -> Result<(), ViewError>;
+
+    /// Tests existence of the certificate with the given hash.
+    async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError>;
 
     /// Reads the certificate with the given hash.
     async fn read_certificate(&self, hash: CryptoHash) -> Result<Certificate, ViewError>;


### PR DESCRIPTION
## Motivation

The original motivation for the `contains_key` was to have a more efficient `check_no_missing_bytecode`. This PR addresses it.

## Proposal

The name of the new functionality is perhaps controversial. I called it `contains_hash`.

## Test Plan

The CI.

## Release Plan

No change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
