### PR TITLE
Fix ChainClient::identity if an owner is regular and super.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -449,15 +449,13 @@ where
         );
         let mut identities = manager
             .ownership
-            .owners
-            .keys()
-            .chain(manager.ownership.super_owners.keys())
+            .all_owners()
             .filter(|owner| self.known_key_pairs.contains_key(owner));
         let Some(identity) = identities.next() else {
             return Err(ChainClientError::CannotFindKeyForChain(self.chain_id));
         };
         ensure!(
-            identities.next().is_none(),
+            identities.all(|id| id == identity),
             ChainClientError::FoundMultipleKeysForChain(self.chain_id)
         );
         Ok(*identity)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -859,11 +859,11 @@ where
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let new_key_pair = KeyPair::generate();
-    // Open the new chain.
-    let (message_id, creation_certificate) = sender
-        .open_chain(ChainOwnership::single(new_key_pair.public()), Amount::ZERO)
-        .await
-        .unwrap();
+    // Open the new chain. We are both regular and super owner.
+    let ownership = ChainOwnership::single(new_key_pair.public())
+        .with_regular_owner(new_key_pair.public(), 100);
+    let (message_id, creation_certificate) =
+        sender.open_chain(ownership, Amount::ZERO).await.unwrap();
     let new_id = ChainId::child(message_id);
     // Transfer after creating the chain.
     let transfer_certificate = sender

--- a/linera-execution/src/ownership.rs
+++ b/linera-execution/src/ownership.rs
@@ -39,6 +39,12 @@ impl ChainOwnership {
         }
     }
 
+    pub fn with_regular_owner(mut self, public_key: PublicKey, weight: u64) -> Self {
+        self.owners
+            .insert(Owner::from(public_key), (public_key, weight));
+        self
+    }
+
     pub fn is_active(&self) -> bool {
         !self.super_owners.is_empty() || !self.owners.is_empty()
     }


### PR DESCRIPTION
## Motivation

`ChainClient::identity` fails if there are multiple matching keys. However, the same owner can appear twice in that list: once as a regular and once as a super owner. That is a legitimate use case: One might want to be able to propose fast blocks in the first round, but also be the assigned leader in some single-leader rounds.

## Proposal

Don't fail if all matching keys are equal.

## Test Plan

A client test has been extended, and was able to reproduce the problem.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
