### PR TITLE
Allow different system runtime implementations

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -56,10 +56,10 @@ use std::{io, path::Path, str::FromStr, sync::Arc};
 use thiserror::Error;
 
 /// An implementation of [`UserContract`]
-pub type UserContractCode = Arc<dyn UserContract + Send + Sync + 'static>;
+pub type UserContractCode = Arc<dyn UserContract<ContractRuntimeSender> + Send + Sync + 'static>;
 
 /// An implementation of [`UserService`].
-pub type UserServiceCode = Arc<dyn UserService + Send + Sync + 'static>;
+pub type UserServiceCode = Arc<dyn UserService<ServiceRuntimeSender> + Send + Sync + 'static>;
 
 #[derive(Error, Debug)]
 pub enum ExecutionError {
@@ -127,12 +127,12 @@ impl From<ViewError> for ExecutionError {
 }
 
 /// The public entry points provided by the contract part of an application.
-pub trait UserContract {
+pub trait UserContract<Runtime> {
     /// Initializes the application state on the chain that owns the application.
     fn initialize(
         &self,
         context: OperationContext,
-        runtime_sender: ContractRuntimeSender,
+        runtime: Runtime,
         argument: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>;
 
@@ -140,7 +140,7 @@ pub trait UserContract {
     fn execute_operation(
         &self,
         context: OperationContext,
-        runtime_sender: ContractRuntimeSender,
+        runtime: Runtime,
         operation: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>;
 
@@ -148,7 +148,7 @@ pub trait UserContract {
     fn execute_message(
         &self,
         context: MessageContext,
-        runtime_sender: ContractRuntimeSender,
+        runtime: Runtime,
         message: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>;
 
@@ -159,7 +159,7 @@ pub trait UserContract {
     fn handle_application_call(
         &self,
         context: CalleeContext,
-        runtime_sender: ContractRuntimeSender,
+        runtime: Runtime,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, ExecutionError>;
@@ -168,7 +168,7 @@ pub trait UserContract {
     fn handle_session_call(
         &self,
         context: CalleeContext,
-        runtime_sender: ContractRuntimeSender,
+        runtime: Runtime,
         session_state: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
@@ -176,12 +176,12 @@ pub trait UserContract {
 }
 
 /// The public entry points provided by the service part of an application.
-pub trait UserService {
+pub trait UserService<Runtime> {
     /// Executes unmetered read-only queries on the state of this application.
     fn handle_query(
         &self,
         context: QueryContext,
-        runtime_sender: ServiceRuntimeSender,
+        runtime: Runtime,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 }

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -187,6 +187,14 @@ impl BaseRuntime for ContractRuntimeSender {
         receiver.recv_response()
     }
 
+    fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError> {
+        self.inner
+            .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
+                batch,
+                response_sender,
+            })
+    }
+
     fn read_value_bytes_new(
         &mut self,
         key: Vec<u8>,
@@ -313,14 +321,6 @@ impl ContractRuntime for ContractRuntimeSender {
                 session_id,
                 argument,
                 forwarded_sessions,
-                response_sender,
-            })
-    }
-
-    fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError> {
-        self.inner
-            .send_sync_request(|response_sender| ContractRequest::WriteBatchAndUnlock {
-                batch,
                 response_sender,
             })
     }
@@ -501,6 +501,10 @@ impl BaseRuntime for ServiceRuntimeSender {
             .take()
             .ok_or_else(|| ExecutionError::PolledTwice)?;
         receiver.recv_response()
+    }
+
+    fn write_batch_and_unlock(&mut self, _batch: Batch) -> Result<(), ExecutionError> {
+        Err(ExecutionError::WriteAttemptToReadOnlyStorage)
     }
 
     fn read_value_bytes_new(

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -28,7 +28,11 @@ use crate::{
     MessageContext, OperationContext, QueryContext, RawExecutionResult, ServiceRuntime,
     SessionCallResult, SessionId, UserContract, UserService, WasmRuntime,
 };
-use std::{path::Path, sync::Arc};
+use std::{
+    marker::{PhantomData, Unpin},
+    path::Path,
+    sync::Arc,
+};
 use thiserror::Error;
 
 /// A user contract in a compiled WebAssembly module.
@@ -44,12 +48,12 @@ pub enum WasmContractModule {
 
 pub struct WasmContract<Runtime> {
     module: WasmContractModule,
-    _marker: std::marker::PhantomData<Runtime>,
+    _marker: PhantomData<Runtime>,
 }
 
 impl<Runtime> WasmContract<Runtime>
 where
-    Runtime: ContractRuntime + Clone + Send + std::marker::Unpin,
+    Runtime: ContractRuntime + Clone + Send + Unpin,
 {
     /// Creates a new [`WasmContract`] using the WebAssembly module with the provided bytecodes.
     pub async fn new(
@@ -101,12 +105,12 @@ pub enum WasmServiceModule {
 
 pub struct WasmService<Runtime> {
     module: WasmServiceModule,
-    _marker: std::marker::PhantomData<Runtime>,
+    _marker: PhantomData<Runtime>,
 }
 
 impl<Runtime> WasmService<Runtime>
 where
-    Runtime: ServiceRuntime + Clone + Send + std::marker::Unpin,
+    Runtime: ServiceRuntime + Clone + Send + Unpin,
 {
     /// Creates a new [`WasmService`] using the WebAssembly module with the provided bytecodes.
     pub async fn new(
@@ -162,7 +166,7 @@ pub enum WasmExecutionError {
 
 impl<Runtime> UserContract<Runtime> for WasmContract<Runtime>
 where
-    Runtime: ContractRuntime + Clone + std::marker::Unpin,
+    Runtime: ContractRuntime + Clone + Unpin,
 {
     fn initialize(
         &self,
@@ -274,7 +278,7 @@ where
 
 impl<Runtime> UserService<Runtime> for WasmService<Runtime>
 where
-    Runtime: ServiceRuntime + Clone + std::marker::Unpin,
+    Runtime: ServiceRuntime + Clone + Unpin,
 {
     fn handle_query(
         &self,
@@ -336,8 +340,8 @@ pub mod test {
         wasm_runtime: impl Into<Option<WasmRuntime>>,
     ) -> Result<(WasmContract<C>, WasmService<S>), anyhow::Error>
     where
-        C: crate::ContractRuntime + Clone + Send + std::marker::Unpin,
-        S: crate::ServiceRuntime + Clone + Send + std::marker::Unpin,
+        C: crate::ContractRuntime + Clone + Send + Unpin,
+        S: crate::ServiceRuntime + Clone + Send + Unpin,
     {
         let (contract_path, service_path) = get_example_bytecode_paths(name)?;
         let wasm_runtime = wasm_runtime.into().unwrap_or_default();

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -145,7 +145,7 @@ pub enum WasmExecutionError {
     ExecuteModuleInWasmtime(#[from] ::wasmtime::Trap),
 }
 
-impl UserContract for WasmContract {
+impl UserContract<ContractRuntimeSender> for WasmContract {
     fn initialize(
         &self,
         context: OperationContext,
@@ -250,7 +250,7 @@ impl UserContract for WasmContract {
     }
 }
 
-impl UserService for WasmService {
+impl UserService<ServiceRuntimeSender> for WasmService {
     fn handle_query(
         &self,
         context: QueryContext,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -5,8 +5,8 @@
 ///
 /// Generates the common code for contract system API types for all Wasm runtimes.
 macro_rules! impl_contract_system_api {
-    ($contract_system_api:ident, $trap:ty) => {
-        impl contract_system_api::ContractSystemApi for $contract_system_api {
+    ($trap:ty) => {
+        impl<T: crate::ContractRuntime> contract_system_api::ContractSystemApi for T {
             type Error = ExecutionError;
 
             type Lock = <Self as BaseRuntime>::Lock;
@@ -130,8 +130,8 @@ macro_rules! impl_contract_system_api {
 ///
 /// Generates the common code for service system API types for all Wasm runtimes.
 macro_rules! impl_service_system_api {
-    ($service_system_api:ident, $trap:ty) => {
-        impl service_system_api::ServiceSystemApi for $service_system_api {
+    ($trap:ty) => {
+        impl<T: crate::ServiceRuntime> service_system_api::ServiceSystemApi for T {
             type Error = ExecutionError;
 
             type Load = <Self as BaseRuntime>::Read;
@@ -247,107 +247,12 @@ macro_rules! impl_service_system_api {
 }
 
 /// Generates an implementation of `ViewSystem` for the provided `view_system_api` type for
-/// application services.
-///
-/// Generates the common code for view system API types for all Wasm runtimes.
-macro_rules! impl_view_system_api_for_service {
-    ($view_system_api:ty, $trap:ty) => {
-        impl view_system_api::ViewSystemApi for $view_system_api {
-            type Error = ExecutionError;
-
-            type ContainsKey = <Self as BaseRuntime>::ContainsKey;
-            type ReadMultiValuesBytes = <Self as BaseRuntime>::ReadMultiValuesBytes;
-            type ReadValueBytes = <Self as BaseRuntime>::ReadValueBytes;
-            type FindKeys = <Self as BaseRuntime>::FindKeysByPrefix;
-            type FindKeyValues = <Self as BaseRuntime>::FindKeyValuesByPrefix;
-
-            fn error_to_trap(&mut self, error: Self::Error) -> $trap {
-                error.into()
-            }
-
-            fn contains_key_new(&mut self, key: &[u8]) -> Result<Self::ContainsKey, Self::Error> {
-                BaseRuntime::contains_key_new(self, key.to_vec())
-            }
-
-            fn contains_key_wait(
-                &mut self,
-                promise: &Self::ContainsKey,
-            ) -> Result<bool, Self::Error> {
-                BaseRuntime::contains_key_wait(self, promise)
-            }
-
-            fn read_multi_values_bytes_new(
-                &mut self,
-                keys: Vec<&[u8]>,
-            ) -> Result<Self::ReadMultiValuesBytes, Self::Error> {
-                let keys = keys.into_iter().map(Vec::from).collect();
-                BaseRuntime::read_multi_values_bytes_new(self, keys)
-            }
-
-            fn read_multi_values_bytes_wait(
-                &mut self,
-                promise: &Self::ReadMultiValuesBytes,
-            ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-                BaseRuntime::read_multi_values_bytes_wait(self, promise)
-            }
-
-            fn read_value_bytes_new(
-                &mut self,
-                key: &[u8],
-            ) -> Result<Self::ReadValueBytes, Self::Error> {
-                BaseRuntime::read_value_bytes_new(self, key.to_vec())
-            }
-
-            fn read_value_bytes_wait(
-                &mut self,
-                promise: &Self::ReadValueBytes,
-            ) -> Result<Option<Vec<u8>>, Self::Error> {
-                BaseRuntime::read_value_bytes_wait(self, promise)
-            }
-
-            fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
-                self.find_keys_by_prefix_new(key_prefix.to_vec())
-            }
-
-            fn find_keys_wait(
-                &mut self,
-                promise: &Self::FindKeys,
-            ) -> Result<Vec<Vec<u8>>, Self::Error> {
-                self.find_keys_by_prefix_wait(promise)
-            }
-
-            fn find_key_values_new(
-                &mut self,
-                key_prefix: &[u8],
-            ) -> Result<Self::FindKeyValues, Self::Error> {
-                self.find_key_values_by_prefix_new(key_prefix.to_vec())
-            }
-
-            fn find_key_values_wait(
-                &mut self,
-                promise: &Self::FindKeyValues,
-            ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Self::Error> {
-                self.find_key_values_by_prefix_wait(promise)
-            }
-
-            fn write_batch(
-                &mut self,
-                _operations: Vec<view_system_api::WriteOperation>,
-            ) -> Result<(), Self::Error> {
-                // Not calling the runtime to save time.
-                Err(ExecutionError::WriteAttemptToReadOnlyStorage)
-            }
-        }
-    };
-}
-
-/// Generates an implementation of `ViewSystem` for the provided `view_system_api` type for
-/// application contracts.
+/// applications.
 ///
 /// Generates the common code for view system API types for all WASM runtimes.
-macro_rules! impl_view_system_api_for_contract {
-    ($view_system_api:ty, $trap:ty) => {
-        impl view_system_api::ViewSystemApi for $view_system_api {
+macro_rules! impl_view_system_api {
+    ($trap:ty) => {
+        impl<T: crate::BaseRuntime> view_system_api::ViewSystemApi for T {
             type Error = ExecutionError;
 
             type ContainsKey = <Self as BaseRuntime>::ContainsKey;
@@ -361,14 +266,14 @@ macro_rules! impl_view_system_api_for_contract {
             }
 
             fn contains_key_new(&mut self, key: &[u8]) -> Result<Self::ContainsKey, Self::Error> {
-                BaseRuntime::contains_key_new(self, key.to_vec())
+                self.contains_key_new(key.to_vec())
             }
 
             fn contains_key_wait(
                 &mut self,
                 promise: &Self::ContainsKey,
             ) -> Result<bool, Self::Error> {
-                BaseRuntime::contains_key_wait(self, promise)
+                self.contains_key_wait(promise)
             }
 
             fn read_multi_values_bytes_new(
@@ -376,28 +281,28 @@ macro_rules! impl_view_system_api_for_contract {
                 keys: Vec<&[u8]>,
             ) -> Result<Self::ReadMultiValuesBytes, Self::Error> {
                 let keys = keys.into_iter().map(Vec::from).collect();
-                BaseRuntime::read_multi_values_bytes_new(self, keys)
+                self.read_multi_values_bytes_new(keys)
             }
 
             fn read_multi_values_bytes_wait(
                 &mut self,
                 promise: &Self::ReadMultiValuesBytes,
             ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-                BaseRuntime::read_multi_values_bytes_wait(self, promise)
+                self.read_multi_values_bytes_wait(promise)
             }
 
             fn read_value_bytes_new(
                 &mut self,
                 key: &[u8],
             ) -> Result<Self::ReadValueBytes, Self::Error> {
-                BaseRuntime::read_value_bytes_new(self, key.to_vec())
+                self.read_value_bytes_new(key.to_vec())
             }
 
             fn read_value_bytes_wait(
                 &mut self,
                 promise: &Self::ReadValueBytes,
             ) -> Result<Option<Vec<u8>>, Self::Error> {
-                BaseRuntime::read_value_bytes_wait(self, promise)
+                self.read_value_bytes_wait(promise)
             }
 
             fn find_keys_new(&mut self, key_prefix: &[u8]) -> Result<Self::FindKeys, Self::Error> {
@@ -430,7 +335,7 @@ macro_rules! impl_view_system_api_for_contract {
                 &mut self,
                 operations: Vec<view_system_api::WriteOperation>,
             ) -> Result<(), Self::Error> {
-                let mut batch = Batch::new();
+                let mut batch = linera_views::batch::Batch::new();
                 for operation in operations {
                     match operation {
                         view_system_api::WriteOperation::Delete(key) => {
@@ -444,6 +349,7 @@ macro_rules! impl_view_system_api_for_contract {
                         }
                     }
                 }
+                // Hack: The following is a no-op for services.
                 self.write_batch_and_unlock(batch)
             }
         }

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -38,13 +38,12 @@ use super::{
     ApplicationCallResult, SessionCallResult, WasmContract, WasmExecutionError, WasmService,
 };
 use crate::{
-    BaseRuntime, Bytecode, CalleeContext, ContractRuntime, ContractRuntimeSender, ExecutionError,
-    MessageContext, OperationContext, QueryContext, RawExecutionResult, ServiceRuntime,
-    ServiceRuntimeSender,
+    wasm::{WasmContractModule, WasmServiceModule},
+    BaseRuntime, Bytecode, CalleeContext, ContractRuntime, ExecutionError, MessageContext,
+    OperationContext, QueryContext, RawExecutionResult, ServiceRuntime,
 };
 use bytes::Bytes;
 use linera_base::{identifiers::SessionId, sync::Lazy};
-use linera_views::batch::Batch;
 use std::{marker::PhantomData, sync::Arc};
 use tokio::sync::Mutex;
 use wasmer::{
@@ -67,17 +66,21 @@ static CONTRACT_CACHE: Lazy<Mutex<ModuleCache<CachedContractModule>>> = Lazy::ne
 static SERVICE_CACHE: Lazy<Mutex<ModuleCache<Module>>> = Lazy::new(Mutex::default);
 
 /// Type representing the [Wasmer](https://wasmer.io/) contract runtime.
-pub struct Contract {
+pub struct Contract<Runtime> {
     contract: contract::Contract,
+    _marker: std::marker::PhantomData<Runtime>,
 }
 
-impl ApplicationRuntimeContext for Contract {
+impl<Runtime> ApplicationRuntimeContext for Contract<Runtime>
+where
+    Runtime: ContractRuntime + Send + std::marker::Unpin,
+{
     type Store = Store;
     type Error = RuntimeError;
-    type Extra = WasmerContractExtra;
+    type Extra = WasmerContractExtra<Runtime>;
 
     fn configure_initial_fuel(context: &mut WasmRuntimeContext<Self>) -> Result<(), Self::Error> {
-        let remaining_points = context.extra.runtime_sender.remaining_fuel()?;
+        let remaining_points = context.extra.runtime.remaining_fuel()?;
 
         metering::set_remaining_points(
             &mut context.store,
@@ -95,10 +98,7 @@ impl ApplicationRuntimeContext for Contract {
                 MeteringPoints::Remaining(fuel) => fuel,
             };
 
-        context
-            .extra
-            .runtime_sender
-            .set_remaining_fuel(remaining_fuel)?;
+        context.extra.runtime.set_remaining_fuel(remaining_fuel)?;
 
         Ok(())
     }
@@ -123,7 +123,10 @@ impl ApplicationRuntimeContext for Service {
     }
 }
 
-impl WasmContract {
+impl<Runtime> WasmContract<Runtime>
+where
+    Runtime: ContractRuntime + Clone + Send + std::marker::Unpin,
+{
     /// Creates a new [`WasmContract`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
@@ -132,26 +135,32 @@ impl WasmContract {
             .map_err(WasmExecutionError::LoadContractModule)?
             .create_execution_instance()
             .map_err(WasmExecutionError::LoadContractModule)?;
-
-        Ok(WasmContract::Wasmer { engine, module })
+        let module = WasmContractModule::Wasmer { engine, module };
+        Ok(WasmContract {
+            module,
+            _marker: std::marker::PhantomData,
+        })
     }
 
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare_contract_runtime_with_wasmer(
         contract_engine: &Engine,
         contract_module: &Module,
-        runtime_sender: ContractRuntimeSender,
-    ) -> Result<WasmRuntimeContext<Contract>, WasmExecutionError> {
+        runtime: Runtime,
+    ) -> Result<WasmRuntimeContext<Contract<Runtime>>, WasmExecutionError> {
         let mut store = Store::new(contract_engine);
         let mut imports = imports! {};
         let system_api_setup =
-            contract_system_api::add_to_imports(&mut store, &mut imports, runtime_sender.clone());
+            contract_system_api::add_to_imports(&mut store, &mut imports, runtime.clone());
         let views_api_setup =
-            view_system_api::add_to_imports(&mut store, &mut imports, runtime_sender.clone());
+            view_system_api::add_to_imports(&mut store, &mut imports, runtime.clone());
         let (contract, instance) =
             contract::Contract::instantiate(&mut store, contract_module, &mut imports)
                 .map_err(WasmExecutionError::LoadContractModule)?;
-        let application = Contract { contract };
+        let application = Contract {
+            contract,
+            _marker: std::marker::PhantomData,
+        };
 
         system_api_setup(&instance, &store).map_err(WasmExecutionError::LoadContractModule)?;
         views_api_setup(&instance, &store).map_err(WasmExecutionError::LoadContractModule)?;
@@ -159,13 +168,12 @@ impl WasmContract {
         Ok(WasmRuntimeContext {
             application,
             store,
-            extra: WasmerContractExtra {
-                runtime_sender,
-                instance,
-            },
+            extra: WasmerContractExtra { runtime, instance },
         })
     }
+}
 
+impl WasmContractModule {
     /// Calculates the fuel cost of a WebAssembly [`Operator`].
     ///
     /// The rules try to follow the hardcoded [rules in the Wasmtime runtime
@@ -184,7 +192,10 @@ impl WasmContract {
     }
 }
 
-impl WasmService {
+impl<Runtime> WasmService<Runtime>
+where
+    Runtime: ServiceRuntime + Clone + Send + std::marker::Unpin,
+{
     /// Creates a new [`WasmService`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
@@ -194,21 +205,23 @@ impl WasmService {
                     .map_err(wit_bindgen_host_wasmer_rust::anyhow::Error::from)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;
-
-        Ok(WasmService::Wasmer { module })
+        let module = WasmServiceModule::Wasmer { module };
+        Ok(WasmService {
+            module,
+            _marker: std::marker::PhantomData,
+        })
     }
 
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare_service_runtime_with_wasmer(
         service_module: &Module,
-        runtime_sender: ServiceRuntimeSender,
+        runtime: Runtime,
     ) -> Result<WasmRuntimeContext<Service>, WasmExecutionError> {
         let mut store = Store::new(&*SERVICE_ENGINE);
         let mut imports = imports! {};
         let system_api_setup =
-            service_system_api::add_to_imports(&mut store, &mut imports, runtime_sender.clone());
-        let views_api_setup =
-            view_system_api::add_to_imports(&mut store, &mut imports, runtime_sender);
+            service_system_api::add_to_imports(&mut store, &mut imports, runtime.clone());
+        let views_api_setup = view_system_api::add_to_imports(&mut store, &mut imports, runtime);
         let (service, instance) =
             service::Service::instantiate(&mut store, service_module, &mut imports)
                 .map_err(WasmExecutionError::LoadServiceModule)?;
@@ -225,7 +238,10 @@ impl WasmService {
     }
 }
 
-impl common::Contract for Contract {
+impl<Runtime> common::Contract for Contract<Runtime>
+where
+    Runtime: ContractRuntime + Send + std::marker::Unpin,
+{
     fn initialize(
         &self,
         store: &mut Store,
@@ -314,14 +330,13 @@ impl common::Service for Service {
     }
 }
 
-impl_contract_system_api!(ContractRuntimeSender, wasmer::RuntimeError);
-impl_service_system_api!(ServiceRuntimeSender, wasmer::RuntimeError);
-impl_view_system_api_for_contract!(ContractRuntimeSender, wasmer::RuntimeError);
-impl_view_system_api_for_service!(ServiceRuntimeSender, wasmer::RuntimeError);
+impl_contract_system_api!(wasmer::RuntimeError);
+impl_service_system_api!(wasmer::RuntimeError);
+impl_view_system_api!(wasmer::RuntimeError);
 
 /// Extra parameters necessary when cleaning up after contract execution.
-pub struct WasmerContractExtra {
-    runtime_sender: ContractRuntimeSender,
+pub struct WasmerContractExtra<Runtime> {
+    runtime: Runtime,
     instance: Instance,
 }
 
@@ -376,7 +391,7 @@ impl CachedContractModule {
 
     /// Creates a new [`Engine`] to compile a contract bytecode.
     fn create_compilation_engine() -> Engine {
-        let metering = Arc::new(Metering::new(0, WasmContract::operation_cost));
+        let metering = Arc::new(Metering::new(0, WasmContractModule::operation_cost));
         let mut compiler_config = Singlepass::default();
         compiler_config.push_middleware(metering);
         compiler_config.canonicalize_nans(true);

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -42,11 +42,11 @@ use super::{
     WasmContract, WasmExecutionError, WasmService,
 };
 use crate::{
-    ApplicationCallResult, BaseRuntime, Bytecode, CalleeContext, ContractRuntime,
-    ContractRuntimeSender, ExecutionError, MessageContext, OperationContext, QueryContext,
-    RawExecutionResult, ServiceRuntime, ServiceRuntimeSender, SessionCallResult, SessionId,
+    wasm::{WasmContractModule, WasmServiceModule},
+    ApplicationCallResult, BaseRuntime, Bytecode, CalleeContext, ContractRuntime, ExecutionError,
+    MessageContext, OperationContext, QueryContext, RawExecutionResult, ServiceRuntime,
+    SessionCallResult, SessionId,
 };
-use linera_views::batch::Batch;
 use once_cell::sync::Lazy;
 use std::error::Error;
 use tokio::sync::Mutex;
@@ -76,18 +76,24 @@ static SERVICE_CACHE: Lazy<Mutex<ModuleCache<Module>>> = Lazy::new(Mutex::defaul
 ///
 /// The runtime has a lifetime so that it does not outlive the trait object used to export the
 /// system API.
-pub struct Contract {
-    contract: contract::Contract<ContractState>,
+pub struct Contract<Runtime>
+where
+    Runtime: ContractRuntime,
+{
+    contract: contract::Contract<ContractState<Runtime>>,
 }
 
-impl ApplicationRuntimeContext for Contract {
-    type Store = Store<ContractState>;
+impl<Runtime> ApplicationRuntimeContext for Contract<Runtime>
+where
+    Runtime: ContractRuntime + Send,
+{
+    type Store = Store<ContractState<Runtime>>;
     type Error = Trap;
     type Extra = ();
 
     fn configure_initial_fuel(context: &mut WasmRuntimeContext<Self>) -> Result<(), Self::Error> {
-        let runtime_sender = &mut context.store.data_mut().system_api;
-        let fuel = runtime_sender.remaining_fuel()?;
+        let runtime = &mut context.store.data_mut().system_api;
+        let fuel = runtime.remaining_fuel()?;
 
         context
             .store
@@ -102,23 +108,29 @@ impl ApplicationRuntimeContext for Contract {
             .store
             .fuel_consumed()
             .expect("Failed to read consumed fuel");
-        let runtime_sender = &mut context.store.data_mut().system_api;
-        let initial_fuel = runtime_sender.remaining_fuel()?;
+        let runtime = &mut context.store.data_mut().system_api;
+        let initial_fuel = runtime.remaining_fuel()?;
         let remaining_fuel = initial_fuel.saturating_sub(consumed_fuel);
 
-        runtime_sender.set_remaining_fuel(remaining_fuel)?;
+        runtime.set_remaining_fuel(remaining_fuel)?;
 
         Ok(())
     }
 }
 
 /// Type representing the [Wasmtime](https://wasmtime.dev/) runtime for services.
-pub struct Service {
-    service: service::Service<ServiceState>,
+pub struct Service<Runtime>
+where
+    Runtime: ServiceRuntime,
+{
+    service: service::Service<ServiceState<Runtime>>,
 }
 
-impl ApplicationRuntimeContext for Service {
-    type Store = Store<ServiceState>;
+impl<Runtime> ApplicationRuntimeContext for Service<Runtime>
+where
+    Runtime: ServiceRuntime + Send,
+{
+    type Store = Store<ServiceState<Runtime>>;
     type Error = Trap;
     type Extra = ();
 
@@ -131,7 +143,10 @@ impl ApplicationRuntimeContext for Service {
     }
 }
 
-impl WasmContract {
+impl<Runtime> WasmContract<Runtime>
+where
+    Runtime: ContractRuntime + Send,
+{
     /// Creates a new [`WasmContract`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(
         contract_bytecode: Bytecode,
@@ -142,15 +157,18 @@ impl WasmContract {
                 Module::new(&CONTRACT_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadContractModule)?;
-
-        Ok(WasmContract::Wasmtime { module })
+        let module = WasmContractModule::Wasmtime { module };
+        Ok(WasmContract {
+            module,
+            _marker: std::marker::PhantomData,
+        })
     }
 
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare_contract_runtime_with_wasmtime(
         contract_module: &Module,
-        runtime: ContractRuntimeSender,
-    ) -> Result<WasmRuntimeContext<Contract>, WasmExecutionError> {
+        runtime: Runtime,
+    ) -> Result<WasmRuntimeContext<Contract<Runtime>>, WasmExecutionError> {
         let mut linker = Linker::new(&CONTRACT_ENGINE);
 
         contract_system_api::add_to_linker(&mut linker, ContractState::system_api)
@@ -177,7 +195,10 @@ impl WasmContract {
     }
 }
 
-impl WasmService {
+impl<Runtime> WasmService<Runtime>
+where
+    Runtime: ServiceRuntime + Send,
+{
     /// Creates a new [`WasmService`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
@@ -186,15 +207,18 @@ impl WasmService {
                 Module::new(&SERVICE_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;
-
-        Ok(WasmService::Wasmtime { module })
+        let module = WasmServiceModule::Wasmtime { module };
+        Ok(WasmService {
+            module,
+            _marker: std::marker::PhantomData,
+        })
     }
 
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare_service_runtime_with_wasmtime(
         service_module: &Module,
-        runtime: ServiceRuntimeSender,
-    ) -> Result<WasmRuntimeContext<Service>, WasmExecutionError> {
+        runtime: Runtime,
+    ) -> Result<WasmRuntimeContext<Service<Runtime>>, WasmExecutionError> {
         let mut linker = Linker::new(&SERVICE_ENGINE);
 
         service_system_api::add_to_linker(&mut linker, ServiceState::system_api)
@@ -222,26 +246,35 @@ impl WasmService {
 }
 
 /// Data stored by the runtime that's necessary for handling calls to and from the Wasm module.
-pub struct ContractState {
+pub struct ContractState<Runtime>
+where
+    Runtime: ContractRuntime,
+{
     data: ContractData,
-    system_api: ContractRuntimeSender,
-    system_tables: ContractSystemApiTables<ContractRuntimeSender>,
-    views_tables: ViewSystemApiTables<ContractRuntimeSender>,
+    system_api: Runtime,
+    system_tables: ContractSystemApiTables<Runtime>,
+    views_tables: ViewSystemApiTables<Runtime>,
 }
 
 /// Data stored by the runtime that's necessary for handling queries to and from the Wasm module.
-pub struct ServiceState {
+pub struct ServiceState<Runtime>
+where
+    Runtime: ServiceRuntime,
+{
     data: ServiceData,
-    system_api: ServiceRuntimeSender,
-    system_tables: ServiceSystemApiTables<ServiceRuntimeSender>,
-    views_tables: ViewSystemApiTables<ServiceRuntimeSender>,
+    system_api: Runtime,
+    system_tables: ServiceSystemApiTables<Runtime>,
+    views_tables: ViewSystemApiTables<Runtime>,
 }
 
-impl ContractState {
+impl<Runtime> ContractState<Runtime>
+where
+    Runtime: ContractRuntime,
+{
     /// Creates a new instance of [`ContractState`].
     ///
     /// Uses `runtime` to export the system API.
-    pub fn new(system_api: ContractRuntimeSender) -> Self {
+    pub fn new(system_api: Runtime) -> Self {
         Self {
             data: ContractData::default(),
             system_api,
@@ -256,31 +289,24 @@ impl ContractState {
     }
 
     /// Obtains the data required by the runtime to export the system API.
-    pub fn system_api(
-        &mut self,
-    ) -> (
-        &mut ContractRuntimeSender,
-        &mut ContractSystemApiTables<ContractRuntimeSender>,
-    ) {
+    pub fn system_api(&mut self) -> (&mut Runtime, &mut ContractSystemApiTables<Runtime>) {
         (&mut self.system_api, &mut self.system_tables)
     }
 
     /// Obtains the data required by the runtime to export the views API.
-    pub fn views_api(
-        &mut self,
-    ) -> (
-        &mut ContractRuntimeSender,
-        &mut ViewSystemApiTables<ContractRuntimeSender>,
-    ) {
+    pub fn views_api(&mut self) -> (&mut Runtime, &mut ViewSystemApiTables<Runtime>) {
         (&mut self.system_api, &mut self.views_tables)
     }
 }
 
-impl ServiceState {
+impl<Runtime> ServiceState<Runtime>
+where
+    Runtime: ServiceRuntime,
+{
     /// Creates a new instance of [`ServiceState`].
     ///
     /// Uses `runtime` to export the system API.
-    pub fn new(system_api: ServiceRuntimeSender) -> Self {
+    pub fn new(system_api: Runtime) -> Self {
         Self {
             data: ServiceData::default(),
             system_api,
@@ -295,30 +321,23 @@ impl ServiceState {
     }
 
     /// Obtains the data required by the runtime to export the system API.
-    pub fn system_api(
-        &mut self,
-    ) -> (
-        &mut ServiceRuntimeSender,
-        &mut ServiceSystemApiTables<ServiceRuntimeSender>,
-    ) {
+    pub fn system_api(&mut self) -> (&mut Runtime, &mut ServiceSystemApiTables<Runtime>) {
         (&mut self.system_api, &mut self.system_tables)
     }
 
     /// Obtains the data required by the runtime to export the views API.
-    pub fn views_api(
-        &mut self,
-    ) -> (
-        &mut ServiceRuntimeSender,
-        &mut ViewSystemApiTables<ServiceRuntimeSender>,
-    ) {
+    pub fn views_api(&mut self) -> (&mut Runtime, &mut ViewSystemApiTables<Runtime>) {
         (&mut self.system_api, &mut self.views_tables)
     }
 }
 
-impl common::Contract for Contract {
+impl<Runtime> common::Contract for Contract<Runtime>
+where
+    Runtime: ContractRuntime + Send,
+{
     fn initialize(
         &self,
-        store: &mut Store<ContractState>,
+        store: &mut Store<ContractState<Runtime>>,
         context: OperationContext,
         argument: Vec<u8>,
     ) -> Result<Result<RawExecutionResult<Vec<u8>>, String>, Trap> {
@@ -328,7 +347,7 @@ impl common::Contract for Contract {
 
     fn execute_operation(
         &self,
-        store: &mut Store<ContractState>,
+        store: &mut Store<ContractState<Runtime>>,
         context: OperationContext,
         operation: Vec<u8>,
     ) -> Result<Result<RawExecutionResult<Vec<u8>>, String>, Trap> {
@@ -338,7 +357,7 @@ impl common::Contract for Contract {
 
     fn execute_message(
         &self,
-        store: &mut Store<ContractState>,
+        store: &mut Store<ContractState<Runtime>>,
         context: MessageContext,
         message: Vec<u8>,
     ) -> Result<Result<RawExecutionResult<Vec<u8>>, String>, Trap> {
@@ -348,7 +367,7 @@ impl common::Contract for Contract {
 
     fn handle_application_call(
         &self,
-        store: &mut Store<ContractState>,
+        store: &mut Store<ContractState<Runtime>>,
         context: CalleeContext,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
@@ -370,7 +389,7 @@ impl common::Contract for Contract {
 
     fn handle_session_call(
         &self,
-        store: &mut Store<ContractState>,
+        store: &mut Store<ContractState<Runtime>>,
         context: CalleeContext,
         session: Vec<u8>,
         argument: Vec<u8>,
@@ -393,10 +412,13 @@ impl common::Contract for Contract {
     }
 }
 
-impl common::Service for Service {
+impl<Runtime> common::Service for Service<Runtime>
+where
+    Runtime: ServiceRuntime + Send,
+{
     fn handle_query(
         &self,
-        store: &mut Store<ServiceState>,
+        store: &mut Store<ServiceState<Runtime>>,
         context: QueryContext,
         argument: Vec<u8>,
     ) -> Result<Result<Vec<u8>, String>, Trap> {
@@ -404,10 +426,9 @@ impl common::Service for Service {
     }
 }
 
-impl_contract_system_api!(ContractRuntimeSender, wasmtime::Trap);
-impl_view_system_api_for_contract!(ContractRuntimeSender, wasmtime::Trap);
-impl_service_system_api!(ServiceRuntimeSender, wasmtime::Trap);
-impl_view_system_api_for_service!(ServiceRuntimeSender, wasmtime::Trap);
+impl_contract_system_api!(wasmtime::Trap);
+impl_service_system_api!(wasmtime::Trap);
+impl_view_system_api!(wasmtime::Trap);
 
 impl From<ExecutionError> for wasmtime::Trap {
     fn from(error: ExecutionError) -> Self {

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -48,7 +48,7 @@ use crate::{
     SessionCallResult, SessionId,
 };
 use once_cell::sync::Lazy;
-use std::error::Error;
+use std::{error::Error, marker::PhantomData};
 use tokio::sync::Mutex;
 use wasmtime::{Config, Engine, Linker, Module, Store, Trap};
 use wit_bindgen_host_wasmtime_rust::Le;
@@ -160,7 +160,7 @@ where
         let module = WasmContractModule::Wasmtime { module };
         Ok(WasmContract {
             module,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         })
     }
 
@@ -210,7 +210,7 @@ where
         let module = WasmServiceModule::Wasmtime { module };
         Ok(WasmService {
             module,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         })
     }
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_execution::{policy::ResourceControlPolicy, *};
 use linera_views::{batch::Batch, common::Context, memory::MemoryContext, views::View};
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 
 #[tokio::test]
 async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
@@ -65,14 +65,14 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
 
 struct TestApplication<Runtime> {
     owner: Owner,
-    _runtime_marker: std::marker::PhantomData<Runtime>,
+    _runtime_marker: PhantomData<Runtime>,
 }
 
 impl<Runtime> TestApplication<Runtime> {
     fn new(owner: Owner) -> Self {
         Self {
             owner,
-            _runtime_marker: std::marker::PhantomData,
+            _runtime_marker: PhantomData,
         }
     }
 }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -80,7 +80,7 @@ enum TestOperation {
     FailingCrossApplicationCall,
 }
 
-impl UserContract for TestApplication {
+impl UserContract<ContractRuntimeSender> for TestApplication {
     /// Nothing needs to be done during initialization.
     fn initialize(
         &self,
@@ -205,7 +205,7 @@ impl UserContract for TestApplication {
     }
 }
 
-impl UserService for TestApplication {
+impl UserService<ServiceRuntimeSender> for TestApplication {
     /// Returns the application state.
     fn handle_query(
         &self,


### PR DESCRIPTION
## Motivation

Allow experimenting with alternative system runtime implementations

## Proposal

Add a type parameter to `UserContract` and `UserService`.

This was mostly uneventful. The only issue is that `write_batch` had to be moved to `BaseRuntime` otherwise we get a error due to the conflicting blanket implementations in `system_api.rs`. On the plus side, I removed the duplicated code there.

## Test Plan

CI
