### PR TITLE
Dynamic support for experimental runtimes

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -30,7 +30,8 @@ use linera_execution::{
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
     GenericApplicationId, Message, Operation, OperationContext, ResourceTracker,
-    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmContract, WasmRuntime,
+    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmContractModule,
+    WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage};
 use linera_views::views::{CryptoHashView, ViewError};
@@ -116,7 +117,8 @@ where
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
     let contract_bytecode = Bytecode::load_from_file(contract_path).await?;
     let service_bytecode = Bytecode::load_from_file(service_path).await?;
-    let contract = Arc::new(WasmContract::new(contract_bytecode.clone(), wasm_runtime).await?);
+    let contract =
+        Arc::new(WasmContractModule::new(contract_bytecode.clone(), wasm_runtime).await?);
 
     // Publish some bytecode.
     let publish_operation = SystemOperation::PublishBytecode {

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -185,7 +185,7 @@ where
             .extra()
             .get_user_contract(&description)
             .await?;
-        let contract = contract.instantiate_with_actor_runtime();
+        let mut contract = contract.instantiate_with_actor_runtime();
         let signer = action.signer();
         // Create the execution runtime for this transaction.
         let mut session_manager = SessionManager::default();
@@ -380,7 +380,7 @@ where
                     .extra()
                     .get_user_service(&description)
                     .await?;
-                let service = service.instantiate_with_actor_runtime();
+                let mut service = service.instantiate_with_actor_runtime();
                 // Create the execution runtime for this transaction.
                 let mut session_manager = SessionManager::default();
                 let mut results = Vec::new();

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -185,6 +185,7 @@ where
             .extra()
             .get_user_contract(&description)
             .await?;
+        let contract = contract.instantiate_with_actor_runtime();
         let signer = action.signer();
         // Create the execution runtime for this transaction.
         let mut session_manager = SessionManager::default();
@@ -379,6 +380,7 @@ where
                     .extra()
                     .get_user_service(&description)
                     .await?;
+                let service = service.instantiate_with_actor_runtime();
                 // Create the execution runtime for this transaction.
                 let mut session_manager = SessionManager::default();
                 let mut results = Vec::new();

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -145,7 +145,7 @@ impl From<ViewError> for ExecutionError {
 pub trait UserContract<Runtime> {
     /// Initializes the application state on the chain that owns the application.
     fn initialize(
-        &self,
+        &mut self,
         context: OperationContext,
         runtime: Runtime,
         argument: Vec<u8>,
@@ -153,7 +153,7 @@ pub trait UserContract<Runtime> {
 
     /// Applies an operation from the current block.
     fn execute_operation(
-        &self,
+        &mut self,
         context: OperationContext,
         runtime: Runtime,
         operation: Vec<u8>,
@@ -161,7 +161,7 @@ pub trait UserContract<Runtime> {
 
     /// Applies a message originating from a cross-chain message.
     fn execute_message(
-        &self,
+        &mut self,
         context: MessageContext,
         runtime: Runtime,
         message: Vec<u8>,
@@ -172,7 +172,7 @@ pub trait UserContract<Runtime> {
     /// When an application is executing an operation or a message it may call other applications,
     /// which can in turn call other applications.
     fn handle_application_call(
-        &self,
+        &mut self,
         context: CalleeContext,
         runtime: Runtime,
         argument: Vec<u8>,
@@ -181,7 +181,7 @@ pub trait UserContract<Runtime> {
 
     /// Executes a call from another application into a session created by this application.
     fn handle_session_call(
-        &self,
+        &mut self,
         context: CalleeContext,
         runtime: Runtime,
         session_state: Vec<u8>,
@@ -194,7 +194,7 @@ pub trait UserContract<Runtime> {
 pub trait UserService<Runtime> {
     /// Executes unmetered read-only queries on the state of this application.
     fn handle_query(
-        &self,
+        &mut self,
         context: QueryContext,
         runtime: Runtime,
         argument: Vec<u8>,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -15,7 +15,7 @@ pub mod runtime_actor;
 pub mod system;
 mod wasm;
 
-pub use crate::runtime_actor::{ContractRuntimeSender, ServiceRuntimeSender};
+pub use crate::runtime_actor::{ContractActorRuntime, ServiceActorRuntime};
 pub use applications::{
     ApplicationRegistryView, BytecodeLocation, GenericApplicationId, UserApplicationDescription,
     UserApplicationId,
@@ -65,14 +65,14 @@ pub type UserServiceCode = Arc<dyn UserServiceModule + Send + Sync + 'static>;
 pub trait UserContractModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserContract<ContractRuntimeSender> + Send + Sync + 'static>;
+    ) -> Box<dyn UserContract<ContractActorRuntime> + Send + Sync + 'static>;
 }
 
 /// A factory trait to obtain a [`UserService`] from a [`UserServiceModule`]
 pub trait UserServiceModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserService<ServiceRuntimeSender> + Send + Sync + 'static>;
+    ) -> Box<dyn UserService<ServiceActorRuntime> + Send + Sync + 'static>;
 }
 
 /// A type for errors happening during execution.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -65,14 +65,16 @@ pub type UserServiceCode = Arc<dyn UserServiceModule + Send + Sync + 'static>;
 pub trait UserContractModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserContract<ContractActorRuntime> + Send + Sync + 'static>;
+        runtime: ContractActorRuntime,
+    ) -> Box<dyn UserContract + Send + Sync + 'static>;
 }
 
 /// A factory trait to obtain a [`UserService`] from a [`UserServiceModule`]
 pub trait UserServiceModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserService<ServiceActorRuntime> + Send + Sync + 'static>;
+        runtime: ServiceActorRuntime,
+    ) -> Box<dyn UserService + Send + Sync + 'static>;
 }
 
 /// A type for errors happening during execution.
@@ -142,12 +144,11 @@ impl From<ViewError> for ExecutionError {
 }
 
 /// The public entry points provided by the contract part of an application.
-pub trait UserContract<Runtime> {
+pub trait UserContract {
     /// Initializes the application state on the chain that owns the application.
     fn initialize(
         &mut self,
         context: OperationContext,
-        runtime: Runtime,
         argument: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>;
 
@@ -155,7 +156,6 @@ pub trait UserContract<Runtime> {
     fn execute_operation(
         &mut self,
         context: OperationContext,
-        runtime: Runtime,
         operation: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>;
 
@@ -163,7 +163,6 @@ pub trait UserContract<Runtime> {
     fn execute_message(
         &mut self,
         context: MessageContext,
-        runtime: Runtime,
         message: Vec<u8>,
     ) -> Result<RawExecutionResult<Vec<u8>>, ExecutionError>;
 
@@ -174,7 +173,6 @@ pub trait UserContract<Runtime> {
     fn handle_application_call(
         &mut self,
         context: CalleeContext,
-        runtime: Runtime,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<ApplicationCallResult, ExecutionError>;
@@ -183,7 +181,6 @@ pub trait UserContract<Runtime> {
     fn handle_session_call(
         &mut self,
         context: CalleeContext,
-        runtime: Runtime,
         session_state: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
@@ -191,12 +188,11 @@ pub trait UserContract<Runtime> {
 }
 
 /// The public entry points provided by the service part of an application.
-pub trait UserService<Runtime> {
+pub trait UserService {
     /// Executes unmetered read-only queries on the state of this application.
     fn handle_query(
         &mut self,
         context: QueryContext,
-        runtime: Runtime,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -273,7 +273,7 @@ pub struct QueryContext {
     pub chain_id: ChainId,
 }
 
-pub trait BaseRuntime: Send + Sync + 'static {
+pub trait BaseRuntime {
     type Read: fmt::Debug + Send;
     type Lock: fmt::Debug + Send;
     type Unlock: fmt::Debug + Send;

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -5,7 +5,7 @@ use crate::{
     execution::ExecutionStateView,
     resources::{RuntimeCounts, RuntimeLimits},
     runtime_actor::{
-        ContractRequest, ContractRuntimeSender, RuntimeActor, ServiceRequest, ServiceRuntimeSender,
+        ContractActorRuntime, ContractRequest, RuntimeActor, ServiceActorRuntime, ServiceRequest,
     },
     CallResult, ExecutionError, ExecutionResult, ExecutionRuntimeContext, SessionId,
     UserApplicationDescription, UserApplicationId, UserContractCode, UserServiceCode,
@@ -533,10 +533,10 @@ where
 {
     pub(crate) fn service_runtime_actor(
         &self,
-    ) -> (RuntimeActor<&Self, ServiceRequest>, ServiceRuntimeSender) {
+    ) -> (RuntimeActor<&Self, ServiceRequest>, ServiceActorRuntime) {
         let (sender, receiver) = futures::channel::mpsc::unbounded();
         let actor = RuntimeActor::new(self, receiver);
-        let sender = ServiceRuntimeSender::new(sender);
+        let sender = ServiceActorRuntime::new(sender);
         (actor, sender)
     }
 
@@ -583,11 +583,11 @@ where
         &self,
     ) -> (
         RuntimeActor<async_lock::RwLock<&Self>, ContractRequest>,
-        ContractRuntimeSender,
+        ContractActorRuntime,
     ) {
         let (sender, receiver) = futures::channel::mpsc::unbounded();
         let actor = RuntimeActor::new(async_lock::RwLock::new(self), receiver);
-        let sender = ContractRuntimeSender::new(sender);
+        let sender = ContractActorRuntime::new(sender);
         (actor, sender)
     }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -548,7 +548,7 @@ where
     ) -> Result<Vec<u8>, ExecutionError> {
         // Load the application.
         let (code, description) = self.load_service(queried_id).await?;
-        let code = code.instantiate_with_actor_runtime();
+        let mut code = code.instantiate_with_actor_runtime();
         // Make the call to user code.
         let query_context = crate::QueryContext {
             chain_id: self.chain_id,
@@ -684,7 +684,7 @@ where
             .clone();
         // Load the application.
         let (code, description) = self.load_contract(callee_id).await?;
-        let code = code.instantiate_with_actor_runtime();
+        let mut code = code.instantiate_with_actor_runtime();
         // Change the owners of forwarded sessions.
         self.forward_sessions(&forwarded_sessions, caller.id, callee_id)?;
         // Make the call to user code.
@@ -751,7 +751,7 @@ where
             .clone();
         // Load the application.
         let (code, description) = self.load_contract(callee_id).await?;
-        let code = code.instantiate_with_actor_runtime();
+        let mut code = code.instantiate_with_actor_runtime();
         // Change the owners of forwarded sessions.
         self.forward_sessions(&forwarded_sessions, caller.id, callee_id)?;
         // Load the session.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -548,6 +548,7 @@ where
     ) -> Result<Vec<u8>, ExecutionError> {
         // Load the application.
         let (code, description) = self.load_service(queried_id).await?;
+        let code = code.instantiate_with_actor_runtime();
         // Make the call to user code.
         let query_context = crate::QueryContext {
             chain_id: self.chain_id,
@@ -683,6 +684,7 @@ where
             .clone();
         // Load the application.
         let (code, description) = self.load_contract(callee_id).await?;
+        let code = code.instantiate_with_actor_runtime();
         // Change the owners of forwarded sessions.
         self.forward_sessions(&forwarded_sessions, caller.id, callee_id)?;
         // Make the call to user code.
@@ -749,6 +751,7 @@ where
             .clone();
         // Load the application.
         let (code, description) = self.load_contract(callee_id).await?;
+        let code = code.instantiate_with_actor_runtime();
         // Change the owners of forwarded sessions.
         self.forward_sessions(&forwarded_sessions, caller.id, callee_id)?;
         // Load the session.

--- a/linera-execution/src/runtime_actor/handlers.rs
+++ b/linera-execution/src/runtime_actor/handlers.rs
@@ -173,7 +173,7 @@ where
 }
 
 /// Helper trait to send a response and log on failure.
-trait RespondExt {
+pub trait RespondExt {
     type Response;
 
     /// Responds to a request using the `response_sender` channel endpoint.

--- a/linera-execution/src/runtime_actor/mod.rs
+++ b/linera-execution/src/runtime_actor/mod.rs
@@ -12,7 +12,7 @@ use self::handlers::RequestHandler;
 pub use self::{
     handlers::RespondExt,
     requests::{BaseRequest, ContractRequest, ServiceRequest},
-    senders::{ContractRuntimeSender, ServiceRuntimeSender},
+    senders::{ContractActorRuntime, ServiceActorRuntime},
     sync_response::{SyncReceiver, SyncSender},
 };
 use crate::ExecutionError;

--- a/linera-execution/src/runtime_actor/mod.rs
+++ b/linera-execution/src/runtime_actor/mod.rs
@@ -10,6 +10,7 @@ mod sync_response;
 
 use self::handlers::RequestHandler;
 pub use self::{
+    handlers::RespondExt,
     requests::{BaseRequest, ContractRequest, ServiceRequest},
     senders::{ContractRuntimeSender, ServiceRuntimeSender},
     sync_response::{SyncReceiver, SyncSender},

--- a/linera-execution/src/runtime_actor/senders.rs
+++ b/linera-execution/src/runtime_actor/senders.rs
@@ -22,11 +22,11 @@ pub struct RuntimeSender<Request> {
     inner: mpsc::UnboundedSender<Request>,
 }
 
-pub type ContractRuntimeSender = RuntimeSender<ContractRequest>;
-pub type ServiceRuntimeSender = RuntimeSender<ServiceRequest>;
+pub type ContractActorRuntime = RuntimeSender<ContractRequest>;
+pub type ServiceActorRuntime = RuntimeSender<ServiceRequest>;
 
 impl<Request> RuntimeSender<Request> {
-    /// Creates a new [`ContractRuntimeSender`] instance.
+    /// Creates a new [`ContractActorRuntime`] instance.
     pub(crate) fn new(inner: mpsc::UnboundedSender<Request>) -> Self {
         Self { inner }
     }
@@ -40,7 +40,7 @@ impl<Request> Clone for RuntimeSender<Request> {
     }
 }
 
-impl BaseRuntime for ContractRuntimeSender {
+impl BaseRuntime for ContractActorRuntime {
     type Read = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
     type Lock = Mutex<Option<oneshot::Receiver<()>>>;
     type Unlock = Mutex<Option<oneshot::Receiver<()>>>;
@@ -275,7 +275,7 @@ impl BaseRuntime for ContractRuntimeSender {
     }
 }
 
-impl ContractRuntime for ContractRuntimeSender {
+impl ContractRuntime for ContractActorRuntime {
     fn try_read_and_lock_my_state(&mut self) -> Result<Option<Vec<u8>>, ExecutionError> {
         self.inner
             .send_sync_request(|response_sender| ContractRequest::TryReadAndLockMyState {
@@ -340,7 +340,7 @@ impl ContractRuntime for ContractRuntimeSender {
     }
 }
 
-impl BaseRuntime for ServiceRuntimeSender {
+impl BaseRuntime for ServiceActorRuntime {
     type Read = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
     type Lock = Mutex<Option<oneshot::Receiver<()>>>;
     type Unlock = Mutex<Option<oneshot::Receiver<()>>>;
@@ -587,7 +587,7 @@ impl BaseRuntime for ServiceRuntimeSender {
     }
 }
 
-impl ServiceRuntime for ServiceRuntimeSender {
+impl ServiceRuntime for ServiceActorRuntime {
     type TryQueryApplication = Mutex<Option<oneshot::Receiver<Vec<u8>>>>;
 
     fn try_query_application_new(

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -200,7 +200,7 @@ where
     Runtime: ContractRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     fn initialize(
-        &self,
+        &mut self,
         context: OperationContext,
         runtime: Runtime,
         argument: Vec<u8>,
@@ -220,7 +220,7 @@ where
     }
 
     fn execute_operation(
-        &self,
+        &mut self,
         context: OperationContext,
         runtime: Runtime,
         operation: Vec<u8>,
@@ -240,7 +240,7 @@ where
     }
 
     fn execute_message(
-        &self,
+        &mut self,
         context: MessageContext,
         runtime: Runtime,
         message: Vec<u8>,
@@ -260,7 +260,7 @@ where
     }
 
     fn handle_application_call(
-        &self,
+        &mut self,
         context: CalleeContext,
         runtime: Runtime,
         argument: Vec<u8>,
@@ -281,7 +281,7 @@ where
     }
 
     fn handle_session_call(
-        &self,
+        &mut self,
         context: CalleeContext,
         runtime: Runtime,
         session_state: Vec<u8>,
@@ -312,7 +312,7 @@ where
     Runtime: ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     fn handle_query(
-        &self,
+        &mut self,
         context: QueryContext,
         runtime: Runtime,
         argument: Vec<u8>,

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -53,7 +53,7 @@ pub struct WasmContract<Runtime> {
 
 impl<Runtime> WasmContract<Runtime>
 where
-    Runtime: ContractRuntime + Clone + Send + Unpin,
+    Runtime: ContractRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     /// Creates a new [`WasmContract`] using the WebAssembly module with the provided bytecodes.
     pub async fn new(
@@ -110,7 +110,7 @@ pub struct WasmService<Runtime> {
 
 impl<Runtime> WasmService<Runtime>
 where
-    Runtime: ServiceRuntime + Clone + Send + Unpin,
+    Runtime: ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     /// Creates a new [`WasmService`] using the WebAssembly module with the provided bytecodes.
     pub async fn new(
@@ -166,7 +166,7 @@ pub enum WasmExecutionError {
 
 impl<Runtime> UserContract<Runtime> for WasmContract<Runtime>
 where
-    Runtime: ContractRuntime + Clone + Unpin,
+    Runtime: ContractRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     fn initialize(
         &self,
@@ -278,7 +278,7 @@ where
 
 impl<Runtime> UserService<Runtime> for WasmService<Runtime>
 where
-    Runtime: ServiceRuntime + Clone + Unpin,
+    Runtime: ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     fn handle_query(
         &self,
@@ -340,8 +340,8 @@ pub mod test {
         wasm_runtime: impl Into<Option<WasmRuntime>>,
     ) -> Result<(WasmContract<C>, WasmService<S>), anyhow::Error>
     where
-        C: crate::ContractRuntime + Clone + Send + Unpin,
-        S: crate::ServiceRuntime + Clone + Send + Unpin,
+        C: crate::ContractRuntime + Clone + Send + Sync + Unpin + 'static,
+        S: crate::ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
     {
         let (contract_path, service_path) = get_example_bytecode_paths(name)?;
         let wasm_runtime = wasm_runtime.into().unwrap_or_default();

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -24,9 +24,9 @@ mod wasmtime;
 
 use self::sanitizer::sanitize;
 use crate::{
-    ApplicationCallResult, Bytecode, CalleeContext, ContractRuntime, ContractRuntimeSender,
+    ApplicationCallResult, Bytecode, CalleeContext, ContractActorRuntime, ContractRuntime,
     ExecutionError, MessageContext, OperationContext, QueryContext, RawExecutionResult,
-    ServiceRuntime, ServiceRuntimeSender, SessionCallResult, SessionId, UserContract,
+    ServiceActorRuntime, ServiceRuntime, SessionCallResult, SessionId, UserContract,
     UserContractModule, UserService, UserServiceModule, WasmRuntime,
 };
 use std::{
@@ -106,7 +106,7 @@ impl<Runtime> From<WasmContractModule> for WasmContract<Runtime> {
 impl UserContractModule for WasmContractModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserContract<ContractRuntimeSender> + Send + Sync + 'static> {
+    ) -> Box<dyn UserContract<ContractActorRuntime> + Send + Sync + 'static> {
         Box::new(WasmContract::from(self.clone()))
     }
 }
@@ -171,7 +171,7 @@ impl<Runtime> From<WasmServiceModule> for WasmService<Runtime> {
 impl UserServiceModule for WasmServiceModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserService<ServiceRuntimeSender> + Send + Sync + 'static> {
+    ) -> Box<dyn UserService<ServiceActorRuntime> + Send + Sync + 'static> {
         Box::new(WasmService::from(self.clone()))
     }
 }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -54,7 +54,7 @@ pub struct WasmContract<Runtime> {
 }
 
 impl WasmContractModule {
-    /// Creates a new [`WasmContract`] using the WebAssembly module with the provided bytecodes.
+    /// Creates a new [`WasmContractModule`] using the WebAssembly module with the provided bytecodes.
     pub async fn new(
         contract_bytecode: Bytecode,
         runtime: WasmRuntime,
@@ -78,7 +78,7 @@ impl WasmContractModule {
         }
     }
 
-    /// Creates a new [`WasmContract`] using the WebAssembly module in `bytecode_file`.
+    /// Creates a new [`WasmContractModule`] using the WebAssembly module in `bytecode_file`.
     pub async fn from_file(
         contract_bytecode_file: impl AsRef<Path>,
         runtime: WasmRuntime,
@@ -126,7 +126,7 @@ pub struct WasmService<Runtime> {
 }
 
 impl WasmServiceModule {
-    /// Creates a new [`WasmService`] using the WebAssembly module with the provided bytecodes.
+    /// Creates a new [`WasmServiceModule`] using the WebAssembly module with the provided bytecodes.
     pub async fn new(
         service_bytecode: Bytecode,
         runtime: WasmRuntime,
@@ -143,7 +143,7 @@ impl WasmServiceModule {
         }
     }
 
-    /// Creates a new [`WasmService`] using the WebAssembly module in `bytecode_file`.
+    /// Creates a new [`WasmServiceModule`] using the WebAssembly module in `bytecode_file`.
     pub async fn from_file(
         service_bytecode_file: impl AsRef<Path>,
         runtime: WasmRuntime,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -6,7 +6,9 @@
 /// Generates the common code for contract system API types for all Wasm runtimes.
 macro_rules! impl_contract_system_api {
     ($trap:ty) => {
-        impl<T: crate::ContractRuntime> contract_system_api::ContractSystemApi for T {
+        impl<T: crate::ContractRuntime + Send + Sync + 'static>
+            contract_system_api::ContractSystemApi for T
+        {
             type Error = ExecutionError;
 
             type Lock = <Self as BaseRuntime>::Lock;
@@ -131,7 +133,9 @@ macro_rules! impl_contract_system_api {
 /// Generates the common code for service system API types for all Wasm runtimes.
 macro_rules! impl_service_system_api {
     ($trap:ty) => {
-        impl<T: crate::ServiceRuntime> service_system_api::ServiceSystemApi for T {
+        impl<T: crate::ServiceRuntime + Send + Sync + 'static> service_system_api::ServiceSystemApi
+            for T
+        {
             type Error = ExecutionError;
 
             type Load = <Self as BaseRuntime>::Read;
@@ -252,7 +256,7 @@ macro_rules! impl_service_system_api {
 /// Generates the common code for view system API types for all WASM runtimes.
 macro_rules! impl_view_system_api {
     ($trap:ty) => {
-        impl<T: crate::BaseRuntime> view_system_api::ViewSystemApi for T {
+        impl<T: crate::BaseRuntime + Send + Sync + 'static> view_system_api::ViewSystemApi for T {
             type Error = ExecutionError;
 
             type ContainsKey = <Self as BaseRuntime>::ContainsKey;

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -126,10 +126,7 @@ impl ApplicationRuntimeContext for Service {
     }
 }
 
-impl<Runtime> WasmContract<Runtime>
-where
-    Runtime: ContractRuntime + Clone + Send + Sync + Unpin + 'static,
-{
+impl WasmContractModule {
     /// Creates a new [`WasmContract`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
@@ -138,13 +135,14 @@ where
             .map_err(WasmExecutionError::LoadContractModule)?
             .create_execution_instance()
             .map_err(WasmExecutionError::LoadContractModule)?;
-        let module = WasmContractModule::Wasmer { engine, module };
-        Ok(WasmContract {
-            module,
-            _marker: PhantomData,
-        })
+        Ok(WasmContractModule::Wasmer { engine, module })
     }
+}
 
+impl<Runtime> WasmContract<Runtime>
+where
+    Runtime: ContractRuntime + Clone + Send + Sync + Unpin + 'static,
+{
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare_contract_runtime_with_wasmer(
         contract_engine: &Engine,
@@ -195,10 +193,7 @@ impl WasmContractModule {
     }
 }
 
-impl<Runtime> WasmService<Runtime>
-where
-    Runtime: ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
-{
+impl WasmServiceModule {
     /// Creates a new [`WasmService`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
@@ -208,13 +203,14 @@ where
                     .map_err(wit_bindgen_host_wasmer_rust::anyhow::Error::from)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;
-        let module = WasmServiceModule::Wasmer { module };
-        Ok(WasmService {
-            module,
-            _marker: PhantomData,
-        })
+        Ok(WasmServiceModule::Wasmer { module })
     }
+}
 
+impl<Runtime> WasmService<Runtime>
+where
+    Runtime: ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
+{
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare_service_runtime_with_wasmer(
         service_module: &Module,

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -128,7 +128,7 @@ impl ApplicationRuntimeContext for Service {
 
 impl<Runtime> WasmContract<Runtime>
 where
-    Runtime: ContractRuntime + Clone + Send + Unpin,
+    Runtime: ContractRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     /// Creates a new [`WasmContract`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
@@ -197,7 +197,7 @@ impl WasmContractModule {
 
 impl<Runtime> WasmService<Runtime>
 where
-    Runtime: ServiceRuntime + Clone + Send + Unpin,
+    Runtime: ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
 {
     /// Creates a new [`WasmService`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -127,7 +127,7 @@ impl ApplicationRuntimeContext for Service {
 }
 
 impl WasmContractModule {
-    /// Creates a new [`WasmContract`] using Wasmer with the provided bytecodes.
+    /// Creates a new [`WasmContractModule`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(contract_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut contract_cache = CONTRACT_CACHE.lock().await;
         let (engine, module) = contract_cache
@@ -194,7 +194,7 @@ impl WasmContractModule {
 }
 
 impl WasmServiceModule {
-    /// Creates a new [`WasmService`] using Wasmer with the provided bytecodes.
+    /// Creates a new [`WasmServiceModule`] using Wasmer with the provided bytecodes.
     pub async fn new_with_wasmer(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
         let module = service_cache

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -144,7 +144,7 @@ where
 }
 
 impl WasmContractModule {
-    /// Creates a new [`WasmContract`] using Wasmtime with the provided bytecodes.
+    /// Creates a new [`WasmContractModule`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(
         contract_bytecode: Bytecode,
     ) -> Result<Self, WasmExecutionError> {
@@ -194,7 +194,7 @@ where
 }
 
 impl WasmServiceModule {
-    /// Creates a new [`WasmService`] using Wasmtime with the provided bytecodes.
+    /// Creates a new [`WasmServiceModule`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
         let module = service_cache

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -78,14 +78,14 @@ static SERVICE_CACHE: Lazy<Mutex<ModuleCache<Module>>> = Lazy::new(Mutex::defaul
 /// system API.
 pub struct Contract<Runtime>
 where
-    Runtime: ContractRuntime,
+    Runtime: ContractRuntime + Send + Sync + 'static,
 {
     contract: contract::Contract<ContractState<Runtime>>,
 }
 
 impl<Runtime> ApplicationRuntimeContext for Contract<Runtime>
 where
-    Runtime: ContractRuntime + Send,
+    Runtime: ContractRuntime + Send + Sync,
 {
     type Store = Store<ContractState<Runtime>>;
     type Error = Trap;
@@ -121,14 +121,14 @@ where
 /// Type representing the [Wasmtime](https://wasmtime.dev/) runtime for services.
 pub struct Service<Runtime>
 where
-    Runtime: ServiceRuntime,
+    Runtime: ServiceRuntime + Send + Sync + 'static,
 {
     service: service::Service<ServiceState<Runtime>>,
 }
 
 impl<Runtime> ApplicationRuntimeContext for Service<Runtime>
 where
-    Runtime: ServiceRuntime + Send,
+    Runtime: ServiceRuntime + Send + Sync,
 {
     type Store = Store<ServiceState<Runtime>>;
     type Error = Trap;
@@ -145,7 +145,7 @@ where
 
 impl<Runtime> WasmContract<Runtime>
 where
-    Runtime: ContractRuntime + Send,
+    Runtime: ContractRuntime + Send + Sync + 'static,
 {
     /// Creates a new [`WasmContract`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(
@@ -197,7 +197,7 @@ where
 
 impl<Runtime> WasmService<Runtime>
 where
-    Runtime: ServiceRuntime + Send,
+    Runtime: ServiceRuntime + Send + Sync + 'static,
 {
     /// Creates a new [`WasmService`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
@@ -248,7 +248,7 @@ where
 /// Data stored by the runtime that's necessary for handling calls to and from the Wasm module.
 pub struct ContractState<Runtime>
 where
-    Runtime: ContractRuntime,
+    Runtime: ContractRuntime + Send + Sync + 'static,
 {
     data: ContractData,
     system_api: Runtime,
@@ -259,7 +259,7 @@ where
 /// Data stored by the runtime that's necessary for handling queries to and from the Wasm module.
 pub struct ServiceState<Runtime>
 where
-    Runtime: ServiceRuntime,
+    Runtime: ServiceRuntime + Send + Sync + 'static,
 {
     data: ServiceData,
     system_api: Runtime,
@@ -269,7 +269,7 @@ where
 
 impl<Runtime> ContractState<Runtime>
 where
-    Runtime: ContractRuntime,
+    Runtime: ContractRuntime + Send + Sync + 'static,
 {
     /// Creates a new instance of [`ContractState`].
     ///
@@ -301,7 +301,7 @@ where
 
 impl<Runtime> ServiceState<Runtime>
 where
-    Runtime: ServiceRuntime,
+    Runtime: ServiceRuntime + Send + Sync + 'static,
 {
     /// Creates a new instance of [`ServiceState`].
     ///
@@ -333,7 +333,7 @@ where
 
 impl<Runtime> common::Contract for Contract<Runtime>
 where
-    Runtime: ContractRuntime + Send,
+    Runtime: ContractRuntime + Send + Sync + 'static,
 {
     fn initialize(
         &self,
@@ -414,7 +414,7 @@ where
 
 impl<Runtime> common::Service for Service<Runtime>
 where
-    Runtime: ServiceRuntime + Send,
+    Runtime: ServiceRuntime + Send + Sync + 'static,
 {
     fn handle_query(
         &self,

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -48,7 +48,7 @@ use crate::{
     SessionCallResult, SessionId,
 };
 use once_cell::sync::Lazy;
-use std::{error::Error, marker::PhantomData};
+use std::error::Error;
 use tokio::sync::Mutex;
 use wasmtime::{Config, Engine, Linker, Module, Store, Trap};
 use wit_bindgen_host_wasmtime_rust::Le;
@@ -143,10 +143,7 @@ where
     }
 }
 
-impl<Runtime> WasmContract<Runtime>
-where
-    Runtime: ContractRuntime + Send + Sync + 'static,
-{
+impl WasmContractModule {
     /// Creates a new [`WasmContract`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(
         contract_bytecode: Bytecode,
@@ -157,13 +154,14 @@ where
                 Module::new(&CONTRACT_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadContractModule)?;
-        let module = WasmContractModule::Wasmtime { module };
-        Ok(WasmContract {
-            module,
-            _marker: PhantomData,
-        })
+        Ok(WasmContractModule::Wasmtime { module })
     }
+}
 
+impl<Runtime> WasmContract<Runtime>
+where
+    Runtime: ContractRuntime + Send + Sync + 'static,
+{
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare_contract_runtime_with_wasmtime(
         contract_module: &Module,
@@ -195,10 +193,7 @@ where
     }
 }
 
-impl<Runtime> WasmService<Runtime>
-where
-    Runtime: ServiceRuntime + Send + Sync + 'static,
-{
+impl WasmServiceModule {
     /// Creates a new [`WasmService`] using Wasmtime with the provided bytecodes.
     pub async fn new_with_wasmtime(service_bytecode: Bytecode) -> Result<Self, WasmExecutionError> {
         let mut service_cache = SERVICE_CACHE.lock().await;
@@ -207,13 +202,14 @@ where
                 Module::new(&SERVICE_ENGINE, bytecode)
             })
             .map_err(WasmExecutionError::LoadServiceModule)?;
-        let module = WasmServiceModule::Wasmtime { module };
-        Ok(WasmService {
-            module,
-            _marker: PhantomData,
-        })
+        Ok(WasmServiceModule::Wasmtime { module })
     }
+}
 
+impl<Runtime> WasmService<Runtime>
+where
+    Runtime: ServiceRuntime + Send + Sync + 'static,
+{
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare_service_runtime_with_wasmtime(
         service_module: &Module,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -113,7 +113,7 @@ where
 {
     /// Nothing needs to be done during initialization.
     fn initialize(
-        &self,
+        &mut self,
         context: OperationContext,
         _runtime: Runtime,
         _argument: Vec<u8>,
@@ -127,7 +127,7 @@ where
     /// Calls itself during the operation, opening a session. The session is intentionally
     /// leaked if the test operation is [`TestOperation::LeakingSession`].
     fn execute_operation(
-        &self,
+        &mut self,
         context: OperationContext,
         mut runtime: Runtime,
         operation: Vec<u8>,
@@ -167,7 +167,7 @@ where
 
     /// Attempts to call ourself while the state is locked.
     fn execute_message(
-        &self,
+        &mut self,
         context: MessageContext,
         mut runtime: Runtime,
         message: Vec<u8>,
@@ -187,7 +187,7 @@ where
 
     /// Creates a session.
     fn handle_application_call(
-        &self,
+        &mut self,
         context: CalleeContext,
         _runtime: Runtime,
         argument: Vec<u8>,
@@ -207,7 +207,7 @@ where
 
     /// Closes the session.
     fn handle_session_call(
-        &self,
+        &mut self,
         context: CalleeContext,
         _runtime: Runtime,
         session_state: Vec<u8>,
@@ -239,7 +239,7 @@ where
 {
     /// Returns the application state.
     fn handle_query(
-        &self,
+        &mut self,
         _context: QueryContext,
         mut runtime: Runtime,
         _argument: Vec<u8>,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -13,7 +13,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, Owner, SessionId},
 };
 use linera_execution::{
-    policy::ResourceControlPolicy, ContractRuntimeSender, ServiceRuntimeSender, *,
+    policy::ResourceControlPolicy, ContractActorRuntime, ServiceActorRuntime, *,
 };
 use linera_views::{batch::Batch, common::Context, memory::MemoryContext, views::View};
 use std::{marker::PhantomData, sync::Arc};
@@ -102,7 +102,7 @@ enum TestOperation {
 impl UserContractModule for TestModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserContract<ContractRuntimeSender> + Send + Sync + 'static> {
+    ) -> Box<dyn UserContract<ContractActorRuntime> + Send + Sync + 'static> {
         Box::new(TestApplication::from(self.clone()))
     }
 }
@@ -228,7 +228,7 @@ where
 impl UserServiceModule for TestModule {
     fn instantiate_with_actor_runtime(
         &self,
-    ) -> Box<dyn UserService<ServiceRuntimeSender> + Send + Sync + 'static> {
+    ) -> Box<dyn UserService<ServiceActorRuntime> + Send + Sync + 'static> {
         Box::new(TestApplication::from(self.clone()))
     }
 }

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -14,8 +14,8 @@ use linera_base::{
 use linera_execution::{
     policy::ResourceControlPolicy, ExecutionResult, ExecutionRuntimeContext, ExecutionStateView,
     Operation, OperationContext, Query, QueryContext, RawExecutionResult, ResourceTracker,
-    Response, SystemExecutionState, TestExecutionRuntimeContext, WasmContract, WasmRuntime,
-    WasmService,
+    Response, SystemExecutionState, TestExecutionRuntimeContext, WasmContractModule, WasmRuntime,
+    WasmServiceModule,
 };
 use linera_views::{memory::MemoryContext, views::View};
 use serde_json::json;
@@ -50,14 +50,14 @@ async fn test_fuel_for_counter_wasm_application(
         .await?;
 
     let contract =
-        WasmContract::from_file("tests/fixtures/counter_contract.wasm", wasm_runtime).await?;
+        WasmContractModule::from_file("tests/fixtures/counter_contract.wasm", wasm_runtime).await?;
     view.context()
         .extra
         .user_contracts()
         .insert(app_id, Arc::new(contract));
 
     let service =
-        WasmService::from_file("tests/fixtures/counter_service.wasm", wasm_runtime).await?;
+        WasmServiceModule::from_file("tests/fixtures/counter_service.wasm", wasm_runtime).await?;
     view.context()
         .extra
         .user_services()

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -56,7 +56,7 @@ use std::{fmt::Debug, sync::Arc};
 #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
 use {
     linera_chain::data_types::CertificateValue,
-    linera_execution::{Operation, SystemOperation, WasmContract, WasmService},
+    linera_execution::{Operation, SystemOperation, WasmContractModule, WasmServiceModule},
 };
 
 /// Communicate with a persistent storage using the "views" abstraction.
@@ -208,7 +208,9 @@ pub trait Storage: Sized {
         else {
             unreachable!();
         };
-        Ok(Arc::new(WasmContract::new(contract, wasm_runtime).await?))
+        Ok(Arc::new(
+            WasmContractModule::new(contract, wasm_runtime).await?,
+        ))
     }
 
     #[cfg(not(any(feature = "wasmer", feature = "wasmtime")))]
@@ -239,7 +241,9 @@ pub trait Storage: Sized {
         else {
             unreachable!();
         };
-        Ok(Arc::new(WasmService::new(service, wasm_runtime).await?))
+        Ok(Arc::new(
+            WasmServiceModule::new(service, wasm_runtime).await?,
+        ))
     }
 
     #[cfg(not(any(feature = "wasmer", feature = "wasmtime")))]


### PR DESCRIPTION
## Motivation

* #1393 made the Wasm code generic w.r.t. system runtimes but the global map of applications is still specialized.
* Eventually support reentrant calls

## Proposal

* Separate code (module) and contract instances.
* Use a factory trait `UserContractModule` to generate instances of each possible runtime (currently only one exists)

Adding system runtimes will involve patching the trait `UserContractModule` (in a trivial way). I think that's fine.

nits:
* Move some trait bounds to Wasm (this is needed to re-use the trait internally in runtime implementations)
* Rename legacy runtime senders
* Move runtime to contract objects, remove it from trait calls: this is what we want in the end for reentrancy. It turns out it was easy to do already and makes the code nicer. The Wasm code can probably be heavily simplified after this.

## Test Plan

CI