### PR TITLE
Introduce `PriceAsk/PriceBid` for the matching engine.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "webassembly-test",
 ]
 
 [[package]]

--- a/examples/matching-engine/Cargo.toml
+++ b/examples/matching-engine/Cargo.toml
@@ -19,6 +19,9 @@ fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true }
 
+[dev-dependencies]
+webassembly-test = { workspace = true }
+
 [[bin]]
 name = "matching_engine_contract"
 path = "src/contract.rs"

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -198,3 +198,45 @@ pub enum ApplicationCall {
     /// The order from the application
     ExecuteOrder { order: Order },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{PriceAsk, PriceBid};
+    use linera_sdk::views::CustomSerialize;
+    use webassembly_test::webassembly_test;
+
+    #[webassembly_test]
+    fn test_ordering_serialization() {
+        let n = 20;
+        let mut vec = Vec::new();
+        let mut val = 1;
+        for _ in 0..n {
+            val *= 3;
+            vec.push(val);
+        }
+        for i in 1..vec.len() {
+            let val1 = vec[i - 1];
+            let val2 = vec[i];
+            assert!(val1 < val2);
+            let price_ask1 = PriceAsk { price: val1 };
+            let price_ask2 = PriceAsk { price: val2 };
+            let price_bid1 = PriceBid { price: val1 };
+            let price_bid2 = PriceBid { price: val2 };
+            let ser_ask1 = price_ask1.to_custom_bytes().unwrap();
+            let ser_ask2 = price_ask2.to_custom_bytes().unwrap();
+            let ser_bid1 = price_bid1.to_custom_bytes().unwrap();
+            let ser_bid2 = price_bid2.to_custom_bytes().unwrap();
+            assert!(ser_ask1 < ser_ask2);
+            assert!(ser_bid1 > ser_bid2);
+
+            let price_ask1_back = PriceAsk::from_custom_bytes(&ser_ask1).unwrap();
+            let price_ask2_back = PriceAsk::from_custom_bytes(&ser_ask2).unwrap();
+            let price_bid1_back = PriceBid::from_custom_bytes(&ser_bid1).unwrap();
+            let price_bid2_back = PriceBid::from_custom_bytes(&ser_bid2).unwrap();
+            assert_eq!(price_ask1.price, price_ask1_back.price);
+            assert_eq!(price_ask2.price, price_ask2_back.price);
+            assert_eq!(price_bid1.price, price_bid1_back.price);
+            assert_eq!(price_bid2.price, price_bid2_back.price);
+        }
+    }
+}

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -10,7 +10,7 @@ use linera_sdk::{
         ViewError, ViewStorageContext,
     },
 };
-use matching_engine::{OrderId, OrderNature, Price};
+use matching_engine::{OrderId, OrderNature, Price, PriceAsk, PriceBid};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 use thiserror::Error;
@@ -116,11 +116,11 @@ pub struct MatchingEngine {
     /// The map of the outstanding bids, by the bitwise complement of
     /// the revert of the price. The order is from the best price
     /// level (highest proposed by buyer) to the worse
-    pub bids: CustomCollectionView<Price, LevelView>,
+    pub bids: CustomCollectionView<PriceBid, LevelView>,
     /// The map of the outstanding asks, by the bitwise complement of
     /// the price. The order is from the best one (smallest asked price
     /// by seller) to the worse.
-    pub asks: CustomCollectionView<Price, LevelView>,
+    pub asks: CustomCollectionView<PriceAsk, LevelView>,
     /// The map with the list of orders giving for each order_id the
     /// fundamental information on the order (nature, owner, amount)
     pub orders: MapView<OrderId, KeyBook>,


### PR DESCRIPTION
## Motivation

The matching engine is currently using the Price type and a trick of reverting the price. We need that trick because the best ask price is the smallest one and the best bid price is the highest one.

That trick works but pollutes the output since the result of GraphQL which is unfortunate and makes the program difficult to use.

## Proposal

The following is done:
* The types `PriceAsk/PriceBid` are introduced with their own CustomSerialize implementations.
* This led to a simpler and more straightforward code for `contract.rs`.

## Test Plan

The CI should address it. Unfortunately, the corresponding end-to-end test is currently ignored
and I could not make it work on my laptop.
More tests are added to the serialization to make sure it works.

## Release Plan

No change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
