### PR TITLE
Add synchronous runtime and make it the default for Wasm system APIs

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -28,10 +28,10 @@ use linera_execution::{
     committee::Epoch,
     policy::ResourceControlPolicy,
     system::{SystemChannel, SystemMessage, SystemOperation},
-    Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionStateView,
-    GenericApplicationId, Message, Operation, OperationContext, ResourceTracker,
-    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmContractModule,
-    WasmRuntime,
+    Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionRuntimeConfig,
+    ExecutionStateView, GenericApplicationId, Message, Operation, OperationContext,
+    ResourceTracker, SystemExecutionState, UserApplicationDescription, UserApplicationId,
+    WasmContractModule, WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage};
 use linera_views::views::{CryptoHashView, ViewError};
@@ -246,9 +246,11 @@ where
         timestamp: Timestamp::from(2),
         ..make_state(Epoch::ZERO, creator_chain, admin_id)
     };
-    let creator_state =
-        ExecutionStateView::from_system_state(creator_system_state.clone(), Default::default())
-            .await;
+    let creator_state = ExecutionStateView::from_system_state(
+        creator_system_state.clone(),
+        ExecutionRuntimeConfig::default(),
+    )
+    .await;
     let subscribe_block_proposal = HashedValue::new_confirmed(ExecutedBlock {
         block: subscribe_block,
         messages: vec![OutgoingMessage {
@@ -372,8 +374,11 @@ where
         .known_applications
         .insert(application_id, application_description.clone());
     creator_system_state.timestamp = Timestamp::from(4);
-    let mut creator_state =
-        ExecutionStateView::from_system_state(creator_system_state, Default::default()).await;
+    let mut creator_state = ExecutionStateView::from_system_state(
+        creator_system_state,
+        ExecutionRuntimeConfig::default(),
+    )
+    .await;
     creator_state
         .simulate_initialization(
             contract,

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -246,7 +246,9 @@ where
         timestamp: Timestamp::from(2),
         ..make_state(Epoch::ZERO, creator_chain, admin_id)
     };
-    let creator_state = ExecutionStateView::from_system_state(creator_system_state.clone()).await;
+    let creator_state =
+        ExecutionStateView::from_system_state(creator_system_state.clone(), Default::default())
+            .await;
     let subscribe_block_proposal = HashedValue::new_confirmed(ExecutedBlock {
         block: subscribe_block,
         messages: vec![OutgoingMessage {
@@ -370,7 +372,8 @@ where
         .known_applications
         .insert(application_id, application_description.clone());
     creator_system_state.timestamp = Timestamp::from(4);
-    let mut creator_state = ExecutionStateView::from_system_state(creator_system_state).await;
+    let mut creator_state =
+        ExecutionStateView::from_system_state(creator_system_state, Default::default()).await;
     creator_state
         .simulate_initialization(
             contract,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -30,9 +30,9 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
     system::{Account, AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
-    ChainOwnership, ChannelSubscription, ExecutionError, ExecutionStateView, GenericApplicationId,
-    Message, Query, Response, SystemExecutionError, SystemExecutionState, SystemQuery,
-    SystemResponse,
+    ChainOwnership, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
+    ExecutionStateView, GenericApplicationId, Message, Query, Response, SystemExecutionError,
+    SystemExecutionState, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, MemoryStorage, Storage, TestClock};
 use linera_views::{
@@ -63,7 +63,7 @@ struct Dummy;
 impl BcsSignable for Dummy {}
 
 async fn make_state_hash(state: SystemExecutionState) -> CryptoHash {
-    ExecutionStateView::from_system_state(state, Default::default())
+    ExecutionStateView::from_system_state(state, ExecutionRuntimeConfig::default())
         .await
         .crypto_hash()
         .await

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -63,7 +63,7 @@ struct Dummy;
 impl BcsSignable for Dummy {}
 
 async fn make_state_hash(state: SystemExecutionState) -> CryptoHash {
-    ExecutionStateView::from_system_state(state)
+    ExecutionStateView::from_system_state(state, Default::default())
         .await
         .crypto_hash()
         .await

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,10 +6,12 @@ use crate::{
     resources::{ResourceTracker, RuntimeLimits},
     runtime::{ApplicationStatus, ExecutionRuntime, SessionManager},
     system::SystemExecutionStateView,
-    ExecutionError, ExecutionResult, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
-    MessageContext, Operation, OperationContext, Query, QueryContext, RawExecutionResult,
-    RawOutgoingMessage, Response, SystemMessage, UserApplicationDescription, UserApplicationId,
+    ContractSyncRuntime, ExecutionError, ExecutionResult, ExecutionRuntimeConfig,
+    ExecutionRuntimeContext, Message, MessageContext, Operation, OperationContext, Query,
+    QueryContext, RawExecutionResult, RawOutgoingMessage, Response, ServiceSyncRuntime,
+    SystemMessage, UserApplicationDescription, UserApplicationId,
 };
+use futures::StreamExt;
 use linera_base::{
     ensure,
     identifiers::{ChainId, Owner},
@@ -143,14 +145,14 @@ where
     }
 }
 
-enum UserAction {
+pub enum UserAction {
     Initialize(OperationContext, Vec<u8>),
     Operation(OperationContext, Vec<u8>),
     Message(MessageContext, Vec<u8>),
 }
 
 impl UserAction {
-    fn signer(&self) -> Option<Owner> {
+    pub(crate) fn signer(&self) -> Option<Owner> {
         use UserAction::*;
         match self {
             Initialize(context, _) => context.authenticated_signer,
@@ -167,6 +169,40 @@ where
     C::Extra: ExecutionRuntimeContext,
 {
     async fn run_user_action(
+        &mut self,
+        application_id: UserApplicationId,
+        chain_id: ChainId,
+        action: UserAction,
+        policy: &ResourceControlPolicy,
+        tracker: &mut ResourceTracker,
+    ) -> Result<Vec<ExecutionResult>, ExecutionError> {
+        let execution_results = match self.context().extra().execution_runtime_config() {
+            ExecutionRuntimeConfig::Actor => {
+                self.run_user_action_with_actor_runtime(
+                    application_id,
+                    chain_id,
+                    action,
+                    policy,
+                    tracker,
+                )
+                .await?
+            }
+            ExecutionRuntimeConfig::Synchronous => {
+                self.run_user_action_with_synchronous_runtime(
+                    application_id,
+                    chain_id,
+                    action,
+                    policy,
+                    tracker,
+                )
+                .await?
+            }
+        };
+        self.update_execution_results_with_app_registrations(execution_results)
+            .await
+    }
+
+    async fn run_user_action_with_actor_runtime(
         &mut self,
         application_id: UserApplicationId,
         chain_id: ChainId,
@@ -210,7 +246,7 @@ where
         // Make the call to user code.
         let (runtime_actor, runtime_sender) = runtime.contract_runtime_actor();
         let mut contract = contract.instantiate_with_actor_runtime(runtime_sender)?;
-        let call_result_future = tokio::task::spawn_blocking(move || match action {
+        let execution_result_future = tokio::task::spawn_blocking(move || match action {
             UserAction::Initialize(context, argument) => contract.initialize(context, argument),
             UserAction::Operation(context, operation) => {
                 contract.execute_operation(context, operation)
@@ -218,10 +254,10 @@ where
             UserAction::Message(context, message) => contract.execute_message(context, message),
         });
         runtime_actor.run().await?;
-        let mut call_result = call_result_future.await??;
+        let mut execution_result = execution_result_future.await??;
 
         // Set the authenticated signer to be used in outgoing messages.
-        call_result.authenticated_signer = signer;
+        execution_result.authenticated_signer = signer;
         let runtime_counts = runtime.runtime_counts().await;
         let balance = self.system.balance.get_mut();
         tracker.update_limits(balance, policy, runtime_counts)?;
@@ -229,15 +265,66 @@ where
         // Check that applications were correctly stacked and unstacked.
         assert_eq!(applications.len(), 1);
         assert_eq!(applications[0].id, application_id);
-        // Make sure to declare the application first for all recipients of the user
-        // execution result.
+
+        // Update externally-visible results.
+        results.push(ExecutionResult::User(application_id, execution_result));
+        // Check that all sessions were properly closed.
+        ensure!(
+            session_manager.states.is_empty(),
+            ExecutionError::SessionWasNotClosed
+        );
+        Ok(results)
+    }
+
+    async fn run_user_action_with_synchronous_runtime(
+        &mut self,
+        application_id: UserApplicationId,
+        chain_id: ChainId,
+        action: UserAction,
+        policy: &ResourceControlPolicy,
+        tracker: &mut ResourceTracker,
+    ) -> Result<Vec<ExecutionResult>, ExecutionError> {
+        let balance = self.system.balance.get();
+        let runtime_limits = tracker.limits(policy, balance);
+        let initial_remaining_fuel = policy.remaining_fuel(*balance);
+        let (execution_state_sender, mut execution_state_receiver) =
+            futures::channel::mpsc::unbounded();
+        let execution_results_future = tokio::task::spawn_blocking(move || {
+            ContractSyncRuntime::run_action(
+                execution_state_sender,
+                application_id,
+                chain_id,
+                runtime_limits,
+                initial_remaining_fuel,
+                action,
+            )
+        });
+        while let Some(request) = execution_state_receiver.next().await {
+            self.handle_request(request).await?;
+        }
+        let (execution_results, runtime_counts) = execution_results_future.await??;
+        let balance = self.system.balance.get_mut();
+        tracker.update_limits(balance, policy, runtime_counts)?;
+        Ok(execution_results)
+    }
+
+    async fn update_execution_results_with_app_registrations(
+        &self,
+        mut results: Vec<ExecutionResult>,
+    ) -> Result<Vec<ExecutionResult>, ExecutionError> {
+        // TODO: It looks like we are forgetting about messages by early entries in `results`.
+        let Some(ExecutionResult::User(application_id, result)) = results.last() else {
+            return Ok(results);
+        };
+        // Make sure to declare applications before recipients execute messages produced
+        // by the user execution results.
         let mut system_result = RawExecutionResult::default();
         let applications = self
             .system
             .registry
-            .describe_applications_with_dependencies(vec![application_id], &Default::default())
+            .describe_applications_with_dependencies(vec![*application_id], &Default::default())
             .await?;
-        for message in &call_result.messages {
+        for message in &result.messages {
             system_result.messages.push(RawOutgoingMessage {
                 destination: message.destination.clone(),
                 authenticated: false,
@@ -248,15 +335,8 @@ where
             });
         }
         if !system_result.messages.is_empty() {
-            results.push(ExecutionResult::System(system_result));
+            results.insert(0, ExecutionResult::System(system_result));
         }
-        // Update externally-visible results.
-        results.push(ExecutionResult::User(application_id, call_result));
-        // Check that all sessions were properly closed.
-        ensure!(
-            session_manager.states.is_empty(),
-            ExecutionError::SessionWasNotClosed
-        );
         Ok(results)
     }
 
@@ -349,50 +429,86 @@ where
                 application_id,
                 bytes,
             } => {
-                // Load the service.
-                let description = self
-                    .system
-                    .registry
-                    .describe_application(application_id)
-                    .await?;
-                let service = self
-                    .context()
-                    .extra()
-                    .get_user_service(&description)
-                    .await?;
-                // Create the execution runtime for this transaction.
-                let mut session_manager = SessionManager::default();
-                let mut results = Vec::new();
-                let mut applications = vec![ApplicationStatus {
-                    id: application_id,
-                    parameters: description.parameters,
-                    signer: None,
-                }];
-                let runtime_limits = RuntimeLimits::default();
-                let remaining_fuel = 0;
-                let runtime = ExecutionRuntime::new(
-                    context.chain_id,
-                    &mut applications,
-                    self,
-                    &mut session_manager,
-                    &mut results,
-                    remaining_fuel,
-                    runtime_limits,
-                );
-                let (runtime_actor, runtime_sender) = runtime.service_runtime_actor();
-                let mut service = service.instantiate_with_actor_runtime(runtime_sender)?;
-                // Run the query.
-                let response_future =
-                    tokio::task::spawn_blocking(move || service.handle_query(context, bytes));
-                runtime_actor.run().await?;
-                let response = response_future.await??;
-
-                // Check that applications were correctly stacked and unstacked.
-                assert_eq!(applications.len(), 1);
-                assert_eq!(applications[0].id, application_id);
+                let response = match self.context().extra().execution_runtime_config() {
+                    ExecutionRuntimeConfig::Actor => {
+                        self.query_application_with_actor_runtime(application_id, context, bytes)
+                            .await?
+                    }
+                    ExecutionRuntimeConfig::Synchronous => {
+                        self.query_application_with_sync_runtime(application_id, context, bytes)
+                            .await?
+                    }
+                };
                 Ok(Response::User(response))
             }
         }
+    }
+
+    async fn query_application_with_actor_runtime(
+        &mut self,
+        application_id: UserApplicationId,
+        context: QueryContext,
+        query: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        // Load the service.
+        let description = self
+            .system
+            .registry
+            .describe_application(application_id)
+            .await?;
+        let service = self
+            .context()
+            .extra()
+            .get_user_service(&description)
+            .await?;
+        // Create the execution runtime for this transaction.
+        let mut session_manager = SessionManager::default();
+        let mut results = Vec::new();
+        let mut applications = vec![ApplicationStatus {
+            id: application_id,
+            parameters: description.parameters,
+            signer: None,
+        }];
+        let runtime_limits = RuntimeLimits::default();
+        let remaining_fuel = 0;
+        let runtime = ExecutionRuntime::new(
+            context.chain_id,
+            &mut applications,
+            self,
+            &mut session_manager,
+            &mut results,
+            remaining_fuel,
+            runtime_limits,
+        );
+        let (runtime_actor, runtime_sender) = runtime.service_runtime_actor();
+        let mut service = service.instantiate_with_actor_runtime(runtime_sender)?;
+        // Run the query.
+        let response_future =
+            tokio::task::spawn_blocking(move || service.handle_query(context, query));
+        runtime_actor.run().await?;
+        let response = response_future.await??;
+
+        // Check that applications were correctly stacked and unstacked.
+        assert_eq!(applications.len(), 1);
+        assert_eq!(applications[0].id, application_id);
+        Ok(response)
+    }
+
+    async fn query_application_with_sync_runtime(
+        &mut self,
+        application_id: UserApplicationId,
+        context: QueryContext,
+        query: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let (execution_state_sender, mut execution_state_receiver) =
+            futures::channel::mpsc::unbounded();
+        let query_result_future = tokio::task::spawn_blocking(move || {
+            ServiceSyncRuntime::run_query(execution_state_sender, application_id, context, query)
+        });
+        while let Some(request) = execution_state_receiver.next().await {
+            self.handle_request(request).await?;
+        }
+        query_result_future.await?
     }
 
     pub async fn list_applications(

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -308,7 +308,8 @@ where
         &self,
         mut results: Vec<ExecutionResult>,
     ) -> Result<Vec<ExecutionResult>, ExecutionError> {
-        // TODO: It looks like we are forgetting about messages by early entries in `results`.
+        // TODO(#1417): It looks like we are forgetting about the recipients of messages
+        // sent by earlier entries in `results` (i.e. application calls).
         let Some(ExecutionResult::User(application_id, result)) = results.last() else {
             return Ok(results);
         };

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -12,10 +12,7 @@ use crate::{
     SystemMessage, UserApplicationDescription, UserApplicationId,
 };
 use futures::StreamExt;
-use linera_base::{
-    ensure,
-    identifiers::{ChainId, Owner},
-};
+use linera_base::identifiers::{ChainId, Owner};
 use linera_views::{
     common::Context,
     key_value_store_view::KeyValueStoreView,
@@ -269,10 +266,9 @@ where
         // Update externally-visible results.
         results.push(ExecutionResult::User(application_id, execution_result));
         // Check that all sessions were properly closed.
-        ensure!(
-            session_manager.states.is_empty(),
-            ExecutionError::SessionWasNotClosed
-        );
+        if let Some(session_id) = session_manager.states.keys().next() {
+            return Err(ExecutionError::SessionWasNotClosed(*session_id));
+        }
         Ok(results)
     }
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -218,7 +218,7 @@ where
 
         // Set the authenticated signer to be used in outgoing messages.
         call_result.authenticated_signer = signer;
-        let runtime_counts = runtime.runtime_counts();
+        let runtime_counts = runtime.runtime_counts().await;
         let balance = self.system.balance.get_mut();
         tracker.update_limits(balance, policy, runtime_counts)?;
 

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -6,9 +6,9 @@ use crate::{
     resources::{ResourceTracker, RuntimeLimits},
     runtime::{ApplicationStatus, ExecutionRuntime, SessionManager},
     system::SystemExecutionStateView,
-    ExecutionError, ExecutionResult, ExecutionRuntimeContext, Message, MessageContext, Operation,
-    OperationContext, Query, QueryContext, RawExecutionResult, RawOutgoingMessage, Response,
-    SystemMessage, UserApplicationDescription, UserApplicationId,
+    ExecutionError, ExecutionResult, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
+    MessageContext, Operation, OperationContext, Query, QueryContext, RawExecutionResult,
+    RawOutgoingMessage, Response, SystemMessage, UserApplicationDescription, UserApplicationId,
 };
 use linera_base::{
     ensure,
@@ -52,7 +52,10 @@ where
 {
     /// Creates an in-memory view where the system state is set. This is used notably to
     /// generate state hashes in tests.
-    pub async fn from_system_state(state: SystemExecutionState) -> Self {
+    pub async fn from_system_state(
+        state: SystemExecutionState,
+        execution_runtime_config: ExecutionRuntimeConfig,
+    ) -> Self {
         // Destructure, to make sure we don't miss any fields.
         let SystemExecutionState {
             description,
@@ -69,6 +72,7 @@ where
         let guard = Arc::new(Mutex::new(BTreeMap::new())).lock_arc().await;
         let extra = TestExecutionRuntimeContext::new(
             description.expect("Chain description should be set").into(),
+            execution_runtime_config,
         );
         let context = MemoryContext::new(guard, TEST_MEMORY_MAX_STREAM_QUERIES, extra);
         let mut view = Self::load(context)

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -1,0 +1,204 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Handle requests from the synchronous execution thread of user applications.
+
+use crate::{
+    runtime_actor::RespondExt, ExecutionError, ExecutionRuntimeContext, ExecutionStateView,
+    UserApplicationDescription, UserApplicationId, UserContractCode, UserServiceCode,
+};
+use futures::channel::mpsc;
+use linera_base::data_types::{Amount, Timestamp};
+use linera_views::{
+    batch::Batch,
+    common::Context,
+    views::{View, ViewError},
+};
+use oneshot::Sender;
+
+pub(crate) type ExecutionStateSender = mpsc::UnboundedSender<Request>;
+
+impl<C> ExecutionStateView<C>
+where
+    C: Context + Clone + Send + Sync + 'static,
+    ViewError: From<C::Error>,
+    C::Extra: ExecutionRuntimeContext,
+{
+    // TODO(#1416): Support concurrent I/O.
+    pub(crate) async fn handle_request(&mut self, request: Request) -> Result<(), ExecutionError> {
+        use Request::*;
+        match request {
+            LoadContract { id, callback } => {
+                let description = self.system.registry.describe_application(id).await?;
+                let code = self
+                    .context()
+                    .extra()
+                    .get_user_contract(&description)
+                    .await?;
+                callback.respond((code, description));
+            }
+
+            LoadService { id, callback } => {
+                let description = self.system.registry.describe_application(id).await?;
+                let code = self
+                    .context()
+                    .extra()
+                    .get_user_service(&description)
+                    .await?;
+                callback.respond((code, description));
+            }
+
+            SystemBalance { callback } => {
+                let balance = *self.system.balance.get();
+                callback.respond(balance);
+            }
+
+            SystemTimestamp { callback } => {
+                let timestamp = *self.system.timestamp.get();
+                callback.respond(timestamp);
+            }
+
+            ReadSimpleUserState { id, callback } => {
+                let state = self
+                    .simple_users
+                    .try_load_entry_mut(&id)
+                    .await
+                    .unwrap()
+                    .get()
+                    .to_vec();
+                callback.respond(state);
+            }
+
+            SaveSimpleUserState {
+                id,
+                bytes,
+                callback,
+            } => {
+                self.simple_users
+                    .try_load_entry_mut(&id)
+                    .await
+                    .unwrap()
+                    .set(bytes);
+                callback.respond(());
+            }
+
+            ContainsKey { id, key, callback } => {
+                let view = self.view_users.try_load_entry(&id).await?;
+                let result = view.contains_key(&key).await?;
+                callback.respond(result);
+            }
+
+            ReadMultiValuesBytes { id, keys, callback } => {
+                let view = self.view_users.try_load_entry(&id).await?;
+                let values = view.multi_get(keys).await?;
+                callback.respond(values);
+            }
+
+            ReadValueBytes { id, key, callback } => {
+                let view = self.view_users.try_load_entry(&id).await?;
+                let result = view.get(&key).await?;
+                callback.respond(result);
+            }
+
+            FindKeysByPrefix {
+                id,
+                key_prefix,
+                callback,
+            } => {
+                let view = self.view_users.try_load_entry(&id).await?;
+                let result = view.find_keys_by_prefix(&key_prefix).await?;
+                callback.respond(result);
+            }
+
+            FindKeyValuesByPrefix {
+                id,
+                key_prefix,
+                callback,
+            } => {
+                let view = self.view_users.try_load_entry(&id).await?;
+                let result = view.find_key_values_by_prefix(&key_prefix).await?;
+                callback.respond(result);
+            }
+
+            WriteBatch {
+                id,
+                batch,
+                callback,
+            } => {
+                let mut view = self.view_users.try_load_entry_mut(&id).await?;
+                view.write_batch(batch).await?;
+                callback.respond(());
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Requests to the execution state.
+pub enum Request {
+    LoadContract {
+        id: UserApplicationId,
+        callback: Sender<(UserContractCode, UserApplicationDescription)>,
+    },
+
+    LoadService {
+        id: UserApplicationId,
+        callback: Sender<(UserServiceCode, UserApplicationDescription)>,
+    },
+
+    SystemBalance {
+        callback: Sender<Amount>,
+    },
+
+    SystemTimestamp {
+        callback: Sender<Timestamp>,
+    },
+
+    ReadSimpleUserState {
+        id: UserApplicationId,
+        callback: Sender<Vec<u8>>,
+    },
+
+    SaveSimpleUserState {
+        id: UserApplicationId,
+        bytes: Vec<u8>,
+        callback: Sender<()>,
+    },
+
+    ReadValueBytes {
+        id: UserApplicationId,
+        key: Vec<u8>,
+        callback: Sender<Option<Vec<u8>>>,
+    },
+
+    ContainsKey {
+        id: UserApplicationId,
+        key: Vec<u8>,
+        callback: Sender<bool>,
+    },
+
+    ReadMultiValuesBytes {
+        id: UserApplicationId,
+        keys: Vec<Vec<u8>>,
+        callback: Sender<Vec<Option<Vec<u8>>>>,
+    },
+
+    FindKeysByPrefix {
+        id: UserApplicationId,
+        key_prefix: Vec<u8>,
+        callback: Sender<Vec<Vec<u8>>>,
+    },
+
+    FindKeyValuesByPrefix {
+        id: UserApplicationId,
+        key_prefix: Vec<u8>,
+        callback: Sender<Vec<(Vec<u8>, Vec<u8>)>>,
+    },
+
+    WriteBatch {
+        id: UserApplicationId,
+        batch: Batch,
+        callback: Sender<()>,
+    },
+}

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -245,8 +245,8 @@ pub struct SessionCallResult {
 /// System runtime implementation in use.
 #[derive(Default, Clone, Copy)]
 pub enum ExecutionRuntimeConfig {
-    #[default]
     Actor,
+    #[default]
     Synchronous,
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -217,11 +217,21 @@ pub struct SessionCallResult {
     pub close_session: bool,
 }
 
+/// System runtime implementation in use.
+#[derive(Default, Clone, Copy)]
+pub enum ExecutionRuntimeConfig {
+    #[default]
+    Actor,
+    Synchronous,
+}
+
 /// Requirements for the `extra` field in our state views (and notably the
 /// [`ExecutionStateView`]).
 #[async_trait]
 pub trait ExecutionRuntimeContext {
     fn chain_id(&self) -> ChainId;
+
+    fn execution_runtime_config(&self) -> ExecutionRuntimeConfig;
 
     fn user_contracts(&self) -> &Arc<DashMap<UserApplicationId, UserContractCode>>;
 
@@ -653,15 +663,17 @@ impl OperationContext {
 #[derive(Clone)]
 pub struct TestExecutionRuntimeContext {
     chain_id: ChainId,
+    execution_runtime_config: ExecutionRuntimeConfig,
     user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
     user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
 }
 
 #[cfg(any(test, feature = "test"))]
 impl TestExecutionRuntimeContext {
-    fn new(chain_id: ChainId) -> Self {
+    fn new(chain_id: ChainId, execution_runtime_config: ExecutionRuntimeConfig) -> Self {
         Self {
             chain_id,
+            execution_runtime_config,
             user_contracts: Arc::default(),
             user_services: Arc::default(),
         }
@@ -673,6 +685,10 @@ impl TestExecutionRuntimeContext {
 impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
     fn chain_id(&self) -> ChainId {
         self.chain_id
+    }
+
+    fn execution_runtime_config(&self) -> ExecutionRuntimeConfig {
+        self.execution_runtime_config
     }
 
     fn user_contracts(&self) -> &Arc<DashMap<UserApplicationId, UserContractCode>> {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -135,9 +135,9 @@ pub enum ExecutionError {
     #[error("Session {0} is still opened at the end of a transaction")]
     SessionWasNotClosed(SessionId),
 
-    #[error("Attempted to call an application while the state is locked")]
+    #[error("Attempted to call application {0} while the state is locked")]
     ApplicationIsInUse(UserApplicationId),
-    #[error("Attempted to read an application state that is not locked")]
+    #[error("Attempted to read the state of application {0} but it is not locked")]
     ApplicationStateNotLocked(UserApplicationId),
     #[error("Failed to load bytecode from storage {0:?}")]
     ApplicationBytecodeNotFound(Box<UserApplicationDescription>),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -110,6 +110,8 @@ pub enum ExecutionError {
     JoinError(#[from] tokio::task::JoinError),
     #[error("Host future was polled after it had finished")]
     PolledTwice,
+    #[error("The given promise is invalid or was polled once already")]
+    InvalidPromise,
     #[error("Attempt to use a system API to write to read-only storage")]
     WriteAttemptToReadOnlyStorage,
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -144,9 +144,11 @@ pub enum ExecutionError {
 
     #[error("Pricing error: {0}")]
     PricingError(#[from] PricingError),
-    #[error("Excessive readings from storage")]
+    #[error("Excessive number of read queries from storage")]
+    ExcessiveNumReads,
+    #[error("Excessive number of bytes read from storage")]
     ExcessiveRead,
-    #[error("Excessive writings to storage")]
+    #[error("Excessive number of bytes written to storage")]
     ExcessiveWrite,
     #[error("Runtime failed to respond to application")]
     MissingRuntimeResponse,

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -54,9 +54,8 @@ impl ResourceControlPolicy {
     }
 
     pub fn messages_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
-        let size =
-            u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
-        Ok(self.messages.try_mul(size)?)
+        let size = bcs::serialized_size(data)?;
+        Ok(self.messages.try_mul(size as u128)?)
     }
 
     pub fn storage_num_reads_price(&self, count: u64) -> Result<Amount, PricingError> {
@@ -75,9 +74,8 @@ impl ResourceControlPolicy {
         &self,
         data: &impl Serialize,
     ) -> Result<Amount, PricingError> {
-        let size =
-            u128::try_from(bcs::serialized_size(data)?).map_err(|_| ArithmeticError::Overflow)?;
-        Ok(self.storage_bytes_written.try_mul(size)?)
+        let size = bcs::serialized_size(data)?;
+        Ok(self.storage_bytes_written.try_mul(size as u128)?)
     }
 
     pub fn storage_bytes_stored_price(&self, count: u64) -> Result<Amount, PricingError> {

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -161,10 +161,13 @@ impl RuntimeCounts {
         limits: &RuntimeLimits,
         increment: u64,
     ) -> Result<(), ExecutionError> {
-        self.bytes_read = self.bytes_read
+        self.bytes_read = self
+            .bytes_read
             .checked_add(increment)
             .ok_or(ExecutionError::ExcessiveRead)?;
-        if self.bytes_read >= limits.max_budget_bytes_read || self.bytes_read >= limits.maximum_bytes_left_to_read {
+        if self.bytes_read >= limits.max_budget_bytes_read
+            || self.bytes_read >= limits.maximum_bytes_left_to_read
+        {
             return Err(ExecutionError::ExcessiveRead);
         }
         Ok(())
@@ -175,10 +178,13 @@ impl RuntimeCounts {
         limits: &RuntimeLimits,
         increment: u64,
     ) -> Result<(), ExecutionError> {
-        self.bytes_written = self.bytes_written
+        self.bytes_written = self
+            .bytes_written
             .checked_add(increment)
             .ok_or(ExecutionError::ExcessiveWrite)?;
-        if self.bytes_written >= limits.max_budget_bytes_written || self.bytes_written >= limits.maximum_bytes_left_to_write {
+        if self.bytes_written >= limits.max_budget_bytes_written
+            || self.bytes_written >= limits.maximum_bytes_left_to_write
+        {
             return Err(ExecutionError::ExcessiveWrite);
         }
         Ok(())

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -13,7 +13,7 @@ use crate::{
 use async_lock::{Mutex, MutexGuard, MutexGuardArc};
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{ArithmeticError, Timestamp},
+    data_types::Timestamp,
     ensure, hex_debug,
     identifiers::{ChainId, Owner},
 };
@@ -28,10 +28,7 @@ use linera_views::{
 use std::{
     collections::{btree_map, BTreeMap},
     ops::DerefMut,
-    sync::{
-        atomic::{AtomicI32, AtomicU64, Ordering},
-        Arc,
-    },
+    sync::Arc,
 };
 
 /// Runtime data tracked during the execution of a transaction.
@@ -54,16 +51,8 @@ pub(crate) struct ExecutionRuntime<'a, C, const WRITABLE: bool> {
     /// Accumulate the externally visible results (e.g. cross-chain messages) of applications.
     execution_results: Mutex<&'a mut Vec<ExecutionResult>>,
 
-    /// The amount of fuel available for executing the application.
-    remaining_fuel: AtomicU64,
-    /// The number of reads
-    num_reads: AtomicU64,
-    /// the total size being read
-    bytes_read: AtomicU64,
-    /// The total size being written
-    bytes_written: AtomicU64,
-    /// The total size being written
-    stored_size_delta: AtomicI32,
+    /// The runtime counters.
+    runtime_counts: Mutex<RuntimeCounts>,
     /// The runtime limits
     runtime_limits: RuntimeLimits,
 }
@@ -117,7 +106,7 @@ where
         execution_state: &'a mut ExecutionStateView<C>,
         session_manager: &'a mut SessionManager,
         execution_results: &'a mut Vec<ExecutionResult>,
-        fuel: u64,
+        remaining_fuel: u64,
         runtime_limits: RuntimeLimits,
     ) -> Self {
         assert_eq!(chain_id, execution_state.context().extra().chain_id());
@@ -129,11 +118,10 @@ where
             active_view_user_states: Mutex::default(),
             active_sessions: Mutex::default(),
             execution_results: Mutex::new(execution_results),
-            remaining_fuel: AtomicU64::new(fuel),
-            num_reads: AtomicU64::new(0),
-            bytes_read: AtomicU64::new(0),
-            bytes_written: AtomicU64::new(0),
-            stored_size_delta: AtomicI32::new(0),
+            runtime_counts: Mutex::new(RuntimeCounts {
+                remaining_fuel,
+                ..Default::default()
+            }),
             runtime_limits,
             chain_id,
         }
@@ -336,43 +324,24 @@ where
 }
 
 impl<'a, C, const W: bool> ExecutionRuntime<'a, C, W> {
-    fn increment_num_reads(&self) -> Result<(), ExecutionError> {
-        self.num_reads.fetch_add(1, Ordering::Relaxed);
-        let bytes = self.num_reads.load(Ordering::Acquire);
-        if bytes >= self.runtime_limits.max_budget_num_reads {
-            return Err(ExecutionError::ArithmeticError(ArithmeticError::Overflow));
-        }
-        Ok(())
+    async fn increment_num_reads(&self) -> Result<(), ExecutionError> {
+        let mut counts = self.runtime_counts.lock().await;
+        counts.increment_num_reads(&self.runtime_limits)
     }
 
-    fn increment_bytes_read(&self, increment: u64) -> Result<(), ExecutionError> {
-        if increment >= u64::MAX / 2 {
-            return Err(ExecutionError::ExcessiveRead);
-        }
-        self.bytes_read.fetch_add(increment, Ordering::Relaxed);
-        let bytes = self.bytes_read.load(Ordering::Acquire);
-        if bytes >= self.runtime_limits.max_budget_bytes_read {
-            return Err(ExecutionError::ArithmeticError(ArithmeticError::Overflow));
-        }
-        if bytes >= self.runtime_limits.maximum_bytes_left_to_read {
-            return Err(ExecutionError::ExcessiveRead);
-        }
-        Ok(())
+    async fn increment_bytes_read(&self, increment: u64) -> Result<(), ExecutionError> {
+        let mut counts = self.runtime_counts.lock().await;
+        counts.increment_bytes_read(&self.runtime_limits, increment)
     }
 
-    fn increment_bytes_written(&self, increment: u64) -> Result<(), ExecutionError> {
-        if increment >= u64::MAX / 2 {
-            return Err(ExecutionError::ExcessiveWrite);
-        }
-        self.bytes_written.fetch_add(increment, Ordering::Relaxed);
-        let bytes = self.bytes_written.load(Ordering::Acquire);
-        if bytes >= self.runtime_limits.max_budget_bytes_written {
-            return Err(ExecutionError::ArithmeticError(ArithmeticError::Overflow));
-        }
-        if bytes >= self.runtime_limits.maximum_bytes_left_to_write {
-            return Err(ExecutionError::ExcessiveWrite);
-        }
-        Ok(())
+    async fn increment_bytes_written(&self, increment: u64) -> Result<(), ExecutionError> {
+        let mut counts = self.runtime_counts.lock().await;
+        counts.increment_bytes_written(&self.runtime_limits, increment)
+    }
+
+    async fn update_stored_size(&self, delta: i32) -> Result<(), ExecutionError> {
+        let mut counts = self.runtime_counts.lock().await;
+        counts.update_stored_size(delta)
     }
 }
 
@@ -450,7 +419,7 @@ where
             .get(&self.application_id())
             .ok_or_else(|| ExecutionError::ApplicationStateNotLocked)?;
         let result = view.contains_key(&key).await?;
-        self.increment_num_reads()?;
+        self.increment_num_reads().await?;
         Ok(result)
     }
 
@@ -463,9 +432,9 @@ where
             .get(&self.application_id())
             .ok_or_else(|| ExecutionError::ApplicationStateNotLocked)?;
         let result = view.get(&key).await?;
-        self.increment_num_reads()?;
+        self.increment_num_reads().await?;
         if let Some(value) = &result {
-            self.increment_bytes_read(value.len() as u64)?;
+            self.increment_bytes_read(value.len() as u64).await?;
         }
         Ok(result)
     }
@@ -479,9 +448,9 @@ where
             .get(&self.application_id())
             .ok_or_else(|| ExecutionError::ApplicationStateNotLocked)?;
         let results = view.multi_get(keys).await?;
-        self.increment_num_reads()?;
+        self.increment_num_reads().await?;
         for value in results.iter().flatten() {
-            self.increment_bytes_read(value.len() as u64)?;
+            self.increment_bytes_read(value.len() as u64).await?;
         }
         Ok(results)
     }
@@ -496,12 +465,12 @@ where
             .get(&self.application_id())
             .ok_or_else(|| ExecutionError::ApplicationStateNotLocked)?;
         let keys = view.find_keys_by_prefix(&key_prefix).await?;
-        self.increment_num_reads()?;
+        self.increment_num_reads().await?;
         let mut read_size = 0;
         for key in &keys {
             read_size += key.len();
         }
-        self.increment_bytes_read(read_size as u64)?;
+        self.increment_bytes_read(read_size as u64).await?;
         Ok(keys)
     }
 
@@ -515,12 +484,12 @@ where
             .get(&self.application_id())
             .ok_or_else(|| ExecutionError::ApplicationStateNotLocked)?;
         let key_values = view.find_key_values_by_prefix(&key_prefix).await?;
-        self.increment_num_reads()?;
+        self.increment_num_reads().await?;
         let mut read_size = 0;
         for (key, value) in &key_values {
             read_size += key.len() + value.len();
         }
-        self.increment_bytes_read(read_size as u64)?;
+        self.increment_bytes_read(read_size as u64).await?;
         Ok(key_values)
     }
 }
@@ -587,27 +556,16 @@ where
         (actor, sender)
     }
 
-    pub(crate) fn remaining_fuel(&self) -> u64 {
-        self.remaining_fuel.load(Ordering::Acquire)
+    pub(crate) async fn remaining_fuel(&self) -> u64 {
+        self.runtime_counts.lock().await.remaining_fuel
     }
 
-    pub(crate) fn runtime_counts(&self) -> RuntimeCounts {
-        let remaining_fuel = self.remaining_fuel.load(Ordering::Acquire);
-        let num_reads = self.num_reads.load(Ordering::Acquire);
-        let bytes_read = self.bytes_read.load(Ordering::Acquire);
-        let bytes_written = self.bytes_written.load(Ordering::Acquire);
-        let stored_size_delta = self.stored_size_delta.load(Ordering::Acquire);
-        RuntimeCounts {
-            remaining_fuel,
-            num_reads,
-            bytes_read,
-            bytes_written,
-            stored_size_delta,
-        }
+    pub(crate) async fn runtime_counts(&self) -> RuntimeCounts {
+        *self.runtime_counts.lock().await
     }
 
-    pub(crate) fn set_remaining_fuel(&self, remaining_fuel: u64) {
-        self.remaining_fuel.store(remaining_fuel, Ordering::Release);
+    pub(crate) async fn set_remaining_fuel(&self, remaining_fuel: u64) {
+        self.runtime_counts.lock().await.remaining_fuel = remaining_fuel;
     }
 
     pub(crate) async fn try_read_and_lock_my_state(&self) -> Result<Vec<u8>, ExecutionError> {
@@ -646,7 +604,7 @@ where
     pub(crate) async fn write_batch_and_unlock(&self, batch: Batch) -> Result<(), ExecutionError> {
         // Update the write costs
         let size = batch.size() as u64;
-        self.increment_bytes_written(size)?;
+        self.increment_bytes_written(size).await?;
         // Write the batch and make the view available again.
         match self
             .active_view_user_states_mut()
@@ -658,8 +616,7 @@ where
                 view.write_batch(batch).await?;
                 let new_stored_size = view.total_size().sum_i32()?;
                 let increment = new_stored_size - stored_size;
-                self.stored_size_delta
-                    .fetch_add(increment, Ordering::Relaxed);
+                self.update_stored_size(increment).await?;
                 Ok(())
             }
             None => Err(ExecutionError::ApplicationStateNotLocked),

--- a/linera-execution/src/runtime_actor/handlers.rs
+++ b/linera-execution/src/runtime_actor/handlers.rs
@@ -95,12 +95,14 @@ where
                 self.read().await.handle_request(base_request).await?
             }
             ContractRequest::RemainingFuel { response_sender } => {
-                response_sender.respond(self.read().await.remaining_fuel())
+                response_sender.respond(self.read().await.remaining_fuel().await)
             }
             ContractRequest::SetRemainingFuel {
                 remaining_fuel,
                 response_sender,
-            } => response_sender.respond(self.write().await.set_remaining_fuel(remaining_fuel)),
+            } => {
+                response_sender.respond(self.write().await.set_remaining_fuel(remaining_fuel).await)
+            }
             ContractRequest::TryReadAndLockMyState { response_sender } => response_sender.respond(
                 match self.write().await.try_read_and_lock_my_state().await {
                     Ok(bytes) => Some(bytes),

--- a/linera-execution/src/sync_runtime.rs
+++ b/linera-execution/src/sync_runtime.rs
@@ -177,7 +177,9 @@ struct ViewUserState {
 
 impl ViewUserState {
     fn force_all_pending_queries(&mut self) -> Result<(), ExecutionError> {
+        self.contains_key_queries.force_all()?;
         self.read_value_queries.force_all()?;
+        self.read_multi_values_queries.force_all()?;
         self.find_keys_queries.force_all()?;
         self.find_key_values_queries.force_all()?;
         Ok(())
@@ -371,7 +373,7 @@ impl<const W: bool> SyncRuntime<W> {
     fn into_inner(self) -> Option<SyncRuntimeInternal<W>> {
         let runtime = Arc::into_inner(self.0)?
             .into_inner()
-            .expect("thread should not panicked");
+            .expect("thread should not have panicked");
         Some(runtime)
     }
 

--- a/linera-execution/src/sync_runtime.rs
+++ b/linera-execution/src/sync_runtime.rs
@@ -141,7 +141,7 @@ impl<T> QueryManager<T> {
         let promise = self
             .pending_queries
             .remove(&id)
-            .ok_or(ExecutionError::PolledTwice)?;
+            .ok_or(ExecutionError::InvalidPromise)?;
         let value = promise.read()?;
         self.active_query_count -= 1;
         Ok(value)
@@ -568,9 +568,9 @@ impl<const W: bool> BaseRuntime for SyncRuntimeInternal<W> {
         let state = self
             .simple_user_states
             .get_mut(&id)
-            .ok_or(ExecutionError::PolledTwice)?;
+            .ok_or(ExecutionError::InvalidPromise)?;
         let receiver =
-            std::mem::take(&mut state.pending_query).ok_or(ExecutionError::PolledTwice)?;
+            std::mem::take(&mut state.pending_query).ok_or(ExecutionError::InvalidPromise)?;
         receiver.recv_response()
     }
 

--- a/linera-execution/src/sync_runtime.rs
+++ b/linera-execution/src/sync_runtime.rs
@@ -1,0 +1,1044 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    execution::UserAction,
+    execution_state_actor::{ExecutionStateSender, Request},
+    resources::{RuntimeCounts, RuntimeLimits},
+    runtime_actor::{ReceiverExt, UnboundedSenderExt},
+    BaseRuntime, CallResult, ContractRuntime, ExecutionError, ExecutionResult, ServiceRuntime,
+    SessionId, UserApplicationDescription, UserApplicationId, UserContractCode, UserServiceCode,
+};
+use custom_debug_derive::Debug;
+use linera_base::{
+    data_types::{Amount, ArithmeticError, Timestamp},
+    ensure,
+    identifiers::{ChainId, Owner},
+};
+use linera_views::batch::Batch;
+use oneshot::Receiver;
+use std::{
+    collections::BTreeMap,
+    ops::DerefMut,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Clone, Debug)]
+pub struct SyncRuntime<const W: bool>(Arc<Mutex<SyncRuntimeInternal<W>>>);
+
+pub type ContractSyncRuntime = SyncRuntime<true>;
+pub type ServiceSyncRuntime = SyncRuntime<false>;
+
+/// Runtime data tracked during the execution of a transaction on the synchronous thread.
+#[derive(Debug)]
+pub struct SyncRuntimeInternal<const WRITABLE: bool> {
+    /// The current chain ID.
+    chain_id: ChainId,
+
+    /// How to interact with the storage view of the execution state.
+    execution_state_sender: ExecutionStateSender,
+
+    /// The current stack of application descriptions.
+    applications: Vec<ApplicationStatus>,
+    /// Accumulate the externally visible results (e.g. cross-chain messages) of applications.
+    execution_results: Vec<ExecutionResult>,
+
+    /// All the sessions and their IDs.
+    session_manager: SessionManager,
+    /// Track application states (simple case).
+    simple_user_states: BTreeMap<UserApplicationId, SimpleUserState>,
+    /// Track application states (view case).
+    view_user_states: BTreeMap<UserApplicationId, ViewUserState>,
+
+    /// Counters to track fuel and storage consumption.
+    runtime_counts: RuntimeCounts,
+    /// The runtime limits.
+    runtime_limits: RuntimeLimits,
+}
+
+/// The runtime status of an application.
+#[derive(Debug, Clone)]
+struct ApplicationStatus {
+    /// The application id.
+    id: UserApplicationId,
+    /// The parameters from the application description.
+    parameters: Vec<u8>,
+    /// The authenticated signer for the execution thread, if any.
+    signer: Option<Owner>,
+}
+
+#[derive(Debug, Default)]
+struct SessionManager {
+    /// Track the next session index to be used for each application.
+    counters: BTreeMap<UserApplicationId, u64>,
+    /// Track the current state (owner and data) of each session.
+    states: BTreeMap<SessionId, SessionState>,
+}
+
+#[derive(Debug)]
+enum Promise<T> {
+    Ready(T),
+    Pending(Receiver<T>),
+}
+
+impl<T> Promise<T> {
+    fn force(&mut self) -> Result<(), ExecutionError> {
+        if let Promise::Pending(receiver) = self {
+            let value = receiver
+                .recv_ref()
+                .map_err(|oneshot::RecvError| ExecutionError::MissingRuntimeResponse)?;
+            *self = Promise::Ready(value);
+        }
+        Ok(())
+    }
+
+    fn read(self) -> Result<T, ExecutionError> {
+        match self {
+            Promise::Pending(receiver) => {
+                let value = receiver.recv_response()?;
+                Ok(value)
+            }
+            Promise::Ready(value) => Ok(value),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct SimpleUserState {
+    /// Whether the application state was locked.
+    locked: bool,
+    /// A read query in progress on the internal state, if any.
+    pending_query: Option<Receiver<Vec<u8>>>,
+}
+
+/// Manages a set of pending queries returning values of type `T`.
+#[derive(Debug, Default)]
+struct QueryManager<T> {
+    /// The queries in progress.
+    pending_queries: BTreeMap<u32, Promise<T>>,
+    /// The number of queries ever registered so far. Used for the index of the next query.
+    query_count: u32,
+    /// The number of active queries.
+    active_query_count: u32,
+}
+
+impl<T> QueryManager<T> {
+    fn register(&mut self, receiver: Receiver<T>) -> Result<u32, ExecutionError> {
+        let id = self.query_count;
+        self.pending_queries.insert(id, Promise::Pending(receiver));
+        self.query_count = self
+            .query_count
+            .checked_add(1)
+            .ok_or(ArithmeticError::Overflow)?;
+        self.active_query_count = self
+            .active_query_count
+            .checked_add(1)
+            .ok_or(ArithmeticError::Overflow)?;
+        Ok(id)
+    }
+
+    fn wait(&mut self, id: u32) -> Result<T, ExecutionError> {
+        let promise = self
+            .pending_queries
+            .remove(&id)
+            .ok_or(ExecutionError::PolledTwice)?;
+        let value = promise.read()?;
+        self.active_query_count -= 1;
+        Ok(value)
+    }
+
+    fn force_all(&mut self) -> Result<(), ExecutionError> {
+        for promise in self.pending_queries.values_mut() {
+            promise.force()?;
+        }
+        Ok(())
+    }
+}
+
+type Keys = Vec<Vec<u8>>;
+type Value = Vec<u8>;
+type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
+
+#[derive(Debug, Default)]
+struct ViewUserState {
+    /// Whether the application state was locked.
+    locked: bool,
+    /// The contains-key queries in progress.
+    contains_key_queries: QueryManager<bool>,
+    /// The read-value queries in progress.
+    read_value_queries: QueryManager<Option<Value>>,
+    /// The read-multi-values queries in progress.
+    read_multi_values_queries: QueryManager<Vec<Option<Value>>>,
+    /// The find-keys queries in progress.
+    find_keys_queries: QueryManager<Keys>,
+    /// The find-key-values queries in progress.
+    find_key_values_queries: QueryManager<KeyValues>,
+}
+
+impl ViewUserState {
+    fn force_all_pending_queries(&mut self) -> Result<(), ExecutionError> {
+        self.read_value_queries.force_all()?;
+        self.find_keys_queries.force_all()?;
+        self.find_key_values_queries.force_all()?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SessionState {
+    /// Track which application can call into the session.
+    owner: UserApplicationId,
+    /// Whether the session is already active.
+    locked: bool,
+    /// Some data saved inside the session.
+    data: Vec<u8>,
+}
+
+impl<const W: bool> SyncRuntimeInternal<W> {
+    fn new(
+        chain_id: ChainId,
+        execution_state_sender: ExecutionStateSender,
+        runtime_limits: RuntimeLimits,
+        remaining_fuel: u64,
+    ) -> Self {
+        let runtime_counts = RuntimeCounts {
+            remaining_fuel,
+            ..Default::default()
+        };
+        Self {
+            chain_id,
+            execution_state_sender,
+            applications: Vec::new(),
+            execution_results: Vec::default(),
+            session_manager: SessionManager::default(),
+            simple_user_states: BTreeMap::default(),
+            view_user_states: BTreeMap::default(),
+            runtime_counts,
+            runtime_limits,
+        }
+    }
+
+    fn load_contract(
+        &mut self,
+        id: UserApplicationId,
+    ) -> Result<(UserContractCode, UserApplicationDescription), ExecutionError> {
+        self.execution_state_sender
+            .send_request(|callback| Request::LoadContract { id, callback })?
+            .recv_response()
+    }
+
+    fn load_service(
+        &mut self,
+        id: UserApplicationId,
+    ) -> Result<(UserServiceCode, UserApplicationDescription), ExecutionError> {
+        self.execution_state_sender
+            .send_request(|callback| Request::LoadService { id, callback })?
+            .recv_response()
+    }
+
+    fn forward_sessions(
+        &mut self,
+        session_ids: &[SessionId],
+        from_id: UserApplicationId,
+        to_id: UserApplicationId,
+    ) -> Result<(), ExecutionError> {
+        let states = &mut self.session_manager.states;
+        for id in session_ids {
+            let state = states.get_mut(id).ok_or(ExecutionError::InvalidSession)?;
+            // Verify ownership.
+            ensure!(state.owner == from_id, ExecutionError::InvalidSessionOwner);
+            // Transfer the session.
+            state.owner = to_id;
+        }
+        Ok(())
+    }
+
+    fn make_sessions(
+        &mut self,
+        new_sessions: Vec<Vec<u8>>,
+        creator_id: UserApplicationId,
+        receiver_id: UserApplicationId,
+    ) -> Vec<SessionId> {
+        let manager = &mut self.session_manager;
+        let states = &mut manager.states;
+        let counter = manager.counters.entry(creator_id).or_default();
+        let mut session_ids = Vec::new();
+        for data in new_sessions {
+            let id = SessionId {
+                application_id: creator_id,
+                index: *counter,
+            };
+            *counter += 1;
+            session_ids.push(id);
+            let state = SessionState {
+                owner: receiver_id,
+                locked: false,
+                data,
+            };
+            states.insert(id, state);
+        }
+        session_ids
+    }
+
+    fn try_load_session(
+        &mut self,
+        session_id: SessionId,
+        application_id: UserApplicationId,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let state = self
+            .session_manager
+            .states
+            .get_mut(&session_id)
+            .ok_or(ExecutionError::InvalidSession)?;
+        // Verify locking.
+        ensure!(!state.locked, ExecutionError::SessionIsInUse);
+        // Verify ownership.
+        ensure!(
+            state.owner == application_id,
+            ExecutionError::InvalidSessionOwner
+        );
+        // Lock state and return data.
+        state.locked = true;
+        Ok(state.data.clone())
+    }
+
+    fn try_save_session(
+        &mut self,
+        session_id: SessionId,
+        application_id: UserApplicationId,
+        data: Vec<u8>,
+    ) -> Result<(), ExecutionError> {
+        let state = self
+            .session_manager
+            .states
+            .get_mut(&session_id)
+            .ok_or(ExecutionError::InvalidSession)?;
+        // Verify locking.
+        ensure!(state.locked, ExecutionError::SessionStateNotLocked);
+        // Verify ownership.
+        ensure!(
+            state.owner == application_id,
+            ExecutionError::InvalidSessionOwner
+        );
+        // Save data.
+        state.data = data;
+        state.locked = false;
+        Ok(())
+    }
+
+    fn try_close_session(
+        &mut self,
+        session_id: SessionId,
+        application_id: UserApplicationId,
+    ) -> Result<(), ExecutionError> {
+        let state = self
+            .session_manager
+            .states
+            .get(&session_id)
+            .ok_or(ExecutionError::InvalidSession)?;
+        // Verify locking.
+        ensure!(state.locked, ExecutionError::SessionStateNotLocked);
+        // Verify ownership.
+        ensure!(
+            state.owner == application_id,
+            ExecutionError::InvalidSessionOwner
+        );
+        // Delete the session entirely.
+        self.session_manager
+            .states
+            .remove(&session_id)
+            .ok_or(ExecutionError::InvalidSession)?;
+        Ok(())
+    }
+}
+
+impl<const W: bool> SyncRuntime<W> {
+    fn new(runtime: SyncRuntimeInternal<W>) -> Self {
+        SyncRuntime(Arc::new(Mutex::new(runtime)))
+    }
+
+    fn into_inner(self) -> Option<SyncRuntimeInternal<W>> {
+        let runtime = Arc::into_inner(self.0)?
+            .into_inner()
+            .expect("thread should not panicked");
+        Some(runtime)
+    }
+
+    fn as_inner(&mut self) -> std::sync::MutexGuard<'_, SyncRuntimeInternal<W>> {
+        self.0
+            .try_lock()
+            .expect("Synchronous runtimes run on a single execution thread")
+    }
+}
+
+impl<const W: bool> BaseRuntime for SyncRuntime<W> {
+    type Read = <SyncRuntimeInternal<W> as BaseRuntime>::Read;
+    type Lock = <SyncRuntimeInternal<W> as BaseRuntime>::Lock;
+    type Unlock = <SyncRuntimeInternal<W> as BaseRuntime>::Unlock;
+    type ReadValueBytes = <SyncRuntimeInternal<W> as BaseRuntime>::ReadValueBytes;
+    type ContainsKey = <SyncRuntimeInternal<W> as BaseRuntime>::ContainsKey;
+    type ReadMultiValuesBytes = <SyncRuntimeInternal<W> as BaseRuntime>::ReadMultiValuesBytes;
+    type FindKeysByPrefix = <SyncRuntimeInternal<W> as BaseRuntime>::FindKeysByPrefix;
+    type FindKeyValuesByPrefix = <SyncRuntimeInternal<W> as BaseRuntime>::FindKeyValuesByPrefix;
+
+    fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+        self.as_inner().chain_id()
+    }
+
+    fn application_id(&mut self) -> Result<UserApplicationId, ExecutionError> {
+        self.as_inner().application_id()
+    }
+
+    fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
+        self.as_inner().application_parameters()
+    }
+
+    fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
+        self.as_inner().read_system_balance()
+    }
+
+    fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
+        self.as_inner().read_system_timestamp()
+    }
+
+    fn try_read_my_state_new(&mut self) -> Result<Self::Read, ExecutionError> {
+        self.as_inner().try_read_my_state_new()
+    }
+
+    fn try_read_my_state_wait(&mut self, promise: &Self::Read) -> Result<Vec<u8>, ExecutionError> {
+        self.as_inner().try_read_my_state_wait(promise)
+    }
+
+    fn lock_new(&mut self) -> Result<Self::Lock, ExecutionError> {
+        self.as_inner().lock_new()
+    }
+
+    fn lock_wait(&mut self, promise: &Self::Lock) -> Result<(), ExecutionError> {
+        self.as_inner().lock_wait(promise)
+    }
+
+    fn unlock_new(&mut self) -> Result<Self::Unlock, ExecutionError> {
+        self.as_inner().unlock_new()
+    }
+
+    fn unlock_wait(&mut self, promise: &Self::Unlock) -> Result<(), ExecutionError> {
+        self.as_inner().unlock_wait(promise)
+    }
+
+    fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError> {
+        self.as_inner().write_batch_and_unlock(batch)
+    }
+
+    fn contains_key_new(&mut self, key: Vec<u8>) -> Result<Self::ContainsKey, ExecutionError> {
+        self.as_inner().contains_key_new(key)
+    }
+
+    fn contains_key_wait(&mut self, promise: &Self::ContainsKey) -> Result<bool, ExecutionError> {
+        self.as_inner().contains_key_wait(promise)
+    }
+
+    fn read_multi_values_bytes_new(
+        &mut self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Self::ReadMultiValuesBytes, ExecutionError> {
+        self.as_inner().read_multi_values_bytes_new(keys)
+    }
+
+    fn read_multi_values_bytes_wait(
+        &mut self,
+        promise: &Self::ReadMultiValuesBytes,
+    ) -> Result<Vec<Option<Vec<u8>>>, ExecutionError> {
+        self.as_inner().read_multi_values_bytes_wait(promise)
+    }
+
+    fn read_value_bytes_new(
+        &mut self,
+        key: Vec<u8>,
+    ) -> Result<Self::ReadValueBytes, ExecutionError> {
+        self.as_inner().read_value_bytes_new(key)
+    }
+
+    fn read_value_bytes_wait(
+        &mut self,
+        promise: &Self::ReadValueBytes,
+    ) -> Result<Option<Vec<u8>>, ExecutionError> {
+        self.as_inner().read_value_bytes_wait(promise)
+    }
+
+    fn find_keys_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeysByPrefix, ExecutionError> {
+        self.as_inner().find_keys_by_prefix_new(key_prefix)
+    }
+
+    fn find_keys_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeysByPrefix,
+    ) -> Result<Vec<Vec<u8>>, ExecutionError> {
+        self.as_inner().find_keys_by_prefix_wait(promise)
+    }
+
+    fn find_key_values_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError> {
+        self.as_inner().find_key_values_by_prefix_new(key_prefix)
+    }
+
+    fn find_key_values_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeyValuesByPrefix,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
+        self.as_inner().find_key_values_by_prefix_wait(promise)
+    }
+}
+
+impl<const W: bool> BaseRuntime for SyncRuntimeInternal<W> {
+    type Read = ();
+    type Lock = ();
+    type Unlock = ();
+    type ReadValueBytes = u32;
+    type ContainsKey = u32;
+    type ReadMultiValuesBytes = u32;
+    type FindKeysByPrefix = u32;
+    type FindKeyValuesByPrefix = u32;
+
+    fn chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+        Ok(self.chain_id)
+    }
+
+    fn application_id(&mut self) -> Result<UserApplicationId, ExecutionError> {
+        let id = self
+            .applications
+            .last()
+            .expect("at least one application description should be present in the stack")
+            .id;
+        Ok(id)
+    }
+
+    fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
+        let parameters = self
+            .applications
+            .last()
+            .expect("at least one application description should be present in the stack")
+            .parameters
+            .clone();
+        Ok(parameters)
+    }
+
+    fn read_system_balance(&mut self) -> Result<Amount, ExecutionError> {
+        self.execution_state_sender
+            .send_request(|callback| Request::SystemBalance { callback })?
+            .recv_response()
+    }
+
+    fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
+        self.execution_state_sender
+            .send_request(|callback| Request::SystemTimestamp { callback })?
+            .recv_response()
+    }
+
+    fn try_read_my_state_new(&mut self) -> Result<Self::Read, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.simple_user_states.entry(id).or_default();
+        ensure!(!state.locked, ExecutionError::ApplicationIsInUse); // TODO: include the id
+        let receiver = self
+            .execution_state_sender
+            .send_request(|callback| Request::ReadSimpleUserState { id, callback })?;
+        state.pending_query = Some(receiver);
+        Ok(())
+    }
+
+    fn try_read_my_state_wait(&mut self, _promise: &Self::Read) -> Result<Vec<u8>, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self
+            .simple_user_states
+            .get_mut(&id)
+            .ok_or(ExecutionError::PolledTwice)?;
+        let receiver =
+            std::mem::take(&mut state.pending_query).ok_or(ExecutionError::PolledTwice)?;
+        receiver.recv_response()
+    }
+
+    // TODO(#1152): simplify away
+    fn lock_new(&mut self) -> Result<Self::Lock, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(!state.locked, ExecutionError::ApplicationIsInUse); // TODO: include the id
+        state.locked = true;
+        Ok(())
+    }
+
+    fn lock_wait(&mut self, _promise: &Self::Lock) -> Result<(), ExecutionError> {
+        Ok(())
+    }
+
+    fn unlock_new(&mut self) -> Result<Self::Unlock, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(state.locked, ExecutionError::ApplicationStateNotLocked);
+        state.locked = false;
+        Ok(())
+    }
+
+    fn unlock_wait(&mut self, _promise: &Self::Unlock) -> Result<(), ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        state.force_all_pending_queries()?;
+        Ok(())
+    }
+
+    fn write_batch_and_unlock(&mut self, batch: Batch) -> Result<(), ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(state.locked, ExecutionError::ApplicationStateNotLocked);
+        state.force_all_pending_queries()?;
+        self.execution_state_sender
+            .send_request(|callback| Request::WriteBatch {
+                id,
+                batch,
+                callback,
+            })?
+            .recv_response()?;
+        state.locked = false;
+        Ok(())
+    }
+
+    fn contains_key_new(&mut self, key: Vec<u8>) -> Result<Self::ContainsKey, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(state.locked, ExecutionError::ApplicationStateNotLocked); // TODO: include the id
+        self.runtime_counts
+            .increment_num_reads(&self.runtime_limits)?;
+        let receiver = self
+            .execution_state_sender
+            .send_request(move |callback| Request::ContainsKey { id, key, callback })?;
+        state.contains_key_queries.register(receiver)
+    }
+
+    fn contains_key_wait(&mut self, promise: &Self::ContainsKey) -> Result<bool, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        let value = state.contains_key_queries.wait(*promise)?;
+        Ok(value)
+    }
+
+    fn read_multi_values_bytes_new(
+        &mut self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Self::ReadMultiValuesBytes, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(state.locked, ExecutionError::ApplicationStateNotLocked); // TODO: include the id
+        self.runtime_counts
+            .increment_num_reads(&self.runtime_limits)?;
+        let receiver = self
+            .execution_state_sender
+            .send_request(move |callback| Request::ReadMultiValuesBytes { id, keys, callback })?;
+        state.read_multi_values_queries.register(receiver)
+    }
+
+    fn read_multi_values_bytes_wait(
+        &mut self,
+        promise: &Self::ReadMultiValuesBytes,
+    ) -> Result<Vec<Option<Vec<u8>>>, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        let values = state.read_multi_values_queries.wait(*promise)?;
+        for value in &values {
+            if let Some(value) = &value {
+                self.runtime_counts
+                    .increment_bytes_read(&self.runtime_limits, value.len() as u64)?;
+            }
+        }
+        Ok(values)
+    }
+
+    fn read_value_bytes_new(
+        &mut self,
+        key: Vec<u8>,
+    ) -> Result<Self::ReadValueBytes, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(state.locked, ExecutionError::ApplicationStateNotLocked); // TODO: include the id
+        self.runtime_counts
+            .increment_num_reads(&self.runtime_limits)?;
+        let receiver = self
+            .execution_state_sender
+            .send_request(move |callback| Request::ReadValueBytes { id, key, callback })?;
+        state.read_value_queries.register(receiver)
+    }
+
+    fn read_value_bytes_wait(
+        &mut self,
+        promise: &Self::ReadValueBytes,
+    ) -> Result<Option<Vec<u8>>, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        let value = state.read_value_queries.wait(*promise)?;
+        if let Some(value) = &value {
+            self.runtime_counts
+                .increment_bytes_read(&self.runtime_limits, value.len() as u64)?;
+        }
+        Ok(value)
+    }
+
+    fn find_keys_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeysByPrefix, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(state.locked, ExecutionError::ApplicationStateNotLocked); // TODO: include the id
+        self.runtime_counts
+            .increment_num_reads(&self.runtime_limits)?;
+        let receiver = self.execution_state_sender.send_request(move |callback| {
+            Request::FindKeysByPrefix {
+                id,
+                key_prefix,
+                callback,
+            }
+        })?;
+        state.find_keys_queries.register(receiver)
+    }
+
+    fn find_keys_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeysByPrefix,
+    ) -> Result<Vec<Vec<u8>>, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        let keys = state.find_keys_queries.wait(*promise)?;
+        let mut read_size = 0;
+        for key in &keys {
+            read_size += key.len();
+        }
+        self.runtime_counts
+            .increment_bytes_read(&self.runtime_limits, read_size as u64)?;
+        Ok(keys)
+    }
+
+    fn find_key_values_by_prefix_new(
+        &mut self,
+        key_prefix: Vec<u8>,
+    ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        ensure!(state.locked, ExecutionError::ApplicationStateNotLocked); // TODO: include the id
+        self.runtime_counts
+            .increment_num_reads(&self.runtime_limits)?;
+        let receiver = self.execution_state_sender.send_request(move |callback| {
+            Request::FindKeyValuesByPrefix {
+                id,
+                key_prefix,
+                callback,
+            }
+        })?;
+        state.find_key_values_queries.register(receiver)
+    }
+
+    fn find_key_values_by_prefix_wait(
+        &mut self,
+        promise: &Self::FindKeyValuesByPrefix,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ExecutionError> {
+        let id = self.application_id()?;
+        let state = self.view_user_states.entry(id).or_default();
+        let key_values = state.find_key_values_queries.wait(*promise)?;
+        let mut read_size = 0;
+        for (key, value) in &key_values {
+            read_size += key.len() + value.len();
+        }
+        self.runtime_counts
+            .increment_bytes_read(&self.runtime_limits, read_size as u64)?;
+        Ok(key_values)
+    }
+}
+
+impl ContractSyncRuntime {
+    /// Main entry point to start executing a user action.
+    pub(crate) fn run_action(
+        execution_state_sender: ExecutionStateSender,
+        application_id: UserApplicationId,
+        chain_id: ChainId,
+        runtime_limits: RuntimeLimits,
+        initial_remaining_fuel: u64,
+        action: UserAction,
+    ) -> Result<(Vec<ExecutionResult>, RuntimeCounts), ExecutionError> {
+        let mut runtime = SyncRuntimeInternal::new(
+            chain_id,
+            execution_state_sender,
+            runtime_limits,
+            initial_remaining_fuel,
+        );
+        let (code, description) = runtime.load_contract(application_id)?;
+        let signer = action.signer();
+        runtime.applications.push(ApplicationStatus {
+            id: application_id,
+            parameters: description.parameters,
+            signer,
+        });
+        let runtime = ContractSyncRuntime::new(runtime);
+        let execution_result = {
+            let mut code = code.instantiate_with_sync_runtime(runtime.clone())?;
+            match action {
+                UserAction::Initialize(context, argument) => code.initialize(context, argument)?,
+                UserAction::Operation(context, operation) => {
+                    code.execute_operation(context, operation)?
+                }
+                UserAction::Message(context, message) => code.execute_message(context, message)?,
+            }
+        };
+        let mut runtime = runtime
+            .into_inner()
+            .expect("Runtime clones should have been freed by now");
+        assert_eq!(runtime.applications.len(), 1);
+        assert_eq!(runtime.applications[0].id, application_id);
+        // Check that all sessions were properly closed.
+        ensure!(
+            runtime.session_manager.states.is_empty(),
+            ExecutionError::SessionWasNotClosed
+        );
+        // Adds the results of the last call to the execution results.
+        runtime.execution_results.push(ExecutionResult::User(
+            application_id,
+            execution_result.with_authenticated_signer(signer),
+        ));
+        Ok((runtime.execution_results, runtime.runtime_counts))
+    }
+}
+
+impl ContractRuntime for ContractSyncRuntime {
+    fn remaining_fuel(&mut self) -> Result<u64, ExecutionError> {
+        let this = self.as_inner();
+        Ok(this.runtime_counts.remaining_fuel)
+    }
+
+    fn set_remaining_fuel(&mut self, remaining_fuel: u64) -> Result<(), ExecutionError> {
+        let mut this = self.as_inner();
+        this.runtime_counts.remaining_fuel = remaining_fuel;
+        Ok(())
+    }
+
+    fn try_read_and_lock_my_state(&mut self) -> Result<Option<Vec<u8>>, ExecutionError> {
+        let mut this = self.as_inner();
+        let this = this.deref_mut();
+        let id = this.application_id()?;
+        let state = this.simple_user_states.entry(id).or_default();
+        if state.locked {
+            return Ok(None);
+        }
+        let receiver = this
+            .execution_state_sender
+            .send_request(|callback| Request::ReadSimpleUserState { id, callback })?;
+        let bytes = receiver.recv_response()?;
+        state.locked = true;
+        Ok(Some(bytes))
+    }
+
+    fn save_and_unlock_my_state(&mut self, bytes: Vec<u8>) -> Result<bool, ExecutionError> {
+        let mut this = self.as_inner();
+        let this = this.deref_mut();
+        let id = this.application_id()?;
+        let state = this.simple_user_states.entry(id).or_default();
+        if !state.locked {
+            return Ok(false);
+        }
+        let receiver =
+            this.execution_state_sender
+                .send_request(|callback| Request::SaveSimpleUserState {
+                    id,
+                    bytes,
+                    callback,
+                })?;
+        receiver.recv_response()?;
+        state.locked = false;
+        Ok(true)
+    }
+
+    fn try_call_application(
+        &mut self,
+        authenticated: bool,
+        callee_id: UserApplicationId,
+        argument: Vec<u8>,
+        forwarded_sessions: Vec<SessionId>,
+    ) -> Result<CallResult, ExecutionError> {
+        let (callee_context, authenticated_signer, code) = {
+            let mut this = self.as_inner();
+            let caller = this.applications.last().expect("caller must exist").clone();
+            // Load the application.
+            let (code, description) = this.load_contract(callee_id)?;
+            // Change the owners of forwarded sessions.
+            this.forward_sessions(&forwarded_sessions, caller.id, callee_id)?;
+            // Make the call to user code.
+            let authenticated_signer = match caller.signer {
+                Some(signer) if authenticated => Some(signer),
+                _ => None,
+            };
+            let authenticated_caller_id = authenticated.then_some(caller.id);
+            let callee_context = crate::CalleeContext {
+                chain_id: this.chain_id,
+                authenticated_signer,
+                authenticated_caller_id,
+            };
+            this.applications.push(ApplicationStatus {
+                id: callee_id,
+                parameters: description.parameters,
+                // Allow further nested calls to be authenticated if this one is.
+                signer: authenticated_signer,
+            });
+            (callee_context, authenticated_signer, code)
+        };
+        let mut code = code.instantiate_with_sync_runtime(self.clone())?;
+        let raw_result =
+            code.handle_application_call(callee_context, argument, forwarded_sessions)?;
+        {
+            let mut this = self.as_inner();
+            this.applications.pop();
+
+            // Interpret the results of the call.
+            this.execution_results.push(ExecutionResult::User(
+                callee_id,
+                raw_result
+                    .execution_result
+                    .with_authenticated_signer(authenticated_signer),
+            ));
+            let caller_id = this.application_id()?;
+            let sessions = this.make_sessions(raw_result.create_sessions, callee_id, caller_id);
+            let result = CallResult {
+                value: raw_result.value,
+                sessions,
+            };
+            Ok(result)
+        }
+    }
+
+    fn try_call_session(
+        &mut self,
+        authenticated: bool,
+        session_id: SessionId,
+        argument: Vec<u8>,
+        forwarded_sessions: Vec<SessionId>,
+    ) -> Result<CallResult, ExecutionError> {
+        let (callee_context, authenticated_signer, session_state, code) = {
+            let mut this = self.as_inner();
+            let callee_id = session_id.application_id;
+            let caller = this.applications.last().expect("caller must exist").clone();
+            // Load the application.
+            let (code, description) = this.load_contract(callee_id)?;
+            // Change the owners of forwarded sessions.
+            this.forward_sessions(&forwarded_sessions, caller.id, callee_id)?;
+            // Load the session.
+            let session_state = this.try_load_session(session_id, caller.id)?;
+            // Make the call to user code.
+            let authenticated_signer = match caller.signer {
+                Some(signer) if authenticated => Some(signer),
+                _ => None,
+            };
+            let authenticated_caller_id = authenticated.then_some(caller.id);
+            let callee_context = crate::CalleeContext {
+                chain_id: this.chain_id,
+                authenticated_signer,
+                authenticated_caller_id,
+            };
+            this.applications.push(ApplicationStatus {
+                id: callee_id,
+                parameters: description.parameters,
+                // Allow further nested calls to be authenticated if this one is.
+                signer: authenticated_signer,
+            });
+            (callee_context, authenticated_signer, session_state, code)
+        };
+        let mut code = code.instantiate_with_sync_runtime(self.clone())?;
+        let (raw_result, session_state) =
+            code.handle_session_call(callee_context, session_state, argument, forwarded_sessions)?;
+        {
+            let mut this = self.as_inner();
+            this.applications.pop();
+
+            // Interpret the results of the call.
+            let caller_id = this.application_id()?;
+            if raw_result.close_session {
+                // Terminate the session.
+                this.try_close_session(session_id, caller_id)?;
+            } else {
+                // Save the session.
+                this.try_save_session(session_id, caller_id, session_state)?;
+            }
+            let inner_result = raw_result.inner;
+            let callee_id = session_id.application_id;
+            this.execution_results.push(ExecutionResult::User(
+                callee_id,
+                inner_result
+                    .execution_result
+                    .with_authenticated_signer(authenticated_signer),
+            ));
+            let sessions = this.make_sessions(inner_result.create_sessions, callee_id, caller_id);
+            let result = CallResult {
+                value: inner_result.value,
+                sessions,
+            };
+            Ok(result)
+        }
+    }
+}
+
+impl ServiceSyncRuntime {
+    pub(crate) fn run_query(
+        execution_state_sender: ExecutionStateSender,
+        application_id: UserApplicationId,
+        context: crate::QueryContext,
+        query: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let runtime = SyncRuntimeInternal::new(
+            context.chain_id,
+            execution_state_sender,
+            RuntimeLimits::default(),
+            0,
+        );
+        ServiceSyncRuntime::new(runtime).try_query_application(application_id, query)
+    }
+}
+
+impl ServiceRuntime for ServiceSyncRuntime {
+    type TryQueryApplication = Vec<u8>;
+
+    /// Note that queries are not available from writable contexts.
+    // TODO(#1152): make synchronous
+    fn try_query_application_new(
+        &mut self,
+        queried_id: UserApplicationId,
+        argument: Vec<u8>,
+    ) -> Result<Self::TryQueryApplication, ExecutionError> {
+        let (query_context, code) = {
+            let mut this = self.as_inner();
+
+            // Load the application.
+            let (code, description) = this.load_service(queried_id)?;
+            // Make the call to user code.
+            let query_context = crate::QueryContext {
+                chain_id: this.chain_id,
+            };
+            this.applications.push(ApplicationStatus {
+                id: queried_id,
+                parameters: description.parameters,
+                signer: None,
+            });
+            (query_context, code)
+        };
+        let mut code = code.instantiate_with_sync_runtime(self.clone())?;
+        let promise = code.handle_query(query_context, argument)?;
+        {
+            let mut this = self.as_inner();
+            this.applications.pop();
+        }
+        Ok(promise)
+    }
+
+    fn try_query_application_wait(
+        &mut self,
+        promise: &Self::TryQueryApplication,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        Ok(promise.to_vec())
+    }
+}

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -995,7 +995,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ExecutionStateView, TestExecutionRuntimeContext};
+    use crate::{ExecutionRuntimeConfig, ExecutionStateView, TestExecutionRuntimeContext};
     use linera_base::{
         crypto::{BcsSignable, KeyPair},
         data_types::BlockHeight,
@@ -1029,7 +1029,8 @@ mod tests {
             committees: BTreeMap::new(),
             ..SystemExecutionState::default()
         };
-        let view = ExecutionStateView::from_system_state(state, Default::default()).await;
+        let view =
+            ExecutionStateView::from_system_state(state, ExecutionRuntimeConfig::default()).await;
         (view, context)
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -1029,7 +1029,7 @@ mod tests {
             committees: BTreeMap::new(),
             ..SystemExecutionState::default()
         };
-        let view = ExecutionStateView::from_system_state(state).await;
+        let view = ExecutionStateView::from_system_state(state, Default::default()).await;
         (view, context)
     }
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -418,7 +418,10 @@ async fn test_simple_user_operation_with_leaking_session(
         )
         .await;
 
-    assert!(matches!(result, Err(ExecutionError::SessionWasNotClosed)));
+    assert!(matches!(
+        result,
+        Err(ExecutionError::SessionWasNotClosed(_))
+    ));
     Ok(())
 }
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -23,8 +23,11 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
 
     let app_desc = create_dummy_user_application_description();
     let app_id = view
@@ -268,8 +271,11 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
     let app_desc = create_dummy_user_application_description();
     let app_id = view
         .system
@@ -345,8 +351,11 @@ async fn test_simple_user_operation_with_leaking_session() -> anyhow::Result<()>
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
     let app_desc = create_dummy_user_application_description();
     let app_id = view
         .system
@@ -394,8 +403,11 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
     let app_desc = create_dummy_user_application_description();
     let app_id = view
         .system

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -24,8 +24,11 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     state.description = Some(ChainDescription::Root(0));
     state.balance = Amount::from_tokens(4);
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
     let operation = SystemOperation::Transfer {
         owner: None,
         amount: Amount::from_tokens(4),
@@ -63,8 +66,11 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
     let message = SystemMessage::Credit {
         amount: Amount::from_tokens(4),
         account: Account::chain(ChainId::root(0)),
@@ -100,8 +106,11 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
     state.description = Some(ChainDescription::Root(0));
     state.balance = Amount::from_tokens(4);
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
     let context = QueryContext {
         chain_id: ChainId::root(0),
     };

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -40,8 +40,11 @@ async fn test_fuel_for_counter_wasm_application(
         ..Default::default()
     };
     let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(state)
-            .await;
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            Default::default(),
+        )
+        .await;
     let app_desc = create_dummy_user_application_description();
     let app_id = view
         .system

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -9,7 +9,9 @@ use linera_chain::{
     data_types::{Certificate, CertificateValue, HashedValue, LiteCertificate},
     ChainStateView,
 };
-use linera_execution::{UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime};
+use linera_execution::{
+    ExecutionRuntimeConfig, UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime,
+};
 use linera_views::{
     batch::Batch,
     common::{ContextFromStore, KeyValueStore},
@@ -106,6 +108,7 @@ impl<Client> DbStorageInner<Client> {
 pub struct DbStorage<Client, Clock> {
     pub(crate) client: Arc<DbStorageInner<Client>>,
     pub clock: Clock,
+    pub execution_runtime_config: ExecutionRuntimeConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -188,6 +191,7 @@ where
         let runtime_context = ChainRuntimeContext {
             storage: self.clone(),
             chain_id,
+            execution_runtime_config: self.execution_runtime_config,
             user_contracts: self.client.user_contracts.clone(),
             user_services: self.client.user_services.clone(),
             _chain_guard: Arc::new(guard),

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
-use linera_execution::WasmRuntime;
+use linera_execution::{ExecutionRuntimeConfig, WasmRuntime};
 use linera_views::{
     common::TableStatus,
     dynamo_db::{DynamoDbContextError, DynamoDbStore, DynamoDbStoreConfig},
@@ -85,7 +85,7 @@ impl DynamoDbStorage<TestClock> {
         let storage = DynamoDbStorage {
             client: Arc::new(storage),
             clock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok((storage, table_status))
     }
@@ -100,7 +100,7 @@ impl DynamoDbStorage<WallClock> {
         let storage = DynamoDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok(storage)
     }
@@ -114,7 +114,7 @@ impl DynamoDbStorage<WallClock> {
         let storage = DynamoDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok((storage, table_status))
     }

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -85,6 +85,7 @@ impl DynamoDbStorage<TestClock> {
         let storage = DynamoDbStorage {
             client: Arc::new(storage),
             clock,
+            execution_runtime_config: Default::default(),
         };
         Ok((storage, table_status))
     }
@@ -99,6 +100,7 @@ impl DynamoDbStorage<WallClock> {
         let storage = DynamoDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
+            execution_runtime_config: Default::default(),
         };
         Ok(storage)
     }
@@ -112,6 +114,7 @@ impl DynamoDbStorage<WallClock> {
         let storage = DynamoDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
+            execution_runtime_config: Default::default(),
         };
         Ok((storage, table_status))
     }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -44,8 +44,8 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    ChainOwnership, ExecutionError, ExecutionRuntimeContext, UserApplicationDescription,
-    UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime,
+    ChainOwnership, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
+    UserApplicationDescription, UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime,
 };
 use linera_views::{
     common::Context,
@@ -298,6 +298,7 @@ async fn read_publish_bytecode_operation(
 pub struct ChainRuntimeContext<S> {
     storage: S,
     chain_id: ChainId,
+    execution_runtime_config: ExecutionRuntimeConfig,
     user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
     user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
     _chain_guard: Arc<ChainGuard>,
@@ -310,6 +311,10 @@ where
 {
     fn chain_id(&self) -> ChainId {
         self.chain_id
+    }
+
+    fn execution_runtime_config(&self) -> linera_execution::ExecutionRuntimeConfig {
+        self.execution_runtime_config
     }
 
     fn user_contracts(&self) -> &Arc<DashMap<UserApplicationId, UserContractCode>> {

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::db_storage::{DbStorage, DbStorageInner};
-use linera_execution::WasmRuntime;
+use linera_execution::{ExecutionRuntimeConfig, WasmRuntime};
 use linera_views::memory::{create_memory_store_stream_queries, MemoryStore};
 use std::sync::Arc;
 
@@ -31,7 +31,7 @@ impl<C> MemoryStorage<C> {
         Self {
             client: Arc::new(MemoryStorageInner::make(wasm_runtime, max_stream_queries)),
             clock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         }
     }
 }

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -31,6 +31,7 @@ impl<C> MemoryStorage<C> {
         Self {
             client: Arc::new(MemoryStorageInner::make(wasm_runtime, max_stream_queries)),
             clock,
+            execution_runtime_config: Default::default(),
         }
     }
 }

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
-use linera_execution::WasmRuntime;
+use linera_execution::{ExecutionRuntimeConfig, WasmRuntime};
 use linera_views::{
     common::TableStatus,
     rocks_db::{RocksDbContextError, RocksDbStore, RocksDbStoreConfig},
@@ -80,7 +80,7 @@ impl RocksDbStorage<TestClock> {
         let storage = RocksDbStorage {
             client: Arc::new(storage),
             clock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok((storage, table_status))
     }
@@ -95,7 +95,7 @@ impl RocksDbStorage<WallClock> {
         let storage = RocksDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok(storage)
     }
@@ -108,7 +108,7 @@ impl RocksDbStorage<WallClock> {
         let storage = RocksDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok((storage, table_status))
     }

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -80,6 +80,7 @@ impl RocksDbStorage<TestClock> {
         let storage = RocksDbStorage {
             client: Arc::new(storage),
             clock,
+            execution_runtime_config: Default::default(),
         };
         Ok((storage, table_status))
     }
@@ -94,6 +95,7 @@ impl RocksDbStorage<WallClock> {
         let storage = RocksDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
+            execution_runtime_config: Default::default(),
         };
         Ok(storage)
     }
@@ -106,6 +108,7 @@ impl RocksDbStorage<WallClock> {
         let storage = RocksDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
+            execution_runtime_config: Default::default(),
         };
         Ok((storage, table_status))
     }

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::db_storage::{DbStorage, DbStorageInner, WallClock};
-use linera_execution::WasmRuntime;
+use linera_execution::{ExecutionRuntimeConfig, WasmRuntime};
 use linera_views::{
     common::TableStatus,
     scylla_db::{ScyllaDbContextError, ScyllaDbStore, ScyllaDbStoreConfig},
@@ -81,7 +81,7 @@ impl ScyllaDbStorage<TestClock> {
         let storage = ScyllaDbStorage {
             client: Arc::new(storage),
             clock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok((storage, table_status))
     }
@@ -96,7 +96,7 @@ impl ScyllaDbStorage<WallClock> {
         let storage = ScyllaDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok(storage)
     }
@@ -110,7 +110,7 @@ impl ScyllaDbStorage<WallClock> {
         let storage = ScyllaDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
-            execution_runtime_config: Default::default(),
+            execution_runtime_config: ExecutionRuntimeConfig::default(),
         };
         Ok((storage, table_status))
     }

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -81,6 +81,7 @@ impl ScyllaDbStorage<TestClock> {
         let storage = ScyllaDbStorage {
             client: Arc::new(storage),
             clock,
+            execution_runtime_config: Default::default(),
         };
         Ok((storage, table_status))
     }
@@ -95,6 +96,7 @@ impl ScyllaDbStorage<WallClock> {
         let storage = ScyllaDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
+            execution_runtime_config: Default::default(),
         };
         Ok(storage)
     }
@@ -108,6 +110,7 @@ impl ScyllaDbStorage<WallClock> {
         let storage = ScyllaDbStorage {
             client: Arc::new(storage),
             clock: WallClock,
+            execution_runtime_config: Default::default(),
         };
         Ok((storage, table_status))
     }


### PR DESCRIPTION
## Motivation

* Use one thread for all contract calls of a transaction (#1193)
* One step closer to share memory states between distinct calls of the same application in the same transaction (#488)

## Proposal

* Create a new "synchronous" implementation of the system API traits
* Improve error handling
* Make the new runtime the default (but do not remove the old one for now)

## Test Plan

CI