### PR TITLE
Box ChainInfo to prevent stack overflows.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -298,7 +298,7 @@ where
     }
 
     /// Obtains the basic `ChainInfo` data for the local chain.
-    async fn chain_info(&mut self) -> Result<ChainInfo, LocalNodeError> {
+    async fn chain_info(&mut self) -> Result<Box<ChainInfo>, LocalNodeError> {
         let query = ChainInfoQuery::new(self.chain_id);
         let response = self.node_client.handle_chain_info_query(query).await?;
         Ok(response.info)
@@ -479,7 +479,7 @@ where
         this: Arc<Mutex<Self>>,
         chain_id: ChainId,
         local_node: &mut LocalNodeClient<S>,
-    ) -> Option<ChainInfo> {
+    ) -> Option<Box<ChainInfo>> {
         let mut guard = this.lock().await;
         let Ok(info) = local_node.local_chain_info(chain_id).await else {
             error!("Fail to read local chain info for {chain_id}");
@@ -657,7 +657,7 @@ where
     }
 
     /// Prepares the chain for the next operation.
-    async fn prepare_chain(&mut self) -> Result<ChainInfo, ChainClientError> {
+    async fn prepare_chain(&mut self) -> Result<Box<ChainInfo>, ChainClientError> {
         // Verify that our local storage contains enough history compared to the
         // expected block height. Otherwise, download the missing history from the
         // network.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -164,7 +164,7 @@ pub struct ChainInfo {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "test"), derive(Eq, PartialEq))]
 pub struct ChainInfoResponse {
-    pub info: ChainInfo,
+    pub info: Box<ChainInfo>,
     pub signature: Option<Signature>,
 }
 
@@ -243,15 +243,15 @@ where
 
 impl ChainInfoResponse {
     pub fn new(info: impl Into<ChainInfo>, key_pair: Option<&KeyPair>) -> Self {
-        let info = info.into();
-        let signature = key_pair.map(|kp| Signature::new(&info, kp));
+        let info = Box::new(info.into());
+        let signature = key_pair.map(|kp| Signature::new(&*info, kp));
         Self { info, signature }
     }
 
     #[allow(clippy::result_large_err)]
     pub fn check(&self, name: ValidatorName) -> Result<(), NodeError> {
         match self.signature {
-            Some(sig) => Ok(sig.check(&self.info, name.0)?),
+            Some(sig) => Ok(sig.check(&*self.info, name.0)?),
             None => Err(NodeError::InvalidChainInfoResponse),
         }
     }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -179,7 +179,7 @@ where
         node: &mut A,
         chain_id: ChainId,
         certificates: Vec<Certificate>,
-    ) -> Option<ChainInfo>
+    ) -> Option<Box<ChainInfo>>
     where
         A: ValidatorNode + Send + Sync + 'static + Clone,
     {
@@ -232,7 +232,7 @@ where
     pub(crate) async fn local_chain_info(
         &mut self,
         chain_id: ChainId,
-    ) -> Result<ChainInfo, LocalNodeError> {
+    ) -> Result<Box<ChainInfo>, LocalNodeError> {
         let query = ChainInfoQuery::new(chain_id);
         Ok(self.handle_chain_info_query(query).await?.info)
     }
@@ -265,7 +265,7 @@ where
         mut validators: Vec<(ValidatorName, A)>,
         chain_id: ChainId,
         target_next_block_height: BlockHeight,
-    ) -> Result<ChainInfo, LocalNodeError>
+    ) -> Result<Box<ChainInfo>, LocalNodeError>
     where
         A: ValidatorNode + Send + Sync + 'static + Clone,
     {
@@ -401,7 +401,7 @@ where
                 let ChainInfo {
                     requested_sent_certificates,
                     ..
-                } = response.info;
+                } = *response.info;
                 self.try_process_certificates(
                     name,
                     &mut node,
@@ -418,7 +418,7 @@ where
         &mut self,
         validators: Vec<(ValidatorName, A)>,
         chain_id: ChainId,
-    ) -> Result<ChainInfo, LocalNodeError>
+    ) -> Result<Box<ChainInfo>, LocalNodeError>
     where
         A: ValidatorNode + Send + Sync + 'static + Clone,
     {

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -545,7 +545,7 @@ where
                     let ChainInfo {
                         mut requested_sent_certificates,
                         ..
-                    } = response.info;
+                    } = *response.info;
                     if let Some(cert) = requested_sent_certificates.pop() {
                         if cert.value().is_confirmed()
                             && cert.value().chain_id() == chain_id

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1287,8 +1287,8 @@ where
     let (replay_response, _actions) = worker.handle_block_proposal(block_proposal).await.unwrap();
     // Workaround lack of equality.
     assert_eq!(
-        CryptoHash::new(&response.info),
-        CryptoHash::new(&replay_response.info)
+        CryptoHash::new(&*response.info),
+        CryptoHash::new(&*replay_response.info)
     );
 }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -197,7 +197,7 @@ where
         &mut self,
         certificate: Certificate,
         delivery: CrossChainMessageDelivery,
-    ) -> Result<ChainInfo, NodeError> {
+    ) -> Result<Box<ChainInfo>, NodeError> {
         let mut result = self
             .send_optimized_certificate(&certificate, delivery)
             .await;
@@ -246,7 +246,7 @@ where
     async fn send_block_proposal(
         &mut self,
         proposal: BlockProposal,
-    ) -> Result<ChainInfo, NodeError> {
+    ) -> Result<Box<ChainInfo>, NodeError> {
         let chain_id = proposal.content.block.chain_id;
         let response = match self.node.handle_block_proposal(proposal.clone()).await {
             Ok(response) => response,

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -524,7 +524,7 @@ pub mod tests {
 
     #[test]
     pub fn test_chain_info_response() {
-        let chain_info = ChainInfo {
+        let chain_info = Box::new(ChainInfo {
             chain_id: ChainId::root(0),
             epoch: None,
             description: None,
@@ -540,7 +540,7 @@ pub mod tests {
             count_received_log: 0,
             requested_received_log: vec![],
             requested_blob: None,
-        };
+        });
 
         let chain_info_response_none = ChainInfoResponse {
             // `info` is bincode so no need to test conversions extensively


### PR DESCRIPTION
## Motivation

In https://github.com/linera-io/linera-protocol/pull/1305 the DynamoDB failed with a stack overflow again. The problem seems to be `ChainInfo`, which has a lot of fields.

## Proposal

`Box` `ChainInfo` in several method signatures, so it is on the heap instead of the stack.

## Test Plan

No logic was changed, and it does fix the https://github.com/linera-io/linera-protocol/pull/1305 tests.

## Links

- Problem surfaced in https://github.com/linera-io/linera-protocol/pull/1305.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
