### PR TITLE
`flake.nix`: add kind and Kubernetes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,9 @@
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         nonRustDeps = with pkgs; [
           clang
+          kubernetes-helm
+          kind
+          kubectl
           libclang.lib
           libiconv
           nodejs


### PR DESCRIPTION
## Motivation

Allow running the Kubernetes tests locally in the Nix-specified development environment.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Add `kind` and `kubernetes` to the Nix flake.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Try to `linera net up --kubernetes` from within the development environment.

## Release Plan

Minor patch.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
