### PR TITLE
`linera-service`: don't drop errors in `LocalKubernetesNet::run`

### DIFF
--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -464,7 +464,9 @@ impl LocalKubernetesNet {
             validators_initialization_futures.push(future);
         }
 
-        join_all(validators_initialization_futures).await;
-        Ok(())
+        future::join_all(validators_initialization_futures)
+            .await
+            .into_iter()
+            .collect()
     }
 }


### PR DESCRIPTION
## Motivation

Currently any failure to execute `helm` or some other things in `LocalKubernetesNet::run` will be silently ignored, as the results of executing these operations are dropped, and a blanket `Ok(())` returned instead.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Don't drop the results; instead, collect them into the `Result` that is returned.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

Bugfix.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
