### PR TITLE
Allow mutable access to custom user data

### DIFF
--- a/linera-witty/src/runtime/borrowed_instance.rs
+++ b/linera-witty/src/runtime/borrowed_instance.rs
@@ -23,6 +23,10 @@ where
     where
         Self::UserData: 'a,
         Self: 'a;
+    type UserDataMutReference<'a> = I::UserDataMutReference<'a>
+    where
+        Self::UserData: 'a,
+        Self: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<<Self::Runtime as Runtime>::Export> {
         I::load_export(*self, name)
@@ -30,6 +34,10 @@ where
 
     fn user_data(&self) -> Self::UserDataReference<'_> {
         I::user_data(*self)
+    }
+
+    fn user_data_mut(&mut self) -> Self::UserDataMutReference<'_> {
+        I::user_data_mut(*self)
     }
 }
 

--- a/linera-witty/src/runtime/test.rs
+++ b/linera-witty/src/runtime/test.rs
@@ -182,6 +182,10 @@ impl<UserData> Instance for MockInstance<UserData> {
     where
         Self::UserData: 'a,
         Self: 'a;
+    type UserDataMutReference<'a> = MutexGuard<'a, UserData>
+    where
+        Self::UserData: 'a,
+        Self: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<String> {
         if name == "memory" || self.exported_functions.contains_key(name) {
@@ -192,6 +196,12 @@ impl<UserData> Instance for MockInstance<UserData> {
     }
 
     fn user_data(&self) -> Self::UserDataReference<'_> {
+        self.user_data
+            .try_lock()
+            .expect("Unexpected reentrant access to user data in `MockInstance`")
+    }
+
+    fn user_data_mut(&mut self) -> Self::UserDataMutReference<'_> {
         self.user_data
             .try_lock()
             .expect("Unexpected reentrant access to user data in `MockInstance`")

--- a/linera-witty/src/runtime/traits.rs
+++ b/linera-witty/src/runtime/traits.rs
@@ -6,7 +6,7 @@
 use super::{memory::Memory, RuntimeError};
 use crate::memory_layout::FlatLayout;
 use frunk::HList;
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 /// A Wasm runtime.
 ///
@@ -33,11 +33,20 @@ pub trait Instance: Sized {
         Self::UserData: 'a,
         Self: 'a;
 
+    /// A mutable reference to the custom user data stored in the instance.
+    type UserDataMutReference<'a>: DerefMut<Target = Self::UserData>
+    where
+        Self::UserData: 'a,
+        Self: 'a;
+
     /// Loads an export from the guest module.
     fn load_export(&mut self, name: &str) -> Option<<Self::Runtime as Runtime>::Export>;
 
     /// Returns a reference to the custom user data stored in this instance.
     fn user_data(&self) -> Self::UserDataReference<'_>;
+
+    /// Returns a mutable reference to the custom user data stored in this instance.
+    fn user_data_mut(&mut self) -> Self::UserDataMutReference<'_>;
 }
 
 /// How a runtime supports a function signature.

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -130,12 +130,20 @@ impl<UserData> Instance for EntrypointInstance<UserData> {
     where
         Self::UserData: 'a,
         Self: 'a;
+    type UserDataMutReference<'a> = MutexGuard<'a, UserData>
+    where
+        Self::UserData: 'a,
+        Self: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         self.instance.load_export(name)
     }
 
     fn user_data(&self) -> Self::UserDataReference<'_> {
+        self.instance.user_data()
+    }
+
+    fn user_data_mut(&mut self) -> Self::UserDataMutReference<'_> {
         self.instance.user_data()
     }
 }
@@ -154,6 +162,10 @@ where
     where
         Self::UserData: 'a,
         Self: 'a;
+    type UserDataMutReference<'a> = MutexGuard<'a, UserData>
+    where
+        Self::UserData: 'a,
+        Self: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         self.data_mut().load_export(name)
@@ -161,6 +173,10 @@ where
 
     fn user_data(&self) -> Self::UserDataReference<'_> {
         FunctionEnvMut::data(self).user_data()
+    }
+
+    fn user_data_mut(&mut self) -> Self::UserDataMutReference<'_> {
+        FunctionEnvMut::data_mut(self).user_data()
     }
 }
 

--- a/linera-witty/src/runtime/wasmtime/mod.rs
+++ b/linera-witty/src/runtime/wasmtime/mod.rs
@@ -58,6 +58,10 @@ impl<UserData> Instance for EntrypointInstance<UserData> {
     where
         Self: 'a,
         UserData: 'a;
+    type UserDataMutReference<'a> = &'a mut UserData
+    where
+        Self: 'a,
+        UserData: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         self.instance.get_export(&mut self.store, name)
@@ -65,6 +69,10 @@ impl<UserData> Instance for EntrypointInstance<UserData> {
 
     fn user_data(&self) -> Self::UserDataReference<'_> {
         self.store.data()
+    }
+
+    fn user_data_mut(&mut self) -> Self::UserDataMutReference<'_> {
+        self.store.data_mut()
     }
 }
 
@@ -79,6 +87,10 @@ impl<UserData> Instance for Caller<'_, UserData> {
     where
         Self: 'a,
         UserData: 'a;
+    type UserDataMutReference<'a> = &'a mut UserData
+    where
+        Self: 'a,
+        UserData: 'a;
 
     fn load_export(&mut self, name: &str) -> Option<Extern> {
         Caller::get_export(self, name)
@@ -86,5 +98,9 @@ impl<UserData> Instance for Caller<'_, UserData> {
 
     fn user_data(&self) -> Self::UserDataReference<'_> {
         Caller::data(self)
+    }
+
+    fn user_data_mut(&mut self) -> Self::UserDataMutReference<'_> {
+        Caller::data_mut(self)
     }
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
PR #1310 added support for using custom user data when exporting host functions to guest Wasm modules. However, only a single getter was made available to access the data in a shared manner. Accessing the data using an exclusive mutable reference was possible behind the hood, but was unfortunately left out at the API level. There's no reason to not include it.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add a `Instance::user_data_mut()` getter method to retrieve an exclusive mutable reference to the underlying data.

## Test Plan

<!-- How to test that the changes are correct. -->
The new API will be covered later when `linera-execution` uses Witty.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal change, nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
