### PR TITLE
Have client discard incoming messages that fail to execute

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -29,10 +29,10 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, HashedValue,
-        IncomingMessage, LiteCertificate, LiteVote,
+        Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, ExecutedBlock,
+        HashedValue, IncomingMessage, LiteCertificate, LiteVote,
     },
-    ChainError, ChainStateView,
+    ChainError, ChainExecutionContext, ChainStateView,
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
@@ -1180,6 +1180,31 @@ where
         Ok(certificate)
     }
 
+    async fn stage_block_execution_and_discard_failing_messages(
+        &mut self,
+        mut block: Block,
+    ) -> Result<ExecutedBlock, ChainClientError> {
+        loop {
+            let result = self.node_client.stage_block_execution(block.clone()).await;
+            if let Err(LocalNodeError::WorkerError(WorkerError::ChainError(chain_error))) = &result
+            {
+                if let ChainError::ExecutionError(
+                    _,
+                    ChainExecutionContext::IncomingMessage(index),
+                ) = **chain_error
+                {
+                    // Remove the faulty message from the block.
+                    // TODO(#990): To optimize receiver's liveness and sender's
+                    // experience, we probably don't want to this message to stay pending and be
+                    // selected again next time we create a block.
+                    block.incoming_messages.remove(index as usize);
+                    continue;
+                }
+            }
+            return Ok(result?.0);
+        }
+    }
+
     /// Executes (or retries) a regular block proposal. Updates local balance.
     async fn propose_block(&mut self, block: Block) -> Result<Certificate, ChainClientError> {
         ensure!(
@@ -1197,14 +1222,7 @@ where
             block.previous_block_hash == self.block_hash,
             ChainClientError::BlockProposalError("Unexpected previous block hash")
         );
-        // Collect blobs required for execution.
-        let committee = self.local_committee().await?;
-        let nodes = self.validator_node_provider.make_nodes(&committee)?;
-        let blobs = self
-            .node_client
-            .read_or_download_blobs(nodes, block.bytecode_locations())
-            .await?;
-        // Build the initial query.
+        // Gather information on the current local state.
         let query = ChainInfoQuery::new(self.chain_id).with_manager_values();
         let response = self.node_client.handle_chain_info_query(query).await?;
         let manager = response.info.manager;
@@ -1217,9 +1235,8 @@ where
                 "Cannot propose a block; there is already a proposal in the current round",
             ));
         };
-        let key_pair = self.key_pair().await?;
+        // Make sure that we follow the steps in the multi-round protocol.
         let validated = manager.highest_validated().cloned();
-        // TODO(#66): return the block that should be proposed instead
         if let Some(validated) = &validated {
             ensure!(
                 validated.value().block() == Some(&block),
@@ -1228,6 +1245,26 @@ where
                 )
             );
         }
+        // Make sure every incoming message succeeds and otherwise remove them.
+        // Also, compute the final certified hash while we're at it.
+        let executed_block = self
+            .stage_block_execution_and_discard_failing_messages(block)
+            .await?;
+        let block = executed_block.block.clone();
+        let hashed_value = if next_round.is_fast() {
+            HashedValue::new_confirmed(executed_block)
+        } else {
+            HashedValue::new_validated(executed_block)
+        };
+        // Collect the blobs required for execution.
+        let committee = self.local_committee().await?;
+        let nodes = self.validator_node_provider.make_nodes(&committee)?;
+        let blobs = self
+            .node_client
+            .read_or_download_blobs(nodes, block.bytecode_locations())
+            .await?;
+        // Create the final block proposal.
+        let key_pair = self.key_pair().await?;
         let proposal = BlockProposal::new(
             BlockAndRound {
                 block: block.clone(),
@@ -1237,21 +1274,10 @@ where
             blobs,
             validated,
         );
-        // Try to execute the block locally first.
+        // Check the final block proposal. This will be cheaper after #1401.
         self.node_client
             .handle_block_proposal(proposal.clone())
             .await?;
-        // Sadly, we have to execute the block again for the expected hashed value. This
-        // should be fine after #1401.
-        let (executed_block, _) = self
-            .node_client
-            .stage_block_execution(block.clone())
-            .await?;
-        let hashed_value = if proposal.content.round.is_fast() {
-            HashedValue::new_confirmed(executed_block)
-        } else {
-            HashedValue::new_validated(executed_block)
-        };
         // Remember what we are trying to do before sending the proposal to the validators.
         self.pending_block = Some(block);
         // Send the query to validators.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -210,6 +210,15 @@ where
     receiver.receive_certificate(cert).await?;
     let cert = receiver.process_inbox().await?.pop().unwrap();
 
+    // The first `Claim` message was not selected by the receiver.
+    assert_eq!(cert.value().block().unwrap().incoming_messages.len(), 1);
+    assert_eq!(
+        cert.value().block().unwrap().incoming_messages[0]
+            .event
+            .height,
+        BlockHeight::from(2)
+    );
+
     sender.receive_certificate(cert).await?;
     sender.process_inbox().await?;
     assert_eq!(

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -559,11 +559,10 @@ where
             owner: sender_owner,
         },
     };
-    // TODO(#989): Make user errors fail blocks again.
-    receiver
+    assert!(receiver
         .execute_operation(Operation::user(application_id, &transfer)?)
         .await
-        .unwrap();
+        .is_err());
     receiver.clear_pending_block().await;
 
     // Try another transfer in the other direction with the correct amount.

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -202,7 +202,7 @@ where
         messages: vec![OutgoingMessage {
             destination: broadcast_channel,
             authenticated_signer: None,
-            is_skippable: false,
+            is_skippable: true,
             message: Message::System(broadcast_message.clone()),
         }],
         message_counts: vec![1],
@@ -356,7 +356,7 @@ where
                 height: broadcast_block_height,
                 index: 0,
                 authenticated_signer: None,
-                is_skippable: false,
+                is_skippable: true,
                 timestamp: Timestamp::from(1),
                 message: Message::System(broadcast_message),
             },

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -394,8 +394,8 @@ pub enum SystemExecutionError {
     #[error(transparent)]
     ViewError(#[from] ViewError),
 
-    #[error("Invalid new chain id: {0}")]
-    InvalidNewChainId(ChainId),
+    #[error("Incorrect chain id: {0}")]
+    IncorrectChainId(ChainId),
     #[error("Invalid admin id in new chain: {0}")]
     InvalidNewChainAdminId(ChainId),
     #[error("Invalid committees")]
@@ -798,14 +798,6 @@ where
     }
 
     /// Executes a cross-chain message that represents the recipient's side of an operation.
-    ///
-    /// * Messages should not return an error unless it is a temporary failure (e.g.
-    /// storage) or a global system failure. An error will fail the entire cross-chain
-    /// request, allowing it to be retried later.
-    ///
-    /// * If execution is impossible for a deterministic reason (e.g. insufficient
-    /// funds), messages should fail silently and be skipped (similar to a transaction in
-    /// traditional blockchains).
     pub async fn execute_message(
         &mut self,
         context: MessageContext,
@@ -814,7 +806,11 @@ where
         let mut result = RawExecutionResult::default();
         use SystemMessage::*;
         match message {
-            Credit { amount, account } if context.chain_id == account.chain_id => {
+            Credit { amount, account } => {
+                ensure!(
+                    account.chain_id == context.chain_id,
+                    SystemExecutionError::IncorrectChainId(account.chain_id)
+                );
                 match &account.owner {
                     None => {
                         let new_balance = self.balance.get().saturating_add(amount);
@@ -828,19 +824,27 @@ where
             }
             Withdraw {
                 amount,
-                account:
-                    Account {
-                        owner: Some(owner),
-                        chain_id,
-                    },
+                account: Account { owner, chain_id },
                 user_data: _,
                 recipient,
-            } if chain_id == context.chain_id
-                && context.authenticated_signer.as_ref() == Some(&owner) =>
-            {
-                let balance = self.balances.get_mut_or_default(&owner).await?;
-                if balance.try_sub_assign(amount).is_ok() {
-                    if let Recipient::Account(account) = recipient {
+            } => {
+                ensure!(
+                    chain_id == context.chain_id,
+                    SystemExecutionError::IncorrectChainId(chain_id)
+                );
+                ensure!(
+                    owner.is_some(),
+                    SystemExecutionError::UnauthenticatedClaimOwner
+                );
+                ensure!(
+                    context.authenticated_signer == owner,
+                    SystemExecutionError::UnauthenticatedClaimOwner
+                );
+
+                let balance = self.balances.get_mut_or_default(&owner.unwrap()).await?;
+                balance.try_sub_assign(amount)?;
+                match recipient {
+                    Recipient::Account(account) => {
                         let message = RawOutgoingMessage {
                             destination: Destination::Recipient(account.chain_id),
                             authenticated: false,
@@ -849,8 +853,7 @@ where
                         };
                         result.messages.push(message);
                     }
-                } else {
-                    tracing::info!("Withdrawal request was skipped due to lack of funds.");
+                    Recipient::Burn => (),
                 }
             }
             SetCommittees { epoch, committees } => {
@@ -861,7 +864,11 @@ where
                 self.epoch.set(Some(epoch));
                 self.committees.set(committees);
             }
-            Subscribe { id, subscription } if subscription.chain_id == context.chain_id => {
+            Subscribe { id, subscription } => {
+                ensure!(
+                    subscription.chain_id == context.chain_id,
+                    SystemExecutionError::IncorrectChainId(subscription.chain_id)
+                );
                 // Notify the subscriber about this block, so that it is included in the
                 // receive_log of the subscriber and correctly synchronized.
                 let message = RawOutgoingMessage {
@@ -873,7 +880,11 @@ where
                 result.messages.push(message);
                 result.subscribe.push((subscription.name.clone(), id));
             }
-            Unsubscribe { id, subscription } if subscription.chain_id == context.chain_id => {
+            Unsubscribe { id, subscription } => {
+                ensure!(
+                    subscription.chain_id == context.chain_id,
+                    SystemExecutionError::IncorrectChainId(subscription.chain_id)
+                );
                 let message = RawOutgoingMessage {
                     destination: Destination::Recipient(id),
                     authenticated: false,
@@ -905,10 +916,6 @@ where
                     self.registry.register_published_bytecode(id, location)?;
                 }
             }
-            ApplicationCreated | Notify { .. } => (),
-            OpenChain { .. } => {
-                // This special message is executed immediately when cross-chain requests are received.
-            }
             RegisterApplications { applications } => {
                 for application in applications {
                     self.registry
@@ -917,37 +924,25 @@ where
                 }
             }
             RequestApplication(application_id) => {
-                match self
+                let applications = self
                     .registry
                     .describe_applications_with_dependencies(
                         vec![application_id],
                         &Default::default(),
                     )
-                    .await
-                {
-                    Err(SystemExecutionError::UnknownApplicationId(id)) => {
-                        tracing::info!(
-                            %id,
-                            "Application request was skipped: application not known."
-                        );
-                    }
-                    Err(err) => return Err(err),
-                    Ok(applications) => {
-                        let message = RawOutgoingMessage {
-                            destination: Destination::Recipient(context.message_id.chain_id),
-                            authenticated: false,
-                            is_skippable: true,
-                            message: SystemMessage::RegisterApplications { applications },
-                        };
-                        result.messages.push(message);
-                    }
-                }
+                    .await?;
+                let message = RawOutgoingMessage {
+                    destination: Destination::Recipient(context.message_id.chain_id),
+                    authenticated: false,
+                    is_skippable: true,
+                    message: SystemMessage::RegisterApplications { applications },
+                };
+                result.messages.push(message);
             }
-            _ => {
-                tracing::error!(
-                    "Skipping unexpected received message: {message:?} with context: {context:?}"
-                );
+            OpenChain { .. } => {
+                // This special message is executed immediately when cross-chain requests are received.
             }
+            ApplicationCreated | Notify { .. } => (),
         }
         Ok(result)
     }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -633,7 +633,7 @@ where
                 let message = RawOutgoingMessage {
                     destination: Destination::Recipient(target),
                     authenticated: true,
-                    is_skippable: false,
+                    is_skippable: true, // because it can fail
                     message: SystemMessage::Withdraw {
                         amount,
                         account: Account {
@@ -787,7 +787,7 @@ where
                 let message = RawOutgoingMessage {
                     destination: Destination::Recipient(chain_id),
                     authenticated: false,
-                    is_skippable: false,
+                    is_skippable: true, // because it can fail
                     message: SystemMessage::RequestApplication(application_id),
                 };
                 result.messages.push(message);
@@ -906,7 +906,7 @@ where
                 let message = RawOutgoingMessage {
                     destination: Destination::Subscribers(SystemChannel::PublishedBytecodes.name()),
                     authenticated: false,
-                    is_skippable: false,
+                    is_skippable: true,
                     message: SystemMessage::BytecodeLocations { locations },
                 };
                 result.messages.push(message);


### PR DESCRIPTION
## Motivation

Solve #989

## Proposal

* Remove failing messages repeatedly by staging execution in the client. This relies on previous PR #1029.
* Make system messages fallible
* Stop ignoring user errors during execution of Wasm applications

In the future, this could be made linear-time using additional features in `linera-views`.

## Test Plan

CI + new unit test