### PR TITLE
Correct the authentication of the matching engine application.

### DIFF
--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -107,7 +107,11 @@ impl Contract for MatchingEngine {
         match argument {
             ApplicationCall::ExecuteOrder { order } => {
                 let owner = Self::get_owner(&order);
-                Self::check_account_authentication(context.authenticated_caller_id, context.authenticated_signer, owner)?;
+                Self::check_account_authentication(
+                    context.authenticated_caller_id,
+                    context.authenticated_signer,
+                    owner,
+                )?;
                 if context.chain_id == system_api::current_application_id().creation.chain_id {
                     self.execute_order_local(order).await?;
                 } else {
@@ -135,9 +139,18 @@ impl MatchingEngine {
     /// Get the owner from the order
     fn get_owner(order: &Order) -> AccountOwner {
         match order {
-            Order::Insert { owner, amount: _, nature: _, price: _ } => owner.clone(),
-            Order::Cancel { owner, order_id: _ } => owner.clone(),
-            Order::Modify { owner, order_id: _, cancel_amount: _ } => owner.clone(),
+            Order::Insert {
+                owner,
+                amount: _,
+                nature: _,
+                price: _,
+            } => *owner,
+            Order::Cancel { owner, order_id: _ } => *owner,
+            Order::Modify {
+                owner,
+                order_id: _,
+                cancel_amount: _,
+            } => *owner,
         }
     }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -14,7 +14,7 @@ use std::cmp::min;
 use async_trait::async_trait;
 use fungible::{Account, AccountOwner, Destination, FungibleTokenAbi};
 use linera_sdk::{
-    base::{Amount, ApplicationId, SessionId, WithContractAbi},
+    base::{Amount, ApplicationId, Owner, SessionId, WithContractAbi},
     contract::system_api,
     ensure, ApplicationCallResult, CalleeContext, Contract, ExecutionResult, MessageContext,
     OperationContext, OutgoingMessage, SessionCallResult, ViewStateStorage,
@@ -62,6 +62,8 @@ impl Contract for MatchingEngine {
         let mut result = ExecutionResult::default();
         match operation {
             Operation::ExecuteOrder { order } => {
+                let owner = Self::get_owner(&order);
+                Self::check_account_authentication(None, context.authenticated_signer, owner)?;
                 if context.chain_id == system_api::current_application_id().creation.chain_id {
                     self.execute_order_local(order).await?;
                 } else {
@@ -84,6 +86,8 @@ impl Contract for MatchingEngine {
         );
         match message {
             Message::ExecuteOrder { order } => {
+                let owner = Self::get_owner(&order);
+                Self::check_account_authentication(None, context.authenticated_signer, owner)?;
                 self.execute_order_local(order).await?;
             }
         }
@@ -102,6 +106,8 @@ impl Contract for MatchingEngine {
         let mut result = ApplicationCallResult::default();
         match argument {
             ApplicationCall::ExecuteOrder { order } => {
+                let owner = Self::get_owner(&order);
+                Self::check_account_authentication(context.authenticated_caller_id, context.authenticated_signer, owner)?;
                 if context.chain_id == system_api::current_application_id().creation.chain_id {
                     self.execute_order_local(order).await?;
                 } else {
@@ -126,6 +132,28 @@ impl Contract for MatchingEngine {
 }
 
 impl MatchingEngine {
+    /// Get the owner from the order
+    fn get_owner(order: &Order) -> AccountOwner {
+        match order {
+            Order::Insert { owner, amount: _, nature: _, price: _ } => owner.clone(),
+            Order::Cancel { owner, order_id: _ } => owner.clone(),
+            Order::Modify { owner, order_id: _, cancel_amount: _ } => owner.clone(),
+        }
+    }
+
+    /// authenticate the originator of the message
+    fn check_account_authentication(
+        authenticated_application_id: Option<ApplicationId>,
+        authenticated_signer: Option<Owner>,
+        owner: AccountOwner,
+    ) -> Result<(), MatchingEngineError> {
+        match owner {
+            AccountOwner::User(address) if authenticated_signer == Some(address) => Ok(()),
+            AccountOwner::Application(id) if authenticated_application_id == Some(id) => Ok(()),
+            _ => Err(MatchingEngineError::IncorrectAuthentication),
+        }
+    }
+
     /// The application engine is trading between two tokens. Those tokens are the parameters of the
     /// construction of the exchange and are accessed by index in the system.
     fn fungible_id(token_idx: u32) -> Result<ApplicationId<FungibleTokenAbi>, MatchingEngineError> {

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -23,6 +23,10 @@ pub enum MatchingEngineError {
     #[error("Invalid query")]
     InvalidQuery(#[from] serde_json::Error),
 
+    /// Failed authentication
+    #[error("failed authentication")]
+    IncorrectAuthentication,
+
     /// Action can only be executed on the chain that created the matching engine.
     #[error("Action can only be executed on the chain that created the matching engine")]
     MatchingEngineChainOnly,

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -248,11 +248,11 @@ async fn single_transaction() {
 
     // Cancelling the remaining orders
     let mut orders_cancels = Vec::new();
-    for (owner, order_ids) in [(owner_a, order_ids_a), (owner_b, order_ids_b)] {
+    for (owner, user_chain, order_ids) in [(owner_a, &user_chain_a, order_ids_a), (owner_b, &user_chain_b, order_ids_b)] {
         for order_id in order_ids {
             let order = Order::Cancel { owner, order_id };
             let operation = Operation::ExecuteOrder { order };
-            let order_messages = user_chain_a
+            let order_messages = user_chain
                 .add_block(|block| {
                     block.with_operation(matching_id, operation);
                 })

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -248,7 +248,10 @@ async fn single_transaction() {
 
     // Cancelling the remaining orders
     let mut orders_cancels = Vec::new();
-    for (owner, user_chain, order_ids) in [(owner_a, &user_chain_a, order_ids_a), (owner_b, &user_chain_b, order_ids_b)] {
+    for (owner, user_chain, order_ids) in [
+        (owner_a, &user_chain_a, order_ids_a),
+        (owner_b, &user_chain_b, order_ids_b),
+    ] {
         for order_id in order_ids {
             let order = Order::Cancel { owner, order_id };
             let operation = Operation::ExecuteOrder { order };

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -919,12 +919,15 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     assert_eq!(order_ids_b.len(), 2); // The order of price 2 is partially filled.
 
     // Now cancelling all the orders
-    for (owner, order_ids) in [(owner_a, order_ids_a), (owner_b, order_ids_b)] {
-        for order_id in order_ids {
-            app_matching_admin
-                .order(matching_engine::Order::Cancel { owner, order_id })
-                .await;
-        }
+    for order_id in order_ids_a {
+        app_matching_a
+            .order(matching_engine::Order::Cancel { owner: owner_a, order_id })
+            .await;
+    }
+    for order_id in order_ids_b {
+        app_matching_b
+            .order(matching_engine::Order::Cancel { owner: owner_b, order_id })
+            .await;
     }
     node_service_admin
         .process_inbox(&chain_admin)

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -921,12 +921,18 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     // Now cancelling all the orders
     for order_id in order_ids_a {
         app_matching_a
-            .order(matching_engine::Order::Cancel { owner: owner_a, order_id })
+            .order(matching_engine::Order::Cancel {
+                owner: owner_a,
+                order_id,
+            })
             .await;
     }
     for order_id in order_ids_b {
         app_matching_b
-            .order(matching_engine::Order::Cancel { owner: owner_b, order_id })
+            .order(matching_engine::Order::Cancel {
+                owner: owner_b,
+                order_id,
+            })
             .await;
     }
     node_service_admin


### PR DESCRIPTION
## Motivation

In a previous PR about the matching engine it was identified that the authentication was inadequate. In particular it was possible for anyone to cancel anyone orders. This PR addresses that.

## Proposal

The following was done:
* The authentication was done following the pattern of the `fungible` application.
* This led to some errors in the integration test that were corrected.
* This also led to some errors in the end-to-end test that were also corrected.


## Test Plan

The CI should do the job. However, one proposal would be to enable again the test for `test_wasm_end_to_end_matching_engine` if only for `rocksdb`. This would likely detect some problems.

## Release Plan

No relevant entries.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
