### PR TITLE
Improve authentication of AMM smart contract.

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -43,8 +43,6 @@ impl Contract for Amm {
         operation: Self::Operation,
     ) -> Result<ExecutionResult<Self::Message>, AmmError> {
         let mut result = ExecutionResult::default();
-        let owner = Self::get_owner(&operation);
-        Self::check_account_authentication(None, context.authenticated_signer, owner)?;
         if context.chain_id == system_api::current_application_id().creation.chain_id {
             self.execute_order_local(operation).await?;
         } else {

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -125,27 +125,6 @@ impl Contract for Amm {
 }
 
 impl Amm {
-    /// Get the owner from the order
-    fn get_owner(operation: &Operation) -> AccountOwner {
-        match operation {
-            Operation::Swap {
-                owner,
-                input_token_idx: _,
-                input_amount: _,
-            } => *owner,
-            Operation::AddLiquidity {
-                owner,
-                max_token0_amount: _,
-                max_token1_amount: _,
-            } => *owner,
-            Operation::RemoveLiquidity {
-                owner,
-                token_to_remove_idx: _,
-                token_to_remove_amount: _,
-            } => *owner,
-        }
-    }
-
     /// authenticate the originator of the message
     fn check_account_authentication(
         authenticated_application_id: Option<ApplicationId>,

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -96,6 +96,10 @@ pub enum AmmError {
     #[error("Invalid pool balance")]
     InvalidPoolBalanceError,
 
+    /// Failed authentication
+    #[error("failed authentication")]
+    IncorrectAuthentication,
+
     #[error("Token not found in the pool")]
     TokenNotFoundInPoolError,
 


### PR DESCRIPTION
## Motivation

The AMM smart contract security is possibly incorrect. Additional checks were added.

## Proposal

The security of smart contracts is based on the following principles:
* Only the user chain can authenticate a user.
* Thus the operations that are not done locally can be authenticated and that is the `Swap` operations.
It is an open question to me whether this protection is actually needed since the operations rely on fungible which is itself authenticated.

## Test Plan

The CI still pass after those changes.

## Release Plan

It would be nice to improve the documentation of the security of Linera.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
