### PR TITLE
Extend CLI wrappers to prepare for benchmarks.

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -16,7 +16,7 @@ use linera_base::{
     data_types::Amount,
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
-use linera_execution::{committee::ValidatorName, Bytecode};
+use linera_execution::{committee::ValidatorName, system::SystemChannel, Bytecode};
 use serde::{de::DeserializeOwned, ser::Serialize};
 use serde_json::{json, Value};
 use std::{
@@ -251,20 +251,49 @@ impl ClientWrapper {
     pub async fn create_application<A: ContractAbi>(
         &self,
         bytecode_id: &BytecodeId,
+        parameters: &A::Parameters,
         argument: &A::InitializationArgument,
+        required_application_ids: &[ApplicationId],
         creator: impl Into<Option<ChainId>>,
     ) -> Result<ApplicationId<A>> {
+        let json_parameters = serde_json::to_string(parameters)?;
         let json_argument = serde_json::to_string(argument)?;
-        let stdout = self
-            .command()
-            .await?
+        let mut command = self.command().await?;
+        command
             .arg("create-application")
             .arg(bytecode_id.to_string())
+            .args(["--json-parameters", &json_parameters])
             .args(["--json-argument", &json_argument])
-            .args(creator.into().iter().map(ChainId::to_string))
-            .spawn_and_wait_for_stdout()
-            .await?;
+            .args(creator.into().iter().map(ChainId::to_string));
+        if !required_application_ids.is_empty() {
+            command.arg("--required-application-ids");
+            command.args(
+                required_application_ids
+                    .iter()
+                    .map(ApplicationId::to_string),
+            );
+        }
+        let stdout = command.spawn_and_wait_for_stdout().await?;
         Ok(stdout.trim().parse::<ApplicationId>()?.with_abi())
+    }
+
+    /// Runs `linera request-application`
+    pub async fn request_application(
+        &self,
+        application_id: ApplicationId,
+        requester_chain_id: ChainId,
+        target_chain_id: Option<ChainId>,
+    ) -> Result<BytecodeId> {
+        let mut command = self.command().await?;
+        command
+            .arg("request-application")
+            .arg(application_id.to_string())
+            .args(["--requester-chain-id", &requester_chain_id.to_string()]);
+        if let Some(target_chain_id) = target_chain_id {
+            command.args(["--target-chain-id", &target_chain_id.to_string()]);
+        }
+        let stdout = command.spawn_and_wait_for_stdout().await?;
+        Ok(stdout.trim().parse()?)
     }
 
     /// Runs `linera service`.
@@ -560,10 +589,7 @@ impl ClientWrapper {
             .context("error while parsing the result of `linera sync-balance`")?;
         Ok(amount)
     }
-}
 
-#[cfg(any(test, feature = "test"))]
-impl ClientWrapper {
     pub async fn build_application(
         &self,
         path: &Path,
@@ -590,7 +616,10 @@ impl ClientWrapper {
 
         Ok((contract, service))
     }
+}
 
+#[cfg(any(test, feature = "test"))]
+impl ClientWrapper {
     pub async fn build_example(&self, name: &str) -> Result<(PathBuf, PathBuf)> {
         self.build_application(Self::example_path(name)?.as_path(), name, true)
             .await
@@ -788,6 +817,23 @@ impl NodeService {
         let data = self.query_node(query).await?;
         serde_json::from_value(data["requestApplication"].clone())
             .context("missing requestApplication field in response")
+    }
+
+    pub async fn subscribe(
+        &self,
+        subscriber_chain_id: ChainId,
+        publisher_chain_id: ChainId,
+        channel: SystemChannel,
+    ) -> Result<()> {
+        let query = format!(
+            "mutation {{ subscribe(\
+                 subscriberChainId: \"{subscriber_chain_id}\", \
+                 publisherChainId: \"{publisher_chain_id}\", \
+                 channel: \"{channel}\") \
+             }}"
+        );
+        self.query_node(query).await?;
+        Ok(())
     }
 }
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -230,7 +230,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
         .await
         .unwrap();
     let application_id = client
-        .create_application::<CounterAbi>(&bytecode_id, &original_counter_value, None)
+        .create_application::<CounterAbi>(&bytecode_id, &(), &original_counter_value, &[], None)
         .await
         .unwrap();
     let mut node_service = client.run_node_service(None).await.unwrap();
@@ -280,7 +280,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
         .await
         .unwrap();
     let application_id = client1
-        .create_application::<SocialAbi>(&bytecode_id, &(), None)
+        .create_application::<SocialAbi>(&bytecode_id, &(), &(), &[], None)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Motivation

We will add a `linera-benchmarks` binary to measure the network's performance. These will use the CLI wrappers.

## Proposal

Extend the CLI wrappers so that they provide the needed functionality:
* Add `parameters` and `required_application_ids` to `create_application`.
* Add `request_application`.
* Make `build_application` not test-only.

## Test Plan

`create_application` is already used in tests. The others will be used by the fungible benchmark, and otherwise are not used in production code yet.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
