### PR TITLE
Make `try-query-application` system API synchronous

### DIFF
--- a/examples/meta-counter/src/service.rs
+++ b/examples/meta-counter/src/service.rs
@@ -29,7 +29,7 @@ impl Service for MetaCounter {
         request: Request,
     ) -> Result<Response, Self::Error> {
         let counter_id = Self::parameters()?;
-        Self::query_application(counter_id, &request).await
+        Self::query_application(counter_id, &request)
     }
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -471,29 +471,11 @@ pub trait BaseRuntime {
 }
 
 pub trait ServiceRuntime: BaseRuntime {
-    type TryQueryApplication: fmt::Debug + Send;
-
     /// Queries another application.
     fn try_query_application(
         &mut self,
         queried_id: UserApplicationId,
         argument: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
-        let promise = self.try_query_application_new(queried_id, argument)?;
-        self.try_query_application_wait(&promise)
-    }
-
-    /// Queries another application (new).
-    fn try_query_application_new(
-        &mut self,
-        queried_id: UserApplicationId,
-        argument: Vec<u8>,
-    ) -> Result<Self::TryQueryApplication, ExecutionError>;
-
-    /// Queries another application (wait).
-    fn try_query_application_wait(
-        &mut self,
-        promise: &Self::TryQueryApplication,
     ) -> Result<Vec<u8>, ExecutionError>;
 }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1013,15 +1013,12 @@ impl ServiceSyncRuntime {
 }
 
 impl ServiceRuntime for ServiceSyncRuntime {
-    type TryQueryApplication = Vec<u8>;
-
     /// Note that queries are not available from writable contexts.
-    // TODO(#1152): make synchronous
-    fn try_query_application_new(
+    fn try_query_application(
         &mut self,
         queried_id: UserApplicationId,
         argument: Vec<u8>,
-    ) -> Result<Self::TryQueryApplication, ExecutionError> {
+    ) -> Result<Vec<u8>, ExecutionError> {
         let (query_context, code) = {
             let mut this = self.as_inner();
 
@@ -1039,18 +1036,11 @@ impl ServiceRuntime for ServiceSyncRuntime {
             (query_context, code)
         };
         let mut code = code.instantiate(self.clone())?;
-        let promise = code.handle_query(query_context, argument)?;
+        let response = code.handle_query(query_context, argument)?;
         {
             let mut this = self.as_inner();
             this.applications.pop();
         }
-        Ok(promise)
-    }
-
-    fn try_query_application_wait(
-        &mut self,
-        promise: &Self::TryQueryApplication,
-    ) -> Result<Vec<u8>, ExecutionError> {
-        Ok(promise.to_vec())
+        Ok(response)
     }
 }

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -214,13 +214,7 @@ macro_rules! impl_service_system_api {
                 application: service_system_api::ApplicationId,
                 argument: &[u8],
             ) -> Result<Result<Vec<u8>, String>, Self::Error> {
-                let promise = ServiceRuntime::try_query_application_new(
-                    self,
-                    application.into(),
-                    argument.to_vec(),
-                )?;
-
-                ServiceRuntime::try_query_application_wait(self, &promise)
+                ServiceRuntime::try_query_application(self, application.into(), argument.to_vec())
                     // TODO(#1153): remove
                     .map(Ok)
             }

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -141,7 +141,6 @@ macro_rules! impl_service_system_api {
             type Load = <Self as BaseRuntime>::Read;
             type Lock = <Self as BaseRuntime>::Lock;
             type Unlock = <Self as BaseRuntime>::Unlock;
-            type TryQueryApplication = <Self as ServiceRuntime>::TryQueryApplication;
 
             fn error_to_trap(&mut self, error: Self::Error) -> $trap {
                 error.into()
@@ -210,23 +209,18 @@ macro_rules! impl_service_system_api {
                     .map(Ok)
             }
 
-            fn try_query_application_new(
+            fn try_query_application(
                 &mut self,
                 application: service_system_api::ApplicationId,
                 argument: &[u8],
-            ) -> Result<Self::TryQueryApplication, Self::Error> {
-                ServiceRuntime::try_query_application_new(
+            ) -> Result<Result<Vec<u8>, String>, Self::Error> {
+                let promise = ServiceRuntime::try_query_application_new(
                     self,
                     application.into(),
                     argument.to_vec(),
-                )
-            }
+                )?;
 
-            fn try_query_application_wait(
-                &mut self,
-                promise: &Self::TryQueryApplication,
-            ) -> Result<Result<Vec<u8>, String>, Self::Error> {
-                ServiceRuntime::try_query_application_wait(self, promise)
+                ServiceRuntime::try_query_application_wait(self, &promise)
                     // TODO(#1153): remove
                     .map(Ok)
             }

--- a/linera-sdk/service_system_api.wit
+++ b/linera-sdk/service_system_api.wit
@@ -29,14 +29,10 @@ resource unlock {
     wait: func() -> result<unit, string>
 }
 
-resource try-query-application {
-    static new: func(
-        application: application-id,
-        query: list<u8>,
-    ) -> try-query-application
-
-    wait: func() -> result<list<u8>, string>
-}
+try-query-application: func(
+    application: application-id,
+    query: list<u8>,
+) -> result<list<u8>, string>
 
 record application-id {
     bytecode-id: bytecode-id,

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -305,7 +305,7 @@ pub trait Service: WithServiceAbi + ServiceAbi {
     ) -> Result<Self::QueryResponse, Self::Error>;
 
     /// Queries another application.
-    async fn query_application<A: ServiceAbi + Send>(
+    fn query_application<A: ServiceAbi + Send>(
         application: ApplicationId<A>,
         query: &A::Query,
     ) -> Result<A::QueryResponse, Self::Error>

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -315,7 +315,6 @@ pub trait Service: WithServiceAbi + ServiceAbi {
         let query_bytes = serde_json::to_vec(&query)?;
         let response_bytes =
             crate::service::system_api::query_application(application.forget_abi(), &query_bytes)
-                .await
                 .map_err(String::from)?;
         let response = serde_json::from_slice(&response_bytes)?;
         Ok(response)

--- a/linera-sdk/src/service/system_api/private.rs
+++ b/linera-sdk/src/service/system_api/private.rs
@@ -58,7 +58,5 @@ pub async fn query_application(
     application: ApplicationId,
     argument: &[u8],
 ) -> Result<Vec<u8>, String> {
-    let promise = wit::TryQueryApplication::new(application.into(), argument);
-    yield_once().await;
-    promise.wait()
+    wit::try_query_application(application.into(), argument)
 }

--- a/linera-sdk/src/service/system_api/private.rs
+++ b/linera-sdk/src/service/system_api/private.rs
@@ -54,9 +54,6 @@ pub fn current_application_parameters() -> Vec<u8> {
 }
 
 /// Queries another application.
-pub async fn query_application(
-    application: ApplicationId,
-    argument: &[u8],
-) -> Result<Vec<u8>, String> {
+pub fn query_application(application: ApplicationId, argument: &[u8]) -> Result<Vec<u8>, String> {
     wit::try_query_application(application.into(), argument)
 }

--- a/linera-sdk/wasm-tests/src/lib.rs
+++ b/linera-sdk/wasm-tests/src/lib.rs
@@ -416,8 +416,7 @@ fn mock_query() {
     };
     let query = vec![17, 23, 31, 37];
 
-    let response =
-        service::system_api::private::query_application(application_id, &query).blocking_wait();
+    let response = service::system_api::private::query_application(application_id, &query);
 
     assert_eq!(
         unsafe { INTERCEPTED_APPLICATION_ID.take() },


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The system call for querying another application was unnecessarily `async`.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Make the system call synchronous, removing the promise APIs for it, and update the higher level API to not be `async`.

## Test Plan

<!-- How to test that the changes are correct. -->


## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This changes the SDK and the system API, so:

- Need to bump the major version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

This is part of issue #1152, but does **not** close it.