### PR TITLE
Synchronize faucet balance from validators on startup.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -322,7 +322,7 @@ where
 
     /// Verifies that this chain is up-to-date and all the messages executed ahead of time
     /// have been properly received by now.
-    pub async fn validate_incoming_messages(&mut self) -> Result<(), ChainError> {
+    pub async fn validate_incoming_messages(&self) -> Result<(), ChainError> {
         let chain_id = self.chain_id();
         let origins = self.inboxes.indices().await?;
         let inboxes = self.inboxes.try_load_entries(&origins).await?;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2507,7 +2507,7 @@ where
         .await
         .unwrap();
     {
-        let mut admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
+        let admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
         admin_chain.validate_incoming_messages().await.unwrap();
         assert_eq!(
             BlockHeight::from(1),
@@ -3169,7 +3169,7 @@ where
 
     {
         // The admin chain has an anticipated message.
-        let mut admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
+        let admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
         assert!(matches!(
             admin_chain.validate_incoming_messages().await,
             Err(ChainError::MissingCrossChainUpdate { .. })
@@ -3185,7 +3185,7 @@ where
 
     {
         // The admin chain has no more anticipated messages.
-        let mut admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
+        let admin_chain = worker.storage.load_active_chain(admin_id).await.unwrap();
         admin_chain.validate_incoming_messages().await.unwrap();
     }
 }

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -206,7 +206,7 @@ where
         genesis_config: Arc<GenesisConfig>,
     ) -> anyhow::Result<Self> {
         let start_timestamp = client.storage_client().await.current_time();
-        let start_balance = client.local_balance().await?;
+        let start_balance = client.synchronize_from_validators().await?;
         Ok(Self {
             client: Arc::new(Mutex::new(client)),
             genesis_config,


### PR DESCRIPTION
## Motivation

During local testing I sometimes ran into the situation where I killed and restarted the faucet, and then its local storage was not in sync with the wallet.

## Proposal

Call `synchronize_from_validators` on startup.
(Also: Remove another unused `mut`.)

## Test Plan

Locally, this solved the issue for me.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
