### PR TITLE
Default to last hour on linera general dashboard

### DIFF
--- a/kubernetes/linera-validator/grafana-dashboards/linera-general.json
+++ b/kubernetes/linera-validator/grafana-dashboards/linera-general.json
@@ -207,8 +207,8 @@
     "list": []
   },
   "time": {
-    "from": "2024-01-03T14:32:01.797Z",
-    "to": "2024-01-03T15:54:46.957Z"
+    "from": "now-24h",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [


### PR DESCRIPTION
## Motivation

The dashboard was accidentally committed with an absolute time range

## Proposal

Changing to last hour instead

## Test Plan

Deployed locally, saw dashboard with the updated time, auto updating as expected

