### PR TITLE
Corrections of bugs in CollectionView for the hash.

### DIFF
--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -176,7 +176,6 @@ where
     /// # })
     /// ```
     pub async fn load_entry_mut(&mut self, short_key: Vec<u8>) -> Result<&mut W, ViewError> {
-        *self.hash.get_mut() = None;
         self.do_load_entry_mut(short_key).await
     }
 
@@ -280,7 +279,6 @@ where
     /// # })
     /// ```
     pub async fn reset_entry_to_default(&mut self, short_key: Vec<u8>) -> Result<(), ViewError> {
-        *self.hash.get_mut() = None;
         let view = self.load_entry_mut(short_key).await?;
         view.clear();
         Ok(())
@@ -318,6 +316,7 @@ where
     }
 
     async fn do_load_entry_mut(&mut self, short_key: Vec<u8>) -> Result<&mut W, ViewError> {
+        *self.hash.get_mut() = None;
         match self.updates.get_mut().entry(short_key.clone()) {
             btree_map::Entry::Occupied(entry) => {
                 let entry = entry.into_mut();

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -336,7 +336,6 @@ where
         &mut self,
         short_key: Vec<u8>,
     ) -> Result<(), ViewError> {
-        *self.hash.get_mut() = None;
         let mut view = self.try_load_entry_mut(short_key).await?;
         view.clear();
         Ok(())

--- a/linera-views/tests/reentrant_tests.rs
+++ b/linera-views/tests/reentrant_tests.rs
@@ -7,6 +7,7 @@ use linera_views::{
     register_view::RegisterView,
     views::{CryptoHashRootView, RootView, View},
 };
+use linera_views::views::CryptoHashView;
 use rand::{Rng, SeedableRng};
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -24,6 +25,7 @@ async fn reentrant_collection_view_check() {
     let nmax: u8 = 25;
     for _ in 0..n {
         let mut view = StateView::load(context.clone()).await.unwrap();
+        let hash = view.crypto_hash().await.unwrap();
         let save = rng.gen::<bool>();
         //
         let count_oper = rng.gen_range(0..25);
@@ -80,6 +82,13 @@ async fn reentrant_collection_view_check() {
                 // Doing the rollback
                 view.rollback();
                 new_map = map.clone();
+            }
+            let new_hash = view.crypto_hash().await.unwrap();
+            if new_map == map {
+                assert_eq!(hash, new_hash);
+            } else {
+                // Inequality could be a bug or a hash collision (unlikely)
+                assert_ne!(hash, new_hash);
             }
             // Checking the keys
             let keys_view = view.v.indices().await.unwrap();

--- a/linera-views/tests/reentrant_tests.rs
+++ b/linera-views/tests/reentrant_tests.rs
@@ -5,9 +5,8 @@ use linera_views::{
     memory::create_memory_context,
     reentrant_collection_view::ReentrantCollectionView,
     register_view::RegisterView,
-    views::{CryptoHashRootView, RootView, View},
+    views::{CryptoHashRootView, CryptoHashView, RootView, View},
 };
-use linera_views::views::CryptoHashView;
 use rand::{Rng, SeedableRng};
 use std::collections::{BTreeMap, BTreeSet};
 


### PR DESCRIPTION
## Motivation

It was recently identified that the hash is not set to None for the code of CollectionView. This PR addresses that. Further work is needed to improve the tests.

## Proposal

The following was done:
* Addition of the missing `hash = None`instance in `CollectionView` code.
* Removal of two instances of `hash = None` in `CollectionView` and addition of one in `ReentrantCollectionView`. There is no point in having excessive `hash = None` in the hope of being safe. Cleaning helps.
* Addition of a test of hash for the reentrant collection view.

## Test Plan

The hash test improves the situation, but there are further checks to add.

## Release Plan

No change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
