### PR TITLE
Handle cross-chain messages in parallel.

### DIFF
--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -26,6 +26,10 @@ pub struct CrossChainConfig {
     /// Drop cross-chain messages randomly at the given rate (0 <= rate < 1) (meant for testing).
     #[arg(long = "cross-chain-sender-failure-rate", default_value = "0.0")]
     pub(crate) sender_failure_rate: f32,
+
+    /// How many parallel tasks to spawn for cross-chain message handling RPCs.
+    #[arg(long = "cross-chain-max-tasks", default_value = "10")]
+    pub(crate) max_tasks: usize,
 }
 
 #[derive(Clone, Debug, clap::Parser)]

--- a/linera-rpc/src/config.rs
+++ b/linera-rpc/src/config.rs
@@ -27,9 +27,9 @@ pub struct CrossChainConfig {
     #[arg(long = "cross-chain-sender-failure-rate", default_value = "0.0")]
     pub(crate) sender_failure_rate: f32,
 
-    /// How many parallel tasks to spawn for cross-chain message handling RPCs.
+    /// How many concurrent tasks to spawn for cross-chain message handling RPCs.
     #[arg(long = "cross-chain-max-tasks", default_value = "10")]
-    pub(crate) max_tasks: usize,
+    pub(crate) max_concurrent_tasks: usize,
 }
 
 #[derive(Clone, Debug, clap::Parser)]

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -230,7 +230,7 @@ where
                 Duration::from_millis(cross_chain_config.retry_delay_ms),
                 Duration::from_millis(cross_chain_config.sender_delay_ms),
                 cross_chain_config.sender_failure_rate,
-                cross_chain_config.max_tasks,
+                cross_chain_config.max_concurrent_tasks,
                 shard_id,
                 cross_chain_receiver,
             )
@@ -351,15 +351,15 @@ where
         cross_chain_retry_delay: Duration,
         cross_chain_sender_delay: Duration,
         cross_chain_sender_failure_rate: f32,
-        cross_chain_max_tasks: usize,
+        cross_chain_max_concurrent_tasks: usize,
         this_shard: ShardId,
         receiver: mpsc::Receiver<(linera_core::data_types::CrossChainRequest, ShardId)>,
     ) {
         let pool = ConnectionPool::default();
-        let max_tasks = Some(cross_chain_max_tasks);
+        let max_concurrent_tasks = Some(cross_chain_max_concurrent_tasks);
 
         receiver
-            .for_each_concurrent(max_tasks, |(cross_chain_request, shard_id)| {
+            .for_each_concurrent(max_concurrent_tasks, |(cross_chain_request, shard_id)| {
                 let shard = network.shard(shard_id);
                 let remote_address = format!("http://{}", shard.address());
 

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -230,6 +230,7 @@ where
                 Duration::from_millis(cross_chain_config.retry_delay_ms),
                 Duration::from_millis(cross_chain_config.sender_delay_ms),
                 cross_chain_config.sender_failure_rate,
+                cross_chain_config.max_tasks,
                 shard_id,
                 cross_chain_receiver,
             )
@@ -350,13 +351,15 @@ where
         cross_chain_retry_delay: Duration,
         cross_chain_sender_delay: Duration,
         cross_chain_sender_failure_rate: f32,
+        cross_chain_max_tasks: usize,
         this_shard: ShardId,
         receiver: mpsc::Receiver<(linera_core::data_types::CrossChainRequest, ShardId)>,
     ) {
         let pool = ConnectionPool::default();
+        let max_tasks = Some(cross_chain_max_tasks);
 
         receiver
-            .for_each_concurrent(None, |(cross_chain_request, shard_id)| {
+            .for_each_concurrent(max_tasks, |(cross_chain_request, shard_id)| {
                 let shard = network.shard(shard_id);
                 let remote_address = format!("http://{}", shard.address());
 


### PR DESCRIPTION
## Motivation

When I tried out the fungible benchmark locally I often saw the cross-chain message queue overflow.

## Proposal

When making the remote `handle_cross_chain_message` call, don't `await` the result before making the next one.

(Also: The benchmark shouldn't fail if we send fewer transactions per wallet than we have wallets.)

## Test Plan

It locally fixes the problem for me.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
