### PR TITLE
performance fix: do not call RNG for testing failures when not needed

### DIFF
--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -356,7 +356,9 @@ where
         let pool = ConnectionPool::default();
 
         while let Some((cross_chain_request, shard_id)) = receiver.next().await {
-            if rand::thread_rng().gen::<f32>() < cross_chain_sender_failure_rate {
+            if cross_chain_sender_failure_rate > 0.0
+                && rand::thread_rng().gen::<f32>() < cross_chain_sender_failure_rate
+            {
                 warn!("Dropped 1 cross-chain message intentionally.");
                 continue;
             }

--- a/linera-rpc/src/simple_network.rs
+++ b/linera-rpc/src/simple_network.rs
@@ -95,7 +95,9 @@ where
             .expect("Initialization should not fail");
 
         while let Some((message, shard_id)) = receiver.next().await {
-            if rand::thread_rng().gen::<f32>() < cross_chain_sender_failure_rate {
+            if cross_chain_sender_failure_rate > 0.0
+                && rand::thread_rng().gen::<f32>() < cross_chain_sender_failure_rate
+            {
                 warn!("Dropped 1 cross-message intentionally.");
                 continue;
             }


### PR DESCRIPTION
## Motivation

Small performance improvement

## Proposal

Fix the condition to skip the RNG if the failure is 0 (as expected in production).

## Test Plan

CI