### PR TITLE
Remove cargo-rdme comments in files not generated by rdme.

### DIFF
--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -1,5 +1,3 @@
-<!-- cargo-rdme start -->
-
 # Automated Market Maker (AMM) Example Application
 
 This example implements an Automated Market Maker (AMM) which demonstrates DeFi capabilities of the 
@@ -162,5 +160,3 @@ mutation{
   )
 }
 ```
-
-<!-- cargo-rdme end -->

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,5 +1,3 @@
-<!-- cargo-rdme start -->
-
 # Counter Example Application
 
 This example application implements a simple counter contract, it is initialized with an 
@@ -106,5 +104,3 @@ The following command will print the URL of the web UI:
 ```bash
 echo "http://localhost:3000/$CHAIN_1?app=$APPLICATION_ID&owner=$OWNER_1&port=$PORT"
 ```
-
-<!-- cargo-rdme end -->

--- a/examples/matching-engine/README.md
+++ b/examples/matching-engine/README.md
@@ -1,5 +1,3 @@
-<!-- cargo-rdme start -->
-
 # Matching Engine Example Application
 
 This sample application demonstrates a matching engine, showcasing the DeFi capabilities
@@ -143,5 +141,3 @@ query{
   }
 }
 ```
-
-<!-- cargo-rdme end -->

--- a/examples/meta-counter/README.md
+++ b/examples/meta-counter/README.md
@@ -1,5 +1,3 @@
-<!-- cargo-rdme start -->
-
 # Meta-Counter Example Application
 
 This application demonstrates how `cross_application_call` works in Linera. 
@@ -65,7 +63,7 @@ META_COUNTER_ID=$(linera --wait-for-outgoing-messages publish-and-create \
   --json-argument="null" --json-parameters '"'"$APPLICATION_ID"'"' --required-application-ids $APPLICATION_ID)
 ```
 
-## Using the Counter Application
+## Using the Meta Counter Application
 
 First, a node service for the current wallet has to be started:
 
@@ -79,13 +77,13 @@ linera service --port $PORT &
 - Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$META_COUNTER_ID`.
 - To get the current value of `counter`, run the query:
 ```json
-    query{
+    query {
         value
     }
 ```
 - To increase the value of the counter by 3, perform the `increment` operation:
 ```json
-    mutation Increment{
+    mutation Increment {
         increment(value: 3)
     }
 ```
@@ -93,4 +91,3 @@ linera service --port $PORT &
 
 Now, if we check from `counter` application we will also get `4` because eventually we modified the state.
 
-<!-- cargo-rdme end -->


### PR DESCRIPTION
## Motivation

Some of the example application README files are not generated by `cargo-rdme` but contain comments that suggest they are.

## Proposal

Remove the spurious comments.

## Test Plan

The README files are checked by `test_script_in_readme`.


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
