### PR TITLE
`.github/workflows`: move heavy workflows to GCP

### DIFF
--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -33,16 +33,12 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
-    timeout-minutes: 30
+    runs-on: gcp-large
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v3
     - uses: Twey/setup-rust-toolchain@v1
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -29,17 +29,13 @@ permissions:
 
 jobs:
   kind-deployment-e2e-tests:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: gcp-large
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - uses: Twey/setup-rust-toolchain@v1
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build client binary
         run: |
           cargo build --release --locked --bin linera --bin linera-proxy --bin linera-server --bin linera-db --features scylladb,rocksdb,kubernetes

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   test:
     runs-on: gcp-large
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,13 @@ jobs:
         cache: false
     - name: Enable `sccache` for Rust builds
       run: |
+        cargo install sccache
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        echo $PATH
+        type -P sccache ||:
+        ls -lah ~/.cargo ||:
+        ls -lah ~/.cache ||:
+        ls -lah ~/.cache/cargo ||:
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,16 +41,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Enable `sccache` for Rust builds
-      run: |
-        echo $PATH
-        type -P sccache ||:
-        ls -lah ~/.cargo ||:
-        ls -lah ~/.cache ||:
-        ls -lah ~/.cache/cargo ||:
-
-        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-        env
+      # - name: Enable `sccache` for Rust builds
+      #   run: echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,10 +40,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: Twey/setup-rust-toolchain@v1
-    - uses: mozilla-actions/sccache-action@v0.0.3
+      with:
+        # We use `sccache`, so don't use `Swatinem/rust-cache` as well
+        cache: false
     - name: Enable `sccache` for Rust builds
       run: |
-        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
     - name: Build example applications
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,44 +54,44 @@ jobs:
     - name: Compile the workspace with the default features (build)
       run: |
         cargo build --locked
-    - name: Check sccache efficiency
-      run: sccache --show-stats
-    - name: Run all tests using the default features
+    - name: Check what's going on with the cache
       run: |
-        cargo test --locked
-    - name: Run some extra execution tests with wasmtime
-      run: |
-        cargo test --locked -p linera-execution --features wasmtime
-    - name: Run the benchmark test
-      run: |
-        cargo build --locked -p linera-service --bin linera-benchmark --features benchmark
-        cargo test --locked -p linera-service --features benchmark benchmark
-    - name: Build Wasm test runner
-      # use debug mode to avoid building wasmtime in release mode
-      run: |
-        cargo build --locked --bin linera-wasm-test-runner
-    - name: Run Linera SDK Wasm tests
-      env:
-        CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: "target/debug/linera-wasm-test-runner"
-      run: |
-        cargo test --locked -p linera-sdk-wasm-tests --target wasm32-unknown-unknown
-    - name: Run Wasm application tests
-      run: |
-        cd examples
-        CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=../target/debug/linera-wasm-test-runner cargo test --target wasm32-unknown-unknown
-        cargo test --locked --target x86_64-unknown-linux-gnu
-    - name: Run Witty integration tests
-      run: |
-        cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
-        cargo test -p linera-witty --features wasmer,wasmtime
-    - name: Check for outdated CLI.md
-      run: |
-        if ! diff CLI.md <(cargo run --bin linera -- help-markdown)
-        then
-          echo '`CLI.md` differs from the output of `linera help-markdown`'
-          echo 'Run `linera help-markdown > CLI.md` to update it.'
-          exit 1
-        fi
+        pwd
+        ls target
+    #     cargo test --locked
+    # - name: Run some extra execution tests with wasmtime
+    #   run: |
+    #     cargo test --locked -p linera-execution --features wasmtime
+    # - name: Run the benchmark test
+    #   run: |
+    #     cargo build --locked -p linera-service --bin linera-benchmark --features benchmark
+    #     cargo test --locked -p linera-service --features benchmark benchmark
+    # - name: Build Wasm test runner
+    #   # use debug mode to avoid building wasmtime in release mode
+    #   run: |
+    #     cargo build --locked --bin linera-wasm-test-runner
+    # - name: Run Linera SDK Wasm tests
+    #   env:
+    #     CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: "target/debug/linera-wasm-test-runner"
+    #   run: |
+    #     cargo test --locked -p linera-sdk-wasm-tests --target wasm32-unknown-unknown
+    # - name: Run Wasm application tests
+    #   run: |
+    #     cd examples
+    #     CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=../target/debug/linera-wasm-test-runner cargo test --target wasm32-unknown-unknown
+    #     cargo test --locked --target x86_64-unknown-linux-gnu
+    # - name: Run Witty integration tests
+    #   run: |
+    #     cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
+    #     cargo test -p linera-witty --features wasmer,wasmtime
+    # - name: Check for outdated CLI.md
+    #   run: |
+    #     if ! diff CLI.md <(cargo run --bin linera -- help-markdown)
+    #     then
+    #       echo '`CLI.md` differs from the output of `linera help-markdown`'
+    #       echo 'Run `linera help-markdown > CLI.md` to update it.'
+    #       exit 1
+    #     fi
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,6 @@ jobs:
 
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         env
-        sccache --show-stats
     - name: Build example applications
       run: |
         cd examples
@@ -62,6 +61,8 @@ jobs:
     - name: Compile the workspace with the default features (build)
       run: |
         cargo build --locked
+    - name: Check sccache efficiency
+      run: sccache --show-stats
     - name: Run all tests using the default features
       run: |
         cargo test --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: Twey/setup-rust-toolchain@v1
-      with:
-        # We use `sccache`, so don't use `Swatinem/rust-cache` as well
-        cache: false
+    # - uses: Twey/setup-rust-toolchain@v1
+    #   with:
+    #     # We use `sccache`, so don't use `Swatinem/rust-cache` as well
+    #     cache: false
     - name: Enable `sccache` for Rust builds
       run: |
         echo $PATH
@@ -51,7 +51,7 @@ jobs:
         ls -lah ~/.cache ||:
         ls -lah ~/.cache/cargo ||:
 
-        cargo install sccache
+        # cargo install sccache
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
     - name: Build example applications
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,8 +34,8 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 45
+    runs-on: gcp-large
+    timeout-minutes: 50
 
     steps:
     - uses: actions/checkout@v3
@@ -46,10 +46,6 @@ jobs:
         sudo rm -rf /opt/ghc
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,13 +45,14 @@ jobs:
         cache: false
     - name: Enable `sccache` for Rust builds
       run: |
-        cargo install sccache
-        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
         echo $PATH
         type -P sccache ||:
         ls -lah ~/.cargo ||:
         ls -lah ~/.cache ||:
         ls -lah ~/.cache/cargo ||:
+
+        cargo install sccache
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,17 +35,16 @@ permissions:
 jobs:
   test:
     runs-on: gcp-large
-    timeout-minutes: 50
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3
     - uses: Twey/setup-rust-toolchain@v1
-    - name: Clear up some space
+    - uses: mozilla-actions/sccache-action@v0.0.3
+    - name: Enable `sccache` for Rust builds
       run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /opt/ghc
-        sudo rm -rf "/usr/local/share/boost"
-        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,10 +39,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    # - uses: Twey/setup-rust-toolchain@v1
-    #   with:
-    #     # We use `sccache`, so don't use `Swatinem/rust-cache` as well
-    #     cache: false
+      with:
+        fetch-depth: 0
     - name: Enable `sccache` for Rust builds
       run: |
         echo $PATH
@@ -51,8 +49,9 @@ jobs:
         ls -lah ~/.cache ||:
         ls -lah ~/.cache/cargo ||:
 
-        # cargo install sccache
         echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+        env
+        sccache --show-stats
     - name: Build example applications
       run: |
         cd examples

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -34,7 +34,7 @@ jobs:
 
   test:
     runs-on: gcp-large
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -34,7 +34,7 @@ jobs:
 
   test:
     runs-on: gcp-large
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -33,16 +33,12 @@ permissions:
 jobs:
 
   test:
-    runs-on: ubuntu-latest-8-cores
-    timeout-minutes: 30
+    runs-on: gcp-large
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v3
     - uses: Twey/setup-rust-toolchain@v1
-    - name: Install Protoc
-      uses: arduino/setup-protoc@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Build example applications
       run: |
         cd examples

--- a/linera-service/src/cli_wrappers/helmfile.rs
+++ b/linera-service/src/cli_wrappers/helmfile.rs
@@ -30,6 +30,7 @@ impl HelmFile {
             .env("LINERA_HELMFILE_SET_NUM_SHARDS", num_shards.to_string())
             .arg("sync")
             .arg("--wait")
+            .arg("--debug")
             .args(["--kube-context", &format!("kind-{}", cluster_id)])
             .spawn_and_wait()
             .await


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->

We'd like to run heavy workflows on a beefy GCP machine, where we have credit.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->

Update our workflow specs to run on GCP machines if they're too large to reasonably run on GitHub's `ubuntu-latest`.

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

CI/CD only: no need to consider for release.

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- https://github.com/linera-io/linera-infra/pull/26
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
