### PR TITLE
Benchmark: Don't check chains that didn't receive a transfer.

### DIFF
--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -212,6 +212,9 @@ async fn benchmark_with_fungible(
         |((_, context, node_service), expected_balances)| {
             try_join_all(apps.iter().zip(expected_balances).map(
                 |((_, sender_context, _), expected_balance)| async move {
+                    if expected_balance == Amount::ZERO {
+                        return Ok(()); // No transfers: The app won't be registered on this chain.
+                    }
                     let app = FungibleApp(
                         node_service
                             .make_application(

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2132,13 +2132,13 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) {
     command
         .current_dir(dir)
         .arg("fungible")
-        .args(["--wallets", "2"])
+        .args(["--wallets", "3"])
         .args(["--transactions", "1"])
         .arg("--uniform")
         .args(["--faucet".to_string(), faucet.url()]);
     let stdout = command.spawn_and_wait_for_stdout().await.unwrap();
     let json = serde_json::from_str::<serde_json::Value>(&stdout).unwrap();
-    assert_eq!(json["successes"], 2);
+    assert_eq!(json["successes"], 3);
 
     faucet.ensure_is_running().unwrap();
     faucet.terminate().await.unwrap();


### PR DESCRIPTION
## Motivation

The benchmark fails if there are fewer transfers per wallet than there are wallets, because then not every application is installed on every chain.

## Proposal

Only check those tokens that are expected to have a nonzero balance.

## Test Plan

The test was changed to have three wallets and only one transfer per wallet, with uniform distribution. So each app is registered on the chain where it was created, and on _one_ more chain, but not on the third one. This fails without the fix.


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
