### PR TITLE
Use the view system APIs to read and write simple storage states

### DIFF
--- a/linera-sdk/src/contract/system_api/mod.rs
+++ b/linera-sdk/src/contract/system_api/mod.rs
@@ -9,8 +9,7 @@ mod private;
 pub mod private;
 
 pub(crate) use self::private::{
-    call_application, call_session, current_application_parameters, load, load_view, store,
-    store_view,
+    call_application, call_session, current_application_parameters, load_view, store_view,
 };
 use super::contract_system_api as wit;
 use linera_base::{

--- a/linera-sdk/src/contract/system_api/private.rs
+++ b/linera-sdk/src/contract/system_api/private.rs
@@ -8,40 +8,10 @@ use super::super::contract_system_api as wit;
 use crate::views::ViewStorageContext;
 use linera_base::identifiers::{ApplicationId, SessionId};
 use linera_views::views::{RootView, View};
-use serde::{de::DeserializeOwned, Serialize};
 
 /// Retrieves the current application parameters.
 pub fn current_application_parameters() -> Vec<u8> {
     wit::application_parameters()
-}
-
-/// Deserializes the application state or creates a new one if the `bytes` vector is empty.
-fn deserialize_state<State>(bytes: Vec<u8>) -> State
-where
-    State: Default + DeserializeOwned,
-{
-    if bytes.is_empty() {
-        State::default()
-    } else {
-        bcs::from_bytes(&bytes).expect("Invalid application state")
-    }
-}
-
-/// Loads the application state.
-pub fn load<State>() -> Option<State>
-where
-    State: Default + DeserializeOwned,
-{
-    let state_bytes = wit::load();
-    Some(deserialize_state(state_bytes))
-}
-
-/// Saves the application state.
-pub async fn store<State>(state: State)
-where
-    State: Serialize,
-{
-    wit::store(&bcs::to_bytes(&state).expect("State serialization failed"));
 }
 
 /// Loads the application state or create a new one if it doesn't exist.

--- a/linera-sdk/src/service/system_api/mod.rs
+++ b/linera-sdk/src/service/system_api/mod.rs
@@ -8,9 +8,7 @@ mod private;
 #[cfg(any(test, feature = "test"))]
 pub mod private;
 
-pub(crate) use self::private::{
-    current_application_parameters, load, load_view, query_application,
-};
+pub(crate) use self::private::{current_application_parameters, load_view, query_application};
 use super::service_system_api as wit;
 use linera_base::{
     data_types::{Amount, Timestamp},

--- a/linera-sdk/src/service/system_api/private.rs
+++ b/linera-sdk/src/service/system_api/private.rs
@@ -5,25 +5,9 @@
 //! that shouldn't be used by applications directly.
 
 use super::super::service_system_api as wit;
-use crate::{util::yield_once, views::ViewStorageContext};
+use crate::views::ViewStorageContext;
 use linera_base::identifiers::ApplicationId;
 use linera_views::views::View;
-use serde::de::DeserializeOwned;
-
-/// Loads the application state, without locking it for writes.
-pub async fn load<State>() -> State
-where
-    State: Default + DeserializeOwned,
-{
-    let promise = wit::Load::new();
-    yield_once().await;
-    let bytes = promise.wait().expect("Failed to load application state");
-    if bytes.is_empty() {
-        State::default()
-    } else {
-        bcs::from_bytes(&bytes).expect("Invalid application state")
-    }
-}
 
 /// Helper function to load the service state or create a new one if it doesn't exist.
 pub async fn load_view<State: View<ViewStorageContext>>() -> State {

--- a/linera-sdk/src/views/mod.rs
+++ b/linera-sdk/src/views/mod.rs
@@ -5,6 +5,7 @@
 
 mod system_api;
 
+pub(crate) use self::system_api::AppStateStore;
 pub use self::system_api::ViewStorageContext;
 pub use linera_views::{
     self,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Applications have two alternatives for storage, a "simple" blob-like storage and one using [`linera-views`](https://docs.rs/linera-views). Both were implemented separately in the SDK and in the host, but they could be simplified to use a common set of system APIs, which simplifies the interface between the host and the Wasm guest and simplifies the runtime in the host.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Update the SDK to use the view system APIs to read and write the application state of applications that opted to use the simple blob-like storage.

## Test Plan

<!-- How to test that the changes are correct. -->
This is a refactoring, and all tests with Wasm applications should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Changes the SDK, so
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

This is part of #1152, but it does **not** close it.
