### PR TITLE
Rename _micros to _us.

### DIFF
--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -254,7 +254,7 @@ pub struct Key {
 impl CustomSerialize for Key {
     fn to_custom_bytes(&self) -> Result<Vec<u8>, ViewError> {
         let data = (
-            (!self.timestamp.micros()).to_be_bytes(),
+            (!self.timestamp.us()).to_be_bytes(),
             &self.author,
             (!self.index).to_be_bytes(),
         );

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -85,32 +85,32 @@ impl Timestamp {
     }
 
     /// Returns the number of microseconds since the Unix epoch.
-    pub fn micros(&self) -> u64 {
+    pub fn us(&self) -> u64 {
         self.0
     }
 
     /// Returns the number of microseconds from `other` until `self`, or `0` if `other` is not
     /// earlier than `self`.
-    pub fn saturating_diff_micros(&self, other: Timestamp) -> u64 {
+    pub fn saturating_diff_us(&self, other: Timestamp) -> u64 {
         self.0.saturating_sub(other.0)
     }
 
     /// Returns the timestamp that is `duration` later than `self`.
     pub fn saturating_add(&self, duration: Duration) -> Timestamp {
-        let micros = u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
-        Timestamp(self.0.saturating_add(micros))
+        let us = u64::try_from(duration.as_micros()).unwrap_or(u64::MAX);
+        Timestamp(self.0.saturating_add(us))
     }
 
-    /// Returns a timestamp `micros` microseconds later than `self`, or the highest possible value
+    /// Returns a timestamp `us` microseconds later than `self`, or the highest possible value
     /// if it would overflow.
-    pub fn saturating_add_micros(&self, micros: u64) -> Timestamp {
-        Timestamp(self.0.saturating_add(micros))
+    pub fn saturating_add_us(&self, us: u64) -> Timestamp {
+        Timestamp(self.0.saturating_add(us))
     }
 
-    /// Returns a timestamp `micros` microseconds earlier than `self`, or the lowest possible value
+    /// Returns a timestamp `us` microseconds earlier than `self`, or the lowest possible value
     /// if it would underflow.
-    pub fn saturating_sub_micros(&self, micros: u64) -> Timestamp {
-        Timestamp(self.0.saturating_sub(micros))
+    pub fn saturating_sub_us(&self, us: u64) -> Timestamp {
+        Timestamp(self.0.saturating_sub(us))
     }
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -98,7 +98,7 @@ where
     let worker = WorkerState::new("Single validator node".to_string(), Some(key_pair), storage)
         .with_allow_inactive_chains(is_client)
         .with_allow_messages_from_deprecated_epochs(is_client)
-        .with_grace_period_micros(TEST_GRACE_PERIOD_MICROS);
+        .with_grace_period_us(TEST_GRACE_PERIOD_MICROS);
     (committee, worker)
 }
 
@@ -584,7 +584,7 @@ where
 
     {
         let block_proposal = make_child_block(&certificate.value)
-            .with_timestamp(block_0_time.saturating_sub_micros(1))
+            .with_timestamp(block_0_time.saturating_sub_us(1))
             .into_fast_proposal(&key_pair);
         // Timestamp older than previous one
         assert!(matches!(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -239,7 +239,7 @@ pub struct WorkerState<StorageClient> {
     allow_messages_from_deprecated_epochs: bool,
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
-    grace_period_micros: u64,
+    grace_period_us: u64,
     /// Cached values by hash.
     recent_values: Arc<Mutex<LruCache<CryptoHash, HashedValue>>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
@@ -261,7 +261,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             storage,
             allow_inactive_chains: false,
             allow_messages_from_deprecated_epochs: false,
-            grace_period_micros: 0,
+            grace_period_us: 0,
             recent_values,
             delivery_notifiers: Arc::default(),
         }
@@ -279,7 +279,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             storage,
             allow_inactive_chains: false,
             allow_messages_from_deprecated_epochs: false,
-            grace_period_micros: 0,
+            grace_period_us: 0,
             recent_values,
             delivery_notifiers,
         }
@@ -299,8 +299,8 @@ impl<StorageClient> WorkerState<StorageClient> {
     ///
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
-    pub fn with_grace_period_micros(mut self, grace_period_micros: u64) -> Self {
-        self.grace_period_micros = grace_period_micros;
+    pub fn with_grace_period_us(mut self, grace_period_us: u64) -> Self {
+        self.grace_period_us = grace_period_us;
         self
     }
 
@@ -1056,9 +1056,9 @@ where
         // Write the values so that the bytecode is available during execution.
         self.storage.write_values(blobs).await?;
         let local_time = self.storage.current_time();
-        let time_till_block = block.timestamp.saturating_diff_micros(local_time);
+        let time_till_block = block.timestamp.saturating_diff_us(local_time);
         ensure!(
-            time_till_block <= self.grace_period_micros,
+            time_till_block <= self.grace_period_us,
             WorkerError::InvalidTimestamp
         );
         if time_till_block > 0 {

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -36,7 +36,7 @@ macro_rules! impl_contract_system_api {
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<contract_system_api::Timestamp, Self::Error> {
-                BaseRuntime::read_system_timestamp(self).map(|timestamp| timestamp.micros())
+                BaseRuntime::read_system_timestamp(self).map(|timestamp| timestamp.us())
             }
 
             // TODO(#1152): remove
@@ -148,7 +148,7 @@ macro_rules! impl_service_system_api {
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<service_system_api::Timestamp, Self::Error> {
-                BaseRuntime::read_system_timestamp(self).map(|timestamp| timestamp.micros())
+                BaseRuntime::read_system_timestamp(self).map(|timestamp| timestamp.us())
             }
 
             // TODO(#1152): remove

--- a/linera-sdk/src/test/unit/mod.rs
+++ b/linera-sdk/src/test/unit/mod.rs
@@ -138,7 +138,7 @@ impl wit::MockSystemApi for MockSystemApi {
                 "Unexpected call to the `read_system_timestamp` system API. \
                 Please call `mock_system_timestamp` first",
             )
-            .micros()
+            .us()
     }
 
     fn mocked_log(message: String, level: wit::LogLevel) {

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -127,10 +127,8 @@ where
         if self.start_timestamp < self.end_timestamp {
             let local_time = client.storage_client().await.current_time();
             if local_time < self.end_timestamp {
-                let full_duration = self
-                    .end_timestamp
-                    .saturating_diff_micros(self.start_timestamp);
-                let remaining_duration = self.end_timestamp.saturating_diff_micros(local_time);
+                let full_duration = self.end_timestamp.saturating_diff_us(self.start_timestamp);
+                let remaining_duration = self.end_timestamp.saturating_diff_us(local_time);
                 let balance = client.local_balance().await?;
                 let Ok(remaining_balance) = balance.try_sub(self.amount) else {
                     return Err(Error::new("The faucet is empty."));

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1836,9 +1836,9 @@ impl Runnable for Job {
                 let chain_client = context.make_chain_client(storage, chain_id);
                 let end_timestamp = limit_rate_until
                     .map(|et| {
-                        let micros = u64::try_from(et.timestamp_micros())
+                        let us = u64::try_from(et.timestamp_micros())
                             .expect("End timestamp before 1970");
-                        Timestamp::from(micros)
+                        Timestamp::from(us)
                     })
                     .unwrap_or_else(Timestamp::now);
                 let genesis_config = Arc::new(context.wallet_state.genesis_config().clone());
@@ -2424,9 +2424,9 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
             };
             let timestamp = start_timestamp
                 .map(|st| {
-                    let micros =
+                    let us =
                         u64::try_from(st.timestamp_micros()).expect("Start timestamp before 1970");
-                    Timestamp::from(micros)
+                    Timestamp::from(us)
                 })
                 .unwrap_or_else(Timestamp::now);
             let admin_id = ChainId::root(*admin_root);

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1019,7 +1019,7 @@ pub async fn wait_for_next_round(stream: NotificationStream, timeout: RoundTimeo
     future::select(
         Box::pin(stream.next()),
         Box::pin(tokio::time::sleep(Duration::from_micros(
-            timeout.timestamp.saturating_diff_micros(Timestamp::now()),
+            timeout.timestamp.saturating_diff_us(Timestamp::now()),
         ))),
     )
     .await;

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -36,7 +36,7 @@ struct ServerContext {
     cross_chain_config: CrossChainConfig,
     notification_config: NotificationConfig,
     shard: Option<usize>,
-    grace_period_micros: u64,
+    grace_period_us: u64,
 }
 
 impl ServerContext {
@@ -58,7 +58,7 @@ impl ServerContext {
         )
         .with_allow_inactive_chains(false)
         .with_allow_messages_from_deprecated_epochs(false)
-        .with_grace_period_micros(self.grace_period_micros);
+        .with_grace_period_us(self.grace_period_us);
         (state, shard_id, shard.clone())
     }
 
@@ -441,7 +441,7 @@ async fn run(options: ServerOptions) {
                 cross_chain_config,
                 notification_config,
                 shard,
-                grace_period_micros: grace_period,
+                grace_period_us: grace_period,
             };
             let wasm_runtime = wasm_runtime.with_wasm_default();
             let common_config = CommonStoreConfig {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -156,13 +156,12 @@ impl TestClock {
     /// Sets the current time.
     pub fn set(&self, timestamp: Timestamp) {
         self.0
-            .store(timestamp.micros(), std::sync::atomic::Ordering::SeqCst);
+            .store(timestamp.us(), std::sync::atomic::Ordering::SeqCst);
     }
 
     /// Advances the current time by the specified number of microseconds.
-    pub fn add_micros(&self, micros: u64) {
-        self.0
-            .fetch_add(micros, std::sync::atomic::Ordering::SeqCst);
+    pub fn add_us(&self, us: u64) {
+        self.0.fetch_add(us, std::sync::atomic::Ordering::SeqCst);
     }
 }
 


### PR DESCRIPTION
## Motivation

We are using both `micros` and `us` for "microseconds". This is inconsistent.

## Proposal

Use `us` everywhere in our code.
(Except for the standard library and `chrono` functions, which use `micros`.)

## Test Plan

No logic has changed.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
