### PR TITLE
linera-service uses fs_err for better errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2217,6 +2217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fungible"
 version = "0.1.0"
 dependencies = [
@@ -3423,6 +3433,7 @@ dependencies = [
  "current_platform",
  "dirs",
  "file-lock",
+ "fs-err",
  "fungible",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ ed25519 = "1.5.3"
 ed25519-dalek = { version = "1.0.1", features = ["batch", "serde"] }
 either = "1.9.0"
 frunk = "0.4.2"
+fs-err = { version = "2.11.0", features = ["tokio"] }
 futures = "0.3.29"
 generic-array = { version = "0.14.7", features = ["serde"] }
 hex = "0.4.3"

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -37,6 +37,7 @@ comfy-table = { workspace = true }
 current_platform = "0.2.0"
 dirs = { workspace = true }
 file-lock = "2.1.10"
+fs-err = { workspace = true }
 fungible = { workspace = true, optional = true }
 futures = { workspace = true }
 hex = { workspace = true }

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -18,7 +18,7 @@ use kube::{
     Client,
 };
 use linera_base::data_types::Amount;
-use std::{fs, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use tempfile::{tempdir, TempDir};
 use tokio::process::Command;
 #[cfg(any(test, feature = "test"))]
@@ -340,7 +340,7 @@ impl LocalKubernetesNet {
                 "#
             ));
         }
-        fs::write(&path, content)?;
+        fs_err::write(&path, content)?;
         path.into_os_string().into_string().map_err(|error| {
             anyhow!(
                 "could not parse OS string into string: {}",
@@ -381,7 +381,7 @@ impl LocalKubernetesNet {
             .join("kubernetes")
             .join("linera-validator")
             .join("working");
-        fs::copy(
+        fs_err::copy(
             self.tmp_dir.path().join("genesis.json"),
             base_dir.join("genesis.json"),
         )?;
@@ -404,7 +404,7 @@ impl LocalKubernetesNet {
                 kind_cluster.load_docker_image(&docker_image_name).await?;
 
                 let server_config_filename = format!("server_{}.json", i);
-                fs::copy(
+                fs_err::copy(
                     tmp_dir_path.join(&server_config_filename),
                     base_dir.join(&server_config_filename),
                 )?;

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use linera_base::data_types::Amount;
 use std::{
     collections::{BTreeMap, HashSet},
-    env, fs,
+    env,
     sync::Arc,
     time::Duration,
 };
@@ -308,7 +308,7 @@ impl LocalNet {
                 "#
             ));
         }
-        fs::write(&path, content)?;
+        fs_err::write(&path, content)?;
         path.into_os_string().into_string().map_err(|error| {
             anyhow!(
                 "could not parse OS string into string: {}",

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -614,14 +614,8 @@ impl ClientWrapper {
         let contract = release_dir.join(format!("{}_contract.wasm", name.replace('-', "_")));
         let service = release_dir.join(format!("{}_service.wasm", name.replace('-', "_")));
 
-        let contract_size = tokio::fs::metadata(&contract)
-            .await
-            .with_context(|| format!("Cannot find bytecode file {contract:?}"))?
-            .len();
-        let service_size = tokio::fs::metadata(&service)
-            .await
-            .with_context(|| format!("Cannot find bytecode file {service:?}"))?
-            .len();
+        let contract_size = fs_err::tokio::metadata(&contract).await?.len();
+        let service_size = fs_err::tokio::metadata(&service).await?.len();
         info!("Done building application {name}: contract_size={contract_size}, service_size={service_size}");
 
         Ok((contract, service))

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -51,7 +51,7 @@ use rand07::Rng;
 use serde_json::Value;
 use std::{
     collections::HashMap,
-    env, fs, iter,
+    env, iter,
     num::NonZeroU16,
     path::PathBuf,
     sync::Arc,
@@ -185,7 +185,7 @@ impl ClientContext {
         config_dir.push("linera");
         if !config_dir.exists() {
             debug!("{} does not exist, creating...", config_dir.display());
-            fs::create_dir(&config_dir)?;
+            fs_err::create_dir(&config_dir)?;
             debug!("{} created.", config_dir.display());
         }
         Ok(config_dir)
@@ -1372,7 +1372,7 @@ fn read_json(string: Option<String>, path: Option<PathBuf>) -> Result<Vec<u8>, a
         (Some(_), Some(_)) => bail!("cannot have both a json string and file"),
         (Some(s), None) => serde_json::from_str(&s)?,
         (None, Some(path)) => {
-            let s = fs::read_to_string(path)?;
+            let s = fs_err::read_to_string(path)?;
             serde_json::from_str(&s)?
         }
         (None, None) => Value::Null,

--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -5,8 +5,8 @@ use crate::util;
 use anyhow::{ensure, Context, Result};
 use cargo_toml::Manifest;
 use current_platform::CURRENT_PLATFORM;
+use fs_err::File;
 use std::{
-    fs::File,
     io::Write,
     path::{Path, PathBuf},
     process::Command,
@@ -37,7 +37,7 @@ impl Project {
             "Project name {name} should not have a file extension",
         );
         debug!("Creating directory at {}", root.display());
-        std::fs::create_dir_all(&root)?;
+        fs_err::create_dir_all(&root)?;
 
         debug!("Creating the source directory");
         let source_directory = Self::create_source_directory(&root)?;
@@ -125,7 +125,7 @@ impl Project {
 
     fn create_source_directory(project_root: &Path) -> Result<PathBuf> {
         let source_directory = project_root.join("src");
-        std::fs::create_dir(&source_directory)?;
+        fs_err::create_dir(&source_directory)?;
         Ok(source_directory)
     }
 
@@ -209,7 +209,7 @@ impl Project {
     fn create_cargo_config(project_root: &Path) -> Result<()> {
         let config_dir_path = project_root.join(".cargo");
         let config_file_path = config_dir_path.join("config.toml");
-        std::fs::create_dir(&config_dir_path)?;
+        fs_err::create_dir(&config_dir_path)?;
         Self::write_string_to_file(
             &config_file_path,
             include_str!("../template/config.toml.template"),

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -29,7 +29,6 @@ use linera_storage::Storage;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
 use serde::Deserialize;
 use std::{net::SocketAddr, path::PathBuf, time::Duration};
-use tokio::fs;
 use tracing::{error, info};
 
 struct ServerContext {
@@ -466,7 +465,7 @@ async fn run(options: ServerOptions) {
             let mut config_validators = Vec::new();
             let mut rng = Box::<dyn CryptoRng>::from(testing_prng_seed);
             for options_path in validators {
-                let options_string = fs::read_to_string(options_path)
+                let options_string = fs_err::tokio::read_to_string(options_path)
                     .await
                     .expect("Unable to read validator options file");
                 let options: ValidatorOptions =

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -216,13 +216,13 @@ pub struct QuotedBashScript {
 #[cfg(any(test, feature = "test"))]
 impl QuotedBashScript {
     pub fn from_markdown<P: AsRef<Path>>(source_path: P) -> Result<Self, std::io::Error> {
-        let file = std::io::BufReader::new(std::fs::File::open(source_path.as_ref())?);
+        let file = std::io::BufReader::new(fs_err::File::open(source_path.as_ref())?);
         let tmp_dir = tempdir()?;
         let quotes = Self::read_bash_quotes(file)?;
 
         let path = tmp_dir.path().join("test.sh");
 
-        let mut test_script = std::fs::File::create(&path)?;
+        let mut test_script = fs_err::File::create(&path)?;
         for quote in quotes {
             writeln!(&mut test_script, "{}", quote)?;
         }


### PR DESCRIPTION
## Motivation

`std::fs` errors are not comprehensive (intentionally) when it comes to reporting why an `fs` operation failed. For example, a file will be reported as missing without the file name being provided in the error itself, making debugging difficult.

## Proposal

Move to `fs_err` which is a drop-in replacement for `std::fs` with convenient error reporting.

Before:
```
The system cannot find the file specified. (os error 2)
```
After:
```
failed to open file `does not exist.txt`
    caused by: The system cannot find the file specified. (os error 2)
```

## Test Plan

Tested by CI.
