### PR TITLE
Remove `String` error types from APIs to query other application services

### DIFF
--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -143,10 +143,8 @@ macro_rules! impl_service_system_api {
                 &mut self,
                 application: service_system_api::ApplicationId,
                 argument: &[u8],
-            ) -> Result<Result<Vec<u8>, String>, Self::Error> {
+            ) -> Result<Vec<u8>, Self::Error> {
                 ServiceRuntime::try_query_application(self, application.into(), argument.to_vec())
-                    // TODO(#1153): remove
-                    .map(Ok)
             }
 
             fn log(

--- a/linera-sdk/mock_system_api.wit
+++ b/linera-sdk/mock_system_api.wit
@@ -20,10 +20,7 @@ mocked-find-keys: func(prefix: list<u8>) -> list<list<u8>>
 mocked-find-key-values: func(prefix: list<u8>) -> list<tuple<list<u8>,list<u8>>>
 mocked-write-batch: func(operations: list<write-operation>)
 
-mocked-try-query-application: func(
-    application: application-id,
-    query: list<u8>,
-) -> result<list<u8>, string>
+mocked-try-query-application: func(application: application-id, query: list<u8>) -> list<u8>
 
 variant write-operation {
     delete(list<u8>),

--- a/linera-sdk/service_system_api.wit
+++ b/linera-sdk/service_system_api.wit
@@ -14,10 +14,7 @@ enum log-level {
     error,
 }
 
-try-query-application: func(
-    application: application-id,
-    query: list<u8>,
-) -> result<list<u8>, string>
+try-query-application: func(application: application-id, query: list<u8>) -> list<u8>
 
 record application-id {
     bytecode-id: bytecode-id,

--- a/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
+++ b/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
@@ -640,7 +640,7 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                             } \
                         }, \
                         query: list<u8>\
-                    ) -> result<list<u8>, string>",
+                    ) -> list<u8>",
                 )
                 .expect(
                     "Missing `mocked-try-query-application` function in the module. \
@@ -690,7 +690,8 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                         Please ensure `linera_sdk::test::mock_try_call_application` was called",
                     );
 
-                copy_memory_slices(&mut caller, result_offset, return_offset, 12);
+                store_in_memory(&mut caller, return_offset, 0_u8);
+                copy_memory_slices(&mut caller, result_offset, return_offset + 4, 8);
             })
         },
     )?;

--- a/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
+++ b/linera-sdk/src/bin/linera-wasm-test-runner/mock_system_api.rs
@@ -596,7 +596,7 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                 } \
             }, \
             query: list<u8>\
-        ) -> result<list<u8>, string>",
+        ) -> list<u8>",
         move |mut caller: Caller<'_, Resources>,
               application_bytecode_chain_id_part1: i64,
               application_bytecode_chain_id_part2: i64,
@@ -690,8 +690,7 @@ pub fn add_to_linker(linker: &mut Linker<Resources>) -> Result<()> {
                         Please ensure `linera_sdk::test::mock_try_call_application` was called",
                     );
 
-                store_in_memory(&mut caller, return_offset, 0_u8);
-                copy_memory_slices(&mut caller, result_offset, return_offset + 4, 8);
+                copy_memory_slices(&mut caller, result_offset, return_offset, 8);
             })
         },
     )?;

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -305,8 +305,7 @@ pub trait Service: WithServiceAbi + ServiceAbi {
     {
         let query_bytes = serde_json::to_vec(&query)?;
         let response_bytes =
-            crate::service::system_api::query_application(application.forget_abi(), &query_bytes)
-                .map_err(String::from)?;
+            crate::service::system_api::query_application(application.forget_abi(), &query_bytes);
         let response = serde_json::from_slice(&response_bytes)?;
         Ok(response)
     }

--- a/linera-sdk/src/service/system_api/private.rs
+++ b/linera-sdk/src/service/system_api/private.rs
@@ -24,5 +24,5 @@ pub fn current_application_parameters() -> Vec<u8> {
 
 /// Queries another application.
 pub fn query_application(application: ApplicationId, argument: &[u8]) -> Result<Vec<u8>, String> {
-    wit::try_query_application(application.into(), argument)
+    Ok(wit::try_query_application(application.into(), argument))
 }

--- a/linera-sdk/src/service/system_api/private.rs
+++ b/linera-sdk/src/service/system_api/private.rs
@@ -23,6 +23,6 @@ pub fn current_application_parameters() -> Vec<u8> {
 }
 
 /// Queries another application.
-pub fn query_application(application: ApplicationId, argument: &[u8]) -> Result<Vec<u8>, String> {
-    Ok(wit::try_query_application(application.into(), argument))
+pub fn query_application(application: ApplicationId, argument: &[u8]) -> Vec<u8> {
+    wit::try_query_application(application.into(), argument)
 }

--- a/linera-sdk/wasm-tests/src/lib.rs
+++ b/linera-sdk/wasm-tests/src/lib.rs
@@ -363,7 +363,7 @@ fn mock_query() {
             INTERCEPTED_ARGUMENT = Some(query);
         }
 
-        Ok::<_, String>(response.clone())
+        response.clone()
     });
 
     let application_id = ApplicationId {

--- a/linera-sdk/wasm-tests/src/lib.rs
+++ b/linera-sdk/wasm-tests/src/lib.rs
@@ -355,7 +355,7 @@ static mut INTERCEPTED_ARGUMENT: Option<Vec<u8>> = None;
 #[webassembly_test]
 fn mock_query() {
     let response = vec![0xff, 0xfe, 0xfd];
-    let expected_response = Ok(response.clone());
+    let expected_response = response.clone();
 
     test::mock_try_query_application(move |application_id, query| {
         unsafe {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Application services can call other application's services to execute queries. The API to execute those calls had a return type that included a `Result` with a `String` error type. The error type is not useful for the services, because it can only indicate an error in the Linera execution mechanism, and not in the called service. Such error should be reported to the user directly instead of to the caller application.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Change the APIs to not be fallible.

## Test Plan

<!-- How to test that the changes are correct. -->
No new features added, so no extra coverage needed. Existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This PR changes the system API and the SDK, so
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

This is part of #1153, but does **not** close it.
