### PR TITLE
Make round timeouts configurable.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -152,6 +152,13 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
 
   Default value: `0`
+* `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds
+* `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds
+
+  Default value: `10000`
+* `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round
+
+  Default value: `1000`
 
 
 

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -153,9 +153,9 @@ impl ChainManager {
             None
         };
 
-        let round_micros = ownership.round_timeout_micros(ownership.first_round());
+        let round_duration = ownership.round_timeout(ownership.first_round());
         let round_timeout = local_time
-            .saturating_add_micros(u64::try_from(round_micros.as_micros()).unwrap_or(u64::MAX));
+            .saturating_add_micros(u64::try_from(round_duration.as_micros()).unwrap_or(u64::MAX));
 
         Ok(ChainManager {
             ownership,
@@ -392,14 +392,12 @@ impl ChainManager {
         if self.current_round() > round {
             return;
         }
-        let round_micros = self
+        let round_duration = self
             .ownership
             .next_round(round)
-            .map_or(Duration::MAX, |round| {
-                self.ownership.round_timeout_micros(round)
-            });
+            .map_or(Duration::MAX, |round| self.ownership.round_timeout(round));
         self.round_timeout = local_time
-            .saturating_add_micros(u64::try_from(round_micros.as_micros()).unwrap_or(u64::MAX));
+            .saturating_add_micros(u64::try_from(round_duration.as_micros()).unwrap_or(u64::MAX));
     }
 
     /// Updates the round number and timer if the timeout certificate is from a higher round than

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -33,7 +33,7 @@ use linera_execution::{
     policy::ResourceControlPolicy,
     system::{Account, Recipient, SystemOperation, UserData},
     ChainOwnership, ExecutionError, Message, Operation, SystemExecutionError, SystemMessage,
-    SystemQuery, SystemResponse,
+    SystemQuery, SystemResponse, TimeoutConfig,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -1613,6 +1613,7 @@ where
         super_owners: Vec::new(),
         owners: vec![(pub_key0, 100), (pub_key1, 100)],
         multi_leader_rounds: 0,
+        timeout_config: TimeoutConfig::default(),
     }
     .into();
     client.execute_operation(owner_change_op).await.unwrap();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -32,7 +32,7 @@ use linera_execution::{
     system::{Account, AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
     ChainOwnership, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
     ExecutionStateView, GenericApplicationId, Message, MessageKind, Query, Response,
-    SystemExecutionError, SystemExecutionState, SystemQuery, SystemResponse,
+    SystemExecutionError, SystemExecutionState, SystemQuery, SystemResponse, TimeoutConfig,
 };
 use linera_storage::{DbStorage, MemoryStorage, Storage, TestClock};
 use linera_views::{
@@ -3777,6 +3777,7 @@ where
         super_owners: Vec::new(),
         owners: vec![(pub_key0, 100), (pub_key1, 100)],
         multi_leader_rounds: 0,
+        timeout_config: TimeoutConfig::default(),
     });
     let (executed_block0, _) = worker.stage_block_execution(block0).await.unwrap();
     let value0 = HashedValue::new_confirmed(executed_block0);
@@ -4012,6 +4013,7 @@ where
         super_owners: vec![pub_key0],
         owners: vec![(pub_key0, 100), (pub_key1, 100)],
         multi_leader_rounds: 2,
+        timeout_config: TimeoutConfig::default(),
     });
     let (executed_block0, _) = worker.stage_block_execution(block0).await.unwrap();
     let value0 = HashedValue::new_confirmed(executed_block0);

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -22,7 +22,7 @@ pub use applications::{
     UserApplicationId,
 };
 pub use execution::ExecutionStateView;
-pub use ownership::ChainOwnership;
+pub use ownership::{ChainOwnership, TimeoutConfig};
 pub use resources::ResourceTracker;
 pub use system::{
     SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,

--- a/linera-execution/src/ownership.rs
+++ b/linera-execution/src/ownership.rs
@@ -3,7 +3,28 @@
 
 use linera_base::{crypto::PublicKey, data_types::Round, identifiers::Owner};
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, iter};
+use std::{collections::BTreeMap, iter, time::Duration};
+
+/// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
+#[derive(PartialEq, Eq, Clone, Hash, Debug, Serialize, Deserialize)]
+pub struct TimeoutConfig {
+    /// The duration of the fast round.
+    pub fast_round_duration: Duration,
+    /// The duration of the first single-leader and all multi-leader rounds.
+    pub base_timeout: Duration,
+    /// The number of microseconds by which the timeout increases after each single-leader round.
+    pub timeout_increment: Duration,
+}
+
+impl Default for TimeoutConfig {
+    fn default() -> Self {
+        Self {
+            fast_round_duration: Duration::MAX,
+            base_timeout: Duration::from_secs(10),
+            timeout_increment: Duration::from_secs(1),
+        }
+    }
+}
 
 /// Represents the owner(s) of a chain.
 #[derive(PartialEq, Eq, Clone, Hash, Debug, Default, Serialize, Deserialize)]
@@ -14,6 +35,8 @@ pub struct ChainOwnership {
     pub owners: BTreeMap<Owner, (PublicKey, u64)>,
     /// The number of initial rounds after 0 in which all owners are allowed to propose blocks.
     pub multi_leader_rounds: u32,
+    /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
+    pub timeout_config: TimeoutConfig,
 }
 
 impl ChainOwnership {
@@ -22,12 +45,14 @@ impl ChainOwnership {
             super_owners: iter::once((Owner::from(public_key), public_key)).collect(),
             owners: BTreeMap::new(),
             multi_leader_rounds: 2,
+            timeout_config: TimeoutConfig::default(),
         }
     }
 
     pub fn multiple(
         keys_and_weights: impl IntoIterator<Item = (PublicKey, u64)>,
         multi_leader_rounds: u32,
+        timeout_config: TimeoutConfig,
     ) -> Self {
         ChainOwnership {
             super_owners: BTreeMap::new(),
@@ -36,6 +61,7 @@ impl ChainOwnership {
                 .map(|(public_key, weight)| (Owner::from(public_key), (public_key, weight)))
                 .collect(),
             multi_leader_rounds,
+            timeout_config,
         }
     }
 
@@ -54,6 +80,21 @@ impl ChainOwnership {
             Some(*public_key)
         } else {
             self.owners.get(owner).map(|(public_key, _)| *public_key)
+        }
+    }
+
+    /// Returns the duration of the given round in milliseconds.
+    pub fn round_timeout_micros(&self, round: Round) -> Duration {
+        let tc = &self.timeout_config;
+        match round {
+            Round::Fast => tc.fast_round_duration,
+            Round::MultiLeader(r) if r.saturating_add(1) == self.multi_leader_rounds => {
+                tc.base_timeout
+            }
+            Round::MultiLeader(_) => Duration::MAX,
+            Round::SingleLeader(r) => tc
+                .base_timeout
+                .saturating_add(tc.timeout_increment.saturating_mul(r)),
         }
     }
 
@@ -109,5 +150,55 @@ impl ChainOwnership {
             }
         };
         Some(previous_round)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use linera_base::crypto::KeyPair;
+
+    #[test]
+    fn test_ownership_round_timeouts() {
+        let super_pub_key = KeyPair::generate().public();
+        let super_owner = Owner::from(super_pub_key);
+        let pub_key = KeyPair::generate().public();
+        let owner = Owner::from(pub_key);
+
+        let ownership = ChainOwnership {
+            super_owners: BTreeMap::from_iter([(super_owner, super_pub_key)]),
+            owners: BTreeMap::from_iter([(owner, (pub_key, 100))]),
+            multi_leader_rounds: 10,
+            timeout_config: TimeoutConfig {
+                fast_round_duration: Duration::from_secs(5),
+                base_timeout: Duration::from_secs(10),
+                timeout_increment: Duration::from_secs(1),
+            },
+        };
+
+        assert_eq!(
+            ownership.round_timeout_micros(Round::Fast),
+            Duration::from_secs(5)
+        );
+        assert_eq!(
+            ownership.round_timeout_micros(Round::MultiLeader(8)),
+            Duration::MAX
+        );
+        assert_eq!(
+            ownership.round_timeout_micros(Round::MultiLeader(9)),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            ownership.round_timeout_micros(Round::SingleLeader(0)),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            ownership.round_timeout_micros(Round::SingleLeader(1)),
+            Duration::from_secs(11)
+        );
+        assert_eq!(
+            ownership.round_timeout_micros(Round::SingleLeader(8)),
+            Duration::from_secs(18)
+        );
     }
 }

--- a/linera-execution/src/ownership.rs
+++ b/linera-execution/src/ownership.rs
@@ -83,8 +83,8 @@ impl ChainOwnership {
         }
     }
 
-    /// Returns the duration of the given round in milliseconds.
-    pub fn round_timeout_micros(&self, round: Round) -> Duration {
+    /// Returns the duration of the given round.
+    pub fn round_timeout(&self, round: Round) -> Duration {
         let tc = &self.timeout_config;
         match round {
             Round::Fast => tc.fast_round_duration,
@@ -176,28 +176,25 @@ mod tests {
             },
         };
 
+        assert_eq!(ownership.round_timeout(Round::Fast), Duration::from_secs(5));
         assert_eq!(
-            ownership.round_timeout_micros(Round::Fast),
-            Duration::from_secs(5)
-        );
-        assert_eq!(
-            ownership.round_timeout_micros(Round::MultiLeader(8)),
+            ownership.round_timeout(Round::MultiLeader(8)),
             Duration::MAX
         );
         assert_eq!(
-            ownership.round_timeout_micros(Round::MultiLeader(9)),
+            ownership.round_timeout(Round::MultiLeader(9)),
             Duration::from_secs(10)
         );
         assert_eq!(
-            ownership.round_timeout_micros(Round::SingleLeader(0)),
+            ownership.round_timeout(Round::SingleLeader(0)),
             Duration::from_secs(10)
         );
         assert_eq!(
-            ownership.round_timeout_micros(Round::SingleLeader(1)),
+            ownership.round_timeout(Round::SingleLeader(1)),
             Duration::from_secs(11)
         );
         assert_eq!(
-            ownership.round_timeout_micros(Round::SingleLeader(8)),
+            ownership.round_timeout(Round::SingleLeader(8)),
             Duration::from_secs(18)
         );
     }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     committee::{Committee, Epoch},
+    ownership::TimeoutConfig,
     ApplicationRegistryView, Bytecode, BytecodeLocation, ChainOwnership, ChannelName,
     ChannelSubscription, Destination, MessageContext, MessageKind, OperationContext, QueryContext,
     RawExecutionOutcome, RawOutgoingMessage, UserApplicationDescription, UserApplicationId,
@@ -128,6 +129,8 @@ pub enum SystemOperation {
         owners: Vec<(PublicKey, u64)>,
         /// The number of initial rounds after 0 in which all owners are allowed to propose blocks.
         multi_leader_rounds: u32,
+        /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
+        timeout_config: TimeoutConfig,
     },
     /// Subscribes to a system channel.
     Subscribe {
@@ -550,6 +553,7 @@ where
                 super_owners,
                 owners,
                 multi_leader_rounds,
+                timeout_config,
             } => {
                 self.ownership.set(ChainOwnership {
                     super_owners: super_owners
@@ -561,6 +565,7 @@ where
                         .map(|(public_key, weight)| (Owner::from(public_key), (public_key, weight)))
                         .collect(),
                     multi_leader_rounds,
+                    timeout_config,
                 });
             }
             CloseChain => {

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -256,6 +256,8 @@ ChainOwnership:
               - TYPENAME: PublicKey
               - U64
     - multi_leader_rounds: U32
+    - timeout_config:
+        TYPENAME: TimeoutConfig
 ChannelFullName:
   STRUCT:
     - application_id:
@@ -325,6 +327,10 @@ Destination:
       Subscribers:
         NEWTYPE:
           TYPENAME: ChannelName
+Duration:
+  STRUCT:
+    - secs: U64
+    - nanos: U32
 Epoch:
   NEWTYPESTRUCT: U32
 Event:
@@ -802,6 +808,8 @@ SystemOperation:
                   - TYPENAME: PublicKey
                   - U64
           - multi_leader_rounds: U32
+          - timeout_config:
+              TYPENAME: TimeoutConfig
     5:
       Subscribe:
         STRUCT:
@@ -844,6 +852,14 @@ SystemOperation:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation
+TimeoutConfig:
+  STRUCT:
+    - fast_round_duration:
+        TYPENAME: Duration
+    - base_timeout:
+        TYPENAME: Duration
+    - timeout_increment:
+        TYPENAME: Duration
 Timestamp:
   NEWTYPESTRUCT: U64
 UserApplicationDescription:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -461,7 +461,7 @@ type MutationRoot {
 	Creates (or activates) a new chain by installing the given authentication keys.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openMultiOwnerChain(chainId: ChainId!, publicKeys: [PublicKey!]!, weights: [Int!], multiLeaderRounds: Int, balance: Amount): ChainId!
+	openMultiOwnerChain(chainId: ChainId!, publicKeys: [PublicKey!]!, weights: [Int!], multiLeaderRounds: Int, balance: Amount, fastRoundMs: Int, baseTimeoutMs: Int! = 10000, timeoutIncrementMs: Int! = 1000): ChainId!
 	"""
 	Closes the chain.
 	"""
@@ -473,7 +473,7 @@ type MutationRoot {
 	"""
 	Changes the authentication key of the chain.
 	"""
-	changeMultipleOwners(chainId: ChainId!, newPublicKeys: [PublicKey!]!, newWeights: [Int!]!, multiLeaderRounds: Int!): CryptoHash!
+	changeMultipleOwners(chainId: ChainId!, newPublicKeys: [PublicKey!]!, newWeights: [Int!]!, multiLeaderRounds: Int!, fastRoundMs: Int, baseTimeoutMs: Int! = 10000, timeoutIncrementMs: Int! = 1000): CryptoHash!
 	"""
 	(admin chain only) Registers a new committee. This will notify the subscribers of
 	the admin chain so that they can migrate to the new epoch (by accepting the


### PR DESCRIPTION
## Motivation

The round timeouts are currently hard-coded, but different use cases may require different timeouts on different chains.

## Proposal

Make the timeouts configurable as part of the ownership config.

## Test Plan

A unit test for the round timeout computation was added.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
