### PR TITLE
Remove redundant write_certificates.

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -832,7 +832,6 @@ where
             return Ok(None);
         };
         // Process the received messages in certificates.
-        self.storage.write_certificates(&certificates).await?;
         for certificate in certificates {
             let hash = certificate.hash();
             match certificate.value.into_inner() {

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -129,6 +129,10 @@ impl LineraNetConfig for LocalNetConfig {
     type Net = LocalNet;
 
     async fn instantiate(self) -> Result<(Self::Net, ClientWrapper)> {
+        ensure!(
+            self.num_shards == 1 || self.database != Database::RocksDb,
+            "Multiple shards not supported with RocksDB"
+        );
         let mut net = LocalNet::new(
             self.database,
             self.network,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -436,6 +436,13 @@ async fn run(options: ServerOptions) {
             let server_config = ValidatorServerConfig::read(&server_config_path)
                 .expect("Fail to read server config");
 
+            #[cfg(feature = "rocksdb")]
+            if server_config.internal_network.shards.len() > 1
+                && matches!(storage_config, StorageConfig::RocksDb { .. })
+            {
+                panic!("Multiple shards not supported with RocksDB");
+            }
+
             let job = ServerContext {
                 server_config,
                 cross_chain_config,


### PR DESCRIPTION
## Motivation

The system will require that all workers have access to the same data. In that case, it is unnecessary for the recipient of a cross-chain message to store the certificates, because they were already stored by the sender.

## Proposal

Don't save certificates received in a cross-chain message.

## Test Plan

The tests still pass, because we already don't use RocksDB with multiple shards anymore, and the other databases are already shared between all shards.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
