### PR TITLE
Docker container has openssl and ca-certificates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,6 +104,11 @@ FROM builder$copy as binaries
 # Stage 4 - Setup running environment for container
 FROM debian:latest
 
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    openssl
+RUN update-ca-certificates
+
 ARG environment
 ARG target
 


### PR DESCRIPTION
## Motivation

The proxy needs to make calls to validators over TLS - therefore requiring CA certificates.

## Proposal

Add CA certificates to primary container.

## Test Plan

Checked implicitly in linera-infra.
