### PR TITLE
Split the KeyValueStore trait.

### DIFF
--- a/linera-sdk/src/contract/storage.rs
+++ b/linera-sdk/src/contract/storage.rs
@@ -14,7 +14,11 @@ use crate::{
 };
 use async_trait::async_trait;
 use futures::TryFutureExt;
-use linera_views::{batch::Batch, common::KeyValueStore, views::RootView};
+use linera_views::{
+    batch::Batch,
+    common::{ReadableKeyValueStore, WritableKeyValueStore},
+    views::RootView,
+};
 use serde::{de::DeserializeOwned, Serialize};
 use std::future::Future;
 

--- a/linera-sdk/src/service/storage.rs
+++ b/linera-sdk/src/service/storage.rs
@@ -13,7 +13,7 @@ use crate::{
     Service, SimpleStateStorage, ViewStateStorage,
 };
 use async_trait::async_trait;
-use linera_views::{common::KeyValueStore, views::RootView};
+use linera_views::{common::ReadableKeyValueStore, views::RootView};
 use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
 

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -43,7 +43,6 @@ impl AppStateStore {
 impl ReadableKeyValueStore<ViewError> for AppStateStore {
     // The AppStateStore of the system_api does not have limits
     // on the size of its values.
-    const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -103,6 +102,8 @@ impl ReadableKeyValueStore<ViewError> for AppStateStore {
 
 #[async_trait]
 impl WritableKeyValueStore<ViewError> for AppStateStore {
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+
     async fn write_batch(&self, batch: Batch, _base_key: &[u8]) -> Result<(), ViewError> {
         let mut operations = Vec::new();
         for operation in &batch.operations {

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -304,9 +304,6 @@ pub trait KeyValueIterable<Error> {
 /// Low-level, asynchronous read key-value operations. Useful for storage APIs not based on views.
 #[async_trait]
 pub trait ReadableKeyValueStore<E> {
-    /// The maximal size of values that can be stored.
-    const MAX_VALUE_SIZE: usize;
-
     /// The maximal size of keys that can be stored.
     const MAX_KEY_SIZE: usize;
 
@@ -361,6 +358,9 @@ pub trait ReadableKeyValueStore<E> {
 /// Low-level, asynchronous write key-value operations. Useful for storage APIs not based on views.
 #[async_trait]
 pub trait WritableKeyValueStore<E> {
+    /// The maximal size of values that can be stored.
+    const MAX_VALUE_SIZE: usize;
+
     /// Writes the `batch` in the database with `base_key` the base key of the entries for the journal.
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), E>;
 
@@ -369,7 +369,7 @@ pub trait WritableKeyValueStore<E> {
     async fn clear_journal(&self, base_key: &[u8]) -> Result<(), E>;
 }
 
-/// Low-level, asynchronous write key-value operations. Useful for storage APIs not based on views.
+/// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
 pub trait KeyValueStore:
     ReadableKeyValueStore<Self::Error> + WritableKeyValueStore<Self::Error>
 {

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -301,59 +301,43 @@ pub trait KeyValueIterable<Error> {
     fn into_iterator_owned(self) -> Self::IteratorOwned;
 }
 
-/// Low-level, asynchronous key-value operations. Useful for storage APIs not based on views.
+/// Low-level, asynchronous read key-value operations. Useful for storage APIs not based on views.
 #[async_trait]
-pub trait KeyValueStore {
+pub trait ReadableKeyValueStore<E> {
     /// The maximal size of values that can be stored.
     const MAX_VALUE_SIZE: usize;
 
     /// The maximal size of keys that can be stored.
     const MAX_KEY_SIZE: usize;
 
-    /// The error type.
-    type Error: Debug;
-
     /// Returns type for key search operations.
-    type Keys: KeyIterable<Self::Error>;
+    type Keys: KeyIterable<E>;
 
     /// Returns type for key-value search operations.
-    type KeyValues: KeyValueIterable<Self::Error>;
+    type KeyValues: KeyValueIterable<E>;
 
     /// Retrieve the number of stream queries.
     fn max_stream_queries(&self) -> usize;
 
     /// Retrieves a `Vec<u8>` from the database using the provided `key`.
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, E>;
 
     /// Test whether a key exists in the database
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error>;
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, E>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
-    async fn read_multi_values_bytes(
-        &self,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
+    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, E>;
 
     /// Finds the `key` matching the prefix. The prefix is not included in the returned keys.
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error>;
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, E>;
 
     /// Finds the `(key,value)` pairs matching the prefix. The prefix is not included in the returned keys.
-    async fn find_key_values_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::Error>;
-
-    /// Writes the `batch` in the database with `base_key` the base key of the entries for the journal.
-    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), Self::Error>;
-
-    /// Clears any journal entry that may remain.
-    /// The journal is located at the `base_key`.
-    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error>;
+    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, E>;
 
     /// Reads a single `key` and deserializes the result if present.
-    async fn read_value<V: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<V>, Self::Error>
+    async fn read_value<V: DeserializeOwned>(&self, key: &[u8]) -> Result<Option<V>, E>
     where
-        Self::Error: From<bcs::Error>,
+        E: From<bcs::Error>,
     {
         from_bytes_opt(&self.read_value_bytes(key).await?)
     }
@@ -362,9 +346,9 @@ pub trait KeyValueStore {
     async fn read_multi_values<V: DeserializeOwned + Send>(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<V>>, Self::Error>
+    ) -> Result<Vec<Option<V>>, E>
     where
-        Self::Error: From<bcs::Error>,
+        E: From<bcs::Error>,
     {
         let mut values = Vec::with_capacity(keys.len());
         for entry in self.read_multi_values_bytes(keys).await? {
@@ -372,6 +356,25 @@ pub trait KeyValueStore {
         }
         Ok(values)
     }
+}
+
+/// Low-level, asynchronous write key-value operations. Useful for storage APIs not based on views.
+#[async_trait]
+pub trait WritableKeyValueStore<E> {
+    /// Writes the `batch` in the database with `base_key` the base key of the entries for the journal.
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), E>;
+
+    /// Clears any journal entry that may remain.
+    /// The journal is located at the `base_key`.
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), E>;
+}
+
+/// Low-level, asynchronous write key-value operations. Useful for storage APIs not based on views.
+pub trait KeyValueStore:
+    ReadableKeyValueStore<Self::Error> + WritableKeyValueStore<Self::Error>
+{
+    /// The error type.
+    type Error: Debug;
 }
 
 #[doc(hidden)]

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -1124,7 +1124,6 @@ impl DynamoDbStoreInternal {
 
 #[async_trait]
 impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
-    const MAX_VALUE_SIZE: usize = VISIBLE_MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = DynamoDbKeys;
     type KeyValues = DynamoDbKeyValues;
@@ -1181,6 +1180,8 @@ impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
 
 #[async_trait]
 impl WritableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
+    const MAX_VALUE_SIZE: usize = VISIBLE_MAX_VALUE_SIZE;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), DynamoDbContextError> {
         let block_operations = DynamoDbBatch::from_batch(self, batch).await?;
         if block_operations.is_fastpath_feasible() {
@@ -1213,7 +1214,6 @@ pub struct DynamoDbStore {
 
 #[async_trait]
 impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
-    const MAX_VALUE_SIZE: usize = DynamoDbStoreInternal::MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE - 4;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -1254,6 +1254,8 @@ impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
 
 #[async_trait]
 impl WritableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
+    const MAX_VALUE_SIZE: usize = DynamoDbStoreInternal::MAX_VALUE_SIZE;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), DynamoDbContextError> {
         self.store.write_batch(batch, base_key).await
     }

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -976,7 +976,6 @@ where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,
 {
-    const MAX_VALUE_SIZE: usize = C::MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = C::MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -1023,6 +1022,8 @@ where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,
 {
+    const MAX_VALUE_SIZE: usize = C::MAX_VALUE_SIZE;
+
     async fn write_batch(&self, batch: Batch, _base_key: &[u8]) -> Result<(), ViewError> {
         let mut view = self.view.write().await;
         view.write_batch(batch).await?;

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -98,7 +98,6 @@ where
     K: KeyValueStore + Send + Sync,
 {
     // The LRU cache does not change the underlying client's size limits.
-    const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
     type Keys = K::Keys;
     type KeyValues = K::KeyValues;
@@ -194,6 +193,9 @@ impl<K> WritableKeyValueStore<K::Error> for LruCachingStore<K>
 where
     K: KeyValueStore + Send + Sync,
 {
+    // The LRU cache does not change the underlying client's size limits.
+    const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), K::Error> {
         match &self.lru_read_values {
             None => {

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -38,7 +38,6 @@ pub struct MemoryStore {
 
 #[async_trait]
 impl ReadableKeyValueStore<MemoryContextError> for MemoryStore {
-    const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -99,6 +98,8 @@ impl ReadableKeyValueStore<MemoryContextError> for MemoryStore {
 
 #[async_trait]
 impl WritableKeyValueStore<MemoryContextError> for MemoryStore {
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+
     async fn write_batch(&self, batch: Batch, _base_key: &[u8]) -> Result<(), MemoryContextError> {
         let mut map = self.map.write().await;
         for ent in batch.operations {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -55,7 +55,6 @@ pub struct RocksDbStoreConfig {
 
 #[async_trait]
 impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
-    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -162,6 +161,8 @@ impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
 
 #[async_trait]
 impl WritableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
+    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
+
     async fn write_batch(
         &self,
         mut batch: Batch,
@@ -365,7 +366,6 @@ pub type RocksDbContext<E> = ContextFromStore<E, RocksDbStore>;
 
 #[async_trait]
 impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStore {
-    const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -406,6 +406,8 @@ impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStore {
 
 #[async_trait]
 impl WritableKeyValueStore<RocksDbContextError> for RocksDbStore {
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), RocksDbContextError> {
         self.store.write_batch(batch, base_key).await
     }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -21,7 +21,8 @@ use crate::{lru_caching::TEST_CACHE_SIZE, test_utils::get_table_name};
 use crate::{
     batch::{Batch, DeletePrefixExpander},
     common::{
-        get_upper_bound_option, CommonStoreConfig, ContextFromStore, KeyValueStore, TableStatus,
+        get_upper_bound_option, CommonStoreConfig, ContextFromStore, KeyValueStore,
+        ReadableKeyValueStore, TableStatus, WritableKeyValueStore,
     },
     lru_caching::LruCachingStore,
     value_splitting::DatabaseConsistencyError,
@@ -117,10 +118,9 @@ impl From<ScyllaDbContextError> for crate::views::ViewError {
 }
 
 #[async_trait]
-impl KeyValueStore for ScyllaDbStoreInternal {
+impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
-    type Error = ScyllaDbContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -128,13 +128,13 @@ impl KeyValueStore for ScyllaDbStoreInternal {
         self.max_stream_queries
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ScyllaDbContextError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         Self::read_value_internal(store, key.to_vec()).await
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, ScyllaDbContextError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         Self::contains_key_internal(store, key.to_vec()).await
@@ -143,7 +143,7 @@ impl KeyValueStore for ScyllaDbStoreInternal {
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+    ) -> Result<Vec<Option<Vec<u8>>>, ScyllaDbContextError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         let handles = keys
@@ -153,7 +153,10 @@ impl KeyValueStore for ScyllaDbStoreInternal {
         Ok(result.into_iter().collect::<Result<_, _>>()?)
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+    async fn find_keys_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::Keys, ScyllaDbContextError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         Self::find_keys_by_prefix_internal(store, key_prefix.to_vec()).await
@@ -162,21 +165,32 @@ impl KeyValueStore for ScyllaDbStoreInternal {
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::Error> {
+    ) -> Result<Self::KeyValues, ScyllaDbContextError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         Self::find_key_values_by_prefix_internal(store, key_prefix.to_vec()).await
     }
+}
 
-    async fn write_batch(&self, batch: Batch, _base_key: &[u8]) -> Result<(), Self::Error> {
+#[async_trait]
+impl WritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
+    async fn write_batch(
+        &self,
+        batch: Batch,
+        _base_key: &[u8],
+    ) -> Result<(), ScyllaDbContextError> {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         Self::write_batch_internal(store, batch).await
     }
 
-    async fn clear_journal(&self, _base_key: &[u8]) -> Result<(), Self::Error> {
+    async fn clear_journal(&self, _base_key: &[u8]) -> Result<(), ScyllaDbContextError> {
         Ok(())
     }
+}
+
+impl KeyValueStore for ScyllaDbStoreInternal {
+    type Error = ScyllaDbContextError;
 }
 
 #[async_trait]
@@ -670,50 +684,60 @@ pub struct ScyllaDbStoreConfig {
 }
 
 #[async_trait]
-impl KeyValueStore for ScyllaDbStore {
+impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
     const MAX_VALUE_SIZE: usize = ScyllaDbStoreInternal::MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = ScyllaDbStoreInternal::MAX_KEY_SIZE;
-    type Error = <ScyllaDbStoreInternal as KeyValueStore>::Error;
-    type Keys = <ScyllaDbStoreInternal as KeyValueStore>::Keys;
-    type KeyValues = <ScyllaDbStoreInternal as KeyValueStore>::KeyValues;
+    type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore<ScyllaDbContextError>>::Keys;
+    type KeyValues =
+        <ScyllaDbStoreInternal as ReadableKeyValueStore<ScyllaDbContextError>>::KeyValues;
 
     fn max_stream_queries(&self) -> usize {
         self.store.max_stream_queries()
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ScyllaDbContextError> {
         self.store.read_value_bytes(key).await
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, ScyllaDbContextError> {
         self.store.contains_key(key).await
     }
 
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+    ) -> Result<Vec<Option<Vec<u8>>>, ScyllaDbContextError> {
         self.store.read_multi_values_bytes(keys).await
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+    async fn find_keys_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::Keys, ScyllaDbContextError> {
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::Error> {
+    ) -> Result<Self::KeyValues, ScyllaDbContextError> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
+}
 
-    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), Self::Error> {
+#[async_trait]
+impl WritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), ScyllaDbContextError> {
         self.store.write_batch(batch, base_key).await
     }
 
-    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), ScyllaDbContextError> {
         self.store.clear_journal(base_key).await
     }
+}
+
+impl KeyValueStore for ScyllaDbStore {
+    type Error = ScyllaDbContextError;
 }
 
 impl ScyllaDbStore {

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -119,7 +119,6 @@ impl From<ScyllaDbContextError> for crate::views::ViewError {
 
 #[async_trait]
 impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
-    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -174,6 +173,8 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
 
 #[async_trait]
 impl WritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
+    const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
+
     async fn write_batch(
         &self,
         batch: Batch,
@@ -685,7 +686,6 @@ pub struct ScyllaDbStoreConfig {
 
 #[async_trait]
 impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
-    const MAX_VALUE_SIZE: usize = ScyllaDbStoreInternal::MAX_VALUE_SIZE;
     const MAX_KEY_SIZE: usize = ScyllaDbStoreInternal::MAX_KEY_SIZE;
     type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore<ScyllaDbContextError>>::Keys;
     type KeyValues =
@@ -727,6 +727,8 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
 
 #[async_trait]
 impl WritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
+    const MAX_VALUE_SIZE: usize = ScyllaDbStoreInternal::MAX_VALUE_SIZE;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), ScyllaDbContextError> {
         self.store.write_batch(batch, base_key).await
     }

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{ContextFromStore, KeyIterable, KeyValueIterable, KeyValueStore},
+    common::{
+        ContextFromStore, KeyIterable, KeyValueIterable, KeyValueStore, ReadableKeyValueStore,
+        WritableKeyValueStore,
+    },
     memory::{MemoryContextError, MemoryStore, MemoryStoreMap, TEST_MEMORY_MAX_STREAM_QUERIES},
 };
 use async_lock::{Mutex, MutexGuardArc};
@@ -41,14 +44,13 @@ pub struct ValueSplittingStore<K> {
 }
 
 #[async_trait]
-impl<K> KeyValueStore for ValueSplittingStore<K>
+impl<K> ReadableKeyValueStore<K::Error> for ValueSplittingStore<K>
 where
     K: KeyValueStore + Send + Sync,
     K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
 {
     const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE - 4;
-    type Error = K::Error;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -56,7 +58,7 @@ where
         self.store.max_stream_queries()
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, K::Error> {
         let mut big_key = key.to_vec();
         big_key.extend(&[0, 0, 0, 0]);
         let value = self.store.read_value_bytes(&big_key).await?;
@@ -87,7 +89,7 @@ where
         Ok(Some(big_value))
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, K::Error> {
         let mut big_key = key.to_vec();
         big_key.extend(&[0, 0, 0, 0]);
         self.store.contains_key(&big_key).await
@@ -96,7 +98,7 @@ where
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+    ) -> Result<Vec<Option<Vec<u8>>>, K::Error> {
         let mut big_keys = Vec::new();
         for key in &keys {
             let mut big_key = key.clone();
@@ -146,7 +148,7 @@ where
         Ok(big_values)
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, K::Error> {
         let mut keys = Vec::new();
         for big_key in self.store.find_keys_by_prefix(key_prefix).await?.iterator() {
             let big_key = big_key?;
@@ -162,7 +164,7 @@ where
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::Error> {
+    ) -> Result<Self::KeyValues, K::Error> {
         let small_key_values = self.store.find_key_values_by_prefix(key_prefix).await?;
         let mut small_kv_iterator = small_key_values.into_iterator_owned();
         let mut key_values = Vec::new();
@@ -191,8 +193,15 @@ where
         }
         Ok(key_values)
     }
+}
 
-    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), Self::Error> {
+#[async_trait]
+impl<K> WritableKeyValueStore<K::Error> for ValueSplittingStore<K>
+where
+    K: KeyValueStore + Send + Sync,
+    K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
+{
+    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), K::Error> {
         let mut batch_new = Batch::new();
         for operation in batch.operations {
             match operation {
@@ -225,9 +234,17 @@ where
         self.store.write_batch(batch_new, base_key).await
     }
 
-    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), K::Error> {
         self.store.clear_journal(base_key).await
     }
+}
+
+impl<K> KeyValueStore for ValueSplittingStore<K>
+where
+    K: KeyValueStore + Send + Sync,
+    K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
+{
+    type Error = K::Error;
 }
 
 impl<K> ValueSplittingStore<K>
@@ -284,12 +301,11 @@ pub struct TestMemoryStoreInternal {
 }
 
 #[async_trait]
-impl KeyValueStore for TestMemoryStoreInternal {
+impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
     // We set up the MAX_VALUE_SIZE to the artificially low value of 100
     // purely for testing purposes.
     const MAX_VALUE_SIZE: usize = 100;
     const MAX_KEY_SIZE: usize = usize::MAX;
-    type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -325,7 +341,10 @@ impl KeyValueStore for TestMemoryStoreInternal {
     ) -> Result<Self::KeyValues, MemoryContextError> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
+}
 
+#[async_trait]
+impl WritableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
         ensure!(
             batch.check_value_size(Self::MAX_VALUE_SIZE),
@@ -334,9 +353,13 @@ impl KeyValueStore for TestMemoryStoreInternal {
         self.store.write_batch(batch, base_key).await
     }
 
-    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), MemoryContextError> {
         self.store.clear_journal(base_key).await
     }
+}
+
+impl KeyValueStore for TestMemoryStoreInternal {
+    type Error = MemoryContextError;
 }
 
 impl TestMemoryStoreInternal {
@@ -354,10 +377,9 @@ pub struct TestMemoryStore {
 }
 
 #[async_trait]
-impl KeyValueStore for TestMemoryStore {
+impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStore {
     const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = usize::MAX;
-    type Error = MemoryContextError;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
@@ -393,14 +415,21 @@ impl KeyValueStore for TestMemoryStore {
     ) -> Result<Self::KeyValues, MemoryContextError> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
+}
 
+#[async_trait]
+impl WritableKeyValueStore<MemoryContextError> for TestMemoryStore {
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
         self.store.write_batch(batch, base_key).await
     }
 
-    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), Self::Error> {
+    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), MemoryContextError> {
         self.store.clear_journal(base_key).await
     }
+}
+
+impl KeyValueStore for TestMemoryStore {
+    type Error = MemoryContextError;
 }
 
 impl TestMemoryStore {
@@ -486,7 +515,7 @@ pub fn create_test_memory_context_internal() -> TestMemoryContextInternal<()> {
 mod tests {
     use linera_views::{
         batch::Batch,
-        common::KeyValueStore,
+        common::{ReadableKeyValueStore, WritableKeyValueStore},
         value_splitting::{
             create_test_memory_store_internal, TestMemoryStoreInternal, ValueSplittingStore,
         },

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -49,7 +49,6 @@ where
     K: KeyValueStore + Send + Sync,
     K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
 {
-    const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE - 4;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -201,6 +200,8 @@ where
     K: KeyValueStore + Send + Sync,
     K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
 {
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), K::Error> {
         let mut batch_new = Batch::new();
         for operation in batch.operations {
@@ -302,9 +303,6 @@ pub struct TestMemoryStoreInternal {
 
 #[async_trait]
 impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
-    // We set up the MAX_VALUE_SIZE to the artificially low value of 100
-    // purely for testing purposes.
-    const MAX_VALUE_SIZE: usize = 100;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -345,6 +343,10 @@ impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
 
 #[async_trait]
 impl WritableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
+    // We set up the MAX_VALUE_SIZE to the artificially low value of 100
+    // purely for testing purposes.
+    const MAX_VALUE_SIZE: usize = 100;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
         ensure!(
             batch.check_value_size(Self::MAX_VALUE_SIZE),
@@ -378,7 +380,6 @@ pub struct TestMemoryStore {
 
 #[async_trait]
 impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStore {
-    const MAX_VALUE_SIZE: usize = usize::MAX;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -419,6 +420,8 @@ impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStore {
 
 #[async_trait]
 impl WritableKeyValueStore<MemoryContextError> for TestMemoryStore {
+    const MAX_VALUE_SIZE: usize = usize::MAX;
+
     async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryContextError> {
         self.store.write_batch(batch, base_key).await
     }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -3,7 +3,9 @@
 
 use linera_views::{
     batch::{Batch, WriteOperation},
-    common::{KeyIterable, KeyValueIterable, KeyValueStore},
+    common::{
+        KeyIterable, KeyValueIterable, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+    },
     key_value_store_view::ViewContainer,
     memory::{create_memory_context, create_memory_store},
     test_utils::{


### PR DESCRIPTION
## Motivation

The `KeyValueStore` trait is quite complex so it makes sense to split it.

## Proposal

We separate the write and read part of the functions.

## Test Plan

The CI does the job of it.

## Release Plan

No change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
