### PR TITLE
A fast block proposal must be treated as locked.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -245,6 +245,14 @@ impl ChainManager {
                 // We already accepted a proposal in this round or in a higher round.
                 return Err(ChainError::InsufficientRound(old_proposal.content.round));
             }
+            // Any proposal in the fast round is considered locked, because validators vote to
+            // confirm it immediately.
+            if old_proposal.content.round.is_fast() && validated.is_none() {
+                ensure!(
+                    old_proposal.content.block == *new_block,
+                    ChainError::HasLockedBlock(new_block.height, Round::Fast)
+                )
+            }
         }
         // If we have a locked block, it must either match the proposal, or the proposal must
         // include a higher certificate that validates the proposed block.

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1476,17 +1476,15 @@ where
                 }
             }
             if can_propose {
-                // If there is a locked block, we have to propose that one, because validators are
-                // not allowed to sign anything else.
-                if let Some(block) = manager
+                let locked_block = manager
                     .highest_validated()
                     .and_then(|certificate| certificate.value().block())
                     .or(manager
                         .requested_proposed
                         .as_ref()
                         .filter(|proposal| proposal.content.round.is_fast())
-                        .map(|proposal| &proposal.content.block))
-                {
+                        .map(|proposal| &proposal.content.block));
+                if let Some(block) = locked_block {
                     return match self.propose_block(block.clone()).await {
                         Ok(certificate) => Ok(ExecuteBlockOutcome::Conflict(certificate)),
                         Err(error @ ChainClientError::CommunicationError(_))


### PR DESCRIPTION
## Motivation

If a validator signed to confirm a fast block, that must be treated as a locked block for the protocol to be safe.

## Proposal

Add the corresponding check to the chain manager and to the chain client.

## Test Plan

The new worker test fails without the fix.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/1479.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
