### PR TITLE
Make timeouts optional. Don't return Timestamp::MAX as a timeout.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1627,7 +1627,7 @@ where
         ))
     ));
 
-    clock.set(manager.round_timeout);
+    clock.set(manager.round_timeout.unwrap());
 
     // After the timeout they will.
     let certificate = client.request_leader_timeout().await.unwrap();
@@ -1651,7 +1651,7 @@ where
         if manager.leader == Some(Owner::from(pub_key1)) {
             break manager.current_round;
         }
-        clock.set(manager.round_timeout);
+        clock.set(manager.round_timeout.unwrap());
         assert!(client.request_leader_timeout().await.is_ok());
     };
     let round_number = match round {
@@ -1686,7 +1686,7 @@ where
         if manager.leader == Some(Owner::from(pub_key0)) {
             break;
         }
-        clock.set(manager.round_timeout);
+        clock.set(manager.round_timeout.unwrap());
         assert!(client.request_leader_timeout().await.is_ok());
     }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3808,7 +3808,7 @@ where
     assert!(response.info.manager.timeout_vote.is_none());
 
     // Set the clock to the end of the round.
-    clock.set(response.info.manager.round_timeout);
+    clock.set(response.info.manager.round_timeout.unwrap());
 
     // Now the validator will sign a leader timeout vote.
     let query = ChainInfoQuery::new(chain_id).with_leader_timeout();
@@ -4014,7 +4014,7 @@ where
         owners: vec![(pub_key0, 100), (pub_key1, 100)],
         multi_leader_rounds: 2,
         timeout_config: TimeoutConfig {
-            fast_round_duration: Duration::from_millis(5),
+            fast_round_duration: Some(Duration::from_secs(5)),
             ..TimeoutConfig::default()
         },
     });
@@ -4048,7 +4048,7 @@ where
     assert!(response.info.manager.timeout_vote.is_none());
 
     // Set the clock to the end of the round.
-    clock.set(response.info.manager.round_timeout);
+    clock.set(response.info.manager.round_timeout.unwrap());
 
     // Now the validator will sign a leader timeout vote.
     let query = ChainInfoQuery::new(chain_id).with_leader_timeout();
@@ -4136,7 +4136,7 @@ where
         owners: vec![(pub_key0, 100), (pub_key1, 100)],
         multi_leader_rounds: 2,
         timeout_config: TimeoutConfig {
-            fast_round_duration: Duration::from_millis(5),
+            fast_round_duration: Some(Duration::from_millis(5)),
             ..TimeoutConfig::default()
         },
     });
@@ -4165,7 +4165,7 @@ where
     assert_eq!(vote.value.value_hash, value1.hash());
 
     // Set the clock to the end of the round.
-    clock.set(response.info.manager.round_timeout);
+    clock.set(response.info.manager.round_timeout.unwrap());
 
     // Once we provide the validator with a timeout certificate, the next round starts.
     let value_timeout =

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -238,7 +238,8 @@ ChainManagerInfo:
         OPTION:
           TYPENAME: Owner
     - round_timeout:
-        TYPENAME: Timestamp
+        OPTION:
+          TYPENAME: Timestamp
 ChainOwnership:
   STRUCT:
     - super_owners:
@@ -855,7 +856,8 @@ SystemOperation:
 TimeoutConfig:
   STRUCT:
     - fast_round_duration:
-        TYPENAME: Duration
+        OPTION:
+          TYPENAME: Duration
     - base_timeout:
         TYPENAME: Duration
     - timeout_increment:

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -1493,7 +1493,7 @@ impl Runnable for Job {
                 };
                 let multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
                 let timeout_config = TimeoutConfig {
-                    fast_round_duration: fast_round_duration.unwrap_or(Duration::MAX),
+                    fast_round_duration,
                     base_timeout,
                     timeout_increment,
                 };

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -430,7 +430,7 @@ where
         };
         let multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
         let timeout_config = TimeoutConfig {
-            fast_round_duration: fast_round_ms.map_or(Duration::MAX, Duration::from_millis),
+            fast_round_duration: fast_round_ms.map(Duration::from_millis),
             base_timeout: Duration::from_millis(base_timeout_ms),
             timeout_increment: Duration::from_millis(timeout_increment_ms),
         };
@@ -505,7 +505,7 @@ where
             owners: new_public_keys.into_iter().zip(new_weights).collect(),
             multi_leader_rounds,
             timeout_config: TimeoutConfig {
-                fast_round_duration: fast_round_ms.map_or(Duration::MAX, Duration::from_millis),
+                fast_round_duration: fast_round_ms.map(Duration::from_millis),
                 base_timeout: Duration::from_millis(base_timeout_ms),
                 timeout_increment: Duration::from_millis(timeout_increment_ms),
             },


### PR DESCRIPTION
## Motivation

`WaitForTimeout` should only be returned with a realistic timeout. We have been using `Duration::MAX` for rounds that don't time out, which is confusing.

## Proposal

Make timeouts `Option`s.

## Test Plan

The tests have been updated.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
