### PR TITLE
Code style improvements after #1419

### DIFF
--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -398,9 +398,6 @@ pub trait SimplifiedBatch: Sized + Send + Sync {
         value_size: &mut usize,
     ) -> Result<bool, bcs::Error>;
 
-    /// Returns the serialization and clears the simplified batch
-    fn to_bytes(&mut self) -> Result<Vec<u8>, bcs::Error>;
-
     /// Adds an individual delete operation
     fn add_delete(&mut self, key: Vec<u8>);
 
@@ -486,13 +483,6 @@ impl SimplifiedBatch for SimpleUnorderedBatch {
         } else {
             Ok(false)
         }
-    }
-
-    fn to_bytes(&mut self) -> Result<Vec<u8>, bcs::Error> {
-        let value = bcs::to_bytes(&self)?;
-        self.deletions.clear();
-        self.insertions.clear();
-        Ok(value)
     }
 
     fn add_delete(&mut self, key: Vec<u8>) {
@@ -591,14 +581,6 @@ impl SimplifiedBatch for UnorderedBatch {
             self.simple_unordered_batch
                 .try_append(&mut iter.insert_deletion_iter, value_size)
         }
-    }
-
-    fn to_bytes(&mut self) -> Result<Vec<u8>, bcs::Error> {
-        let value = bcs::to_bytes(&self)?;
-        self.key_prefix_deletions.clear();
-        self.simple_unordered_batch.deletions.clear();
-        self.simple_unordered_batch.insertions.clear();
-        Ok(value)
     }
 
     fn add_delete(&mut self, key: Vec<u8>) {

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -386,7 +386,7 @@ pub trait SimplifiedBatch: Sized + Send + Sync {
     fn len(&self) -> usize;
 
     /// Returns the total number of bytes of the simplified batch
-    fn bytes(&self) -> usize;
+    fn num_bytes(&self) -> usize;
 
     /// Returns the overhead size of the simplified batch
     fn overhead_size(&self) -> usize;
@@ -455,7 +455,7 @@ impl SimplifiedBatch for SimpleUnorderedBatch {
         self.deletions.len() + self.insertions.len()
     }
 
-    fn bytes(&self) -> usize {
+    fn num_bytes(&self) -> usize {
         let mut total_size = 0;
         for (key, value) in &self.insertions {
             total_size += key.len() + value.len();
@@ -565,8 +565,8 @@ impl SimplifiedBatch for UnorderedBatch {
         self.key_prefix_deletions.len() + self.simple_unordered_batch.len()
     }
 
-    fn bytes(&self) -> usize {
-        let mut total_size = self.simple_unordered_batch.bytes();
+    fn num_bytes(&self) -> usize {
+        let mut total_size = self.simple_unordered_batch.num_bytes();
         for prefix_deletion in &self.key_prefix_deletions {
             total_size += prefix_deletion.len();
         }

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -914,14 +914,11 @@ impl DirectWritableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal
     const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_SIZE;
     const MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE;
     const MAX_VALUE_SIZE: usize = VISIBLE_MAX_VALUE_SIZE;
-    // The DynamoDB does not support the `DeletePrefix` operation.
-    // Therefore it does not make sense to have a delete prefix and they have to
-    // be downloaded for making a list.
-    // Also we remove the deletes that are followed by inserts on the same key because
-    // the TransactWriteItem and BatchWriteItem are not going to work that way.
+
+    // DynamoDB does not support the `DeletePrefix` operation.
     type Batch = SimpleUnorderedBatch;
 
-    async fn write_simplified_batch(&self, batch: Self::Batch) -> Result<(), DynamoDbContextError> {
+    async fn write_batch(&self, batch: Self::Batch) -> Result<(), DynamoDbContextError> {
         let mut builder = TransactionBuilder::default();
         for key in batch.deletions {
             builder.insert_delete_request(key, self)?;

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -911,8 +911,8 @@ impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
 
 #[async_trait]
 impl DirectWritableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
-    const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_SIZE;
-    const MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE;
+    const MAX_BATCH_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_SIZE;
+    const MAX_BATCH_TOTAL_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE;
     const MAX_VALUE_SIZE: usize = VISIBLE_MAX_VALUE_SIZE;
 
     // DynamoDB does not support the `DeletePrefix` operation.

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -919,17 +919,17 @@ impl DirectWritableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal
     // be downloaded for making a list.
     // Also we remove the deletes that are followed by inserts on the same key because
     // the TransactWriteItem and BatchWriteItem are not going to work that way.
-    type SimpBatch = SimpleUnorderedBatch;
+    type Batch = SimpleUnorderedBatch;
 
     async fn write_simplified_batch(
         &self,
-        simp_batch: &mut Self::SimpBatch,
+        batch: &mut Self::Batch,
     ) -> Result<(), DynamoDbContextError> {
         let mut tb = TransactionBuilder::default();
-        for key in mem::take(&mut simp_batch.deletions) {
+        for key in mem::take(&mut batch.deletions) {
             tb.insert_delete_request(key, self)?;
         }
-        for (key, value) in mem::take(&mut simp_batch.insertions) {
+        for (key, value) in mem::take(&mut batch.insertions) {
             tb.insert_put_request(key, value, self)?;
         }
         if !tb.transacts.is_empty() {

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -925,18 +925,18 @@ impl DirectWritableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal
         &self,
         batch: &mut Self::Batch,
     ) -> Result<(), DynamoDbContextError> {
-        let mut tb = TransactionBuilder::default();
+        let mut builder = TransactionBuilder::default();
         for key in mem::take(&mut batch.deletions) {
-            tb.insert_delete_request(key, self)?;
+            builder.insert_delete_request(key, self)?;
         }
         for (key, value) in mem::take(&mut batch.insertions) {
-            tb.insert_put_request(key, value, self)?;
+            builder.insert_put_request(key, value, self)?;
         }
-        if !tb.transacts.is_empty() {
+        if !builder.transacts.is_empty() {
             let _guard = self.acquire().await;
             self.client
                 .transact_write_items()
-                .set_transact_items(Some(tb.transacts))
+                .set_transact_items(Some(builder.transacts))
                 .send()
                 .await?;
         }

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -7,11 +7,11 @@ use crate::{
         CommonStoreConfig, ContextFromStore, KeyIterable, KeyValueIterable, KeyValueStore,
         ReadableKeyValueStore, TableStatus, WritableKeyValueStore,
     },
-    lru_caching::LruCachingStore,
-    simple_store::{
+    journaling::{
         DirectKeyValueStore, DirectWritableKeyValueStore, JournalConsistencyError,
         JournalingKeyValueStore,
     },
+    lru_caching::LruCachingStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
 };
 use async_lock::{Semaphore, SemaphoreGuard};

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -265,7 +265,8 @@ where
             };
             if value_flush {
                 value_size += batch.overhead_size();
-                let value = batch.to_bytes()?;
+                let value = bcs::to_bytes(&batch)?;
+                batch = K::Batch::default();
                 assert_eq!(value.len(), value_size);
                 let key = get_journaling_key(base_key, KeyTag::Entry as u8, block_count)?;
                 transacts.add_insert(key, value);

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -300,7 +300,7 @@ where
         if batch.len() > K::MAX_TRANSACT_WRITE_ITEM_SIZE {
             return false;
         }
-        batch.bytes() <= K::MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE
+        batch.num_bytes() <= K::MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE
     }
 }
 

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -59,8 +59,8 @@ pub mod batch;
 /// The definitions used for the `KeyValueStore` and `Context`.
 pub mod common;
 
-/// The definitions used for the `DirectKeyValueStore` and the `SimplifiedKeyValueStore`
-pub mod simple_store;
+/// The code to turn a `DirectKeyValueStore` into a `KeyValueStore` by adding journaling.
+pub mod journaling;
 
 /// The code for handling big values by splitting them into several small ones.
 pub mod value_splitting;

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -238,7 +238,7 @@ impl<K> LruCachingStore<K>
 where
     K: KeyValueStore,
 {
-    /// Creates a new key-value store that implements an LRU cache.
+    /// Creates a new key-value store that provides LRU caching at top of the given store.
     pub fn new(store: K, max_size: usize) -> Self {
         if max_size == 0 {
             Self {

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -24,11 +24,11 @@ use crate::{
         get_upper_bound_option, CommonStoreConfig, ContextFromStore, KeyValueStore,
         ReadableKeyValueStore, TableStatus, WritableKeyValueStore,
     },
-    lru_caching::LruCachingStore,
-    simple_store::{
+    journaling::{
         DirectKeyValueStore, DirectWritableKeyValueStore, JournalConsistencyError,
         JournalingKeyValueStore,
     },
+    lru_caching::LruCachingStore,
     value_splitting::DatabaseConsistencyError,
 };
 use async_lock::{Semaphore, SemaphoreGuard};

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -186,7 +186,7 @@ impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal
     const MAX_BATCH_TOTAL_SIZE: usize = 16000000;
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
 
-    // ScyllaDb cannot take a `crate::batch::Batch` directly. Indeed, if a delete is
+    // ScyllaDB cannot take a `crate::batch::Batch` directly. Indeed, if a delete is
     // followed by a write, then the delete takes priority. See the sentence "The first
     // tie-breaking rule when two cells have the same write timestamp is that dead cells
     // win over live cells" from
@@ -207,6 +207,7 @@ impl DirectKeyValueStore for ScyllaDbStoreInternal {
 #[async_trait]
 impl DeletePrefixExpander for ScyllaDbStorePair {
     type Error = ScyllaDbContextError;
+
     async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
         ScyllaDbStoreInternal::find_keys_by_prefix_internal(self, key_prefix.to_vec()).await
     }
@@ -675,7 +676,7 @@ pub struct ScyllaDbStore {
     store: LruCachingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>,
 }
 
-/// The type for building a new ScyllaDb Key Value Store
+/// The type for building a new ScyllaDB Key Value Store
 #[derive(Debug)]
 pub struct ScyllaDbStoreConfig {
     /// The url to which the requests have to be sent
@@ -689,7 +690,9 @@ pub struct ScyllaDbStoreConfig {
 #[async_trait]
 impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
     const MAX_KEY_SIZE: usize = ScyllaDbStoreInternal::MAX_KEY_SIZE;
+
     type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore<ScyllaDbContextError>>::Keys;
+
     type KeyValues =
         <ScyllaDbStoreInternal as ReadableKeyValueStore<ScyllaDbContextError>>::KeyValues;
 
@@ -745,7 +748,7 @@ impl KeyValueStore for ScyllaDbStore {
 }
 
 impl ScyllaDbStore {
-    /// Gets the table name of the ScyllaDb store
+    /// Gets the table name of the ScyllaDB store.
     pub async fn get_table_name(&self) -> String {
         self.store.store.store.get_table_name().await
     }
@@ -815,7 +818,7 @@ impl ScyllaDbStore {
     }
 }
 
-/// Creates the common initialization for RocksDB
+/// Creates the common initialization for RocksDB.
 #[cfg(any(test, feature = "test"))]
 pub fn create_scylla_db_common_config() -> CommonStoreConfig {
     CommonStoreConfig {
@@ -825,7 +828,7 @@ pub fn create_scylla_db_common_config() -> CommonStoreConfig {
     }
 }
 
-/// Creates a ScyllaDB test store
+/// Creates a ScyllaDB test store.
 #[cfg(any(test, feature = "test"))]
 pub async fn create_scylla_db_test_store() -> ScyllaDbStore {
     let uri = "localhost:9042".to_string();

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -743,9 +743,9 @@ impl KeyValueStore for ScyllaDbStore {
 }
 
 impl ScyllaDbStore {
-    /// Gets the table name of a store
+    /// Gets the table name of the ScyllaDb store
     pub async fn get_table_name(&self) -> String {
-        self.store.client.client.get_table_name().await
+        self.store.store.store.get_table_name().await
     }
 
     /// Creates a [`ScyllaDbStore`] from the input parameters.

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -181,9 +181,9 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
 
 #[async_trait]
 impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
-    const MAX_TRANSACT_WRITE_ITEM_SIZE: usize = usize::MAX;
+    const MAX_BATCH_SIZE: usize = usize::MAX;
     /// The total size is 16M
-    const MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE: usize = 16000000;
+    const MAX_BATCH_TOTAL_SIZE: usize = 16000000;
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
 
     // ScyllaDb cannot take a `crate::batch::Batch` directly. Indeed, if a delete is


### PR DESCRIPTION
## Motivation

While reviewing #1419 in depth, I thought I would try to make the code nicer to help me understand it.

## Proposal

* Generally try to keep names short and trust the type system of Rust.
* Make some comments shorter (or more neural)
* Rename SimplifiedBatchIter into BatchValueWriter and move two methods around.
* Rename the module `simple_store` into `journaling` (the thing we care about!)

There should be no changes in the algorithms at all.

## Test Plan

CI