### PR TITLE
Test and fix re-proposing a validated block.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -330,6 +330,9 @@ impl ChainManager {
         // even if it is older than the current round. Validators will only sign in the current
         // round, though. (See `create_final_vote` below.)
         if let Some(locked) = &self.locked {
+            if locked.hash() == certificate.hash() {
+                return Ok(Outcome::Skip);
+            }
             ensure!(
                 new_round > locked.round,
                 ChainError::InsufficientRound(locked.round)

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -748,10 +748,11 @@ where
                 "A different operation was executed in parallel (consider retrying the operation)"
             )
         );
-        // Since `handle_block_proposal` succeeded, we have the needed bytecode.
-        // Leaving blobs empty.
-        self.process_certificate(certificate.clone(), vec![])
-            .await?;
+        self.receive_certificate_internal(
+            certificate.clone(),
+            ReceiveCertificateMode::AlreadyChecked,
+        )
+        .await?;
         Ok(certificate)
     }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -467,8 +467,19 @@ where
                 return Ok(());
             }
         };
-        self.try_process_certificates(name, &mut node, chain_id, info.requested_sent_certificates)
-            .await;
+        if !info.requested_sent_certificates.is_empty()
+            && self
+                .try_process_certificates(
+                    name,
+                    &mut node,
+                    chain_id,
+                    info.requested_sent_certificates,
+                )
+                .await
+                .is_none()
+        {
+            return Ok(());
+        };
         if let Some(proposal) = info.manager.requested_proposed {
             if proposal.content.block.chain_id == chain_id {
                 let owner = proposal.owner;

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -467,13 +467,8 @@ where
                 return Ok(());
             }
         };
-        if self
-            .try_process_certificates(name, &mut node, chain_id, info.requested_sent_certificates)
-            .await
-            .is_none()
-        {
-            return Ok(());
-        };
+        self.try_process_certificates(name, &mut node, chain_id, info.requested_sent_certificates)
+            .await;
         if let Some(proposal) = info.manager.requested_proposed {
             if proposal.content.block.chain_id == chain_id {
                 let owner = proposal.owner;


### PR DESCRIPTION
## Motivation

If there is a validated block certificate in a past round on a multi-owner chain, any owner needs to re-propose the latest such block, since the validators are not allowed to vote for anything else. This is currently not working in all cases.

## Proposal

Add a test where a client has a local pending block in multi-leader round 0, but there is also a validated block certificate in round 1. If the client now tries to commit any operation, it has to first re-propose that validated block (_not_ its older local pending block), and then, on the next block height, the operation itself.

Fix the test and a few related issues:
* The chain manager should return `Skip` if it receives its locked block again.
* The client needs to call `process_certificate` if it finalized someone else's validated block.
* The client must not refuse to re-propose a later validated block, even if it matches its own, older, pending block. The pending block is only critical in the fast round.
* If a client receives a pending block proposal from a validator, let's not re-propose it for now. We may add that back later, but for now, this reduces the difference compared to the behavior of single-owner chain before the chain manager merge.

## Test Plan

New `*_propose_validated` client tests were added.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
