### PR TITLE
Fix missing application registration messages

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -216,6 +216,12 @@ impl ApplicationCallOutcome {
         self.execution_outcome.messages.push(message);
         self
     }
+
+    /// Registers a new session to be created with the provided `session_state`.
+    pub fn with_new_session(mut self, session_state: Vec<u8>) -> Self {
+        self.create_sessions.push(session_state);
+        self
+    }
 }
 
 /// The result of calling into a session.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -210,6 +210,14 @@ pub struct ApplicationCallOutcome {
     pub create_sessions: Vec<Vec<u8>>,
 }
 
+impl ApplicationCallOutcome {
+    /// Adds a `message` to this [`ApplicationCallOutcome`].
+    pub fn with_message(mut self, message: RawOutgoingMessage<Vec<u8>>) -> Self {
+        self.execution_outcome.messages.push(message);
+        self
+    }
+}
+
 /// The result of calling into a session.
 #[derive(Default)]
 pub struct SessionCallOutcome {
@@ -593,6 +601,12 @@ impl ExecutionOutcome {
 impl<Message> RawExecutionOutcome<Message> {
     pub fn with_authenticated_signer(mut self, authenticated_signer: Option<Owner>) -> Self {
         self.authenticated_signer = authenticated_signer;
+        self
+    }
+
+    /// Adds a `message` to this [`RawExecutionOutcome`].
+    pub fn with_message(mut self, message: RawOutgoingMessage<Message>) -> Self {
+        self.messages.push(message);
         self
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -531,7 +531,7 @@ pub enum Response {
 }
 
 /// A message together with routing information.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(any(test, feature = "test"), derive(Eq, PartialEq))]
 pub struct RawOutgoingMessage<Message> {
     /// The destination of the message.

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -514,6 +514,106 @@ async fn test_simple_message() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests if a message is scheduled to be sent while an application is handling a cross-application
+/// call.
+#[tokio::test]
+async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
+    let mut state = SystemExecutionState::default();
+    state.description = Some(ChainDescription::Root(0));
+    let mut view =
+        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
+            state,
+            ExecutionRuntimeConfig::Synchronous,
+        )
+        .await;
+
+    let mut applications = register_mock_applications(&mut view, 2).await?;
+    let (caller_id, caller_application) = applications
+        .next()
+        .expect("Caller mock application should be registered");
+    let (target_id, target_application) = applications
+        .next()
+        .expect("Target mock application should be registered");
+
+    caller_application.expect_call(ExpectedCall::execute_operation(
+        move |runtime, _context, _operation| {
+            runtime.try_call_application(
+                /* authenticated */ false,
+                target_id,
+                vec![],
+                vec![],
+            )?;
+            Ok(RawExecutionOutcome::default())
+        },
+    ));
+
+    let destination_chain = ChainId::from(ChainDescription::Root(1));
+    let dummy_message = RawOutgoingMessage {
+        destination: Destination::from(destination_chain),
+        authenticated: false,
+        kind: MessageKind::Simple,
+        message: b"msg".to_vec(),
+    };
+
+    target_application.expect_call(ExpectedCall::handle_application_call({
+        let dummy_message = dummy_message.clone();
+        |_runtime, _context, _argument, _forwarded_sessions| {
+            Ok(ApplicationCallOutcome {
+                value: vec![],
+                execution_outcome: RawExecutionOutcome::default().with_message(dummy_message),
+                create_sessions: vec![],
+            })
+        }
+    }));
+
+    let context = OperationContext {
+        chain_id: ChainId::root(0),
+        height: BlockHeight(0),
+        index: 0,
+        authenticated_signer: None,
+        next_message_index: 0,
+    };
+    let mut tracker = ResourceTracker::default();
+    let policy = ResourceControlPolicy::default();
+    let outcomes = view
+        .execute_operation(
+            context,
+            Operation::User {
+                application_id: caller_id,
+                bytes: vec![],
+            },
+            &policy,
+            &mut tracker,
+        )
+        .await?;
+
+    let target_description = view.system.registry.describe_application(target_id).await?;
+    let registration_message = RawOutgoingMessage {
+        destination: Destination::from(destination_chain),
+        authenticated: false,
+        kind: MessageKind::Simple,
+        message: SystemMessage::RegisterApplications {
+            applications: vec![target_description],
+        },
+    };
+
+    assert_eq!(
+        outcomes,
+        &[
+            ExecutionOutcome::System(
+                RawExecutionOutcome::default().with_message(registration_message)
+            ),
+            ExecutionOutcome::User(
+                target_id,
+                RawExecutionOutcome::default().with_message(dummy_message)
+            ),
+            ExecutionOutcome::User(caller_id, RawExecutionOutcome::default()),
+        ]
+    );
+
+    Ok(())
+}
+
 /// Creates `count` [`MockApplication`]s and registers them in the provided [`ExecutionStateView`].
 ///
 /// Returns an iterator over pairs of [`UserApplicationId`]s and their respective

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -83,10 +83,10 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
         .next()
-        .expect("Missing caller mock application");
+        .expect("Caller mock application should be registered");
     let (target_id, target_application) = applications
         .next()
-        .expect("Missing target mock application");
+        .expect("Target mock application should be registered");
 
     let owner = Owner::from(PublicKey::debug(0));
     let state_key = vec![];
@@ -230,10 +230,10 @@ async fn test_leaking_session() -> anyhow::Result<()> {
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
         .next()
-        .expect("Missing caller mock application");
+        .expect("Caller mock application should be registered");
     let (target_id, target_application) = applications
         .next()
-        .expect("Missing target mock application");
+        .expect("Target mock application should be registered");
 
     caller_application.expect_call(ExpectedCall::execute_operation(
         move |runtime, _context, _operation| {
@@ -294,10 +294,10 @@ async fn test_simple_session() -> anyhow::Result<()> {
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
         .next()
-        .expect("Missing caller mock application");
+        .expect("Caller mock application should be registered");
     let (target_id, target_application) = applications
         .next()
-        .expect("Missing target mock application");
+        .expect("Target mock application should be registered");
 
     caller_application.expect_call(ExpectedCall::execute_operation(
         move |runtime, _context, _operation| {
@@ -378,10 +378,10 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
         .next()
-        .expect("Missing caller mock application");
+        .expect("Caller mock application should be registered");
     let (target_id, target_application) = applications
         .next()
-        .expect("Missing target mock application");
+        .expect("Target mock application should be registered");
 
     caller_application.expect_call(ExpectedCall::execute_operation(
         move |runtime, _context, _operation| {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Messages sent by called applications were not preceded by system messages to register the application to receive the message on the destination chain. This meant that receiving the messages would fail unless the application was already registered or if a chain owner requests for the application manually.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Rewrite `update_execution_outcomes_with_app_registrations` to check for outgoing messages in all execution outcomes of the call stack. System messages are then created for all outgoing user application messages to their respective destination chains.

## Test Plan

<!-- How to test that the changes are correct. -->
Some unit tests were added to cover different scenarios of called applications sending messages.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

Fixes #1417
