### PR TITLE
Added command to `subscribe` and `unsubscribe` to other chains

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -10,6 +10,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
 * [`linera close-chain`↴](#linera-close-chain)
 * [`linera subscribe`↴](#linera-subscribe)
+* [`linera unsubscribe`↴](#linera-unsubscribe)
 * [`linera query-balance`↴](#linera-query-balance)
 * [`linera sync-balance`↴](#linera-sync-balance)
 * [`linera query-validators`↴](#linera-query-validators)
@@ -178,7 +179,18 @@ Close (i.e. deactivate) an existing chain
 
 Subscribes to a system channel, available channels in the application are admin and published-bytecodes
 
-**Usage:** `linera subscribe [OPTIONS] --subscriber <CHAIN_ID> --publisher <CHAIN_ID>`
+**Usage:** `linera subscribe [OPTIONS] --subscriber <CHAIN_ID> --publisher <CHAIN_ID> --channel <SYSTEM_CHANNEL>`
+
+###### **Options:**
+* `--subscriber <CHAIN_ID>` — Chain id (must be one of our chains)
+* `--publisher <CHAIN_ID>` — Chain id (must be one of our chains)
+* `--channel <SYSTEM_CHANNEL>` - System Channel (admin or published-bytecodes)
+
+## `linera unsubscribe`
+
+Unsubscribes from a system channel 
+
+**Usage:** `linera unsubscribe [OPTIONS] --subscriber <CHAIN_ID> --publisher <CHAIN_ID> --channel <SYSTEM_CHANNEL>`
 
 ###### **Options:**
 * `--subscriber <CHAIN_ID>` — Chain id (must be one of our chains)

--- a/CLI.md
+++ b/CLI.md
@@ -9,6 +9,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera open-chain`↴](#linera-open-chain)
 * [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
 * [`linera close-chain`↴](#linera-close-chain)
+* [`linera subscribe`↴](#linera-subscribe)
 * [`linera query-balance`↴](#linera-query-balance)
 * [`linera sync-balance`↴](#linera-sync-balance)
 * [`linera query-validators`↴](#linera-query-validators)
@@ -50,6 +51,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `open-chain` — Open (i.e. activate) a new chain deriving the UID from an existing one
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `close-chain` — Close (i.e. deactivate) an existing chain
+* `subscribe` - Subscribes to a system channel
 * `query-balance` — Read the balance of the chain from the local state of the client
 * `sync-balance` — Synchronize the local state of the chain (including a conservative estimation of the available balance) with a quorum validators
 * `query-validators` — Show the current set of validators for a chain
@@ -172,6 +174,16 @@ Close (i.e. deactivate) an existing chain
 
 * `--from <CHAIN_ID>` — Chain id (must be one of our chains)
 
+## `linera subscribe`
+
+Subscribes to a system channel, available channels in the application are admin and published-bytecodes
+
+**Usage:** `linera subscribe [OPTIONS] --subscriber <CHAIN_ID> --publisher <CHAIN_ID>`
+
+###### **Options:**
+* `--subscriber <CHAIN_ID>` — Chain id (must be one of our chains)
+* `--publisher <CHAIN_ID>` — Chain id (must be one of our chains)
+* `--channel <SYSTEM_CHANNEL>` - System Channel (admin or published-bytecodes)
 
 
 ## `linera query-balance`

--- a/CLI.md
+++ b/CLI.md
@@ -50,7 +50,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
 * `transfer` — Transfer funds
 * `open-chain` — Open (i.e. activate) a new chain deriving the UID from an existing one
-* `subscribe` — Subscribes to a system channel, available channels in the application are admin and published-bytecodes
+* `subscribe` — Subscribes to a system channel
 * `unsubscribe` — Unsubscribes from a system channel
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `close-chain` — Close (i.e. deactivate) an existing chain
@@ -104,9 +104,6 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
-
-  Possible values: `true`, `false`
-
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
 
 
@@ -146,15 +143,15 @@ Open (i.e. activate) a new chain deriving the UID from an existing one
 
 ## `linera subscribe`
 
-Subscribes to a system channel, available channels in the application are admin and published-bytecodes
+Subscribes to a system channel
 
-**Usage:** `linera subscribe --subscriber <SUBSCRIBER> --publisher <PUBLISHER> --channel <CHANNEL>`
+**Usage:** `linera subscribe [OPTIONS] --channel <CHANNEL>`
 
 ###### **Options:**
 
-* `--subscriber <SUBSCRIBER>`
-* `--publisher <PUBLISHER>`
-* `--channel <CHANNEL>`
+* `--subscriber <SUBSCRIBER>` — Chain id (must be one of our chains)
+* `--publisher <PUBLISHER>` — Chain id (must be one of our chains)
+* `--channel <CHANNEL>` — System channel available in the system application
 
   Possible values:
   - `admin`:
@@ -169,13 +166,13 @@ Subscribes to a system channel, available channels in the application are admin 
 
 Unsubscribes from a system channel
 
-**Usage:** `linera unsubscribe --subscriber <SUBSCRIBER> --publisher <PUBLISHER> --channel <CHANNEL>`
+**Usage:** `linera unsubscribe [OPTIONS] --channel <CHANNEL>`
 
 ###### **Options:**
 
-* `--subscriber <SUBSCRIBER>`
-* `--publisher <PUBLISHER>`
-* `--channel <CHANNEL>`
+* `--subscriber <SUBSCRIBER>` — Chain id (must be one of our chains)
+* `--publisher <PUBLISHER>` — Chain id (must be one of our chains)
+* `--channel <CHANNEL>` — System channel available in the system application
 
   Possible values:
   - `admin`:
@@ -369,9 +366,6 @@ Watch the network for notifications
 ###### **Options:**
 
 * `--raw` — Show all notifications from all validators
-
-  Possible values: `true`, `false`
-
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -53,6 +53,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `close-chain` — Close (i.e. deactivate) an existing chain
 * `subscribe` - Subscribes to a system channel
+* `unsubscribe` - Unsubscribes from a system channel
 * `query-balance` — Read the balance of the chain from the local state of the client
 * `sync-balance` — Synchronize the local state of the chain (including a conservative estimation of the available balance) with a quorum validators
 * `query-validators` — Show the current set of validators for a chain
@@ -175,9 +176,11 @@ Close (i.e. deactivate) an existing chain
 
 * `--from <CHAIN_ID>` — Chain id (must be one of our chains)
 
+
+
 ## `linera subscribe`
 
-Subscribes to a system channel, available channels in the application are admin and published-bytecodes
+Subscribes to a system channel
 
 **Usage:** `linera subscribe [OPTIONS] --subscriber <CHAIN_ID> --publisher <CHAIN_ID> --channel <SYSTEM_CHANNEL>`
 
@@ -185,6 +188,8 @@ Subscribes to a system channel, available channels in the application are admin 
 * `--subscriber <CHAIN_ID>` — Chain id (must be one of our chains)
 * `--publisher <CHAIN_ID>` — Chain id (must be one of our chains)
 * `--channel <SYSTEM_CHANNEL>` - System Channel (admin or published-bytecodes)
+
+
 
 ## `linera unsubscribe`
 
@@ -196,6 +201,7 @@ Unsubscribes from a system channel
 * `--subscriber <CHAIN_ID>` — Chain id (must be one of our chains)
 * `--publisher <CHAIN_ID>` — Chain id (must be one of our chains)
 * `--channel <SYSTEM_CHANNEL>` - System Channel (admin or published-bytecodes)
+
 
 
 ## `linera query-balance`

--- a/CLI.md
+++ b/CLI.md
@@ -7,10 +7,10 @@ This document contains the help content for the `linera` command-line program.
 * [`linera`↴](#linera)
 * [`linera transfer`↴](#linera-transfer)
 * [`linera open-chain`↴](#linera-open-chain)
-* [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
-* [`linera close-chain`↴](#linera-close-chain)
 * [`linera subscribe`↴](#linera-subscribe)
 * [`linera unsubscribe`↴](#linera-unsubscribe)
+* [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
+* [`linera close-chain`↴](#linera-close-chain)
 * [`linera query-balance`↴](#linera-query-balance)
 * [`linera sync-balance`↴](#linera-sync-balance)
 * [`linera query-validators`↴](#linera-query-validators)
@@ -50,10 +50,10 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
 * `transfer` — Transfer funds
 * `open-chain` — Open (i.e. activate) a new chain deriving the UID from an existing one
+* `subscribe` — Subscribes to a system channel, available channels in the application are admin and published-bytecodes
+* `unsubscribe` — Unsubscribes from a system channel
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `close-chain` — Close (i.e. deactivate) an existing chain
-* `subscribe` - Subscribes to a system channel
-* `unsubscribe` - Unsubscribes from a system channel
 * `query-balance` — Read the balance of the chain from the local state of the client
 * `sync-balance` — Synchronize the local state of the chain (including a conservative estimation of the available balance) with a quorum validators
 * `query-validators` — Show the current set of validators for a chain
@@ -104,6 +104,9 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
+
+  Possible values: `true`, `false`
+
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
 
 
@@ -141,6 +144,48 @@ Open (i.e. activate) a new chain deriving the UID from an existing one
 
 
 
+## `linera subscribe`
+
+Subscribes to a system channel, available channels in the application are admin and published-bytecodes
+
+**Usage:** `linera subscribe --subscriber <SUBSCRIBER> --publisher <PUBLISHER> --channel <CHANNEL>`
+
+###### **Options:**
+
+* `--subscriber <SUBSCRIBER>`
+* `--publisher <PUBLISHER>`
+* `--channel <CHANNEL>`
+
+  Possible values:
+  - `admin`:
+    Channel used to broadcast reconfigurations
+  - `published-bytecodes`:
+    Channel used to broadcast new published bytecodes
+
+
+
+
+## `linera unsubscribe`
+
+Unsubscribes from a system channel
+
+**Usage:** `linera unsubscribe --subscriber <SUBSCRIBER> --publisher <PUBLISHER> --channel <CHANNEL>`
+
+###### **Options:**
+
+* `--subscriber <SUBSCRIBER>`
+* `--publisher <PUBLISHER>`
+* `--channel <CHANNEL>`
+
+  Possible values:
+  - `admin`:
+    Channel used to broadcast reconfigurations
+  - `published-bytecodes`:
+    Channel used to broadcast new published bytecodes
+
+
+
+
 ## `linera open-multi-owner-chain`
 
 Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
@@ -175,32 +220,6 @@ Close (i.e. deactivate) an existing chain
 ###### **Options:**
 
 * `--from <CHAIN_ID>` — Chain id (must be one of our chains)
-
-
-
-## `linera subscribe`
-
-Subscribes to a system channel
-
-**Usage:** `linera subscribe [OPTIONS] --subscriber <CHAIN_ID> --publisher <CHAIN_ID> --channel <SYSTEM_CHANNEL>`
-
-###### **Options:**
-* `--subscriber <CHAIN_ID>` — Chain id (must be one of our chains)
-* `--publisher <CHAIN_ID>` — Chain id (must be one of our chains)
-* `--channel <SYSTEM_CHANNEL>` - System Channel (admin or published-bytecodes)
-
-
-
-## `linera unsubscribe`
-
-Unsubscribes from a system channel 
-
-**Usage:** `linera unsubscribe [OPTIONS] --subscriber <CHAIN_ID> --publisher <CHAIN_ID> --channel <SYSTEM_CHANNEL>`
-
-###### **Options:**
-* `--subscriber <CHAIN_ID>` — Chain id (must be one of our chains)
-* `--publisher <CHAIN_ID>` — Chain id (must be one of our chains)
-* `--channel <SYSTEM_CHANNEL>` - System Channel (admin or published-bytecodes)
 
 
 
@@ -350,6 +369,9 @@ Watch the network for notifications
 ###### **Options:**
 
 * `--raw` — Show all notifications from all validators
+
+  Possible values: `true`, `false`
+
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3178,6 +3178,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "bytes",
+ "clap 4.4.11",
  "counter",
  "custom_debug_derive",
  "dashmap",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1713,6 +1713,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "bytes",
+ "clap",
  "custom_debug_derive",
  "dashmap",
  "derive_more",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -29,6 +29,7 @@ async-trait = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true, optional = true }
 custom_debug_derive = { workspace = true }
+clap = { workspace = true }
 dashmap = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -28,8 +28,8 @@ async-lock = { workspace = true }
 async-trait = { workspace = true }
 bcs = { workspace = true }
 bytes = { workspace = true, optional = true }
-custom_debug_derive = { workspace = true }
 clap = { workspace = true }
+custom_debug_derive = { workspace = true }
 dashmap = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -287,7 +287,9 @@ pub struct SystemResponse {
 }
 
 /// The channels available in the system application.
-#[derive(Enum, Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, clap::ValueEnum)]
+#[derive(
+    Enum, Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, clap::ValueEnum,
+)]
 pub enum SystemChannel {
     /// Channel used to broadcast reconfigurations.
     Admin,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -287,7 +287,7 @@ pub struct SystemResponse {
 }
 
 /// The channels available in the system application.
-#[derive(Enum, Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Enum, Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize, clap::ValueEnum)]
 pub enum SystemChannel {
     /// Channel used to broadcast reconfigurations.
     Admin,


### PR DESCRIPTION
## Motivation

To add command to `subscribe` and `unsubscribe` to other chains, earlier it was only possible through GraphQL mutation, after successfully merge this PR, it can be done through CLI. For example:
`linera subscribe --subscriber $CHAIN_2 --publisher $CHAIN_1 --channel admin`

## Proposal

Added subscribe and unsubscribe in [`linera.rs`](https://github.com/linera-io/linera-protocol/blob/main/linera-service/src/linera.rs) also had to add `clap::ValueEnum` in the `SystemChannel`

Should close #1342

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
