### PR TITLE
Test and fix re-proposing a pending block in the fast round.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -553,7 +553,7 @@ impl ChainManagerInfo {
             .max_by_key(|cert| cert.round)
     }
 
-    /// Returns the next round in which a proposal could be accepted.
+    /// Returns the next round in which a new proposal could be accepted.
     ///
     /// This is the current round if there is no proposal or validated block certificate in the
     /// current round yet. If there is, and we are in multi-leader mode, this is the next round.

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1477,7 +1477,15 @@ where
                 Some(Round::Fast) => manager.ownership.super_owners.contains_key(&identity),
                 Some(Round::MultiLeader(_)) => true,
                 Some(Round::SingleLeader(_)) => manager.leader == Some(identity),
-                None => false,
+                None => {
+                    // If we have a pending block in the fast round, we can retry our proposal.
+                    manager.current_round.is_fast()
+                        && manager
+                            .requested_proposed
+                            .as_ref()
+                            .map(|proposal| &proposal.content.block)
+                            == self.pending_block.as_ref()
+                }
             };
             // If blocks are already validated, try to finalize the highest one.
             if let Some(certificate) = manager.highest_validated() {


### PR DESCRIPTION
## Motivation

`ChainManagerInfo::next_round` says `None` if we are in the fast round and there is already a proposal. However, if that proposal is our own pending block, we _should_ retry.

## Proposal

In `execute_block`, set `can_propose` to `true` in this case.

## Test Plan

A test for this case was added.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
