### PR TITLE
Run e2e tests against Devnet

### DIFF
--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -16,10 +16,19 @@ test = ["linera-views/test"]
 benchmark = ["linera-base/test", "dep:fungible", "dep:port-selector"]
 wasmer = ["linera-execution/wasmer", "linera-storage/wasmer"]
 wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
-rocksdb = ["linera-views/rocksdb", "linera-core/rocksdb", "linera-storage/rocksdb"]
+rocksdb = [
+    "linera-views/rocksdb",
+    "linera-core/rocksdb",
+    "linera-storage/rocksdb",
+]
 aws = ["linera-views/aws", "linera-core/aws", "linera-storage/aws"]
-scylladb = ["linera-views/scylladb", "linera-core/scylladb", "linera-storage/scylladb"]
+scylladb = [
+    "linera-views/scylladb",
+    "linera-core/scylladb",
+    "linera-storage/scylladb",
+]
 kubernetes = ["dep:k8s-openapi", "dep:kube", "dep:pathdiff", "dep:fs_extra"]
+remote_net = ["dep:k8s-openapi", "dep:kube"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -12,10 +12,7 @@ use anyhow::{anyhow, bail, ensure, Result};
 use async_trait::async_trait;
 use futures::{future, lock::Mutex};
 use k8s_openapi::api::core::v1::Pod;
-use kube::{
-    api::{Api, ListParams},
-    Client,
-};
+use kube::{api::ListParams, Api, Client};
 use linera_base::data_types::Amount;
 use std::{path::PathBuf, sync::Arc};
 use tempfile::{tempdir, TempDir};
@@ -167,7 +164,7 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
                 if num_validators > 0 {
                     net.generate_initial_validator_config().await.unwrap();
                     initial_client
-                        .create_genesis_config(Amount::from_tokens(1000))
+                        .create_genesis_config(Amount::from_tokens(2000))
                         .await
                         .unwrap();
                     net.run().await.unwrap();
@@ -179,9 +176,12 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
 
         let mut net = net.clone();
         let client = net.make_client().await;
+        // The tests assume we've created a genesis config with 10
+        // chains with 10 tokens each. We create the first chain here
         client.wallet_init(&[], FaucetOption::None).await.unwrap();
 
-        for _ in 0..2 {
+        // And the remaining 9 here
+        for _ in 0..9 {
             initial_client
                 .open_and_assign(&client, Amount::from_tokens(10))
                 .await

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -22,6 +22,9 @@ mod kubectl;
 pub mod local_kubernetes_net;
 /// How to run Linera validators locally as native processes.
 pub mod local_net;
+#[cfg(feature = "remote_net")]
+/// How to connect to running GCP DevNet.
+pub mod remote_net;
 #[cfg(feature = "kubernetes")]
 /// Util functions for the wrappers
 mod util;

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    cli_wrappers::{ClientWrapper, Faucet, FaucetOption, LineraNet, LineraNetConfig, Network},
+    config::Export,
+};
+use anyhow::Result;
+use async_trait::async_trait;
+use linera_base::data_types::Amount;
+use std::sync::Arc;
+use tempfile::{tempdir, TempDir};
+
+#[cfg(any(test, feature = "test"))]
+pub struct RemoteNetTestingConfig {
+    faucet_url: String,
+}
+
+#[cfg(any(test, feature = "test"))]
+impl RemoteNetTestingConfig {
+    pub fn new(faucet_url: Option<&str>) -> Self {
+        Self {
+            faucet_url: String::from(faucet_url.unwrap_or("https://faucet.devnet.linera.net")),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+#[async_trait]
+impl LineraNetConfig for RemoteNetTestingConfig {
+    type Net = RemoteNet;
+
+    async fn instantiate(self) -> Result<(Self::Net, ClientWrapper)> {
+        let seed = 37;
+        let mut net = RemoteNet::new(Some(seed), &self.faucet_url)
+            .await
+            .expect("Creating RemoteNet should not fail");
+
+        let client = net.make_client().await;
+        // The tests assume we've created a genesis config with 10
+        // chains with 10 tokens each. We create the first chain here
+        client
+            .wallet_init(&[], FaucetOption::NewChain(&self.faucet_url))
+            .await
+            .unwrap();
+
+        // And the remaining 9 here
+        for _ in 0..9 {
+            client
+                .open_and_assign(&client, Amount::from_tokens(10))
+                .await
+                .unwrap();
+        }
+
+        Ok((net, client))
+    }
+}
+
+/// Remote net
+#[cfg(any(test, feature = "test"))]
+#[derive(Clone)]
+pub struct RemoteNet {
+    network: Network,
+    testing_prng_seed: Option<u64>,
+    next_client_id: usize,
+    tmp_dir: Arc<TempDir>,
+}
+
+#[cfg(any(test, feature = "test"))]
+#[async_trait]
+impl LineraNet for RemoteNet {
+    async fn ensure_is_running(&mut self) -> Result<()> {
+        // Leaving this just returning for now.
+        // We would have to connect to each validator in the remote net then run
+        // ensure_connected_cluster_is_running
+        Ok(())
+    }
+
+    async fn make_client(&mut self) -> ClientWrapper {
+        let client = ClientWrapper::new(
+            self.tmp_dir.clone(),
+            self.network,
+            self.testing_prng_seed,
+            self.next_client_id,
+        );
+        if let Some(seed) = self.testing_prng_seed {
+            self.testing_prng_seed = Some(seed + 1);
+        }
+        self.next_client_id += 1;
+        client
+    }
+
+    async fn terminate(&mut self) -> Result<()> {
+        // We're not killing the remote net :)
+        Ok(())
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl RemoteNet {
+    async fn new(testing_prng_seed: Option<u64>, faucet_url: &str) -> Result<Self> {
+        let tmp_dir = Arc::new(tempdir()?);
+        let genesis_config = Faucet::request_genesis_config(faucet_url).await?;
+        // Write json config to disk
+        genesis_config.write(tmp_dir.path().join("genesis.json").as_path())?;
+        Ok(Self {
+            network: Network::Grpc,
+            testing_prng_seed,
+            next_client_id: 0,
+            tmp_dir,
+        })
+    }
+}

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -27,6 +27,8 @@ use tracing::{info, warn};
 
 #[cfg(feature = "kubernetes")]
 use linera_service::cli_wrappers::local_kubernetes_net::SharedLocalKubernetesNetTestingConfig;
+#[cfg(feature = "remote_net")]
+use linera_service::cli_wrappers::remote_net::RemoteNetTestingConfig;
 
 fn get_fungible_account_owner(client: &ClientWrapper) -> fungible::AccountOwner {
     let owner = client.get_owner().unwrap();
@@ -162,6 +164,7 @@ impl AmmApp {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) {
     use counter::CounterAbi;
@@ -212,6 +215,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfig) {
     use counter::CounterAbi;
@@ -260,6 +264,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) {
     use social::SocialAbi;
@@ -354,6 +359,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
     use fungible::{FungibleTokenAbi, InitialState};
@@ -476,6 +482,7 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_same_wallet_fungible(config: impl LineraNetConfig) {
     use fungible::{FungibleTokenAbi, InitialState};
@@ -565,6 +572,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(config: impl LineraNetConfig)
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
     use crowd_funding::{CrowdFundingAbi, InitializationArgument};
@@ -696,6 +704,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
 // #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 // #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 // #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+// #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[cfg_attr(feature = "rocksdb", test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
@@ -979,6 +988,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
     use amm::{AmmAbi, Parameters};
@@ -1478,6 +1488,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_open_chain_node_service(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1633,6 +1644,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1870,6 +1882,7 @@ async fn test_example_publish(database: Database, network: Network) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1962,6 +1975,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -2027,6 +2041,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -2112,6 +2127,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, None) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) {
     use linera_service::util::CommandExt as _;


### PR DESCRIPTION
## Motivation

As a way to also test the devnet, we need the e2e tests to run against it also

## Proposal

Implement the config for that, and run the tests with it

## Test Plan

Ran `cargo test -p linera-service --features scylladb,remote_net --test end_to_end_tests -- remote_net_grpc`, all tests passed

