### PR TITLE
Don't update npm lock files in README tests.

### DIFF
--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -88,7 +88,7 @@ Installing and starting the web server:
 
 ```bash
 cd examples/counter/web-frontend
-npm install
+npm install --no-save
 
 # Start the server but not open the web page right away.
 BROWSER=none npm start &

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -90,7 +90,7 @@ Installing and starting the web server:
 
 ```bash
 cd examples/counter/web-frontend
-npm install
+npm install --no-save
 
 # Start the server but not open the web page right away.
 BROWSER=none npm start &

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -130,7 +130,7 @@ Then the web frontend:
 
 ```bash
 cd examples/fungible/web-frontend
-npm install
+npm install --no-save
 
 # Start the server but not open the web page right away.
 BROWSER=none npm start &

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -132,7 +132,7 @@ Then the web frontend:
 
 ```bash
 cd examples/fungible/web-frontend
-npm install
+npm install --no-save
 
 # Start the server but not open the web page right away.
 BROWSER=none npm start &


### PR DESCRIPTION
## Motivation

Each time the README tests are executed, they modify the `package-lock.json` of the web frontends for the counter and fungible example applications.

## Proposal

Add `--no-save` to the `npm install` commands in the READMEs to avoid updating the lock files. Whenever we do want to update their dependencies, we should make a separate PR for that.

## Test Plan

Running `cargo test readme` now doesn't update the lock files anymore.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
