### PR TITLE
Improvements on `CollectionView`, resolution of bug and API change.

### DIFF
--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -246,7 +246,7 @@ where
                         .context
                         .base_tag_index(KeyTag::Subview as u8, &short_key);
                     let context = self.context.clone_with_base_key(key);
-                    let mut view = W::load(context).await?;
+                    let view = W::load(context).await?;
                     entry.insert(Update::Set(view));
                     let guard = RwLockWriteGuard::downgrade(updates);
                     Ok(Some(ReadGuardedView { guard, short_key }))

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -247,9 +247,6 @@ where
                         .base_tag_index(KeyTag::Subview as u8, &short_key);
                     let context = self.context.clone_with_base_key(key);
                     let mut view = W::load(context).await?;
-                    if self.delete_storage_first {
-                        view.clear();
-                    }
                     entry.insert(Update::Set(view));
                     let guard = RwLockWriteGuard::downgrade(updates);
                     Ok(Some(ReadGuardedView { guard, short_key }))

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -236,9 +236,7 @@ where
                         let guard = RwLockWriteGuard::downgrade(updates);
                         Ok(Some(ReadGuardedView { guard, short_key }))
                     }
-                    Update::Removed => {
-                        Ok(None)
-                    }
+                    Update::Removed => Ok(None),
                 }
             }
             btree_map::Entry::Vacant(entry) => {
@@ -693,7 +691,10 @@ where
     ///   assert!(view.try_load_entry(&24).await.unwrap().is_none());
     /// # })
     /// ```
-    pub async fn try_load_entry<Q>(&self, index: &Q) -> Result<Option<ReadGuardedView<W>>, ViewError>
+    pub async fn try_load_entry<Q>(
+        &self,
+        index: &Q,
+    ) -> Result<Option<ReadGuardedView<W>>, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + ?Sized,
@@ -1010,7 +1011,10 @@ where
     ///   assert!(view.try_load_entry(&24).await.unwrap().is_none());
     /// # })
     /// ```
-    pub async fn try_load_entry<Q>(&self, index: &Q) -> Result<Option<ReadGuardedView<W>>, ViewError>
+    pub async fn try_load_entry<Q>(
+        &self,
+        index: &Q,
+    ) -> Result<Option<ReadGuardedView<W>>, ViewError>
     where
         I: Borrow<Q>,
         Q: CustomSerialize + ?Sized,

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -187,12 +187,12 @@ where
     /// # let context = create_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(vec![0, 1]).await.unwrap();
-    ///   let subview = view.load_entry(vec![0, 1]).await.unwrap();
+    ///   let subview = view.load_entry_or_insert(vec![0, 1]).await.unwrap();
     ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
-    pub async fn load_entry(&mut self, short_key: Vec<u8>) -> Result<&W, ViewError> {
+    pub async fn load_entry_or_insert(&mut self, short_key: Vec<u8>) -> Result<&W, ViewError> {
         Ok(self.do_load_entry_mut(short_key).await?)
     }
 
@@ -619,18 +619,18 @@ where
     /// # let context = create_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
-    ///   let subview = view.load_entry(&23).await.unwrap();
+    ///   let subview = view.load_entry_or_insert(&23).await.unwrap();
     ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
-    pub async fn load_entry<Q>(&mut self, index: &Q) -> Result<&W, ViewError>
+    pub async fn load_entry_or_insert<Q>(&mut self, index: &Q) -> Result<&W, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + ?Sized,
     {
         let short_key = C::derive_short_key(index)?;
-        self.collection.load_entry(short_key).await
+        self.collection.load_entry_or_insert(short_key).await
     }
 
     /// Same as `load_entry_mut` but for read-only access. May fail if one subview is
@@ -927,18 +927,18 @@ where
     /// # let context = create_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
-    ///   let subview = view.load_entry(&23).await.unwrap();
+    ///   let subview = view.load_entry_or_insert(&23).await.unwrap();
     ///   let value = subview.get();
     ///   assert_eq!(*value, String::default());
     /// # })
     /// ```
-    pub async fn load_entry<Q>(&mut self, index: &Q) -> Result<&W, ViewError>
+    pub async fn load_entry_or_insert<Q>(&mut self, index: &Q) -> Result<&W, ViewError>
     where
         I: Borrow<Q>,
         Q: CustomSerialize + ?Sized,
     {
         let short_key = index.to_custom_bytes()?;
-        self.collection.load_entry(short_key).await
+        self.collection.load_entry_or_insert(short_key).await
     }
 
     /// Same as `load_entry_mut` but for read-only access. May fail if one subview is

--- a/linera-views/src/graphql.rs
+++ b/linera-views/src/graphql.rs
@@ -460,10 +460,11 @@ where
     }
 
     async fn entry(&self, key: K) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
-        Ok(Entry {
-            value: self.try_load_entry(&key).await?,
-            key,
-        })
+        let value = self
+            .try_load_entry(&key)
+            .await?
+            .ok_or_else(|| missing_key_error(&key))?;
+        Ok(Entry { value, key })
     }
 
     async fn entries(
@@ -481,10 +482,11 @@ where
 
         let mut values = vec![];
         for key in keys {
-            values.push(Entry {
-                value: self.try_load_entry(&key).await?,
-                key,
-            })
+            let value = self
+                .try_load_entry(&key)
+                .await?
+                .ok_or_else(|| missing_key_error(&key))?;
+            values.push(Entry { value, key })
         }
 
         Ok(values)
@@ -517,10 +519,11 @@ where
     }
 
     async fn entry(&self, key: K) -> Result<Entry<K, ReadGuardedView<V>>, async_graphql::Error> {
-        Ok(Entry {
-            value: self.try_load_entry(&key).await?,
-            key,
-        })
+        let value = self
+            .try_load_entry(&key)
+            .await?
+            .ok_or_else(|| missing_key_error(&key))?;
+        Ok(Entry { value, key })
     }
 
     async fn entries(
@@ -538,10 +541,11 @@ where
 
         let mut values = vec![];
         for key in keys {
-            values.push(Entry {
-                value: self.try_load_entry(&key).await?,
-                key,
-            })
+            let value = self
+                .try_load_entry(&key)
+                .await?
+                .ok_or_else(|| missing_key_error(&key))?;
+            values.push(Entry { value, key })
         }
 
         Ok(values)

--- a/linera-views/tests/collection_tests.rs
+++ b/linera-views/tests/collection_tests.rs
@@ -48,7 +48,7 @@ async fn classic_collection_view_check() {
         let count_oper = rng.gen_range(0..25);
         let mut new_map = map.clone();
         for _ in 0..count_oper {
-            let choice = rng.gen_range(0..6);
+            let choice = rng.gen_range(0..7);
             if choice == 0 {
                 // deleting random stuff
                 let pos = rng.gen_range(0..nmax);
@@ -71,7 +71,7 @@ async fn classic_collection_view_check() {
                 let n_load = rng.gen_range(0..5);
                 for _i in 0..n_load {
                     let pos = rng.gen_range(0..nmax);
-                    let _subview = view.v.load_entry(&pos).await.unwrap();
+                    let _subview = view.v.load_entry_or_insert(&pos).await.unwrap();
                     new_map.entry(pos).or_insert(0);
                 }
             }
@@ -84,12 +84,12 @@ async fn classic_collection_view_check() {
                     new_map.insert(pos, 0);
                 }
             }
-            if choice == 4 {
+            if choice == 5 {
                 // Doing the clearing
                 view.clear();
                 new_map.clear();
             }
-            if choice == 5 {
+            if choice == 6 {
                 // Doing the rollback
                 view.rollback();
                 new_map = map.clone();

--- a/linera-views/tests/collection_tests.rs
+++ b/linera-views/tests/collection_tests.rs
@@ -25,7 +25,7 @@ where
         let mut map = BTreeMap::new();
         let keys = self.v.indices().await.unwrap();
         for key in keys {
-            let subview = self.v.try_load_entry(&key).await.unwrap();
+            let subview = self.v.try_load_entry(&key).await.unwrap().unwrap();
             let value = subview.get();
             map.insert(key, *value);
         }

--- a/linera-views/tests/collection_tests.rs
+++ b/linera-views/tests/collection_tests.rs
@@ -104,7 +104,7 @@ async fn classic_collection_view_check() {
             // Checking the behavior of "try_load_entry"
             for _ in 0..10 {
                 let pos = rng.gen::<u8>();
-                let test_view = !view.v.try_load_entry(&pos).await.unwrap().is_none();
+                let test_view = view.v.try_load_entry(&pos).await.unwrap().is_some();
                 let test_map = new_map.contains_key(&pos);
                 assert_eq!(test_view, test_map);
             }

--- a/linera-views/tests/collection_tests.rs
+++ b/linera-views/tests/collection_tests.rs
@@ -48,7 +48,7 @@ async fn classic_collection_view_check() {
         let count_oper = rng.gen_range(0..25);
         let mut new_map = map.clone();
         for _ in 0..count_oper {
-            let choice = rng.gen_range(0..7);
+            let choice = rng.gen_range(0..6);
             if choice == 0 {
                 // deleting random stuff
                 let pos = rng.gen_range(0..nmax);
@@ -84,12 +84,12 @@ async fn classic_collection_view_check() {
                     new_map.insert(pos, 0);
                 }
             }
-            if choice == 5 {
+            if choice == 4 {
                 // Doing the clearing
                 view.clear();
                 new_map.clear();
             }
-            if choice == 6 {
+            if choice == 5 {
                 // Doing the rollback
                 view.rollback();
                 new_map = map.clone();
@@ -100,6 +100,13 @@ async fn classic_collection_view_check() {
                 assert_eq!(new_hash, hash);
             } else {
                 assert_ne!(new_hash, hash);
+            }
+            // Checking the behavior of "try_load_entry"
+            for _ in 0..10 {
+                let pos = rng.gen::<u8>();
+                let test_view = !view.v.try_load_entry(&pos).await.unwrap().is_none();
+                let test_map = new_map.contains_key(&pos);
+                assert_eq!(test_view, test_map);
             }
             // Checking the keys
             let key_values = view.key_values().await;

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -445,7 +445,12 @@ where
                     .unwrap();
                 assert_eq!(count, 1);
             }
-            let subview = view.collection.try_load_entry("hola").await.unwrap().unwrap();
+            let subview = view
+                .collection
+                .try_load_entry("hola")
+                .await
+                .unwrap()
+                .unwrap();
             assert_eq!(subview.read(0..10).await.unwrap(), vec![17, 18]);
         }
     };
@@ -551,7 +556,12 @@ where
             assert!(!view.set.contains(&59).await.unwrap());
         }
         if config.with_collection {
-            let subview = view.collection.try_load_entry("hola").await.unwrap().unwrap();
+            let subview = view
+                .collection
+                .try_load_entry("hola")
+                .await
+                .unwrap()
+                .unwrap();
             assert_eq!(subview.read(0..10).await.unwrap(), vec![17, 18]);
             assert_eq!(subview.read(..).await.unwrap(), vec![17, 18]);
             assert_eq!(subview.read(1..).await.unwrap(), vec![18]);

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -445,7 +445,7 @@ where
                     .unwrap();
                 assert_eq!(count, 1);
             }
-            let subview = view.collection.try_load_entry("hola").await.unwrap();
+            let subview = view.collection.try_load_entry("hola").await.unwrap().unwrap();
             assert_eq!(subview.read(0..10).await.unwrap(), vec![17, 18]);
         }
     };
@@ -471,7 +471,7 @@ where
             assert!(!view.set.contains(&42).await.unwrap());
         }
         if config.with_collection {
-            let subview = view.collection.try_load_entry("hola").await.unwrap();
+            let subview = view.collection.load_entry_or_insert("hola").await.unwrap();
             assert_eq!(subview.read(0..10).await.unwrap(), Vec::<u32>::new());
             let subview = view.collection2.load_entry_mut("ciao").await.unwrap();
             let subsubview = subview.load_entry_mut("!").await.unwrap();
@@ -551,7 +551,7 @@ where
             assert!(!view.set.contains(&59).await.unwrap());
         }
         if config.with_collection {
-            let subview = view.collection.try_load_entry("hola").await.unwrap();
+            let subview = view.collection.try_load_entry("hola").await.unwrap().unwrap();
             assert_eq!(subview.read(0..10).await.unwrap(), vec![17, 18]);
             assert_eq!(subview.read(..).await.unwrap(), vec![17, 18]);
             assert_eq!(subview.read(1..).await.unwrap(), vec![18]);
@@ -562,7 +562,7 @@ where
         }
         if config.with_collection {
             let subview = view.collection2.load_entry_mut("ciao").await.unwrap();
-            let subsubview = subview.try_load_entry("!").await.unwrap();
+            let subsubview = subview.try_load_entry("!").await.unwrap().unwrap();
             assert!(subview.try_load_entry("!").await.is_err());
             assert_eq!(subsubview.get(), &3);
             assert_eq!(
@@ -650,7 +650,7 @@ where
     {
         let mut view = store.load(1).await.unwrap();
         if config.with_collection {
-            let subview = view.collection.try_load_entry("hola").await.unwrap();
+            let subview = view.collection.load_entry_or_insert("hola").await.unwrap();
             assert_eq!(subview.read(0..10).await.unwrap(), Vec::<u32>::new());
         }
         if config.with_queue {


### PR DESCRIPTION
## Motivation

The work done recently for `ReentrantCollectionView` has revealed some similar issues with
`CollectionView`, which we now correct.

## Proposal

The following was done:
* The `load_entry` has been renamed as `load_entry_or_insert`.
* The `contains_key` is added to the `CollectionView`.
* The `try_load_entry` is now a true `&self` function (e.g. the hash does not change) though the interior mutability is still needed.
* The `try_load_entry` is now returning an `Option<ReadGuardedView<W>>`.

The function `try_load_entry` has been added to the tests.

## Test Plan

The CI test has been improved.

## Release Plan

No change. The documentation of the library is changed accordingly.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
