### PR TITLE
Retry pending block

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -552,30 +552,4 @@ impl ChainManagerInfo {
             )
             .max_by_key(|cert| cert.round)
     }
-
-    /// Returns the next round in which a new proposal could be accepted.
-    ///
-    /// This is the current round if there is no proposal or validated block certificate in the
-    /// current round yet. If there is, and we are in multi-leader mode, this is the next round.
-    /// Otherwise it is `None`, because no new proposal can be made before the round times out.
-    pub fn next_round(&self) -> Option<Round> {
-        let proposal_round = self
-            .requested_proposed
-            .as_ref()
-            .map(|proposal| proposal.content.round);
-        let locked_round = self
-            .requested_locked
-            .as_ref()
-            .map(|certificate| certificate.round);
-        if proposal_round != Some(self.current_round) && locked_round != Some(self.current_round) {
-            // There's no proposal or locked block yet in the current round.
-            Some(self.current_round)
-        } else if self.current_round.is_multi_leader() {
-            // We're still in multi-leader mode, so we can propose in the next round at any time.
-            self.ownership.next_round(self.current_round)
-        } else {
-            // We're in single-leader mode, so the next proposal can only be made after the timeout.
-            None
-        }
-    }
 }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1369,7 +1369,12 @@ where
         Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(_)))
     ));
     // There is no pending block, since the proposal wasn't valid at the time.
-    assert!(client2.retry_pending_block().await.unwrap().is_none());
+    assert!(client2
+        .retry_pending_block()
+        .await
+        .unwrap()
+        .unwrap()
+        .is_none());
     // Retrying the whole command works after synchronization.
     assert_eq!(
         client2.synchronize_from_validators().await.unwrap(),

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -519,7 +519,7 @@ where
         .execute_operation(Operation::user(application_id, &transfer)?)
         .await
         .is_err());
-    receiver.clear_pending_block().await;
+    receiver.clear_pending_block();
 
     // Try another transfer in the other direction with the correct amount.
     let transfer = fungible::Operation::Transfer {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -4028,7 +4028,6 @@ where
 
     // The first round is the fast-block round, and owner 0 is a super owner.
     assert_eq!(response.info.manager.current_round, Round::Fast);
-    assert_eq!(response.info.manager.next_round(), Some(Round::Fast));
     assert_eq!(response.info.manager.leader, None);
 
     // So owner 1 cannot propose a block in this round. And the next round hasn't started yet.
@@ -4067,10 +4066,6 @@ where
         .await
         .unwrap();
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
-    assert_eq!(
-        response.info.manager.next_round(),
-        Some(Round::MultiLeader(0))
-    );
     assert_eq!(response.info.manager.leader, None);
 
     // Now any owner can propose a block. And multi-leader rounds can be skipped without timeout.
@@ -4082,10 +4077,6 @@ where
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
     let (response, _) = worker.handle_chain_info_query(query_values).await.unwrap();
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(1));
-    assert_eq!(
-        response.info.manager.next_round(),
-        Some(Round::SingleLeader(0))
-    );
 }
 
 #[test(tokio::test)]
@@ -4150,7 +4141,6 @@ where
 
     // The first round is the fast-block round, and owner 0 is a super owner.
     assert_eq!(response.info.manager.current_round, Round::Fast);
-    assert_eq!(response.info.manager.next_round(), Some(Round::Fast));
     assert_eq!(response.info.manager.leader, None);
 
     // Owner 0 proposes another block. The validator votes to confirm.
@@ -4177,10 +4167,6 @@ where
         .await
         .unwrap();
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
-    assert_eq!(
-        response.info.manager.next_round(),
-        Some(Round::MultiLeader(0))
-    );
     assert_eq!(response.info.manager.leader, None);
 
     // Now any owner can propose a block. But block1 is locked.

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -2079,11 +2079,15 @@ impl Runnable for Job {
 
             RetryPendingBlock { chain_id } => {
                 let mut chain_client = context.make_chain_client(storage, chain_id);
-                if let Some(certificate) = chain_client.retry_pending_block().await? {
-                    info!("Pending block committed successfully.");
-                    println!("{}", certificate.hash());
-                } else {
-                    info!("No block is currently pending.");
+                match chain_client.retry_pending_block().await? {
+                    ClientOutcome::Committed(Some(certificate)) => {
+                        info!("Pending block committed successfully.");
+                        println!("{}", certificate.hash());
+                    }
+                    ClientOutcome::Committed(None) => info!("No block is currently pending."),
+                    ClientOutcome::WaitForTimeout(timeout) => {
+                        info!("Please try again at {}", timeout.timestamp)
+                    }
                 }
                 context.update_and_save_wallet(&mut chain_client).await;
             }


### PR DESCRIPTION
## Motivation

The BFT-aware `execute_block` is very complicated and returns `WaitForTimeout` in many cases where it's not clear that is the right action.

## Proposal

Move most of the BFT logic to `retry_pending_block_without_prepare`: It will not only try to commit our own pending block but also e.g. a locked block, if there is one.

In `execute_block`, we first run `retry_pending_block_without_prepare` to get into a state where we can make a new proposal. Then we set the local pending block. Then we run `retry_pending_block_without_prepare` again to try and commit it.

## Test Plan

The tests already cover most of the behavior.

One test was updated because with the new code we always try to commit our existing pending block first, before resetting it to something else. 

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
