### PR TITLE
Address @afck's comment on #1483

### DIFF
--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -248,8 +248,7 @@ where
                 if iter.is_empty() || block_batch.len() == K::MAX_BATCH_SIZE - 2 {
                     (true, true)
                 } else {
-                    let next_block_size =
-                        block_size + iter.next_value_size()? + block_batch.overhead_size();
+                    let next_block_size = iter.next_batch_size(&block_batch, block_size)?;
                     let next_transaction_size = transaction_size + next_block_size;
                     let transaction_flush = next_transaction_size > K::MAX_BATCH_TOTAL_SIZE;
                     let block_flush = transaction_flush || next_block_size > K::MAX_VALUE_SIZE;


### PR DESCRIPTION
## Motivation

As [pointed out](https://github.com/linera-io/linera-protocol/pull/1483#discussion_r1450127052) by @afck, my last-minute change PR #1483 that was incorrect.

## Proposal

Partially revert commit a12f10a8b70bf5baa0 from PR #1483 to bring back `next_batch_size`

## Test Plan

CI