### PR TITLE
Added helpful error message if the examples cannot be found

### DIFF
--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -120,7 +120,9 @@ async fn benchmark_with_fungible(
     }
 
     info!("Building the fungible application bytecode.");
-    let path = Path::new("examples/fungible").canonicalize().unwrap();
+    let path = Path::new("examples/fungible").canonicalize().context(
+        "`linera-benchmark` is meant to run from the root of the `linera-protocol` repository",
+    )?;
     let (contract, service) = publisher.build_application(&path, "fungible", true).await?;
 
     info!("Publishing the fungible application bytecode.");


### PR DESCRIPTION
## Motivation

If you run `linera-benchmark` outside of `linera-protocol` you cannot resolve the `examples/fungible` path and you just get a not-found error.

## Proposal

Add some context to the error.

## Test Plan

Tested manually.
