### PR TITLE
Create option `--new-chain` to explicitly request a chain from a faucet

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -519,7 +519,8 @@ Initialize a wallet from the genesis configuration
 ###### **Options:**
 
 * `--genesis <GENESIS_CONFIG_PATH>` — The path to the genesis configuration for a Linera deployment. Either this or `--faucet` must be specified
-* `--faucet <FAUCET>` — The address of a faucet. If this is specified, the default chain will be newly created, and credited with tokens
+* `--faucet <FAUCET>` — The address of a faucet
+* `--with-new-chain` — Request a new chain from the faucet, credited with tokens. This requires `--faucet`
 * `--with-other-chains <WITH_OTHER_CHAINS>` — Other chains to follow
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -11,7 +11,7 @@ use linera_base::{
     identifiers::{ApplicationId, ChainId, Owner},
 };
 use linera_execution::system::SystemChannel;
-use linera_service::cli_wrappers::{ApplicationWrapper, ClientWrapper, Network};
+use linera_service::cli_wrappers::{ApplicationWrapper, ClientWrapper, FaucetOption, Network};
 use port_selector::random_free_tcp_port;
 use rand::{Rng as _, SeedableRng};
 use serde_json::Value;
@@ -82,7 +82,9 @@ async fn benchmark_with_fungible(
     info!("Creating the clients and initializing the wallets");
     let dir = Arc::new(tempdir().context("cannot create temp dir")?);
     let publisher = ClientWrapper::new(dir, Network::Grpc, None, num_wallets);
-    publisher.wallet_init(&[], Some(&faucet)).await?;
+    publisher
+        .wallet_init(&[], FaucetOption::NewChain(&faucet))
+        .await?;
     let clients = (0..num_wallets)
         .map(|n| {
             let dir = Arc::new(tempdir().context("cannot create temp dir")?);
@@ -92,7 +94,7 @@ async fn benchmark_with_fungible(
     try_join_all(
         clients
             .iter()
-            .map(|client| client.wallet_init(&[], Some(&faucet))),
+            .map(|client| client.wallet_init(&[], FaucetOption::NewChain(&faucet))),
     )
     .await?;
 

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -23,7 +23,7 @@ use tokio::process::Command;
 
 #[cfg(any(test, feature = "test"))]
 use {
-    crate::cli_wrappers::wallet::FaucetOption, crate::util::current_binary_parent,
+    crate::{cli_wrappers::wallet::FaucetOption, util::current_binary_parent},
     tokio::sync::OnceCell,
 };
 

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{
-    docker::DockerImage, kind::KindCluster, kubectl::KubectlInstance, util::get_github_root,
-};
 use crate::{
-    cli_wrappers::{helmfile::HelmFile, ClientWrapper, LineraNet, LineraNetConfig, Network},
+    cli_wrappers::{
+        docker::DockerImage, helmfile::HelmFile, kind::KindCluster, kubectl::KubectlInstance,
+        util::get_github_root, wallet::FaucetOption, ClientWrapper, LineraNet, LineraNetConfig,
+        Network,
+    },
     util::{self, CommandExt},
 };
 use anyhow::{anyhow, bail, ensure, Result};
@@ -173,7 +174,7 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
 
         let mut net = net.clone();
         let client = net.make_client().await;
-        client.wallet_init(&[], None).await.unwrap();
+        client.wallet_init(&[], FaucetOption::None).await.unwrap();
 
         for _ in 0..2 {
             initial_client

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -4,8 +4,7 @@
 use crate::{
     cli_wrappers::{
         docker::DockerImage, helmfile::HelmFile, kind::KindCluster, kubectl::KubectlInstance,
-        util::get_github_root, wallet::FaucetOption, ClientWrapper, LineraNet, LineraNetConfig,
-        Network,
+        util::get_github_root, ClientWrapper, LineraNet, LineraNetConfig, Network,
     },
     util::{self, CommandExt},
 };
@@ -21,8 +20,12 @@ use linera_base::data_types::Amount;
 use std::{path::PathBuf, sync::Arc};
 use tempfile::{tempdir, TempDir};
 use tokio::process::Command;
+
 #[cfg(any(test, feature = "test"))]
-use {crate::util::current_binary_parent, tokio::sync::OnceCell};
+use {
+    crate::cli_wrappers::wallet::FaucetOption, crate::util::current_binary_parent,
+    tokio::sync::OnceCell,
+};
 
 #[cfg(any(test, feature = "test"))]
 static SHARED_LOCAL_KUBERNETES_TESTING_NET: OnceCell<(

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -28,7 +28,7 @@ mod util;
 /// How to run a linera wallet and its GraphQL service.
 mod wallet;
 
-pub use wallet::{ApplicationWrapper, ClientWrapper, Faucet, NodeService};
+pub use wallet::{ApplicationWrapper, ClientWrapper, Faucet, FaucetOption, NodeService};
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -168,7 +168,7 @@ impl ClientWrapper {
         let mut command = self.command().await?;
         command.args(["wallet", "init"]);
         if let Some(faucet_url) = faucet {
-            command.args(["--faucet", faucet_url]);
+            command.args(["--with-new-chain", "--faucet", faucet_url]);
         } else {
             command.args(["--genesis", "genesis.json"]);
         }

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -29,14 +29,12 @@ use linera_execution::{
     WasmRuntime, WithWasmDefault,
 };
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
-#[cfg(feature = "kubernetes")]
-use linera_service::cli_wrappers::local_kubernetes_net::LocalKubernetesNetConfig;
 use linera_service::{
     chain_listener::{self, ChainListenerConfig},
     cli_wrappers::{
         self,
         local_net::{Database, LocalNetConfig},
-        ClientWrapper, LineraNet, LineraNetConfig, Network,
+        ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
     },
     config::{CommitteeConfig, Export, GenesisConfig, Import, UserChain, WalletState},
     faucet::FaucetService,
@@ -59,6 +57,9 @@ use std::{
 };
 use tokio::{signal::unix, sync::mpsc};
 use tracing::{debug, info, warn};
+
+#[cfg(feature = "kubernetes")]
+use linera_service::cli_wrappers::local_kubernetes_net::LocalKubernetesNetConfig;
 
 #[cfg(feature = "benchmark")]
 use {
@@ -2353,7 +2354,7 @@ async fn net_up(
     if let Some(extra_wallets) = *extra_wallets {
         for wallet in 1..=extra_wallets {
             let extra_wallet = net.make_client().await;
-            extra_wallet.wallet_init(&[], None).await?;
+            extra_wallet.wallet_init(&[], FaucetOption::None).await?;
             let unassigned_key = extra_wallet.keygen().await?;
             let new_chain_msg_id = client1
                 .open_chain(default_chain, Some(unassigned_key), Amount::ZERO)

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -12,12 +12,10 @@ use linera_base::{
     data_types::{Amount, Timestamp},
     identifiers::ChainId,
 };
-#[cfg(feature = "kubernetes")]
-use linera_service::cli_wrappers::local_kubernetes_net::SharedLocalKubernetesNetTestingConfig;
 use linera_service::{
     cli_wrappers::{
         local_net::{Database, LocalNet, LocalNetConfig, LocalNetTestingConfig},
-        ApplicationWrapper, ClientWrapper, LineraNet, LineraNetConfig, Network,
+        ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
     },
     util,
 };
@@ -26,6 +24,9 @@ use serde_json::{json, Value};
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
 use test_case::test_case;
 use tracing::{info, warn};
+
+#[cfg(feature = "kubernetes")]
+use linera_service::cli_wrappers::local_kubernetes_net::SharedLocalKubernetesNetTestingConfig;
 
 fn get_fungible_account_owner(client: &ClientWrapper) -> fungible::AccountOwner {
     let owner = client.get_owner().unwrap();
@@ -267,7 +268,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await.unwrap();
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
     let chain2 = client1
@@ -362,7 +363,7 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await.unwrap();
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
     let chain2 = client1
@@ -574,7 +575,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await.unwrap();
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
     let chain2 = client1
@@ -708,8 +709,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     let client_a = net.make_client().await;
     let client_b = net.make_client().await;
 
-    client_a.wallet_init(&[], None).await.unwrap();
-    client_b.wallet_init(&[], None).await.unwrap();
+    client_a.wallet_init(&[], FaucetOption::None).await.unwrap();
+    client_b.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     // Create initial server and client config.
     let (contract_fungible_a, service_fungible_a) =
@@ -988,8 +989,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
 
     let client0 = net.make_client().await;
     let client1 = net.make_client().await;
-    client0.wallet_init(&[], None).await.unwrap();
-    client1.wallet_init(&[], None).await.unwrap();
+    client0.wallet_init(&[], FaucetOption::None).await.unwrap();
+    client1.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let (contract_fungible, service_fungible) =
         client_admin.build_example("fungible").await.unwrap();
@@ -1334,7 +1335,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
     let (mut net, client) = config.instantiate().await.unwrap();
 
     let client_2 = net.make_client().await;
-    client_2.wallet_init(&[], None).await.unwrap();
+    client_2.wallet_init(&[], FaucetOption::None).await.unwrap();
     let chain_1 = client.get_wallet().unwrap().default_chain().unwrap();
 
     let (node_service_2, chain_2) = match network {
@@ -1577,7 +1578,10 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig
     let client2 = net.make_client().await;
     let chain = ChainId::root(0);
     let mut height = 0;
-    client2.wallet_init(&[chain], None).await.unwrap();
+    client2
+        .wallet_init(&[chain], FaucetOption::None)
+        .await
+        .unwrap();
 
     // Listen for updates on root chain 0. There are no blocks on that chain yet.
     let mut node_service2 = client2.run_node_service(8081).await.unwrap();
@@ -1637,7 +1641,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await.unwrap();
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     // Get some chain owned by Client 1.
     let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
@@ -1874,7 +1878,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await.unwrap();
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
 
@@ -1966,7 +1970,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await.unwrap();
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
 
@@ -2031,7 +2035,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     let (mut net, client1) = config.instantiate().await.unwrap();
 
     let client2 = net.make_client().await;
-    client2.wallet_init(&[], None).await.unwrap();
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
 
@@ -2048,7 +2052,10 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
 
     // Use the faucet directly to initialize client 3.
     let client3 = net.make_client().await;
-    let outcome = client3.wallet_init(&[], Some(&faucet.url())).await.unwrap();
+    let outcome = client3
+        .wallet_init(&[], FaucetOption::NewChain(&faucet.url()))
+        .await
+        .unwrap();
     let chain3 = outcome.unwrap().chain_id;
     assert_eq!(
         chain3,


### PR DESCRIPTION
## Motivation

`linera wallet init --faucet URI` creates a (default) chain implicitly. This caused some confusion because `linera wallet init --genesis FILE` does not.

## Proposal

* Require that `--new-chain` is passed `linera wallet init --faucet URI --new-chain`
* Create type `FaucetOption`

## Test Plan

CI

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
