### PR TITLE
Reuse contract and service instances inside transaction

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -62,12 +62,18 @@ pub type UserContractCode = Arc<dyn UserContractModule + Send + Sync + 'static>;
 /// An implementation of [`UserServiceModule`].
 pub type UserServiceCode = Arc<dyn UserServiceModule + Send + Sync + 'static>;
 
+/// An implementation of [`UserContract`].
+pub type UserContractInstance = Box<dyn UserContract + Send + Sync + 'static>;
+
+/// An implementation of [`UserService`].
+pub type UserServiceInstance = Box<dyn UserService + Send + Sync + 'static>;
+
 /// A factory trait to obtain a [`UserContract`] from a [`UserContractModule`]
 pub trait UserContractModule {
     fn instantiate(
         &self,
         runtime: ContractSyncRuntime,
-    ) -> Result<Box<dyn UserContract + Send + Sync + 'static>, ExecutionError>;
+    ) -> Result<UserContractInstance, ExecutionError>;
 }
 
 /// A factory trait to obtain a [`UserService`] from a [`UserServiceModule`]
@@ -75,7 +81,7 @@ pub trait UserServiceModule {
     fn instantiate(
         &self,
         runtime: ServiceSyncRuntime,
-    ) -> Result<Box<dyn UserService + Send + Sync + 'static>, ExecutionError>;
+    ) -> Result<UserServiceInstance, ExecutionError>;
 }
 
 /// A type for errors happening during execution.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -56,7 +56,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt, io, path::Path, str::FromStr, sync::Arc};
 use thiserror::Error;
 
-/// An implementation of [`UserContractModule`]
+/// An implementation of [`UserContractModule`].
 pub type UserContractCode = Arc<dyn UserContractModule + Send + Sync + 'static>;
 
 /// An implementation of [`UserServiceModule`].

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -218,24 +218,6 @@ impl<const W: bool> SyncRuntimeInternal<W> {
         }
     }
 
-    fn load_contract(
-        &mut self,
-        id: UserApplicationId,
-    ) -> Result<(UserContractCode, UserApplicationDescription), ExecutionError> {
-        self.execution_state_sender
-            .send_request(|callback| Request::LoadContract { id, callback })?
-            .recv_response()
-    }
-
-    fn load_service(
-        &mut self,
-        id: UserApplicationId,
-    ) -> Result<(UserServiceCode, UserApplicationDescription), ExecutionError> {
-        self.execution_state_sender
-            .send_request(|callback| Request::LoadService { id, callback })?
-            .recv_response()
-    }
-
     /// Returns the [`ApplicationStatus`] of the current application.
     ///
     /// The current application is the last to be pushed to the `call_stack`.
@@ -270,6 +252,17 @@ impl<const W: bool> SyncRuntimeInternal<W> {
             .pop()
             .expect("Can't remove application from empty call stack");
         assert!(self.active_applications.remove(&status.id));
+    }
+}
+
+impl SyncRuntimeInternal<true> {
+    fn load_contract(
+        &mut self,
+        id: UserApplicationId,
+    ) -> Result<(UserContractCode, UserApplicationDescription), ExecutionError> {
+        self.execution_state_sender
+            .send_request(|callback| Request::LoadContract { id, callback })?
+            .recv_response()
     }
 
     fn forward_sessions(
@@ -396,6 +389,17 @@ impl<const W: bool> SyncRuntimeInternal<W> {
             .remove(&session_id)
             .ok_or(ExecutionError::InvalidSession(session_id))?;
         Ok(())
+    }
+}
+
+impl SyncRuntimeInternal<false> {
+    fn load_service(
+        &mut self,
+        id: UserApplicationId,
+    ) -> Result<(UserServiceCode, UserApplicationDescription), ExecutionError> {
+        self.execution_state_sender
+            .send_request(|callback| Request::LoadService { id, callback })?
+            .recv_response()
     }
 }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -777,13 +777,11 @@ impl ContractSyncRuntime {
 
 impl ContractRuntime for ContractSyncRuntime {
     fn remaining_fuel(&mut self) -> Result<u64, ExecutionError> {
-        let this = self.inner();
-        Ok(this.runtime_counts.remaining_fuel)
+        Ok(self.inner().runtime_counts.remaining_fuel)
     }
 
     fn set_remaining_fuel(&mut self, remaining_fuel: u64) -> Result<(), ExecutionError> {
-        let mut this = self.inner();
-        this.runtime_counts.remaining_fuel = remaining_fuel;
+        self.inner().runtime_counts.remaining_fuel = remaining_fuel;
         Ok(())
     }
 
@@ -962,10 +960,7 @@ impl ServiceRuntime for ServiceSyncRuntime {
         };
         let mut code = code.instantiate(self.clone())?;
         let response = code.handle_query(query_context, argument)?;
-        {
-            let mut this = self.inner();
-            this.pop_application();
-        }
+        self.inner().pop_application();
         Ok(response)
     }
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -318,15 +318,14 @@ impl SyncRuntimeInternal<UserContractInstance> {
     fn load_contract_instance(
         &mut self,
         id: UserApplicationId,
-    ) -> Result<(Arc<Mutex<UserContractInstance>>, UserApplicationDescription), ExecutionError>
-    {
+    ) -> Result<LoadedApplication<UserContractInstance>, ExecutionError> {
         let (code, description) = self.load_contract(id)?;
         let instance = code.instantiate(SyncRuntime(
             self.reference
                 .upgrade()
                 .expect("`SyncRuntimeInner` should only be used by `SyncRuntime`"),
         ))?;
-        Ok((Arc::new(Mutex::new(instance)), description))
+        Ok(LoadedApplication::new(instance, description))
     }
 
     /// Configures the runtime for executing a call to a different contract.
@@ -339,7 +338,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
         self.check_for_reentrancy(callee_id)?;
 
         // Load the application.
-        let (contract, description) = self.load_contract_instance(callee_id)?;
+        let application = self.load_contract_instance(callee_id)?;
 
         let caller = self.current_application();
         let caller_id = caller.id;
@@ -359,11 +358,11 @@ impl SyncRuntimeInternal<UserContractInstance> {
         };
         self.push_application(ApplicationStatus {
             id: callee_id,
-            parameters: description.parameters,
+            parameters: application.parameters,
             // Allow further nested calls to be authenticated if this one is.
             signer: authenticated_signer,
         });
-        Ok((contract, callee_context))
+        Ok((application.instance, callee_context))
     }
 
     /// Cleans up the runtime after the execution of a call to a different contract.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -73,6 +73,34 @@ struct ApplicationStatus {
     signer: Option<Owner>,
 }
 
+/// A loaded application instance.
+#[derive(Debug)]
+struct LoadedApplication<Instance> {
+    instance: Arc<Mutex<Instance>>,
+    parameters: Vec<u8>,
+}
+
+impl<Instance> LoadedApplication<Instance> {
+    /// Creates a new [`LoadedApplication`] entry from the `instance` and its `description`.
+    fn new(instance: Instance, description: UserApplicationDescription) -> Self {
+        LoadedApplication {
+            instance: Arc::new(Mutex::new(instance)),
+            parameters: description.parameters,
+        }
+    }
+}
+
+impl<Instance> Clone for LoadedApplication<Instance> {
+    // Manual implementation is needed to prevent the derive macro from adding an `Instance: Clone`
+    // bound
+    fn clone(&self) -> Self {
+        LoadedApplication {
+            instance: self.instance.clone(),
+            parameters: self.parameters.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct SessionManager {
     /// Track the next session index to be used for each application.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -542,6 +542,21 @@ impl SyncRuntimeInternal<UserServiceInstance> {
             .send_request(|callback| Request::LoadService { id, callback })?
             .recv_response()
     }
+
+    /// Initializes a service instance with this runtime.
+    fn load_service_instance(
+        &mut self,
+        id: UserApplicationId,
+    ) -> Result<LoadedApplication<UserServiceInstance>, ExecutionError> {
+        let (code, description) = self.load_service(id)?;
+        let instance = code.instantiate(SyncRuntime(
+            self.reference
+                .upgrade()
+                .expect("`SyncRuntimeInner` should only be used by `SyncRuntime`"),
+        ))?;
+
+        Ok(LoadedApplication::new(instance, description))
+    }
 }
 
 impl<ContractOrService> SyncRuntime<ContractOrService> {
@@ -1016,24 +1031,26 @@ impl ServiceRuntime for ServiceSyncRuntime {
         queried_id: UserApplicationId,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        let (query_context, code) = {
+        let (query_context, service) = {
             let mut this = self.inner();
 
             // Load the application.
-            let (code, description) = this.load_service(queried_id)?;
+            let application = this.load_service_instance(queried_id)?;
             // Make the call to user code.
             let query_context = crate::QueryContext {
                 chain_id: this.chain_id,
             };
             this.push_application(ApplicationStatus {
                 id: queried_id,
-                parameters: description.parameters,
+                parameters: application.parameters,
                 signer: None,
             });
-            (query_context, code)
+            (query_context, application.instance)
         };
-        let mut code = code.instantiate(self.clone())?;
-        let response = code.handle_query(query_context, argument)?;
+        let response = service
+            .try_lock()
+            .expect("Applications should not have reentrant calls")
+            .handle_query(query_context, argument)?;
         self.inner().pop_application();
         Ok(response)
     }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -23,8 +23,8 @@ mod wasmtime;
 
 use self::sanitizer::sanitize;
 use crate::{
-    Bytecode, ContractSyncRuntime, ExecutionError, ServiceSyncRuntime, UserContract,
-    UserContractModule, UserService, UserServiceModule, WasmRuntime,
+    Bytecode, ContractSyncRuntime, ExecutionError, ServiceSyncRuntime, UserContractInstance,
+    UserContractModule, UserServiceInstance, UserServiceModule, WasmRuntime,
 };
 use std::{path::Path, sync::Arc};
 use thiserror::Error;
@@ -91,7 +91,7 @@ impl UserContractModule for WasmContractModule {
     fn instantiate(
         &self,
         runtime: ContractSyncRuntime,
-    ) -> Result<Box<dyn UserContract + Send + Sync + 'static>, ExecutionError> {
+    ) -> Result<UserContractInstance, ExecutionError> {
         match self {
             #[cfg(feature = "wasmtime")]
             WasmContractModule::Wasmtime { module } => Ok(Box::new(
@@ -152,7 +152,7 @@ impl UserServiceModule for WasmServiceModule {
     fn instantiate(
         &self,
         runtime: ServiceSyncRuntime,
-    ) -> Result<Box<dyn UserService + Send + Sync + 'static>, ExecutionError> {
+    ) -> Result<UserServiceInstance, ExecutionError> {
         match self {
             #[cfg(feature = "wasmtime")]
             WasmServiceModule::Wasmtime { module } => {

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -938,7 +938,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
 pub async fn register_mock_applications<C>(
     state: &mut ExecutionStateView<C>,
     count: u64,
-) -> anyhow::Result<vec::IntoIter<(UserApplicationId, MockApplication<()>)>>
+) -> anyhow::Result<vec::IntoIter<(UserApplicationId, MockApplication)>>
 where
     C: Context<Extra = TestExecutionRuntimeContext> + Clone + Send + Sync + 'static,
     ViewError: From<C::Error>,

--- a/linera-sdk/src/log.rs
+++ b/linera-sdk/src/log.rs
@@ -3,10 +3,15 @@
 
 use crate::{contract, service};
 use log::{LevelFilter, Log, Metadata, Record};
-use std::panic::{self, PanicInfo};
+use std::{
+    panic::{self, PanicInfo},
+    sync::Once,
+};
 
 static CONTRACT_LOGGER: ContractLogger = ContractLogger;
 static SERVICE_LOGGER: ServiceLogger = ServiceLogger;
+
+static INSTALL_LOGGER: Once = Once::new();
 
 /// A logger that uses the system API for contracts.
 #[derive(Clone, Copy, Debug)]
@@ -15,9 +20,11 @@ pub struct ContractLogger;
 impl ContractLogger {
     /// Configures [`log`] to use the log system API for contracts.
     pub fn install() {
-        log::set_logger(&CONTRACT_LOGGER).expect("Failed to initialize contract logger");
-        log::set_max_level(LevelFilter::Trace);
-        panic::set_hook(Box::new(log_panic));
+        INSTALL_LOGGER.call_once(|| {
+            log::set_logger(&CONTRACT_LOGGER).expect("Failed to initialize contract logger");
+            log::set_max_level(LevelFilter::Trace);
+            panic::set_hook(Box::new(log_panic));
+        });
     }
 }
 
@@ -40,9 +47,11 @@ pub struct ServiceLogger;
 impl ServiceLogger {
     /// Configures [`log`] to use the log system API for services.
     pub fn install() {
-        log::set_logger(&SERVICE_LOGGER).expect("Failed to initialize service logger");
-        log::set_max_level(LevelFilter::Trace);
-        panic::set_hook(Box::new(log_panic));
+        INSTALL_LOGGER.call_once(|| {
+            log::set_logger(&SERVICE_LOGGER).expect("Failed to initialize service logger");
+            log::set_max_level(LevelFilter::Trace);
+            panic::set_hook(Box::new(log_panic));
+        });
     }
 }
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Every time an application calls another, a new instance of the callee application is created. However, the ability to reuse an instance may increase performance and allow the application to use volatile memory that is persisted for longer than one call.

As a first step, the instance should be reused if there are multiple calls to the application inside the *same transaction*.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Store a map of loaded applications in the runtime, and reuse entries if an application is called again in the same transaction.

There's a small issue with this. The `SyncRuntimeInternal` contains the map but it is placed inside an `Arc<Mutex<_>>` that is then used as the runtime implementation. Each loaded application has a copy of the `Arc<Mutex<_>>` to use as its runtime. This leads to a circular dependency where the runtime stores the loaded applications which themself refer back to the runtime.

The solution adopted here (at least temporarily) is to ensure the map is cleared before finishing execution. Failure to do so prevents the `ExecutionStateView` from detecting that execution has finished (because the runtime leaks and the sender endpoint it has inside isn't dropped), which then hangs.

## Test Plan

<!-- How to test that the changes are correct. -->
The `MockApplication` helper type was refactored to create a separate `MockApplicationInstance` type. Now, when the `MockApplication` is used through `UserContractModule` or `UserServiceModule` to create a `MockApplicationInstance` it forwards all expected calls instead of forwarding a reference to them. In practice this means that each instance has a separate list of expected calls.

This allows testing if the instances are reused or not, since if they are not any session calls fail because they won't reuse the instance of the application that created them. Reapply the commit with this refactor to `main` shows that the tests with sessions fail as expected, but pass in this PR.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Since this changes the execution behavior:
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

Closes #488
