### PR TITLE
Generalize --with-other-chain

### DIFF
--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -125,10 +125,11 @@ impl UserChain {
         }
     }
 
-    /// Creates an entry for a chain that we don't own.
-    pub fn make_other(description: ChainDescription, timestamp: Timestamp) -> Self {
+    /// Creates an entry for a chain that we don't own. The timestamp must be the genesis
+    /// timestamp or earlier.
+    pub fn make_other(chain_id: ChainId, timestamp: Timestamp) -> Self {
         Self {
-            chain_id: description.into(),
+            chain_id,
             key_pair: None,
             block_hash: None,
             timestamp,

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -2626,12 +2626,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 let timestamp = genesis_config.timestamp;
                 let chains = with_other_chains
                     .iter()
-                    .filter_map(|chain_id| {
-                        let i = (0..(genesis_config.chains.len() as u32))
-                            .find(|i| ChainId::root(*i) == *chain_id)?;
-                        let description = ChainDescription::Root(i);
-                        Some(UserChain::make_other(description, timestamp))
-                    })
+                    .map(|chain_id| UserChain::make_other(*chain_id, timestamp))
                     .collect();
                 let mut context =
                     ClientContext::create(&options, genesis_config, *testing_prng_seed, chains)?;


### PR DESCRIPTION
## Motivation

See if we can let wallets follow any chain (not just root chains)

## Proposal

Remove the need for a chain description

## Test Plan

Tested manually
```
linera_spawn_and_read_wallet_variables linera net up
linera faucet
```
then
```
export LINERA_WALLET_1=wallet_1.json
export LINERA_STORAGE_1=rocksdb:client_1.db
export LINERA_WALLET_2=wallet_2.json
export LINERA_STORAGE_2=rocksdb:client_2.db
linera -w 1 wallet init --faucet http://localhost:8080 --with-new-chain
linera -w 1 wallet show  # Note CHAIN_ID1 
linera -w 2 wallet init --faucet http://localhost:8080 --with-new-chain --with-other-chains $CHAIN_ID1
linera -w 2 service &
linera -w 1 close-chain $CHAIN_ID1
```
kill service then check the height of $CHAIN_ID1 seen by wallet 2 with
```
linera -w 2 show
```
