### PR TITLE
Add missing genesis options in cli wrappers

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -262,11 +262,11 @@ View or update the resource control policy
 
 Create genesis configuration for a Linera deployment. Create initial user chains and print information to be used for initialization of validator setup. This will also create an initial wallet for the owner of the initial "root" chains
 
-**Usage:** `linera create-genesis-config [OPTIONS] --committee <COMMITTEE_CONFIG_PATH> --genesis <GENESIS_CONFIG_PATH> <NUM>`
+**Usage:** `linera create-genesis-config [OPTIONS] --committee <COMMITTEE_CONFIG_PATH> --genesis <GENESIS_CONFIG_PATH> <NUM_OTHER_INITIAL_CHAINS>`
 
 ###### **Arguments:**
 
-* `<NUM>` — Number of additional chains to create
+* `<NUM_OTHER_INITIAL_CHAINS>` — Number of initial (aka "root") chains to create in addition to the admin chain
 
 ###### **Options:**
 
@@ -614,6 +614,12 @@ Start a Local Linera Network
 ###### **Options:**
 
 * `--extra-wallets <EXTRA_WALLETS>` — The number of extra wallets and user chains to initialise. Default is 0
+* `--other-initial-chains <OTHER_INITIAL_CHAINS>` — The number of initial "root" chains created in the genesis config on top of the default "admin" chain. All initial chains belong to the first "admin" wallet
+
+  Default value: `10`
+* `--initial-amount <INITIAL_AMOUNT>` — The initial amount of native tokens credited in the initial "root" chains, including the default "admin" chain
+
+  Default value: `10`
 * `--validators <VALIDATORS>` — The number of validators in the local test network. Default is 1
 
   Default value: `1`

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -34,6 +34,8 @@ static SHARED_LOCAL_KUBERNETES_TESTING_NET: OnceCell<(
 pub struct LocalKubernetesNetConfig {
     pub network: Network,
     pub testing_prng_seed: Option<u64>,
+    pub num_other_initial_chains: u32,
+    pub initial_amount: Amount,
     pub num_initial_validators: usize,
     pub num_shards: usize,
     pub binaries: Option<Option<PathBuf>>,
@@ -121,7 +123,7 @@ impl LineraNetConfig for LocalKubernetesNetConfig {
         let client = net.make_client().await;
         net.generate_initial_validator_config().await.unwrap();
         client
-            .create_genesis_config(Amount::from_tokens(10))
+            .create_genesis_config(self.num_other_initial_chains, self.initial_amount)
             .await
             .unwrap();
         net.run().await.unwrap();
@@ -164,7 +166,7 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
                 if num_validators > 0 {
                     net.generate_initial_validator_config().await.unwrap();
                     initial_client
-                        .create_genesis_config(Amount::from_tokens(2000))
+                        .create_genesis_config(10, Amount::from_tokens(2000))
                         .await
                         .unwrap();
                     net.run().await.unwrap();

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -28,6 +28,8 @@ pub struct LocalNetConfig {
     pub network: Network,
     pub testing_prng_seed: Option<u64>,
     pub table_name: String,
+    pub num_other_initial_chains: u32,
+    pub initial_amount: Amount,
     pub num_initial_validators: usize,
     pub num_shards: usize,
 }
@@ -148,7 +150,7 @@ impl LineraNetConfig for LocalNetConfig {
         );
         net.generate_initial_validator_config().await.unwrap();
         client
-            .create_genesis_config(Amount::from_tokens(10))
+            .create_genesis_config(self.num_other_initial_chains, self.initial_amount)
             .await
             .unwrap();
         net.run().await.unwrap();
@@ -182,7 +184,7 @@ impl LineraNetConfig for LocalNetTestingConfig {
         if num_validators > 0 {
             net.generate_initial_validator_config().await.unwrap();
             client
-                .create_genesis_config(Amount::from_tokens(10))
+                .create_genesis_config(10, Amount::from_tokens(10))
                 .await
                 .unwrap();
             net.run().await.unwrap();

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -145,10 +145,17 @@ impl ClientWrapper {
     }
 
     /// Runs `linera create-genesis-config`.
-    pub async fn create_genesis_config(&self, initial_funding: Amount) -> Result<()> {
+    pub async fn create_genesis_config(
+        &self,
+        num_other_initial_chains: u32,
+        initial_funding: Amount,
+    ) -> Result<()> {
         let mut command = self.command().await?;
         command
-            .args(["create-genesis-config", "10"])
+            .args([
+                "create-genesis-config",
+                &num_other_initial_chains.to_string(),
+            ])
             .args(["--initial-funding", &initial_funding.to_string()])
             .args(["--committee", "committee.json"])
             .args(["--genesis", "genesis.json"]);

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1754,6 +1754,8 @@ async fn test_project_publish(database: Database, network: Network) {
         network,
         testing_prng_seed: Some(37),
         table_name,
+        num_other_initial_chains: 10,
+        initial_amount: Amount::from_tokens(10),
         num_initial_validators: 1,
         num_shards: 1,
     };
@@ -1851,6 +1853,8 @@ async fn test_example_publish(database: Database, network: Network) {
         network,
         testing_prng_seed: Some(37),
         table_name,
+        num_other_initial_chains: 10,
+        initial_amount: Amount::from_tokens(10),
         num_initial_validators: 1,
         num_shards: 1,
     };


### PR DESCRIPTION
## Motivation

* Make sure the number of initial root chains and their initial amount are configurable in `linera net up`
* Bring back a meaningful `linera benchmark`

## Proposal

* Add the missing options and CLI parameters
* Make sure the initial amount in the local kubernetes tests matches the local net

## Test Plan

```
linera_spawn_and_read_wallet_variables \
   linera net up --other-initial-chains 1000 --validators 4
   
linera benchmark
```