### PR TITLE
Tweak default histogram buckets

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -47,8 +47,16 @@ pub static NUM_BLOCKS_EXECUTED: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 
 pub static BLOCK_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!("block_execution_latency", "Block execution latency", &[])
-        .expect("Counter creation should not fail")
+    register_histogram_vec!(
+        "block_execution_latency",
+        "Block execution latency",
+        &[],
+        vec![
+            0.000_01, 0.000_03, 0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025,
+            0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0,
+        ],
+    )
+    .expect("Counter creation should not fail")
 });
 
 pub static WASM_FUEL_USED_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -52,8 +52,16 @@ pub static BLOCK_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
 });
 
 pub static WASM_FUEL_USED_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!("wasm_fuel_used_per_block", "Wasm fuel used per block", &[])
-        .expect("Counter creation should not fail")
+    register_histogram_vec!(
+        "wasm_fuel_used_per_block",
+        "Wasm fuel used per block",
+        &[],
+        vec![
+            50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10_000.0, 25_000.0, 50_000.0,
+            100_000.0, 250_000.0, 500_000.0
+        ],
+    )
+    .expect("Counter creation should not fail")
 });
 
 pub static WASM_NUM_READS_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -70,7 +70,24 @@ pub static WASM_BYTES_READ_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "wasm_bytes_read_per_block",
         "Wasm number of bytes read per block",
-        &[]
+        &[],
+        vec![
+            0.5,
+            1.0,
+            10.0,
+            100.0,
+            256.0,
+            512.0,
+            1024.0,
+            2048.0,
+            4096.0,
+            8192.0,
+            16384.0,
+            65_536.0,
+            524_288.0,
+            1_048_576.0,
+            8_388_608.0
+        ],
     )
     .expect("Counter can be created")
 });
@@ -79,7 +96,24 @@ pub static WASM_BYTES_WRITTEN_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "wasm_bytes_written_per_block",
         "Wasm number of bytes written per block",
-        &[]
+        &[],
+        vec![
+            0.5,
+            1.0,
+            10.0,
+            100.0,
+            256.0,
+            512.0,
+            1024.0,
+            2048.0,
+            4096.0,
+            8192.0,
+            16384.0,
+            65_536.0,
+            524_288.0,
+            1_048_576.0,
+            8_388_608.0
+        ],
     )
     .expect("Counter can be created")
 });

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -60,7 +60,8 @@ pub static WASM_NUM_READS_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "wasm_num_reads_per_block",
         "Wasm number of reads per block",
-        &[]
+        &[],
+        vec![0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 50.0, 100.0],
     )
     .expect("Counter can be created")
 });

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -58,7 +58,8 @@ pub static NUM_ROUNDS_IN_CERTIFICATE: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "num_rounds_in_certificate",
         "Number of rounds in certificate",
-        &["certificate_value", "round_type"]
+        &["certificate_value", "round_type"],
+        vec![0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0],
     )
     .expect("Counter creation should not fail")
 });
@@ -67,7 +68,8 @@ pub static NUM_ROUNDS_IN_BLOCK_PROPOSAL: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "num_rounds_in_block_proposal",
         "Number of rounds in block proposal",
-        &["round_type"]
+        &["round_type"],
+        vec![0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0],
     )
     .expect("Counter creation should not fail")
 });


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The default histogram buckets don't map particularly well to some metrics. Finding optimal values will require some discussion and experimentation. However, we could use better temporary values until then.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Tweak the buckets of some histogram metrics, to use temporary values that are better than the defaults.

## Test Plan

<!-- How to test that the changes are correct. -->
Manually executed the Crowd-Funding integration tests tweaked to print out the metrics in the end.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal changes, nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
