### PR TITLE
Increase scylladb dev resources

### DIFF
--- a/kubernetes/linera-validator/scylla.values.yaml
+++ b/kubernetes/linera-validator/scylla.values.yaml
@@ -6,11 +6,11 @@ racks:
   - name: rack-1
     members: 1
     storage:
-      capacity: 1Gi
+      capacity: 2Gi
     resources:
       limits:
         cpu: 1
-        memory: 0.2Gi
+        memory: 2Gi
       requests:
         cpu: 1
-        memory: 0.2Gi
+        memory: 2Gi


### PR DESCRIPTION
## Motivation

ScyllaDB occasionally runs out of connections due to running out of memory for new connections.

## Proposal

Increase the dev profile default resources.

## Test Plan

Implicitly in CI.
