### PR TITLE
Create wrappers for registering Prometheus metrics

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -63,11 +63,11 @@ jobs:
       - name: Check Proxy metric
         # Check one random proxy metric that we expect to be logged after running the e2e tests
         run: |
-          curl -s 'http://127.0.0.1:9090/api/v1/query?query=proxy_request_latency_bucket' | jq -r '.data.result[]' | grep -q .
+          curl -s 'http://127.0.0.1:9090/api/v1/query?query=linera_proxy_request_latency_bucket' | jq -r '.data.result[]' | grep -q .
       - name: Check Server metric
         # Check one random server metric that we expect to be logged after running the e2e tests
         run: |
-          curl -s 'http://127.0.0.1:9090/api/v1/query?query=server_request_latency_bucket' | jq -r '.data.result[]' | grep -q .
+          curl -s 'http://127.0.0.1:9090/api/v1/query?query=linera_server_request_latency_bucket' | jq -r '.data.result[]' | grep -q .
       - name: Destroy the kind clusters
         if: always()
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3105,6 +3105,7 @@ dependencies = [
  "generic-array",
  "hex",
  "linera-base",
+ "prometheus",
  "proptest",
  "rand 0.7.3",
  "serde",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1643,6 +1643,7 @@ dependencies = [
  "ed25519-dalek",
  "generic-array",
  "hex",
+ "prometheus",
  "proptest",
  "rand 0.7.3",
  "serde",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { workspace = true }
 rand07 = { workspace = true }
+prometheus = { workspace = true }
 
 [dev-dependencies]
 custom_debug_derive = { workspace = true }

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -12,6 +12,8 @@ pub mod crypto;
 pub mod data_types;
 mod graphql;
 pub mod identifiers;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod prometheus_util;
 pub mod sync;
 
 pub use graphql::BcsHexParseError;

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module defines util functions for interacting with Prometheus (logging metrics, etc)
+
+use prometheus::{
+    histogram_opts, register_histogram_vec, register_int_counter_vec, Error, HistogramVec,
+    IntCounterVec, Opts,
+};
+
+const LINERA_NAMESPACE: &str = "linera";
+
+/// Wrapper arount prometheus register_int_counter_vec! macro which also sets the linera namespace
+pub fn register_int_counter_vec(
+    name: &str,
+    description: &str,
+    label_names: &[&str],
+) -> Result<IntCounterVec, Error> {
+    let counter_opts = Opts::new(name, description).namespace(LINERA_NAMESPACE);
+    register_int_counter_vec!(counter_opts, label_names)
+}
+
+/// Wrapper arount prometheus register_histogram_vec! macro which also sets the linera namespace
+pub fn register_histogram_vec(
+    name: &str,
+    description: &str,
+    label_names: &[&str],
+    buckets: Option<Vec<f64>>,
+) -> Result<HistogramVec, Error> {
+    let histogram_opts = if let Some(buckets) = buckets {
+        histogram_opts!(name, description, buckets).namespace(LINERA_NAMESPACE)
+    } else {
+        histogram_opts!(name, description).namespace(LINERA_NAMESPACE)
+    };
+
+    register_histogram_vec!(histogram_opts, label_names)
+}

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -17,6 +17,7 @@ use linera_base::{
     data_types::{Amount, ArithmeticError, BlockHeight, Timestamp},
     ensure,
     identifiers::{ChainId, Destination, MessageId},
+    prometheus_util,
     sync::Lazy,
 };
 use linera_execution::{
@@ -34,7 +35,7 @@ use linera_views::{
     set_view::SetView,
     views::{CryptoHashView, RootView, View, ViewError},
 };
-use prometheus::{register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec};
+use prometheus::{HistogramVec, IntCounterVec};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
@@ -42,52 +43,56 @@ use std::{
 };
 
 pub static NUM_BLOCKS_EXECUTED: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("num_blocks_executed", "Number of blocks executed", &[])
-        .expect("Counter creation should not fail")
+    prometheus_util::register_int_counter_vec(
+        "num_blocks_executed",
+        "Number of blocks executed",
+        &[],
+    )
+    .expect("Counter creation should not fail")
 });
 
 pub static BLOCK_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "block_execution_latency",
         "Block execution latency",
         &[],
-        vec![
+        Some(vec![
             0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-            1.0, 2.5, 5.0, 10.0, 25.0, 50.0
-        ],
+            1.0, 2.5, 5.0, 10.0, 25.0, 50.0,
+        ]),
     )
     .expect("Counter creation should not fail")
 });
 
 pub static WASM_FUEL_USED_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "wasm_fuel_used_per_block",
         "Wasm fuel used per block",
         &[],
-        vec![
+        Some(vec![
             50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10_000.0, 25_000.0, 50_000.0,
-            100_000.0, 250_000.0, 500_000.0
-        ],
+            100_000.0, 250_000.0, 500_000.0,
+        ]),
     )
     .expect("Counter creation should not fail")
 });
 
 pub static WASM_NUM_READS_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "wasm_num_reads_per_block",
         "Wasm number of reads per block",
         &[],
-        vec![0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 50.0, 100.0],
+        Some(vec![0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 50.0, 100.0]),
     )
-    .expect("Counter can be created")
+    .expect("Counter creation should not fail")
 });
 
 pub static WASM_BYTES_READ_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "wasm_bytes_read_per_block",
         "Wasm number of bytes read per block",
         &[],
-        vec![
+        Some(vec![
             0.5,
             1.0,
             10.0,
@@ -102,18 +107,18 @@ pub static WASM_BYTES_READ_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
             65_536.0,
             524_288.0,
             1_048_576.0,
-            8_388_608.0
-        ],
+            8_388_608.0,
+        ]),
     )
-    .expect("Counter can be created")
+    .expect("Counter creation should not fail")
 });
 
 pub static WASM_BYTES_WRITTEN_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "wasm_bytes_written_per_block",
         "Wasm number of bytes written per block",
         &[],
-        vec![
+        Some(vec![
             0.5,
             1.0,
             10.0,
@@ -128,10 +133,10 @@ pub static WASM_BYTES_WRITTEN_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
             65_536.0,
             524_288.0,
             1_048_576.0,
-            8_388_608.0
-        ],
+            8_388_608.0,
+        ]),
     )
-    .expect("Counter can be created")
+    .expect("Counter creation should not fail")
 });
 
 /// A view accessing the state of a chain.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -10,6 +10,7 @@ use linera_base::{
     data_types::{ArithmeticError, BlockHeight, Round},
     doc_scalar, ensure,
     identifiers::{ChainId, Owner},
+    prometheus_util,
     sync::Lazy,
 };
 use linera_chain::{
@@ -30,7 +31,7 @@ use linera_views::{
     views::{RootView, View, ViewError},
 };
 use lru::LruCache;
-use prometheus::{register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec};
+use prometheus::{HistogramVec, IntCounterVec};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -55,27 +56,31 @@ use {
 mod worker_tests;
 
 pub static NUM_ROUNDS_IN_CERTIFICATE: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "num_rounds_in_certificate",
         "Number of rounds in certificate",
         &["certificate_value", "round_type"],
-        vec![0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0],
+        Some(vec![
+            0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0,
+        ]),
     )
     .expect("Counter creation should not fail")
 });
 
 pub static NUM_ROUNDS_IN_BLOCK_PROPOSAL: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "num_rounds_in_block_proposal",
         "Number of rounds in block proposal",
         &["round_type"],
-        vec![0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0],
+        Some(vec![
+            0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 8.0, 10.0, 15.0, 25.0, 50.0,
+        ]),
     )
     .expect("Counter creation should not fail")
 });
 
 pub static TRANSACTION_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("transaction_count", "Transaction count", &[])
+    prometheus_util::register_int_counter_vec("transaction_count", "Transaction count", &[])
         .expect("Counter creation should not fail")
 });
 

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -35,7 +35,7 @@ use grpc::{
     BlockProposal, Certificate, ChainInfoQuery, ChainInfoResult, CrossChainRequest,
     LiteCertificate, SubscriptionRequest,
 };
-use linera_base::{identifiers::ChainId, sync::Lazy};
+use linera_base::{identifiers::ChainId, prometheus_util, sync::Lazy};
 use linera_chain::data_types;
 use linera_core::{
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
@@ -43,7 +43,7 @@ use linera_core::{
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use prometheus::{register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec};
+use prometheus::{HistogramVec, IntCounterVec};
 use rand::Rng;
 use std::{
     fmt::Debug,
@@ -69,44 +69,44 @@ type CrossChainSender = mpsc::Sender<(linera_core::data_types::CrossChainRequest
 type NotificationSender = mpsc::Sender<Notification>;
 
 pub static SERVER_REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "server_request_latency",
         "Server request latency",
         &[],
-        vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]
+        Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
     )
     .expect("Counter creation should not fail")
 });
 
 pub static SERVER_REQUEST_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("server_request_count", "Server request count", &[])
+    prometheus_util::register_int_counter_vec("server_request_count", "Server request count", &[])
         .expect("Counter creation should not fail")
 });
 
 pub static SERVER_REQUEST_SUCCESS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "server_request_success",
         "Server request success",
-        &["method_name"]
+        &["method_name"],
     )
     .expect("Counter creation should not fail")
 });
 
 pub static SERVER_REQUEST_ERROR: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "server_request_error",
         "Server request error",
-        &["method_name"]
+        &["method_name"],
     )
     .expect("Counter creation should not fail")
 });
 
 pub static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "server_request_latency_per_request_type",
         "Server request latency per request type",
         &["method_name"],
-        vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]
+        Some(vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]),
     )
     .expect("Counter creation should not fail")
 });

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -5,7 +5,7 @@ use crate::prometheus_server;
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::{future::BoxFuture, FutureExt};
-use linera_base::{identifiers::ChainId, sync::Lazy};
+use linera_base::{identifiers::ChainId, prometheus_util, sync::Lazy};
 use linera_core::notifier::Notifier;
 use linera_rpc::{
     config::{
@@ -23,7 +23,7 @@ use linera_rpc::{
     },
     grpc_pool::ConnectionPool,
 };
-use prometheus::{register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec};
+use prometheus::{HistogramVec, IntCounterVec};
 use rcgen::generate_simple_self_signed;
 use std::{
     fmt::Debug,
@@ -42,37 +42,37 @@ use tower::{builder::ServiceBuilder, Layer, Service};
 use tracing::{debug, info, instrument};
 
 pub static PROXY_REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
+    prometheus_util::register_histogram_vec(
         "proxy_request_latency",
         "Proxy request latency",
         &[],
-        vec![
+        Some(vec![
             0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 25.0,
-            50.0, 100.0, 200.0, 300.0, 400.0
-        ]
+            50.0, 100.0, 200.0, 300.0, 400.0,
+        ]),
     )
     .expect("Counter creation should not fail")
 });
 
 pub static PROXY_REQUEST_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!("proxy_request_count", "Proxy request count", &[])
+    prometheus_util::register_int_counter_vec("proxy_request_count", "Proxy request count", &[])
         .expect("Counter creation should not fail")
 });
 
 pub static PROXY_REQUEST_SUCCESS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "proxy_request_success",
         "Proxy request success",
-        &["method_name"]
+        &["method_name"],
     )
     .expect("Counter creation should not fail")
 });
 
 pub static PROXY_REQUEST_ERROR: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "proxy_request_error",
         "Proxy request error",
-        &["method_name"]
+        &["method_name"],
     )
     .expect("Counter creation should not fail")
 });

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -4,7 +4,9 @@
 use crate::{chain_guards::ChainGuards, ChainRuntimeContext, Storage};
 use async_trait::async_trait;
 use dashmap::DashMap;
-use linera_base::{crypto::CryptoHash, data_types::Timestamp, identifiers::ChainId, sync::Lazy};
+use linera_base::{
+    crypto::CryptoHash, data_types::Timestamp, identifiers::ChainId, prometheus_util, sync::Lazy,
+};
 use linera_chain::{
     data_types::{Certificate, CertificateValue, HashedValue, LiteCertificate},
     ChainStateView,
@@ -18,66 +20,66 @@ use linera_views::{
     value_splitting::DatabaseConsistencyError,
     views::{View, ViewError},
 };
-use prometheus::{register_int_counter_vec, IntCounterVec};
+use prometheus::IntCounterVec;
 use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
 
 /// The metric counting how often a value is read from storage.
 pub static CONTAINS_VALUE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "contains_value",
         "The metric counting how often a value is tested for existence from storage",
-        &[]
+        &[],
     )
     .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a value is read from storage.
 pub static CONTAINS_CERTIFICATE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "contains_certificate",
         "The metric counting how often a certificate is tested for existence from storage",
-        &[]
+        &[],
     )
     .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a value is read from storage.
 pub static READ_VALUE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "read_value",
         "The metric counting how often a value is read from storage",
-        &[]
+        &[],
     )
     .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a value is written to storage.
 pub static WRITE_VALUE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "write_value",
         "The metric counting how often a value is written to storage",
-        &[]
+        &[],
     )
     .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a certificate is read from storage.
 pub static READ_CERTIFICATE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "read_certificate",
         "The metric counting how often a certificate is read from storage",
-        &[]
+        &[],
     )
     .expect("Counter creation should not fail")
 });
 
 /// The metric counting how often a certificate is written to storage.
 pub static WRITE_CERTIFICATE_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "write_certificate",
         "The metric counting how often a certificate is written to storage",
-        &[]
+        &[],
     )
     .expect("Counter creation should not fail")
 });

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -122,6 +122,7 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
 
     let increment_counter = if root {
         quote! {
+            #[cfg(not(target_arch = "wasm32"))]
             linera_views::increment_counter(
                 &linera_views::LOAD_VIEW_COUNTER,
                 stringify!(#struct_name),
@@ -191,6 +192,7 @@ fn generate_save_delete_view_code(input: ItemStruct) -> TokenStream2 {
         {
             async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
                 use linera_views::{common::Context, batch::Batch, views::View};
+                #[cfg(not(target_arch = "wasm32"))]
                 linera_views::increment_counter(
                     &linera_views::SAVE_VIEW_COUNTER,
                     stringify!(#struct_name),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-2.snap
@@ -6,6 +6,7 @@ expression: pretty(generate_save_delete_view_code(input))
 impl linera_views::views::RootView<CustomContext> for TestView {
     async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
         use linera_views::{common::Context, batch::Batch, views::View};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::SAVE_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-3.snap
@@ -6,6 +6,7 @@ expression: pretty(generate_save_delete_view_code(input))
 impl linera_views::views::RootView<custom::path::to::ContextType> for TestView {
     async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
         use linera_views::{common::Context, batch::Batch, views::View};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::SAVE_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code-4.snap
@@ -6,6 +6,7 @@ expression: pretty(generate_save_delete_view_code(input))
 impl linera_views::views::RootView<custom::GenericContext<T>> for TestView {
     async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
         use linera_views::{common::Context, batch::Batch, views::View};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::SAVE_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_save_delete_view_code.snap
@@ -10,6 +10,7 @@ where
 {
     async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
         use linera_views::{common::Context, batch::Batch, views::View};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::SAVE_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-2.snap
@@ -12,6 +12,7 @@ impl linera_views::views::View<CustomContext> for TestView {
         context: CustomContext,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::{futures::join, common::Context};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-3.snap
@@ -12,6 +12,7 @@ impl linera_views::views::View<custom::path::to::ContextType> for TestView {
         context: custom::path::to::ContextType,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::{futures::join, common::Context};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-4.snap
@@ -12,6 +12,7 @@ impl linera_views::views::View<custom::GenericContext<T>> for TestView {
         context: custom::GenericContext<T>,
     ) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::{futures::join, common::Context};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code.snap
@@ -14,6 +14,7 @@ where
     }
     async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
         use linera_views::{futures::join, common::Context};
+        #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -53,6 +53,12 @@
 
 #![deny(missing_docs)]
 
+#[cfg(not(target_arch = "wasm32"))]
+use {
+    linera_base::{prometheus_util, sync::Lazy},
+    prometheus::IntCounterVec,
+};
+
 /// The definition of the batches for writing in the database.
 pub mod batch;
 
@@ -133,20 +139,17 @@ pub mod test_utils;
 /// Re-exports used by the derive macros of this library.
 #[doc(hidden)]
 pub use {
-    async_lock,
-    async_trait::async_trait,
-    futures, generic_array,
-    linera_base::{crypto, sync::Lazy},
-    prometheus::{register_int_counter_vec, IntCounterVec},
-    serde, sha3,
+    async_lock, async_trait::async_trait, futures, generic_array, linera_base::crypto, serde, sha3,
 };
 
 /// Does nothing. Use the metrics feature to enable.
 #[cfg(not(feature = "metrics"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub fn increment_counter(_counter: &Lazy<IntCounterVec>, _struct_name: &str, _base_key: &[u8]) {}
 
 /// Increments the metrics counter with the given name, with the struct and base key as labels.
 #[cfg(feature = "metrics")]
+#[cfg(not(target_arch = "wasm32"))]
 pub fn increment_counter(counter: &Lazy<IntCounterVec>, struct_name: &str, base_key: &[u8]) {
     let base_key = hex::encode(base_key);
     let labels = [struct_name, &base_key];
@@ -154,20 +157,22 @@ pub fn increment_counter(counter: &Lazy<IntCounterVec>, struct_name: &str, base_
 }
 
 /// The metric counting how often a view is read from storage.
+#[cfg(not(target_arch = "wasm32"))]
 pub static LOAD_VIEW_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "load_view",
         "The metric counting how often a view is read from storage",
-        &["type", "base_key"]
+        &["type", "base_key"],
     )
     .expect("Counter creation should not fail")
 });
 /// The metric counting how often a view is written from storage.
+#[cfg(not(target_arch = "wasm32"))]
 pub static SAVE_VIEW_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    prometheus_util::register_int_counter_vec(
         "save_view",
         "The metric counting how often a view is written from storage",
-        &["type", "base_key"]
+        &["type", "base_key"],
     )
     .expect("Counter creation should not fail")
 });


### PR DESCRIPTION
## Motivation

Ideally we would want a way to set a namespace to all our registered metrics

## Proposal

Created wrappers for the metric registration macros we're using, and made sure we set the linera namespace for all of them. Setting the namespace will also add a prefix to the exported metrics. We need to only use these wrappers from now on when registering new metrics, otherwise the namespace won't be properly set

## Test Plan

![Screenshot 2024-01-18 at 14.25.37.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/443eb64f-b459-4dce-a12e-93cb335c4253.png)

