### PR TITLE
Standardize latency metrics to ms

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -52,8 +52,8 @@ pub static BLOCK_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
         "Block execution latency",
         &[],
         vec![
-            0.000_01, 0.000_03, 0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025,
-            0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 5.0,
+            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+            1.0, 2.5, 5.0, 10.0, 25.0, 50.0
         ],
     )
     .expect("Counter creation should not fail")
@@ -764,7 +764,7 @@ where
         NUM_BLOCKS_EXECUTED.with_label_values(&[]).inc();
         BLOCK_EXECUTION_LATENCY
             .with_label_values(&[])
-            .observe(start_time.elapsed().as_secs_f64());
+            .observe(start_time.elapsed().as_millis() as f64);
         WASM_FUEL_USED_PER_BLOCK
             .with_label_values(&[])
             .observe(tracker.used_fuel as f64);

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -69,8 +69,13 @@ type CrossChainSender = mpsc::Sender<(linera_core::data_types::CrossChainRequest
 type NotificationSender = mpsc::Sender<Notification>;
 
 pub static SERVER_REQUEST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!("server_request_latency", "Server request latency", &[])
-        .expect("Counter creation should not fail")
+    register_histogram_vec!(
+        "server_request_latency",
+        "Server request latency",
+        &[],
+        vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]
+    )
+    .expect("Counter creation should not fail")
 });
 
 pub static SERVER_REQUEST_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -100,7 +105,8 @@ pub static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: Lazy<HistogramVec> = Lazy::n
     register_histogram_vec!(
         "server_request_latency_per_request_type",
         "Server request latency per request type",
-        &["method_name"]
+        &["method_name"],
+        vec![0.5, 1.0, 2.5, 5.0, 10.0, 25.0, 50.0]
     )
     .expect("Counter creation should not fail")
 });
@@ -182,7 +188,7 @@ where
             let response = future.await?;
             SERVER_REQUEST_LATENCY
                 .with_label_values(&[])
-                .observe(start.elapsed().as_secs_f64());
+                .observe(start.elapsed().as_millis() as f64);
             SERVER_REQUEST_COUNT.with_label_values(&[]).inc();
             Ok(response)
         }
@@ -423,7 +429,7 @@ where
     fn log_request_success_and_latency(start: Instant, method_name: &str) {
         SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE
             .with_label_values(&[method_name])
-            .observe(start.elapsed().as_secs_f64());
+            .observe(start.elapsed().as_millis() as f64);
         SERVER_REQUEST_SUCCESS
             .with_label_values(&[method_name])
             .inc();


### PR DESCRIPTION
## Motivation

All latency metrics should be in ms

## Proposal

Do that

## Test Plan

Ran e2e tests locally, saw metrics logged with higher ms amounts

