### PR TITLE
Fix Prometheus metrics on Proxy

### DIFF
--- a/kubernetes/linera-validator/templates/proxy.yaml
+++ b/kubernetes/linera-validator/templates/proxy.yaml
@@ -12,6 +12,8 @@ spec:
     - port: {{ .Values.proxyPort }}
       name: linera-port
       targetPort: {{ .Values.proxyPort }}
+    - port: {{ .Values.metricsPort }}
+      name: metrics
   selector:
     app: proxy
   type: NodePort

--- a/kubernetes/linera-validator/values-local.yaml
+++ b/kubernetes/linera-validator/values-local.yaml
@@ -5,6 +5,7 @@ lineraImage: linera-test:latest
 lineraImagePullPolicy: Never
 logLevel: "debug"
 proxyPort: 19100
+metricsPort: 21100
 numShards: 10
 
 # Loki


### PR DESCRIPTION
## Motivation

Metrics on the proxy side were not working

## Proposal

Fix it

## Test Plan

Ran locally, saw metrics:

![Screenshot 2024-01-18 at 17.31.55.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/d77dab89-d2e7-40ba-8d33-6588e867bec2.png)

