### PR TITLE
Improve resource policy

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -246,15 +246,18 @@ View or update the resource control policy
 
 ###### **Options:**
 
-* `--certificate <CERTIFICATE>` — Set the base price for each certificate
-* `--fuel <FUEL>` — Set the price per unit of fuel when executing user messages and operations
-* `--storage-num-reads <STORAGE_NUM_READS>` — Set the price per byte to read data per operation
-* `--storage-bytes-read <STORAGE_BYTES_READ>` — Set the price per byte to read data per byte
-* `--storage-bytes-written <STORAGE_BYTES_WRITTEN>` — Set the price per byte to write data per byte
-* `--storage-bytes-stored <STORAGE_BYTES_STORED>` — Set the price per byte stored
-* `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum quantity of data to read per block
-* `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum quantity of data to write per block
-* `--messages <MESSAGES>` — Set the price per byte to store and send outgoing cross-chain messages
+* `--block <BLOCK>` — Set the base price for creating a block
+* `--fuel-unit <FUEL_UNIT>` — Set the price per unit of fuel
+* `--read-operation <READ_OPERATION>` — Set the price per read operation
+* `--byte-read <BYTE_READ>` — Set the price per byte read
+* `--byte-written <BYTE_WRITTEN>` — Set the price per byte written
+* `--byte-stored <BYTE_STORED>` — Set the price per byte stored
+* `--operation <OPERATION>` — Set the base price of sending a operation from a block..
+* `--operation-byte <OPERATION_BYTE>` — Set the additional price for each byte in the argument of a user operation
+* `--message <MESSAGE>` — Set the base price of sending a message from a block..
+* `--message-byte <MESSAGE_BYTE>` — Set the additional price for each byte in the argument of a user message
+* `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
+* `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
 
 
 
@@ -279,29 +282,38 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 
   Default value: `0`
 * `--start-timestamp <START_TIMESTAMP>` — The start timestamp: no blocks can be created before this time
-* `--certificate-price <CERTIFICATE_PRICE>` — Set the base price for each certificate
+* `--block-price <BLOCK_PRICE>` — Set the base price for creating a block
 
   Default value: `0`
-* `--fuel-price <FUEL_PRICE>` — Set the price per unit of fuel when executing user messages and operations
+* `--fuel-unit-price <FUEL_UNIT_PRICE>` — Set the price per unit of fuel
 
   Default value: `0`
-* `--storage-num-reads-price <STORAGE_NUM_READS_PRICE>` — Set the price per operation to read data
+* `--read-operation-price <READ_OPERATION_PRICE>` — Set the price per read operation
 
   Default value: `0`
-* `--storage-bytes-read-price <STORAGE_BYTES_READ_PRICE>` — Set the price per byte to read data
+* `--byte-read-price <BYTE_READ_PRICE>` — Set the price per byte read
 
   Default value: `0`
-* `--storage-bytes-written-price <STORAGE_BYTES_WRITTEN_PRICE>` — Set the price per byte to write data
+* `--byte-written-price <BYTE_WRITTEN_PRICE>` — Set the price per byte written
 
   Default value: `0`
-* `--storage-bytes-stored-price <STORAGE_BYTES_STORED_PRICE>` — Set the price per byte stored
+* `--byte-stored-price <BYTE_STORED_PRICE>` — Set the price per byte stored
+
+  Default value: `0`
+* `--operation-price <OPERATION_PRICE>` — Set the base price of sending a operation from a block..
+
+  Default value: `0`
+* `--operation-byte-price <OPERATION_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user operation
+
+  Default value: `0`
+* `--message-price <MESSAGE_PRICE>` — Set the base price of sending a message from a block..
+
+  Default value: `0`
+* `--message-byte-price <MESSAGE_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user message
 
   Default value: `0`
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
-* `--messages-price <MESSAGES_PRICE>` — Set the price per byte to store and send outgoing cross-chain messages
-
-  Default value: `0`
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 * `--network-name <NETWORK_NAME>` — A unique name to identify this network
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -601,13 +601,7 @@ where
         let policy = committee.policy().clone();
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
-        let mut tracker = ResourceTracker {
-            used_fuel: 0,
-            num_reads: 0,
-            bytes_read: 0,
-            bytes_written: 0,
-            stored_size_delta: 0,
-        };
+        let mut tracker = ResourceTracker::default();
         // The first incoming message of any child chain must be `OpenChain`. A root chain must
         // already be initialized
         if block.height == BlockHeight::ZERO

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -601,15 +601,11 @@ where
         let policy = committee.policy().clone();
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
-        let maximum_bytes_left_to_read = policy.maximum_bytes_read_per_block;
-        let maximum_bytes_left_to_write = policy.maximum_bytes_written_per_block;
         let mut tracker = ResourceTracker {
             used_fuel: 0,
             num_reads: 0,
             bytes_read: 0,
             bytes_written: 0,
-            maximum_bytes_left_to_read,
-            maximum_bytes_left_to_write,
             stored_size_delta: 0,
         };
         // The first incoming message of any child chain must be `OpenChain`. A root chain must

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -718,7 +718,7 @@ where
             let balance = self.execution_state.system.balance.get_mut();
             Self::sub_assign_fees(
                 balance,
-                policy.operation_price(&operation)?,
+                policy.operation_price(operation)?,
                 chain_execution_context,
             )?;
             for message_out in &messages_out {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -85,7 +85,7 @@ where
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
-        .with_policy(ResourceControlPolicy::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_block());
     let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -265,7 +265,7 @@ where
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
-        .with_policy(ResourceControlPolicy::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_block());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -335,7 +335,7 @@ where
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
-        .with_policy(ResourceControlPolicy::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_block());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
@@ -1233,7 +1233,7 @@ where
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
-        .with_policy(ResourceControlPolicy::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_block());
     let mut client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;
@@ -1558,7 +1558,7 @@ where
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
-        .with_policy(ResourceControlPolicy::fuel_and_certificate());
+        .with_policy(ResourceControlPolicy::fuel_and_block());
     let mut sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -118,7 +118,7 @@ impl ResourceControlPolicy {
     }
 
     #[cfg(any(test, feature = "test"))]
-    /// Creates a pricing with no cost for anything except fuel.
+    /// Creates a policy with no cost for anything except fuel.
     ///
     /// This can be used in tests that need whole numbers in their chain balance and don't expect
     /// to execute any Wasm code.
@@ -130,7 +130,7 @@ impl ResourceControlPolicy {
     }
 
     #[cfg(any(test, feature = "test"))]
-    /// Creates a pricing with no cost for anything except fuel, and 0.001 per block.
+    /// Creates a policy with no cost for anything except fuel, and 0.001 per block.
     ///
     /// This can be used in tests that don't expect to execute any Wasm code, and that keep track of
     /// how many blocks were created.
@@ -143,7 +143,7 @@ impl ResourceControlPolicy {
     }
 
     #[cfg(any(test, feature = "test"))]
-    /// Creates a pricing where all categories have a small non-zero cost.
+    /// Creates a policy where all categories have a small non-zero cost.
     pub fn all_categories() -> Self {
         Self {
             block: Amount::from_milli(1),

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -3,92 +3,118 @@
 
 //! This module contains types related to fees and pricing.
 
+use crate::{Message, Operation};
 use async_graphql::InputObject;
 use linera_base::data_types::{Amount, ArithmeticError};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// A collection of costs associated with blocks in validators.
+/// A collection of prices and limits associated with block execution.
 #[derive(Eq, PartialEq, Hash, Clone, Debug, Serialize, Deserialize, InputObject)]
 pub struct ResourceControlPolicy {
-    /// The base price for each certificate, to compensate for the communication and signing
-    /// overhead.
-    pub certificate: Amount,
-    /// The price per unit of fuel used when executing messages and operations for user applications.
-    pub fuel: Amount,
-    /// The cost to read data per operation
-    pub storage_num_reads: Amount,
-    /// The cost to read data per byte
-    pub storage_bytes_read: Amount,
-    /// The cost to store data per byte
-    pub storage_bytes_written: Amount,
-    /// The cost of the total storage used
-    pub storage_bytes_stored: Amount,
+    /// The base price for creating a new block.
+    pub block: Amount,
+    /// The price per unit of fuel (aka gas) for VM execution.
+    pub fuel_unit: Amount,
+    /// The price of one read operation.
+    pub read_operation: Amount,
+    // TODO(#1530): Write operation.
+    /// The price of reading a byte.
+    pub byte_read: Amount,
+    /// The price to writting a byte
+    pub byte_written: Amount,
+    /// The price of increasing storage by a byte.
+    pub byte_stored: Amount,
+    /// The base price of adding an operation to a block.
+    pub operation: Amount,
+    /// The additional price for each byte in the argument of a user operation.
+    pub operation_byte: Amount,
+    /// The base price of sending a message from a block.
+    pub message: Amount,
+    /// The additional price for each byte in the argument of a user message.
+    pub message_byte: Amount,
+
     /// The maximum data to read per block
     pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
     pub maximum_bytes_written_per_block: u64,
-    /// The cost to store and send cross-chain messages, per byte.
-    pub messages: Amount,
 }
 
 impl Default for ResourceControlPolicy {
     fn default() -> Self {
-        ResourceControlPolicy {
-            certificate: Amount::default(),
-            fuel: Amount::default(),
-            storage_num_reads: Amount::default(),
-            storage_bytes_read: Amount::default(),
-            storage_bytes_written: Amount::default(),
-            storage_bytes_stored: Amount::default(),
-            maximum_bytes_read_per_block: u64::MAX / 2,
-            maximum_bytes_written_per_block: u64::MAX / 2,
-            messages: Amount::default(),
+        Self {
+            block: Amount::default(),
+            fuel_unit: Amount::default(),
+            read_operation: Amount::default(),
+            byte_read: Amount::default(),
+            byte_written: Amount::default(),
+            byte_stored: Amount::default(),
+            operation: Amount::default(),
+            operation_byte: Amount::default(),
+            message: Amount::default(),
+            message_byte: Amount::default(),
+            maximum_bytes_read_per_block: u64::MAX,
+            maximum_bytes_written_per_block: u64::MAX,
         }
     }
 }
 
 impl ResourceControlPolicy {
-    pub fn certificate_price(&self) -> Amount {
-        self.certificate
+    pub fn block_price(&self) -> Amount {
+        self.block
     }
 
-    pub fn messages_price(&self, data: &impl Serialize) -> Result<Amount, PricingError> {
-        let size = bcs::serialized_size(data)?;
-        Ok(self.messages.try_mul(size as u128)?)
+    pub fn operation_price(&self, operation: &Operation) -> Result<Amount, PricingError> {
+        match operation {
+            Operation::System(_) => Ok(self.operation),
+            Operation::User { bytes, .. } => {
+                let size = bytes.len();
+                let price = self
+                    .operation_byte
+                    .try_mul(size as u128)?
+                    .try_add(self.operation)?;
+                Ok(price)
+            }
+        }
+    }
+
+    pub fn message_price(&self, message: &Message) -> Result<Amount, PricingError> {
+        match message {
+            Message::System(_) => Ok(self.message),
+            Message::User { bytes, .. } => {
+                let size = bytes.len();
+                let price = self
+                    .message_byte
+                    .try_mul(size as u128)?
+                    .try_add(self.message)?;
+                Ok(price)
+            }
+        }
     }
 
     pub fn storage_num_reads_price(&self, count: u64) -> Result<Amount, PricingError> {
-        Ok(self.storage_num_reads.try_mul(count as u128)?)
+        Ok(self.read_operation.try_mul(count as u128)?)
     }
 
     pub fn storage_bytes_read_price(&self, count: u64) -> Result<Amount, PricingError> {
-        Ok(self.storage_bytes_read.try_mul(count as u128)?)
+        Ok(self.byte_read.try_mul(count as u128)?)
     }
 
     pub fn storage_bytes_written_price(&self, count: u64) -> Result<Amount, PricingError> {
-        Ok(self.storage_bytes_written.try_mul(count as u128)?)
-    }
-
-    pub fn storage_bytes_written_price_raw(
-        &self,
-        data: &impl Serialize,
-    ) -> Result<Amount, PricingError> {
-        let size = bcs::serialized_size(data)?;
-        Ok(self.storage_bytes_written.try_mul(size as u128)?)
+        Ok(self.byte_written.try_mul(count as u128)?)
     }
 
     pub fn storage_bytes_stored_price(&self, count: u64) -> Result<Amount, PricingError> {
-        Ok(self.storage_bytes_stored.try_mul(count as u128)?)
+        Ok(self.byte_stored.try_mul(count as u128)?)
     }
 
     pub fn fuel_price(&self, fuel: u64) -> Result<Amount, PricingError> {
-        Ok(self.fuel.try_mul(u128::from(fuel))?)
+        Ok(self.fuel_unit.try_mul(u128::from(fuel))?)
     }
 
     /// Returns how much fuel can be paid with the given balance.
     pub fn remaining_fuel(&self, balance: Amount) -> u64 {
-        u64::try_from(balance.saturating_div(self.fuel)).unwrap_or(u64::MAX)
+        u64::try_from(balance.saturating_div(self.fuel_unit)).unwrap_or(u64::MAX)
     }
 
     #[cfg(any(test, feature = "test"))]
@@ -97,51 +123,38 @@ impl ResourceControlPolicy {
     /// This can be used in tests that need whole numbers in their chain balance and don't expect
     /// to execute any Wasm code.
     pub fn only_fuel() -> Self {
-        ResourceControlPolicy {
-            certificate: Amount::ZERO,
-            fuel: Amount::from_atto(1_000_000_000_000),
-            storage_num_reads: Amount::ZERO,
-            storage_bytes_read: Amount::ZERO,
-            storage_bytes_written: Amount::ZERO,
-            storage_bytes_stored: Amount::ZERO,
-            maximum_bytes_read_per_block: u64::MAX / 2,
-            maximum_bytes_written_per_block: u64::MAX / 2,
-            messages: Amount::ZERO,
+        Self {
+            fuel_unit: Amount::from_atto(1_000_000_000_000),
+            ..Self::default()
         }
     }
 
     #[cfg(any(test, feature = "test"))]
-    /// Creates a pricing with no cost for anything except fuel, and 0.001 per certificate.
+    /// Creates a pricing with no cost for anything except fuel, and 0.001 per block.
     ///
     /// This can be used in tests that don't expect to execute any Wasm code, and that keep track of
-    /// how many certificates were created.
-    pub fn fuel_and_certificate() -> Self {
-        ResourceControlPolicy {
-            certificate: Amount::from_milli(1),
-            fuel: Amount::from_atto(1_000_000_000_000),
-            storage_num_reads: Amount::ZERO,
-            storage_bytes_read: Amount::ZERO,
-            storage_bytes_written: Amount::ZERO,
-            storage_bytes_stored: Amount::ZERO,
-            maximum_bytes_read_per_block: u64::MAX,
-            maximum_bytes_written_per_block: u64::MAX,
-            messages: Amount::ZERO,
+    /// how many blocks were created.
+    pub fn fuel_and_block() -> Self {
+        Self {
+            block: Amount::from_milli(1),
+            fuel_unit: Amount::from_atto(1_000_000_000_000),
+            ..Self::default()
         }
     }
 
     #[cfg(any(test, feature = "test"))]
     /// Creates a pricing where all categories have a small non-zero cost.
     pub fn all_categories() -> Self {
-        ResourceControlPolicy {
-            certificate: Amount::from_milli(1),
-            fuel: Amount::from_atto(1_000_000_000),
-            storage_num_reads: Amount::ZERO,
-            storage_bytes_read: Amount::from_atto(100),
-            storage_bytes_written: Amount::from_atto(1_000),
-            storage_bytes_stored: Amount::ZERO,
-            maximum_bytes_read_per_block: u64::MAX,
-            maximum_bytes_written_per_block: u64::MAX,
-            messages: Amount::from_atto(1),
+        Self {
+            block: Amount::from_milli(1),
+            fuel_unit: Amount::from_atto(1_000_000_000),
+            byte_read: Amount::from_atto(100),
+            byte_written: Amount::from_atto(1_000),
+            operation: Amount::from_atto(10),
+            operation_byte: Amount::from_atto(1),
+            message: Amount::from_atto(10),
+            message_byte: Amount::from_atto(1),
+            ..Self::default()
         }
     }
 }
@@ -150,6 +163,4 @@ impl ResourceControlPolicy {
 pub enum PricingError {
     #[error(transparent)]
     ArithmeticError(#[from] ArithmeticError),
-    #[error(transparent)]
-    SerializationError(#[from] bcs::Error),
 }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -96,13 +96,17 @@ impl ResourceTracker {
     /// Obtain the limits for the running of the system
     pub fn limits(&self, policy: &ResourceControlPolicy, balance: &Amount) -> RuntimeLimits {
         let max_budget_num_reads =
-            u64::try_from(balance.saturating_div(policy.storage_num_reads)).unwrap_or(u64::MAX);
+            u64::try_from(balance.saturating_div(policy.read_operation)).unwrap_or(u64::MAX);
         let max_budget_bytes_read =
-            u64::try_from(balance.saturating_div(policy.storage_bytes_read)).unwrap_or(u64::MAX);
+            u64::try_from(balance.saturating_div(policy.byte_read)).unwrap_or(u64::MAX);
         let max_budget_bytes_written =
-            u64::try_from(balance.saturating_div(policy.storage_bytes_written)).unwrap_or(u64::MAX);
-        let maximum_bytes_left_to_read = policy.maximum_bytes_read_per_block.saturating_sub(self.bytes_read);
-        let maximum_bytes_left_to_write = policy.maximum_bytes_written_per_block.saturating_sub(self.bytes_written);
+            u64::try_from(balance.saturating_div(policy.byte_written)).unwrap_or(u64::MAX);
+        let maximum_bytes_left_to_read = policy
+            .maximum_bytes_read_per_block
+            .saturating_sub(self.bytes_read);
+        let maximum_bytes_left_to_write = policy
+            .maximum_bytes_written_per_block
+            .saturating_sub(self.bytes_written);
         RuntimeLimits {
             max_budget_num_reads,
             max_budget_bytes_read,

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -78,7 +78,7 @@ async fn test_fuel_for_counter_wasm_application(
     };
     let increments = [2_u64, 9, 7, 1000];
     let policy = ResourceControlPolicy {
-        fuel: Amount::from_atto(1),
+        fuel_unit: Amount::from_atto(1),
         ..ResourceControlPolicy::default()
     };
     let mut tracker = ResourceTracker::default();

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -597,22 +597,28 @@ Recipient:
           TYPENAME: Account
 ResourceControlPolicy:
   STRUCT:
-    - certificate:
+    - block:
         TYPENAME: Amount
-    - fuel:
+    - fuel_unit:
         TYPENAME: Amount
-    - storage_num_reads:
+    - read_operation:
         TYPENAME: Amount
-    - storage_bytes_read:
+    - byte_read:
         TYPENAME: Amount
-    - storage_bytes_written:
+    - byte_written:
         TYPENAME: Amount
-    - storage_bytes_stored:
+    - byte_stored:
+        TYPENAME: Amount
+    - operation:
+        TYPENAME: Amount
+    - operation_byte:
+        TYPENAME: Amount
+    - message:
+        TYPENAME: Amount
+    - message_byte:
         TYPENAME: Amount
     - maximum_bytes_read_per_block: U64
     - maximum_bytes_written_per_block: U64
-    - messages:
-        TYPENAME: Amount
 Round:
   ENUM:
     0:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -617,34 +617,49 @@ type ReentrantCollectionView_Target_OutboxStateView {
 }
 
 """
-A collection of costs associated with blocks in validators.
+A collection of prices and limits associated with block execution.
 """
 input ResourceControlPolicy {
 	"""
-	The base price for each certificate, to compensate for the communication and signing
-	overhead.
+	The base price for creating a new block.
 	"""
-	certificate: Amount!
+	block: Amount!
 	"""
-	The price per unit of fuel used when executing messages and operations for user applications.
+	The price per unit of fuel (aka gas) for VM execution.
 	"""
-	fuel: Amount!
+	fuelUnit: Amount!
 	"""
-	The cost to read data per operation
+	The price of one read operation.
 	"""
-	storageNumReads: Amount!
+	readOperation: Amount!
 	"""
-	The cost to read data per byte
+	The price of reading a byte.
 	"""
-	storageBytesRead: Amount!
+	byteRead: Amount!
 	"""
-	The cost to store data per byte
+	The price to writting a byte
 	"""
-	storageBytesWritten: Amount!
+	byteWritten: Amount!
 	"""
-	The cost of the total storage used
+	The price of increasing storage by a byte.
 	"""
-	storageBytesStored: Amount!
+	byteStored: Amount!
+	"""
+	The base price of adding an operation to a block.
+	"""
+	operation: Amount!
+	"""
+	The additional price for each byte in the argument of a user operation.
+	"""
+	operationByte: Amount!
+	"""
+	The base price of sending a message from a block.
+	"""
+	message: Amount!
+	"""
+	The additional price for each byte in the argument of a user message.
+	"""
+	messageByte: Amount!
 	"""
 	The maximum data to read per block
 	"""
@@ -653,10 +668,6 @@ input ResourceControlPolicy {
 	The maximum data to write per block
 	"""
 	maximumBytesWrittenPerBlock: Int!
-	"""
-	The cost to store and send cross-chain messages, per byte.
-	"""
-	messages: Amount!
 }
 
 

--- a/linera-service/src/linera.rs
+++ b/linera-service/src/linera.rs
@@ -945,41 +945,53 @@ enum ClientCommand {
 
     /// View or update the resource control policy
     ResourceControlPolicy {
-        /// Set the base price for each certificate.
+        /// Set the base price for creating a block.
         #[arg(long)]
-        certificate: Option<Amount>,
+        block: Option<Amount>,
 
-        /// Set the price per unit of fuel when executing user messages and operations.
+        /// Set the price per unit of fuel.
         #[arg(long)]
-        fuel: Option<Amount>,
+        fuel_unit: Option<Amount>,
 
-        /// Set the price per byte to read data per operation
+        /// Set the price per read operation.
         #[arg(long)]
-        storage_num_reads: Option<Amount>,
+        read_operation: Option<Amount>,
 
-        /// Set the price per byte to read data per byte
+        /// Set the price per byte read.
         #[arg(long)]
-        storage_bytes_read: Option<Amount>,
+        byte_read: Option<Amount>,
 
-        /// Set the price per byte to write data per byte
+        /// Set the price per byte written.
         #[arg(long)]
-        storage_bytes_written: Option<Amount>,
+        byte_written: Option<Amount>,
 
-        /// Set the price per byte stored
+        /// Set the price per byte stored.
         #[arg(long)]
-        storage_bytes_stored: Option<Amount>,
+        byte_stored: Option<Amount>,
 
-        /// Set the maximum quantity of data to read per block
+        /// Set the base price of sending a operation from a block..
+        #[arg(long)]
+        operation: Option<Amount>,
+
+        /// Set the additional price for each byte in the argument of a user operation.
+        #[arg(long)]
+        operation_byte: Option<Amount>,
+
+        /// Set the base price of sending a message from a block..
+        #[arg(long)]
+        message: Option<Amount>,
+
+        /// Set the additional price for each byte in the argument of a user message.
+        #[arg(long)]
+        message_byte: Option<Amount>,
+
+        /// Set the maximum read data per block.
         #[arg(long)]
         maximum_bytes_read_per_block: Option<u64>,
 
-        /// Set the maximum quantity of data to write per block
+        /// Set the maximum write data per block.
         #[arg(long)]
         maximum_bytes_written_per_block: Option<u64>,
-
-        /// Set the price per byte to store and send outgoing cross-chain messages.
-        #[arg(long)]
-        messages: Option<Amount>,
     },
 
     /// Send one transfer per chain in bulk mode
@@ -1021,41 +1033,53 @@ enum ClientCommand {
         /// Number of initial (aka "root") chains to create in addition to the admin chain.
         num_other_initial_chains: u32,
 
-        /// Set the base price for each certificate.
+        /// Set the base price for creating a block.
         #[arg(long, default_value = "0")]
-        certificate_price: Amount,
+        block_price: Amount,
 
-        /// Set the price per unit of fuel when executing user messages and operations.
+        /// Set the price per unit of fuel.
         #[arg(long, default_value = "0")]
-        fuel_price: Amount,
+        fuel_unit_price: Amount,
 
-        /// Set the price per operation to read data
+        /// Set the price per read operation.
         #[arg(long, default_value = "0")]
-        storage_num_reads_price: Amount,
+        read_operation_price: Amount,
 
-        /// Set the price per byte to read data
+        /// Set the price per byte read.
         #[arg(long, default_value = "0")]
-        storage_bytes_read_price: Amount,
+        byte_read_price: Amount,
 
-        /// Set the price per byte to write data
+        /// Set the price per byte written.
         #[arg(long, default_value = "0")]
-        storage_bytes_written_price: Amount,
+        byte_written_price: Amount,
 
-        /// Set the price per byte stored
+        /// Set the price per byte stored.
         #[arg(long, default_value = "0")]
-        storage_bytes_stored_price: Amount,
+        byte_stored_price: Amount,
 
-        /// Set the maximum read data per block
+        /// Set the base price of sending a operation from a block..
+        #[arg(long, default_value = "0")]
+        operation_price: Amount,
+
+        /// Set the additional price for each byte in the argument of a user operation.
+        #[arg(long, default_value = "0")]
+        operation_byte_price: Amount,
+
+        /// Set the base price of sending a message from a block..
+        #[arg(long, default_value = "0")]
+        message_price: Amount,
+
+        /// Set the additional price for each byte in the argument of a user message.
+        #[arg(long, default_value = "0")]
+        message_byte_price: Amount,
+
+        /// Set the maximum read data per block.
         #[arg(long)]
         maximum_bytes_read_per_block: Option<u64>,
 
-        /// Set the maximum write data per block
+        /// Set the maximum write data per block.
         #[arg(long)]
         maximum_bytes_written_per_block: Option<u64>,
-
-        /// Set the price per byte to store and send outgoing cross-chain messages.
-        #[arg(long, default_value = "0")]
-        messages_price: Amount,
 
         /// Force this wallet to generate keys using a PRNG and a given seed. USE FOR
         /// TESTING ONLY.
@@ -1649,33 +1673,48 @@ impl Runnable for Job {
                                     }
                                 }
                                 ResourceControlPolicy {
-                                    certificate,
-                                    fuel,
-                                    storage_num_reads,
-                                    storage_bytes_read,
-                                    storage_bytes_written,
-                                    storage_bytes_stored,
+                                    block,
+                                    fuel_unit,
+                                    read_operation,
+                                    byte_read,
+                                    byte_written,
+                                    byte_stored,
+                                    operation,
+                                    operation_byte,
+                                    message,
+                                    message_byte,
                                     maximum_bytes_read_per_block,
                                     maximum_bytes_written_per_block,
-                                    messages,
                                 } => {
-                                    if let Some(certificate) = certificate {
-                                        policy.certificate = certificate;
+                                    if let Some(block) = block {
+                                        policy.block = block;
                                     }
-                                    if let Some(fuel) = fuel {
-                                        policy.fuel = fuel;
+                                    if let Some(fuel_unit) = fuel_unit {
+                                        policy.fuel_unit = fuel_unit;
                                     }
-                                    if let Some(storage_num_reads) = storage_num_reads {
-                                        policy.storage_num_reads = storage_num_reads;
+                                    if let Some(read_operation) = read_operation {
+                                        policy.read_operation = read_operation;
                                     }
-                                    if let Some(storage_bytes_read) = storage_bytes_read {
-                                        policy.storage_bytes_read = storage_bytes_read;
+                                    if let Some(byte_read) = byte_read {
+                                        policy.byte_read = byte_read;
                                     }
-                                    if let Some(storage_bytes_written) = storage_bytes_written {
-                                        policy.storage_bytes_written = storage_bytes_written;
+                                    if let Some(byte_written) = byte_written {
+                                        policy.byte_written = byte_written;
                                     }
-                                    if let Some(storage_bytes_stored) = storage_bytes_stored {
-                                        policy.storage_bytes_stored = storage_bytes_stored;
+                                    if let Some(byte_stored) = byte_stored {
+                                        policy.byte_stored = byte_stored;
+                                    }
+                                    if let Some(operation) = operation {
+                                        policy.operation = operation;
+                                    }
+                                    if let Some(operation_byte) = operation_byte {
+                                        policy.operation_byte = operation_byte;
+                                    }
+                                    if let Some(message) = message {
+                                        policy.message = message;
+                                    }
+                                    if let Some(message_byte) = message_byte {
+                                        policy.message_byte = message_byte;
                                     }
                                     if let Some(maximum_bytes_read_per_block) =
                                         maximum_bytes_read_per_block
@@ -1689,39 +1728,45 @@ impl Runnable for Job {
                                         policy.maximum_bytes_written_per_block =
                                             maximum_bytes_written_per_block;
                                     }
-                                    if let Some(messages) = messages {
-                                        policy.messages = messages;
-                                    }
                                     info!(
                                         "ResourceControlPolicy:\n\
                             {:.2} base cost per block\n\
-                            {:.2} cost per byte of operations and incoming messages\n\
-                            {:.2} cost per byte operation\n\
-                            {:.2} cost per bytes read\n\
-                            {:.2} cost per bytes written\n\
-                            {:.2} cost per bytes stored\n\
-                            {:.2} per byte of outgoing messages\n\
+                            {:.2} cost per fuel unit\n\
+                            {:.2} cost per read operation\n\
+                            {:.2} cost per byte read\n\
+                            {:.2} cost per byte written\n\
+                            {:.2} cost per byte stored\n\
+                            {:.2} per operation\n\
+                            {:.2} per byte in the argument of an operation\n\
+                            {:.2} per outgoing messages\n\
+                            {:.2} per byte in the argument of an outgoing messages\n\
                             {:.2} maximum number bytes read per block\n\
                             {:.2} maximum number bytes written per block",
-                                        policy.certificate,
-                                        policy.fuel,
-                                        policy.storage_num_reads,
-                                        policy.storage_bytes_read,
-                                        policy.storage_bytes_written,
-                                        policy.storage_bytes_stored,
-                                        policy.messages,
+                                        policy.block,
+                                        policy.fuel_unit,
+                                        policy.read_operation,
+                                        policy.byte_read,
+                                        policy.byte_written,
+                                        policy.byte_stored,
+                                        policy.operation,
+                                        policy.operation_byte,
+                                        policy.message,
+                                        policy.message_byte,
                                         policy.maximum_bytes_read_per_block,
                                         policy.maximum_bytes_written_per_block
                                     );
-                                    if certificate.is_none()
-                                        && fuel.is_none()
-                                        && storage_num_reads.is_none()
-                                        && storage_bytes_read.is_none()
-                                        && storage_bytes_written.is_none()
-                                        && storage_bytes_stored.is_none()
+                                    if block.is_none()
+                                        && fuel_unit.is_none()
+                                        && read_operation.is_none()
+                                        && byte_read.is_none()
+                                        && byte_written.is_none()
+                                        && byte_stored.is_none()
+                                        && operation.is_none()
+                                        && operation_byte.is_none()
+                                        && message.is_none()
+                                        && message_byte.is_none()
                                         && maximum_bytes_read_per_block.is_none()
                                         && maximum_bytes_written_per_block.is_none()
-                                        && messages.is_none()
                                     {
                                         return (Ok(ClientOutcome::Committed(None)), chain_client);
                                     }
@@ -2441,15 +2486,18 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
             initial_funding,
             start_timestamp,
             num_other_initial_chains,
-            certificate_price,
-            fuel_price,
-            storage_num_reads_price,
-            storage_bytes_read_price,
-            storage_bytes_written_price,
-            storage_bytes_stored_price,
+            block_price,
+            fuel_unit_price,
+            read_operation_price,
+            byte_read_price,
+            byte_written_price,
+            byte_stored_price,
+            operation_price,
+            operation_byte_price,
+            message_price,
+            message_byte_price,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
-            messages_price,
             testing_prng_seed,
             network_name,
         } => {
@@ -2464,15 +2512,18 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 None => u64::MAX,
             };
             let policy = ResourceControlPolicy {
-                certificate: *certificate_price,
-                fuel: *fuel_price,
-                storage_num_reads: *storage_num_reads_price,
-                storage_bytes_read: *storage_bytes_read_price,
-                storage_bytes_written: *storage_bytes_written_price,
-                storage_bytes_stored: *storage_bytes_stored_price,
+                block: *block_price,
+                fuel_unit: *fuel_unit_price,
+                read_operation: *read_operation_price,
+                byte_read: *byte_read_price,
+                byte_written: *byte_written_price,
+                byte_stored: *byte_stored_price,
+                operation_byte: *operation_byte_price,
+                operation: *operation_price,
+                message_byte: *message_byte_price,
+                message: *message_price,
                 maximum_bytes_read_per_block,
                 maximum_bytes_written_per_block,
-                messages: *messages_price,
             };
             let timestamp = start_timestamp
                 .map(|st| {


### PR DESCRIPTION
## Motivation

* Part of the effort to finalize sender fees (#1474)
* The current policy (notably on messages) is difficult to explain

## Proposal

Follows PR #1534

* Align the field names of ResourceControlPolicy with `linera_sdk::Resources`
* Do not use BCS-serialized sizes of protocol objects: developers (and soon the runtime for grant computations) cannot do anything with these.
* Charge per outgoing message and per byte in the argument of a user message.
* Charge per operation and per byte in the argument of a user operation.
* Simplify `ResourceTracker` to not contain policy data.

## Test Plan

CI