### PR TITLE
Refactor fee computation during runtime execution

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -249,6 +249,7 @@ View or update the resource control policy
 * `--block <BLOCK>` — Set the base price for creating a block
 * `--fuel-unit <FUEL_UNIT>` — Set the price per unit of fuel
 * `--read-operation <READ_OPERATION>` — Set the price per read operation
+* `--write-operation <WRITE_OPERATION>` — Set the price per write operation
 * `--byte-read <BYTE_READ>` — Set the price per byte read
 * `--byte-written <BYTE_WRITTEN>` — Set the price per byte written
 * `--byte-stored <BYTE_STORED>` — Set the price per byte stored
@@ -289,6 +290,9 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 
   Default value: `0`
 * `--read-operation-price <READ_OPERATION_PRICE>` — Set the price per read operation
+
+  Default value: `0`
+* `--write-operation-price <WRITE_OPERATION_PRICE>` — Set the price per write operation
 
   Default value: `0`
 * `--byte-read-price <BYTE_READ_PRICE>` — Set the price per byte read

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -153,7 +153,6 @@ pub struct Resources {
     /// A number of read operations to be executed.
     pub read_operations: u32,
     /// A number of write operations to be executed.
-    // TODO(#1530): This is not used at the moment.
     pub write_operations: u32,
     /// A number of bytes to read.
     pub bytes_to_read: u32,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -752,10 +752,10 @@ where
             .observe(start_time.elapsed().as_secs_f64() * 1000.0);
         WASM_FUEL_USED_PER_BLOCK
             .with_label_values(&[])
-            .observe(tracker.used_fuel as f64);
+            .observe(tracker.fuel as f64);
         WASM_NUM_READS_PER_BLOCK
             .with_label_values(&[])
-            .observe(tracker.num_reads as f64);
+            .observe(tracker.read_operations as f64);
         WASM_BYTES_READ_PER_BLOCK
             .with_label_values(&[])
             .observe(tracker.bytes_read as f64);

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -14,17 +14,16 @@ use async_graphql::SimpleObject;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, ArithmeticError, BlockHeight, Timestamp},
+    data_types::{ArithmeticError, BlockHeight, Timestamp},
     ensure,
     identifiers::{ChainId, Destination, MessageId},
     sync::Lazy,
 };
 use linera_execution::{
-    system::{SystemExecutionError, SystemMessage},
-    ExecutionError, ExecutionOutcome, ExecutionRuntimeContext, ExecutionStateView,
+    system::SystemMessage, ExecutionOutcome, ExecutionRuntimeContext, ExecutionStateView,
     GenericApplicationId, Message, MessageContext, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, ResourceTracker, Response, UserApplicationDescription,
-    UserApplicationId,
+    RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker, Response,
+    UserApplicationDescription, UserApplicationId,
 };
 use linera_views::{
     common::Context,
@@ -38,6 +37,7 @@ use prometheus::{register_histogram_vec, register_int_counter_vec, HistogramVec,
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashSet},
+    sync::Arc,
     time::Instant,
 };
 
@@ -266,22 +266,6 @@ where
     ViewError: From<C::Error>,
     C::Extra: ExecutionRuntimeContext,
 {
-    /// Substracts an amount from a balance and reports an error if that is impossible
-    fn sub_assign_fees(
-        balance: &mut Amount,
-        fees: Amount,
-        chain_execution_context: ChainExecutionContext,
-    ) -> Result<(), ChainError> {
-        balance.try_sub_assign(fees).map_err(|_| {
-            ChainError::ExecutionError(
-                ExecutionError::SystemError(SystemExecutionError::InsufficientFunding {
-                    current_balance: *balance,
-                }),
-                chain_execution_context,
-            )
-        })
-    }
-
     pub fn chain_id(&self) -> ChainId {
         self.context().extra().chain_id()
     }
@@ -597,11 +581,15 @@ where
         let Some((_, committee)) = self.execution_state.system.current_committee() else {
             return Err(ChainError::InactiveChain(chain_id));
         };
-
-        let policy = committee.policy().clone();
+        let mut resource_controller = ResourceController {
+            policy: Arc::new(committee.policy().clone()),
+            tracker: ResourceTracker::default(),
+            // TODO(#1537): Allow using the personal account of the block producer.
+            account: None,
+        };
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
-        let mut tracker = ResourceTracker::default();
+
         // The first incoming message of any child chain must be `OpenChain`. A root chain must
         // already be initialized
         if block.height == BlockHeight::ZERO
@@ -649,8 +637,7 @@ where
                     .execute_message(
                         context,
                         message.event.message.clone(),
-                        &policy,
-                        &mut tracker,
+                        &mut resource_controller,
                     )
                     .await
                     .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?,
@@ -681,13 +668,12 @@ where
                 .process_execution_outcomes(context.height, outcomes)
                 .await?;
             if let MessageAction::Accept = message.action {
-                let balance = self.execution_state.system.balance.get_mut();
                 for message_out in &messages_out {
-                    Self::sub_assign_fees(
-                        balance,
-                        policy.message_price(&message_out.message)?,
-                        chain_execution_context,
-                    )?;
+                    resource_controller
+                        .with(&mut self.execution_state)
+                        .await?
+                        .track_message(&message_out.message)
+                        .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
                 }
             }
             messages.append(&mut messages_out);
@@ -709,31 +695,35 @@ where
             };
             let outcomes = self
                 .execution_state
-                .execute_operation(context, operation.clone(), &policy, &mut tracker)
+                .execute_operation(context, operation.clone(), &mut resource_controller)
                 .await
                 .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
             let mut messages_out = self
                 .process_execution_outcomes(context.height, outcomes)
                 .await?;
-            let balance = self.execution_state.system.balance.get_mut();
-            Self::sub_assign_fees(
-                balance,
-                policy.operation_price(operation)?,
-                chain_execution_context,
-            )?;
+            resource_controller
+                .with(&mut self.execution_state)
+                .await?
+                .track_operation(operation)
+                .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
             for message_out in &messages_out {
-                Self::sub_assign_fees(
-                    balance,
-                    policy.message_price(&message_out.message)?,
-                    chain_execution_context,
-                )?;
+                resource_controller
+                    .with(&mut self.execution_state)
+                    .await?
+                    .track_message(&message_out.message)
+                    .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
             }
             messages.append(&mut messages_out);
             message_counts
                 .push(u32::try_from(messages.len()).map_err(|_| ArithmeticError::Overflow)?);
         }
-        let balance = self.execution_state.system.balance.get_mut();
-        Self::sub_assign_fees(balance, policy.block_price(), ChainExecutionContext::Block)?;
+
+        // Finally, charge for the block fee.
+        resource_controller
+            .with(&mut self.execution_state)
+            .await?
+            .track_block()
+            .map_err(|err| ChainError::ExecutionError(err, ChainExecutionContext::Block))?;
 
         // Recompute the state hash.
         let state_hash = self.execution_state.crypto_hash().await?;
@@ -752,16 +742,16 @@ where
             .observe(start_time.elapsed().as_secs_f64() * 1000.0);
         WASM_FUEL_USED_PER_BLOCK
             .with_label_values(&[])
-            .observe(tracker.fuel as f64);
+            .observe(resource_controller.tracker.fuel as f64);
         WASM_NUM_READS_PER_BLOCK
             .with_label_values(&[])
-            .observe(tracker.read_operations as f64);
+            .observe(resource_controller.tracker.read_operations as f64);
         WASM_BYTES_READ_PER_BLOCK
             .with_label_values(&[])
-            .observe(tracker.bytes_read as f64);
+            .observe(resource_controller.tracker.bytes_read as f64);
         WASM_BYTES_WRITTEN_PER_BLOCK
             .with_label_values(&[])
-            .observe(tracker.bytes_written as f64);
+            .observe(resource_controller.tracker.bytes_written as f64);
 
         assert_eq!(
             message_counts.len(),

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -20,7 +20,7 @@ use linera_base::{
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
     identifiers::ChainId,
 };
-use linera_execution::{policy::PricingError, ExecutionError};
+use linera_execution::ExecutionError;
 use linera_views::views::ViewError;
 use rand_distr::WeightedError;
 use thiserror::Error;
@@ -35,8 +35,6 @@ pub enum ChainError {
     ViewError(#[from] ViewError),
     #[error("Execution error: {0} during {1:?}")]
     ExecutionError(ExecutionError, ChainExecutionContext),
-    #[error("Pricing error: {0}")]
-    PricingError(#[from] PricingError),
 
     #[error("The chain being queried is not active {0:?}")]
     InactiveChain(ChainId),

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -26,11 +26,10 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::Epoch,
-    policy::ResourceControlPolicy,
     system::{SystemChannel, SystemMessage, SystemOperation},
     Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionRuntimeConfig,
     ExecutionStateView, GenericApplicationId, Message, MessageKind, Operation, OperationContext,
-    ResourceTracker, SystemExecutionState, UserApplicationDescription, UserApplicationId,
+    ResourceController, SystemExecutionState, UserApplicationDescription, UserApplicationId,
     WasmContractModule, WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage};
@@ -430,8 +429,7 @@ where
         index: 0,
         next_message_index: 0,
     };
-    let mut tracker = ResourceTracker::default();
-    let policy = ResourceControlPolicy::default();
+    let mut controller = ResourceController::default();
     creator_state
         .execute_operation(
             operation_context,
@@ -439,8 +437,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            &policy,
-            &mut tracker,
+            &mut controller,
         )
         .await?;
     creator_state.system.timestamp.set(Timestamp::from(5));

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -23,7 +23,7 @@ pub use applications::{
 };
 pub use execution::ExecutionStateView;
 pub use ownership::{ChainOwnership, TimeoutConfig};
-pub use resources::ResourceTracker;
+pub use resources::{ResourceController, ResourceTracker};
 pub use system::{
     SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,
     SystemResponse,
@@ -38,7 +38,6 @@ pub use wasm::{WasmContractModule, WasmExecutionError, WasmServiceModule};
 #[cfg(any(test, feature = "test"))]
 pub use {applications::ApplicationRegistry, system::SystemExecutionState};
 
-use crate::policy::PricingError;
 use async_graphql::SimpleObject;
 use async_trait::async_trait;
 use custom_debug_derive::Debug;
@@ -123,10 +122,6 @@ pub enum ExecutionError {
     #[error("Failed to load bytecode from storage {0:?}")]
     ApplicationBytecodeNotFound(Box<UserApplicationDescription>),
 
-    #[error("Pricing error: {0}")]
-    PricingError(#[from] PricingError),
-    #[error("Excessive number of read queries from storage")]
-    ExcessiveNumReads,
     #[error("Excessive number of bytes read from storage")]
     ExcessiveRead,
     #[error("Excessive number of bytes written to storage")]

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -18,12 +18,14 @@ pub struct ResourceControlPolicy {
     pub fuel_unit: Amount,
     /// The price of one read operation.
     pub read_operation: Amount,
-    // TODO(#1530): Write operation.
+    /// The price of one write operation.
+    pub write_operation: Amount,
     /// The price of reading a byte.
     pub byte_read: Amount,
-    /// The price to writting a byte
+    /// The price to writing a byte
     pub byte_written: Amount,
     /// The price of increasing storage by a byte.
+    // TODO(#1536): This is not fully supported.
     pub byte_stored: Amount,
     /// The base price of adding an operation to a block.
     pub operation: Amount,
@@ -34,6 +36,8 @@ pub struct ResourceControlPolicy {
     /// The additional price for each byte in the argument of a user message.
     pub message_byte: Amount,
 
+    // TODO(#1538): Cap the number of transactions per block and the total size of their
+    // arguments.
     /// The maximum data to read per block
     pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
@@ -46,6 +50,7 @@ impl Default for ResourceControlPolicy {
             block: Amount::default(),
             fuel_unit: Amount::default(),
             read_operation: Amount::default(),
+            write_operation: Amount::default(),
             byte_read: Amount::default(),
             byte_written: Amount::default(),
             byte_stored: Amount::default(),
@@ -92,19 +97,23 @@ impl ResourceControlPolicy {
         }
     }
 
-    pub fn storage_num_reads_price(&self, count: u64) -> Result<Amount, PricingError> {
+    pub fn read_operations_price(&self, count: u32) -> Result<Amount, PricingError> {
         Ok(self.read_operation.try_mul(count as u128)?)
     }
 
-    pub fn storage_bytes_read_price(&self, count: u64) -> Result<Amount, PricingError> {
+    pub fn write_operations_price(&self, count: u32) -> Result<Amount, PricingError> {
+        Ok(self.write_operation.try_mul(count as u128)?)
+    }
+
+    pub fn bytes_read_price(&self, count: u64) -> Result<Amount, PricingError> {
         Ok(self.byte_read.try_mul(count as u128)?)
     }
 
-    pub fn storage_bytes_written_price(&self, count: u64) -> Result<Amount, PricingError> {
+    pub fn bytes_written_price(&self, count: u64) -> Result<Amount, PricingError> {
         Ok(self.byte_written.try_mul(count as u128)?)
     }
 
-    pub fn storage_bytes_stored_price(&self, count: u64) -> Result<Amount, PricingError> {
+    pub fn bytes_stored_price(&self, count: u64) -> Result<Amount, PricingError> {
         Ok(self.byte_stored.try_mul(count as u128)?)
     }
 

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -20,7 +20,7 @@ pub struct ResourceControlPolicy {
     pub write_operation: Amount,
     /// The price of reading a byte.
     pub byte_read: Amount,
-    /// The price to writing a byte
+    /// The price of writing a byte
     pub byte_written: Amount,
     /// The price of increasing storage by a byte.
     // TODO(#1536): This is not fully supported.

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -4,193 +4,128 @@
 //! This module tracks the resources used during the execution of a transaction.
 
 use crate::{policy::ResourceControlPolicy, system::SystemExecutionError, ExecutionError};
-
 use custom_debug_derive::Debug;
-use linera_base::data_types::Amount;
+use linera_base::data_types::{Amount, ArithmeticError};
+use std::sync::Arc;
 
-/// The resource constraints applicable to an execution process.
-#[derive(Copy, Debug, Clone)]
-pub struct RuntimeLimits {
-    /// The maximum read requests per block
-    pub max_budget_num_reads: u64,
-    /// The maximum number of bytes that can be read per block
-    pub max_budget_bytes_read: u64,
-    /// The maximum number of bytes that can be written per block
-    pub max_budget_bytes_written: u64,
-    /// The maximum size of read allowed per block
-    pub maximum_bytes_left_to_read: u64,
-    /// The maximum size of write allowed per block
-    pub maximum_bytes_left_to_write: u64,
+#[derive(Debug, Default)]
+pub(crate) struct ResourceController {
+    /// The (fixed) policy used to charge fees and control resource usage.
+    pub(crate) policy: Arc<ResourceControlPolicy>,
+    /// How the resources were used so far.
+    pub(crate) tracker: ResourceTracker,
+    /// The remaining balance of the account paying for the resource usage.
+    pub(crate) balance: Amount,
 }
 
 /// The resources used so far by an execution process.
 #[derive(Copy, Debug, Clone, Default)]
 pub struct ResourceTracker {
-    /// The used fuel in the computation
-    pub used_fuel: u64,
-    /// The number of reads in the computation
-    pub num_reads: u64,
-    /// The number of writes in the computation
-    pub num_writes: u64,
-    /// The total number of bytes read
+    /// The fuel used so far.
+    pub fuel: u64,
+    /// The number of read operations.
+    pub read_operations: u32,
+    /// The number of write operations.
+    pub write_operations: u32,
+    /// The number of bytes read.
     pub bytes_read: u64,
-    /// The total number of bytes written
+    /// The number of bytes written.
     pub bytes_written: u64,
-    /// The change in the total data being stored
-    pub stored_size_delta: i32,
+    /// The change in the number of bytes being stored by user applications.
+    pub bytes_stored: i32,
+    /// The number of operations executed.
+    pub operations: u32,
+    /// The total size of the arguments of user operations.
+    pub operation_bytes: u32,
+    /// The number of messages executed.
+    pub messages: u32,
+    /// The total size of the arguments of user messages.
+    pub message_bytes: u32,
 }
 
-impl Default for RuntimeLimits {
-    fn default() -> Self {
-        RuntimeLimits {
-            max_budget_num_reads: u64::MAX / 2,
-            max_budget_bytes_read: u64::MAX / 2,
-            max_budget_bytes_written: u64::MAX / 2,
-            maximum_bytes_left_to_read: u64::MAX / 2,
-            maximum_bytes_left_to_write: u64::MAX / 2,
-        }
-    }
-}
-
-impl ResourceTracker {
-    /// Subtracts an amount from a balance and reports an error if that is impossible
-    fn sub_assign_fees(balance: &mut Amount, fees: Amount) -> Result<(), SystemExecutionError> {
-        balance
-            .try_sub_assign(fees)
-            .map_err(|_| SystemExecutionError::InsufficientFunding {
-                current_balance: *balance,
-            })
-    }
-
-    /// Updates the limits for the maximum and updates the balance.
-    pub fn update_limits(
-        &mut self,
-        balance: &mut Amount,
-        policy: &ResourceControlPolicy,
-        runtime_counts: RuntimeCounts,
-    ) -> Result<(), ExecutionError> {
-        // The fuel being used
-        let initial_fuel = policy.remaining_fuel(*balance);
-        let used_fuel = initial_fuel.saturating_sub(runtime_counts.remaining_fuel);
-        self.used_fuel += used_fuel;
-        Self::sub_assign_fees(balance, policy.fuel_price(used_fuel)?)?;
-
-        // The number of reads
-        Self::sub_assign_fees(
-            balance,
-            policy.storage_num_reads_price(runtime_counts.num_reads)?,
-        )?;
-        self.num_reads += runtime_counts.num_reads;
-
-        // The number of bytes read
-        let bytes_read = runtime_counts.bytes_read;
-        self.bytes_read += runtime_counts.bytes_read;
-        Self::sub_assign_fees(balance, policy.storage_bytes_read_price(bytes_read)?)?;
-
-        // The number of bytes written
-        let bytes_written = runtime_counts.bytes_written;
-        self.bytes_written += bytes_written;
-        Self::sub_assign_fees(balance, policy.storage_bytes_written_price(bytes_written)?)?;
-
+impl ResourceController {
+    /// Subtracts an amount from a balance and reports an error if that is impossible.
+    fn update_balance(&mut self, fees: Amount) -> Result<(), ExecutionError> {
+        self.balance.try_sub_assign(fees).map_err(|_| {
+            SystemExecutionError::InsufficientFunding {
+                current_balance: self.balance,
+            }
+        })?;
         Ok(())
     }
 
-    /// Obtain the limits for the running of the system
-    pub fn limits(&self, policy: &ResourceControlPolicy, balance: &Amount) -> RuntimeLimits {
-        let max_budget_num_reads =
-            u64::try_from(balance.saturating_div(policy.read_operation)).unwrap_or(u64::MAX);
-        let max_budget_bytes_read =
-            u64::try_from(balance.saturating_div(policy.byte_read)).unwrap_or(u64::MAX);
-        let max_budget_bytes_written =
-            u64::try_from(balance.saturating_div(policy.byte_written)).unwrap_or(u64::MAX);
-        let maximum_bytes_left_to_read = policy
-            .maximum_bytes_read_per_block
-            .saturating_sub(self.bytes_read);
-        let maximum_bytes_left_to_write = policy
-            .maximum_bytes_written_per_block
-            .saturating_sub(self.bytes_written);
-        RuntimeLimits {
-            max_budget_num_reads,
-            max_budget_bytes_read,
-            max_budget_bytes_written,
-            maximum_bytes_left_to_read,
-            maximum_bytes_left_to_write,
-        }
-    }
-}
-
-/// The entries of the runtime related to fuel and storage
-#[derive(Copy, Debug, Clone, Default)]
-pub struct RuntimeCounts {
-    /// The remaining fuel available
-    pub remaining_fuel: u64,
-    /// The number of read operations
-    pub num_reads: u64,
-    /// The number of write operations
-    pub num_writes: u64,
-    /// The bytes that have been read
-    pub bytes_read: u64,
-    /// The bytes that have been written
-    pub bytes_written: u64,
-    /// The change in the total data stored
-    pub stored_size_delta: i32,
-}
-
-impl RuntimeCounts {
-    pub fn increment_num_reads(&mut self, limits: &RuntimeLimits) -> Result<(), ExecutionError> {
-        self.num_reads += 1;
-        if self.num_reads >= limits.max_budget_num_reads {
-            return Err(ExecutionError::ExcessiveNumReads);
-        }
-        Ok(())
+    /// Obtains the amount of fuel that could be spent by consuming the entire balance.
+    pub(crate) fn remaining_fuel(&self) -> u64 {
+        self.policy.remaining_fuel(self.balance)
     }
 
-    /// Increments the number of executed write operations.
-    pub fn increment_num_writes(
-        &mut self,
-        _limits: &RuntimeLimits,
-        amount: u64,
-    ) -> Result<(), ExecutionError> {
-        self.num_writes += amount;
-        Ok(())
+    /// Tracks the used fuel.
+    pub(crate) fn track_fuel(&mut self, fuel: u64) -> Result<(), ExecutionError> {
+        self.tracker.fuel = self
+            .tracker
+            .fuel
+            .checked_add(fuel)
+            .ok_or(ArithmeticError::Overflow)?;
+        self.update_balance(self.policy.fuel_price(fuel)?)
     }
 
-    pub fn increment_bytes_read(
-        &mut self,
-        limits: &RuntimeLimits,
-        increment: u64,
-    ) -> Result<(), ExecutionError> {
-        self.bytes_read = self
+    /// Tracks a read operation.
+    pub(crate) fn track_read_operations(&mut self, count: u32) -> Result<(), ExecutionError> {
+        self.tracker.read_operations = self
+            .tracker
+            .read_operations
+            .checked_add(count)
+            .ok_or(ArithmeticError::Overflow)?;
+        self.update_balance(self.policy.read_operations_price(count)?)
+    }
+
+    /// Tracks a write operation.
+    pub(crate) fn track_write_operations(&mut self, count: u32) -> Result<(), ExecutionError> {
+        self.tracker.write_operations = self
+            .tracker
+            .write_operations
+            .checked_add(count)
+            .ok_or(ArithmeticError::Overflow)?;
+        self.update_balance(self.policy.write_operations_price(count)?)
+    }
+
+    /// Tracks a number of bytes read.
+    pub(crate) fn track_bytes_read(&mut self, count: u64) -> Result<(), ExecutionError> {
+        self.tracker.bytes_read = self
+            .tracker
             .bytes_read
-            .checked_add(increment)
-            .ok_or(ExecutionError::ExcessiveRead)?;
-        if self.bytes_read >= limits.max_budget_bytes_read
-            || self.bytes_read >= limits.maximum_bytes_left_to_read
-        {
+            .checked_add(count)
+            .ok_or(ArithmeticError::Overflow)?;
+        if self.tracker.bytes_read >= self.policy.maximum_bytes_read_per_block {
             return Err(ExecutionError::ExcessiveRead);
         }
+        self.update_balance(self.policy.bytes_read_price(count)?)?;
         Ok(())
     }
 
-    pub fn increment_bytes_written(
-        &mut self,
-        limits: &RuntimeLimits,
-        increment: u64,
-    ) -> Result<(), ExecutionError> {
-        self.bytes_written = self
+    /// Tracks a number of bytes written.
+    pub(crate) fn track_bytes_written(&mut self, count: u64) -> Result<(), ExecutionError> {
+        self.tracker.bytes_written = self
+            .tracker
             .bytes_written
-            .checked_add(increment)
-            .ok_or(ExecutionError::ExcessiveWrite)?;
-        if self.bytes_written >= limits.max_budget_bytes_written
-            || self.bytes_written >= limits.maximum_bytes_left_to_write
-        {
+            .checked_add(count)
+            .ok_or(ArithmeticError::Overflow)?;
+        if self.tracker.bytes_written >= self.policy.maximum_bytes_written_per_block {
             return Err(ExecutionError::ExcessiveWrite);
         }
+        self.update_balance(self.policy.bytes_written_price(count)?)?;
         Ok(())
     }
 
-    pub fn update_stored_size(&mut self, delta: i32) -> Result<(), ExecutionError> {
-        self.stored_size_delta += delta;
+    /// Tracks a change in the number of bytes stored.
+    // TODO(#1536): This is not fully implemented.
+    #[allow(dead_code)]
+    pub(crate) fn track_stored_bytes(&mut self, delta: i32) -> Result<(), ExecutionError> {
+        self.tracker.bytes_stored = self
+            .tracker
+            .bytes_stored
+            .checked_add(delta)
+            .ok_or(ArithmeticError::Overflow)?;
         Ok(())
     }
 }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -47,9 +47,9 @@ pub struct ResourceTracker {
     pub operations: u32,
     /// The total size of the arguments of user operations.
     pub operation_bytes: u64,
-    /// The number of messages executed.
+    /// The number of outgoing messages created (system and user).
     pub messages: u32,
-    /// The total size of the arguments of user messages.
+    /// The total size of the arguments of outgoing user messages.
     pub message_bytes: u64,
 }
 
@@ -106,7 +106,7 @@ where
         self.update_balance(self.policy.block)
     }
 
-    /// Tracks a block operation.
+    /// Tracks the execution of an operation in block.
     pub fn track_operation(&mut self, operation: &Operation) -> Result<(), ExecutionError> {
         self.tracker.as_mut().operations = self
             .tracker
@@ -131,7 +131,7 @@ where
         }
     }
 
-    /// Tracks a block message.
+    /// Tracks the creation of an outgoing message.
     pub fn track_message(&mut self, message: &Message) -> Result<(), ExecutionError> {
         self.tracker.as_mut().messages = self
             .tracker

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -700,8 +700,12 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         let id = self.application_id()?;
         let state = self.view_user_states.entry(id).or_default();
         state.force_all_pending_queries()?;
-        self.resource_controller
-            .track_write_operations(batch.num_operations() as u32)?;
+        self.resource_controller.track_write_operations(
+            batch
+                .num_operations()
+                .try_into()
+                .map_err(|_| ExecutionError::from(ArithmeticError::Overflow))?,
+        )?;
         self.resource_controller
             .track_bytes_written(batch.size() as u64)?;
         self.execution_state_sender

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -5,7 +5,7 @@
 
 use super::{ApplicationStatus, SyncRuntimeInternal};
 use crate::{
-    execution_state_actor::Request, resources::RuntimeLimits, BaseRuntime, UserContractInstance,
+    execution_state_actor::Request, runtime::ResourceController, BaseRuntime, UserContractInstance,
 };
 use futures::{channel::mpsc, StreamExt};
 use linera_base::{
@@ -72,11 +72,11 @@ fn test_write_batch() {
         .expect("Failed to write test batch");
 
     assert_eq!(
-        runtime.runtime_counts.num_writes,
-        expected_write_count as u64
+        runtime.resource_controller.tracker.write_operations,
+        expected_write_count as u32
     );
     assert_eq!(
-        runtime.runtime_counts.bytes_written,
+        runtime.resource_controller.tracker.bytes_written,
         expected_bytes_count as u64
     );
 }
@@ -89,9 +89,10 @@ fn create_contract_runtime() -> (
 ) {
     let chain_id = ChainDescription::Root(0).into();
     let (execution_state_sender, execution_state_receiver) = mpsc::unbounded();
-    let limits = RuntimeLimits::default();
+    let resource_controller = ResourceController::default();
 
-    let mut runtime = SyncRuntimeInternal::new(chain_id, execution_state_sender, limits, 0);
+    let mut runtime =
+        SyncRuntimeInternal::new(chain_id, execution_state_sender, resource_controller);
 
     runtime.push_application(create_dummy_application());
 

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -9,10 +9,9 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
-    policy::ResourceControlPolicy,
     system::{Recipient, UserData},
     ExecutionOutcome, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionOutcome, ResourceTracker, Response, SystemExecutionState,
+    Query, QueryContext, RawExecutionOutcome, ResourceController, Response, SystemExecutionState,
     SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
@@ -42,10 +41,9 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         authenticated_signer: None,
         next_message_index: 0,
     };
-    let mut tracker = ResourceTracker::default();
-    let policy = ResourceControlPolicy::default();
+    let mut controller = ResourceController::default();
     let outcomes = view
-        .execute_operation(context, Operation::System(operation), &policy, &mut tracker)
+        .execute_operation(context, Operation::System(operation), &mut controller)
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::ZERO);
@@ -88,10 +86,9 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
     };
-    let mut tracker = ResourceTracker::default();
-    let policy = ResourceControlPolicy::default();
+    let mut controller = ResourceController::default();
     let outcomes = view
-        .execute_message(context, Message::System(message), &policy, &mut tracker)
+        .execute_message(context, Message::System(message), &mut controller)
         .await
         .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -107,8 +107,8 @@ async fn test_fuel_for_counter_wasm_application(
     assert_eq!(controller.tracker.fuel, expected_fuel);
     assert_eq!(
         controller.with(&mut view).await?.balance(),
-        Amount::from_tokens(1)
-            .try_sub(Amount::from_atto(1).try_mul(expected_fuel as u128).unwrap())
+        Amount::ONE
+            .try_sub(Amount::from_atto(expected_fuel as u128))
             .unwrap()
     );
 

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -101,7 +101,7 @@ async fn test_fuel_for_counter_wasm_application(
             )]
         );
     }
-    assert_eq!(tracker.used_fuel, expected_fuel);
+    assert_eq!(tracker.fuel, expected_fuel);
 
     let context = QueryContext {
         chain_id: ChainId::root(0),

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -14,7 +14,7 @@ use linera_base::{
 use linera_execution::{
     policy::ResourceControlPolicy, ExecutionOutcome, ExecutionRuntimeConfig,
     ExecutionRuntimeContext, ExecutionStateView, Operation, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, ResourceTracker, Response, SystemExecutionState,
+    RawExecutionOutcome, ResourceController, ResourceTracker, Response, SystemExecutionState,
     TestExecutionRuntimeContext, WasmContractModule, WasmRuntime, WasmServiceModule,
 };
 use linera_views::{memory::MemoryContext, views::View};
@@ -81,16 +81,19 @@ async fn test_fuel_for_counter_wasm_application(
         fuel_unit: Amount::from_atto(1),
         ..ResourceControlPolicy::default()
     };
-    let mut tracker = ResourceTracker::default();
     let amount = Amount::from_tokens(1);
     *view.system.balance.get_mut() = amount;
+    let mut controller = ResourceController {
+        policy: Arc::new(policy),
+        tracker: ResourceTracker::default(),
+        account: None,
+    };
     for increment in &increments {
         let outcomes = view
             .execute_operation(
                 context,
                 Operation::user(app_id, increment).unwrap(),
-                &policy,
-                &mut tracker,
+                &mut controller,
             )
             .await?;
         assert_eq!(
@@ -101,7 +104,13 @@ async fn test_fuel_for_counter_wasm_application(
             )]
         );
     }
-    assert_eq!(tracker.fuel, expected_fuel);
+    assert_eq!(controller.tracker.fuel, expected_fuel);
+    assert_eq!(
+        controller.with(&mut view).await?.balance(),
+        Amount::from_tokens(1)
+            .try_sub(Amount::from_atto(1).try_mul(expected_fuel as u128).unwrap())
+            .unwrap()
+    );
 
     let context = QueryContext {
         chain_id: ChainId::root(0),

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -603,6 +603,8 @@ ResourceControlPolicy:
         TYPENAME: Amount
     - read_operation:
         TYPENAME: Amount
+    - write_operation:
+        TYPENAME: Amount
     - byte_read:
         TYPENAME: Amount
     - byte_written:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -641,7 +641,7 @@ input ResourceControlPolicy {
 	"""
 	byteRead: Amount!
 	"""
-	The price to writing a byte
+	The price of writing a byte
 	"""
 	byteWritten: Amount!
 	"""

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -633,11 +633,15 @@ input ResourceControlPolicy {
 	"""
 	readOperation: Amount!
 	"""
+	The price of one write operation.
+	"""
+	writeOperation: Amount!
+	"""
 	The price of reading a byte.
 	"""
 	byteRead: Amount!
 	"""
-	The price to writting a byte
+	The price to writing a byte
 	"""
 	byteWritten: Amount!
 	"""

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -300,6 +300,10 @@ pub enum ClientCommand {
         #[arg(long)]
         read_operation: Option<Amount>,
 
+        /// Set the price per write operation.
+        #[arg(long)]
+        write_operation: Option<Amount>,
+
         /// Set the price per byte read.
         #[arg(long)]
         byte_read: Option<Amount>,
@@ -387,6 +391,10 @@ pub enum ClientCommand {
         /// Set the price per read operation.
         #[arg(long, default_value = "0")]
         read_operation_price: Amount,
+
+        /// Set the price per write operation.
+        #[arg(long, default_value = "0")]
+        write_operation_price: Amount,
 
         /// Set the price per byte read.
         #[arg(long, default_value = "0")]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -359,6 +359,7 @@ impl Runnable for Job {
                                     block,
                                     fuel_unit,
                                     read_operation,
+                                    write_operation,
                                     byte_read,
                                     byte_written,
                                     byte_stored,
@@ -377,6 +378,9 @@ impl Runnable for Job {
                                     }
                                     if let Some(read_operation) = read_operation {
                                         policy.read_operation = read_operation;
+                                    }
+                                    if let Some(write_operation) = write_operation {
+                                        policy.write_operation = write_operation;
                                     }
                                     if let Some(byte_read) = byte_read {
                                         policy.byte_read = byte_read;
@@ -416,6 +420,7 @@ impl Runnable for Job {
                             {:.2} base cost per block\n\
                             {:.2} cost per fuel unit\n\
                             {:.2} cost per read operation\n\
+                            {:.2} cost per write operation\n\
                             {:.2} cost per byte read\n\
                             {:.2} cost per byte written\n\
                             {:.2} cost per byte stored\n\
@@ -428,6 +433,7 @@ impl Runnable for Job {
                                         policy.block,
                                         policy.fuel_unit,
                                         policy.read_operation,
+                                        policy.write_operation,
                                         policy.byte_read,
                                         policy.byte_written,
                                         policy.byte_stored,
@@ -441,6 +447,7 @@ impl Runnable for Job {
                                     if block.is_none()
                                         && fuel_unit.is_none()
                                         && read_operation.is_none()
+                                        && write_operation.is_none()
                                         && byte_read.is_none()
                                         && byte_written.is_none()
                                         && byte_stored.is_none()
@@ -1174,6 +1181,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
             block_price,
             fuel_unit_price,
             read_operation_price,
+            write_operation_price,
             byte_read_price,
             byte_written_price,
             byte_stored_price,
@@ -1200,6 +1208,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 block: *block_price,
                 fuel_unit: *fuel_unit_price,
                 read_operation: *read_operation_price,
+                write_operation: *write_operation_price,
                 byte_read: *byte_read_price,
                 byte_written: *byte_written_price,
                 byte_stored: *byte_stored_price,


### PR DESCRIPTION
## Motivation

The current code is difficult to adapt for #1474 and other missing features like #1537.

## Proposal

* Add the missing code to price write operations
* Remove `RuntimeCounts` and `RuntimeLimits`
* Introduce `ResourceController` to keep together a (fixed) policy, a tracker, and a balance.
* The balance is systematically decreased when a new operation is "tracked".
* Use a similar idea in `ChainStateView::execute_block`. This requires generalizing the code so that we can store the resource funding balance in the system execution view (where transactions can modify it any time).

Follows #1535

## Test Plan

CI

## Release Plan

We may want to update [linera-infra/validators/scripts/create_and_upload_genesis.sh](https://github.com/linera-io/linera-infra/blob/21164476fc8c25359932714ac3d8ccc4b9dbdce5/validators/scripts/create_and_upload_genesis.sh#L35) to use the new fee options.