### PR TITLE
Benchmark: Respect num-chains and max-in-flight parameters.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -298,7 +298,7 @@ where
     }
 
     /// Obtains the basic `ChainInfo` data for the local chain.
-    async fn chain_info(&mut self) -> Result<Box<ChainInfo>, LocalNodeError> {
+    pub async fn chain_info(&mut self) -> Result<Box<ChainInfo>, LocalNodeError> {
         let query = ChainInfoQuery::new(self.chain_id);
         let response = self.node_client.handle_chain_info_query(query).await?;
         Ok(response.info)

--- a/linera-rpc/src/mass.rs
+++ b/linera-rpc/src/mass.rs
@@ -19,6 +19,9 @@ pub enum MassClientError {
 
 #[async_trait]
 pub trait MassClient: Send + Sync {
-    async fn send(&mut self, requests: Vec<RpcMessage>)
-        -> Result<Vec<RpcMessage>, MassClientError>;
+    async fn send(
+        &mut self,
+        requests: Vec<RpcMessage>,
+        max_in_flight: usize,
+    ) -> Result<Vec<RpcMessage>, MassClientError>;
 }

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -479,7 +479,7 @@ impl ClientContext {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        let mut key_pairs: HashMap<_, _> = HashMap::new();
+        let mut key_pairs = HashMap::new();
         for chain_id in self.wallet_state.own_chain_ids() {
             if key_pairs.len() == num_chains {
                 break;

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -344,9 +344,9 @@ pub enum ClientCommand {
         #[arg(long, default_value = "200")]
         max_in_flight: u64,
 
-        /// Use a subset of the chains to generate N transfers
-        #[arg(long)]
-        max_proposals: Option<usize>,
+        /// How many chains to use for the benchmark
+        #[arg(long, default_value = "10")]
+        num_chains: usize,
     },
 
     /// Create genesis configuration for a Linera deployment.

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -342,7 +342,7 @@ pub enum ClientCommand {
     Benchmark {
         /// Maximum number of blocks in flight
         #[arg(long, default_value = "200")]
-        max_in_flight: u64,
+        max_in_flight: usize,
 
         /// How many chains to use for the benchmark
         #[arg(long, default_value = "10")]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -529,12 +529,10 @@ impl Runnable for Job {
                 let votes = responses
                     .into_iter()
                     .filter_map(|message| {
-                        deserialize_response(message).and_then(|response| {
-                            response.info.manager.pending.and_then(|vote| {
-                                let value = values.get(&vote.value.value_hash)?.clone();
-                                vote.clone().with_value(value)
-                            })
-                        })
+                        let response = deserialize_response(message)?;
+                        let vote = response.info.manager.pending?;
+                        let value = values.get(&vote.value.value_hash)?.clone();
+                        vote.clone().with_value(value)
                     })
                     .collect::<Vec<_>>();
                 info!("Received {} valid votes.", votes.len());

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -493,7 +493,7 @@ impl Runnable for Job {
             #[cfg(feature = "benchmark")]
             Benchmark {
                 max_in_flight,
-                max_proposals,
+                num_chains,
             } => {
                 // Below all block proposals are supposed to succeed without retries, we
                 // must make sure that all incoming payments have been accepted on-chain
@@ -502,12 +502,14 @@ impl Runnable for Job {
                     .process_inboxes_and_force_validator_updates(&storage)
                     .await;
 
+                let key_pairs = context
+                    .make_benchmark_chains(num_chains, storage.clone())
+                    .await?;
+
                 // For this command, we create proposals and gather certificates without using
                 // the client library. We update the wallet storage at the end using a local node.
-                let max_proposals =
-                    max_proposals.unwrap_or_else(|| context.wallet_state().num_chains());
                 info!("Starting benchmark phase 1 (block proposals)");
-                let proposals = context.make_benchmark_block_proposals(max_proposals);
+                let proposals = context.make_benchmark_block_proposals(&key_pairs);
                 let num_proposal = proposals.len();
                 let mut values = HashMap::new();
 


### PR DESCRIPTION
## Motivation

The benchmark uses `max-proposals` only as a maximum, and uses at most as many chains as there are already in the wallet. This is inconvenient if one wants to e.g. test with 100 chains against devnet.

The `max-in-flight` parameter is only respected with the simple network client, not with gRPC, which handles all requests in sequence.

## Proposal

Rename `max-proposals` to `num-chains` and create more chains if necessary.

Use `buffer_unordered` to handle up to `max-in-flight` requests concurrently also with gRPC.

## Test Plan

Tested manually against devnet.

## Links

- This is stacked on top of #1542.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
