### PR TITLE
Add workspace file with examples

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -144,7 +144,7 @@ jobs:
         cargo machete
     - name: Check for outdated README.md
       run: |
-        (set -e; for I in linera-*; do echo $I; cargo rdme --check --no-fail-on-warnings -w $I; done)
+        (set -e; for I in linera-*; do if [ -d "$I" ]; then echo $I; cargo rdme --check --no-fail-on-warnings -w $I; fi; done)
         cd examples
         (set -e; for I in fungible social crowd-funding amm counter meta-counter matching-engine; do echo $I; cargo rdme --check --no-fail-on-warnings -w $I; done)
     - name: Run Wasm application lints

--- a/linera-protocol.code-workspace
+++ b/linera-protocol.code-workspace
@@ -1,0 +1,13 @@
+{
+	"folders": [
+		{
+			"path": "."
+		},
+		{
+			"path": "examples"
+		}
+	],
+	"settings": {
+		"rust-analyzer.showUnlinkedFileNotification": false
+	}
+}


### PR DESCRIPTION
## Motivation

For VSCode users, right now `rust-analyzer` doesn't recognize anything in the examples folder. That makes the red squiggles for errors, auto complete, jump to definition, etc not work from within the examples folder.

## Proposal

The reason for that is because examples isn't included in the workspace. I'm adding with this PR a workspace file. If you open your `linera-protocol` checkout using File -> Open Workspace from File and choose this file, it'll open a workspace with both the root directory and the examples directory in it, making all `rust-analyzer` features work on the examples folder as well.

## Test Plan

Tested locally, I see errors in examples now (in my WIP code for another PR)

