### PR TITLE
Add some metrics related to execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,7 @@ dependencies = [
  "lru",
  "once_cell",
  "oneshot",
+ "prometheus",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1725,6 +1725,7 @@ dependencies = [
  "lru",
  "once_cell",
  "oneshot",
+ "prometheus",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/linera-base/src/prometheus_util.rs
+++ b/linera-base/src/prometheus_util.rs
@@ -7,6 +7,7 @@ use prometheus::{
     histogram_opts, register_histogram_vec, register_int_counter_vec, Error, HistogramVec,
     IntCounterVec, Opts,
 };
+use std::time::Instant;
 
 const LINERA_NAMESPACE: &str = "linera";
 
@@ -34,4 +35,75 @@ pub fn register_histogram_vec(
     };
 
     register_histogram_vec!(histogram_opts, label_names)
+}
+
+/// A guard for an active latency measurement.
+///
+/// Finishes the measurement when dropped, and then updates the `Metric`.
+pub struct ActiveMeasurementGuard<'metric, Metric>
+where
+    Metric: MeasureLatency,
+{
+    start: Instant,
+    metric: Option<&'metric Metric>,
+}
+
+impl<Metric> ActiveMeasurementGuard<'_, Metric>
+where
+    Metric: MeasureLatency,
+{
+    /// Finishes the measurement, updates the `Metric` and the returns the measured latency in
+    /// milliseconds.
+    pub fn finish(mut self) -> f64 {
+        self.finish_by_ref()
+    }
+
+    /// Finishes the measurement without taking ownership of this [`ActiveMeasurementGuard`],
+    /// updates the `Metric` and the returns the measured latency in milliseconds.
+    fn finish_by_ref(&mut self) -> f64 {
+        match self.metric.take() {
+            Some(metric) => {
+                let latency = self.start.elapsed().as_secs_f64() * 1000.0;
+                metric.finish_measurement(latency);
+                latency
+            }
+            None => {
+                // This is getting called from `Drop` after `finish` has already been
+                // executed
+                f64::NAN
+            }
+        }
+    }
+}
+
+impl<Metric> Drop for ActiveMeasurementGuard<'_, Metric>
+where
+    Metric: MeasureLatency,
+{
+    fn drop(&mut self) {
+        self.finish_by_ref();
+    }
+}
+
+/// An extension trait for metrics that can be used to measure latencies.
+pub trait MeasureLatency: Sized {
+    /// Starts measuring the latency, finishing when the returned
+    /// [`ActiveMeasurementGuard`] is dropped.
+    fn measure_latency(&self) -> ActiveMeasurementGuard<'_, Self>;
+
+    /// Updates the metric with measured latency in `milliseconds`.
+    fn finish_measurement(&self, milliseconds: f64);
+}
+
+impl MeasureLatency for HistogramVec {
+    fn measure_latency(&self) -> ActiveMeasurementGuard<'_, Self> {
+        ActiveMeasurementGuard {
+            start: Instant::now(),
+            metric: Some(self),
+        }
+    }
+
+    fn finish_measurement(&self, milliseconds: f64) {
+        self.with_label_values(&[]).observe(milliseconds);
+    }
 }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -76,6 +76,19 @@ static MESSAGE_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     .expect("Histogram creation should not fail")
 });
 
+static OPERATION_EXECUTION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    prometheus_util::register_histogram_vec(
+        "operation_execution_latency",
+        "Operation execution latency",
+        &[],
+        Some(vec![
+            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+            1.0, 2.5,
+        ]),
+    )
+    .expect("Histogram creation should not fail")
+});
+
 pub static WASM_FUEL_USED_PER_BLOCK: Lazy<HistogramVec> = Lazy::new(|| {
     prometheus_util::register_histogram_vec(
         "wasm_fuel_used_per_block",
@@ -712,6 +725,7 @@ where
         }
         // Second, execute the operations in the block and remember the recipients to notify.
         for (index, operation) in block.operations.iter().enumerate() {
+            let _operation_latency = OPERATION_EXECUTION_LATENCY.measure_latency();
             let index = u32::try_from(index).map_err(|_| ArithmeticError::Overflow)?;
             let chain_execution_context = ChainExecutionContext::Operation(index);
             let next_message_index =

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -38,6 +38,7 @@ linera-views-derive = { workspace = true }
 lru = { workspace = true }
 once_cell = { workspace = true }
 oneshot = { workspace = true }
+prometheus = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -26,6 +26,11 @@ use crate::{
     Bytecode, ContractSyncRuntime, ExecutionError, ServiceSyncRuntime, UserContractInstance,
     UserContractModule, UserServiceInstance, UserServiceModule, WasmRuntime,
 };
+use linera_base::{
+    prometheus_util::{self, MeasureLatency},
+    sync::Lazy,
+};
+use prometheus::HistogramVec;
 use std::{path::Path, sync::Arc};
 use thiserror::Error;
 
@@ -33,6 +38,30 @@ use thiserror::Error;
 use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 #[cfg(feature = "wasmtime")]
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
+
+static CONTRACT_INSTANTIATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    prometheus_util::register_histogram_vec(
+        "contract_instantiation_latency",
+        "Contract instantiation latency",
+        &[],
+        Some(vec![
+            0.000_1, 0.000_3, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
+        ]),
+    )
+    .expect("Histogram creation should not fail")
+});
+
+static SERVICE_INSTANTIATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    prometheus_util::register_histogram_vec(
+        "service_instantiation_latency",
+        "Service instantiation latency",
+        &[],
+        Some(vec![
+            0.000_1, 0.000_3, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0,
+        ]),
+    )
+    .expect("Histogram creation should not fail")
+});
 
 /// A user contract in a compiled WebAssembly module.
 #[derive(Clone)]
@@ -92,16 +121,20 @@ impl UserContractModule for WasmContractModule {
         &self,
         runtime: ContractSyncRuntime,
     ) -> Result<UserContractInstance, ExecutionError> {
-        match self {
+        let _instantiation_latency = CONTRACT_INSTANTIATION_LATENCY.measure_latency();
+
+        let instance: UserContractInstance = match self {
             #[cfg(feature = "wasmtime")]
-            WasmContractModule::Wasmtime { module } => Ok(Box::new(
-                WasmtimeContractInstance::prepare(module, runtime)?,
-            )),
+            WasmContractModule::Wasmtime { module } => {
+                Box::new(WasmtimeContractInstance::prepare(module, runtime)?)
+            }
             #[cfg(feature = "wasmer")]
-            WasmContractModule::Wasmer { engine, module } => Ok(Box::new(
-                WasmerContractInstance::prepare(engine, module, runtime)?,
-            )),
-        }
+            WasmContractModule::Wasmer { engine, module } => {
+                Box::new(WasmerContractInstance::prepare(engine, module, runtime)?)
+            }
+        };
+
+        Ok(instance)
     }
 }
 
@@ -153,16 +186,20 @@ impl UserServiceModule for WasmServiceModule {
         &self,
         runtime: ServiceSyncRuntime,
     ) -> Result<UserServiceInstance, ExecutionError> {
-        match self {
+        let _instantiation_latency = SERVICE_INSTANTIATION_LATENCY.measure_latency();
+
+        let instance: UserServiceInstance = match self {
             #[cfg(feature = "wasmtime")]
             WasmServiceModule::Wasmtime { module } => {
-                Ok(Box::new(WasmtimeServiceInstance::prepare(module, runtime)?))
+                Box::new(WasmtimeServiceInstance::prepare(module, runtime)?)
             }
             #[cfg(feature = "wasmer")]
             WasmServiceModule::Wasmer { module } => {
-                Ok(Box::new(WasmerServiceInstance::prepare(module, runtime)?))
+                Box::new(WasmerServiceInstance::prepare(module, runtime)?)
             }
-        }
+        };
+
+        Ok(instance)
     }
 }
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Linera aims to be a low-latency block chain, and execution is in the critical path. Therefore, we should measure different parts related to execution.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a `MeasureLatency` helper extension trait to make it easy to add new latency measurements, and add histogram metrics for different execution parts.

## Test Plan

<!-- How to test that the changes are correct. -->
No functionalities changed, just manually executed and printed all metrics.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
