### PR TITLE
Don't use .as_millis()

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -749,7 +749,7 @@ where
         NUM_BLOCKS_EXECUTED.with_label_values(&[]).inc();
         BLOCK_EXECUTION_LATENCY
             .with_label_values(&[])
-            .observe(start_time.elapsed().as_millis() as f64);
+            .observe(start_time.elapsed().as_secs_f64() * 1000.0);
         WASM_FUEL_USED_PER_BLOCK
             .with_label_values(&[])
             .observe(tracker.used_fuel as f64);

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -188,7 +188,7 @@ where
             let response = future.await?;
             SERVER_REQUEST_LATENCY
                 .with_label_values(&[])
-                .observe(start.elapsed().as_millis() as f64);
+                .observe(start.elapsed().as_secs_f64() * 1000.0);
             SERVER_REQUEST_COUNT.with_label_values(&[]).inc();
             Ok(response)
         }
@@ -429,7 +429,7 @@ where
     fn log_request_success_and_latency(start: Instant, method_name: &str) {
         SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE
             .with_label_values(&[method_name])
-            .observe(start.elapsed().as_millis() as f64);
+            .observe(start.elapsed().as_secs_f64() * 1000.0);
         SERVER_REQUEST_SUCCESS
             .with_label_values(&[method_name])
             .inc();

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -113,7 +113,7 @@ where
             let response = future.await?;
             PROXY_REQUEST_LATENCY
                 .with_label_values(&[])
-                .observe(start.elapsed().as_millis() as f64);
+                .observe(start.elapsed().as_secs_f64() * 1000.0);
             PROXY_REQUEST_COUNT.with_label_values(&[]).inc();
             Ok(response)
         }


### PR DESCRIPTION
## Motivation

@jvff pointed out to me that `.as_millis()` returns an integer, so we lose precision for microseconds and so on, because it gets capped. I also remembered that's why I went with seconds to begin with, because at least we got full precision 😅

## Proposal

Roll back to using `.as_secs_f64()`, but multiply by 1000.0 so we have the values in milliseconds

## Test Plan

Make sure we have floating point precision again

