### PR TITLE
Support funding from authenticated accounts

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -54,7 +54,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `unsubscribe` — Unsubscribes from a system channel
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `close-chain` — Close (i.e. deactivate) an existing chain
-* `query-balance` — Simulate the execution of pending messages in the local inbox, then read the balance of the chain from the local state of the client
+* `query-balance` — Simulate the execution of one block made of pending messages from the local inbox, then read the native-token balance of the account from the local state
 * `sync-balance` — Synchronize the local state of the chain with a quorum validators, then query the local balance
 * `query-validators` — Show the current set of validators for a chain
 * `set-validator` — Add or modify a validator (admin only)
@@ -222,13 +222,15 @@ Close (i.e. deactivate) an existing chain
 
 ## `linera query-balance`
 
-Simulate the execution of pending messages in the local inbox, then read the balance of the chain from the local state of the client
+Simulate the execution of one block made of pending messages from the local inbox, then read the native-token balance of the account from the local state.
 
-**Usage:** `linera query-balance [CHAIN_ID]`
+The balance does not reflect messages that have not been synchronized from validators yet. Call `linera sync` first to do so.
+
+**Usage:** `linera query-balance [ACCOUNT]`
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>` — Chain id
+* `<ACCOUNT>` — The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the chain balance. By defaults, we read the chain balance of the default chain in the wallet
 
 
 
@@ -236,11 +238,11 @@ Simulate the execution of pending messages in the local inbox, then read the bal
 
 Synchronize the local state of the chain with a quorum validators, then query the local balance
 
-**Usage:** `linera sync-balance [CHAIN_ID]`
+**Usage:** `linera sync-balance [ACCOUNT]`
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>` — Chain id
+* `<ACCOUNT>` — The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the chain balance. By defaults, we read the chain balance of the default chain in the wallet
 
 
 
@@ -252,7 +254,7 @@ Show the current set of validators for a chain
 
 ###### **Arguments:**
 
-* `<CHAIN_ID>` — Chain id
+* `<CHAIN_ID>` — The chain to query. If omitted, query the default chain of the wallet
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -54,8 +54,8 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `unsubscribe` — Unsubscribes from a system channel
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `close-chain` — Close (i.e. deactivate) an existing chain
-* `query-balance` — Read the balance of the chain from the local state of the client
-* `sync-balance` — Synchronize the local state of the chain (including a conservative estimation of the available balance) with a quorum validators
+* `query-balance` — Simulate the execution of pending messages in the local inbox, then read the balance of the chain from the local state of the client
+* `sync-balance` — Synchronize the local state of the chain with a quorum validators, then query the local balance
 * `query-validators` — Show the current set of validators for a chain
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
@@ -222,7 +222,7 @@ Close (i.e. deactivate) an existing chain
 
 ## `linera query-balance`
 
-Read the balance of the chain from the local state of the client
+Simulate the execution of pending messages in the local inbox, then read the balance of the chain from the local state of the client
 
 **Usage:** `linera query-balance [CHAIN_ID]`
 
@@ -234,7 +234,7 @@ Read the balance of the chain from the local state of the client
 
 ## `linera sync-balance`
 
-Synchronize the local state of the chain (including a conservative estimation of the available balance) with a quorum validators
+Synchronize the local state of the chain with a quorum validators, then query the local balance
 
 **Usage:** `linera sync-balance [CHAIN_ID]`
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -19,7 +19,7 @@ use std::{
 /// The owner of a chain. This is currently the hash of the owner's public key used to
 /// verify signatures.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "test"), derive(Default))]
+#[cfg_attr(any(test, feature = "test"), derive(Default, test_strategy::Arbitrary))]
 pub struct Owner(pub CryptoHash);
 
 /// How to create a chain.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -626,8 +626,7 @@ where
         let mut resource_controller = ResourceController {
             policy: Arc::new(committee.policy().clone()),
             tracker: ResourceTracker::default(),
-            // TODO(#1537): Allow using the personal account of the block producer.
-            account: None,
+            account: block.authenticated_signer,
         };
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1640,8 +1640,7 @@ where
         Ok(balance)
     }
 
-    /// Reads the local balance of a user account after staging the execution of any
-    /// incoming transfers.
+    /// Reads the local balance of a user account.
     ///
     /// Does not process the inbox or attempt to synchronize with validators.
     pub async fn local_owner_balance(&mut self, owner: Owner) -> Result<Amount, ChainClientError> {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1560,32 +1560,38 @@ where
         }
     }
 
-    /// Obtains the local balance of the default account after staging the execution of
-    /// any incoming transfers.
+    /// Obtains the local balance of the chain account after staging the execution of
+    /// incoming messages in a new block.
     ///
-    /// Does not attempt to synchronize with validators.
-    pub async fn local_balance(&mut self) -> Result<Amount, ChainClientError> {
-        let (balance, _) = self.local_balances_with_owner(None).await?;
+    /// Does not attempt to synchronize with validators. The result will reflect up to
+    /// `max_pending_messages` incoming messages and the execution fees for a single
+    /// block.
+    pub async fn query_balance(&mut self) -> Result<Amount, ChainClientError> {
+        let (balance, _) = self.query_balances_with_owner(None).await?;
         Ok(balance)
     }
 
-    /// Obtains the local balance of a user account after staging the execution of any
-    /// incoming transfers.
+    /// Obtains the local balance of a user account after staging the execution of
+    /// incoming messages in a new block.
     ///
-    /// Does not attempt to synchronize with validators.
-    pub async fn local_owner_balance(&mut self, owner: Owner) -> Result<Amount, ChainClientError> {
+    /// Does not attempt to synchronize with validators. The result will reflect up to
+    /// `max_pending_messages` incoming messages and the execution fees for a single
+    /// block.
+    pub async fn query_owner_balance(&mut self, owner: Owner) -> Result<Amount, ChainClientError> {
         Ok(self
-            .local_balances_with_owner(Some(owner))
+            .query_balances_with_owner(Some(owner))
             .await?
             .1
             .unwrap_or(Amount::ZERO))
     }
 
-    /// Obtains the local balance of the default account and optionally another user after
-    /// staging the execution of any incoming transfers.
+    /// Obtains the local balance of the chain account and optionally another user after
+    /// staging the execution of incoming messages in a new block.
     ///
-    /// Does not attempt to synchronize with validators.
-    async fn local_balances_with_owner(
+    /// Does not attempt to synchronize with validators. The result will reflect up to
+    /// `max_pending_messages` incoming messages and the execution fees for a single
+    /// block.
+    async fn query_balances_with_owner(
         &mut self,
         owner: Option<Owner>,
     ) -> Result<(Amount, Option<Amount>), ChainClientError> {
@@ -1628,6 +1634,46 @@ where
             }
             Err(error) => Err(error),
         }
+    }
+
+    /// Reads the local balance of the chain account.
+    ///
+    /// Does not process the inbox or attempt to synchronize with validators.
+    pub async fn local_balance(&mut self) -> Result<Amount, ChainClientError> {
+        let (balance, _) = self.local_balances_with_owner(None).await?;
+        Ok(balance)
+    }
+
+    /// Reads the local balance of a user account after staging the execution of any
+    /// incoming transfers.
+    ///
+    /// Does not process the inbox or attempt to synchronize with validators.
+    pub async fn local_owner_balance(&mut self, owner: Owner) -> Result<Amount, ChainClientError> {
+        Ok(self
+            .local_balances_with_owner(Some(owner))
+            .await?
+            .1
+            .unwrap_or(Amount::ZERO))
+    }
+
+    /// Reads the local balance of the chain account and optionally another user.
+    ///
+    /// Does not process the inbox or attempt to synchronize with validators.
+    async fn local_balances_with_owner(
+        &mut self,
+        owner: Option<Owner>,
+    ) -> Result<(Amount, Option<Amount>), ChainClientError> {
+        ensure!(
+            self.chain_info().await?.next_block_height == self.next_block_height,
+            ChainClientError::WalletSynchronizationError
+        );
+        let mut query = ChainInfoQuery::new(self.chain_id);
+        query.request_system_balance = owner;
+        let response = self.node_client.handle_chain_info_query(query).await?;
+        Ok((
+            response.info.system_balance,
+            response.info.requested_system_balance,
+        ))
     }
 
     /// Attempts to update all validators about the local chain.
@@ -1683,11 +1729,16 @@ where
             .await
     }
 
-    /// Attempts to synchronize with validators and re-compute our balance.
-    pub async fn synchronize_from_validators(&mut self) -> Result<Amount, ChainClientError> {
+    /// Attempts to synchronize chains that have sent us messages and populate our local
+    /// inbox.
+    ///
+    /// To create a block that actually executes the messages in the inbox,
+    /// `process_inbox` must be called separately.
+    pub async fn synchronize_from_validators(
+        &mut self,
+    ) -> Result<Box<ChainInfo>, ChainClientError> {
         self.find_received_certificates().await?;
-        self.prepare_chain().await?;
-        self.local_balance().await
+        self.prepare_chain().await
     }
 
     /// Processes the last pending block

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -156,7 +156,7 @@ pub struct ChainInfo {
     pub next_block_height: BlockHeight,
     /// The hash of the current execution state.
     pub state_hash: Option<CryptoHash>,
-    /// The request system balance, if any.
+    /// The requested system balance, if any.
     pub requested_system_balance: Option<Amount>,
     /// The current committees.
     pub requested_committees: Option<BTreeMap<Epoch, Committee>>,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -6,7 +6,7 @@ use crate::client::ChainClientError;
 use linera_base::{
     crypto::{BcsSignable, CryptoError, CryptoHash, KeyPair, Signature},
     data_types::{Amount, BlockHeight, Round, Timestamp},
-    identifiers::{ChainDescription, ChainId},
+    identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -55,6 +55,8 @@ pub struct ChainInfoQuery {
     pub chain_id: ChainId,
     /// Optionally test that the block height is the one expected.
     pub test_next_block_height: Option<BlockHeight>,
+    /// Request the system balance of a given `Owner`.
+    pub request_system_balance: Option<Owner>,
     /// Query the current committees.
     pub request_committees: bool,
     /// Query the received messages that are waiting be picked in the next block.
@@ -77,6 +79,7 @@ impl ChainInfoQuery {
             chain_id,
             test_next_block_height: None,
             request_committees: false,
+            request_system_balance: None,
             request_pending_messages: false,
             request_sent_certificates_in_range: None,
             request_received_log_excluding_first_nth: None,
@@ -93,6 +96,11 @@ impl ChainInfoQuery {
 
     pub fn with_committees(mut self) -> Self {
         self.request_committees = true;
+        self
+    }
+
+    pub fn with_system_balance(mut self, owner: Owner) -> Self {
+        self.request_system_balance = Some(owner);
         self
     }
 
@@ -148,6 +156,8 @@ pub struct ChainInfo {
     pub next_block_height: BlockHeight,
     /// The hash of the current execution state.
     pub state_hash: Option<CryptoHash>,
+    /// The request system balance, if any.
+    pub requested_system_balance: Option<Amount>,
     /// The current committees.
     pub requested_committees: Option<BTreeMap<Epoch, Committee>>,
     /// The received messages that are waiting be picked in the next block (if requested).
@@ -233,6 +243,7 @@ where
             timestamp: *view.execution_state.system.timestamp.get(),
             state_hash: *view.execution_state_hash.get(),
             requested_committees: None,
+            requested_system_balance: None,
             requested_pending_messages: Vec::new(),
             requested_sent_certificates: Vec::new(),
             count_received_log: view.received_log.count(),

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1173,10 +1173,7 @@ where
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
     // Obtain the certificate but do not process the inbox yet.
     client2.synchronize_from_validators().await.unwrap();
-    assert_eq!(
-        client2.local_balance().await.unwrap(),
-        Amount::from_tokens(0)
-    );
+    assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
     assert_eq!(
         client2.query_system_application(SystemQuery).await.unwrap(),
         SystemResponse {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -185,6 +185,17 @@ where
     receiver.process_inbox().await?;
     // The received amount is not in the unprotected balance.
     assert_eq!(receiver.local_balance().await.unwrap(), Amount::ZERO);
+    assert_eq!(
+        receiver.local_owner_balance(owner).await.unwrap(),
+        Amount::from_tokens(3)
+    );
+    assert_eq!(
+        receiver
+            .local_balances_with_owner(Some(owner))
+            .await
+            .unwrap(),
+        (Amount::ZERO, Some(Amount::from_tokens(3)))
+    );
 
     // First attempt that should be rejected.
     sender

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -399,8 +399,13 @@ where
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         let mut chain = self.storage.load_active_chain(block.chain_id).await?;
         let local_time = self.storage.current_time();
+        let signer = block.authenticated_signer;
         let executed_block = chain.execute_block(&block, local_time).await?.with(block);
-        let response = ChainInfoResponse::new(&chain, None);
+        let mut response = ChainInfoResponse::new(&chain, None);
+        if let Some(signer) = signer {
+            response.info.requested_system_balance =
+                chain.execution_state.system.balances.get(&signer).await?;
+        }
         // Do not save the new state.
         Ok((executed_block, response))
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1204,6 +1204,10 @@ where
         if query.request_committees {
             info.requested_committees = Some(chain.execution_state.system.committees.get().clone());
         }
+        if let Some(owner) = query.request_system_balance {
+            info.requested_system_balance =
+                chain.execution_state.system.balances.get(&owner).await?;
+        }
         if let Some(next_block_height) = query.test_next_block_height {
             ensure!(
                 chain.tip_state.get().next_block_height == next_block_height,

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -291,7 +291,7 @@ where
             .balances
             .get(owner)
             .now_or_never()
-            .expect("The map entry was previously loaded by OwnedView::with")
+            .expect("The map entry was previously loaded by ResourceController::with")
             .expect("Account was created there as well")
             .expect("No I/O can fail here")
     }
@@ -302,7 +302,7 @@ where
             .balances
             .get_mut(owner)
             .now_or_never()
-            .expect("The map entry was previously loaded by OwnedView::with")
+            .expect("The map entry was previously loaded by ResourceController::with")
             .expect("Account was created there as well")
             .expect("No I/O can fail here")
     }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -57,11 +57,9 @@ pub struct ResourceTracker {
 pub trait BalanceHolder {
     fn as_amount(&self) -> Amount;
 
-    fn as_amount_mut(&mut self) -> &mut Amount;
+    fn try_add_assign(&mut self, other: Amount) -> Result<(), ArithmeticError>;
 
-    fn try_sub_assign(&mut self, other: Amount) -> Result<(), ArithmeticError> {
-        self.as_amount_mut().try_sub_assign(other)
-    }
+    fn try_sub_assign(&mut self, other: Amount) -> Result<(), ArithmeticError>;
 }
 
 // The main accounting functions for a ResourceController.
@@ -71,20 +69,31 @@ where
     Tracker: AsMut<ResourceTracker>,
 {
     /// Obtains the balance of the account.
-    pub fn balance(&mut self) -> Amount {
+    pub fn balance(&self) -> Amount {
         self.account.as_amount()
     }
 
-    /// Obtains a mutable reference on the balance of the account.
-    pub fn balance_mut(&mut self) -> &mut Amount {
-        self.account.as_amount_mut()
+    /// Operates a 3-way merge by transferring the difference between `initial`
+    /// and `other` to `self`.
+    pub fn merge_balance(&mut self, initial: Amount, other: Amount) -> Result<(), ExecutionError> {
+        if other <= initial {
+            self.account
+                .try_sub_assign(initial.try_sub(other).expect("other <= initial"))
+                .map_err(|_| SystemExecutionError::InsufficientFunding {
+                    current_balance: self.balance(),
+                })?;
+        } else {
+            self.account
+                .try_add_assign(other.try_sub(initial).expect("other > initial"))?;
+        }
+        Ok(())
     }
 
     /// Subtracts an amount from a balance and reports an error if that is impossible.
     fn update_balance(&mut self, fees: Amount) -> Result<(), ExecutionError> {
         self.account.try_sub_assign(fees).map_err(|_| {
             SystemExecutionError::InsufficientFunding {
-                current_balance: self.account.as_amount(),
+                current_balance: self.balance(),
             }
         })?;
         Ok(())
@@ -92,7 +101,7 @@ where
 
     /// Obtains the amount of fuel that could be spent by consuming the entire balance.
     pub(crate) fn remaining_fuel(&self) -> u64 {
-        self.policy.remaining_fuel(self.account.as_amount())
+        self.policy.remaining_fuel(self.balance())
     }
 
     /// Tracks the creation of a block.
@@ -239,8 +248,12 @@ impl BalanceHolder for Amount {
         *self
     }
 
-    fn as_amount_mut(&mut self) -> &mut Amount {
-        self
+    fn try_add_assign(&mut self, other: Amount) -> Result<(), ArithmeticError> {
+        self.try_add_assign(other)
+    }
+
+    fn try_sub_assign(&mut self, other: Amount) -> Result<(), ArithmeticError> {
+        self.try_sub_assign(other)
     }
 }
 
@@ -267,6 +280,34 @@ pub struct OwnedView<'a, C> {
     view: &'a mut ExecutionStateView<C>,
 }
 
+impl<'a, C> OwnedView<'a, C>
+where
+    C: Context + Clone + Send + Sync + 'static,
+    ViewError: From<C::Error>,
+{
+    fn get_owner_balance(&self, owner: &Owner) -> Amount {
+        self.view
+            .system
+            .balances
+            .get(owner)
+            .now_or_never()
+            .expect("The map entry was previously loaded by OwnedView::with")
+            .expect("Account was created there as well")
+            .expect("No I/O can fail here")
+    }
+
+    fn get_owner_balance_mut(&mut self, owner: &Owner) -> &mut Amount {
+        self.view
+            .system
+            .balances
+            .get_mut(owner)
+            .now_or_never()
+            .expect("The map entry was previously loaded by OwnedView::with")
+            .expect("Account was created there as well")
+            .expect("No I/O can fail here")
+    }
+}
+
 impl<C> BalanceHolder for OwnedView<'_, C>
 where
     C: Context + Clone + Send + Sync + 'static,
@@ -278,27 +319,44 @@ where
             Some(owner) => self
                 .view
                 .system
-                .balances
-                .get(owner)
-                .now_or_never()
-                .expect("The map entry was previously loaded by OwnedView::with")
-                .expect("Account was created there as well")
-                .expect("No I/O can fail here"),
+                .balance
+                .get()
+                .try_add(self.get_owner_balance(owner))
+                .expect("Overflow was tested in `ResourceController::with` and `add_assign`"),
         }
     }
 
-    fn as_amount_mut(&mut self) -> &mut Amount {
-        match &self.owner {
-            None => self.view.system.balance.get_mut(),
-            Some(owner) => self
-                .view
-                .system
-                .balances
-                .get_mut(owner)
-                .now_or_never()
-                .expect("The map entry was previously loaded by OwnedView::with")
-                .expect("Account was created there as well")
-                .expect("No I/O can fail here"),
+    fn try_add_assign(&mut self, other: Amount) -> Result<(), ArithmeticError> {
+        match self.owner {
+            None => self.view.system.balance.get_mut().try_add_assign(other),
+            Some(owner) => {
+                let balance = self.get_owner_balance_mut(&owner);
+                balance.try_add_assign(other)?;
+                // Safety check. (See discussion below in `ResourceController::with`).
+                balance.try_add(*self.view.system.balance.get())?;
+                Ok(())
+            }
+        }
+    }
+
+    fn try_sub_assign(&mut self, other: Amount) -> Result<(), ArithmeticError> {
+        match self.owner {
+            None => self.view.system.balance.get_mut().try_sub_assign(other),
+            Some(owner) => {
+                // Charge the owner's account first, then the chain's account for the
+                // reminder.
+                if self
+                    .get_owner_balance_mut(&owner)
+                    .try_sub_assign(other)
+                    .is_err()
+                {
+                    let balance = self.get_owner_balance(&owner);
+                    let delta = other.try_sub(balance).expect("balance < other");
+                    self.view.system.balance.get_mut().try_sub_assign(delta)?;
+                    *self.get_owner_balance_mut(&owner) = Amount::ZERO;
+                }
+                Ok(())
+            }
         }
     }
 }
@@ -317,7 +375,11 @@ impl ResourceController<Option<Owner>, ResourceTracker> {
         if let Some(owner) = &self.account {
             // Make sure `owner` has an account and that the account is loaded in memory.
             let balance = view.system.balances.get_mut(owner).await?;
-            if balance.is_none() {
+            if let Some(balance) = balance {
+                // Making sure the sum doesn't overflow. In practice, though, the total
+                // supply of tokens is known so this should never happen.
+                view.system.balance.get().try_add(*balance)?;
+            } else {
                 view.system.balances.insert(owner, Amount::ZERO)?;
             }
         }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -63,7 +63,7 @@ pub struct SystemExecutionStateView<C> {
     pub committees: RegisterView<C, BTreeMap<Epoch, Committee>>,
     /// Ownership of the chain.
     pub ownership: RegisterView<C, ChainOwnership>,
-    /// Balance of the chain (unattributed).
+    /// Balance of the chain. (Available to any user able to create blocks in the chain.)
     pub balance: RegisterView<C, Amount>,
     /// Balances attributed to a given owner.
     pub balances: MapView<C, Owner, Amount>,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -57,9 +57,9 @@ pub struct SystemExecutionStateView<C> {
     /// Track the channels that we have subscribed to.
     pub subscriptions: SetView<C, ChannelSubscription>,
     /// The committees that we trust, indexed by epoch number.
-    /// Not using a `MapView` because the set active of committees is supposed to be
-    /// small. Plus, currently, we would create the `BTreeMap` anyway in various places
-    /// (e.g. the `OpenChain` operation).
+    // Not using a `MapView` because the set active of committees is supposed to be
+    // small. Plus, currently, we would create the `BTreeMap` anyway in various places
+    // (e.g. the `OpenChain` operation).
     pub committees: RegisterView<C, BTreeMap<Epoch, Committee>>,
     /// Ownership of the chain.
     pub ownership: RegisterView<C, ChainOwnership>,

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -133,6 +133,9 @@ message ChainInfoQuery {
 
   // Query a value that contains a binary blob (e.g. bytecode) required by this chain.
   optional bytes request_blob = 9;
+
+  // Query the system balance of a given owner.
+  Owner request_system_balance = 10;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -304,6 +304,10 @@ impl TryFrom<grpc::ChainInfoQuery> for ChainInfoQuery {
 
         Ok(Self {
             request_committees: chain_info_query.request_committees,
+            request_system_balance: chain_info_query
+                .request_system_balance
+                .map(TryInto::try_into)
+                .transpose()?,
             request_pending_messages: chain_info_query.request_pending_messages,
             chain_id: try_proto_convert(chain_info_query.chain_id)?,
             request_sent_certificates_in_range,
@@ -333,6 +337,7 @@ impl TryFrom<ChainInfoQuery> for grpc::ChainInfoQuery {
         Ok(Self {
             chain_id: Some(chain_info_query.chain_id.into()),
             request_committees: chain_info_query.request_committees,
+            request_system_balance: chain_info_query.request_system_balance.map(Into::into),
             request_pending_messages: chain_info_query.request_pending_messages,
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_sent_certificates_in_range,
@@ -555,6 +560,7 @@ pub mod tests {
             next_block_height: BlockHeight::ZERO,
             state_hash: None,
             requested_committees: None,
+            requested_system_balance: None,
             requested_pending_messages: vec![],
             requested_sent_certificates: vec![],
             count_received_log: 0,
@@ -586,6 +592,7 @@ pub mod tests {
             chain_id: ChainId::root(0),
             test_next_block_height: Some(BlockHeight::from(10)),
             request_committees: false,
+            request_system_balance: None,
             request_pending_messages: false,
             request_sent_certificates_in_range: Some(linera_core::data_types::BlockHeightRange {
                 start: BlockHeight::from(3),

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -164,6 +164,9 @@ ChainInfo:
     - state_hash:
         OPTION:
           TYPENAME: CryptoHash
+    - requested_system_balance:
+        OPTION:
+          TYPENAME: Amount
     - requested_committees:
         OPTION:
           MAP:
@@ -191,6 +194,9 @@ ChainInfoQuery:
     - test_next_block_height:
         OPTION:
           TYPENAME: BlockHeight
+    - request_system_balance:
+        OPTION:
+          TYPENAME: Owner
     - request_committees: BOOL
     - request_pending_messages: BOOL
     - request_sent_certificates_in_range:

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -36,11 +36,7 @@ pub struct ChainListenerConfig {
 pub trait ClientContext<P: ValidatorNodeProvider> {
     fn wallet_state(&self) -> &WalletState;
 
-    fn make_chain_client<S>(
-        &self,
-        storage: S,
-        chain_id: impl Into<Option<ChainId>>,
-    ) -> ChainClient<P, S>;
+    fn make_chain_client<S>(&self, storage: S, chain_id: ChainId) -> ChainClient<P, S>;
 
     fn update_wallet_for_new_chain(
         &mut self,

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -206,7 +206,8 @@ where
         genesis_config: Arc<GenesisConfig>,
     ) -> anyhow::Result<Self> {
         let start_timestamp = client.storage_client().await.current_time();
-        let start_balance = client.synchronize_from_validators().await?;
+        client.process_inbox().await?;
+        let start_balance = client.local_balance().await?;
         Ok(Self {
             client: Arc::new(Mutex::new(client)),
             genesis_config,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -277,14 +277,15 @@ pub enum ClientCommand {
         chain_id: ChainId,
     },
 
-    /// Read the balance of the chain from the local state of the client.
+    /// Simulate the execution of pending messages in the local inbox, then read the
+    /// balance of the chain from the local state of the client.
     QueryBalance {
         /// Chain id
         chain_id: Option<ChainId>,
     },
 
-    /// Synchronize the local state of the chain (including a conservative estimation of the
-    /// available balance) with a quorum validators.
+    /// Synchronize the local state of the chain with a quorum validators, then query the
+    /// local balance.
     SyncBalance {
         /// Chain id
         chain_id: Option<ChainId>,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -277,23 +277,30 @@ pub enum ClientCommand {
         chain_id: ChainId,
     },
 
-    /// Simulate the execution of pending messages in the local inbox, then read the
-    /// balance of the chain from the local state of the client.
+    /// Simulate the execution of one block made of pending messages from the local inbox,
+    /// then read the native-token balance of the account from the local state.
+    ///
+    /// The balance does not reflect messages that have not been synchronized from
+    /// validators yet. Call `linera sync` first to do so.
     QueryBalance {
-        /// Chain id
-        chain_id: Option<ChainId>,
+        /// The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the
+        /// chain balance. By defaults, we read the chain balance of the default chain in
+        /// the wallet.
+        account: Option<Account>,
     },
 
     /// Synchronize the local state of the chain with a quorum validators, then query the
     /// local balance.
     SyncBalance {
-        /// Chain id
-        chain_id: Option<ChainId>,
+        /// The account to query, written as `CHAIN-ID:OWNER` or simply `CHAIN-ID` for the
+        /// chain balance. By defaults, we read the chain balance of the default chain in
+        /// the wallet.
+        account: Option<Account>,
     },
 
     /// Show the current set of validators for a chain.
     QueryValidators {
-        /// Chain id
+        /// The chain to query. If omitted, query the default chain of the wallet.
         chain_id: Option<ChainId>,
     },
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -324,9 +324,7 @@ impl Runnable for Job {
                 let mut chain_client = context.make_chain_client(storage, chain_id);
                 info!("Starting query for the local balance");
                 let time_start = Instant::now();
-                let result = chain_client.local_balance().await;
-                context.update_and_save_wallet(&mut chain_client).await;
-                let balance = result.context("Use sync_balance instead")?;
+                let balance = chain_client.query_balance().await?;
                 let time_total = time_start.elapsed();
                 info!("Local balance obtained after {} ms", time_total.as_millis());
                 println!("{}", balance);
@@ -334,9 +332,10 @@ impl Runnable for Job {
 
             SyncBalance { chain_id } => {
                 let mut chain_client = context.make_chain_client(storage, chain_id);
-                info!("Synchronizing chain information");
+                info!("Synchronizing chain information and querying the local balance");
                 let time_start = Instant::now();
-                let result = chain_client.synchronize_from_validators().await;
+                chain_client.synchronize_from_validators().await?;
+                let result = chain_client.query_balance().await;
                 context.update_and_save_wallet(&mut chain_client).await;
                 let balance = result.context("Failed to synchronize from validators")?;
                 let time_total = time_start.elapsed();

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -96,11 +96,7 @@ impl ClientContext<DummyValidatorNodeProvider> for DummyContext {
         unimplemented!()
     }
 
-    fn make_chain_client<S>(
-        &self,
-        _: S,
-        _: impl Into<Option<ChainId>>,
-    ) -> ChainClient<DummyValidatorNodeProvider, S> {
+    fn make_chain_client<S>(&self, _: S, _: ChainId) -> ChainClient<DummyValidatorNodeProvider, S> {
         unimplemented!()
     }
 


### PR DESCRIPTION
## Motivation

* Support funding from authenticated accounts (#1537)
* Allow system balance to be modified from native apps (such as #1547)
* Fix `local-balance` when blocks have fees (or when system messages are failing)

## Proposal

* Create a notion of "3-way merge" for balances (this is classical)
* In the case of authenticated accounts, we may also withdraw from the chain account if the owner's account is not enough. (It could also be the opposite, but this feels nicer.)
* Extend `ChainInfoQuery` to support requesting the balance of a user
* In `client.rs`, rename `local_balance` into `query_balance` (from the name of the CLI command calling it) then use `stage_block_execution_and_discard_failing_messages` in `query_balance` to avoid failing if a message fails.
* Extend CLI to allow querying account balances

## Test Plan

CI