### PR TITLE
An end-to-end test for the benchmark command.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
     - name: Run the benchmark test
       run: |
         cargo build --locked -p linera-service --bin linera-benchmark --features benchmark
-        cargo test --locked -p linera-service --features benchmark test_end_to_end_fungible_benchmark
+        cargo test --locked -p linera-service --features benchmark benchmark
     - name: Build Wasm test runner
       # use debug mode to avoid building wasmtime in release mode
       run: |

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -414,9 +414,7 @@ pub enum SystemExecutionError {
     IncorrectTransferAmount,
     #[error("Transfer from owned account must be authenticated by the right signer")]
     UnauthenticatedTransferOwner,
-    #[error(
-        "The transferred amount must be not exceed the current chain balance: {current_balance}"
-    )]
+    #[error("The transferred amount must not exceed the current chain balance: {current_balance}")]
     InsufficientFunding { current_balance: Amount },
     #[error("Claim must have positive amount")]
     IncorrectClaimAmount,

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -410,12 +410,13 @@ impl ClientWrapper {
     }
 
     /// Runs `linera benchmark`.
-    #[cfg(benchmark)]
-    async fn benchmark(&self, max_in_flight: usize) -> Result<()> {
+    #[cfg(feature = "benchmark")]
+    pub async fn benchmark(&self, max_in_flight: usize, num_chains: usize) -> Result<()> {
         self.command()
-            .await
+            .await?
             .arg("benchmark")
             .args(["--max-in-flight", &max_in_flight.to_string()])
+            .args(["--num-chains", &num_chains.to_string()])
             .spawn_and_wait_for_stdout()
             .await?;
         Ok(())


### PR DESCRIPTION
## Motivation

The `linera benchmark` command currently isn't tested at all (it's marked `cfg(benchmark)` instead of `cfg(feature = "benchmark")`).

## Proposal

Move the benchmark part into a separate test, use the correct feature attribute, and change the arguments so that it also tests creating new chains.

## Test Plan

I changed `rust.yml` so that this also runs in CI.

## Links

- Related: https://github.com/linera-io/linera-protocol/pull/1543
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
