### PR TITLE
Add more benchmark options.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -400,7 +400,7 @@ where
     }
 
     /// Obtains the current epoch of the given chain as well as its set of trusted committees.
-    async fn epoch_and_committees(
+    pub async fn epoch_and_committees(
         &mut self,
         chain_id: ChainId,
     ) -> Result<(Option<Epoch>, BTreeMap<Epoch, Committee>), LocalNodeError> {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -411,12 +411,21 @@ impl ClientWrapper {
 
     /// Runs `linera benchmark`.
     #[cfg(feature = "benchmark")]
-    pub async fn benchmark(&self, max_in_flight: usize, num_chains: usize) -> Result<()> {
+    pub async fn benchmark(
+        &self,
+        max_in_flight: usize,
+        num_chains: usize,
+        transactions_per_block: usize,
+    ) -> Result<()> {
         self.command()
             .await?
             .arg("benchmark")
             .args(["--max-in-flight", &max_in_flight.to_string()])
             .args(["--num-chains", &num_chains.to_string()])
+            .args([
+                "--transactions-per-block",
+                &transactions_per_block.to_string(),
+            ])
             .spawn_and_wait_for_stdout()
             .await?;
         Ok(())

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -473,6 +473,7 @@ impl ClientContext {
     pub async fn make_benchmark_chains<S>(
         &mut self,
         num_chains: usize,
+        balance: Amount,
         storage: S,
     ) -> anyhow::Result<HashMap<ChainId, KeyPair>>
     where
@@ -508,7 +509,7 @@ impl ClientContext {
             let key_pair = self.generate_key_pair();
             let public_key = key_pair.public();
             let (message_id, certificate) = chain_client
-                .open_chain(ChainOwnership::single(public_key), Amount::ONE)
+                .open_chain(ChainOwnership::single(public_key), balance)
                 .await?
                 .expect("should create chain");
             let timestamp = certificate

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -347,6 +347,11 @@ pub enum ClientCommand {
         /// How many chains to use for the benchmark
         #[arg(long, default_value = "10")]
         num_chains: usize,
+
+        /// How many tokens to assign to each newly created chain.
+        /// These need to cover the transaction fees per chain for the benchmark.
+        #[arg(long, default_value = "0.001")]
+        tokens_per_chain: Amount,
     },
 
     /// Create genesis configuration for a Linera deployment.

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -352,6 +352,10 @@ pub enum ClientCommand {
         /// These need to cover the transaction fees per chain for the benchmark.
         #[arg(long, default_value = "0.001")]
         tokens_per_chain: Amount,
+
+        /// How many transactions to put in each block.
+        #[arg(long, default_value = "1")]
+        transactions_per_block: usize,
     },
 
     /// Create genesis configuration for a Linera deployment.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -495,6 +495,7 @@ impl Runnable for Job {
                 max_in_flight,
                 num_chains,
                 tokens_per_chain,
+                transactions_per_block,
             } => {
                 // Below all block proposals are supposed to succeed without retries, we
                 // must make sure that all incoming payments have been accepted on-chain
@@ -510,7 +511,8 @@ impl Runnable for Job {
                 // For this command, we create proposals and gather certificates without using
                 // the client library. We update the wallet storage at the end using a local node.
                 info!("Starting benchmark phase 1 (block proposals)");
-                let proposals = context.make_benchmark_block_proposals(&key_pairs);
+                let proposals =
+                    context.make_benchmark_block_proposals(&key_pairs, transactions_per_block);
                 let num_proposal = proposals.len();
                 let mut values = HashMap::new();
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -494,6 +494,7 @@ impl Runnable for Job {
             Benchmark {
                 max_in_flight,
                 num_chains,
+                tokens_per_chain,
             } => {
                 // Below all block proposals are supposed to succeed without retries, we
                 // must make sure that all incoming payments have been accepted on-chain
@@ -503,7 +504,7 @@ impl Runnable for Job {
                     .await;
 
                 let key_pairs = context
-                    .make_benchmark_chains(num_chains, storage.clone())
+                    .make_benchmark_chains(num_chains, tokens_per_chain, storage.clone())
                     .await?;
 
                 // For this command, we create proposals and gather certificates without using

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2226,7 +2226,7 @@ async fn test_end_to_end_benchmark(config: LocalNetTestingConfig) {
 
     assert_eq!(client.get_wallet().unwrap().num_chains(), 10);
     // Launch local benchmark using all user chains and creating additional ones.
-    client.benchmark(12, 15).await.unwrap();
+    client.benchmark(12, 15, 10).await.unwrap();
     assert_eq!(client.get_wallet().unwrap().num_chains(), 15);
 
     net.ensure_is_running().await.unwrap();


### PR DESCRIPTION
## Motivation

The benchmark should be easy and fast to use in different scenarios.

## Proposal

Make the initial balance for newly created chains configurable, so it can be used with different fee structures and different faucet settings.

Make the transactions per block configurable, so we can test with more than one.

Create more than one new chain per block to speed up the setup process.

## Test Plan

The existing test covers the non-trivial part: creating multiple new chains in one block.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
