### PR TITLE
Add --no-build option to net up --kubernetes

### DIFF
--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -8,21 +8,15 @@ use tokio::process::Command;
 
 use crate::util::{current_binary_parent, CommandExt};
 
-pub struct DockerImage {
-    name: String,
-}
+pub struct DockerImage;
 
 impl DockerImage {
-    pub fn name(&self) -> &String {
-        &self.name
-    }
-
     pub async fn build(
-        name: String,
+        name: &String,
         binaries: &Option<Option<PathBuf>>,
         github_root: &PathBuf,
     ) -> Result<Self> {
-        let docker_image = Self { name: name.clone() };
+        let docker_image = Self {};
         let mut command = Command::new("docker");
         command
             .current_dir(github_root)

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -666,6 +666,11 @@ pub enum NetCommand {
         #[cfg(feature = "kubernetes")]
         #[arg(long, num_args=0..=1)]
         binaries: Option<Option<PathBuf>>,
+
+        /// Don't build the Docker image, just use whatever was last built
+        #[cfg(feature = "kubernetes")]
+        #[arg(long)]
+        no_build: bool,
     },
 
     /// Print a bash helper script to make `linera net up` easier to use. The script is

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1297,6 +1297,8 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 kubernetes,
                 #[cfg(feature = "kubernetes")]
                 binaries,
+                #[cfg(feature = "kubernetes")]
+                no_build,
             } => {
                 if *validators < 1 {
                     panic!("The local test network must have at least one validator.");
@@ -1314,6 +1316,13 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 if *kubernetes {
                     #[cfg(feature = "kubernetes")]
                     {
+                        if *no_build {
+                            ensure!(
+                                binaries.is_none(),
+                                "Can't specify --no-build and --binaries together!"
+                            );
+                        }
+
                         let config = cli_wrappers::local_kubernetes_net::LocalKubernetesNetConfig {
                             network: Network::Grpc,
                             testing_prng_seed: *testing_prng_seed,
@@ -1322,6 +1331,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                             num_initial_validators: *validators,
                             num_shards: *shards,
                             binaries: binaries.clone(),
+                            no_build: *no_build,
                         };
                         let (mut net, client1) = config.instantiate().await?;
                         let result = Ok(net_up(extra_wallets, &mut net, client1).await?);


### PR DESCRIPTION
## Motivation

Sometimes when you're testing locally YAML file configuration changes, you don't care about building a new Docker image. You can just use whatever is already built there most of the time.

## Proposal

Add this `--no-build` option. This will make these runs faster (no build) and also works well if you just want to test YAML files real quick

## Test Plan

Ran `linera net up --kubernetes --no-build` locally, and saw that build didn't happen, and everything still worked

