### PR TITLE
Some fix to Journaling

### DIFF
--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -504,9 +504,7 @@ impl BatchValueWriter<SimpleUnorderedBatch> for SimpleUnorderedBatchIter {
                 + get_uleb128_size(batch.deletions.len())
                 + get_uleb128_size(batch.insertions.len() + 1))
         } else {
-            Ok(batch_size
-                + get_uleb128_size(batch.deletions.len())
-                + get_uleb128_size(batch.insertions.len()))
+            unreachable!();
         }
     }
 }

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -15,11 +15,7 @@
 //! is public because some other libraries require it. But the users using views should
 //! not have to deal with batches.
 
-use crate::{
-    common::{get_uleb128_size, Context, KeyIterable},
-    memory::{MemoryContext, MemoryContextError},
-    views::ViewError,
-};
+use crate::{common::get_uleb128_size, views::ViewError};
 use async_trait::async_trait;
 use bcs::serialized_size;
 use serde::{Deserialize, Serialize};
@@ -354,21 +350,6 @@ pub trait DeletePrefixExpander {
 
     /// Returns the list of keys to be appended to the list.
     async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error>;
-}
-
-#[async_trait]
-impl DeletePrefixExpander for MemoryContext<()> {
-    type Error = MemoryContextError;
-
-    async fn expand_delete_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
-        let mut vector_list = Vec::new();
-        for key in <Vec<Vec<u8>> as KeyIterable<Self::Error>>::iterator(
-            &self.find_keys_by_prefix(key_prefix).await?,
-        ) {
-            vector_list.push(key?.to_vec());
-        }
-        Ok(vector_list)
-    }
 }
 
 /// A notion of batch useful for certain computations (notably journaling).

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -168,7 +168,8 @@ const MAX_KEY_SIZE: usize = 1024;
 
 /// Fundamental constants in DynamoDB: The maximum size of a TransactWriteItem is 4M.
 /// See https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html
-const MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE: usize = 4194304;
+/// We're taking a conservative value because the mode of computation is unclear.
+const MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE: usize = 4000000;
 
 /// The DynamoDb database is potentially handling an infinite number of connections.
 /// However, for testing or some other purpose we really need to decrease the number of

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -316,7 +316,9 @@ where
                 if iter.is_empty() || transaction_batch.len() == K::MAX_BATCH_SIZE - 1 {
                     (true, true)
                 } else {
-                    let next_block_size = iter.next_batch_size(&block_batch, block_size)?;
+                    // We can unwrap the result since if it were None, it would mean that
+                    // there is no next size but we have make sure this is not the case.
+                    let next_block_size = iter.next_batch_size(&block_batch, block_size)?.unwrap();
                     let next_transaction_size = transaction_size + next_block_size + key_len;
                     let transaction_flush = next_transaction_size > max_transaction_size;
                     let block_flush = transaction_flush

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -256,7 +256,7 @@ where
     /// Starting with a batch of operations that is typically too large to be executed in
     /// one go (see `is_fastpath_feasible()` below), the goal of this function is to split
     /// the batch into smaller blocks so that `coherently_resolve_journal` respects the
-    /// constraints of the underlying key-value store (see analysis above)
+    /// constraints of the underlying key-value store (see analysis above).
     ///
     /// For efficiency reasons, we write as many blocks as possible in each "transaction"
     /// batch, using one write-operation per block. Then we also update the journal header

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -316,9 +316,9 @@ where
                 if iter.is_empty() || transaction_batch.len() == K::MAX_BATCH_SIZE - 1 {
                     (true, true)
                 } else {
-                    // We can unwrap the result since if it were None, it would mean that
-                    // there is no next size but we have make sure this is not the case.
-                    let next_block_size = iter.next_batch_size(&block_batch, block_size)?.unwrap();
+                    let next_block_size = iter
+                        .next_batch_size(&block_batch, block_size)?
+                        .expect("iter is not empty");
                     let next_transaction_size = transaction_size + next_block_size + key_len;
                     let transaction_flush = next_transaction_size > max_transaction_size;
                     let block_flush = transaction_flush

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -184,6 +184,9 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
 
 #[async_trait]
 impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
+    // The constant 14000 is an empirical constant that was found to be necessary
+    // to make the ScyllaDb system work. We have not been able to find this or
+    // a similar constant in the source code or the documentation.
     const MAX_BATCH_SIZE: usize = 14000;
     /// The total size is 16M
     const MAX_BATCH_TOTAL_SIZE: usize = 16000000;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -189,7 +189,7 @@ impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal
     // a similar constant in the source code or the documentation.
     // An experimental approach gets us that 14796 is the latest value that is
     // correct.
-    const MAX_BATCH_SIZE: usize = 12000;
+    const MAX_BATCH_SIZE: usize = 5000;
     /// The total size is 16M
     const MAX_BATCH_TOTAL_SIZE: usize = 16000000;
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -187,7 +187,9 @@ impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal
     // The constant 14000 is an empirical constant that was found to be necessary
     // to make the ScyllaDb system work. We have not been able to find this or
     // a similar constant in the source code or the documentation.
-    const MAX_BATCH_SIZE: usize = 14000;
+    // An experimental approach gets us that 14796 is the latest value that is
+    // correct.
+    const MAX_BATCH_SIZE: usize = 12000;
     /// The total size is 16M
     const MAX_BATCH_TOTAL_SIZE: usize = 16000000;
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -184,7 +184,7 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
 
 #[async_trait]
 impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
-    const MAX_BATCH_SIZE: usize = usize::MAX;
+    const MAX_BATCH_SIZE: usize = 14000;
     /// The total size is 16M
     const MAX_BATCH_TOTAL_SIZE: usize = 16000000;
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -442,8 +442,8 @@ async fn run_big_write_read<C: KeyValueStore + Sync>(
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {
     let key_value_store = create_scylla_db_test_store().await;
-    let value_sizes = vec![1000, 200000, 5000000];
-    let target_size = 14000000;
+    let value_sizes = vec![100, 1000, 200000, 5000000];
+    let target_size = 20000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 


### PR DESCRIPTION
## Motivation

The recent merging of the PR on the ScyllaDb journaling left some issues unanswered and a documentation insufficient. The current PR addresses that

## Proposal

The following was done:
* When the iterator reaches a state that it should not reach, then it is "unreachable()" instead of returning something non-sensical.
* The sizes of keys are kept on track for the size of the transaction.
* The changes are fully documented.

On the test side, now the ScyllaDb passes the same tests as the DynamoDb and Memory.

## Test Plan

The CI.

## Release Plan

No impact.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
