### PR TITLE
Optionally use the fungible app in linera benchmark.

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -416,18 +416,22 @@ impl ClientWrapper {
         max_in_flight: usize,
         num_chains: usize,
         transactions_per_block: usize,
+        fungible_application_id: Option<ApplicationId<fungible::FungibleTokenAbi>>,
     ) -> Result<()> {
-        self.command()
-            .await?
+        let mut command = self.command().await?;
+        command
             .arg("benchmark")
             .args(["--max-in-flight", &max_in_flight.to_string()])
             .args(["--num-chains", &num_chains.to_string()])
             .args([
                 "--transactions-per-block",
                 &transactions_per_block.to_string(),
-            ])
-            .spawn_and_wait_for_stdout()
-            .await?;
+            ]);
+        if let Some(application_id) = fungible_application_id {
+            let application_id = application_id.forget_abi().to_string();
+            command.args(["--fungible-application-id", &application_id]);
+        }
+        command.spawn_and_wait_for_stdout().await?;
         Ok(())
     }
 

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -360,6 +360,11 @@ pub enum ClientCommand {
         /// How many transactions to put in each block.
         #[arg(long, default_value = "1")]
         transactions_per_block: usize,
+
+        /// The application ID of a fungible token on the wallet's default chain.
+        /// If none is specified, the benchmark uses the native token.
+        #[arg(long)]
+        fungible_application_id: Option<linera_base::identifiers::ApplicationId>,
     },
 
     /// Create genesis configuration for a Linera deployment.

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2216,9 +2216,6 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetTestingConfig) {
 #[cfg_attr(feature = "rocksdb", test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Tcp) ; "rocksdb_tcp"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Tcp) ; "scylladb_tcp"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Tcp) ; "aws_tcp"))]
-#[cfg_attr(feature = "rocksdb", test_case(LocalNetTestingConfig::new(Database::RocksDb, Network::Udp) ; "rocksdb_udp"))]
-#[cfg_attr(feature = "scylladb", test_case(LocalNetTestingConfig::new(Database::ScyllaDb, Network::Udp) ; "scylladb_udp"))]
-#[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Udp) ; "aws_udp"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_benchmark(config: LocalNetTestingConfig) {
     use fungible::{FungibleTokenAbi, InitialState};

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2221,13 +2221,31 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetTestingConfig) {
 #[cfg_attr(feature = "aws", test_case(LocalNetTestingConfig::new(Database::DynamoDb, Network::Udp) ; "aws_udp"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_benchmark(config: LocalNetTestingConfig) {
+    use fungible::{FungibleTokenAbi, InitialState};
+
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client) = config.instantiate().await.unwrap();
 
     assert_eq!(client.get_wallet().unwrap().num_chains(), 10);
     // Launch local benchmark using all user chains and creating additional ones.
-    client.benchmark(12, 15, 10).await.unwrap();
+    client.benchmark(12, 15, 10, None).await.unwrap();
     assert_eq!(client.get_wallet().unwrap().num_chains(), 15);
+
+    // Now we run the benchmark again, with the fungible token application instead of the
+    // native token.
+    let account_owner = get_fungible_account_owner(&client);
+    let accounts = BTreeMap::from([(account_owner, Amount::from_tokens(1_000_000))]);
+    let state = InitialState { accounts };
+    let (contract, service) = client.build_example("fungible").await.unwrap();
+    let params = fungible::Parameters::new("FUN");
+    let application_id = client
+        .publish_and_create::<FungibleTokenAbi>(contract, service, &params, &state, &[], None)
+        .await
+        .unwrap();
+    client
+        .benchmark(12, 15, 10, Some(application_id))
+        .await
+        .unwrap();
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();


### PR DESCRIPTION
## Motivation

`linera benchmark` currently only creates native token transfer operations.

## Proposal

Add an optional argument so the user can specify a fungible token application that is registered on their default chain. The benchmark will use that instead of the native token.

## Test Plan

Extended the end-to-end test.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
