### PR TITLE
`linera-service`: collect and make available build version info

### DIFF
--- a/linera-base/build.rs
+++ b/linera-base/build.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::BufRead as _;
+
+fn main() {
+    let mut versions = std::process::Command::new("bash")
+        .arg("versions.sh")
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to launch child");
+
+    for line in
+        std::io::BufReader::new(versions.stdout.take().expect("child has no stdout")).lines()
+    {
+        println!(
+            "cargo:rustc-env=LINERA_VERSION_{}",
+            line.expect("failed to read line")
+        );
+    }
+}

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -20,6 +20,9 @@ pub use graphql::BcsHexParseError;
 #[doc(hidden)]
 pub use {async_graphql, bcs, hex};
 
+mod version_info;
+pub use version_info::{VersionInfo, VERSION_INFO};
+
 /// A macro for asserting that a condition is true, returning an error if it is not.
 ///
 /// # Examples

--- a/linera-base/src/version_info.rs
+++ b/linera-base/src/version_info.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::Cow;
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    async_graphql::SimpleObject,
+    serde::Deserialize,
+    serde::Serialize,
+)]
+#[non_exhaustive]
+/// The version info of a build of Linera.
+pub struct VersionInfo {
+    /// The crate version
+    pub ver: Cow<'static, str>,
+    /// The git commit hash
+    pub git: Cow<'static, str>,
+    /// A hash of the RPC API
+    pub rpc: Cow<'static, str>,
+    /// A hash of the GraphQL API
+    pub gql: Cow<'static, str>,
+    /// A hash of the WIT API
+    pub wit: Cow<'static, str>,
+}
+
+/// The version info of this build of Linera.
+pub const VERSION_INFO: VersionInfo = VersionInfo {
+    r#ver: Cow::Borrowed(env!("LINERA_VERSION_VER")),
+    r#git: Cow::Borrowed(env!("LINERA_VERSION_GIT")),
+    r#rpc: Cow::Borrowed(env!("LINERA_VERSION_RPC")),
+    r#gql: Cow::Borrowed(env!("LINERA_VERSION_GQL")),
+    r#wit: Cow::Borrowed(env!("LINERA_VERSION_WIT")),
+};
+
+impl VersionInfo {
+    /// Print a human-readable listing of the version information.
+    pub fn print(&self) {
+        let VersionInfo {
+            ver,
+            git,
+            rpc,
+            gql,
+            wit,
+        } = self;
+
+        println!(
+            "\
+            Linera v{ver}\n\
+            Built from git commit: {git}\n\
+            RPC API hash: {rpc}\n\
+            GraphQL API hash: {gql}\n\
+            WIT API hash: {wit}\n\
+        "
+        );
+    }
+}
+
+impl Default for VersionInfo {
+    fn default() -> Self {
+        VERSION_INFO
+    }
+}

--- a/linera-base/versions.sh
+++ b/linera-base/versions.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+cd $(git rev-parse --show-toplevel)
+
+# git commit
+git=$(git rev-parse @)
+git diff-index --quiet @ || git="$git-dirty"
+echo GIT=$git
+
+# crates version
+echo -n VER=
+cargo metadata --format-version 1 | jq -r '(.workspace_members[0] / " ")[1]'
+
+{
+    # GraphQL API hash
+    echo -n GQL=
+    cat linera-service-graphql-client/gql/*.graphql | sha256sum
+
+    # WIT API hash
+    echo -n WIT=
+    cat linera-sdk/*.wit | sha256sum
+
+    # RPC API hash
+    echo -n RPC=
+    sha256sum linera-rpc/tests/staged/formats.yaml
+} | awk '{print $1}'


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/issues/1555

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Add a build script that collects the version info required, and uses it to populate a static struct available inside `linera-service`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Run the script directly to see the generated versions.

<!-- How to test that the changes are correct. -->

## Release Plan

This PR is invisible to users — no version bump required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
