### PR TITLE
Expose version info to end users

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,6 +3172,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tonic",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3114,6 +3114,7 @@ dependencies = [
  "sha3",
  "test-strategy",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1652,6 +1652,7 @@ dependencies = [
  "sha3",
  "test-strategy",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "async-graphql-value",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.1",
  "bytes",
  "fast_chemail",
  "fnv",
@@ -289,6 +289,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +353,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bcs"
@@ -527,6 +578,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1366,6 +1427,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "h2"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.1.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "handlebars"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,16 +1522,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1702,6 +1835,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tonic",
  "tracing",
 ]
 
@@ -2064,6 +2198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2149,6 +2289,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,7 +2319,7 @@ dependencies = [
  "log",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.8",
  "version_check",
 ]
 
@@ -2266,6 +2417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,6 +2506,26 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2451,6 +2628,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2731,6 +2931,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+dependencies = [
+ "cc",
+ "getrandom 0.2.11",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +3031,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
+dependencies = [
+ "log",
+ "ring 0.16.20",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,6 +3088,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,10 +3109,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring 0.17.7",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3023,6 +3327,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,6 +3416,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
@@ -3228,10 +3554,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
+ "bytes",
+ "libc",
+ "mio",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3243,6 +3584,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -3267,6 +3619,20 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3313,6 +3679,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3345,6 +3778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,6 +3815,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3440,6 +3889,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3481,6 +3942,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3813,7 +4283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcd849399d17d2270141cfe47fa0d91ee52d5f8ea9b98cf7ddde0d53e5f79882"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.13.1",
  "bincode",
  "directories-next",
  "file-per-thread-logger",
@@ -3976,6 +4446,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webassembly-test"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3983,6 +4463,16 @@ checksum = "45e64391864794db026d27b15cbe6edd3c25864222bd90229dfa1a26ebf30705"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring 0.17.7",
+ "untrusted 0.9.0",
 ]
 
 [[package]]

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -26,6 +26,7 @@ serde_bytes = { workspace = true }
 sha3 = { workspace = true }
 test-strategy = { workspace = true, optional = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono = { workspace = true }

--- a/linera-base/build.rs
+++ b/linera-base/build.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::BufRead as _;
+
+fn main() {
+    let mut versions = std::process::Command::new("bash")
+        .arg("versions.sh")
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .expect("failed to launch child");
+
+    for line in
+        std::io::BufReader::new(versions.stdout.take().expect("child has no stdout")).lines()
+    {
+        println!(
+            "cargo:rustc-env=LINERA_VERSION_{}",
+            line.expect("failed to read line")
+        );
+    }
+}

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -20,6 +20,9 @@ pub use graphql::BcsHexParseError;
 #[doc(hidden)]
 pub use {async_graphql, bcs, hex};
 
+mod version_info;
+pub use version_info::{VersionInfo, VERSION_INFO};
+
 /// A macro for asserting that a condition is true, returning an error if it is not.
 ///
 /// # Examples

--- a/linera-base/src/version_info.rs
+++ b/linera-base/src/version_info.rs
@@ -13,7 +13,6 @@ use std::borrow::Cow;
     serde::Deserialize,
     serde::Serialize,
 )]
-#[non_exhaustive]
 /// The version info of a build of Linera.
 pub struct VersionInfo {
     /// The crate version

--- a/linera-base/src/version_info.rs
+++ b/linera-base/src/version_info.rs
@@ -39,7 +39,7 @@ pub const VERSION_INFO: VersionInfo = VersionInfo {
 
 impl VersionInfo {
     /// Print a human-readable listing of the version information.
-    pub fn print(&self) {
+    pub fn log(&self) {
         let VersionInfo {
             crate_version,
             git_commit,
@@ -48,15 +48,11 @@ impl VersionInfo {
             wit_hash,
         } = self;
 
-        println!(
-            "\
-            Linera v{crate_version}\n\
-            Built from git commit: {git_commit}\n\
-            RPC API hash: {rpc_hash}\n\
-            GraphQL API hash: {graphql_hash}\n\
-            WIT API hash: {wit_hash}\n\
-        "
-        );
+        tracing::info!("Linera v{crate_version}");
+        tracing::info!("Built from git commit: {git_commit}");
+        tracing::info!("RPC API hash: {rpc_hash}");
+        tracing::info!("GraphQL API hash: {graphql_hash}");
+        tracing::info!("WIT API hash: {wit_hash}");
     }
 }
 

--- a/linera-base/src/version_info.rs
+++ b/linera-base/src/version_info.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::Cow;
+
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    async_graphql::SimpleObject,
+    serde::Deserialize,
+    serde::Serialize,
+)]
+#[non_exhaustive]
+/// The version info of a build of Linera.
+pub struct VersionInfo {
+    /// The crate version
+    pub crate_version: Cow<'static, str>,
+    /// The git commit hash
+    pub git_commit: Cow<'static, str>,
+    /// A hash of the RPC API
+    pub rpc_hash: Cow<'static, str>,
+    /// A hash of the GraphQL API
+    pub graphql_hash: Cow<'static, str>,
+    /// A hash of the WIT API
+    pub wit_hash: Cow<'static, str>,
+}
+
+/// The version info of this build of Linera.
+pub const VERSION_INFO: VersionInfo = VersionInfo {
+    crate_version: Cow::Borrowed(env!("CARGO_PKG_VERSION")),
+    git_commit: Cow::Borrowed(env!("LINERA_VERSION_GIT_COMMIT")),
+    rpc_hash: Cow::Borrowed(env!("LINERA_VERSION_RPC_HASH")),
+    graphql_hash: Cow::Borrowed(env!("LINERA_VERSION_GRAPHQL_HASH")),
+    wit_hash: Cow::Borrowed(env!("LINERA_VERSION_WIT_HASH")),
+};
+
+impl VersionInfo {
+    /// Print a human-readable listing of the version information.
+    pub fn print(&self) {
+        let VersionInfo {
+            crate_version,
+            git_commit,
+            rpc_hash,
+            graphql_hash,
+            wit_hash,
+        } = self;
+
+        println!(
+            "\
+            Linera v{crate_version}\n\
+            Built from git commit: {git_commit}\n\
+            RPC API hash: {rpc_hash}\n\
+            GraphQL API hash: {graphql_hash}\n\
+            WIT API hash: {wit_hash}\n\
+        "
+        );
+    }
+}
+
+impl Default for VersionInfo {
+    fn default() -> Self {
+        VERSION_INFO
+    }
+}

--- a/linera-base/versions.sh
+++ b/linera-base/versions.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+cd $(git rev-parse --show-toplevel)
+
+if type -P sha256sum &>/dev/null
+then
+    hash=sha256sum
+elif type -P shasum &>/dev/null
+then
+    hash="shasum -a 256"
+else
+    >&2 echo "No SHA256-sum implementation found"
+    exit 1
+fi
+
+# git commit
+git=$(git rev-parse @)
+git diff-index --quiet @ || git="$git-dirty"
+echo GIT_COMMIT=$git
+
+{
+    # GraphQL API hash
+    echo -n GRAPHQL_HASH=
+    cat linera-service-graphql-client/gql/*.graphql | $hash
+
+    # WIT API hash
+    echo -n WIT_HASH=
+    cat linera-sdk/*.wit | $hash
+
+    # RPC API hash
+    echo -n RPC_HASH=
+    $hash linera-rpc/tests/staged/formats.yaml
+} | awk '{print $1}'

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -46,6 +46,7 @@ test-strategy = { workspace = true, optional = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tonic = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -12,6 +12,7 @@ use linera_base::{
     crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight},
     identifiers::ChainId,
+    VersionInfo,
 };
 use linera_chain::{
     data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate, Origin},
@@ -66,6 +67,9 @@ pub trait ValidatorNode {
         &mut self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, NodeError>;
+
+    /// Gets the version info for this validator node.
+    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError>;
 
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(&mut self, chains: Vec<ChainId>) -> Result<NotificationStream, NodeError>;
@@ -174,6 +178,14 @@ pub enum NodeError {
 
     #[error("Failed to make a chain info query on the local node: {error}")]
     LocalNodeQuery { error: String },
+}
+
+impl From<tonic::Status> for NodeError {
+    fn from(status: tonic::Status) -> Self {
+        Self::GrpcError {
+            error: status.to_string(),
+        }
+    }
 }
 
 impl CrossChainMessageDelivery {

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -14,6 +14,7 @@ use linera_base::{
     crypto::*,
     data_types::*,
     identifiers::{ChainDescription, ChainId},
+    VersionInfo,
 };
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 use linera_execution::{
@@ -134,6 +135,10 @@ where
     async fn subscribe(&mut self, chains: Vec<ChainId>) -> Result<NotificationStream, NodeError> {
         self.spawn_and_receive(move |validator, sender| validator.do_subscribe(chains, sender))
             .await
+    }
+
+    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError> {
+        Ok(Default::default())
     }
 }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -48,6 +48,18 @@ service ValidatorNode {
 
   // Subscribe to notifications for a set of Chain Ids.
   rpc Subscribe(SubscriptionRequest) returns (stream Notification);
+
+  // Request the node's version info.
+  rpc GetVersionInfo(google.protobuf.Empty) returns (VersionInfo);
+}
+
+// Information about the version of Linera the validator is running
+message VersionInfo {
+    string crate_version = 1;
+    string git_commit = 2;
+    string rpc_hash = 3;
+    string graphql_hash = 4;
+    string wit_hash = 5;
 }
 
 // A request for client to subscribe to notifications for a given `ChainId`

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -96,4 +96,11 @@ impl ValidatorNode for Client {
             Client::Simple(simple_client) => Box::pin(simple_client.subscribe(chains).await?),
         })
     }
+
+    async fn get_version_info(&mut self) -> Result<linera_base::VersionInfo, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.get_version_info().await?,
+            Client::Simple(simple_client) => simple_client.get_version_info().await?,
+        })
+    }
 }

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -52,6 +52,30 @@ impl From<ProtoConversionError> for Status {
     }
 }
 
+impl From<linera_base::VersionInfo> for grpc::VersionInfo {
+    fn from(version_info: linera_base::VersionInfo) -> grpc::VersionInfo {
+        grpc::VersionInfo {
+            crate_version: version_info.crate_version.into(),
+            git_commit: version_info.git_commit.into(),
+            rpc_hash: version_info.rpc_hash.into(),
+            graphql_hash: version_info.graphql_hash.into(),
+            wit_hash: version_info.wit_hash.into(),
+        }
+    }
+}
+
+impl From<grpc::VersionInfo> for linera_base::VersionInfo {
+    fn from(version_info: grpc::VersionInfo) -> linera_base::VersionInfo {
+        linera_base::VersionInfo {
+            crate_version: version_info.crate_version.into(),
+            git_commit: version_info.git_commit.into(),
+            rpc_hash: version_info.rpc_hash.into(),
+            graphql_hash: version_info.graphql_hash.into(),
+            wit_hash: version_info.wit_hash.into(),
+        }
+    }
+}
+
 impl TryFrom<Notification> for grpc::Notification {
     type Error = ProtoConversionError;
 

--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -35,7 +35,7 @@ use grpc::{
     BlockProposal, Certificate, ChainInfoQuery, ChainInfoResult, CrossChainRequest,
     LiteCertificate, SubscriptionRequest,
 };
-use linera_base::{identifiers::ChainId, prometheus_util, sync::Lazy};
+use linera_base::{identifiers::ChainId, prometheus_util, sync::Lazy, VersionInfo};
 use linera_chain::data_types;
 use linera_core::{
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
@@ -808,6 +808,11 @@ impl ValidatorNode for GrpcClient {
             .filter_map(|result| future::ready(result.ok()));
 
         Ok(Box::pin(notification_stream))
+    }
+
+    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
+    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError> {
+        Ok(self.client.get_version_info(()).await?.into_inner().into())
     }
 }
 

--- a/linera-rpc/src/rpc.rs
+++ b/linera-rpc/src/rpc.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::identifiers::ChainId;
+use linera_base::{identifiers::ChainId, VersionInfo};
 use linera_chain::data_types::{
     BlockProposal, Certificate, HashedValue, LiteCertificate, LiteVote,
 };
@@ -21,10 +21,14 @@ pub enum RpcMessage {
     Certificate(Box<HandleCertificateRequest>),
     LiteCertificate(Box<HandleLiteCertificateRequest<'static>>),
     ChainInfoQuery(Box<ChainInfoQuery>),
+    VersionInfoQuery,
+
     // Outbound
     Vote(Box<LiteVote>),
     ChainInfoResponse(Box<ChainInfoResponse>),
     Error(Box<NodeError>),
+    VersionInfoResponse(Box<VersionInfo>),
+
     // Internal to a validator
     CrossChainRequest(Box<CrossChainRequest>),
 }
@@ -34,17 +38,48 @@ impl RpcMessage {
     ///
     /// Only inbound messages have target chains.
     pub fn target_chain_id(&self) -> Option<ChainId> {
+        use RpcMessage::*;
+
         let chain_id = match self {
-            RpcMessage::BlockProposal(proposal) => proposal.content.block.chain_id,
-            RpcMessage::LiteCertificate(request) => request.certificate.value.chain_id,
-            RpcMessage::Certificate(request) => request.certificate.value().chain_id(),
-            RpcMessage::ChainInfoQuery(query) => query.chain_id,
-            RpcMessage::CrossChainRequest(request) => request.target_chain_id(),
-            RpcMessage::Vote(_) | RpcMessage::Error(_) | RpcMessage::ChainInfoResponse(_) => {
+            BlockProposal(proposal) => proposal.content.block.chain_id,
+            LiteCertificate(request) => request.certificate.value.chain_id,
+            Certificate(request) => request.certificate.value().chain_id(),
+            ChainInfoQuery(query) => query.chain_id,
+            CrossChainRequest(request) => request.target_chain_id(),
+            Vote(_)
+            | Error(_)
+            | ChainInfoResponse(_)
+            | VersionInfoQuery
+            | VersionInfoResponse(_) => {
                 return None;
             }
         };
+
         Some(chain_id)
+    }
+}
+
+impl TryFrom<RpcMessage> for ChainInfoResponse {
+    type Error = NodeError;
+    fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
+        use RpcMessage::*;
+        match message {
+            ChainInfoResponse(response) => Ok(*response),
+            Error(error) => Err(*error),
+            _ => Err(NodeError::UnexpectedMessage),
+        }
+    }
+}
+
+impl TryFrom<RpcMessage> for VersionInfo {
+    type Error = NodeError;
+    fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
+        use RpcMessage::*;
+        match message {
+            VersionInfoResponse(version_info) => Ok(*version_info),
+            Error(error) => Err(*error),
+            _ => Err(NodeError::UnexpectedMessage),
+        }
     }
 }
 
@@ -93,6 +128,12 @@ impl From<NodeError> for RpcMessage {
 impl From<CrossChainRequest> for RpcMessage {
     fn from(cross_chain_request: CrossChainRequest) -> Self {
         RpcMessage::CrossChainRequest(Box::new(cross_chain_request))
+    }
+}
+
+impl From<VersionInfo> for RpcMessage {
+    fn from(version_info: VersionInfo) -> Self {
+        RpcMessage::VersionInfoResponse(Box::new(version_info))
     }
 }
 

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -650,18 +650,24 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: ChainInfoQuery
     4:
+      VersionInfoQuery: UNIT
+    5:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    5:
+    6:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    6:
+    7:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    7:
+    8:
+      VersionInfoResponse:
+        NEWTYPE:
+          TYPENAME: VersionInfo
+    9:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest
@@ -909,4 +915,11 @@ ValidatorState:
   STRUCT:
     - network_address: STR
     - votes: U64
+VersionInfo:
+  STRUCT:
+    - crate_version: STR
+    - git_commit: STR
+    - rpc_hash: STR
+    - graphql_hash: STR
+    - wit_hash: STR
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -583,6 +583,7 @@ type QueryRoot {
 	chains: Chains!
 	block(hash: CryptoHash, chainId: ChainId!): HashedValue
 	blocks(from: CryptoHash, chainId: ChainId!, limit: Int): [HashedValue!]!
+	version: VersionInfo!
 }
 
 type QueueView_BlockHeight {
@@ -726,6 +727,32 @@ scalar UserApplicationDescription
 Optional user message attached to a transfer
 """
 scalar UserData
+
+"""
+The version info of a build of Linera.
+"""
+type VersionInfo {
+	"""
+	The crate version
+	"""
+	crateVersion: String!
+	"""
+	The git commit hash
+	"""
+	gitCommit: String!
+	"""
+	A hash of the RPC API
+	"""
+	rpcHash: String!
+	"""
+	A hash of the GraphQL API
+	"""
+	graphqlHash: String!
+	"""
+	A hash of the WIT API
+	"""
+	witHash: String!
+}
 
 schema {
 	query: QueryRoot

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -17,7 +17,7 @@ use linera_rpc::{
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
             BlockProposal, Certificate, ChainInfoQuery, ChainInfoResult, LiteCertificate,
-            Notification, SubscriptionRequest,
+            Notification, SubscriptionRequest, VersionInfo,
         },
         Proxyable,
     },
@@ -340,6 +340,15 @@ impl ValidatorNode for GrpcProxy {
             .collect::<Result<Vec<ChainId>, _>>()?;
         let rx = self.0.notifier.subscribe(chain_ids);
         Ok(Response::new(UnboundedReceiverStream::new(rx)))
+    }
+
+    #[instrument(skip_all, err(Display))]
+    async fn get_version_info(
+        &self,
+        _request: Request<()>,
+    ) -> Result<Response<VersionInfo>, Status> {
+        // We assume each shard is running the same version as the proxy
+        Ok(Response::new(linera_base::VERSION_INFO.into()))
     }
 }
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -729,6 +729,10 @@ where
             Ok(vec![])
         }
     }
+
+    async fn version(&self) -> linera_base::VersionInfo {
+        linera_base::VersionInfo::default()
+    }
 }
 
 // What follows is a hack to add a chain_id field to `ChainStateView` based on

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use linera_base::{crypto::KeyPair, data_types::Timestamp, identifiers::ChainId};
+use linera_base::{crypto::KeyPair, data_types::Timestamp, identifiers::ChainId, VersionInfo};
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 use linera_core::{
     client::ChainClient,
@@ -58,6 +58,10 @@ impl ValidatorNode for DummyValidatorNode {
     }
 
     async fn subscribe(&mut self, _: Vec<ChainId>) -> Result<NotificationStream, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
+    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -409,6 +409,8 @@ fn main() {
 }
 
 async fn run(options: ServerOptions) {
+    linera_base::VERSION_INFO.log();
+
     match options.command {
         ServerCommand::Run {
             server_config_path,


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/issues/1555

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Expose version info:

- [x] from binaries at startup
- [x] through the GraphQL node API
- [x] through the validator gRPC API
  - [x] with a client command to fetch it 

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

<!-- How to test that the changes are correct. -->

Run each of these types of query and check that the output is correct.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Fixes https://github.com/linera-io/linera-protocol/issues/1555.
