### PR TITLE
Reduce the number of chains in the benchmark e2e test.

### DIFF
--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -39,6 +39,8 @@ pub struct LocalNetConfig {
 pub struct LocalNetTestingConfig {
     pub database: Database,
     pub network: Network,
+    pub num_other_initial_chains: u32,
+    pub initial_amount: Amount,
 }
 
 /// A set of Linera validators running locally as native processes.
@@ -122,7 +124,22 @@ impl Validator {
 #[cfg(any(test, feature = "test"))]
 impl LocalNetTestingConfig {
     pub fn new(database: Database, network: Network) -> Self {
-        Self { database, network }
+        Self {
+            database,
+            network,
+            num_other_initial_chains: 10,
+            initial_amount: Amount::from_tokens(10),
+        }
+    }
+
+    pub fn with_num_other_initial_chains(mut self, num: u32) -> Self {
+        self.num_other_initial_chains = num;
+        self
+    }
+
+    pub fn with_initial_amount(mut self, amount: Amount) -> Self {
+        self.initial_amount = amount;
+        self
     }
 }
 
@@ -184,7 +201,7 @@ impl LineraNetConfig for LocalNetTestingConfig {
         if num_validators > 0 {
             net.generate_initial_validator_config().await.unwrap();
             client
-                .create_genesis_config(10, Amount::from_tokens(10))
+                .create_genesis_config(self.num_other_initial_chains, self.initial_amount)
                 .await
                 .unwrap();
             net.run().await.unwrap();

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2220,13 +2220,14 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetTestingConfig) {
 async fn test_end_to_end_benchmark(config: LocalNetTestingConfig) {
     use fungible::{FungibleTokenAbi, InitialState};
 
+    let config = config.with_num_other_initial_chains(2);
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client) = config.instantiate().await.unwrap();
 
-    assert_eq!(client.get_wallet().unwrap().num_chains(), 10);
+    assert_eq!(client.get_wallet().unwrap().num_chains(), 2);
     // Launch local benchmark using all user chains and creating additional ones.
-    client.benchmark(11, 12, 10, None).await.unwrap();
-    assert_eq!(client.get_wallet().unwrap().num_chains(), 12);
+    client.benchmark(2, 4, 10, None).await.unwrap();
+    assert_eq!(client.get_wallet().unwrap().num_chains(), 4);
 
     // Now we run the benchmark again, with the fungible token application instead of the
     // native token.
@@ -2240,7 +2241,7 @@ async fn test_end_to_end_benchmark(config: LocalNetTestingConfig) {
         .await
         .unwrap();
     client
-        .benchmark(11, 12, 10, Some(application_id))
+        .benchmark(2, 5, 10, Some(application_id))
         .await
         .unwrap();
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2225,8 +2225,8 @@ async fn test_end_to_end_benchmark(config: LocalNetTestingConfig) {
 
     assert_eq!(client.get_wallet().unwrap().num_chains(), 10);
     // Launch local benchmark using all user chains and creating additional ones.
-    client.benchmark(12, 15, 10, None).await.unwrap();
-    assert_eq!(client.get_wallet().unwrap().num_chains(), 15);
+    client.benchmark(11, 12, 10, None).await.unwrap();
+    assert_eq!(client.get_wallet().unwrap().num_chains(), 12);
 
     // Now we run the benchmark again, with the fungible token application instead of the
     // native token.
@@ -2240,7 +2240,7 @@ async fn test_end_to_end_benchmark(config: LocalNetTestingConfig) {
         .await
         .unwrap();
     client
-        .benchmark(12, 15, 10, Some(application_id))
+        .benchmark(11, 12, 10, Some(application_id))
         .await
         .unwrap();
 


### PR DESCRIPTION
## Motivation

We are seeing timeouts in CI, possibly because the benchmark test runs with 15 chains.

## Proposal

Use 4 chains.

## Test Plan

Hopefully CI passes now. :crossed_fingers: 

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
