### PR TITLE
Enable ScyllaDB monitoring

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -68,6 +68,14 @@ jobs:
         # Check one random server metric that we expect to be logged after running the e2e tests
         run: |
           curl -s 'http://127.0.0.1:9090/api/v1/query?query=linera_server_request_latency_bucket' | jq -r '.data.result[]' | grep -q .
+      - name: Check Scylla metric
+        # Check one random server metric that we expect to be logged after running the e2e tests
+        run: |
+          curl -s 'http://127.0.0.1:9090/api/v1/query?query=scylla_database_total_reads' | jq -r '.data.result[]' | grep -q .
+      - name: Check Scylla Manager metric
+        # Check one random server metric that we expect to be logged after running the e2e tests
+        run: |
+          curl -s 'http://127.0.0.1:9090/api/v1/query?query=scylla_manager_agent_rclone_bytes_transferred_total' | jq -r '.data.result[]' | grep -q .
       - name: Destroy the kind clusters
         if: always()
         shell: bash

--- a/kubernetes/linera-validator/templates/scylla-manager-service-monitor.yaml
+++ b/kubernetes/linera-validator/templates/scylla-manager-service-monitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: scylla-manager-service-monitor
+  namespace: scylla-manager
+spec:
+  jobLabel: "app"
+  selector:
+    matchLabels:
+      app: scylla-manager
+  endpoints:
+    - port: metrics
+      metricRelabelings:
+        - sourceLabels: [ host ]
+          targetLabel: instance
+          regex: (.*)
+          replacement: ${1}

--- a/kubernetes/linera-validator/templates/scylla-service-monitor.yaml
+++ b/kubernetes/linera-validator/templates/scylla-service-monitor.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: scylla-service-monitor
+  namespace: scylla
+spec:
+  jobLabel: "app"
+  targetLabels: ["scylla/cluster"]
+  podTargetLabels: ["scylla/datacenter","scylla/rack"]
+  selector:
+    matchLabels:
+      app: scylla
+  endpoints:
+    - port: agent-prometheus
+      metricRelabelings:
+        # rename job label to 'manager_agent' due to hardcoded name
+        # in Scylla Monitoring.
+        - sourceLabels: [ endpoint ]
+          targetLabel: job
+          regex: agent-prometheus
+          replacement: manager_agent
+    - port: prometheus
+      metricRelabelings:
+        - sourceLabels: [ scylla_cluster ]
+          targetLabel: cluster
+          regex: (.*)
+          replacement: ${1}
+          action: replace
+        - sourceLabels: [ scylla_datacenter ]
+          targetLabel: dc
+          regex: (.*)
+          replacement: ${1}
+          action: replace

--- a/kubernetes/linera-validator/values-local.yaml
+++ b/kubernetes/linera-validator/values-local.yaml
@@ -48,6 +48,51 @@ kube-prometheus-stack:
             resources:
               requests:
                 storage: 1Gi
+      # Instruct prometheus operator to search for any ServiceMonitor
+      serviceMonitorSelector: {}
+      serviceMonitorNamespaceSelector: {}
+      # This prevents from adding any Helm label to serviceMonitorSelector if
+      # above is empty.
+      serviceMonitorSelectorNilUsesHelmValues: false
+      # Relabelings needed for Scylla dashboards
+      additionalScrapeConfigs:
+        - job_name: scylla
+          relabel_configs:
+          - source_labels: [ __address__ ]
+            regex: '([^:]+)'
+            target_label: __address__
+            replacement: '${1}:9180'
+          - source_labels: [ __address__ ]
+            regex: '(.*):.+'
+            target_label: instance
+            replacement: '${1}'
+          metric_relabel_configs:
+            - source_labels: [ version ]
+              regex: '(.+)'
+              target_label: CPU
+              replacement: 'cpu'
+            - source_labels: [ version ]
+              regex: '(.+)'
+              target_label: CQL
+              replacement: 'cql'
+            - source_labels: [ version ]
+              regex: '(.+)'
+              target_label: OS
+              replacement: 'os'
+            - source_labels: [ version ]
+              regex: '(.+)'
+              target_label: IO
+              replacement: 'io'
+            - source_labels: [ version ]
+              regex: '(.+)'
+              target_label: Errors
+              replacement: 'errors'
+            - regex: 'help|exported_instance|type'
+              action: labeldrop
+            - source_labels: [ version ]
+              regex: '([0-9]+\.[0-9]+)(\.?[0-9]*).*'
+              replacement: '$1$2'
+              target_label: svr
 
 # Environment
 environment: "kind"


### PR DESCRIPTION
## Motivation

ScyllaDB already exposes 440 Prometheus metrics

## Proposal

Scrape the Prometheus endpoint with our Prometheus instance to have access to those metrics

## Test Plan

Ran e2e tests against the cluster locally, saw the metrics on Prometheus

