### PR TITLE
silence expected scary errors in test

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -429,6 +429,25 @@ impl ClientWrapper {
         Ok(())
     }
 
+    /// Runs `linera transfer` with no logging.
+    pub async fn transfer_with_silent_logs(
+        &self,
+        amount: Amount,
+        from: ChainId,
+        to: ChainId,
+    ) -> Result<()> {
+        self.command()
+            .await?
+            .env("RUST_LOG", "off")
+            .arg("transfer")
+            .arg(amount.to_string())
+            .args(["--from", &from.to_string()])
+            .args(["--to", &to.to_string()])
+            .spawn_and_wait_for_stdout()
+            .await?;
+        Ok(())
+    }
+
     /// Runs `linera transfer` with owner accounts.
     pub async fn transfer_with_accounts(
         &self,

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2312,7 +2312,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetTestingConfig) {
         net.remove_validator(i).unwrap();
     }
     let result = client
-        .transfer(Amount::from_tokens(2), chain_id, ChainId::root(5))
+        .transfer_with_silent_logs(Amount::from_tokens(2), chain_id, ChainId::root(5))
         .await;
     assert!(result.is_err());
     assert_eq!(


### PR DESCRIPTION
## Motivation

Avoid confusing people if possible

## Proposal

Create a new (adhoc) method in CLI wrapper.

An error message still appears on stderr (the uncaught Rust error) but it's not a wall of ERROR logs any more.

## Test Plan

CI
