### PR TITLE
Make the --version option of linera binaries print the full VersionInfo.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ cargo +nightly fmt
 
 * All executables should use `clap_derive`. When tools call each other, the `--version` is
   checked and must match the package version of the caller.  This means that all executables
-  should include a `command(version = clap::crate_version!())` annotation.
+  should include a `command(version = linera_base::VersionInfo::default_str())` annotation.
 
 * Only structured data should be printed to the standard output, preferably as newline-separated JSON values.
 

--- a/linera-base/src/version_info.rs
+++ b/linera-base/src/version_info.rs
@@ -1,18 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::sync::Lazy;
+use async_graphql::SimpleObject;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
-#[derive(
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    Hash,
-    async_graphql::SimpleObject,
-    serde::Deserialize,
-    serde::Serialize,
-)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, SimpleObject, Deserialize, Serialize)]
 /// The version info of a build of Linera.
 pub struct VersionInfo {
     /// The crate version
@@ -47,11 +41,42 @@ impl VersionInfo {
             wit_hash,
         } = self;
 
-        tracing::info!("Linera v{crate_version}");
+        tracing::info!("Linera protocol: v{crate_version}");
         tracing::info!("Built from git commit: {git_commit}");
         tracing::info!("RPC API hash: {rpc_hash}");
         tracing::info!("GraphQL API hash: {graphql_hash}");
         tracing::info!("WIT API hash: {wit_hash}");
+    }
+
+    /// A static string corresponding to `VersionInfo::default().to_string()`.
+    pub fn default_str() -> &'static str {
+        static STRING: Lazy<String> = Lazy::new(|| VERSION_INFO.to_string());
+        STRING.as_str()
+    }
+}
+
+impl std::fmt::Display for VersionInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let VersionInfo {
+            crate_version,
+            git_commit,
+            rpc_hash,
+            graphql_hash,
+            wit_hash,
+        } = self;
+
+        // Starting with a new line is convenient for the clap annotation:
+        // `#[command(version = linera_base::VersionInfo::default_str())]`
+        write!(
+            f,
+            "
+Linera protocol: v{crate_version}
+Built from git commit: {git_commit}
+RPC API hash: {rpc_hash}
+GraphQL API hash: {graphql_hash}
+WIT API hash: {wit_hash}
+"
+        )
     }
 }
 

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -13,7 +13,7 @@ use linera_views::{
 use std::path::PathBuf;
 
 #[derive(clap::Parser, Clone, Debug)]
-#[command(version = clap::crate_version!())]
+#[command(version = linera_base::VersionInfo::default_str())]
 pub struct RocksDbConfig {
     /// RocksDB storage path
     #[arg(long, default_value = "./indexer.db")]

--- a/linera-indexer/lib/src/runner.rs
+++ b/linera-indexer/lib/src/runner.rs
@@ -13,7 +13,7 @@ use tokio::select;
 use tracing::{info, warn};
 
 #[derive(clap::Parser, Debug, Clone)]
-#[command(version = clap::crate_version!())]
+#[command(version = linera_base::VersionInfo::default_str())]
 pub enum IndexerCommand {
     Schema {
         plugin: Option<String>,

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -11,7 +11,7 @@ use linera_views::{
 };
 
 #[derive(clap::Parser, Clone, Debug)]
-#[command(version = clap::crate_version!())]
+#[command(version = linera_base::VersionInfo::default_str())]
 pub struct ScyllaDbConfig {
     /// ScyllaDB address
     #[arg(long, default_value = "localhost:9042")]

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -47,7 +47,7 @@ fn reqwest_client() -> reqwest::Client {
 }
 
 #[derive(clap::Parser, Debug, Clone)]
-#[command(version = clap::crate_version!())]
+#[command(version = linera_base::VersionInfo::default_str())]
 pub struct Service {
     /// The port of the node service
     #[arg(long, default_value = "8080")]

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -66,7 +66,7 @@ enum Action {
 #[command(
     name = "Format generator",
     about = "Trace serde (de)serialization to generate format descriptions",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
 )]
 struct Options {
     #[arg(value_enum, default_value_t = Action::Print, ignore_case = true)]

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -135,7 +135,7 @@ message ChainInfoQuery {
   optional bytes request_blob = 9;
 
   // Query the system balance of a given owner.
-  Owner request_system_balance = 10;
+  optional Owner request_system_balance = 10;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-sdk/src/bin/linera-wasm-test-runner/main.rs
+++ b/linera-sdk/src/bin/linera-wasm-test-runner/main.rs
@@ -42,7 +42,7 @@ use wasmtime::*;
 #[command(
     name = "linera-wasm-test-runner",
     about = "A binary for running unit tests for Linera applications implemented in WebAssembly.",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
 )]
 struct Options {
     module_path: PathBuf,

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -583,6 +583,9 @@ type QueryRoot {
 	chains: Chains!
 	block(hash: CryptoHash, chainId: ChainId!): HashedValue
 	blocks(from: CryptoHash, chainId: ChainId!, limit: Int): [HashedValue!]!
+	"""
+	Returns the version information on this node service.
+	"""
 	version: VersionInfo!
 }
 

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -11,7 +11,9 @@ use linera_base::{
     identifiers::{ApplicationId, ChainId, Owner},
 };
 use linera_execution::system::{self, SystemChannel};
-use linera_service::cli_wrappers::{ApplicationWrapper, ClientWrapper, FaucetOption, Network};
+use linera_service::cli_wrappers::{
+    ApplicationWrapper, ClientWrapper, Faucet, FaucetOption, Network,
+};
 use port_selector::random_free_tcp_port;
 use rand::{Rng as _, SeedableRng};
 use serde_json::Value;
@@ -68,14 +70,16 @@ async fn main() -> Result<()> {
             faucet,
             seed,
             uniform,
-        } => benchmark_with_fungible(wallets, transactions, faucet, seed, uniform).await,
+        } => {
+            benchmark_with_fungible(wallets, transactions, Faucet::new(faucet), seed, uniform).await
+        }
     }
 }
 
 async fn benchmark_with_fungible(
     num_wallets: usize,
     num_transactions: usize,
-    faucet: String,
+    faucet: Faucet,
     seed: u64,
     uniform: bool,
 ) -> Result<()> {

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -23,7 +23,7 @@ use tracing::info;
 #[derive(clap::Parser)]
 #[command(
     name = "linera-benchmark",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
     about = "Run benchmarks against a Linera network",
 )]
 enum Args {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -182,11 +182,11 @@ impl ClientWrapper {
             FaucetOption::None => {
                 command.args(["--genesis", "genesis.json"]);
             }
-            FaucetOption::GenesisOnly(url) => {
-                command.args(["--faucet", url]);
+            FaucetOption::GenesisOnly(faucet) => {
+                command.args(["--faucet", faucet.url()]);
             }
-            FaucetOption::NewChain(url) => {
-                command.args(["--with-new-chain", "--faucet", url]);
+            FaucetOption::NewChain(faucet) => {
+                command.args(["--with-new-chain", "--faucet", faucet.url()]);
             }
         }
         if let Some(seed) = self.testing_prng_seed {
@@ -358,7 +358,7 @@ impl ClientWrapper {
         port: impl Into<Option<u16>>,
         chain_id: ChainId,
         amount: Amount,
-    ) -> Result<Faucet> {
+    ) -> Result<FaucetService> {
         let port = port.into().unwrap_or(8080);
         let mut command = self.command().await?;
         let child = command
@@ -376,7 +376,7 @@ impl ClientWrapper {
                 .await;
             if request.is_ok() {
                 info!("Faucet has started");
-                return Ok(Faucet::new(port, child));
+                return Ok(FaucetService::new(port, child));
             } else {
                 warn!("Waiting for faucet to start");
             }
@@ -675,8 +675,8 @@ impl ClientWrapper {
 #[derive(Clone, Copy, Debug)]
 pub enum FaucetOption<'a> {
     None,
-    GenesisOnly(&'a str),
-    NewChain(&'a str),
+    GenesisOnly(&'a Faucet),
+    NewChain(&'a Faucet),
 }
 
 #[cfg(any(test, feature = "test"))]
@@ -900,12 +900,12 @@ impl NodeService {
 }
 
 /// A running faucet service.
-pub struct Faucet {
+pub struct FaucetService {
     port: u16,
     child: Child,
 }
 
-impl Faucet {
+impl FaucetService {
     fn new(port: u16, child: Child) -> Self {
         Self { port, child }
     }
@@ -921,19 +921,31 @@ impl Faucet {
         self.child.ensure_is_running()
     }
 
-    pub fn url(&self) -> String {
-        format!("http://localhost:{}/", self.port)
+    pub fn instance(&self) -> Faucet {
+        Faucet::new(format!("http://localhost:{}/", self.port))
+    }
+}
+
+/// A faucet instance that can be queried.
+#[derive(Debug, Clone)]
+pub struct Faucet {
+    url: String,
+}
+
+impl Faucet {
+    pub fn new(url: String) -> Self {
+        Self { url }
     }
 
-    pub async fn claim(&self, public_key: &PublicKey) -> Result<ClaimOutcome> {
-        Self::claim_url(public_key, &self.url()).await
+    pub fn url(&self) -> &str {
+        &self.url
     }
 
-    pub async fn request_genesis_config(url: &str) -> Result<GenesisConfig> {
+    pub async fn genesis_config(&self) -> Result<GenesisConfig> {
         let query = "query { genesisConfig }";
         let client = reqwest_client();
         let response = client
-            .post(url)
+            .post(&self.url)
             .json(&json!({ "query": query }))
             .send()
             .await
@@ -955,7 +967,7 @@ impl Faucet {
             .context("could not parse genesis config")
     }
 
-    pub async fn claim_url(public_key: &PublicKey, url: &str) -> Result<ClaimOutcome> {
+    pub async fn claim(&self, public_key: &PublicKey) -> Result<ClaimOutcome> {
         let query = format!(
             "mutation {{ claim(publicKey: \"{public_key}\") {{ \
                 messageId chainId certificateHash \
@@ -963,7 +975,7 @@ impl Faucet {
         );
         let client = reqwest_client();
         let response = client
-            .post(url)
+            .post(&self.url)
             .json(&json!({ "query": &query }))
             .send()
             .await
@@ -1005,11 +1017,11 @@ impl Faucet {
         Ok(outcome)
     }
 
-    pub async fn current_validators(url: &str) -> Result<Vec<(ValidatorName, String)>> {
+    pub async fn current_validators(&self) -> Result<Vec<(ValidatorName, String)>> {
         let query = "query { currentValidators { name networkAddress } }";
         let client = reqwest_client();
         let response = client
-            .post(url)
+            .post(&self.url)
             .json(&json!({ "query": query }))
             .send()
             .await

--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -9,7 +9,7 @@ use std::process;
 #[command(
     name = "Clear database",
     about = "A tool for cleaning up a database",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
 )]
 struct DatabaseToolOptions {
     /// Subcommands. Acceptable values are run and generate.

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -82,6 +82,11 @@ where
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    /// Returns the version information on this faucet service.
+    async fn version(&self) -> linera_base::VersionInfo {
+        linera_base::VersionInfo::default()
+    }
+
     /// Returns the genesis config.
     async fn genesis_config(&self) -> Result<serde_json::Value, Error> {
         Ok(serde_json::to_value(&*self.genesis_config)?)

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -27,7 +27,7 @@ use crate::Job;
 #[derive(clap::Parser)]
 #[command(
     name = "linera",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
     about = "A Byzantine-fault tolerant sidechain with low-latency finality and high throughput",
 )]
 pub struct ClientOptions {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1504,7 +1504,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                         if version_info != linera_base::VERSION_INFO {
                             warn!(
                                 "\
-Make sure to use a Linera client compatible with the Linera network in use.
+Make sure to use a Linera client compatible with this network.
 --- Faucet info ---\
 {}\
 -------------------

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -378,8 +378,10 @@ impl Runnable for Job {
                         .await
                     {
                         Ok(version_info) => {
-                            info!("Version information for validator {name:?}:");
-                            version_info.log();
+                            info!(
+                                "Version information for validator {name:?}:\n{}",
+                                version_info
+                            );
                         }
                         Err(e) => {
                             warn!("Failed to get version information for validator {name:?}:\n{e}")

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -730,6 +730,7 @@ where
         }
     }
 
+    /// Returns the version information on this node service.
     async fn version(&self) -> linera_base::VersionInfo {
         linera_base::VersionInfo::default()
     }

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -25,7 +25,7 @@ use tracing::{error, info, instrument};
 #[command(
     name = "Linera Proxy",
     about = "A proxy to redirect incoming requests to Linera Server shards",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
 )]
 pub struct ProxyOptions {
     /// Path to server configuration.

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -84,7 +84,7 @@ impl ValidatorNodeProvider for DummyValidatorNodeProvider {
 #[command(
     name = "linera-schema-export",
     about = "Export the GraphQL schema for the core data in a Linera chain",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
 )]
 struct Options {}
 

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -213,7 +213,7 @@ impl Runnable for ServerContext {
 #[command(
     name = "linera-server",
     about = "A byzantine fault tolerant payments sidechain with low-latency finality and high throughput",
-    version = clap::crate_version!(),
+    version = linera_base::VersionInfo::default_str(),
 )]
 struct ServerOptions {
     /// Subcommands. Acceptable values are run and generate.

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1315,7 +1315,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
     net.terminate().await.unwrap();
 }
 
-#[tokio::test]
+#[test_log::test(tokio::test)]
 async fn test_resolve_binary() {
     util::resolve_binary("linera", env!("CARGO_PKG_NAME"))
         .await

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2161,6 +2161,10 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     let chain2 = outcome.chain_id;
     let message_id = outcome.message_id;
 
+    // Test version info.
+    let info = faucet.version_info().await.unwrap();
+    assert_eq!(linera_base::VERSION_INFO, info);
+
     // Use the faucet directly to initialize client 3.
     let client3 = net.make_client().await;
     let outcome = client3


### PR DESCRIPTION
## Motivation

Help with debugging

## Proposal

* Make the --version option of linera binaries print the full VersionInfo
* Print a warning when the version of the faucet doesn't match the version of the linera tool

In my understanding, the version information are only computed when `linera-base` is recompiled. This can give unexpected results when developing with incremental builds --> I created https://github.com/linera-io/linera-protocol/issues/1573

## Test Plan

* `linera --version`
* CI
* Tried the faucet manually with different version and got something like this
```
2024-01-28T02:06:40.354322Z  WARN linera: Make sure to use a Linera client compatible with this network.
----- Faucet ------
Linera protocol: v0.6.0
Built from git commit: 54fdd8cf52002774e7518ac3e55220871165ccdc-dirty
RPC API hash: ce8fc4f4f02b50699b5deca42d8ad167d495938ed8a437724fca1f926fc9c75f
GraphQL API hash: 23eedbb2cd7086a4fc4bdbc4e7081e67b5c6fc4cddb337bcedf8b5a5deb87ce8
WIT API hash: b63355cd4660d9fc5ba2db08cb4bfd60fa2e2d8b73dccc81ab941851e7c6372e
-------------------
--- This binary ---
Linera protocol: v0.6.0
Built from git commit: 43c2967ed67d53871bedb695b191c32b4ae54740-dirty
RPC API hash: ce8fc4f4f02b50699b5deca42d8ad167d495938ed8a437724fca1f926fc9c75f
GraphQL API hash: 23eedbb2cd7086a4fc4bdbc4e7081e67b5c6fc4cddb337bcedf8b5a5deb87ce8
WIT API hash: b63355cd4660d9fc5ba2db08cb4bfd60fa2e2d8b73dccc81ab941851e7c6372e
-------------------
```

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
