### PR TITLE
Print more information if request_leader_timeout test assert fails.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1631,12 +1631,17 @@ where
     let manager = client.chain_info().await.unwrap().manager;
 
     // The round has not timed out yet, so validators will not sign a timeout certificate.
-    assert!(matches!(
-        client.request_leader_timeout().await,
-        Err(ChainClientError::CommunicationError(
-            CommunicationError::Trusted(NodeError::MissingVoteInValidatorResponse)
-        ))
-    ));
+    let result = client.request_leader_timeout().await;
+    assert!(
+        matches!(
+            result,
+            Err(ChainClientError::CommunicationError(
+                CommunicationError::Trusted(NodeError::MissingVoteInValidatorResponse)
+            ))
+        ),
+        "unexpected leader timeout result: {:?}",
+        result
+    );
 
     clock.set(manager.round_timeout.unwrap());
 


### PR DESCRIPTION
## Motivation

This assertion fails occasionally, but with a low probability, so it is hard to reproduce.

## Proposal

Print the unexpected result if it fails again.

## Test Plan

Wait until it fails again.

## Links

- https://github.com/linera-io/linera-protocol/issues/1581
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
