### PR TITLE
`VersionInfo`: Remove the `-dirty` flag from `git_commit`

### DIFF
--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -21,7 +21,7 @@ pub use graphql::BcsHexParseError;
 pub use {async_graphql, bcs, hex};
 
 mod version_info;
-pub use version_info::{VersionInfo, VERSION_INFO};
+pub use version_info::VersionInfo;
 
 /// A macro for asserting that a condition is true, returning an error if it is not.
 ///

--- a/linera-base/versions.sh
+++ b/linera-base/versions.sh
@@ -15,14 +15,15 @@ else
     exit 1
 fi
 
+# git commit
 if [ -n "$GIT_COMMIT" ]
 then
     echo GIT_COMMIT=$GIT_COMMIT
+    echo GIT_DIRTY=false
 else
-    # git commit
-    git=$(git rev-parse @)
-    git diff-index --quiet @ || git="$git-dirty"
-    echo GIT_COMMIT=$git
+    echo GIT_COMMIT=$(git rev-parse @)
+    git diff-index --quiet @ || git_dirty=true
+    echo GIT_DIRTY=${git_dirty-false}
 fi
 
 {

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -57,9 +57,10 @@ service ValidatorNode {
 message VersionInfo {
     string crate_version = 1;
     string git_commit = 2;
-    string rpc_hash = 3;
-    string graphql_hash = 4;
-    string wit_hash = 5;
+    bool git_dirty = 3;
+    string rpc_hash = 4;
+    string graphql_hash = 5;
+    string wit_hash = 6;
 }
 
 // A request for client to subscribe to notifications for a given `ChainId`

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -57,6 +57,7 @@ impl From<linera_base::VersionInfo> for grpc::VersionInfo {
         grpc::VersionInfo {
             crate_version: version_info.crate_version.into(),
             git_commit: version_info.git_commit.into(),
+            git_dirty: version_info.git_dirty,
             rpc_hash: version_info.rpc_hash.into(),
             graphql_hash: version_info.graphql_hash.into(),
             wit_hash: version_info.wit_hash.into(),
@@ -69,6 +70,7 @@ impl From<grpc::VersionInfo> for linera_base::VersionInfo {
         linera_base::VersionInfo {
             crate_version: version_info.crate_version.into(),
             git_commit: version_info.git_commit.into(),
+            git_dirty: version_info.git_dirty,
             rpc_hash: version_info.rpc_hash.into(),
             graphql_hash: version_info.graphql_hash.into(),
             wit_hash: version_info.wit_hash.into(),

--- a/linera-rpc/src/simple_network.rs
+++ b/linera-rpc/src/simple_network.rs
@@ -288,7 +288,7 @@ where
                 Ok(None)
             }
 
-            RpcMessage::VersionInfoQuery => Ok(Some(linera_base::VERSION_INFO.into())),
+            RpcMessage::VersionInfoQuery => Ok(Some(linera_base::VersionInfo::default().into())),
 
             RpcMessage::Vote(_)
             | RpcMessage::Error(_)

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -925,6 +925,7 @@ VersionInfo:
   STRUCT:
     - crate_version: STR
     - git_commit: STR
+    - git_dirty: BOOL
     - rpc_hash: STR
     - graphql_hash: STR
     - wit_hash: STR

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -744,6 +744,10 @@ type VersionInfo {
 	"""
 	gitCommit: String!
 	"""
+	Whether the git worktree was dirty
+	"""
+	gitDirty: Boolean!
+	"""
 	A hash of the RPC API
 	"""
 	rpcHash: String!

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -988,7 +988,8 @@ impl Faucet {
     }
 
     pub async fn version_info(&self) -> Result<VersionInfo> {
-        let query = "query { version { crateVersion gitCommit rpcHash graphqlHash witHash } }";
+        let query =
+            "query { version { crateVersion gitCommit gitDirty rpcHash graphqlHash witHash } }";
         let client = reqwest_client();
         let response = client
             .post(&self.url)
@@ -1013,6 +1014,8 @@ impl Faucet {
             .context("could not parse crate version")?;
         let git_commit = serde_json::from_value(value["data"]["version"]["gitCommit"].take())
             .context("could not parse git commit")?;
+        let git_dirty = serde_json::from_value(value["data"]["version"]["gitDirty"].take())
+            .context("could not parse git dirty")?;
         let rpc_hash = serde_json::from_value(value["data"]["version"]["rpcHash"].take())
             .context("could not parse rpc hash")?;
         let graphql_hash = serde_json::from_value(value["data"]["version"]["graphqlHash"].take())
@@ -1022,6 +1025,7 @@ impl Faucet {
         Ok(VersionInfo {
             crate_version,
             git_commit,
+            git_dirty,
             rpc_hash,
             graphql_hash,
             wit_hash,

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -348,7 +348,7 @@ impl ValidatorNode for GrpcProxy {
         _request: Request<()>,
     ) -> Result<Response<VersionInfo>, Status> {
         // We assume each shard is running the same version as the proxy
-        Ok(Response::new(linera_base::VERSION_INFO.into()))
+        Ok(Response::new(linera_base::VersionInfo::default().into()))
     }
 }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1501,7 +1501,9 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                             .version_info()
                             .await
                             .context("Failed to obtain version information from the faucet")?;
-                        if version_info.is_probably_incompatible_with(&linera_base::VERSION_INFO) {
+                        if version_info
+                            .is_probably_incompatible_with(&linera_base::VersionInfo::default())
+                        {
                             warn!(
                                 "\
 Make sure to use a Linera client compatible with this network.
@@ -1512,7 +1514,7 @@ Make sure to use a Linera client compatible with this network.
 {}\
 -------------------",
                                 version_info,
-                                linera_base::VERSION_INFO,
+                                linera_base::VersionInfo::default(),
                             );
                         }
                         faucet

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -118,7 +118,7 @@ impl MessageHandler for SimpleProxy {
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
         if let RpcMessage::VersionInfoQuery = message {
             // We assume each shard is running the same version as the proxy
-            return Some(linera_base::VERSION_INFO.into());
+            return Some(linera_base::VersionInfo::default().into());
         }
 
         let Some(chain_id) = message.target_chain_id() else {

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -409,7 +409,7 @@ fn main() {
 }
 
 async fn run(options: ServerOptions) {
-    linera_base::VERSION_INFO.log();
+    linera_base::VersionInfo::default().log();
 
     match options.command {
         ServerCommand::Run {

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2163,7 +2163,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
 
     // Test version info.
     let info = faucet.version_info().await.unwrap();
-    assert_eq!(linera_base::VERSION_INFO, info);
+    assert_eq!(linera_base::VersionInfo::default(), info);
 
     // Use the faucet directly to initialize client 3.
     let client3 = net.make_client().await;


### PR DESCRIPTION
Instead, put it into a separate `git_dirty` boolean.  This prevents breaking the git source link when the build worktree was dirty.

## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
