### PR TITLE
Expand the scope of the temporary directories in `RocksDb`

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -63,7 +63,7 @@ async fn test_memory_handle_certificates_to_create_application(
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let storage = RocksDbStorage::make_test_storage(Some(wasm_runtime)).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -382,7 +382,7 @@ async fn test_memory_handle_block_proposal_bad_signature() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_bad_signature() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_bad_signature(storage).await;
 }
 
@@ -452,7 +452,7 @@ async fn test_memory_handle_block_proposal_zero_amount() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_zero_amount() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_zero_amount(storage).await;
 }
 
@@ -527,7 +527,7 @@ async fn test_memory_handle_block_proposal_ticks() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_ticks() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_ticks(storage).await;
 }
 
@@ -618,7 +618,7 @@ async fn test_memory_handle_block_proposal_unknown_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_unknown_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_unknown_sender(storage).await;
 }
 
@@ -688,7 +688,7 @@ async fn test_memory_handle_block_proposal_with_chaining() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_with_chaining() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_with_chaining(storage).await;
 }
 
@@ -797,7 +797,7 @@ async fn test_memory_handle_block_proposal_with_incoming_messages() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_with_incoming_messages() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_with_incoming_messages(storage).await;
 }
 
@@ -1171,7 +1171,7 @@ async fn test_memory_handle_block_proposal_exceed_balance() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_exceed_balance() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_exceed_balance(storage).await;
 }
 
@@ -1243,7 +1243,7 @@ async fn test_memory_handle_block_proposal() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal(storage).await;
 }
 
@@ -1311,7 +1311,7 @@ async fn test_memory_handle_block_proposal_replay() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_block_proposal_replay() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_block_proposal_replay(storage).await;
 }
 
@@ -1377,7 +1377,7 @@ async fn test_memory_handle_certificate_unknown_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_unknown_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_unknown_sender(storage).await;
 }
 
@@ -1434,7 +1434,7 @@ async fn test_memory_handle_certificate_with_open_chain() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_with_open_chain() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_with_open_chain(storage).await;
 }
 
@@ -1529,7 +1529,7 @@ async fn test_memory_handle_certificate_wrong_owner() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_wrong_owner() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_wrong_owner(storage).await;
 }
 
@@ -1592,7 +1592,7 @@ async fn test_memory_handle_certificate_bad_block_height() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_bad_block_height() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_bad_block_height(storage).await;
 }
 
@@ -1661,7 +1661,7 @@ async fn test_memory_handle_certificate_with_anticipated_incoming_message() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_with_anticipated_incoming_message() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_with_anticipated_incoming_message(storage).await;
 }
 
@@ -1785,7 +1785,7 @@ async fn test_memory_handle_certificate_receiver_balance_overflow() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_receiver_balance_overflow() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_receiver_balance_overflow(storage).await;
 }
 
@@ -1877,7 +1877,7 @@ async fn test_memory_handle_certificate_receiver_equal_sender() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_receiver_equal_sender() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_receiver_equal_sender(storage).await;
 }
 
@@ -1974,7 +1974,7 @@ async fn test_memory_handle_cross_chain_request() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_cross_chain_request(storage).await;
 }
 
@@ -2070,7 +2070,7 @@ async fn test_memory_handle_cross_chain_request_no_recipient_chain() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request_no_recipient_chain() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain(storage).await;
 }
 
@@ -2128,7 +2128,7 @@ async fn test_memory_handle_cross_chain_request_no_recipient_chain_on_client() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_cross_chain_request_no_recipient_chain_on_client() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_cross_chain_request_no_recipient_chain_on_client(storage).await;
 }
 
@@ -2198,7 +2198,7 @@ async fn test_memory_handle_certificate_to_active_recipient() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_to_active_recipient() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_to_active_recipient(storage).await;
 }
 
@@ -2382,7 +2382,7 @@ async fn test_memory_handle_certificate_to_inactive_recipient() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_to_inactive_recipient() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_to_inactive_recipient(storage).await;
 }
 
@@ -2450,7 +2450,7 @@ async fn test_memory_handle_certificate_with_rejected_transfer() {
 #[test(tokio::test)]
 async fn test_rocks_db_handle_certificate_with_rejected_transfer() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_handle_certificate_with_rejected_transfer(storage).await;
 }
 
@@ -2734,7 +2734,7 @@ async fn test_memory_chain_creation_with_committee_creation() {
 #[test(tokio::test)]
 async fn test_rocks_db_chain_creation_with_committee_creation() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_chain_creation_with_committee_creation(storage).await;
 }
 
@@ -3171,7 +3171,7 @@ async fn test_memory_transfers_and_committee_creation() {
 #[test(tokio::test)]
 async fn test_rocks_db_transfers_and_committee_creation() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_transfers_and_committee_creation(storage).await;
 }
 
@@ -3314,7 +3314,7 @@ async fn test_memory_transfers_and_committee_removal() {
 #[test(tokio::test)]
 async fn test_rocks_db_transfers_and_committee_removal() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_transfers_and_committee_removal(storage).await;
 }
 
@@ -3726,7 +3726,7 @@ async fn test_memory_leader_timeouts() {
 #[test(tokio::test)]
 async fn test_rocks_db_leader_timeouts() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_leader_timeouts(storage).await;
 }
 
@@ -3962,7 +3962,7 @@ async fn test_memory_round_types() {
 #[test(tokio::test)]
 async fn test_rocks_db_round_types() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_round_types(storage).await;
 }
 
@@ -4075,7 +4075,7 @@ async fn test_memory_fast_proposal_is_locked() {
 #[test(tokio::test)]
 async fn test_rocks_db_fast_proposal_is_locked() {
     let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     run_test_fast_proposal_is_locked(storage).await;
 }
 

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -55,7 +55,7 @@ pub type RocksDbStorage<C> = DbStorage<RocksDbStore, C>;
 
 #[cfg(any(test, feature = "test"))]
 impl RocksDbStorage<TestClock> {
-    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
+    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> (Self, TempDir) {
         let dir = TempDir::new().unwrap();
         let path_buf = dir.path().to_path_buf();
         let common_config = create_rocks_db_common_config();
@@ -67,7 +67,7 @@ impl RocksDbStorage<TestClock> {
             RocksDbStorage::new_for_testing(store_config, wasm_runtime, TestClock::new())
                 .await
                 .expect("storage");
-        storage
+        (storage, dir)
     }
 
     pub async fn new_for_testing(

--- a/linera-storage/src/unit_tests/rocks_db.rs
+++ b/linera-storage/src/unit_tests/rocks_db.rs
@@ -9,7 +9,7 @@ use std::mem;
 /// Tests if released guards don't use memory.
 #[tokio::test]
 async fn guards_dont_leak() -> Result<(), anyhow::Error> {
-    let storage = RocksDbStorage::make_test_storage(None).await;
+    let (storage, _dir) = RocksDbStorage::make_test_storage(None).await;
     let chain_id = ChainId::root(1);
     // There should be no active guards when initialized
     assert_eq!(storage.client.guards.active_guards(), 0);

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -372,8 +372,10 @@ pub fn create_rocks_db_common_config() -> CommonStoreConfig {
 }
 
 /// Creates a RocksDB database client to be used for tests.
+/// The tempoorary directory has to be carried because if it goes
+/// out of scope then the RocksDb client can become unstable.
 #[cfg(any(test, feature = "test"))]
-pub async fn create_rocks_db_test_store() -> RocksDbStore {
+pub async fn create_rocks_db_test_store() -> (RocksDbStore, TempDir) {
     let dir = TempDir::new().unwrap();
     let path_buf = dir.path().to_path_buf();
     let common_config = create_rocks_db_common_config();
@@ -384,7 +386,7 @@ pub async fn create_rocks_db_test_store() -> RocksDbStore {
     let (store, _) = RocksDbStore::new_for_testing(store_config)
         .await
         .expect("client");
-    store
+    (store, dir)
 }
 
 /// An implementation of [`crate::common::Context`] based on RocksDB
@@ -457,14 +459,6 @@ impl<E: Clone + Send + Sync> RocksDbContext<E> {
             extra,
         }
     }
-}
-
-/// Create a [`crate::common::Context`] that can be used for tests.
-#[cfg(any(test, feature = "test"))]
-pub async fn create_rocks_db_test_context() -> RocksDbContext<()> {
-    let store = create_rocks_db_test_store().await;
-    let base_key = vec![];
-    RocksDbContext::new(store, base_key, ())
 }
 
 /// The error type for [`RocksDbContext`]

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -372,7 +372,7 @@ pub fn create_rocks_db_common_config() -> CommonStoreConfig {
 }
 
 /// Creates a RocksDB database client to be used for tests.
-/// The tempoorary directory has to be carried because if it goes
+/// The temporary directory has to be carried because if it goes
 /// out of scope then the RocksDB client can become unstable.
 #[cfg(any(test, feature = "test"))]
 pub async fn create_rocks_db_test_store() -> (RocksDbStore, TempDir) {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -373,7 +373,7 @@ pub fn create_rocks_db_common_config() -> CommonStoreConfig {
 
 /// Creates a RocksDB database client to be used for tests.
 /// The tempoorary directory has to be carried because if it goes
-/// out of scope then the RocksDb client can become unstable.
+/// out of scope then the RocksDB client can become unstable.
 #[cfg(any(test, feature = "test"))]
 pub async fn create_rocks_db_test_store() -> (RocksDbStore, TempDir) {
     let dir = TempDir::new().unwrap();

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -169,7 +169,7 @@ async fn test_reads_memory() {
 #[tokio::test]
 async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_rocks_db_test_store().await;
+        let (key_value_store, _dir) = create_rocks_db_test_store().await;
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -368,7 +368,7 @@ async fn test_key_value_store_view_memory_writes_from_blank() {
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_rocks_db_writes_from_blank() {
-    let key_value_store = create_rocks_db_test_store().await;
+    let (key_value_store, _dir) = create_rocks_db_test_store().await;
     run_writes_from_blank(&key_value_store).await;
 }
 
@@ -455,12 +455,10 @@ async fn test_memory_big_write_read() {
     run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 
-// TODO(#1092): That test fails for value of 5M, probably needs value splitting.
-#[ignore]
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_rocks_db_big_write_read() {
-    let key_value_store = create_rocks_db_test_store().await;
+    let (key_value_store, _dir) = create_rocks_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
@@ -595,7 +593,7 @@ async fn test_memory_writes_from_state() {
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn test_rocks_db_writes_from_state() {
-    let key_value_store = create_rocks_db_test_store().await;
+    let (key_value_store, _dir) = create_rocks_db_test_store().await;
     run_writes_from_state(&key_value_store).await;
 }
 

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -34,7 +34,10 @@ use std::{
 };
 
 #[cfg(feature = "rocksdb")]
-use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbContext, RocksDbStore};
+use {
+    linera_views::rocks_db::{create_rocks_db_test_store, RocksDbContext, RocksDbStore},
+    tempfile::TempDir,
+};
 
 #[cfg(feature = "aws")]
 use linera_views::{
@@ -162,6 +165,7 @@ impl StateStore for LruMemoryStore {
 pub struct RocksDbTestStore {
     store: RocksDbStore,
     accessed_chains: BTreeSet<usize>,
+    _dir: TempDir,
 }
 
 #[cfg(feature = "rocksdb")]
@@ -170,11 +174,12 @@ impl StateStore for RocksDbTestStore {
     type Context = RocksDbContext<usize>;
 
     async fn new() -> Self {
-        let store = create_rocks_db_test_store().await;
+        let (store, dir) = create_rocks_db_test_store().await;
         let accessed_chains = BTreeSet::new();
         RocksDbTestStore {
             store,
             accessed_chains,
+            _dir: dir,
         }
     }
 


### PR DESCRIPTION
## Motivation

Some tests in RocksDb fail because of the object `TempDir` going out of the scope. This makes some `RocksDb` tests fail.

## Proposal

The following was done:
* The `create_rocks_db_test_store` is returning a store and a temporary directory.
* The `make_test_storage` is also returning storage and a temporary directory.
* The `create_rocks_db_test_context` is eliminated since unused.
* The test `test_rocks_db_big_write_read` is now enabled.

The proposed solution is definitely making the code less nice. The following alternatives were considered:
* The initial idea was to put an `Arc<Option<TempDir>>` for the `RocksDbStore` and the `RocksDbStoreConfig`. However, that adds an entry that is carried over and that is only relevant to the tests.
* For `create_rocks_db_test_store` this is fine. However for the `make_test_storage` this gives a different API to the one of DynamoDb and ScyllaDb. We could take a temporary directory on input, but again this would break the API.

## Test Plan

The CI should address it.

## Release Plan

No change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
