### PR TITLE
Devnet 2024-01-28 fuel hotfix

### DIFF
--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -925,9 +925,12 @@ impl ContractRuntime for ContractSyncRuntime {
     fn set_remaining_fuel(&mut self, remaining_fuel: u64) -> Result<(), ExecutionError> {
         let mut this = self.inner();
         let previous_fuel = this.resource_controller.remaining_fuel();
-        assert!(previous_fuel >= remaining_fuel);
-        this.resource_controller
-            .track_fuel(previous_fuel - remaining_fuel)
+        // This is temporary. The real fix is #1599.
+        if previous_fuel > remaining_fuel {
+            this.resource_controller
+                .track_fuel(previous_fuel - remaining_fuel)?;
+        }
+        Ok(())
     }
 
     fn try_call_application(


### PR DESCRIPTION
## Motivation

Temporary fix until #1599 lands and a new devnet is deployed

## Proposal

Remove the assert and carry on.

## Test Plan

CI

## Release Plan

pros: This is a conservative extension of the current execution semantics so we can soft-update the devnet.
cons: We could also just cut a new branch :)
