### PR TITLE
Remove Arc<Mutex<LocalKubernetesNet>>.

### DIFF
--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -160,7 +160,7 @@ impl LineraNetConfig for LocalNetConfig {
             self.num_initial_validators,
             self.num_shards,
         )?;
-        let client = net.make_client().await;
+        let client = net.make_client();
         ensure!(
             self.num_initial_validators > 0,
             "There should be at least one initial validator"
@@ -197,7 +197,7 @@ impl LineraNetConfig for LocalNetTestingConfig {
             num_validators,
             num_shards,
         )?;
-        let client = net.make_client().await;
+        let client = net.make_client();
         if num_validators > 0 {
             net.generate_initial_validator_config().await.unwrap();
             client
@@ -219,7 +219,7 @@ impl LineraNet for LocalNet {
         Ok(())
     }
 
-    async fn make_client(&mut self) -> ClientWrapper {
+    fn make_client(&mut self) -> ClientWrapper {
         let client = ClientWrapper::new(
             self.tmp_dir.clone(),
             self.network,

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -49,7 +49,7 @@ pub trait LineraNetConfig {
 pub trait LineraNet {
     async fn ensure_is_running(&mut self) -> Result<()>;
 
-    async fn make_client(&mut self) -> ClientWrapper;
+    fn make_client(&mut self) -> ClientWrapper;
 
     async fn terminate(&mut self) -> Result<()>;
 }

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -38,7 +38,7 @@ impl LineraNetConfig for RemoteNetTestingConfig {
             .await
             .expect("Creating RemoteNet should not fail");
 
-        let client = net.make_client().await;
+        let client = net.make_client();
         // The tests assume we've created a genesis config with 10
         // chains with 10 tokens each. We create the first chain here
         client
@@ -78,7 +78,7 @@ impl LineraNet for RemoteNet {
         Ok(())
     }
 
-    async fn make_client(&mut self) -> ClientWrapper {
+    fn make_client(&mut self) -> ClientWrapper {
         let client = ClientWrapper::new(
             self.tmp_dir.clone(),
             self.network,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1274,7 +1274,7 @@ async fn net_up(
     // Create the extra wallets.
     if let Some(extra_wallets) = *extra_wallets {
         for wallet in 1..=extra_wallets {
-            let extra_wallet = net.make_client().await;
+            let extra_wallet = net.make_client();
             extra_wallet.wallet_init(&[], FaucetOption::None).await?;
             let unassigned_key = extra_wallet.keygen().await?;
             let new_chain_msg_id = client1

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -273,7 +273,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -369,7 +369,7 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig) {
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -583,7 +583,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -716,8 +716,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
 
     let (mut net, client_admin) = config.instantiate().await.unwrap();
 
-    let client_a = net.make_client().await;
-    let client_b = net.make_client().await;
+    let client_a = net.make_client();
+    let client_b = net.make_client();
 
     client_a.wallet_init(&[], FaucetOption::None).await.unwrap();
     client_b.wallet_init(&[], FaucetOption::None).await.unwrap();
@@ -998,8 +998,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
 
     let (mut net, client_admin) = config.instantiate().await.unwrap();
 
-    let client0 = net.make_client().await;
-    let client1 = net.make_client().await;
+    let client0 = net.make_client();
+    let client1 = net.make_client();
     client0.wallet_init(&[], FaucetOption::None).await.unwrap();
     client1.wallet_init(&[], FaucetOption::None).await.unwrap();
 
@@ -1345,7 +1345,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetTestingConfig) {
     let network = config.network;
     let (mut net, client) = config.instantiate().await.unwrap();
 
-    let client_2 = net.make_client().await;
+    let client_2 = net.make_client();
     client_2.wallet_init(&[], FaucetOption::None).await.unwrap();
     let chain_1 = client.get_wallet().unwrap().default_chain().unwrap();
 
@@ -1596,7 +1596,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetTestingConfig
 
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     let chain = ChainId::root(0);
     let mut height = 0;
     client2
@@ -1662,7 +1662,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
     // Create net and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     // Get some chain owned by Client 1.
@@ -1931,7 +1931,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
@@ -2042,7 +2042,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
@@ -2117,7 +2117,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await.unwrap();
 
-    let client2 = net.make_client().await;
+    let client2 = net.make_client();
     client2.wallet_init(&[], FaucetOption::None).await.unwrap();
 
     let chain1 = client1.get_wallet().unwrap().default_chain().unwrap();
@@ -2139,7 +2139,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     assert_eq!(linera_base::VERSION_INFO, info);
 
     // Use the faucet directly to initialize client 3.
-    let client3 = net.make_client().await;
+    let client3 = net.make_client();
     let outcome = client3
         .wallet_init(&[], FaucetOption::NewChain(&faucet))
         .await


### PR DESCRIPTION
## Motivation

To make the end-to-end tests work with fees, a faucet, and ultimately Devnet, I will need to add some functionality to `LineraNet` that is difficult to implement for `Arc<Mutex<LocalKubernetesNet>>`.

## Proposal

Instead of having another wrapper struct, I suggest making `LocalKubernetesNet` shareable. If I understand correctly, that only requires making two fields atomic.

## Test Plan

CI includes the end-to-end tests with the shared Kubernetes configuration.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
