### PR TITLE
Create a `SharedView` helper wrapper

### DIFF
--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -95,6 +95,7 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
     let mut rollback_quotes = Vec::new();
     let mut flush_quotes = Vec::new();
     let mut clear_quotes = Vec::new();
+    let mut share_unchecked_quotes = Vec::new();
     for (idx, e) in input.fields.into_iter().enumerate() {
         let name = e.clone().ident.unwrap();
         let fut = format_ident!("{}_fut", name.to_string());
@@ -115,6 +116,7 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
         rollback_quotes.push(quote! { self.#name.rollback(); });
         flush_quotes.push(quote! { self.#name.flush(batch)?; });
         clear_quotes.push(quote! { self.#name.clear(); });
+        share_unchecked_quotes.push(quote! { #name: self.#name.share_unchecked()?, });
     }
     let first_name_quote = name_quotes
         .first()
@@ -165,6 +167,12 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
 
             fn clear(&mut self) {
                 #(#clear_quotes)*
+            }
+
+            fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+                Ok(Self {
+                    #(#share_unchecked_quotes)*
+                })
             }
         }
     }

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-2.snap
@@ -48,5 +48,11 @@ impl linera_views::views::View<CustomContext> for TestView {
         self.register.clear();
         self.collection.clear();
     }
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
 }
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-3.snap
@@ -48,5 +48,11 @@ impl linera_views::views::View<custom::path::to::ContextType> for TestView {
         self.register.clear();
         self.collection.clear();
     }
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
 }
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code-4.snap
@@ -48,5 +48,11 @@ impl linera_views::views::View<custom::GenericContext<T>> for TestView {
         self.register.clear();
         self.collection.clear();
     }
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
 }
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_view_code.snap
@@ -50,5 +50,11 @@ where
         self.register.clear();
         self.collection.clear();
     }
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
 }
 

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -33,7 +33,7 @@ pub type HasherOutputSize = <sha3::Sha3_256 as sha3::digest::OutputSizeUser>::Ou
 #[doc(hidden)]
 pub type HasherOutput = generic_array::GenericArray<u8, HasherOutputSize>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum Update<T> {
     Removed,
     Set(T),
@@ -458,7 +458,7 @@ impl<E> KeyValueIterable<E> for Vec<(Vec<u8>, Vec<u8>)> {
 /// The context in which a view is operated. Typically, this includes the client to
 /// connect to the database and the address of the current entry.
 #[async_trait]
-pub trait Context {
+pub trait Context: Clone {
     /// The maximal size of values that can be stored.
     const MAX_VALUE_SIZE: usize;
 

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -78,6 +78,15 @@ where
         self.inner.clear();
         *self.hash.get_mut() = None;
     }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(WrappedHashableContainerView {
+            context: self.context.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+            inner: self.inner.share_unchecked()?,
+        })
+    }
 }
 
 #[async_trait]

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -240,6 +240,20 @@ where
         self.sizes.clear();
         *self.hash.get_mut() = None;
     }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(KeyValueStoreView {
+            context: self.context.clone(),
+            delete_storage_first: self.delete_storage_first,
+            updates: self.updates.clone(),
+            stored_total_size: self.stored_total_size,
+            total_size: self.total_size,
+            sizes: self.sizes.share_unchecked()?,
+            deleted_prefixes: self.deleted_prefixes.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
+    }
 }
 
 impl<'a, C> KeyValueStoreView<C>

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -93,6 +93,9 @@ pub mod map_view;
 /// The `SetView` implements a set with ordered entries.
 pub mod set_view;
 
+/// A `SharedView` allows sharing a view between multiple readers and at most one writer.
+pub mod shared_view;
+
 mod graphql;
 
 /// The `CollectionView` implements a map structure whose keys are ordered and the values are views.

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -62,7 +62,7 @@ impl<C, T> View<C> for LogView<C, T>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    T: Send + Sync + Serialize,
+    T: Clone + Send + Sync + Serialize,
 {
     fn context(&self) -> &C {
         &self.context
@@ -126,6 +126,17 @@ where
         self.delete_storage_first = true;
         self.new_values.clear();
         *self.hash.get_mut() = None;
+    }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(LogView {
+            context: self.context.clone(),
+            delete_storage_first: self.delete_storage_first,
+            stored_count: self.stored_count,
+            new_values: self.new_values.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
     }
 }
 

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -64,7 +64,7 @@ impl<C, T> View<C> for QueueView<C, T>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    T: Send + Sync + Serialize,
+    T: Clone + Send + Sync + Serialize,
 {
     fn context(&self) -> &C {
         &self.context
@@ -144,6 +144,18 @@ where
         self.delete_storage_first = true;
         self.new_back_values.clear();
         *self.hash.get_mut() = None;
+    }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(QueueView {
+            context: self.context.clone(),
+            stored_indices: self.stored_indices.clone(),
+            front_delete_count: self.front_delete_count,
+            delete_storage_first: self.delete_storage_first,
+            new_back_values: self.new_back_values.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
     }
 }
 

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -57,7 +57,7 @@ impl<C, T> View<C> for RegisterView<C, T>
 where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
-    T: Default + Send + Sync + Serialize + DeserializeOwned,
+    T: Clone + Default + Send + Sync + Serialize + DeserializeOwned,
 {
     fn context(&self) -> &C {
         &self.context
@@ -113,6 +113,17 @@ where
         self.delete_storage_first = true;
         self.update = Some(Box::default());
         *self.hash.get_mut() = None;
+    }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(RegisterView {
+            delete_storage_first: self.delete_storage_first,
+            context: self.context.clone(),
+            stored_value: self.stored_value.clone(),
+            update: self.update.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
     }
 }
 

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -116,6 +116,16 @@ where
         self.updates.clear();
         *self.hash.get_mut() = None;
     }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(ByteSetView {
+            context: self.context.clone(),
+            delete_storage_first: self.delete_storage_first,
+            updates: self.updates.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
+    }
 }
 
 impl<C> ByteSetView<C>
@@ -407,6 +417,13 @@ where
     fn clear(&mut self) {
         self.set.clear()
     }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(SetView {
+            set: self.set.share_unchecked()?,
+            _phantom: PhantomData,
+        })
+    }
 }
 
 impl<C, I> SetView<C, I>
@@ -641,6 +658,13 @@ where
 
     fn clear(&mut self) {
         self.set.clear()
+    }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(CustomSetView {
+            set: self.set.share_unchecked()?,
+            _phantom: PhantomData,
+        })
     }
 }
 

--- a/linera-views/src/shared_view.rs
+++ b/linera-views/src/shared_view.rs
@@ -1,0 +1,216 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    batch::Batch,
+    common::Context,
+    views::{RootView, View, ViewError},
+};
+use async_lock::{Semaphore, SemaphoreGuardArc};
+use async_trait::async_trait;
+use futures::channel::oneshot;
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::{increment_counter, SAVE_VIEW_COUNTER};
+
+/// A way to safely share a [`View`] among multiple readers and at most one writer.
+///
+/// [`View`]s represent some data persisted in storage, but it also contains some state in
+/// memory that caches the storage state and that queues changes to the persisted state to
+/// be sent later. This means that two views referencing the same data in storage may have
+/// state conflicts in memory, and that's why they can't be trivially shared (using
+/// [`Clone`] for example).
+///
+/// The [`SharedView`] provides a way to share an inner [`View`] more safely, by ensuring
+/// that only one writer is staging changes to the view, and than when it is writing those
+/// changes to storage there aren't any more readers for the same view which would have
+/// their internal state become invalid. The readers are not able to see the changes the
+/// writer is staging, and the writer can only save its staged changes after all readers
+/// have finished.
+pub struct SharedView<C, V> {
+    view: V,
+    reader_count: Arc<AtomicUsize>,
+    writer_semaphore: Arc<Semaphore>,
+    writer_notifier: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    _context: PhantomData<C>,
+}
+
+impl<C, V> SharedView<C, V>
+where
+    V: View<C>,
+{
+    /// Wraps a `view` in a [`SharedView`].
+    pub fn new(view: V) -> Self {
+        SharedView {
+            view,
+            reader_count: Arc::new(AtomicUsize::new(0)),
+            writer_semaphore: Arc::new(Semaphore::new(1)),
+            writer_notifier: Arc::new(Mutex::new(None)),
+            _context: PhantomData,
+        }
+    }
+
+    /// Returns a [`ReadOnlyViewReference`] to the inner [`View`].
+    ///
+    /// If there is a writer with a [`ReadWriteViewReference`] to the inner [`View`], waits
+    /// until that writer is finished.
+    pub async fn inner(&mut self) -> Result<ReadOnlyViewReference<V>, ViewError> {
+        let _no_writer_check = self.writer_semaphore.acquire().await;
+
+        self.reader_count.fetch_add(1, Ordering::SeqCst);
+
+        Ok(ReadOnlyViewReference {
+            view: self.view.share_unchecked()?,
+            reader_count: self.reader_count.clone(),
+            writer_notifier: self.writer_notifier.clone(),
+        })
+    }
+
+    /// Returns a [`ReadWriteViewReference`] to the inner [`View`].
+    ///
+    /// Waits until the previous writer is finished if there is one. There can only be one
+    /// [`ReadWriteViewReference`] to the same inner [`View`].
+    pub async fn inner_mut(&mut self) -> Result<ReadWriteViewReference<V>, ViewError> {
+        let writer_permit = self.writer_semaphore.acquire_arc().await;
+        let (sender, receiver) = oneshot::channel();
+        let mut writer_notifier = self
+            .writer_notifier
+            .lock()
+            .expect("No panics should happen while holding the `write_notifier` lock");
+
+        if let Some(notifier) = writer_notifier.take() {
+            assert!(
+                notifier.send(()).is_err(),
+                "`writer_notifier` should either be already used or the receiving writer should \
+                have already finished"
+            );
+        }
+
+        *writer_notifier = Some(sender);
+
+        Ok(ReadWriteViewReference {
+            view: self.view.share_unchecked()?,
+            write_barrier: Some(receiver),
+            _writer_permit: writer_permit,
+        })
+    }
+}
+
+/// A read-only reference to a [`SharedView`].
+pub struct ReadOnlyViewReference<V> {
+    view: V,
+    reader_count: Arc<AtomicUsize>,
+    writer_notifier: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+}
+
+impl<V> Deref for ReadOnlyViewReference<V> {
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &self.view
+    }
+}
+
+impl<V> Drop for ReadOnlyViewReference<V> {
+    fn drop(&mut self) {
+        if self.reader_count.fetch_sub(1, Ordering::SeqCst) == 1 {
+            let mut writer_notifier = self
+                .writer_notifier
+                .lock()
+                .expect("No panics should happen while holding the `write_notifier` lock");
+
+            if self.reader_count.load(Ordering::Acquire) == 0 {
+                if let Some(notifier) = writer_notifier.take() {
+                    let _ = notifier.send(());
+                }
+            }
+        }
+    }
+}
+
+/// A read-write reference to a [`SharedView`].
+pub struct ReadWriteViewReference<V> {
+    view: V,
+    write_barrier: Option<oneshot::Receiver<()>>,
+    _writer_permit: SemaphoreGuardArc,
+}
+
+impl<V> Deref for ReadWriteViewReference<V> {
+    type Target = V;
+
+    fn deref(&self) -> &Self::Target {
+        &self.view
+    }
+}
+
+impl<V> DerefMut for ReadWriteViewReference<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.view
+    }
+}
+
+#[async_trait]
+impl<C, V> View<C> for ReadWriteViewReference<V>
+where
+    C: Send + 'static,
+    V: View<C>,
+{
+    fn context(&self) -> &C {
+        self.deref().context()
+    }
+
+    async fn load(_context: C) -> Result<Self, ViewError> {
+        unreachable!("`ReadWriteViewReference` should not be loaded directly");
+    }
+
+    fn rollback(&mut self) {
+        self.deref_mut().rollback();
+    }
+
+    fn clear(&mut self) {
+        self.deref_mut().clear();
+    }
+
+    fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError> {
+        self.deref_mut().flush(batch)
+    }
+
+    fn share_unchecked(&mut self) -> Result<Self, ViewError> {
+        unreachable!(
+            "`ReadWriteViewReference` should not be shared without going through its parent \
+            `SharedView`"
+        );
+    }
+}
+
+#[async_trait]
+impl<C, V> RootView<C> for ReadWriteViewReference<V>
+where
+    C: Context + Send + 'static,
+    V: View<C> + Send,
+    ViewError: From<C::Error>,
+{
+    async fn save(&mut self) -> Result<(), ViewError> {
+        if let Some(barrier) = self.write_barrier.take() {
+            let () = barrier
+                .await
+                .expect("`writer_notifier` should never be dropped without notifying first");
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        increment_counter(&SAVE_VIEW_COUNTER, "SharedView", &self.context().base_key());
+
+        let mut batch = Batch::new();
+        self.flush(&mut batch)?;
+        self.context().write_batch(batch).await?;
+        Ok(())
+    }
+}

--- a/linera-views/src/shared_view.rs
+++ b/linera-views/src/shared_view.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
+#[path = "unit_tests/shared_view.rs"]
+mod tests;
+
 use crate::{
     batch::Batch,
     common::Context,

--- a/linera-views/src/unit_tests/shared_view.rs
+++ b/linera-views/src/unit_tests/shared_view.rs
@@ -1,0 +1,57 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests the behavior of [`SharedView`].
+
+use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use linera_views::{
+    memory::create_memory_context,
+    register_view::RegisterView,
+    shared_view::SharedView,
+    views::{View, ViewError},
+};
+use linera_views_derive::RootView;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Test if a [`View`] can be shared among multiple readers.
+#[tokio::test(start_paused = true)]
+async fn test_multiple_readers() -> Result<(), ViewError> {
+    let context = create_memory_context();
+
+    let dummy_value = 82;
+    let mut dummy_view = SimpleView::load(context).await?;
+    dummy_view.byte.set(dummy_value);
+
+    let mut shared_view = SharedView::new(dummy_view);
+
+    let tasks = FuturesUnordered::new();
+
+    for _ in 0..100 {
+        let reference = shared_view
+            .inner()
+            .now_or_never()
+            .expect("Read-only reference should be immediately available")?;
+
+        let task = tokio::spawn(async move {
+            sleep(Duration::from_millis(10)).await;
+            *reference.byte.get()
+        });
+
+        tasks.push(task);
+    }
+
+    tasks
+        .for_each_concurrent(100, |read_value| async {
+            assert_eq!(read_value.unwrap(), dummy_value);
+        })
+        .await;
+
+    Ok(())
+}
+
+/// A simple view used to test sharing views.
+#[derive(RootView)]
+struct SimpleView<C> {
+    byte: RegisterView<C, u8>,
+}

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -35,6 +35,12 @@ pub trait View<C>: Sized {
     /// changes in the `batch` variable first. If the view is dropped without calling `flush`, staged
     /// changes are simply lost.
     fn flush(&mut self, batch: &mut Batch) -> Result<(), ViewError>;
+
+    /// Creates a clone of this view, sharing the underlying storage context but prone to
+    /// data races which can corrupt the view state.
+    ///
+    /// Use [`SharedView`][`crate::shared_view::SharedView`] to share a view safely instead.
+    fn share_unchecked(&mut self) -> Result<Self, ViewError>;
 }
 
 /// Main error type for the crate.


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Because views have their state split between the memory type and the persistent storage, it's not safe to share them trivially (using `Clone`, for example). That's because one view might update the persistent storage with data that conflicts with the memory state of the other view, and that other view has no way to know that it became stale.

Therefore, a different way for sharing views safely is required.

This is some initial work for #1616, in order to be able to share the `ChainStateView` without having to wait for a `ChainGuard` unnecessarily.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a new `SharedView` wrapper type. It contains an inner view, which can only be accessed through `ReadOnlyViewReference` or a `ReadWriteViewReference`. These types enforce a few rules:

- the view can have multiple `ReadOnlyViewReference`s but at most one `ReadWriteViewReference`
- when a `ReadWriteViewReference` is used for saving data (through `RootView::save`), the operation waits until all `ReadOnlyViewReference`s have been dropped before writing to storage

## Test Plan

<!-- How to test that the changes are correct. -->
Added some unit tests to see if the `SharedView` references behave as expected.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
