### PR TITLE
`docker/Dockerfile`: copy all files into the Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,8 +13,7 @@ npm-debug.log
 README-secret.md
 # github related files
 .github/
-scripts/target
-examples/target
+target/
 Dockerfile
 .dockerignore
 .gitignore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,25 +30,7 @@ RUN apt-get update && apt-get install -y \
     protobuf-compiler \
     clang
 
-COPY examples examples
-COPY linera-base linera-base
-COPY linera-chain linera-chain
-COPY linera-core linera-core
-COPY linera-execution linera-execution
-COPY linera-explorer linera-explorer
-COPY linera-indexer linera-indexer
-COPY linera-rpc linera-rpc
-COPY linera-sdk linera-sdk
-COPY linera-sdk-derive linera-sdk-derive
-COPY linera-service linera-service
-COPY linera-service-graphql-client linera-service-graphql-client
-COPY linera-storage linera-storage
-COPY linera-views linera-views
-COPY linera-views-derive linera-views-derive
-COPY linera-witty linera-witty
-COPY linera-witty-macros linera-witty-macros
-COPY scripts scripts
-COPY rust-toolchain* Cargo.* ./
+COPY . .
 
 ENV GIT_COMMIT=${git_commit}
 


### PR DESCRIPTION
## Motivation

Previously we were being very careful about which files we copied into the Docker context, because we were attempting to use [`cargo-chef`](https://github.com/LukeMathWalker/cargo-chef/).  However, due to [an open issue with cross-workspace dependencies](https://github.com/LukeMathWalker/cargo-chef/issues/4), [which we use](https://github.com/linera-io/linera-protocol/issues/1512), we can only use `cargo-chef` if we bust its cache, meaning we get no advantage from it and have removed it from the `Dockerfile`.

As a result, until `cargo-chef` fixes the bug and we re-introduce it, we can replace the list of directory dependencies from `Dockerfile` with a simple `COPY . .`, ensuring that we don't forget to add any new directories.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Add `COPY . .` to the `Dockerfile`, and also add `target` to the `.dockerignore` file.  This latter is safe even in the presence of copied binaries, because we copy the binaries to another location before including them in the Docker context.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI is the flow most likely to be broken by this, so if CI passes we should be okay.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

Invisible to the end user.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
