### PR TITLE
Bump tombstone limit

### DIFF
--- a/kubernetes/linera-validator/scylla.values.yaml
+++ b/kubernetes/linera-validator/scylla.values.yaml
@@ -5,6 +5,7 @@ datacenter: validator
 racks:
   - name: rack-1
     members: 1
+    scyllaConfig: "scylla-config"
     storage:
       capacity: 2Gi
     resources:

--- a/kubernetes/linera-validator/templates/scylla-config.yaml
+++ b/kubernetes/linera-validator/templates/scylla-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scylla-config
+  namespace: scylla
+data:
+  scylla.yaml: |
+    query_tombstone_page_limit: 200000


### PR DESCRIPTION
## Motivation

The query tombstone limit by default in ScyllaDB is 10000 - which we are hitting quite quickly due to performing deletes frequently, probably in the `QueueView` associated with Inboxes.

## Proposal

Increase the Tombstone limit until we implement something more sustainable long term.

Thanks @MathieuDutSik and @andresilva91 for helping out on this.

