### PR TITLE
`linera-execution`: Feature-gate Prometheus

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,30 @@ cargo build --release --target wasm32-unknown-unknown
 The Rust flags are suggested to reduce the size of the Wasm bytecodes.
 
 
+## Platform-specific features
+
+Features that compile only on specific platforms are currently
+addressed using a variant of the [`winit`
+convention](https://stackoverflow.com/questions/67373380/can-i-set-cargo-projects-default-features-depending-on-the-platform).
+
+Let's look at an example: imagine our crate has a feature `metrics` that only works on UNIX platforms.
+
+We use `cfg_aliases` in `build.rs` for our crate to define an alias `with_metrics` that also
+includes the supported platform(s):
+
+``` rust
+fn main() {
+    cfg_aliases::cfg_aliases! {
+        with_metrics: { all(feature = "metrics", target_family = "unix") },
+    }
+}
+```
+
+Now, when we conditionally compile the feature in our code, we use `cfg(with_metrics)`
+instead of `cfg(feature = "metrics")`.  This has the effect that the feature is disabled both
+if it isn't requested _and_ if it is unsupported on the current target platform, allowing us
+to test `--all-targets` with impunity.
+
 ## Debugging techniques
 
 The debugging of tests can be complicated and some tools can help this.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3226,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "bytes",
+ "cfg_aliases",
  "clap 4.4.11",
  "counter",
  "custom_debug_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ bincode = "1.3.3"
 bytes = "1.5.0"
 cargo_metadata = "0.18.1"
 cargo_toml = "0.15.3"
+cfg_aliases = "0.2.0"
 chrono = "0.4.31"
 clap = { version = "4", features = ["cargo", "derive", "env"] }
 clap-markdown = "0.1.3"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1900,7 +1900,6 @@ dependencies = [
  "lru",
  "once_cell",
  "oneshot",
- "prometheus",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -538,6 +538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1894,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "bytes",
+ "cfg_aliases",
  "clap",
  "custom_debug_derive",
  "dashmap",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -11,8 +11,9 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-default = ["wasmer"]
+default = ["wasmer", "metrics"]
 test = ["tokio/macros"]
+metrics = ["prometheus"]
 wasmer = [
     "bytes",
     "dep:wasmer",
@@ -46,7 +47,7 @@ linera-views-derive.workspace = true
 lru.workspace = true
 once_cell.workspace = true
 oneshot.workspace = true
-prometheus.workspace = true
+prometheus = { workspace = true, optional = true }
 serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -73,5 +73,8 @@ test-log = { workspace = true, features = ["trace"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 
+[build-dependencies]
+cfg_aliases.workspace = true
+
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]

--- a/linera-execution/build.rs
+++ b/linera-execution/build.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    cfg_aliases::cfg_aliases! {
+        web: { all(target_arch = "wasm32", target_os = "unknown") },
+        with_metrics: { all(not(web), feature = "metrics") },
+        with_wasmtime: { all(not(web), feature = "wasmtime") },
+        with_wasmer: { all(not(web), feature = "wasmer") },
+    }
+}

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -28,9 +28,9 @@ pub use system::{
     SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,
     SystemResponse,
 };
-#[cfg(all(any(test, feature = "test"), any(feature = "wasmer", with_wasmtime)))]
+#[cfg(all(any(test, feature = "test"), any(with_wasmer, with_wasmtime)))]
 pub use wasm::test as wasm_test;
-#[cfg(any(feature = "wasmer", with_wasmtime))]
+#[cfg(any(with_wasmer, with_wasmtime))]
 pub use wasm::{WasmContractModule, WasmExecutionError, WasmServiceModule};
 #[cfg(any(test, feature = "test"))]
 pub use {applications::ApplicationRegistry, system::SystemExecutionState};
@@ -91,7 +91,7 @@ pub enum ExecutionError {
     SystemError(#[from] SystemExecutionError),
     #[error("User application reported an error: {0}")]
     UserError(String),
-    #[cfg(any(feature = "wasmer", with_wasmtime))]
+    #[cfg(any(with_wasmer, with_wasmtime))]
     #[error(transparent)]
     WasmError(#[from] WasmExecutionError),
     #[error(transparent)]
@@ -819,7 +819,7 @@ pub struct Bytecode {
 
 impl Bytecode {
     /// Creates a new [`Bytecode`] instance using the provided `bytes`.
-    #[cfg(any(feature = "wasmer", with_wasmtime))]
+    #[cfg(any(with_wasmer, with_wasmtime))]
     pub(crate) fn new(bytes: Vec<u8>) -> Self {
         Bytecode { bytes }
     }
@@ -846,17 +846,17 @@ impl std::fmt::Debug for Bytecode {
 
 /// The runtime to use for running the application.
 #[derive(Clone, Copy, Display)]
-#[cfg_attr(any(with_wasmtime, feature = "wasmer"), derive(Debug, Default))]
+#[cfg_attr(any(with_wasmtime, with_wasmer), derive(Debug, Default))]
 pub enum WasmRuntime {
-    #[cfg(feature = "wasmer")]
+    #[cfg(with_wasmer)]
     #[default]
     #[display(fmt = "wasmer")]
     Wasmer,
     #[cfg(with_wasmtime)]
-    #[cfg_attr(not(feature = "wasmer"), default)]
+    #[cfg_attr(not(with_wasmer), default)]
     #[display(fmt = "wasmtime")]
     Wasmtime,
-    #[cfg(feature = "wasmer")]
+    #[cfg(with_wasmer)]
     WasmerWithSanitizer,
     #[cfg(with_wasmtime)]
     WasmtimeWithSanitizer,
@@ -868,13 +868,13 @@ pub trait WithWasmDefault {
 }
 
 impl WasmRuntime {
-    #[cfg(any(feature = "wasmer", with_wasmtime))]
+    #[cfg(any(with_wasmer, with_wasmtime))]
     pub fn default_with_sanitizer() -> Self {
-        #[cfg(feature = "wasmer")]
+        #[cfg(with_wasmer)]
         {
             WasmRuntime::WasmerWithSanitizer
         }
-        #[cfg(not(feature = "wasmer"))]
+        #[cfg(not(with_wasmer))]
         {
             WasmRuntime::WasmtimeWithSanitizer
         }
@@ -882,23 +882,23 @@ impl WasmRuntime {
 
     pub fn needs_sanitizer(self) -> bool {
         match self {
-            #[cfg(feature = "wasmer")]
+            #[cfg(with_wasmer)]
             WasmRuntime::WasmerWithSanitizer => true,
             #[cfg(with_wasmtime)]
             WasmRuntime::WasmtimeWithSanitizer => true,
-            #[cfg(any(with_wasmtime, feature = "wasmer"))]
+            #[cfg(any(with_wasmtime, with_wasmer))]
             _ => false,
         }
     }
 }
 
 impl WithWasmDefault for Option<WasmRuntime> {
-    #[cfg(any(feature = "wasmer", with_wasmtime))]
+    #[cfg(any(with_wasmer, with_wasmtime))]
     fn with_wasm_default(self) -> Self {
         Some(self.unwrap_or_default())
     }
 
-    #[cfg(not(any(feature = "wasmer", with_wasmtime)))]
+    #[cfg(not(any(with_wasmer, with_wasmtime)))]
     fn with_wasm_default(self) -> Self {
         None
     }
@@ -909,7 +909,7 @@ impl FromStr for WasmRuntime {
 
     fn from_str(string: &str) -> Result<Self, Self::Err> {
         match string {
-            #[cfg(feature = "wasmer")]
+            #[cfg(with_wasmer)]
             "wasmer" => Ok(WasmRuntime::Wasmer),
             #[cfg(with_wasmtime)]
             "wasmtime" => Ok(WasmRuntime::Wasmtime),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -827,6 +827,7 @@ impl Bytecode {
         Bytecode { bytes }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     /// Load bytecode from a Wasm module file.
     pub async fn load_from_file(path: impl AsRef<Path>) -> Result<Self, io::Error> {
         let bytes = tokio::fs::read(path).await?;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -16,9 +16,11 @@ use linera_base::{
     data_types::{Amount, ArithmeticError, Timestamp},
     ensure, hex_debug,
     identifiers::{BytecodeId, ChainDescription, ChainId, MessageId, Owner},
-    prometheus_util,
-    sync::Lazy,
 };
+
+#[cfg(metrics)]
+use linera_base::{prometheus_util, sync::Lazy};
+
 use linera_views::{
     common::Context,
     map_view::MapView,
@@ -26,6 +28,7 @@ use linera_views::{
     set_view::SetView,
     views::{HashableView, View, ViewError},
 };
+#[cfg(metrics)]
 use prometheus::IntCounterVec;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -49,6 +52,7 @@ pub static CREATE_APPLICATION_MESSAGE_INDEX: u32 = 0;
 pub static PUBLISH_BYTECODE_MESSAGE_INDEX: u32 = 0;
 
 /// The number of times the [`SystemOperation::OpenChain`] was executed.
+#[cfg(metrics)]
 static OPEN_CHAIN_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     prometheus_util::register_int_counter_vec(
         "open_chain_count",
@@ -560,6 +564,7 @@ where
                     },
                 };
                 outcome.messages.extend([e1, e2]);
+                #[cfg(metrics)]
                 OPEN_CHAIN_COUNT.with_label_values(&[]).inc();
             }
             ChangeOwnership {

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -18,7 +18,7 @@ use linera_base::{
     identifiers::{BytecodeId, ChainDescription, ChainId, MessageId, Owner},
 };
 
-#[cfg(metrics)]
+#[cfg(with_metrics)]
 use linera_base::{prometheus_util, sync::Lazy};
 
 use linera_views::{
@@ -28,7 +28,7 @@ use linera_views::{
     set_view::SetView,
     views::{HashableView, View, ViewError},
 };
-#[cfg(metrics)]
+#[cfg(with_metrics)]
 use prometheus::IntCounterVec;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -52,7 +52,7 @@ pub static CREATE_APPLICATION_MESSAGE_INDEX: u32 = 0;
 pub static PUBLISH_BYTECODE_MESSAGE_INDEX: u32 = 0;
 
 /// The number of times the [`SystemOperation::OpenChain`] was executed.
-#[cfg(metrics)]
+#[cfg(with_metrics)]
 static OPEN_CHAIN_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     prometheus_util::register_int_counter_vec(
         "open_chain_count",
@@ -564,7 +564,7 @@ where
                     },
                 };
                 outcome.messages.extend([e1, e2]);
-                #[cfg(metrics)]
+                #[cfg(with_metrics)]
                 OPEN_CHAIN_COUNT.with_label_values(&[]).inc();
             }
             ChangeOwnership {

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -26,10 +26,14 @@ use crate::{
     Bytecode, ContractSyncRuntime, ExecutionError, ServiceSyncRuntime, UserContractInstance,
     UserContractModule, UserServiceInstance, UserServiceModule, WasmRuntime,
 };
+
+#[cfg(metrics)]
 use linera_base::{
     prometheus_util::{self, MeasureLatency},
     sync::Lazy,
 };
+
+#[cfg(metrics)]
 use prometheus::HistogramVec;
 use std::{path::Path, sync::Arc};
 use thiserror::Error;
@@ -39,6 +43,7 @@ use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 #[cfg(feature = "wasmtime")]
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
 
+#[cfg(metrics)]
 static CONTRACT_INSTANTIATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     prometheus_util::register_histogram_vec(
         "contract_instantiation_latency",
@@ -51,6 +56,7 @@ static CONTRACT_INSTANTIATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     .expect("Histogram creation should not fail")
 });
 
+#[cfg(metrics)]
 static SERVICE_INSTANTIATION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     prometheus_util::register_histogram_vec(
         "service_instantiation_latency",
@@ -121,6 +127,7 @@ impl UserContractModule for WasmContractModule {
         &self,
         runtime: ContractSyncRuntime,
     ) -> Result<UserContractInstance, ExecutionError> {
+        #[cfg(metrics)]
         let _instantiation_latency = CONTRACT_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserContractInstance = match self {
@@ -186,6 +193,7 @@ impl UserServiceModule for WasmServiceModule {
         &self,
         runtime: ServiceSyncRuntime,
     ) -> Result<UserServiceInstance, ExecutionError> {
+        #[cfg(metrics)]
         let _instantiation_latency = SERVICE_INSTANTIATION_LATENCY.measure_latency();
 
         let instance: UserServiceInstance = match self {

--- a/linera-execution/src/wasm/sanitizer.rs
+++ b/linera-execution/src/wasm/sanitizer.rs
@@ -403,7 +403,7 @@ impl<'bytecode> Sanitizer<'bytecode> {
     }
 }
 
-#[cfg(all(test, feature = "wasmer"))]
+#[cfg(all(test, with_wasmer))]
 mod tests {
     use super::sanitize;
     use crate::Bytecode;

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#![cfg(any(feature = "wasmer", with_wasmtime))]
 
 #[allow(dead_code)]
 mod utils;
@@ -29,8 +29,8 @@ use test_case::test_case;
 /// To update the bytecode files, run `linera-execution/update_wasm_fixtures.sh`.
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer, 37_228, ExecutionRuntimeConfig::Synchronous; "wasmer"))]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::WasmerWithSanitizer, 37_655, ExecutionRuntimeConfig::Synchronous; "wasmer_with_sanitizer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime, 37_655, ExecutionRuntimeConfig::Synchronous; "wasmtime"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::WasmtimeWithSanitizer, 37_655, ExecutionRuntimeConfig::Synchronous; "wasmtime_with_sanitizer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmRuntime::Wasmtime, 37_655, ExecutionRuntimeConfig::Synchronous; "wasmtime"))]
+#[cfg_attr(with_wasmtime, test_case(WasmRuntime::WasmtimeWithSanitizer, 37_655, ExecutionRuntimeConfig::Synchronous; "wasmtime_with_sanitizer"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_fuel_for_counter_wasm_application(
     wasm_runtime: WasmRuntime,

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -109,7 +109,6 @@ pub mod lru_caching;
 pub mod reentrant_collection_view;
 
 /// The implementation of a key-value store view.
-#[cfg(not(target_arch = "wasm32"))]
 pub mod key_value_store_view;
 
 /// Wrapping a view to compute a hash.


### PR DESCRIPTION
## Motivation

For the #1608 we will need the Linera protocol crates to compile to Wasm.  Prometheus does not compile to Wasm, and even if it did we have nowhere to put the metrics when we're running in the browser.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Feature-gate Prometheus behind a `metrics` feature, as is done elsewhere in the codebase, that can be disabled when compiling to Wasm.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Build with `--no-default-features --features wasmer` to check that all metrics code has been correctly excised.

<!-- How to test that the changes are correct. -->

## Release Plan

No special care required.  The feature flag is enabled by default, so consumers should see no API change unless they explicitly disable it.

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
