### PR TITLE
Fix a couple of bugs in `cargo-sort`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -135,7 +135,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install cargo-sort
       run: |
-        cargo install cargo-sort --git https://github.com/DevinR528/cargo-sort/#v1.1
+        cargo install cargo-sort --git https://github.com/Twey/cargo-sort/ --tag linera
     - name: Check formatting
       run: |
         cargo fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
     "linera-views-derive",
     "linera-witty",
     "linera-witty-macros",
-    "linera-witty/test-modules"
+    "linera-witty/test-modules",
 ]
 exclude = ["examples", "scripts"]
 resolver = "2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "fungible",
     "matching-engine",
     "meta-counter",
-    "social"
+    "social",
 ]
 
 [workspace.dependencies]

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -25,7 +25,7 @@ test = [
     "tempfile",
     "test-log",
     "test-strategy",
-    "tokio/parking_lot"
+    "tokio/parking_lot",
 ]
 rocksdb = ["linera-views/rocksdb", "linera-storage/rocksdb"]
 aws = ["linera-views/aws", "linera-storage/aws"]

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -19,13 +19,13 @@ wasmer = [
     "wasm-encoder",
     "wasmer-middlewares",
     "wasmparser",
-    "wit-bindgen-host-wasmer-rust"
+    "wit-bindgen-host-wasmer-rust",
 ]
 wasmtime = [
     "dep:wasmtime",
     "wasm-encoder",
     "wasmparser",
-    "wit-bindgen-host-wasmtime-rust"
+    "wit-bindgen-host-wasmtime-rust",
 ]
 
 [dependencies]

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -16,7 +16,7 @@ test = [
     "linera-chain/test",
     "linera-core/test",
     "linera-execution/test",
-    "linera-storage/test"
+    "linera-storage/test",
 ]
 
 [dependencies]

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -22,7 +22,7 @@ wasmer = ["linera-core/wasmer", "linera-execution/wasmer", "linera-storage/wasme
 wasmtime = [
     "linera-core/wasmtime",
     "linera-execution/wasmtime",
-    "linera-storage/wasmtime"
+    "linera-storage/wasmtime",
 ]
 test = []
 

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -19,13 +19,13 @@ wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
 rocksdb = [
     "linera-views/rocksdb",
     "linera-core/rocksdb",
-    "linera-storage/rocksdb"
+    "linera-storage/rocksdb",
 ]
 aws = ["linera-views/aws", "linera-core/aws", "linera-storage/aws"]
 scylladb = [
     "linera-views/scylladb",
     "linera-core/scylladb",
-    "linera-storage/scylladb"
+    "linera-storage/scylladb",
 ]
 kubernetes = ["dep:k8s-openapi", "dep:kube", "dep:pathdiff", "dep:fs_extra"]
 remote_net = ["dep:k8s-openapi", "dep:kube"]

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -17,7 +17,7 @@ test = [
     "tokio/test-util",
     "tokio/time",
     "linera-execution/test",
-    "linera-views/test"
+    "linera-views/test",
 ]
 wasmer = ["linera-execution/wasmer"]
 wasmtime = ["linera-execution/wasmtime"]

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -22,7 +22,7 @@ aws = [
     "aws-sdk-s3",
     "aws-smithy-http",
     "aws-smithy-types",
-    "aws-types"
+    "aws-types",
 ]
 scylladb = ["scylla"]
 db_timings = []


### PR DESCRIPTION
## Motivation

Trailing commas are good :)

This PR previously added a `tomlfmt.toml` that configured the `multiline_trailing_comma` feature.  Unfortunately, this exposed a bug in `cargo-sort` that meant it was impossible to format the workspace `Cargo.toml` to its liking.  Furthermore, on inspection of the documentation, it turns out that `multiline_trailing_comma` should be on by default.

I added [a PR](https://github.com/DevinR528/cargo-sort/pull/70) fixing these bugs, and the test that should have caught them.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Point our CI's `cargo sort` to my branch.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI

<!-- How to test that the changes are correct. -->

## Release Plan

Invisible to users.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- https://github.com/DevinR528/cargo-sort/pull/70