### PR TITLE
`.github/workflows`: use upstream Rust actions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: Twey/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:
@@ -59,7 +59,7 @@ jobs:
 
   #   steps:
   #   - uses: actions/checkout@v3
-  #   - uses: Twey/setup-rust-toolchain@v1
+  #   - uses: actions-rust-lang/setup-rust-toolchain@v1
   #   - name: Checkout docs.rs tool repository
   #     run: |
   #       cd ${{ runner.temp }}

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: Twey/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:

--- a/.github/workflows/explorer.yml
+++ b/.github/workflows/explorer.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
-    - uses: Twey/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Build
       run: |
         cd linera-explorer

--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: Twey/setup-rust-toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: Twey/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Clear up some space
       run: |
         sudo rm -rf /usr/share/dotnet
@@ -119,7 +119,7 @@ jobs:
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/lint/rust-toolchain.toml
-    - uses: Twey/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install cargo-machete
       run: |
         cargo install cargo-machete --locked

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: Twey/setup-rust-toolchain@v1
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
     - name: Install Protoc
       uses: arduino/setup-protoc@v1
       with:


### PR DESCRIPTION
## Motivation

We previously switched to my fork of the Rust toolchain GitHub actions, `Twey/setup-rust-toolchain`, in order to be able to override the toolchain specified in `rust-toolchain.toml`.

Now that this work [has been merged](https://github.com/actions-rust-lang/setup-rust-toolchain/pull/26) into the upstream, we can rejoin to the upstream version.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Revert to the upstream version.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
None needed: CI change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- https://github.com/actions-rust-lang/setup-rust-toolchain/pull/26