### PR TITLE
`scripts/check_copyright_header`: give more useful feedback

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Check Copyright headers
       run: >
         find linera-* examples -name '*.rs' -a -not -wholename '*/target/*' -print0
-        | xargs -0 -L1 ./scripts/target/release/check_copyright_header
+        | xargs -0 scripts/target/release/check_copyright_header
     - name: Put lint toolchain file in place
       run: |
         ln -sf toolchains/lint/rust-toolchain.toml

--- a/scripts/check_copyright_header/src/main.rs
+++ b/scripts/check_copyright_header/src/main.rs
@@ -61,14 +61,22 @@ fn check_file_header(
     Err(CheckFileHeaderError::IncorrectCopyrightHeaderError)
 }
 
-fn main() -> Result<(), CheckFileHeaderError> {
-    let args = env::args().collect::<Vec<_>>();
-    let file_path = args.get(1).expect("Usage: FILE");
+fn main() -> std::process::ExitCode {
+    let args = env::args().skip(1).collect::<Vec<_>>();
 
-    let file = File::open(file_path).expect("Failed to open file");
-    let reader = BufReader::new(file);
+    let mut exit_code = std::process::ExitCode::SUCCESS;
 
-    check_file_header(reader.lines())
+    for file_path in args {
+        let file = File::open(&file_path).expect("Failed to open file");
+        let reader = BufReader::new(file);
+
+        if let Err(e) = check_file_header(reader.lines()) {
+            exit_code = std::process::ExitCode::FAILURE;
+            eprintln!("{}: {}", file_path, e);
+        }
+    }
+
+    exit_code
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation

This script gives no useful feedback when it fails, requiring manual hunting down of the offending files.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Print the file on which it fails, as well as the reason for which it is failing.

Also, as a bonus, support multiple input files, allowing for use with globbing.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.  I have also manually tested a negative example locally.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Invisible to users.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
