### PR TITLE
Default to charging fees from the chain account

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1620,7 +1620,9 @@ where
             ))) if matches!(
                 *error,
                 ChainError::ExecutionError(
-                    ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }),
+                    ExecutionError::SystemError(
+                        SystemExecutionError::InsufficientFundingForFees { .. }
+                    ),
                     ChainExecutionContext::Block
                 )
             ) =>

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1570,13 +1570,24 @@ where
     let obtained_error = sender
         .transfer_to_account(
             None,
+            Amount::from_tokens(4),
+            Account::chain(ChainId::root(2)),
+            UserData(Some(*b"I'm giving away all of my money!")),
+        )
+        .await;
+    assert!(matches!(obtained_error,
+                     Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Operation(0)))
+    ));
+    let obtained_error = sender
+        .transfer_to_account(
+            None,
             Amount::from_tokens(3),
             Account::chain(ChainId::root(2)),
             UserData(Some(*b"I'm giving away all of my money!")),
         )
         .await;
     assert!(matches!(obtained_error,
-                     Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }), ChainExecutionContext::Block))
+                     Err(ChainClientError::LocalNodeError(LocalNodeError::WorkerError(WorkerError::ChainError(error)))) if matches!(*error, ChainError::ExecutionError(ExecutionError::SystemError(SystemExecutionError::InsufficientFundingForFees { .. }), ChainExecutionContext::Block))
     ));
     Ok(())
 }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -330,6 +330,8 @@ where
         match self.owner {
             None => self.view.system.balance.get_mut().try_add_assign(other),
             Some(owner) => {
+                // Try to credit the owner account first.
+                // TODO(#1648): This may need some additional design work.
                 let balance = self.get_owner_balance_mut(&owner);
                 balance.try_add_assign(other)?;
                 // Safety check. (See discussion below in `ResourceController::with`).
@@ -343,17 +345,19 @@ where
         match self.owner {
             None => self.view.system.balance.get_mut().try_sub_assign(other),
             Some(owner) => {
-                // Charge the owner's account first, then the chain's account for the
-                // reminder.
+                // Charge the chain account first then the owner's account.
                 if self
-                    .get_owner_balance_mut(&owner)
+                    .view
+                    .system
+                    .balance
+                    .get_mut()
                     .try_sub_assign(other)
                     .is_err()
                 {
-                    let balance = self.get_owner_balance(&owner);
+                    let balance = *self.view.system.balance.get();
+                    *self.view.system.balance.get_mut() = Amount::ZERO;
                     let delta = other.try_sub(balance).expect("balance < other");
-                    self.view.system.balance.get_mut().try_sub_assign(delta)?;
-                    *self.get_owner_balance_mut(&owner) = Amount::ZERO;
+                    self.get_owner_balance_mut(&owner).try_sub_assign(delta)?;
                 }
                 Ok(())
             }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -79,8 +79,8 @@ where
         if other <= initial {
             self.account
                 .try_sub_assign(initial.try_sub(other).expect("other <= initial"))
-                .map_err(|_| SystemExecutionError::InsufficientFunding {
-                    current_balance: self.balance(),
+                .map_err(|_| SystemExecutionError::InsufficientFundingForFees {
+                    balance: self.balance(),
                 })?;
         } else {
             self.account
@@ -92,8 +92,8 @@ where
     /// Subtracts an amount from a balance and reports an error if that is impossible.
     fn update_balance(&mut self, fees: Amount) -> Result<(), ExecutionError> {
         self.account.try_sub_assign(fees).map_err(|_| {
-            SystemExecutionError::InsufficientFunding {
-                current_balance: self.balance(),
+            SystemExecutionError::InsufficientFundingForFees {
+                balance: self.balance(),
             }
         })?;
         Ok(())

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,8 +9,9 @@ mod utils;
 
 use self::utils::{register_mock_applications, ExpectedCall};
 use linera_base::{
+    crypto::PublicKey,
     data_types::{Amount, BlockHeight},
-    identifiers::{ChainDescription, ChainId},
+    identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_execution::{
     policy::ResourceControlPolicy, ContractRuntime, ExecutionError, ExecutionOutcome,
@@ -22,16 +23,35 @@ use std::{sync::Arc, vec};
 use test_case::test_case;
 
 /// Tests if the chain balance is updated based on the fees spent for consuming resources.
-#[test_case(vec![]; "without any costs")]
-#[test_case(vec![FeeSpend::Fuel(100)]; "with only execution costs")]
-#[test_case(vec![FeeSpend::Read(vec![0, 1], None)]; "with only an empty read")]
+// Chain account only.
+#[test_case(vec![], Amount::ZERO, None; "without any costs")]
+#[test_case(vec![FeeSpend::Fuel(100)], Amount::from_tokens(1_000), None; "with only execution costs")]
+#[test_case(vec![FeeSpend::Read(vec![0, 1], None)], Amount::from_tokens(1_000), None; "with only an empty read")]
 #[test_case(vec![
     FeeSpend::Read(vec![0, 1], None),
     FeeSpend::Fuel(207),
-]; "with execution and an empty read")]
+], Amount::from_tokens(1_000), None; "with execution and an empty read")]
+// Chain account and small owner account.
+#[test_case(vec![FeeSpend::Fuel(100)], Amount::from_tokens(1_000), Some(Amount::from_tokens(1)); "with only execution costs and with owner account")]
+#[test_case(vec![FeeSpend::Read(vec![0, 1], None)], Amount::from_tokens(1_000), Some(Amount::from_tokens(1)); "with only an empty read and with owner account")]
+#[test_case(vec![
+    FeeSpend::Read(vec![0, 1], None),
+    FeeSpend::Fuel(207),
+], Amount::from_tokens(1_000), Some(Amount::from_tokens(1)); "with execution and an empty read and with owner account")]
+// Small chain account and larger owner account.
+#[test_case(vec![FeeSpend::Fuel(100)], Amount::from_tokens(1), Some(Amount::from_tokens(1_000)); "with only execution costs and with larger owner account")]
+#[test_case(vec![FeeSpend::Read(vec![0, 1], None)], Amount::from_tokens(1), Some(Amount::from_tokens(1_000)); "with only an empty read and with larger owner account")]
+#[test_case(vec![
+    FeeSpend::Read(vec![0, 1], None),
+    FeeSpend::Fuel(207),
+], Amount::from_tokens(1), Some(Amount::from_tokens(1_000)); "with execution and an empty read and with larger owner account")]
 // TODO(#1601): Add more test cases
 #[tokio::test]
-async fn test_fee_consumption(spends: Vec<FeeSpend>) -> anyhow::Result<()> {
+async fn test_fee_consumption(
+    spends: Vec<FeeSpend>,
+    chain_balance: Amount,
+    owner_balance: Option<Amount>,
+) -> anyhow::Result<()> {
     let state = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
         ..SystemExecutionState::default()
@@ -43,8 +63,11 @@ async fn test_fee_consumption(spends: Vec<FeeSpend>) -> anyhow::Result<()> {
         )
         .await;
 
-    let initial_balance: Amount = Amount::from_tokens(1_000);
-    view.system.balance.set(initial_balance);
+    let owner = Owner::from(PublicKey::debug(0));
+    view.system.balance.set(chain_balance);
+    if let Some(owner_balance) = owner_balance {
+        view.system.balances.insert(&owner, owner_balance)?;
+    }
 
     let mut applications = register_mock_applications(&mut view, 1).await?;
     let (application_id, application) = applications
@@ -74,8 +97,14 @@ async fn test_fee_consumption(spends: Vec<FeeSpend>) -> anyhow::Result<()> {
             sum.saturating_add(spent_fees)
         });
 
+    let authenticated_signer = if owner_balance.is_some() {
+        Some(owner)
+    } else {
+        None
+    };
     let mut controller = ResourceController {
         policy: Arc::new(prices),
+        account: authenticated_signer,
         ..ResourceController::default()
     };
 
@@ -92,7 +121,7 @@ async fn test_fee_consumption(spends: Vec<FeeSpend>) -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         height: BlockHeight(0),
         index: 0,
-        authenticated_signer: None,
+        authenticated_signer,
         next_message_index: 0,
     };
     let outcomes = view
@@ -106,15 +135,32 @@ async fn test_fee_consumption(spends: Vec<FeeSpend>) -> anyhow::Result<()> {
         )
         .await?;
 
-    let expected_final_balance = initial_balance.saturating_sub(consumed_fees);
-
-    assert_eq!(*view.system.balance.get(), expected_final_balance);
+    let (expected_chain_balance, expected_owner_balance) = if chain_balance >= consumed_fees {
+        (chain_balance.saturating_sub(consumed_fees), owner_balance)
+    } else {
+        let Some(owner_balance) = owner_balance else {
+            panic!("execution should have failed earlier");
+        };
+        (
+            Amount::ZERO,
+            Some(
+                owner_balance
+                    .saturating_add(chain_balance)
+                    .saturating_sub(consumed_fees),
+            ),
+        )
+    };
+    assert_eq!(*view.system.balance.get(), expected_chain_balance);
+    assert_eq!(
+        view.system.balances.get(&owner).await.unwrap(),
+        expected_owner_balance
+    );
     assert_eq!(
         outcomes,
         vec![ExecutionOutcome::User(
             application_id,
-            RawExecutionOutcome::default()
-        ),]
+            RawExecutionOutcome::default().with_authenticated_signer(authenticated_signer),
+        )]
     );
     Ok(())
 }

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -51,7 +51,7 @@ async fn test_fee_consumption(
     spends: Vec<FeeSpend>,
     chain_balance: Amount,
     owner_balance: Option<Amount>,
-) -> anyhow::Result<()> {
+) {
     let state = SystemExecutionState {
         description: Some(ChainDescription::Root(0)),
         ..SystemExecutionState::default()
@@ -66,10 +66,10 @@ async fn test_fee_consumption(
     let owner = Owner::from(PublicKey::debug(0));
     view.system.balance.set(chain_balance);
     if let Some(owner_balance) = owner_balance {
-        view.system.balances.insert(&owner, owner_balance)?;
+        view.system.balances.insert(&owner, owner_balance).unwrap();
     }
 
-    let mut applications = register_mock_applications(&mut view, 1).await?;
+    let mut applications = register_mock_applications(&mut view, 1).await.unwrap();
     let (application_id, application) = applications
         .next()
         .expect("Caller mock application should be registered");
@@ -111,7 +111,7 @@ async fn test_fee_consumption(
     application.expect_call(ExpectedCall::execute_operation(
         move |runtime, _context, _operation| {
             for spend in spends {
-                spend.execute(runtime)?;
+                spend.execute(runtime).unwrap();
             }
             Ok(RawExecutionOutcome::default())
         },
@@ -133,7 +133,8 @@ async fn test_fee_consumption(
             },
             &mut controller,
         )
-        .await?;
+        .await
+        .unwrap();
 
     let (expected_chain_balance, expected_owner_balance) = if chain_balance >= consumed_fees {
         (chain_balance.saturating_sub(consumed_fees), owner_balance)
@@ -162,7 +163,6 @@ async fn test_fee_consumption(
             RawExecutionOutcome::default().with_authenticated_signer(authenticated_signer),
         )]
     );
-    Ok(())
 }
 
 /// A runtime operation that costs some amount of fees.


### PR DESCRIPTION
## Motivation

* Make e2e tests easier to write
* Clarify the role of chain accounts as fee grants
* Prepare #1626 (which will replace this code but we're changing the semantics now)

## Proposal

* Charge the chain account before the owner account
* Refund the owner account (note: in #1626, we check if the owner account exists first. This makes little difference because there are no refund right now)

## Test Plan

CI