### PR TITLE
Add a `SharableView` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,6 +3618,7 @@ dependencies = [
  "sha3",
  "static_assertions",
  "tempfile",
+ "test-case",
  "thiserror",
  "tokio",
  "tokio-test",

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -280,6 +280,31 @@ fn generate_crypto_hash_code(input: ItemStruct) -> TokenStream2 {
     }
 }
 
+fn generate_clonable_view_code(input: ItemStruct) -> TokenStream2 {
+    let struct_name = input.ident;
+    let generics = input.generics;
+    let template_vect = get_seq_parameter(generics.clone());
+
+    let (context, context_constraints) = context_and_constraints(&input.attrs, &template_vect);
+
+    let clone_unchecked_quotes = input.fields.iter().map(|field| {
+        let name = &field.ident;
+        quote! { #name: self.#name.clone_unchecked()?, }
+    });
+
+    quote! {
+        impl #generics linera_views::views::ClonableView<#context> for #struct_name #generics
+        #context_constraints
+        {
+            fn clone_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+                Ok(Self {
+                    #(#clone_unchecked_quotes)*
+                })
+            }
+        }
+    }
+}
+
 #[proc_macro_derive(View, attributes(view))]
 pub fn derive_view(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
@@ -329,6 +354,12 @@ pub fn derive_hashable_root_view(input: TokenStream) -> TokenStream {
     stream.extend(generate_save_delete_view_code(input.clone()));
     stream.extend(generate_hash_view_code(input));
     stream.into()
+}
+
+#[proc_macro_derive(ClonableView, attributes(view))]
+pub fn derive_clonable_view(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    generate_clonable_view_code(input).into()
 }
 
 #[cfg(test)]

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -407,6 +407,14 @@ pub mod tests {
         }
     }
 
+    #[test]
+    fn test_generate_clonable_view_code() {
+        for context in SpecificContextInfo::test_cases() {
+            let input = context.test_view_input();
+            insta::assert_display_snapshot!(pretty(generate_clonable_view_code(input)));
+        }
+    }
+
     pub struct SpecificContextInfo {
         attribute: Option<TokenStream2>,
         context: Type,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
@@ -1,0 +1,13 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_clonable_view_code(input))
+---
+impl linera_views::views::ClonableView<CustomContext> for TestView {
+    fn clone_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.clone_unchecked()?,
+            collection: self.collection.clone_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-3.snap
@@ -1,0 +1,13 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_clonable_view_code(input))
+---
+impl linera_views::views::ClonableView<custom::path::to::ContextType> for TestView {
+    fn clone_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.clone_unchecked()?,
+            collection: self.collection.clone_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-4.snap
@@ -1,0 +1,13 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_clonable_view_code(input))
+---
+impl linera_views::views::ClonableView<custom::GenericContext<T>> for TestView {
+    fn clone_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.clone_unchecked()?,
+            collection: self.collection.clone_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
@@ -1,0 +1,17 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_clonable_view_code(input))
+---
+impl<C> linera_views::views::ClonableView<C> for TestView<C>
+where
+    C: linera_views::common::Context + Send + Sync + Clone + 'static,
+    linera_views::views::ViewError: From<C::Error>,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.clone_unchecked()?,
+            collection: self.collection.clone_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code-2.snap
@@ -1,0 +1,13 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_sharable_view_code(input))
+---
+impl linera_views::views::SharableView<CustomContext> for TestView {
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code-3.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code-3.snap
@@ -1,0 +1,13 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_sharable_view_code(input))
+---
+impl linera_views::views::SharableView<custom::path::to::ContextType> for TestView {
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code-4.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code-4.snap
@@ -1,0 +1,13 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_sharable_view_code(input))
+---
+impl linera_views::views::SharableView<custom::GenericContext<T>> for TestView {
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_sharable_view_code.snap
@@ -1,0 +1,17 @@
+---
+source: linera-views-derive/src/lib.rs
+expression: pretty(generate_sharable_view_code(input))
+---
+impl<C> linera_views::views::SharableView<C> for TestView<C>
+where
+    C: linera_views::common::Context + Send + Sync + Clone + 'static,
+    linera_views::views::ViewError: From<C::Error>,
+{
+    fn share_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
+        Ok(Self {
+            register: self.register.share_unchecked()?,
+            collection: self.collection.share_unchecked()?,
+        })
+    }
+}
+

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -66,3 +66,4 @@ tokio-test.workspace = true
 
 [dev-dependencies]
 linera-views = { path = ".", features = ["test"] }
+test-case.workspace = true

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::Batch,
     common::{Context, CustomSerialize, HasherOutput, KeyIterable, Update, MIN_VIEW_TAG},
-    views::{HashableView, Hasher, View, ViewError},
+    views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 use async_lock::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use async_trait::async_trait;
@@ -156,6 +156,36 @@ where
         self.delete_storage_first = true;
         self.updates.get_mut().clear();
         *self.hash.get_mut() = None;
+    }
+}
+
+impl<C, W> ClonableView<C> for ByteCollectionView<C, W>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    W: ClonableView<C> + Send + Sync,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        let cloned_updates = self
+            .updates
+            .get_mut()
+            .iter_mut()
+            .map(|(key, value)| {
+                let cloned_value = match value {
+                    Update::Removed => Update::Removed,
+                    Update::Set(view) => Update::Set(view.clone_unchecked()?),
+                };
+                Ok((key.clone(), cloned_value))
+            })
+            .collect::<Result<_, ViewError>>()?;
+
+        Ok(ByteCollectionView {
+            context: self.context.clone(),
+            delete_storage_first: self.delete_storage_first,
+            updates: RwLock::new(cloned_updates),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
     }
 }
 
@@ -646,6 +676,21 @@ where
     }
 }
 
+impl<C, I, W> ClonableView<C> for CollectionView<C, I, W>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    I: Send + Sync + Debug + Serialize + DeserializeOwned,
+    W: ClonableView<C> + Send + Sync,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(CollectionView {
+            collection: self.collection.clone_unchecked()?,
+            _phantom: PhantomData,
+        })
+    }
+}
+
 impl<C, I, W> CollectionView<C, I, W>
 where
     C: Context + Send,
@@ -963,6 +1008,21 @@ where
 
     fn clear(&mut self) {
         self.collection.clear()
+    }
+}
+
+impl<C, I, W> ClonableView<C> for CustomCollectionView<C, I, W>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    I: Send + Sync + Debug,
+    W: ClonableView<C> + Send + Sync,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(CustomCollectionView {
+            collection: self.collection.clone_unchecked()?,
+            _phantom: PhantomData,
+        })
     }
 }
 

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -33,7 +33,7 @@ pub type HasherOutputSize = <sha3::Sha3_256 as sha3::digest::OutputSizeUser>::Ou
 #[doc(hidden)]
 pub type HasherOutput = generic_array::GenericArray<u8, HasherOutputSize>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum Update<T> {
     Removed,
     Set(T),
@@ -458,7 +458,7 @@ impl<E> KeyValueIterable<E> for Vec<(Vec<u8>, Vec<u8>)> {
 /// The context in which a view is operated. Typically, this includes the client to
 /// connect to the database and the address of the current entry.
 #[async_trait]
-pub trait Context {
+pub trait Context: Clone {
     /// The maximal size of values that can be stored.
     const MAX_VALUE_SIZE: usize;
 

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::Batch,
     common::{Context, MIN_VIEW_TAG},
-    views::{HashableView, Hasher, View, ViewError},
+    views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -77,6 +77,24 @@ where
     fn clear(&mut self) {
         self.inner.clear();
         *self.hash.get_mut() = None;
+    }
+}
+
+impl<C, W, O> ClonableView<C> for WrappedHashableContainerView<C, W, O>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    W: HashableView<C> + ClonableView<C>,
+    O: Serialize + DeserializeOwned + Send + Sync + Copy + PartialEq,
+    W::Hasher: Hasher<Output = O>,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(WrappedHashableContainerView {
+            context: self.context.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+            inner: self.inner.clone_unchecked()?,
+        })
     }
 }
 

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::Batch,
     common::{from_bytes_opt, Context, HasherOutput, MIN_VIEW_TAG},
-    views::{HashableView, Hasher, View, ViewError},
+    views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -144,6 +144,25 @@ where
         self.delete_storage_first = true;
         self.new_back_values.clear();
         *self.hash.get_mut() = None;
+    }
+}
+
+impl<C, T> ClonableView<C> for QueueView<C, T>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    T: Clone + Send + Sync + Serialize,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(QueueView {
+            context: self.context.clone(),
+            stored_indices: self.stored_indices.clone(),
+            front_delete_count: self.front_delete_count,
+            delete_storage_first: self.delete_storage_first,
+            new_back_values: self.new_back_values.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
     }
 }
 

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -4,7 +4,7 @@
 use crate::{
     batch::Batch,
     common::{Context, CustomSerialize, HasherOutput, KeyIterable, Update, MIN_VIEW_TAG},
-    views::{HashableView, Hasher, View, ViewError},
+    views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -115,6 +115,22 @@ where
         self.delete_storage_first = true;
         self.updates.clear();
         *self.hash.get_mut() = None;
+    }
+}
+
+impl<C> ClonableView<C> for ByteSetView<C>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(ByteSetView {
+            context: self.context.clone(),
+            delete_storage_first: self.delete_storage_first,
+            updates: self.updates.clone(),
+            stored_hash: self.stored_hash,
+            hash: Mutex::new(*self.hash.get_mut()),
+        })
     }
 }
 
@@ -409,6 +425,20 @@ where
     }
 }
 
+impl<C, I> ClonableView<C> for SetView<C, I>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    I: Send + Sync + Serialize,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(SetView {
+            set: self.set.clone_unchecked()?,
+            _phantom: PhantomData,
+        })
+    }
+}
+
 impl<C, I> SetView<C, I>
 where
     C: Context,
@@ -641,6 +671,20 @@ where
 
     fn clear(&mut self) {
         self.set.clear()
+    }
+}
+
+impl<C, I> ClonableView<C> for CustomSetView<C, I>
+where
+    C: Context + Send + Sync,
+    ViewError: From<C::Error>,
+    I: Send + Sync + CustomSerialize,
+{
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
+        Ok(CustomSetView {
+            set: self.set.clone_unchecked()?,
+            _phantom: PhantomData,
+        })
     }
 }
 

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod test_views;
+
 use crate::batch::{
     WriteOperation,
     WriteOperation::{Delete, Put},

--- a/linera-views/src/test_utils/test_views.rs
+++ b/linera-views/src/test_utils/test_views.rs
@@ -1,0 +1,344 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Some [`View`][`crate::views::View`]s that are easy to use with test cases.
+
+use crate::{
+    self as linera_views,
+    collection_view::CollectionView,
+    log_view::LogView,
+    map_view::MapView,
+    memory::MemoryContext,
+    register_view::RegisterView,
+    views::{ClonableView, RootView, ViewError},
+};
+use async_trait::async_trait;
+use std::{collections::HashMap, fmt::Debug};
+
+/// A [`View`][`crate::views::View`] to be used in test cases.
+#[async_trait]
+pub trait TestView:
+    RootView<MemoryContext<()>> + ClonableView<MemoryContext<()>> + Send + Sync + 'static
+{
+    /// Representation of the view's state.
+    type State: Debug + Eq + Send;
+
+    /// Performs some initial changes to the view, staging them, and returning a representation of
+    /// the view's state.
+    async fn stage_initial_changes(&mut self) -> Result<Self::State, ViewError>;
+
+    /// Stages some changes to the view that won't be persisted during the test.
+    ///
+    /// Assumes that the current view state is the initially staged changes. Returns the updated
+    /// state.
+    async fn stage_changes_to_be_discarded(&mut self) -> Result<Self::State, ViewError>;
+
+    /// Stages some changes to the view that will be persisted during the test.
+    ///
+    /// Assumes that the current view state is the initially staged changes. Returns the updated
+    /// state.
+    async fn stage_changes_to_be_persisted(&mut self) -> Result<Self::State, ViewError>;
+
+    /// Reads the view's current state.
+    async fn read(&self) -> Result<Self::State, ViewError>;
+}
+
+/// Wrapper to test with a [`RegisterView`].
+#[derive(RootView, ClonableView)]
+pub struct TestRegisterView<C> {
+    byte: RegisterView<C, u8>,
+}
+
+#[async_trait]
+impl TestView for TestRegisterView<MemoryContext<()>> {
+    type State = u8;
+
+    async fn stage_initial_changes(&mut self) -> Result<Self::State, ViewError> {
+        let dummy_value = 82;
+        self.byte.set(dummy_value);
+        Ok(dummy_value)
+    }
+
+    async fn stage_changes_to_be_discarded(&mut self) -> Result<Self::State, ViewError> {
+        let dummy_value = 209;
+        self.byte.set(dummy_value);
+        Ok(dummy_value)
+    }
+
+    async fn stage_changes_to_be_persisted(&mut self) -> Result<Self::State, ViewError> {
+        let dummy_value = 15;
+        self.byte.set(dummy_value);
+        Ok(dummy_value)
+    }
+
+    async fn read(&self) -> Result<Self::State, ViewError> {
+        Ok(*self.byte.get())
+    }
+}
+
+/// Wrapper to test with a [`LogView`].
+#[derive(RootView, ClonableView)]
+pub struct TestLogView<C> {
+    log: LogView<C, u16>,
+}
+
+#[async_trait]
+impl TestView for TestLogView<MemoryContext<()>> {
+    type State = Vec<u16>;
+
+    async fn stage_initial_changes(&mut self) -> Result<Self::State, ViewError> {
+        let dummy_values = [1, 2, 3, 4, 5];
+
+        for value in dummy_values {
+            self.log.push(value);
+        }
+
+        Ok(dummy_values.to_vec())
+    }
+
+    async fn stage_changes_to_be_discarded(&mut self) -> Result<Self::State, ViewError> {
+        let initial_state = [1, 2, 3, 4, 5];
+        let new_values = [10_000, 20_000, 30_000];
+
+        for value in new_values {
+            self.log.push(value);
+        }
+
+        Ok(initial_state.into_iter().chain(new_values).collect())
+    }
+
+    async fn stage_changes_to_be_persisted(&mut self) -> Result<Self::State, ViewError> {
+        let initial_state = [1, 2, 3, 4, 5];
+        let new_values = [201, 1, 50_050];
+
+        for value in new_values {
+            self.log.push(value);
+        }
+
+        Ok(initial_state.into_iter().chain(new_values).collect())
+    }
+
+    async fn read(&self) -> Result<Self::State, ViewError> {
+        self.log.read(..).await
+    }
+}
+
+/// Wrapper to test with a [`MapView`].
+#[derive(RootView, ClonableView)]
+pub struct TestMapView<C> {
+    map: MapView<C, i32, String>,
+}
+
+#[async_trait]
+impl TestView for TestMapView<MemoryContext<()>> {
+    type State = HashMap<i32, String>;
+
+    async fn stage_initial_changes(&mut self) -> Result<Self::State, ViewError> {
+        let dummy_values = [
+            (0, "zero"),
+            (-1, "minus one"),
+            (2, "two"),
+            (-3, "minus three"),
+            (4, "four"),
+            (-5, "minus five"),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key, value.to_owned()));
+
+        for (key, value) in dummy_values.clone() {
+            self.map.insert(&key, value)?;
+        }
+
+        Ok(dummy_values.collect())
+    }
+
+    async fn stage_changes_to_be_discarded(&mut self) -> Result<Self::State, ViewError> {
+        let new_entries = [(-1_000_000, "foo"), (2_000_000, "bar")]
+            .into_iter()
+            .map(|(key, value)| (key, value.to_owned()));
+
+        let entries_to_remove = [0, -3];
+
+        for (key, value) in new_entries.clone() {
+            self.map.insert(&key, value)?;
+        }
+
+        for key in entries_to_remove {
+            self.map.remove(&key)?;
+        }
+
+        let initial_state = [
+            (0, "zero"),
+            (-1, "minus one"),
+            (2, "two"),
+            (-3, "minus three"),
+            (4, "four"),
+            (-5, "minus five"),
+        ];
+
+        let new_state = initial_state
+            .into_iter()
+            .filter(|(key, _)| !entries_to_remove.contains(key))
+            .map(|(key, value)| (key, value.to_owned()))
+            .chain(new_entries)
+            .collect();
+
+        Ok(new_state)
+    }
+
+    async fn stage_changes_to_be_persisted(&mut self) -> Result<Self::State, ViewError> {
+        let new_entries = [(1_234, "first new entry"), (-2_101_010, "second_new_entry")]
+            .into_iter()
+            .map(|(key, value)| (key, value.to_owned()));
+
+        let entries_to_remove = [-1, 2, 4];
+
+        for (key, value) in new_entries.clone() {
+            self.map.insert(&key, value)?;
+        }
+
+        for key in entries_to_remove {
+            self.map.remove(&key)?;
+        }
+
+        let initial_state = [
+            (0, "zero"),
+            (-1, "minus one"),
+            (2, "two"),
+            (-3, "minus three"),
+            (4, "four"),
+            (-5, "minus five"),
+        ];
+
+        let new_state = initial_state
+            .into_iter()
+            .filter(|(key, _)| !entries_to_remove.contains(key))
+            .map(|(key, value)| (key, value.to_owned()))
+            .chain(new_entries)
+            .collect();
+
+        Ok(new_state)
+    }
+
+    async fn read(&self) -> Result<Self::State, ViewError> {
+        let mut state = HashMap::new();
+        self.map
+            .for_each_index_value(|key, value| {
+                state.insert(key, value);
+                Ok(())
+            })
+            .await?;
+        Ok(state)
+    }
+}
+
+/// Wrapper to test with a [`CollectionView`].
+#[derive(RootView, ClonableView)]
+pub struct TestCollectionView<C> {
+    collection: CollectionView<C, i32, RegisterView<C, String>>,
+}
+
+#[async_trait]
+impl TestView for TestCollectionView<MemoryContext<()>> {
+    type State = HashMap<i32, String>;
+
+    async fn stage_initial_changes(&mut self) -> Result<Self::State, ViewError> {
+        let dummy_values = [
+            (0, "zero"),
+            (-1, "minus one"),
+            (2, "two"),
+            (-3, "minus three"),
+            (4, "four"),
+            (-5, "minus five"),
+        ]
+        .into_iter()
+        .map(|(key, value)| (key, value.to_owned()));
+
+        for (key, value) in dummy_values.clone() {
+            self.collection.load_entry_mut(&key).await?.set(value);
+        }
+
+        Ok(dummy_values.collect())
+    }
+
+    async fn stage_changes_to_be_discarded(&mut self) -> Result<Self::State, ViewError> {
+        let new_entries = [(-1_000_000, "foo"), (2_000_000, "bar")]
+            .into_iter()
+            .map(|(key, value)| (key, value.to_owned()));
+
+        let entries_to_remove = [0, -3];
+
+        for (key, value) in new_entries.clone() {
+            self.collection.load_entry_mut(&key).await?.set(value);
+        }
+
+        for key in entries_to_remove {
+            self.collection.remove_entry(&key)?;
+        }
+
+        let initial_state = [
+            (0, "zero"),
+            (-1, "minus one"),
+            (2, "two"),
+            (-3, "minus three"),
+            (4, "four"),
+            (-5, "minus five"),
+        ];
+
+        let new_state = initial_state
+            .into_iter()
+            .filter(|(key, _)| !entries_to_remove.contains(key))
+            .map(|(key, value)| (key, value.to_owned()))
+            .chain(new_entries)
+            .collect();
+
+        Ok(new_state)
+    }
+
+    async fn stage_changes_to_be_persisted(&mut self) -> Result<Self::State, ViewError> {
+        let new_entries = [(1_234, "first new entry"), (-2_101_010, "second_new_entry")]
+            .into_iter()
+            .map(|(key, value)| (key, value.to_owned()));
+
+        let entries_to_remove = [-1, 2, 4];
+
+        for (key, value) in new_entries.clone() {
+            self.collection.load_entry_mut(&key).await?.set(value);
+        }
+
+        for key in entries_to_remove {
+            self.collection.remove_entry(&key)?;
+        }
+
+        let initial_state = [
+            (0, "zero"),
+            (-1, "minus one"),
+            (2, "two"),
+            (-3, "minus three"),
+            (4, "four"),
+            (-5, "minus five"),
+        ];
+
+        let new_state = initial_state
+            .into_iter()
+            .filter(|(key, _)| !entries_to_remove.contains(key))
+            .map(|(key, value)| (key, value.to_owned()))
+            .chain(new_entries)
+            .collect();
+
+        Ok(new_state)
+    }
+
+    async fn read(&self) -> Result<Self::State, ViewError> {
+        let indices = self.collection.indices().await?;
+        let mut state = HashMap::with_capacity(indices.len());
+
+        for index in indices {
+            if let Some(value) = self.collection.try_load_entry(&index).await? {
+                state.insert(index, value.get().clone());
+            }
+        }
+
+        Ok(state)
+    }
+}

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -323,3 +323,33 @@ where
 
     Ok(())
 }
+
+/// Check if new staged changes are separate between the cloned view and its source.
+#[test_case(PhantomData::<TestCollectionView<_>>; "with CollectionView")]
+#[test_case(PhantomData::<TestLogView<_>>; "with LogView")]
+#[test_case(PhantomData::<TestMapView<_>>; "with MapView")]
+#[test_case(PhantomData::<TestRegisterView<_>>; "with RegisterView")]
+#[tokio::test]
+async fn test_original_and_clone_stage_changes_separately<V>(
+    _view_type: PhantomData<V>,
+) -> Result<(), anyhow::Error>
+where
+    V: TestView,
+{
+    let context = create_memory_context();
+    let mut original = V::load(context).await?;
+    original.stage_initial_changes().await?;
+
+    let mut first_clone = original.clone_unchecked()?;
+    let second_clone = original.clone_unchecked()?;
+
+    let original_state = original.stage_changes_to_be_discarded().await?;
+    let first_clone_state = first_clone.stage_changes_to_be_persisted().await?;
+    let second_clone_state = second_clone.read().await?;
+
+    assert_ne!(original_state, first_clone_state);
+    assert_ne!(original_state, second_clone_state);
+    assert_ne!(first_clone_state, second_clone_state);
+
+    Ok(())
+}

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -6,10 +6,14 @@ use crate::{
     common::Context,
     memory::{create_memory_context, MemoryContext},
     queue_view::QueueView,
+    test_utils::test_views::{
+        TestCollectionView, TestLogView, TestMapView, TestRegisterView, TestView,
+    },
     views::{View, ViewError},
 };
 use async_trait::async_trait;
-use std::collections::VecDeque;
+use std::{collections::VecDeque, marker::PhantomData};
+use test_case::test_case;
 
 #[cfg(feature = "rocksdb")]
 use {
@@ -294,4 +298,28 @@ impl TestContextFactory for ScyllaDbContextFactory {
 
         Ok(context)
     }
+}
+
+/// Check if a cloned view contains the staged changes from its source.
+#[test_case(PhantomData::<TestCollectionView<_>>; "with CollectionView")]
+#[test_case(PhantomData::<TestLogView<_>>; "with LogView")]
+#[test_case(PhantomData::<TestMapView<_>>; "with MapView")]
+#[test_case(PhantomData::<TestRegisterView<_>>; "with RegisterView")]
+#[tokio::test]
+async fn test_clone_includes_staged_changes<V>(
+    _view_type: PhantomData<V>,
+) -> Result<(), anyhow::Error>
+where
+    V: TestView,
+{
+    let context = create_memory_context();
+    let mut original = V::load(context).await?;
+    let original_state = original.stage_initial_changes().await?;
+
+    let clone = original.clone_unchecked()?;
+    let clone_state = clone.read().await?;
+
+    assert_eq!(original_state, clone_state);
+
+    Ok(())
 }

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -4,7 +4,9 @@
 use crate::{batch::Batch, common::HasherOutput};
 use async_trait::async_trait;
 use linera_base::{crypto::CryptoHash, data_types::ArithmeticError};
-pub use linera_views_derive::{CryptoHashRootView, CryptoHashView, HashableView, RootView, View};
+pub use linera_views_derive::{
+    ClonableView, CryptoHashRootView, CryptoHashView, HashableView, RootView, View,
+};
 use serde::Serialize;
 use std::{fmt::Debug, io::Write};
 use thiserror::Error;

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -173,3 +173,16 @@ pub trait CryptoHashView<C>: HashableView<C> {
 /// A [`RootView`] that also supports crypto hash
 #[async_trait]
 pub trait CryptoHashRootView<C>: RootView<C> + CryptoHashView<C> {}
+
+/// A [`ClonableView`] supports being shared (unsafely) by cloning it.
+///
+/// Sharing is unsafe because by having two view instances for the same data, they may have invalid
+/// state if both are used for writing.
+///
+/// Sharing the view is guaranteed to not cause data races if only one of the shared view instances
+/// is used for writing at any given point in time.
+pub trait ClonableView<C>: View<C> {
+    /// Creates a clone of this view, sharing the underlying storage context but prone to
+    /// data races which can corrupt the view state.
+    fn clone_unchecked(&mut self) -> Result<Self, ViewError>;
+}


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Because views have their state split between the memory type and the persistent storage, it's not safe to share them trivially (using Clone, for example). That's because one view might update the persistent storage with data that conflicts with the memory state of the other view, and that other view has no way to know that it became stale.

However, it is still useful in some scenarios to share views while ensuring the states are valid by other means (e.g., ensuring there is only one of the view instances used for writing to the view).

This is some initial work for https://github.com/linera-io/linera-protocol/issues/1616, in order to be able to share the ChainStateView without having to wait for a ChainGuard unnecessarily.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a `SharableView` trait with a `share_unchecked` method. This ensures that when it is used users are opting in to use it despite its risks by typing the longer name. Implement it for all base view types in `linera-views` and allow it to be derived on types.

## Test Plan

<!-- How to test that the changes are correct. -->
A unit test was included for testing the derive macro.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

- This was split off from #1617 
<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
