### PR TITLE
Get rid of `*_approx` in the end-to-end tests.

### DIFF
--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -11,9 +11,9 @@ use async_graphql::{Error, Object};
 use linera_base::{
     data_types::{Amount, Timestamp},
     doc_scalar,
-    identifiers::{ChainDescription, ChainId},
+    identifiers::{ChainDescription, ChainId, Owner},
 };
-use linera_views::{common::Context, views::ViewError};
+use linera_views::{common::Context, map_view::MapView, views::ViewError};
 use std::collections::BTreeMap;
 
 doc_scalar!(
@@ -106,6 +106,11 @@ where
     #[graphql(derived(name = "balance"))]
     async fn _balance(&self) -> &Amount {
         self.balance.get()
+    }
+
+    #[graphql(derived(name = "balances"))]
+    async fn _balances(&self) -> &MapView<C, Owner, Amount> {
+        &self.balances
     }
 
     #[graphql(derived(name = "timestamp"))]

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -291,6 +291,14 @@ type Entry_Origin_InboxStateView {
 """
 A GraphQL-visible map item, complete with key.
 """
+type Entry_Owner_Amount {
+	key: Owner!
+	value: Amount
+}
+
+"""
+A GraphQL-visible map item, complete with key.
+"""
 type Entry_Target_OutboxStateView {
 	key: Target!
 	value: OutboxStateView!
@@ -406,6 +414,10 @@ input MapFilters_Origin {
 	keys: [Origin!]
 }
 
+input MapFilters_Owner {
+	keys: [Owner!]
+}
+
 input MapFilters_Target {
 	keys: [Target!]
 }
@@ -418,8 +430,18 @@ input MapInput_Origin {
 	filters: MapFilters_Origin
 }
 
+input MapInput_Owner {
+	filters: MapFilters_Owner
+}
+
 input MapInput_Target {
 	filters: MapFilters_Target
+}
+
+type MapView_Owner_Amount {
+	keys(count: Int): [Owner!]!
+	entry(key: Owner!): Entry_Owner_Amount!
+	entries(input: MapInput_Owner): [Entry_Owner_Amount!]!
 }
 
 """
@@ -713,6 +735,7 @@ type SystemExecutionStateView {
 	committees: JSONObject!
 	ownership: ChainOwnership!
 	balance: Amount!
+	balances: MapView_Owner_Amount!
 	timestamp: Timestamp!
 }
 

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -600,6 +600,7 @@ impl ClientWrapper {
         to_public_keys: Vec<PublicKey>,
         weights: Vec<u64>,
         multi_leader_rounds: u32,
+        balance: Amount,
     ) -> Result<(MessageId, ChainId)> {
         let mut command = self.command().await?;
         command
@@ -609,7 +610,8 @@ impl ClientWrapper {
             .args(to_public_keys.iter().map(PublicKey::to_string))
             .arg("--weights")
             .args(weights.iter().map(u64::to_string))
-            .args(["--multi-leader-rounds", &multi_leader_rounds.to_string()]);
+            .args(["--multi-leader-rounds", &multi_leader_rounds.to_string()])
+            .args(["--initial-balance", &balance.to_string()]);
 
         let stdout = command.spawn_and_wait_for_stdout().await?;
         let mut split = stdout.split('\n');

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -476,7 +476,7 @@ impl ClientWrapper {
     }
 
     /// Runs `linera transfer`.
-    pub async fn transfer(&self, amount: Amount, from: Account, to: Account) -> Result<()> {
+    pub async fn transfer(&self, amount: Amount, from: ChainId, to: ChainId) -> Result<()> {
         self.command()
             .await?
             .arg("transfer")

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -476,7 +476,7 @@ impl ClientWrapper {
     }
 
     /// Runs `linera transfer`.
-    pub async fn transfer(&self, amount: Amount, from: ChainId, to: ChainId) -> Result<()> {
+    pub async fn transfer(&self, amount: Amount, from: Account, to: Account) -> Result<()> {
         self.command()
             .await?
             .arg("transfer")

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -962,10 +962,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
 
     // Check balances
     app_fungible0_a
-        .assert_balances([
-            (owner_a, Amount::from_tokens(1)),
-            (owner_b, Amount::from_tokens(0)),
-        ])
+        .assert_balances([(owner_a, Amount::ONE), (owner_b, Amount::ZERO)])
         .await;
     app_fungible0_admin
         .assert_balances([
@@ -974,10 +971,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
         ])
         .await;
     app_fungible1_b
-        .assert_balances([
-            (owner_a, Amount::from_tokens(0)),
-            (owner_b, Amount::from_tokens(1)),
-        ])
+        .assert_balances([(owner_a, Amount::ZERO), (owner_b, Amount::ONE)])
         .await;
     app_fungible1_admin
         .assert_balances([
@@ -1611,7 +1605,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) {
             // Add a new block on the chain, triggering a notification.
             client1
                 .transfer(
-                    Amount::from_tokens(1),
+                    Amount::ONE,
                     Account::chain(chain),
                     Account::chain(ChainId::root(9)),
                 )
@@ -1958,11 +1952,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
         .await
         .unwrap();
     client1
-        .transfer(
-            Amount::from_tokens(1),
-            Account::chain(chain2),
-            Account::chain(chain1),
-        )
+        .transfer(Amount::ONE, Account::chain(chain2), Account::chain(chain1))
         .await
         .unwrap();
     client1.sync(chain1).await.unwrap();
@@ -2124,40 +2114,26 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
 
     // Clients 2 and 3 should have the tokens, and own the chain.
     client2.sync(chain2).await.unwrap();
-    assert_approx(
-        client2.query_balance(Account::chain(chain2)).await.unwrap(),
+    assert_eq!(
+        client2.local_balance(Account::chain(chain2)).await.unwrap(),
         Amount::from_tokens(2),
     );
     client2
-        .transfer(
-            Amount::from_tokens(1),
-            Account::chain(chain2),
-            Account::chain(chain1),
-        )
+        .transfer(Amount::ONE, Account::chain(chain2), Account::chain(chain1))
         .await
         .unwrap();
-    assert_approx(
-        client2.query_balance(Account::chain(chain2)).await.unwrap(),
-        Amount::from_tokens(1),
-    );
+    assert!(client2.local_balance(Account::chain(chain2)).await.unwrap() <= Amount::ONE);
 
     client3.sync(chain3).await.unwrap();
-    assert_approx(
-        client3.query_balance(Account::chain(chain3)).await.unwrap(),
+    assert_eq!(
+        client3.local_balance(Account::chain(chain3)).await.unwrap(),
         Amount::from_tokens(2),
     );
     client3
-        .transfer(
-            Amount::from_tokens(1),
-            Account::chain(chain3),
-            Account::chain(chain1),
-        )
+        .transfer(Amount::ONE, Account::chain(chain3), Account::chain(chain1))
         .await
         .unwrap();
-    assert_approx(
-        client3.query_balance(Account::chain(chain3)).await.unwrap(),
-        Amount::from_tokens(1),
-    );
+    assert!(client3.query_balance(Account::chain(chain3)).await.unwrap() <= Amount::ONE);
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
 }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1377,7 +1377,11 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) {
     let balance_1 = client.query_balance(Account::chain(chain_1)).await.unwrap();
     // Transfer 3 units
     client
-        .transfer(Amount::from_tokens(3), chain_1, chain_2)
+        .transfer(
+            Amount::from_tokens(3),
+            Account::chain(chain_1),
+            Account::chain(chain_2),
+        )
         .await
         .unwrap();
 
@@ -1445,7 +1449,11 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) {
     }
 
     client
-        .transfer(Amount::from_tokens(5), chain_1, chain_2)
+        .transfer(
+            Amount::from_tokens(5),
+            Account::chain(chain_1),
+            Account::chain(chain_2),
+        )
         .await
         .unwrap();
     client.sync(chain_2).await.unwrap();
@@ -1632,7 +1640,11 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) {
         for i in 0..10 {
             // Add a new block on the chain, triggering a notification.
             client1
-                .transfer(Amount::from_tokens(1), chain, ChainId::root(9))
+                .transfer(
+                    Amount::from_tokens(1),
+                    Account::chain(chain),
+                    Account::chain(ChainId::root(9)),
+                )
                 .await
                 .unwrap();
             tokio::time::sleep(Duration::from_secs(i)).await;
@@ -1692,7 +1704,11 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
 
     // Transfer 5 units from Chain 1 to Chain 2.
     client1
-        .transfer(Amount::from_tokens(5), chain1, chain2)
+        .transfer(
+            Amount::from_tokens(5),
+            Account::chain(chain1),
+            Account::chain(chain2),
+        )
         .await
         .unwrap();
     client2.sync(chain2).await.unwrap();
@@ -1940,7 +1956,11 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
 
     // Transfer 6 units from Chain 1 to Chain 2.
     client1
-        .transfer(Amount::from_tokens(6), chain1, chain2)
+        .transfer(
+            Amount::from_tokens(6),
+            Account::chain(chain1),
+            Account::chain(chain2),
+        )
         .await
         .unwrap();
     client2.sync(chain2).await.unwrap();
@@ -1960,11 +1980,19 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
 
     // Transfer 2 + 1 units from Chain 2 to Chain 1 using both clients.
     client2
-        .transfer(Amount::from_tokens(2), chain2, chain1)
+        .transfer(
+            Amount::from_tokens(2),
+            Account::chain(chain2),
+            Account::chain(chain1),
+        )
         .await
         .unwrap();
     client1
-        .transfer(Amount::from_tokens(1), chain2, chain1)
+        .transfer(
+            Amount::from_tokens(1),
+            Account::chain(chain2),
+            Account::chain(chain1),
+        )
         .await
         .unwrap();
     client1.sync(chain1).await.unwrap();
@@ -2026,7 +2054,11 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     // Transfer 6 units from Chain 1 to Chain 2. Remaining:
     // 100 - 3 - 6 - two one block fees = 90.998
     client1
-        .transfer(Amount::from_tokens(6), chain1, chain2)
+        .transfer(
+            Amount::from_tokens(6),
+            Account::chain(chain1),
+            Account::chain(chain2),
+        )
         .await
         .unwrap();
     client2.sync(chain2).await.unwrap();
@@ -2037,7 +2069,11 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
 
     // Transfer 2 units from Chain 2 to Chain 1.
     client2
-        .transfer(Amount::from_tokens(2), chain2, chain1)
+        .transfer(
+            Amount::from_tokens(2),
+            Account::chain(chain2),
+            Account::chain(chain1),
+        )
         .await
         .unwrap();
     client1.sync(chain1).await.unwrap();
@@ -2123,7 +2159,11 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
         Amount::from_tokens(2),
     );
     client2
-        .transfer(Amount::from_tokens(1), chain2, chain1)
+        .transfer(
+            Amount::from_tokens(1),
+            Account::chain(chain2),
+            Account::chain(chain1),
+        )
         .await
         .unwrap();
     assert_approx(
@@ -2137,7 +2177,11 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
         Amount::from_tokens(2),
     );
     client3
-        .transfer(Amount::from_tokens(1), chain3, chain1)
+        .transfer(
+            Amount::from_tokens(1),
+            Account::chain(chain3),
+            Account::chain(chain1),
+        )
         .await
         .unwrap();
     assert_approx(


### PR DESCRIPTION
## Motivation

`assert_approx` asserts a balance with an allowed error margin of 0.1 tokens, because of fees. But having approximate asserts in tests is not a good idea in the long run and can cause false positives as well as negatives.

## Proposal

Remove them, or replace them with either exact comparisons where feasible, or with inequalities, or use owner accounts or the fungible application to make them exact.

## Test Plan

The tests should still all serve their intended purpose. In most cases it is only about checking whether a message has arrived.

## Links

- Close #1637.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
