### PR TITLE
Moving system::Account to linera-base

### DIFF
--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
-use linera_base::{data_types::Amount, identifiers::ChainDescription};
+use linera_base::{
+    data_types::Amount,
+    identifiers::{Account, ChainDescription},
+};
 use linera_core::client::{
     self,
     client_test_utils::{MakeMemoryStorage, NodeProvider, StorageBuilder, TestBuilder},
 };
-use linera_execution::system::{Account, Recipient, UserData};
+use linera_execution::system::{Recipient, UserData};
 use linera_storage::{
     Storage, READ_CERTIFICATE_COUNTER, READ_VALUE_COUNTER, WRITE_CERTIFICATE_COUNTER,
     WRITE_VALUE_COUNTER,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -27,7 +27,7 @@ use linera_base::{
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{Amount, ArithmeticError, BlockHeight, Round, Timestamp},
     ensure,
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -39,7 +39,7 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
     system::{
-        Account, AdminOperation, Recipient, SystemChannel, SystemOperation, UserData,
+        AdminOperation, Recipient, SystemChannel, SystemOperation, UserData,
         CREATE_APPLICATION_MESSAGE_INDEX, OPEN_CHAIN_MESSAGE_INDEX, PUBLISH_BYTECODE_MESSAGE_INDEX,
     },
     Bytecode, ChainOwnership, ExecutionError, Message, Operation, Query, Response,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -22,7 +22,7 @@ use futures::{lock::Mutex, StreamExt};
 use linera_base::{
     crypto::*,
     data_types::*,
-    identifiers::{ChainDescription, ChainId, MessageId, Owner},
+    identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_chain::{
     data_types::{CertificateValue, Event, ExecutedBlock},
@@ -31,7 +31,7 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch},
     policy::ResourceControlPolicy,
-    system::{Account, Recipient, SystemOperation, UserData},
+    system::{Recipient, SystemOperation, UserData},
     ChainOwnership, ExecutionError, Message, Operation, SystemExecutionError, SystemMessage,
     SystemQuery, SystemResponse, TimeoutConfig,
 };

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -16,7 +16,7 @@ use crate::{
 use linera_base::{
     crypto::{BcsSignable, CryptoHash, *},
     data_types::*,
-    identifiers::{ChainDescription, ChainId, ChannelName, Destination, MessageId, Owner},
+    identifiers::{Account, ChainDescription, ChainId, ChannelName, Destination, MessageId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -29,7 +29,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    system::{Account, AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
+    system::{AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
     ChainOwnership, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
     ExecutionStateView, GenericApplicationId, Message, MessageKind, Query, Response,
     SystemExecutionError, SystemExecutionState, SystemQuery, SystemResponse, TimeoutConfig,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -15,7 +15,7 @@ use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, ArithmeticError, Timestamp},
     ensure, hex_debug,
-    identifiers::{BytecodeId, ChainDescription, ChainId, MessageId, Owner},
+    identifiers::{Account, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
 };
 
 #[cfg(with_metrics)]
@@ -35,7 +35,6 @@ use std::{
     collections::BTreeMap,
     fmt::{self, Display, Formatter},
     iter,
-    str::FromStr,
 };
 use thiserror::Error;
 
@@ -353,59 +352,6 @@ impl Recipient {
     #[cfg(any(test, feature = "test"))]
     pub fn root(index: u32) -> Recipient {
         Recipient::chain(ChainId::root(index))
-    }
-}
-
-/// A system account.
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
-pub struct Account {
-    /// The chain of the account.
-    pub chain_id: ChainId,
-    /// The owner of the account, or `None` for the chain balance.
-    pub owner: Option<Owner>,
-}
-
-impl Account {
-    pub fn chain(chain_id: ChainId) -> Self {
-        Account {
-            chain_id,
-            owner: None,
-        }
-    }
-
-    pub fn owner(chain_id: ChainId, owner: Owner) -> Self {
-        Account {
-            chain_id,
-            owner: Some(owner),
-        }
-    }
-}
-
-impl std::fmt::Display for Account {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.owner {
-            Some(owner) => write!(f, "{}:{}", self.chain_id, owner),
-            None => write!(f, "{}", self.chain_id),
-        }
-    }
-}
-
-impl FromStr for Account {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = s.split(':').collect::<Vec<_>>();
-        anyhow::ensure!(
-            parts.len() <= 2,
-            "Expecting format `chain-id:address` or `chain-id`"
-        );
-        if parts.len() == 1 {
-            Ok(Account::chain(s.parse()?))
-        } else {
-            let chain_id = parts[0].parse()?;
-            let owner = parts[1].parse()?;
-            Ok(Account::owner(chain_id, owner))
-        }
     }
 }
 

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -8,9 +8,9 @@ use futures::future::{join_all, try_join_all};
 use linera_base::{
     async_graphql::InputType,
     data_types::Amount,
-    identifiers::{AccountOwner, ApplicationId, ChainId, Owner},
+    identifiers::{Account, AccountOwner, ApplicationId, ChainId, Owner},
 };
-use linera_execution::system::{self, SystemChannel};
+use linera_execution::system::SystemChannel;
 use linera_service::cli_wrappers::{
     ApplicationWrapper, ClientWrapper, Faucet, FaucetOption, Network,
 };
@@ -106,7 +106,7 @@ async fn benchmark_with_fungible(
     try_join_all(clients.iter().map(|user| async move {
         let chain = user.default_chain().context("missing default chain")?;
         user.sync(chain).await?;
-        let balance = user.query_balance(system::Account::chain(chain)).await?;
+        let balance = user.query_balance(Account::chain(chain)).await?;
         info!("User {:?} has {}", user.get_owner(), balance);
         Ok::<_, anyhow::Error>(())
     }))

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -14,13 +14,10 @@ use linera_base::{
     abi::ContractAbi,
     crypto::{CryptoHash, PublicKey},
     data_types::Amount,
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
 use linera_execution::{
-    committee::ValidatorName,
-    policy::ResourceControlPolicy,
-    system::{Account, SystemChannel},
-    Bytecode,
+    committee::ValidatorName, policy::ResourceControlPolicy, system::SystemChannel, Bytecode,
 };
 use linera_version::VersionInfo;
 use serde::{de::DeserializeOwned, ser::Serialize};

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -8,7 +8,7 @@ use futures::{future, lock::Mutex, Future};
 use linera_base::{
     crypto::{CryptoRng, KeyPair},
     data_types::{BlockHeight, Timestamp},
-    identifiers::{BytecodeId, ChainId},
+    identifiers::{Account, BytecodeId, ChainId},
 };
 use linera_chain::data_types::Certificate;
 use linera_core::{
@@ -16,7 +16,7 @@ use linera_core::{
     data_types::ClientOutcome,
     node::{CrossChainMessageDelivery, ValidatorNodeProvider},
 };
-use linera_execution::{system::Account, Bytecode};
+use linera_execution::Bytecode;
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_service::{
     chain_listener,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -7,12 +7,11 @@ use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::PublicKey,
     data_types::Amount,
-    identifiers::{BytecodeId, ChainId, MessageId},
+    identifiers::{Account, BytecodeId, ChainId, MessageId},
 };
 use linera_execution::{
-    committee::ValidatorName,
-    system::{Account, SystemChannel},
-    UserApplicationId, WasmRuntime, WithWasmDefault,
+    committee::ValidatorName, system::SystemChannel, UserApplicationId, WasmRuntime,
+    WithWasmDefault,
 };
 use linera_service::{
     chain_listener::{ChainListenerConfig, ClientContext as _},

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -11,9 +11,8 @@ use common::INTEGRATION_TEST_GUARD;
 use linera_base::{
     crypto::KeyPair,
     data_types::{Amount, Timestamp},
-    identifiers::{AccountOwner, ChainId, Owner},
+    identifiers::{Account, AccountOwner, ChainId, Owner},
 };
-use linera_execution::system::Account;
 use linera_service::{
     cli_wrappers::{
         local_net::{Database, LocalNet, LocalNetConfig},


### PR DESCRIPTION
## Motivation

We'll need `Account` for the Native fungible app, but we can't add a dependency on `linera-execution`

## Proposal

Move `Account` to `linera-base`

## Test Plan

CI

