### PR TITLE
Creating pd-balanced StorageClass for GCP

### DIFF
--- a/kubernetes/linera-validator/templates/prometheus.yaml
+++ b/kubernetes/linera-validator/templates/prometheus.yaml
@@ -35,3 +35,13 @@ spec:
   selector:
     matchLabels:
       app: proxy
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: gce-pd-balanced
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-balanced
+reclaimPolicy: Retain
+allowVolumeExpansion: true


### PR DESCRIPTION
## Motivation

We're now using c3 VM type on GCP, which is incompatible with `pd-standard`

## Proposal

Use `pd-balanced` instead. Local runs can keep using `pd-standard`, which is why I'm not altering anything there. Also setting reclaim policy to `Retain` now, as the default was `Delete` before, which is not what we want.

## Test Plan

Restarted Prometheus pod using this StorageClass on the devnet

