### PR TITLE
silence "unknown lints" warning in two files

### DIFF
--- a/linera-rpc/src/grpc_network.rs
+++ b/linera-rpc/src/grpc_network.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // `tracing::instrument` is not compatible with this nightly Clippy lint
+#![allow(unknown_lints)]
 #![allow(clippy::blocks_in_conditions)]
 
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // `tracing::instrument` is not compatible with this nightly Clippy lint
+#![allow(unknown_lints)]
 #![allow(clippy::blocks_in_conditions)]
 
 use crate::prometheus_server;


### PR DESCRIPTION
## Motivation

Silence lint warnings when not running clippy on nightly (probably caused by #1643).

## Proposal

Use `#![allow(unknown_lints)]` twice.

## Test Plan

CI + ran clippy locally
