### PR TITLE
Implement pagination for `DynamoDB` and `ScyllaDB`.

### DIFF
--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -1409,9 +1409,7 @@ pub async fn list_tables_from_client(
             .send()
             .await?;
         if let Some(table_names_blk) = response.table_names {
-            for table_name in table_names_blk {
-                table_names.push(table_name);
-            }
+            table_names.extend(table_names_blk);
         }
         if response.last_evaluated_table_name.is_none() {
             break;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -525,22 +525,22 @@ impl ScyllaDbStoreInternal {
         let result = session.query(query, &[]).await;
 
         // The missing table translates into a very specific error that we matched
-        let mesg_miss1 = format!("unconfigured table {}", table_name);
-        let mesg_miss1 = mesg_miss1.as_str();
-        let mesg_miss2 = "Undefined name dummy in selection clause";
-        let mesg_miss3 = "Keyspace kv does not exist";
+        let miss_msg1 = format!("unconfigured table {}", table_name);
+        let miss_msg1 = miss_msg1.as_str();
+        let miss_msg2 = "Undefined name dummy in selection clause";
+        let miss_msg3 = "Keyspace kv does not exist";
         let Err(error) = result else {
             // If ok, then the table exists
             return Ok(true);
         };
         let test = match &error {
-            QueryError::DbError(db_error, mesg) => {
+            QueryError::DbError(db_error, msg) => {
                 if *db_error != DbError::Invalid {
                     false
                 } else {
-                    mesg.as_str() == mesg_miss1
-                        || mesg.as_str() == mesg_miss2
-                        || mesg.as_str() == mesg_miss3
+                    msg.as_str() == miss_msg1
+                        || msg.as_str() == miss_msg2
+                        || msg.as_str() == miss_msg3
                 }
             }
             _ => false,
@@ -662,7 +662,7 @@ impl ScyllaDbStoreInternal {
             .known_node(store_config.uri.as_str())
             .build()
             .await?;
-        let mesg_miss = "'kv' not found in keyspaces";
+        let miss_msg = "'kv' not found in keyspaces";
         let mut paging_state = None;
         let mut table_names = Vec::new();
         loop {
@@ -672,17 +672,13 @@ impl ScyllaDbStoreInternal {
             let result = match result {
                 Ok(result) => result,
                 Err(error) => {
-                    let test = match &error {
-                        QueryError::DbError(db_error, mesg) => {
-                            if *db_error != DbError::Invalid {
-                                false
-                            } else {
-                                mesg.as_str() == mesg_miss
-                            }
+                    let invalid_or_not_found = match &error {
+                        QueryError::DbError(db_error, msg) => {
+                            *db_error == DbError::Invalid && msg.as_str() == miss_msg
                         }
                         _ => false,
                     };
-                    if test {
+                    if invalid_or_not_found {
                         return Ok(Vec::new());
                     } else {
                         return Err(ScyllaDbContextError::ScyllaDbQueryError(error));
@@ -690,6 +686,11 @@ impl ScyllaDbStoreInternal {
                 }
             };
             if let Some(rows) = result.rows {
+                // The output of the description is the following:
+                // * The first column is the keyspace (in that case kv)
+                // * The second column is the nature of the object.
+                // * The third column is the name
+                // * The fourth column is the command that built it.
                 for row in rows.into_typed::<(String, String, String, String)>() {
                     let value = row?;
                     if value.1 == "table" {


### PR DESCRIPTION
## Motivation

Several operations are not paged and this can create problems.

## Proposal

The following is done:
* The reading of all tables in `DynamoDb` is done using pagination.
* The same is done for `DynamoDb`.
* The `read_value_internal` and `contains_key_internal` are both paged even if 0 or 1 keys are expected to happen.

## Test Plan

The CI does not change. But this functionality has been revealed when writing the PR https://github.com/linera-io/linera-protocol/pull/1640.

## Release Plan

No change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
