### PR TITLE
Improve generics support for the `#[wit_export]` macro

### DIFF
--- a/linera-witty-macros/src/util/mod.rs
+++ b/linera-witty-macros/src/util/mod.rs
@@ -6,6 +6,8 @@
 mod fields;
 mod specialization;
 
+#[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+pub use self::specialization::Specialization;
 pub use self::{fields::FieldsInformation, specialization::Specializations};
 use heck::ToKebabCase;
 use proc_macro2::{Span, TokenStream};
@@ -52,7 +54,7 @@ pub fn extract_namespace(
 
 /// Changes the [`DeriveInput`] by replacing some generic type parameters with specialized types.
 pub fn apply_specialization_attribute(input: &mut DeriveInput) -> Specializations {
-    Specializations::new(input)
+    Specializations::prepare_derive_input(input)
 }
 
 /// A type representing the parameters for an attribute procedural macro.

--- a/linera-witty-macros/src/util/specialization.rs
+++ b/linera-witty-macros/src/util/specialization.rs
@@ -103,6 +103,14 @@ impl Specializations {
         }
     }
 
+    /// Specializes the types in the `target_type`, either itself or its type parameters.
+    #[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+    pub fn apply_to_type(&self, target_type: &mut Type) {
+        for specialization in &self.0 {
+            specialization.change_types_in_type(target_type);
+        }
+    }
+
     /// Retrieves the information related to generics from the provided [`Generics`] after
     /// applying the specializations from this instance.
     ///

--- a/linera-witty-macros/src/util/specialization.rs
+++ b/linera-witty-macros/src/util/specialization.rs
@@ -95,6 +95,14 @@ impl Specializations {
         specializations.into_iter().flatten()
     }
 
+    /// Specializes the types in the [`Generics`] representation.
+    #[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+    pub fn apply_to_generics(&self, generics: &mut Generics) {
+        for specialization in &self.0 {
+            specialization.apply_to_generics(generics);
+        }
+    }
+
     /// Retrieves the information related to generics from the provided [`Generics`] after
     /// applying the specializations from this instance.
     ///
@@ -226,9 +234,14 @@ impl Specialization {
     /// types generic parameters needs to be changed separately (see
     /// [`Specializatons::specialize_type_generics`].
     pub fn apply_to_derive_input(&self, input: &mut DeriveInput) {
-        self.remove_from_where_clause(input.generics.where_clause.as_mut());
-        self.change_types_in_where_clause(input.generics.where_clause.as_mut());
+        self.apply_to_generics(&mut input.generics);
         self.change_types_in_fields(&mut input.data);
+    }
+
+    /// Replaces a type parameter in the [`Generics`] representation with a specialized type.
+    pub fn apply_to_generics(&self, generics: &mut Generics) {
+        self.remove_from_where_clause(generics.where_clause.as_mut());
+        self.change_types_in_where_clause(generics.where_clause.as_mut());
     }
 
     /// Removes from a [`WhereClause`] all predicates for the [`Self::type_parameter`] that this

--- a/linera-witty-macros/src/wit_export/caller_type_parameter.rs
+++ b/linera-witty-macros/src/wit_export/caller_type_parameter.rs
@@ -1,0 +1,186 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Representation of a shared generic type parameter for the caller.
+
+use proc_macro_error::abort;
+use syn::{
+    punctuated::Punctuated, AngleBracketedGenericArguments, AssocType, GenericArgument, Generics,
+    Ident, PathArguments, PathSegment, PredicateType, Token, TraitBound, TraitBoundModifier, Type,
+    TypeParamBound, TypePath, WhereClause, WherePredicate,
+};
+
+/// Information on the  generic type parameter to use for the caller parameter, if present.
+#[derive(Clone, Copy, Debug)]
+pub enum CallerTypeParameter<'input> {
+    NotPresent,
+    WithoutUserData(&'input Ident),
+    WithUserData {
+        caller: &'input Ident,
+        user_data: &'input Type,
+    },
+}
+
+impl<'input> CallerTypeParameter<'input> {
+    /// Parses a type's [`Generics`] to determine if a caller type parameter should be used.
+    pub fn new(generics: &'input Generics) -> Self {
+        let caller_type_parameter = Self::extract_caller_type_parameter(generics);
+        let user_data_type =
+            caller_type_parameter.and_then(|caller| Self::extract_user_data_type(generics, caller));
+
+        match (caller_type_parameter, user_data_type) {
+            (None, None) => CallerTypeParameter::NotPresent,
+            (Some(caller), None) => CallerTypeParameter::WithoutUserData(caller),
+            (Some(caller), Some(user_data)) => {
+                CallerTypeParameter::WithUserData { caller, user_data }
+            }
+            (None, Some(_)) => unreachable!("Missing caller type parameter"),
+        }
+    }
+
+    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
+    fn extract_caller_type_parameter(generics: &'input Generics) -> Option<&'input Ident> {
+        if generics.type_params().count() > 1 {
+            abort!(
+                generics.params,
+                "`#[wit_export]` supports only one generic type parameter \
+                which is assumed to be the caller instance"
+            );
+        }
+
+        generics
+            .type_params()
+            .next()
+            .map(|parameter| &parameter.ident)
+    }
+
+    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
+    fn extract_user_data_type(
+        generics: &'input Generics,
+        caller_parameter: &Ident,
+    ) -> Option<&'input Type> {
+        Self::extract_caller_bounds(generics.where_clause.as_ref()?, caller_parameter)?
+            .filter_map(Self::extract_caller_bound_path)
+            .filter_map(Self::extract_caller_bound_arguments)
+            .filter_map(Self::extract_caller_user_data_type_argument)
+            .next()
+    }
+
+    /// Extracts the type bounds inside a `where` clause specific to the generic
+    /// `caller_parameter`.
+    fn extract_caller_bounds(
+        where_clause: &'input WhereClause,
+        caller_parameter: &Ident,
+    ) -> Option<impl Iterator<Item = &'input TypeParamBound> + 'input> {
+        where_clause
+            .predicates
+            .iter()
+            .filter_map(|predicate| match predicate {
+                WherePredicate::Type(PredicateType {
+                    bounded_ty: Type::Path(TypePath { qself: None, path }),
+                    bounds,
+                    ..
+                }) if path.is_ident(caller_parameter) => Some(bounds.iter()),
+                _ => None,
+            })
+            .next()
+    }
+
+    /// Extracts the path from a trait `bound`.
+    fn extract_caller_bound_path(
+        bound: &'input TypeParamBound,
+    ) -> Option<impl Iterator<Item = &'input PathSegment> + 'input> {
+        match bound {
+            TypeParamBound::Trait(TraitBound {
+                paren_token: None,
+                modifier: TraitBoundModifier::None,
+                lifetimes: None,
+                path,
+            }) => Some(path.segments.iter()),
+            _ => None,
+        }
+    }
+
+    /// Extracts the generic arguments inside the caller parameter path's `segments`.
+    fn extract_caller_bound_arguments(
+        segments: impl Iterator<Item = &'input PathSegment>,
+    ) -> Option<&'input Punctuated<GenericArgument, Token![,]>> {
+        let mut segments = segments.peekable();
+
+        if matches!(
+            segments.peek(),
+            Some(PathSegment { ident, arguments: PathArguments::None })
+                if ident == "linera_witty",
+        ) {
+            segments.next();
+        }
+
+        match segments.next()? {
+            PathSegment {
+                ident,
+                arguments:
+                    PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                        colon2_token: None,
+                        args,
+                        ..
+                    }),
+            } if ident == "Instance" => {
+                if segments.next().is_some() {
+                    return None;
+                }
+
+                Some(args)
+            }
+            _ => None,
+        }
+    }
+
+    /// Extracts the custom user data [`Type`] from the caller bound's generic `arguments`.
+    fn extract_caller_user_data_type_argument(
+        arguments: &'input Punctuated<GenericArgument, Token![,]>,
+    ) -> Option<&'input Type> {
+        if arguments.len() != 1 {
+            abort!(
+                arguments,
+                "Caller type parameter should have a user data type. \
+                E.g. `Caller: linera_witty::Instance<UserData = CustomData>`"
+            );
+        }
+
+        match arguments
+            .iter()
+            .next()
+            .expect("Missing argument in arguments list")
+        {
+            GenericArgument::AssocType(AssocType {
+                ident,
+                generics: None,
+                ty: user_data,
+                ..
+            }) if ident == "UserData" => Some(user_data),
+            _ => abort!(
+                arguments,
+                "Caller type parameter should have a user data type. \
+                E.g. `Caller: linera_witty::Instance<UserData = CustomData>`"
+            ),
+        }
+    }
+
+    /// Returns the [`Ident`]ifier of the generic type parameter used for the caller.
+    pub fn caller(&self) -> Option<&'input Ident> {
+        match self {
+            CallerTypeParameter::NotPresent => None,
+            CallerTypeParameter::WithoutUserData(caller) => Some(caller),
+            CallerTypeParameter::WithUserData { caller, .. } => Some(caller),
+        }
+    }
+
+    /// Returns the type used for custom user data, if there is a caller type parameter.
+    pub fn user_data(&self) -> Option<&'input Type> {
+        match self {
+            CallerTypeParameter::NotPresent => None,
+            CallerTypeParameter::WithoutUserData(_) => None,
+            CallerTypeParameter::WithUserData { user_data, .. } => Some(user_data),
+        }
+    }
+}

--- a/linera-witty-macros/src/wit_export/caller_type_parameter.rs
+++ b/linera-witty-macros/src/wit_export/caller_type_parameter.rs
@@ -261,6 +261,13 @@ impl<'input> CallerTypeParameter<'input> {
         )
     }
 
+    /// Specializes the the [`CallerTypeParameter`] in the `target_type` with the concrete
+    /// `caller_type`.
+    pub fn specialize_type(&self, target_type: &mut Type, caller_type: Type) {
+        self.build_specializations(caller_type)
+            .apply_to_type(target_type);
+    }
+
     /// Builds the [`Specializatons`] instance to replace the [`CallerTypeParameter`] (if there is
     /// one) with the concrete `caller_type`.
     fn build_specializations(&self, caller_type: Type) -> Specializations {

--- a/linera-witty-macros/src/wit_export/caller_type_parameter.rs
+++ b/linera-witty-macros/src/wit_export/caller_type_parameter.rs
@@ -4,10 +4,11 @@
 //! Representation of a shared generic type parameter for the caller.
 
 use proc_macro_error::abort;
+use std::collections::HashMap;
 use syn::{
     punctuated::Punctuated, AngleBracketedGenericArguments, AssocType, GenericArgument, Generics,
     Ident, PathArguments, PathSegment, PredicateType, Token, TraitBound, TraitBoundModifier, Type,
-    TypeParamBound, TypePath, WhereClause, WherePredicate,
+    TypeParam, TypeParamBound, TypePath, WhereClause, WherePredicate,
 };
 
 /// Information on the  generic type parameter to use for the caller parameter, if present.
@@ -24,72 +25,98 @@ pub enum CallerTypeParameter<'input> {
 impl<'input> CallerTypeParameter<'input> {
     /// Parses a type's [`Generics`] to determine if a caller type parameter should be used.
     pub fn new(generics: &'input Generics) -> Self {
-        let caller_type_parameter = Self::extract_caller_type_parameter(generics);
-        let user_data_type =
-            caller_type_parameter.and_then(|caller| Self::extract_user_data_type(generics, caller));
-
-        match (caller_type_parameter, user_data_type) {
-            (None, None) => CallerTypeParameter::NotPresent,
-            (Some(caller), None) => CallerTypeParameter::WithoutUserData(caller),
-            (Some(caller), Some(user_data)) => {
-                CallerTypeParameter::WithUserData { caller, user_data }
-            }
-            (None, Some(_)) => unreachable!("Missing caller type parameter"),
-        }
-    }
-
-    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
-    fn extract_caller_type_parameter(generics: &'input Generics) -> Option<&'input Ident> {
-        if generics.type_params().count() > 1 {
-            abort!(
-                generics.params,
-                "`#[wit_export]` supports only one generic type parameter \
-                which is assumed to be the caller instance"
-            );
-        }
+        let where_bounds = Self::parse_bounds_from_where_clause(generics.where_clause.as_ref());
 
         generics
             .type_params()
+            .filter_map(|parameter| Self::try_from_parameter(parameter, &where_bounds))
             .next()
-            .map(|parameter| &parameter.ident)
+            .unwrap_or(CallerTypeParameter::NotPresent)
     }
 
-    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
-    fn extract_user_data_type(
-        generics: &'input Generics,
-        caller_parameter: &Ident,
-    ) -> Option<&'input Type> {
-        Self::extract_caller_bounds(generics.where_clause.as_ref()?, caller_parameter)?
-            .filter_map(Self::extract_caller_bound_path)
-            .filter_map(Self::extract_caller_bound_arguments)
-            .filter_map(Self::extract_caller_user_data_type_argument)
-            .next()
-    }
-
-    /// Extracts the type bounds inside a `where` clause specific to the generic
-    /// `caller_parameter`.
-    fn extract_caller_bounds(
-        where_clause: &'input WhereClause,
-        caller_parameter: &Ident,
-    ) -> Option<impl Iterator<Item = &'input TypeParamBound> + 'input> {
+    /// Parses the bounds present in an optional `where_clause`.
+    ///
+    /// Returns a map between constrained types and its predicates.
+    fn parse_bounds_from_where_clause(
+        where_clause: Option<&'input WhereClause>,
+    ) -> HashMap<&'input Ident, Vec<&'input TypeParamBound>> {
         where_clause
-            .predicates
-            .iter()
+            .into_iter()
+            .flat_map(|where_clause| where_clause.predicates.iter())
             .filter_map(|predicate| match predicate {
-                WherePredicate::Type(PredicateType {
-                    bounded_ty: Type::Path(TypePath { qself: None, path }),
-                    bounds,
-                    ..
-                }) if path.is_ident(caller_parameter) => Some(bounds.iter()),
+                WherePredicate::Type(predicate) => Self::extract_predicate_bounds(predicate),
                 _ => None,
             })
-            .next()
+            .collect()
+    }
+
+    /// Extracts the constrained type and its bounds from a predicate.
+    ///
+    /// Returns [`None`] if the predicate does not apply to a type that's a single identifier
+    /// (which could be a generic type parameter).
+    fn extract_predicate_bounds(
+        predicate: &'input PredicateType,
+    ) -> Option<(&'input Ident, Vec<&'input TypeParamBound>)> {
+        let target_identifier = Self::extract_identifier(&predicate.bounded_ty)?;
+
+        Some((target_identifier, predicate.bounds.iter().collect()))
+    }
+
+    /// Extracts the [`Ident`] that forms the `candidate_type`, if the [`Type`] is a single
+    /// identifier.
+    fn extract_identifier(candidate_type: &'input Type) -> Option<&'input Ident> {
+        let Type::Path(TypePath { qself: None, path }) = candidate_type else {
+            return None;
+        };
+
+        if path.leading_colon.is_some() || path.segments.len() != 1 {
+            return None;
+        }
+
+        let segment = path.segments.first()?;
+
+        if !matches!(&segment.arguments, PathArguments::None) {
+            return None;
+        }
+
+        Some(&segment.ident)
+    }
+
+    /// Attempts to create a [`CallerTypeParameter`] from a generic [`TypeParam`].
+    ///
+    /// Succeeds if and only if the `where_bounds` map contains a predicate for the `parameter`.
+    fn try_from_parameter(
+        parameter: &'input TypeParam,
+        where_bounds: &HashMap<&'input Ident, Vec<&'input TypeParamBound>>,
+    ) -> Option<Self> {
+        let caller = &parameter.ident;
+
+        let bounds = where_bounds
+            .get(caller)
+            .into_iter()
+            .flatten()
+            .copied()
+            .chain(parameter.bounds.iter());
+
+        let instance_bound_path_segment = bounds
+            .filter_map(Self::extract_trait_bound_path)
+            .filter_map(Self::extract_instance_bound_path_segment)
+            .next()?;
+
+        let maybe_user_data =
+            Self::extract_instance_bound_arguments(&instance_bound_path_segment.arguments)
+                .and_then(Self::extract_instance_bound_user_data);
+
+        match maybe_user_data {
+            Some(user_data) => Some(CallerTypeParameter::WithUserData { caller, user_data }),
+            None => Some(CallerTypeParameter::WithoutUserData(caller)),
+        }
     }
 
     /// Extracts the path from a trait `bound`.
-    fn extract_caller_bound_path(
+    fn extract_trait_bound_path(
         bound: &'input TypeParamBound,
-    ) -> Option<impl Iterator<Item = &'input PathSegment> + 'input> {
+    ) -> Option<impl Iterator<Item = &'input PathSegment> + Clone + 'input> {
         match bound {
             TypeParamBound::Trait(TraitBound {
                 paren_token: None,
@@ -101,10 +128,33 @@ impl<'input> CallerTypeParameter<'input> {
         }
     }
 
-    /// Extracts the generic arguments inside the caller parameter path's `segments`.
-    fn extract_caller_bound_arguments(
+    /// Extracts the [`PathSegment`] with the generic type parameters that could contain the user
+    /// data type.
+    fn extract_instance_bound_path_segment(
+        segments: impl Iterator<Item = &'input PathSegment> + Clone,
+    ) -> Option<&'input PathSegment> {
+        Self::extract_aliased_instance_bound_path_segment(segments.clone())
+            .or_else(|| Self::extract_direct_instance_bound_path_segment(segments))
+    }
+
+    /// Extracts the [`PathSegment`] for the identifier that uses an `InstanceFor..` trait alias
+    /// generated by Witty.
+    fn extract_aliased_instance_bound_path_segment(
+        mut segments: impl Iterator<Item = &'input PathSegment>,
+    ) -> Option<&'input PathSegment> {
+        let segment = segments.next()?;
+
+        if segment.ident.to_string().starts_with("InstanceFor") && segments.next().is_none() {
+            Some(segment)
+        } else {
+            None
+        }
+    }
+
+    /// Extracts the [`PathSegment`] for the identifier that uses an `Instance` trait directly.
+    fn extract_direct_instance_bound_path_segment(
         segments: impl Iterator<Item = &'input PathSegment>,
-    ) -> Option<&'input Punctuated<GenericArgument, Token![,]>> {
+    ) -> Option<&'input PathSegment> {
         let mut segments = segments.peekable();
 
         if matches!(
@@ -115,28 +165,31 @@ impl<'input> CallerTypeParameter<'input> {
             segments.next();
         }
 
-        match segments.next()? {
-            PathSegment {
-                ident,
-                arguments:
-                    PathArguments::AngleBracketed(AngleBracketedGenericArguments {
-                        colon2_token: None,
-                        args,
-                        ..
-                    }),
-            } if ident == "Instance" => {
-                if segments.next().is_some() {
-                    return None;
-                }
+        let segment = segments.next()?;
 
-                Some(args)
-            }
+        if segment.ident == "Instance" && segments.next().is_none() {
+            Some(segment)
+        } else {
+            None
+        }
+    }
+
+    /// Extracts the generic arguments from `arguments`.
+    fn extract_instance_bound_arguments(
+        arguments: &'input PathArguments,
+    ) -> Option<&'input Punctuated<GenericArgument, Token![,]>> {
+        match arguments {
+            PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+                colon2_token: None,
+                args,
+                ..
+            }) => Some(args),
             _ => None,
         }
     }
 
     /// Extracts the custom user data [`Type`] from the caller bound's generic `arguments`.
-    fn extract_caller_user_data_type_argument(
+    fn extract_instance_bound_user_data(
         arguments: &'input Punctuated<GenericArgument, Token![,]>,
     ) -> Option<&'input Type> {
         if arguments.len() != 1 {

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -169,7 +169,7 @@ impl<'input> FunctionInformation<'input> {
         &self,
         namespace: &LitStr,
         type_name: &Ident,
-        caller: &TokenStream,
+        caller: &Type,
     ) -> TokenStream {
         let input_to_guest_parameters = quote! {
             linera_witty::wasmer::WasmerParameters::from_wasmer(input)
@@ -195,7 +195,7 @@ impl<'input> FunctionInformation<'input> {
         &self,
         namespace: &LitStr,
         type_name: &Ident,
-        caller: &TokenStream,
+        caller: &Type,
     ) -> TokenStream {
         let input_to_guest_parameters = quote! {
             linera_witty::wasmtime::WasmtimeParameters::from_wasmtime(input)
@@ -221,7 +221,7 @@ impl<'input> FunctionInformation<'input> {
         &self,
         namespace: &LitStr,
         type_name: &Ident,
-        caller: &TokenStream,
+        caller: &Type,
     ) -> TokenStream {
         let input_to_guest_parameters = quote! { input };
         let guest_results_to_output = quote! { guest_results };
@@ -242,7 +242,7 @@ impl<'input> FunctionInformation<'input> {
         &self,
         namespace: &LitStr,
         type_name: &Ident,
-        caller: &TokenStream,
+        caller: &Type,
         input_to_guest_parameters: TokenStream,
         guest_results_to_output: TokenStream,
         output_results_trait: TokenStream,

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -5,17 +5,15 @@
 
 #![cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
 
+mod caller_type_parameter;
 mod function_information;
 
-use self::function_information::FunctionInformation;
+use self::{caller_type_parameter::CallerTypeParameter, function_information::FunctionInformation};
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
 use syn::{
-    punctuated::Punctuated, token::Paren, AngleBracketedGenericArguments, AssocType,
-    GenericArgument, Generics, Ident, ItemImpl, LitStr, PathArguments, PathSegment, PredicateType,
-    Token, TraitBound, TraitBoundModifier, Type, TypeParamBound, TypePath, TypeTuple, WhereClause,
-    WherePredicate,
+    punctuated::Punctuated, token::Paren, Ident, ItemImpl, LitStr, Type, TypePath, TypeTuple,
 };
 
 /// Returns the code generated for exporting host functions to guest Wasm instances.
@@ -201,179 +199,4 @@ pub fn type_name(implementation: &ItemImpl) -> &Ident {
             abort!(implementation.self_ty, "Missing type name identifier",);
         })
         .ident
-}
-
-/// Information on the  generic type parameter to use for the caller parameter, if present.
-#[derive(Clone, Copy, Debug)]
-enum CallerTypeParameter<'input> {
-    NotPresent,
-    WithoutUserData(&'input Ident),
-    WithUserData {
-        caller: &'input Ident,
-        user_data: &'input Type,
-    },
-}
-
-impl<'input> CallerTypeParameter<'input> {
-    /// Parses a type's [`Generics`] to determine if a caller type parameter should be used.
-    pub fn new(generics: &'input Generics) -> Self {
-        let caller_type_parameter = Self::extract_caller_type_parameter(generics);
-        let user_data_type =
-            caller_type_parameter.and_then(|caller| Self::extract_user_data_type(generics, caller));
-
-        match (caller_type_parameter, user_data_type) {
-            (None, None) => CallerTypeParameter::NotPresent,
-            (Some(caller), None) => CallerTypeParameter::WithoutUserData(caller),
-            (Some(caller), Some(user_data)) => {
-                CallerTypeParameter::WithUserData { caller, user_data }
-            }
-            (None, Some(_)) => unreachable!("Missing caller type parameter"),
-        }
-    }
-
-    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
-    fn extract_caller_type_parameter(generics: &'input Generics) -> Option<&'input Ident> {
-        if generics.type_params().count() > 1 {
-            abort!(
-                generics.params,
-                "`#[wit_export]` supports only one generic type parameter \
-                which is assumed to be the caller instance"
-            );
-        }
-
-        generics
-            .type_params()
-            .next()
-            .map(|parameter| &parameter.ident)
-    }
-
-    /// Extracts the [`Ident`]ifier used for the caller type parameter, if present.
-    fn extract_user_data_type(
-        generics: &'input Generics,
-        caller_parameter: &Ident,
-    ) -> Option<&'input Type> {
-        Self::extract_caller_bounds(generics.where_clause.as_ref()?, caller_parameter)?
-            .filter_map(Self::extract_caller_bound_path)
-            .filter_map(Self::extract_caller_bound_arguments)
-            .filter_map(Self::extract_caller_user_data_type_argument)
-            .next()
-    }
-
-    /// Extracts the type bounds inside a `where` clause specific to the generic
-    /// `caller_parameter`.
-    fn extract_caller_bounds(
-        where_clause: &'input WhereClause,
-        caller_parameter: &Ident,
-    ) -> Option<impl Iterator<Item = &'input TypeParamBound> + 'input> {
-        where_clause
-            .predicates
-            .iter()
-            .filter_map(|predicate| match predicate {
-                WherePredicate::Type(PredicateType {
-                    bounded_ty: Type::Path(TypePath { qself: None, path }),
-                    bounds,
-                    ..
-                }) if path.is_ident(caller_parameter) => Some(bounds.iter()),
-                _ => None,
-            })
-            .next()
-    }
-
-    /// Extracts the path from a trait `bound`.
-    fn extract_caller_bound_path(
-        bound: &'input TypeParamBound,
-    ) -> Option<impl Iterator<Item = &'input PathSegment> + 'input> {
-        match bound {
-            TypeParamBound::Trait(TraitBound {
-                paren_token: None,
-                modifier: TraitBoundModifier::None,
-                lifetimes: None,
-                path,
-            }) => Some(path.segments.iter()),
-            _ => None,
-        }
-    }
-
-    /// Extracts the generic arguments inside the caller parameter path's `segments`.
-    fn extract_caller_bound_arguments(
-        segments: impl Iterator<Item = &'input PathSegment>,
-    ) -> Option<&'input Punctuated<GenericArgument, Token![,]>> {
-        let mut segments = segments.peekable();
-
-        if matches!(
-            segments.peek(),
-            Some(PathSegment { ident, arguments: PathArguments::None })
-                if ident == "linera_witty",
-        ) {
-            segments.next();
-        }
-
-        match segments.next()? {
-            PathSegment {
-                ident,
-                arguments:
-                    PathArguments::AngleBracketed(AngleBracketedGenericArguments {
-                        colon2_token: None,
-                        args,
-                        ..
-                    }),
-            } if ident == "Instance" => {
-                if segments.next().is_some() {
-                    return None;
-                }
-
-                Some(args)
-            }
-            _ => None,
-        }
-    }
-
-    /// Extracts the custom user data [`Type`] from the caller bound's generic `arguments`.
-    fn extract_caller_user_data_type_argument(
-        arguments: &'input Punctuated<GenericArgument, Token![,]>,
-    ) -> Option<&'input Type> {
-        if arguments.len() != 1 {
-            abort!(
-                arguments,
-                "Caller type parameter should have a user data type. \
-                E.g. `Caller: linera_witty::Instance<UserData = CustomData>`"
-            );
-        }
-
-        match arguments
-            .iter()
-            .next()
-            .expect("Missing argument in arguments list")
-        {
-            GenericArgument::AssocType(AssocType {
-                ident,
-                generics: None,
-                ty: user_data,
-                ..
-            }) if ident == "UserData" => Some(user_data),
-            _ => abort!(
-                arguments,
-                "Caller type parameter should have a user data type. \
-                E.g. `Caller: linera_witty::Instance<UserData = CustomData>`"
-            ),
-        }
-    }
-
-    /// Returns the [`Ident`]ifier of the generic type parameter used for the caller.
-    pub fn caller(&self) -> Option<&'input Ident> {
-        match self {
-            CallerTypeParameter::NotPresent => None,
-            CallerTypeParameter::WithoutUserData(caller) => Some(caller),
-            CallerTypeParameter::WithUserData { caller, .. } => Some(caller),
-        }
-    }
-
-    /// Returns the type used for custom user data, if there is a caller type parameter.
-    pub fn user_data(&self) -> Option<&'input Type> {
-        match self {
-            CallerTypeParameter::NotPresent => None,
-            CallerTypeParameter::WithoutUserData(_) => None,
-            CallerTypeParameter::WithUserData { user_data, .. } => Some(user_data),
-        }
-    }
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `#[wit_export]` macro had very limited support for generic types. The type either could not have any generic type parameters or was required to have only a single generic type parameter that was assumed to be the caller type parameter. This made it hard to use on types that needed other type parameters.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Properly extract the `Generics` information for the `impl` block and use the `Specializations` helper type to specialize the caller type parameter.

The `CallerTypeParameter` was tweaked to help with the process of specializing the caller type parameter with a concrete caller type. The `Specializations` and `Specialization` types were updated so that they could be used as helpers to specialize the types.

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
