### PR TITLE
Closed chains still reject messages.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -56,7 +56,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `subscribe` — Subscribes to a system channel
 * `unsubscribe` — Unsubscribes from a system channel
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
-* `close-chain` — Close (i.e. deactivate) an existing chain
+* `close-chain` — Close an existing chain
 * `local-balance` — Read the current native-token balance of the given account directly from the local state
 * `query-balance` — Simulate the execution of one block made of pending messages from the local inbox, then read the native-token balance of the account from the local state
 * `sync-balance` — (DEPRECATED) Synchronize the local state of the chain with a quorum validators, then query the local balance
@@ -216,7 +216,9 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 
 ## `linera close-chain`
 
-Close (i.e. deactivate) an existing chain
+Close an existing chain.
+
+A closed chain cannot execute operations or accept messages anymore. It can still reject incoming messages, so they bounce back to the sender.
 
 **Usage:** `linera close-chain --from <CHAIN_ID>`
 

--- a/CLI.md
+++ b/CLI.md
@@ -53,8 +53,8 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
 * `transfer` — Transfer funds
 * `open-chain` — Open (i.e. activate) a new chain deriving the UID from an existing one
-* `subscribe` — Subscribes to a system channel
-* `unsubscribe` — Unsubscribes from a system channel
+* `subscribe` — Subscribe to a system channel
+* `unsubscribe` — Unsubscribe from a system channel
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
 * `close-chain` — Close an existing chain
 * `local-balance` — Read the current native-token balance of the given account directly from the local state
@@ -149,7 +149,7 @@ Open (i.e. activate) a new chain deriving the UID from an existing one
 
 ## `linera subscribe`
 
-Subscribes to a system channel
+Subscribe to a system channel
 
 **Usage:** `linera subscribe [OPTIONS] --channel <CHANNEL>`
 
@@ -170,7 +170,7 @@ Subscribes to a system channel
 
 ## `linera unsubscribe`
 
-Unsubscribes from a system channel
+Unsubscribe from a system channel
 
 **Usage:** `linera unsubscribe [OPTIONS] --channel <CHANNEL>`
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -631,6 +631,17 @@ where
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
 
+        if *self.execution_state.system.closed.get() {
+            ensure!(
+                block.operations.is_empty()
+                    && block
+                        .incoming_messages
+                        .iter()
+                        .all(|message| message.action == MessageAction::Reject),
+                ChainError::ClosedChain
+            );
+        }
+
         // The first incoming message of any child chain must be `OpenChain`. A root chain must
         // already be initialized
         if block.height == BlockHeight::ZERO

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -100,7 +100,7 @@ pub struct IncomingMessage {
 }
 
 /// What to do with a message picked from the inbox.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Copy, Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum MessageAction {
     /// Execute the incoming message.
     Accept,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -132,6 +132,8 @@ pub enum ChainError {
     InsufficientBalance,
     #[error("Invalid owner weights: {0}")]
     OwnerWeightError(#[from] WeightedError),
+    #[error("Closed chains cannot have operations or accepted messages")]
+    ClosedChain,
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1226,12 +1226,17 @@ where
             let mut messages = Vec::new();
             let origins = chain.inboxes.indices().await?;
             let inboxes = chain.inboxes.try_load_entries(&origins).await?;
+            let action = if *chain.execution_state.system.closed.get() {
+                MessageAction::Reject
+            } else {
+                MessageAction::Accept
+            };
             for (origin, inbox) in origins.into_iter().zip(inboxes) {
                 for event in inbox.added_events.elements().await? {
                     messages.push(IncomingMessage {
                         origin: origin.clone(),
                         event: event.clone(),
-                        action: MessageAction::Accept,
+                        action: action.clone(),
                     });
                 }
             }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1236,7 +1236,7 @@ where
                     messages.push(IncomingMessage {
                         origin: origin.clone(),
                         event: event.clone(),
-                        action: action.clone(),
+                        action,
                     });
                 }
             }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -63,6 +63,7 @@ where
             balances,
             timestamp,
             registry,
+            closed,
         } = state;
         let extra = TestExecutionRuntimeContext::new(
             description.expect("Chain description should be set").into(),
@@ -95,6 +96,7 @@ where
             .registry
             .import(registry)
             .expect("serialization of registry components should not fail");
+        view.system.closed.set(closed);
         view
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -87,6 +87,8 @@ pub struct SystemExecutionStateView<C> {
     pub timestamp: RegisterView<C, Timestamp>,
     /// Track the locations of known bytecodes as well as the descriptions of known applications.
     pub registry: ApplicationRegistryView<C>,
+    /// Whether this chain has been closed.
+    pub closed: RegisterView<C, bool>,
 }
 
 /// For testing only.
@@ -103,6 +105,7 @@ pub struct SystemExecutionState {
     pub balances: BTreeMap<Owner, Amount>,
     pub timestamp: Timestamp,
     pub registry: ApplicationRegistry,
+    pub closed: bool,
 }
 
 /// A system operation.
@@ -533,7 +536,6 @@ where
                 });
             }
             CloseChain => {
-                self.ownership.set(ChainOwnership::default());
                 // Unsubscribe to all channels.
                 self.subscriptions
                     .for_each_index(|subscription| {
@@ -551,6 +553,7 @@ where
                     })
                     .await?;
                 self.subscriptions.clear();
+                self.closed.set(true);
             }
             Transfer {
                 owner,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -269,7 +269,10 @@ pub enum ClientCommand {
         timeout_increment: Duration,
     },
 
-    /// Close (i.e. deactivate) an existing chain.
+    /// Close an existing chain.
+    ///
+    /// A closed chain cannot execute operations or accept messages anymore.
+    /// It can still reject incoming messages, so they bounce back to the sender.
     CloseChain {
         /// Chain id (must be one of our chains)
         #[arg(long = "from")]

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -193,7 +193,7 @@ pub enum ClientCommand {
         balance: Amount,
     },
 
-    /// Subscribes to a system channel.
+    /// Subscribe to a system channel.
     Subscribe {
         /// Chain id (must be one of our chains).
         #[arg(long)]
@@ -208,7 +208,7 @@ pub enum ClientCommand {
         channel: SystemChannel,
     },
 
-    /// Unsubscribes from a system channel.
+    /// Unsubscribe from a system channel.
     Unsubscribe {
         /// Chain id (must be one of our chains).
         #[arg(long)]


### PR DESCRIPTION
## Motivation

Messages with assets can accidentally get sent to chains that get closed without receiving them. The assets are then lost, unless the closed chain is still able to reject and send them back.

## Proposal

Change what "closing a chain" means: The owners are _not_ removed, and can continue making blocks, but the blocks are now required to
* contain no operations and
* not _accept_ all messages.
But they can still reject messages, so they bounce back to the sender.

## Test Plan

The client tests were updated.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/1653.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
