### PR TITLE
Implement a child process for the linera storage server

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,9 +62,6 @@ jobs:
     - name: Compile the workspace with the default features (build)
       run: |
         cargo build --locked
-    - name: Run the storage service used for the linera-storage-service tests
-      run: |
-        target/debug/storage_service_server memory --endpoint 127.0.0.1:8942 &
     - name: Run all tests using the default features
       run: |
         cargo test --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3583,9 +3583,11 @@ dependencies = [
 name = "linera-storage-service"
 version = "0.6.0"
 dependencies = [
+ "anyhow",
  "async-lock",
  "async-trait",
  "clap 4.4.11",
+ "linera-service",
  "linera-storage-service",
  "linera-views",
  "proptest",

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -21,9 +21,7 @@ use tracing::{debug, error};
 /// This is meant for binaries of the Linera repository. We use the current running binary
 /// to locate the parent directory where to look for the given name.
 pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result<PathBuf> {
-    println!("resolve_binary name={} package={}", name, package);
     let current_binary = std::env::current_exe()?;
-    println!("current_binary={}", current_binary.display());
     resolve_binary_in_same_directory_as(&current_binary, name, package).await
 }
 
@@ -61,7 +59,6 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
     package: &'static str,
 ) -> Result<PathBuf> {
     let current_binary = current_binary.as_ref();
-    println!("current_binary={}", current_binary.display());
     debug!(
         "Resolving binary {name} based on the current binary path: {}",
         current_binary.display()
@@ -69,14 +66,10 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
 
     let current_binary_parent =
         binary_parent(current_binary).expect("Fetching binary directory should not fail");
-    println!("current_binary_parent={}", current_binary_parent.display());
 
     let binary = current_binary_parent.join(name);
-    println!("binary={}", binary.display());
     let version = format!("v{}", env!("CARGO_PKG_VERSION"));
-    println!("version={}", version);
     if !binary.exists() {
-        println!("Not existing case");
         error!(
             "Cannot find a binary {name} in the directory {}. \
              Consider using `cargo install {package}` or `cargo build -p {package}`",
@@ -84,7 +77,6 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
         );
         bail!("Failed to resolve binary {name}");
     }
-    println!("The binary exists");
 
     // Quick version check.
     debug!("Checking the version of {}", binary.display());
@@ -100,9 +92,7 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
         })?
         .stdout;
     let version_message = String::from_utf8_lossy(&version_message);
-    println!("version_message={}", version_message);
     let found_version = parse_version_message(&version_message);
-    println!("version={} found_version={}", version, found_version);
     if version != found_version {
         error!("The binary {name} in directory {} should have version {version} (found {found_version}). \
                 Consider using `cargo install {package} --version '{version}'` or `cargo build -p {package}`",

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -21,7 +21,9 @@ use tracing::{debug, error};
 /// This is meant for binaries of the Linera repository. We use the current running binary
 /// to locate the parent directory where to look for the given name.
 pub async fn resolve_binary(name: &'static str, package: &'static str) -> Result<PathBuf> {
+    println!("resolve_binary name={} package={}", name, package);
     let current_binary = std::env::current_exe()?;
+    println!("current_binary={}", current_binary.display());
     resolve_binary_in_same_directory_as(&current_binary, name, package).await
 }
 
@@ -59,6 +61,7 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
     package: &'static str,
 ) -> Result<PathBuf> {
     let current_binary = current_binary.as_ref();
+    println!("current_binary={}", current_binary.display());
     debug!(
         "Resolving binary {name} based on the current binary path: {}",
         current_binary.display()
@@ -66,10 +69,14 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
 
     let current_binary_parent =
         binary_parent(current_binary).expect("Fetching binary directory should not fail");
+    println!("current_binary_parent={}", current_binary_parent.display());
 
     let binary = current_binary_parent.join(name);
+    println!("binary={}", binary.display());
     let version = format!("v{}", env!("CARGO_PKG_VERSION"));
+    println!("version={}", version);
     if !binary.exists() {
+        println!("Not existing case");
         error!(
             "Cannot find a binary {name} in the directory {}. \
              Consider using `cargo install {package}` or `cargo build -p {package}`",
@@ -77,6 +84,7 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
         );
         bail!("Failed to resolve binary {name}");
     }
+    println!("The binary exists");
 
     // Quick version check.
     debug!("Checking the version of {}", binary.display());
@@ -92,7 +100,9 @@ pub async fn resolve_binary_in_same_directory_as<P: AsRef<Path>>(
         })?
         .stdout;
     let version_message = String::from_utf8_lossy(&version_message);
+    println!("version_message={}", version_message);
     let found_version = parse_version_message(&version_message);
+    println!("version={} found_version={}", version, found_version);
     if version != found_version {
         error!("The binary {name} in directory {} should have version {version} (found {found_version}). \
                 Consider using `cargo install {package} --version '{version}'` or `cargo build -p {package}`",

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -22,9 +22,9 @@ name = "storage_service_server"
 path = "src/server.rs"
 
 [dependencies]
+anyhow = { workspace = true }
 async-lock = { workspace = true }
 async-trait = { workspace = true }
-anyhow = { workspace = true }
 clap = { workspace = true }
 linera-service = { workspace = true }
 linera-views = { workspace = true }

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -22,16 +22,16 @@ name = "storage_service_server"
 path = "src/server.rs"
 
 [dependencies]
-anyhow.workspace = true
 async-lock = { workspace = true }
 async-trait = { workspace = true }
+anyhow = { workspace = true }
 clap = { workspace = true }
+linera-service = { workspace = true }
 linera-views = { workspace = true }
 prost = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tonic = { workspace = true }
-linera-service.workspace = true
 
 [dev-dependencies]
 linera-storage-service = { path = ".", features = ["test"] }

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -22,27 +22,27 @@ name = "storage_service_server"
 path = "src/server.rs"
 
 [dependencies]
-anyhow = { workspace = true }
-async-lock = { workspace = true }
-async-trait = { workspace = true }
-clap = { workspace = true }
-linera-service = { workspace = true }
-linera-views = { workspace = true }
-prost = { workspace = true }
-thiserror = { workspace = true }
+anyhow.workspace = true
+async-lock.workspace = true
+async-trait.workspace = true
+clap.workspace = true
+linera-service.workspace = true
+linera-views.workspace = true
+prost.workspace = true
+thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-tonic = { workspace = true }
+tonic.workspace = true
 
 [dev-dependencies]
 linera-storage-service = { path = ".", features = ["test"] }
-proptest = { workspace = true }
-serde-reflection = { workspace = true }
-serde_yaml = { workspace = true }
-similar-asserts = { workspace = true }
-test-strategy = { workspace = true }
+proptest.workspace = true
+serde-reflection.workspace = true
+serde_yaml.workspace = true
+similar-asserts.workspace = true
+test-strategy.workspace = true
 
 [build-dependencies]
-tonic-build = { workspace = true }
+tonic-build.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["proptest", "prost"]

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -22,6 +22,7 @@ name = "storage_service_server"
 path = "src/server.rs"
 
 [dependencies]
+anyhow.workspace = true
 async-lock = { workspace = true }
 async-trait = { workspace = true }
 clap = { workspace = true }
@@ -30,6 +31,7 @@ prost = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tonic = { workspace = true }
+linera-service.workspace = true
 
 [dev-dependencies]
 linera-storage-service = { path = ".", features = ["test"] }

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -36,7 +36,7 @@ pub struct ChildGuard<'a> {
 }
 
 impl<'a> StorageServiceChild {
-    /// The constructor of the storage service child
+    /// Creates a new `StorageServiceChild`
     pub fn new(endpoint: String, binary: String) -> Self {
         Self { endpoint, binary }
     }

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -11,6 +11,7 @@ use tokio::{
 /// The storage service spanner
 pub struct StorageServiceChild {
     endpoint: String,
+    binary: String,
 }
 
 /// The stores created by the `create_shared_test_store`
@@ -33,13 +34,13 @@ pub struct ChildGuard<'a> {
 
 impl<'a> StorageServiceChild {
     /// The constructor of the storage service child
-    pub fn new(endpoint: String) -> Self {
-        Self { endpoint }
+    pub fn new(endpoint: String, binary: String) -> Self {
+        Self { endpoint, binary }
     }
 
     async fn command(&self) -> Result<Command> {
         println!("Child : command endpoint = {}", self.endpoint);
-        let mut command = Command::new("storage_service_server");
+        let mut command = Command::new(&self.binary);
         command.args(["memory", "--endpoint", &self.endpoint]);
         Ok(command)
     }

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -29,7 +29,7 @@ static SHARED_STORE_SEMAPHORE: Semaphore = Semaphore::const_new(1);
 ///
 /// The guard serves two purposes:
 /// * It protects the child from destruction and ends it on drop
-/// * It make sure that only one server is ever created.
+/// * It makes sure that only one server is ever created.
 pub struct ChildGuard<'a> {
     _child: Child,
     _lock: SemaphorePermit<'a>,

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -25,7 +25,9 @@ pub struct StorageServiceChild {
 /// * After the test, the storage is cleaned
 static SHARED_STORE_SEMAPHORE: Semaphore = Semaphore::const_new(1);
 
-/// The guard implements two things:
+/// A storage service running as a child process.
+///
+/// The guard serves two purposes:
 /// * It protects the child from destruction and ends it on drop
 /// * It make sure that only one server is ever created.
 pub struct ChildGuard<'a> {

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -7,24 +7,20 @@ use std::time::Duration;
 use tokio::process::{Child, Command};
 
 /// Configuration for a storage service running as a child process
-pub struct StorageServiceChild {
+pub struct StorageServiceSpanner {
     endpoint: String,
     binary: String,
 }
 
-/// The tests being done have to run in parallel.
-/// For that we spanned a storage-service per test.
-/// In order to avoid collision, we use a different port per test.
-///
 /// A storage service running as a child process.
 ///
 /// The guard preserves the child from destruction and destroys it when
 /// it drops out of scope.
-pub struct ChildGuard {
+pub struct StorageServiceGuard {
     _child: Child,
 }
 
-impl StorageServiceChild {
+impl StorageServiceSpanner {
     /// Creates a new `StorageServiceChild`
     pub fn new(endpoint: String, binary: String) -> Self {
         Self { endpoint, binary }
@@ -37,10 +33,10 @@ impl StorageServiceChild {
         Ok(command)
     }
 
-    pub async fn run_service(&self) -> Result<ChildGuard> {
+    pub async fn run_service(&self) -> Result<StorageServiceGuard> {
         let mut command = self.command().await?;
         let _child = command.spawn_into()?;
-        let guard = ChildGuard { _child };
+        let guard = StorageServiceGuard { _child };
         tokio::time::sleep(Duration::from_secs(5)).await;
         Ok(guard)
     }

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -9,7 +9,7 @@ use tokio::{
     sync::{Semaphore, SemaphorePermit},
 };
 
-/// The storage service spanner
+/// Configuration for a storage service running as a child process
 pub struct StorageServiceChild {
     endpoint: String,
     binary: String,

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -18,8 +18,8 @@ pub struct StorageServiceChild {
 /// The stores created by the `create_shared_test_store`
 /// are all pointing to the same storage.
 /// This is in contrast to other storage that are not
-/// persistent (e.g. memory) or uses a random table_name
-/// (e.g. RocksDb, DynamoDb, ScyllaDb)
+/// persistent (e.g. memory) or uses a random table name
+/// (e.g. RocksDB, DynamoDB, ScyllaDB)
 /// This requires two changes:
 /// * Only one test being run at a time with a semaphore.
 /// * After the test, the storage is cleaned

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -15,7 +15,7 @@ pub struct StorageServiceChild {
     binary: String,
 }
 
-/// The stores created by the `create_shared_test_store`
+/// The stores created by `create_shared_test_store`
 /// are all pointing to the same storage.
 /// This is in contrast to other storage that are not
 /// persistent (e.g. memory) or uses a random table name

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::client::create_shared_test_store;
 use anyhow::Result;
 use linera_service::util::CommandExt;
 use std::time::Duration;
@@ -37,7 +38,17 @@ impl StorageServiceSpanner {
         let mut command = self.command().await?;
         let _child = command.spawn_into()?;
         let guard = StorageServiceGuard { _child };
-        tokio::time::sleep(Duration::from_secs(5)).await;
-        Ok(guard)
+        // We iterate until the child is spanned and can be accessed.
+        // We add an additional waiting period to avoid problems.
+        let mut wait_period = 1;
+        loop {
+            let result = create_shared_test_store(self.endpoint.clone()).await;
+            if result.is_ok() {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                return Ok(guard);
+            }
+            tokio::time::sleep(Duration::from_secs(wait_period)).await;
+            wait_period += 1;
+        }
     }
 }

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use linera_service::util::CommandExt;
+use tokio::{
+    process::{Child, Command},
+    sync::{Semaphore, SemaphorePermit},
+};
+
+/// The storage service spanner
+pub struct StorageServiceChild {
+    endpoint: String,
+}
+
+/// The stores created by the `create_shared_test_store`
+/// are all pointing to the same storage.
+/// This is in contrast to other storage that are not
+/// persistent (e.g. memory) or uses a random table_name
+/// (e.g. RocksDb, DynamoDb, ScyllaDb)
+/// This requires two changes:
+/// * Only one test being run at a time with a semaphore.
+/// * After the test, the storage is cleaned
+static SHARED_STORE_SEMAPHORE: Semaphore = Semaphore::const_new(1);
+
+/// The guard implements two things:
+/// * It protects the child from destruction and ends it on drop
+/// * It make sure that only one server is ever created.
+pub struct ChildGuard<'a> {
+    _child: Child,
+    _lock: SemaphorePermit<'a>,
+}
+
+impl<'a> StorageServiceChild {
+    /// The constructor of the storage service child
+    pub fn new(endpoint: String) -> Self {
+        Self { endpoint }
+    }
+
+    async fn command(&self) -> Result<Command> {
+        println!("Child : command endpoint = {}", self.endpoint);
+        let mut command = Command::new("storage_service_server");
+        command.args(["memory", "--endpoint", &self.endpoint]);
+        Ok(command)
+    }
+
+    pub async fn run_service(&self) -> Result<ChildGuard<'a>> {
+        println!("Child : run_service, begin");
+        let _lock: SemaphorePermit<'a> = SHARED_STORE_SEMAPHORE.acquire().await?;
+        let mut command = self.command().await?;
+        println!("Child : run_service, we have command");
+        println!("command={:?}", command);
+        let _child = command.spawn_into()?;
+        println!("Child : run_service, we have child");
+        let guard = ChildGuard { _child, _lock };
+        Ok(guard)
+    }
+}

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -215,9 +215,9 @@ pub fn create_shared_store_common_config() -> CommonStoreConfig {
 }
 
 #[cfg(any(test, feature = "test"))]
-pub async fn create_shared_test_store() -> SharedStoreClient {
+pub async fn create_shared_test_store(port: u16) -> SharedStoreClient {
     let common_config = create_shared_store_common_config();
-    let endpoint = "http://127.0.0.1:8942".to_string();
+    let endpoint = format!("http://127.0.0.1:{}", port);
     let store_config = SharedStoreConfig {
         endpoint,
         common_config,

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -215,12 +215,14 @@ pub fn create_shared_store_common_config() -> CommonStoreConfig {
 }
 
 #[cfg(any(test, feature = "test"))]
-pub async fn create_shared_test_store(port: u16) -> SharedStoreClient {
+pub async fn create_shared_test_store(
+    endpoint: String,
+) -> Result<SharedStoreClient, SharedContextError> {
     let common_config = create_shared_store_common_config();
-    let endpoint = format!("http://127.0.0.1:{}", port);
+    let endpoint = format!("http://{}", endpoint);
     let store_config = SharedStoreConfig {
         endpoint,
         common_config,
     };
-    SharedStoreClient::new(store_config).await.unwrap()
+    SharedStoreClient::new(store_config).await
 }

--- a/linera-storage-service/src/lib.rs
+++ b/linera-storage-service/src/lib.rs
@@ -9,5 +9,6 @@ pub mod key_value_store {
     tonic::include_proto!("key_value_store.v1");
 }
 
+pub mod child;
 pub mod client;
 pub mod common;

--- a/linera-storage-service/src/lib.rs
+++ b/linera-storage-service/src/lib.rs
@@ -9,6 +9,7 @@ pub mod key_value_store {
     tonic::include_proto!("key_value_store.v1");
 }
 
+#[cfg(any(test, feature = "test"))]
 pub mod child;
 pub mod client;
 pub mod common;

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_storage_service::child::StorageServiceChild;
-
-use linera_views::{batch::Batch, common::WritableKeyValueStore};
-
 use linera_views::test_utils::{
     get_random_test_scenarios, run_reads, run_writes_from_blank, run_writes_from_state,
 };
@@ -13,43 +10,34 @@ use linera_storage_service::client::create_shared_test_store;
 
 /// The endpoint used for the storage service tests.
 #[cfg(test)]
-fn get_storage_service_guard() -> StorageServiceChild {
-    let storage_service_endpoint = "127.0.0.1:8942";
-    let endpoint = storage_service_endpoint.to_string();
+fn get_storage_service_guard(port: u16) -> StorageServiceChild {
+    let endpoint = format!("127.0.0.1:{}", port);
     let binary = env!("CARGO_BIN_EXE_storage_service_server").to_string();
     StorageServiceChild::new(endpoint, binary)
 }
 
-#[cfg(test)]
-async fn clean_storage() {
-    let key_value_store = create_shared_test_store().await;
-    let mut batch = Batch::new();
-    batch.delete_key_prefix(vec![]);
-    key_value_store.write_batch(batch, &[]).await.unwrap();
-}
-
 #[tokio::test]
 async fn test_reads_shared_store() {
-    let _guard = get_storage_service_guard().run_service().await;
+    let port = 8942;
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_shared_test_store().await;
+        let _guard = get_storage_service_guard(port).run_service().await;
+        let key_value_store = create_shared_test_store(port).await;
         run_reads(key_value_store, scenario).await;
-        clean_storage().await;
     }
 }
 
 #[tokio::test]
 async fn test_shared_store_writes_from_blank() {
-    let _guard = get_storage_service_guard().run_service().await;
-    let key_value_store = create_shared_test_store().await;
+    let port = 8943;
+    let _guard = get_storage_service_guard(port).run_service().await;
+    let key_value_store = create_shared_test_store(port).await;
     run_writes_from_blank(&key_value_store).await;
-    clean_storage().await;
 }
 
 #[tokio::test]
 async fn test_shared_store_writes_from_state() {
-    let _guard = get_storage_service_guard().run_service().await;
-    let key_value_store = create_shared_test_store().await;
+    let port = 8944;
+    let _guard = get_storage_service_guard(port).run_service().await;
+    let key_value_store = create_shared_test_store(port).await;
     run_writes_from_state(&key_value_store).await;
-    clean_storage().await;
 }

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -10,34 +10,39 @@ use linera_storage_service::client::create_shared_test_store;
 
 /// The endpoint used for the storage service tests.
 #[cfg(test)]
-fn get_storage_service_guard(port: u16) -> StorageServiceSpanner {
-    let endpoint = format!("127.0.0.1:{}", port);
+fn get_storage_service_guard(endpoint: String) -> StorageServiceSpanner {
     let binary = env!("CARGO_BIN_EXE_storage_service_server").to_string();
     StorageServiceSpanner::new(endpoint, binary)
 }
 
 #[tokio::test]
 async fn test_reads_shared_store() {
-    let port = 8942;
+    let endpoint = "127.0.0.1:8942".to_string();
     for scenario in get_random_test_scenarios() {
-        let _guard = get_storage_service_guard(port).run_service().await;
-        let key_value_store = create_shared_test_store(port).await;
+        let _guard = get_storage_service_guard(endpoint.clone())
+            .run_service()
+            .await;
+        let key_value_store = create_shared_test_store(endpoint.clone()).await.unwrap();
         run_reads(key_value_store, scenario).await;
     }
 }
 
 #[tokio::test]
 async fn test_shared_store_writes_from_blank() {
-    let port = 8943;
-    let _guard = get_storage_service_guard(port).run_service().await;
-    let key_value_store = create_shared_test_store(port).await;
+    let endpoint = "127.0.0.1:8943".to_string();
+    let _guard = get_storage_service_guard(endpoint.clone())
+        .run_service()
+        .await;
+    let key_value_store = create_shared_test_store(endpoint).await.unwrap();
     run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
 async fn test_shared_store_writes_from_state() {
-    let port = 8944;
-    let _guard = get_storage_service_guard(port).run_service().await;
-    let key_value_store = create_shared_test_store(port).await;
+    let endpoint = "127.0.0.1:8944".to_string();
+    let _guard = get_storage_service_guard(endpoint.clone())
+        .run_service()
+        .await;
+    let key_value_store = create_shared_test_store(endpoint).await.unwrap();
     run_writes_from_state(&key_value_store).await;
 }

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_storage_service::child::StorageServiceChild;
+use linera_storage_service::child::StorageServiceSpanner;
 use linera_views::test_utils::{
     get_random_test_scenarios, run_reads, run_writes_from_blank, run_writes_from_state,
 };
@@ -10,10 +10,10 @@ use linera_storage_service::client::create_shared_test_store;
 
 /// The endpoint used for the storage service tests.
 #[cfg(test)]
-fn get_storage_service_guard(port: u16) -> StorageServiceChild {
+fn get_storage_service_guard(port: u16) -> StorageServiceSpanner {
     let endpoint = format!("127.0.0.1:{}", port);
     let binary = env!("CARGO_BIN_EXE_storage_service_server").to_string();
-    StorageServiceChild::new(endpoint, binary)
+    StorageServiceSpanner::new(endpoint, binary)
 }
 
 #[tokio::test]

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -20,7 +20,6 @@ fn get_storage_service_guard() -> StorageServiceChild {
     StorageServiceChild::new(endpoint, binary)
 }
 
-
 #[cfg(test)]
 async fn clean_storage() {
     let key_value_store = create_shared_test_store().await;

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -12,7 +12,14 @@ use linera_views::test_utils::{
 use linera_storage_service::client::create_shared_test_store;
 
 /// The endpoint used for the storage service tests.
-const STORAGE_SERVICE_ENDPOINT: &str = "127.0.0.1:8942";
+#[cfg(test)]
+fn get_storage_service_guard() -> StorageServiceChild {
+    let storage_service_endpoint = "127.0.0.1:8942";
+    let endpoint = storage_service_endpoint.to_string();
+    let binary = env!("CARGO_BIN_EXE_storage_service_server").to_string();
+    StorageServiceChild::new(endpoint, binary)
+}
+
 
 #[cfg(test)]
 async fn clean_storage() {
@@ -24,9 +31,7 @@ async fn clean_storage() {
 
 #[tokio::test]
 async fn test_reads_shared_store() {
-    let _guard = StorageServiceChild::new(STORAGE_SERVICE_ENDPOINT.to_string())
-        .run_service()
-        .await;
+    let _guard = get_storage_service_guard().run_service().await;
     for scenario in get_random_test_scenarios() {
         let key_value_store = create_shared_test_store().await;
         run_reads(key_value_store, scenario).await;
@@ -36,9 +41,7 @@ async fn test_reads_shared_store() {
 
 #[tokio::test]
 async fn test_shared_store_writes_from_blank() {
-    let _guard = StorageServiceChild::new(STORAGE_SERVICE_ENDPOINT.to_string())
-        .run_service()
-        .await;
+    let _guard = get_storage_service_guard().run_service().await;
     let key_value_store = create_shared_test_store().await;
     run_writes_from_blank(&key_value_store).await;
     clean_storage().await;
@@ -46,9 +49,7 @@ async fn test_shared_store_writes_from_blank() {
 
 #[tokio::test]
 async fn test_shared_store_writes_from_state() {
-    let _guard = StorageServiceChild::new(STORAGE_SERVICE_ENDPOINT.to_string())
-        .run_service()
-        .await;
+    let _guard = get_storage_service_guard().run_service().await;
     let key_value_store = create_shared_test_store().await;
     run_writes_from_state(&key_value_store).await;
     clean_storage().await;


### PR DESCRIPTION
## Motivation

The CI is running with a service that needs to be run before running the tests which is not great.

## Proposal

The following was done:
* A subprocess is created and dropped at the end of the scope.
* A duration has to be introduced to wait for the process to be active.
* The `env!("CARGO_BIN_EXE_...")` method is used for obtaining the binary.

## Test Plan

The CI as it is the whole point.

## Release Plan

Nothing relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
