### PR TITLE
Use the assert_matches crate: more helpful output.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-graphql"
 version = "5.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3159,6 +3165,7 @@ dependencies = [
 name = "linera-chain"
 version = "0.8.0"
 dependencies = [
+ "assert_matches",
  "async-graphql",
  "async-trait",
  "futures",
@@ -3180,6 +3187,7 @@ name = "linera-core"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-graphql",
  "async-trait",
  "bcs",
@@ -3220,6 +3228,7 @@ name = "linera-execution"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-graphql",
  "async-trait",
  "bcs",
@@ -3374,6 +3383,7 @@ name = "linera-rpc"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-trait",
  "bincode",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ resolver = "2"
 [workspace.dependencies]
 heck = "0.4.1"
 anyhow = "1.0.75"
+assert_matches = "1.5.0"
 async-graphql = "5.0.10"
 async-graphql-axum = "5.0.10"
 async-lock = "2.8.0"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -168,6 +168,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-graphql"
 version = "5.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +657,7 @@ dependencies = [
 name = "counter"
 version = "0.1.0"
 dependencies = [
+ "assert_matches",
  "async-graphql",
  "async-trait",
  "bcs",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,6 +11,7 @@ members = [
 ]
 
 [workspace.dependencies]
+assert_matches = "1.5.0"
 async-graphql = { version = "5.0.7", default-features = false }
 async-trait = "0.1.58"
 bcs = "0.1.3"

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -19,6 +19,7 @@ linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
 
 [dev-dependencies]
+assert_matches.workspace = true
 linera-sdk = { workspace = true, features = ["test"] }
 webassembly-test.workspace = true
 

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -106,6 +106,7 @@ pub enum Error {
 #[cfg(test)]
 mod tests {
     use super::{Counter, Error};
+    use assert_matches::assert_matches;
     use futures::FutureExt;
     use linera_sdk::{
         base::{BlockHeight, ChainId, MessageId},
@@ -142,7 +143,7 @@ mod tests {
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
-        assert!(matches!(result, Err(Error::MessagesNotSupported)));
+        assert_matches!(result, Err(Error::MessagesNotSupported));
         assert_eq!(counter.value, initial_value);
     }
 
@@ -180,7 +181,7 @@ mod tests {
             .now_or_never()
             .expect("Execution of counter operation should not await anything");
 
-        assert!(matches!(result, Err(Error::SessionsNotSupported)));
+        assert_matches!(result, Err(Error::SessionsNotSupported));
         assert_eq!(counter.value, initial_value);
     }
 

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -29,6 +29,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 linera-chain = { path = ".", features = ["test"] }
 
 [package.metadata.cargo-machete]

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -60,6 +60,7 @@ tonic.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 counter.workspace = true
 criterion = { workspace = true, features = ["async_tokio"] }
 fungible.workspace = true

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -9,6 +9,7 @@
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
 use crate::client::client_tests::{MakeMemoryStorage, StorageBuilder, TestBuilder};
+use assert_matches::assert_matches;
 use async_graphql::Request;
 use linera_base::{
     data_types::Amount,
@@ -442,13 +443,14 @@ where
             message,
             ..
         } = &messages[0];
-        assert!(matches!(
+        assert_matches!(
             message, Message::System(SystemMessage::RegisterApplications { applications })
             if applications.len() == 1 && matches!(
                 applications[0], UserApplicationDescription{ bytecode_id: b_id, .. }
                 if b_id == bytecode_id.forget_abi()
-            )
-        ));
+            ),
+            "Unexpected message"
+        );
         assert_eq!(*destination, Destination::Recipient(receiver.chain_id()));
     }
     receiver.synchronize_from_validators().await.unwrap();

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -63,6 +63,7 @@ wit-bindgen-host-wasmtime-rust = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace = true
+assert_matches.workspace = true
 bcs.workspace = true
 counter.workspace = true
 linera-base = { workspace = true, features = ["test"] }

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -8,6 +8,7 @@ mod utils;
 use self::utils::{
     create_dummy_user_application_registrations, register_mock_applications, ExpectedCall,
 };
+use assert_matches::assert_matches;
 use linera_base::{
     crypto::PublicKey,
     data_types::BlockHeight,
@@ -56,10 +57,10 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
         )
         .await;
 
-    assert!(matches!(
+    assert_matches!(
         result,
         Err(ExecutionError::ApplicationBytecodeNotFound(desc)) if &*desc == app_desc
-    ));
+    );
     Ok(())
 }
 
@@ -263,10 +264,7 @@ async fn test_leaking_session() -> anyhow::Result<()> {
         )
         .await;
 
-    assert!(matches!(
-        result,
-        Err(ExecutionError::SessionWasNotClosed(_))
-    ));
+    assert_matches!(result, Err(ExecutionError::SessionWasNotClosed(_)));
     Ok(())
 }
 
@@ -400,7 +398,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
         next_message_index: 0,
     };
     let mut controller = ResourceController::default();
-    assert!(matches!(
+    assert_matches!(
         view.execute_operation(
             context,
             Operation::User {
@@ -411,7 +409,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
         )
         .await,
         Err(ExecutionError::UserError(message)) if message == error_message
-    ));
+    );
 
     Ok(())
 }

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -51,6 +51,7 @@ tower.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 linera-rpc = { path = ".", features = ["test"] }
 proptest.workspace = true
 serde-reflection.workspace = true

--- a/linera-rpc/src/codec.rs
+++ b/linera-rpc/src/codec.rs
@@ -118,6 +118,7 @@ impl From<Error> for NodeError {
 #[cfg(test)]
 mod tests {
     use super::{Codec, RpcMessage, PREFIX_SIZE};
+    use assert_matches::assert_matches;
     use bytes::{BufMut, BytesMut};
     use linera_core::data_types::ChainInfoQuery;
     use test_strategy::proptest;
@@ -186,7 +187,7 @@ mod tests {
 
         let result = Codec.encode(message, &mut buffer);
 
-        assert!(matches!(result, Ok(())));
+        assert_matches!(result, Ok(()));
         assert_eq!(&buffer[..frame_start], &leading_bytes);
 
         let prefix = u32::from_le_bytes(


### PR DESCRIPTION
## Motivation

We use `assert!(matches!(value, pattern))` in several tests. If the assertion fails, it does not print the unexpected value.

## Proposal

Use the `assert_matches!` macro instead. This is currently an unstable feature in the standard library, but there is a crate with the same name.

## Test Plan

This should make the existing tests easier to debug.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
