### PR TITLE
Fix code generated for `struct`s with named fields where only one field is skipped

### DIFF
--- a/linera-witty-macros/src/util/fields.rs
+++ b/linera-witty-macros/src/util/fields.rs
@@ -85,18 +85,8 @@ impl<'input> FieldsInformation<'input> {
             FieldsKind::Unit => quote! {},
             FieldsKind::Named => {
                 let bindings = self.non_skipped_fields().map(FieldInformation::name);
-
-                let skipped_field_count = self
-                    .fields
-                    .iter()
-                    .filter(|field| field.is_skipped())
-                    .count();
-
-                let ignored_fields = match skipped_field_count {
-                    0 => quote! {},
-                    1 => quote! { _ },
-                    _ => quote! { .. },
-                };
+                let has_skipped_fields = self.fields.iter().any(|field| field.is_skipped());
+                let ignored_fields = has_skipped_fields.then(|| quote! { .. });
 
                 quote! { { #( #bindings, )* #ignored_fields } }
             }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
If a single field was marked to be skipped by Witty, then the code generated for `WitStore` would not compile. This happened because the code generation used a single underscore (`_`) for ignoring the field, but did not add the field name. That was incorrect.

In other words, for the following input:

```rust
#[derive(WitStore)]
pub struct MyType {
    #[witty(skip)]
    skipped: u8,
    not_skipped: u8,
}
```

the following destructuring was generated:

```rust
let MyType {
    not_skipped,
    _,
} = self;
```

where the correct would be:

```rust
let MyType {
    not_skipped,
    skipped: _,
} = self;
```

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Simplify the code generation and always use two dots instead.

In other words, for the example above, the following is now generated:

```rust
let MyType {
    not_skipped,
    ..
} = self;
```

## Test Plan

<!-- How to test that the changes are correct. -->
A new unit test was added to cover this scenario.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- fixes a bug introduced in #1642 
