### PR TITLE
Make Error an associated type of AdminKeyValueStore.

### DIFF
--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -118,7 +118,7 @@ pub struct DbStorageInner<Client> {
 impl<Client> DbStorageInner<Client>
 where
     Client: KeyValueStore
-        + AdminKeyValueStore<<Client as KeyValueStore>::Error>
+        + AdminKeyValueStore<Error = <Client as KeyValueStore>::Error>
         + Clone
         + Send
         + Sync
@@ -419,7 +419,7 @@ where
 impl<Client> DbStorage<Client, WallClock>
 where
     Client: KeyValueStore
-        + AdminKeyValueStore<<Client as KeyValueStore>::Error>
+        + AdminKeyValueStore<Error = <Client as KeyValueStore>::Error>
         + Clone
         + Send
         + Sync

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -325,7 +325,8 @@ pub struct DynamoDbStoreConfig {
 }
 
 #[async_trait]
-impl AdminKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
+impl AdminKeyValueStore for DynamoDbStoreInternal {
+    type Error = DynamoDbContextError;
     type Config = DynamoDbStoreConfig;
 
     async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, DynamoDbContextError> {
@@ -940,7 +941,8 @@ impl WritableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
 }
 
 #[async_trait]
-impl AdminKeyValueStore<DynamoDbContextError> for DynamoDbStore {
+impl AdminKeyValueStore for DynamoDbStore {
+    type Error = DynamoDbContextError;
     type Config = DynamoDbStoreConfig;
 
     async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, DynamoDbContextError> {

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -160,35 +160,35 @@ where
 }
 
 #[async_trait]
-impl<K, E> AdminKeyValueStore<E> for JournalingKeyValueStore<K>
+impl<K> AdminKeyValueStore for JournalingKeyValueStore<K>
 where
-    K: AdminKeyValueStore<E> + Send + Sync,
-    E: Send,
+    K: AdminKeyValueStore + Send + Sync,
 {
+    type Error = K::Error;
     type Config = K::Config;
 
-    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, E> {
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
         let store = K::connect(config, namespace).await?;
         Ok(Self { store })
     }
 
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, E> {
+    async fn list_all(config: &Self::Config) -> Result<Vec<String>, Self::Error> {
         K::list_all(config).await
     }
 
-    async fn delete_all(config: &Self::Config) -> Result<(), E> {
+    async fn delete_all(config: &Self::Config) -> Result<(), Self::Error> {
         K::delete_all(config).await
     }
 
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, E> {
+    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, Self::Error> {
         K::exists(config, namespace).await
     }
 
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), E> {
+    async fn create(config: &Self::Config, namespace: &str) -> Result<(), Self::Error> {
         K::create(config, namespace).await
     }
 
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), E> {
+    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), Self::Error> {
         K::delete(config, namespace).await
     }
 }

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -145,7 +145,8 @@ impl WritableKeyValueStore<MemoryContextError> for MemoryStore {
 }
 
 #[async_trait]
-impl AdminKeyValueStore<MemoryContextError> for MemoryStore {
+impl AdminKeyValueStore for MemoryStore {
+    type Error = MemoryContextError;
     type Config = MemoryStoreConfig;
 
     async fn connect(config: &Self::Config, _namespace: &str) -> Result<Self, MemoryContextError> {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -246,7 +246,8 @@ impl WritableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
 }
 
 #[async_trait]
-impl AdminKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
+impl AdminKeyValueStore for RocksDbStoreInternal {
+    type Error = RocksDbContextError;
     type Config = RocksDbStoreConfig;
 
     async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, RocksDbContextError> {
@@ -437,7 +438,8 @@ impl WritableKeyValueStore<RocksDbContextError> for RocksDbStore {
 }
 
 #[async_trait]
-impl AdminKeyValueStore<RocksDbContextError> for RocksDbStore {
+impl AdminKeyValueStore for RocksDbStore {
+    type Error = RocksDbContextError;
     type Config = RocksDbStoreConfig;
 
     async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, RocksDbContextError> {

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -475,7 +475,8 @@ impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal
 }
 
 #[async_trait]
-impl AdminKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
+impl AdminKeyValueStore for ScyllaDbStoreInternal {
+    type Error = ScyllaDbContextError;
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, ScyllaDbContextError> {
@@ -749,7 +750,8 @@ impl WritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
 }
 
 #[async_trait]
-impl AdminKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
+impl AdminKeyValueStore for ScyllaDbStore {
+    type Error = ScyllaDbContextError;
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, ScyllaDbContextError> {

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -241,35 +241,35 @@ where
 }
 
 #[async_trait]
-impl<K, E> AdminKeyValueStore<E> for ValueSplittingStore<K>
+impl<K> AdminKeyValueStore for ValueSplittingStore<K>
 where
-    K: AdminKeyValueStore<E> + Send + Sync,
-    E: Send,
+    K: AdminKeyValueStore + Send + Sync,
 {
+    type Error = K::Error;
     type Config = K::Config;
 
-    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, E> {
+    async fn connect(config: &Self::Config, namespace: &str) -> Result<Self, Self::Error> {
         let store = K::connect(config, namespace).await?;
         Ok(Self { store })
     }
 
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, E> {
+    async fn list_all(config: &Self::Config) -> Result<Vec<String>, Self::Error> {
         K::list_all(config).await
     }
 
-    async fn delete_all(config: &Self::Config) -> Result<(), E> {
+    async fn delete_all(config: &Self::Config) -> Result<(), Self::Error> {
         K::delete_all(config).await
     }
 
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, E> {
+    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, Self::Error> {
         K::exists(config, namespace).await
     }
 
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), E> {
+    async fn create(config: &Self::Config, namespace: &str) -> Result<(), Self::Error> {
         K::create(config, namespace).await
     }
 
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), E> {
+    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), Self::Error> {
         K::delete(config, namespace).await
     }
 }

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -12,19 +12,22 @@ use rand::{Rng, SeedableRng};
 use std::{collections::BTreeSet, fmt::Debug};
 
 #[cfg(feature = "rocksdb")]
-use linera_views::rocks_db::{create_rocks_db_test_config, RocksDbContextError, RocksDbStore};
+use linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStore};
 
 #[cfg(feature = "aws")]
-use linera_views::dynamo_db::{create_dynamo_db_test_config, DynamoDbContextError, DynamoDbStore};
+use linera_views::dynamo_db::{create_dynamo_db_test_config, DynamoDbStore};
 
 #[cfg(feature = "scylladb")]
-use linera_views::scylla_db::{create_scylla_db_test_config, ScyllaDbContextError, ScyllaDbStore};
+use linera_views::scylla_db::{create_scylla_db_test_config, ScyllaDbStore};
 
 #[cfg(test)]
-async fn namespaces_with_prefix<E: Debug + Send, S: AdminKeyValueStore<E>>(
+async fn namespaces_with_prefix<S: AdminKeyValueStore>(
     config: &S::Config,
     prefix: &str,
-) -> BTreeSet<String> {
+) -> BTreeSet<String>
+where
+    S::Error: Debug,
+{
     let namespaces = S::list_all(config).await.expect("namespaces");
     namespaces
         .into_iter()
@@ -33,9 +36,12 @@ async fn namespaces_with_prefix<E: Debug + Send, S: AdminKeyValueStore<E>>(
 }
 
 #[cfg(test)]
-async fn admin_test<E: Debug + Send, S: AdminKeyValueStore<E>>(config: &S::Config) {
+async fn admin_test<S: AdminKeyValueStore>(config: &S::Config)
+where
+    S::Error: Debug,
+{
     let prefix = generate_test_namespace();
-    let namespaces = namespaces_with_prefix::<E, S>(config, &prefix).await;
+    let namespaces = namespaces_with_prefix::<S>(config, &prefix).await;
     assert_eq!(namespaces.len(), 0);
     let mut rng = rand::rngs::StdRng::seed_from_u64(2);
     let size = 9;
@@ -54,7 +60,7 @@ async fn admin_test<E: Debug + Send, S: AdminKeyValueStore<E>>(config: &S::Confi
         assert!(S::exists(config, namespace).await.expect("test"));
     }
     // Listing all of them
-    let namespaces = namespaces_with_prefix::<E, S>(config, &prefix).await;
+    let namespaces = namespaces_with_prefix::<S>(config, &prefix).await;
     assert_eq!(namespaces, working_namespaces);
     // Selecting at random some for deletion
     let mut deleted_namespaces = BTreeSet::new();
@@ -74,7 +80,7 @@ async fn admin_test<E: Debug + Send, S: AdminKeyValueStore<E>>(config: &S::Confi
     for namespace in &kept_namespaces {
         assert!(S::exists(config, namespace).await.expect("test"));
     }
-    let namespaces = namespaces_with_prefix::<E, S>(config, &prefix).await;
+    let namespaces = namespaces_with_prefix::<S>(config, &prefix).await;
     assert_eq!(namespaces, kept_namespaces);
     for namespace in kept_namespaces {
         S::delete(config, &namespace)
@@ -87,19 +93,19 @@ async fn admin_test<E: Debug + Send, S: AdminKeyValueStore<E>>(config: &S::Confi
 #[tokio::test]
 async fn admin_test_rocks_db() {
     let (config, _dir) = create_rocks_db_test_config().await;
-    admin_test::<RocksDbContextError, RocksDbStore>(&config).await;
+    admin_test::<RocksDbStore>(&config).await;
 }
 
 #[cfg(feature = "aws")]
 #[tokio::test]
 async fn admin_test_dynamo_db() {
     let config = create_dynamo_db_test_config().await;
-    admin_test::<DynamoDbContextError, DynamoDbStore>(&config).await;
+    admin_test::<DynamoDbStore>(&config).await;
 }
 
 #[cfg(feature = "scylladb")]
 #[tokio::test]
 async fn admin_test_scylla_db() {
     let config = create_scylla_db_test_config().await;
-    admin_test::<ScyllaDbContextError, ScyllaDbStore>(&config).await;
+    admin_test::<ScyllaDbStore>(&config).await;
 }


### PR DESCRIPTION
## Motivation

For every `impl AdminKeyValueStore<E> for T`, the error type `E` is determined by `T`.
Just like with e.g. `Context` or `KeyValueStore`, whose errors are associated types.

## Proposal

Make it an associated type instead.

## Test Plan

(Only refactoring.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
