### PR TITLE
Put both the received and the expected epoch in the InvalidEpoch error.

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1044,7 +1044,10 @@ where
             .expect("chain is active");
         ensure!(
             block.epoch == epoch,
-            WorkerError::InvalidEpoch { chain_id, epoch }
+            WorkerError::InvalidEpoch {
+                chain_id: block.chain_id,
+                epoch: block.epoch
+            }
         );
         if let Some(validated) = validated {
             validated.check(committee)?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -197,7 +197,7 @@ pub enum WorkerError {
     },
     #[error("Cannot confirm a block before its predecessors: {current_block_height:?}")]
     MissingEarlierBlocks { current_block_height: BlockHeight },
-    #[error("Unexpected epoch {epoch:}; chain {chain_id:} is at {chain_epoch:}")]
+    #[error("Unexpected epoch {epoch:}: chain {chain_id:} is at {chain_epoch:}")]
     InvalidEpoch {
         chain_id: ChainId,
         chain_epoch: Epoch,


### PR DESCRIPTION
## Motivation

`WorkerError::InvalidEpoch` currently contains the received, but not the expected epoch.

In one place, we erroneously put the expected epoch in it.

## Proposal

Put both epochs in the error.

## Test Plan

This only makes the error more informative.


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
