### PR TITLE
Allow rejecting protected messages on closed chains.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -636,14 +636,9 @@ where
         let mut messages = Vec::new();
         let mut message_counts = Vec::new();
 
-        if *self.execution_state.system.closed.get() {
+        if self.is_closed() {
             ensure!(
-                !block.incoming_messages.is_empty()
-                    && block.operations.is_empty()
-                    && block
-                        .incoming_messages
-                        .iter()
-                        .all(|message| message.action == MessageAction::Reject),
+                !block.incoming_messages.is_empty() && block.only_rejected_messages(),
                 ChainError::ClosedChain
             );
         }
@@ -723,7 +718,7 @@ where
                     // scrapped.
                     let chain_execution_context = ChainExecutionContext::Block;
                     ensure!(
-                        !message.event.is_protected(),
+                        !message.event.is_protected() || self.is_closed(),
                         ChainError::CannotRejectMessage {
                             chain_id,
                             origin: Box::new(message.origin.clone()),

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -638,7 +638,7 @@ where
 
         if self.is_closed() {
             ensure!(
-                !block.incoming_messages.is_empty() && block.only_rejected_messages(),
+                !block.incoming_messages.is_empty() && block.has_only_rejected_messages(),
                 ChainError::ClosedChain
             );
         }

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -73,6 +73,16 @@ impl Block {
         }
         locations
     }
+
+    /// Returns whether the block contains only rejected incoming messages, which
+    /// makes it admissible even on closed chains.
+    pub fn only_rejected_messages(&self) -> bool {
+        self.operations.is_empty()
+            && self
+                .incoming_messages
+                .iter()
+                .all(|message| message.action == MessageAction::Reject)
+    }
 }
 
 /// A chain ID with a block height.

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -76,7 +76,7 @@ impl Block {
 
     /// Returns whether the block contains only rejected incoming messages, which
     /// makes it admissible even on closed chains.
-    pub fn only_rejected_messages(&self) -> bool {
+    pub fn has_only_rejected_messages(&self) -> bool {
         self.operations.is_empty()
             && self
                 .incoming_messages


### PR DESCRIPTION
## Motivation

Closed chains should reject all messages, including protected ones.

## Proposal

Make an exception to the rule: now protected messages _can_ be rejected, but only on closed chains.

## Test Plan

The client test was extended.

## Links

- #1661 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
