### PR TITLE
Waive block fee on closed chains; disallow empty blocks.

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -132,7 +132,7 @@ pub enum ChainError {
     InsufficientBalance,
     #[error("Invalid owner weights: {0}")]
     OwnerWeightError(#[from] WeightedError),
-    #[error("Closed chains cannot have operations or accepted messages")]
+    #[error("Closed chains cannot have operations, accepted messages or empty blocks")]
     ClosedChain,
 }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1055,6 +1055,14 @@ where
             ..
         } if sender == ChainId::root(2)
     );
+
+    // Since blocks are free of charge on closed chains, empty blocks are not allowed.
+    assert_matches!(
+        client1.execute_operations(vec![]).await,
+        Err(ChainClientError::LocalNodeError(
+            LocalNodeError::WorkerError(WorkerError::ChainError(error))
+        )) if matches!(*error, ChainError::ClosedChain)
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Motivation

Closed chains should be able to reject messages, even if their chain balance is empty.

## Proposal

Waive the block fee on closed chains. Rejecting messages is already free anyway.

Since empty blocks are now free of charge but still create work for the system, disallow them: They are not necessary anymore, even in single-leader mode, because every leader should be able to see the same incoming messages eventually.

## Test Plan

The client test was extended.

## Links

- #1661
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
