### PR TITLE
Refactor Witty feature flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,7 @@ dependencies = [
 name = "linera-witty-macros"
 version = "0.8.0"
 dependencies = [
+ "cfg_aliases",
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,7 @@ name = "linera-witty"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "cfg_aliases",
  "either",
  "frunk",
  "linera-witty",

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 proc-macro = true
 
 [features]
-mock-instance = ["syn/extra-traits"]
+test = ["syn/extra-traits"]
 wasmer = ["syn/extra-traits"]
 wasmtime = ["syn/extra-traits"]
 

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -24,3 +24,6 @@ proc-macro-error.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }
+
+[build-dependencies]
+cfg_aliases.workspace = true

--- a/linera-witty-macros/build.rs
+++ b/linera-witty-macros/build.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    cfg_aliases::cfg_aliases! {
+        with_testing: { feature = "test" },
+        with_wasmer: { feature = "wasmer" },
+        with_wasmtime: { feature = "wasmtime" },
+        with_wit_export: {
+            any(feature = "test", feature = "wasmer", feature = "wasmtime")
+        },
+    }
+}

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -19,7 +19,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
-#[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_wit_export)]
 use syn::ItemImpl;
 use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
 
@@ -142,7 +142,7 @@ pub fn wit_import(attribute: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// The code generated depends on the enabled feature flags to determine which Wasm runtimes will
 /// be supported.
-#[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_wit_export)]
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn wit_export(attribute: TokenStream, input: TokenStream) -> TokenStream {

--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -19,7 +19,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::{quote, ToTokens};
-#[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+#[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
 use syn::ItemImpl;
 use syn::{parse_macro_input, Data, DeriveInput, Ident, ItemTrait};
 
@@ -142,7 +142,7 @@ pub fn wit_import(attribute: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// The code generated depends on the enabled feature flags to determine which Wasm runtimes will
 /// be supported.
-#[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+#[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn wit_export(attribute: TokenStream, input: TokenStream) -> TokenStream {

--- a/linera-witty-macros/src/util/mod.rs
+++ b/linera-witty-macros/src/util/mod.rs
@@ -6,7 +6,7 @@
 mod fields;
 mod specialization;
 
-#[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+#[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
 pub use self::specialization::Specialization;
 pub use self::{fields::FieldsInformation, specialization::Specializations};
 use heck::ToKebabCase;

--- a/linera-witty-macros/src/util/mod.rs
+++ b/linera-witty-macros/src/util/mod.rs
@@ -6,7 +6,7 @@
 mod fields;
 mod specialization;
 
-#[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_wit_export)]
 pub use self::specialization::Specialization;
 pub use self::{fields::FieldsInformation, specialization::Specializations};
 use heck::ToKebabCase;

--- a/linera-witty-macros/src/util/specialization.rs
+++ b/linera-witty-macros/src/util/specialization.rs
@@ -96,7 +96,7 @@ impl Specializations {
     }
 
     /// Specializes the types in the [`Generics`] representation.
-    #[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
+    #[cfg(with_wit_export)]
     pub fn apply_to_generics(&self, generics: &mut Generics) {
         for specialization in &self.0 {
             specialization.apply_to_generics(generics);
@@ -104,7 +104,7 @@ impl Specializations {
     }
 
     /// Specializes the types in the `target_type`, either itself or its type parameters.
-    #[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
+    #[cfg(with_wit_export)]
     pub fn apply_to_type(&self, target_type: &mut Type) {
         for specialization in &self.0 {
             specialization.change_types_in_type(target_type);
@@ -228,7 +228,7 @@ impl Parse for Specialization {
 impl Specialization {
     /// Creates a new specialization for the `type_parameter`, to specialize it into the
     /// `specialized_type`.
-    #[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
+    #[cfg(with_wit_export)]
     pub fn new(type_parameter: Ident, specialized_type: Type) -> Self {
         Specialization {
             type_parameter,

--- a/linera-witty-macros/src/util/specialization.rs
+++ b/linera-witty-macros/src/util/specialization.rs
@@ -96,7 +96,7 @@ impl Specializations {
     }
 
     /// Specializes the types in the [`Generics`] representation.
-    #[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+    #[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
     pub fn apply_to_generics(&self, generics: &mut Generics) {
         for specialization in &self.0 {
             specialization.apply_to_generics(generics);
@@ -104,7 +104,7 @@ impl Specializations {
     }
 
     /// Specializes the types in the `target_type`, either itself or its type parameters.
-    #[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+    #[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
     pub fn apply_to_type(&self, target_type: &mut Type) {
         for specialization in &self.0 {
             specialization.change_types_in_type(target_type);
@@ -228,7 +228,7 @@ impl Parse for Specialization {
 impl Specialization {
     /// Creates a new specialization for the `type_parameter`, to specialize it into the
     /// `specialized_type`.
-    #[cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+    #[cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
     pub fn new(type_parameter: Ident, specialized_type: Type) -> Self {
         Specialization {
             type_parameter,

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -216,7 +216,7 @@ impl<'input> FunctionInformation<'input> {
     }
 
     /// Generates the code to export a host function using a mock Wasm instance for testing.
-    #[cfg(feature = "mock-instance")]
+    #[cfg(feature = "test")]
     pub fn generate_for_mock_instance(
         &self,
         namespace: &LitStr,

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -164,7 +164,7 @@ impl<'input> FunctionInformation<'input> {
     }
 
     /// Generates the code to export a host function using the Wasmer runtime.
-    #[cfg(feature = "wasmer")]
+    #[cfg(with_wasmer)]
     pub fn generate_for_wasmer(
         &self,
         namespace: &LitStr,
@@ -190,7 +190,7 @@ impl<'input> FunctionInformation<'input> {
     }
 
     /// Generates the code to export a host function using the Wasmtime runtime.
-    #[cfg(feature = "wasmtime")]
+    #[cfg(with_wasmtime)]
     pub fn generate_for_wasmtime(
         &self,
         namespace: &LitStr,
@@ -216,7 +216,7 @@ impl<'input> FunctionInformation<'input> {
     }
 
     /// Generates the code to export a host function using a mock Wasm instance for testing.
-    #[cfg(feature = "test")]
+    #[cfg(with_testing)]
     pub fn generate_for_mock_instance(
         &self,
         namespace: &LitStr,

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -3,6 +3,7 @@
 
 //! Generation of code to export host functions to a Wasm guest instance.
 
+// TODO(#1683): Remove feature flags by generating runtime agnostic code
 #![cfg(with_wit_export)]
 
 mod caller_type_parameter;

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -3,7 +3,7 @@
 
 //! Generation of code to export host functions to a Wasm guest instance.
 
-#![cfg(any(feature = "mock-instance", feature = "wasmer", feature = "wasmtime"))]
+#![cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
 
 mod caller_type_parameter;
 mod function_information;
@@ -124,7 +124,7 @@ impl<'input> WitExportGenerator<'input> {
 
     /// Generates the code to export functions to a mock instance for testing.
     fn generate_for_mock_instance(&mut self) -> Option<TokenStream> {
-        #[cfg(feature = "mock-instance")]
+        #[cfg(feature = "test")]
         {
             let user_data_type = self.user_data_type();
             let export_target = quote! { linera_witty::MockInstance<#user_data_type> };
@@ -140,7 +140,7 @@ impl<'input> WitExportGenerator<'input> {
 
             Some(self.generate_for(export_target, &target_caller_type, exported_functions))
         }
-        #[cfg(not(feature = "mock-instance"))]
+        #[cfg(not(feature = "test"))]
         {
             None
         }

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -3,7 +3,7 @@
 
 //! Generation of code to export host functions to a Wasm guest instance.
 
-#![cfg(any(feature = "test", feature = "wasmer", feature = "wasmtime"))]
+#![cfg(with_wit_export)]
 
 mod caller_type_parameter;
 mod function_information;
@@ -80,7 +80,7 @@ impl<'input> WitExportGenerator<'input> {
 
     /// Generates the code to export functions using the Wasmer runtime.
     fn generate_for_wasmer(&mut self) -> Option<TokenStream> {
-        #[cfg(feature = "wasmer")]
+        #[cfg(with_wasmer)]
         {
             let user_data_type = self.user_data_type();
             let export_target = quote! { linera_witty::wasmer::InstanceBuilder<#user_data_type> };
@@ -96,7 +96,7 @@ impl<'input> WitExportGenerator<'input> {
 
             Some(self.generate_for(export_target, &target_caller_type, exported_functions))
         }
-        #[cfg(not(feature = "wasmer"))]
+        #[cfg(not(with_wasmer))]
         {
             None
         }
@@ -104,7 +104,7 @@ impl<'input> WitExportGenerator<'input> {
 
     /// Generates the code to export functions using the Wasmtime runtime.
     fn generate_for_wasmtime(&mut self) -> Option<TokenStream> {
-        #[cfg(feature = "wasmtime")]
+        #[cfg(with_wasmtime)]
         {
             let user_data_type = self.user_data_type();
             let export_target = quote! { linera_witty::wasmtime::Linker<#user_data_type> };
@@ -116,7 +116,7 @@ impl<'input> WitExportGenerator<'input> {
 
             Some(self.generate_for(export_target, &target_caller_type, exported_functions))
         }
-        #[cfg(not(feature = "wasmtime"))]
+        #[cfg(not(with_wasmtime))]
         {
             None
         }
@@ -124,7 +124,7 @@ impl<'input> WitExportGenerator<'input> {
 
     /// Generates the code to export functions to a mock instance for testing.
     fn generate_for_mock_instance(&mut self) -> Option<TokenStream> {
-        #[cfg(feature = "test")]
+        #[cfg(with_testing)]
         {
             let user_data_type = self.user_data_type();
             let export_target = quote! { linera_witty::MockInstance<#user_data_type> };
@@ -140,7 +140,7 @@ impl<'input> WitExportGenerator<'input> {
 
             Some(self.generate_for(export_target, &target_caller_type, exported_functions))
         }
-        #[cfg(not(feature = "test"))]
+        #[cfg(not(with_testing))]
         {
             None
         }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2021"
 [features]
 default = ["macros"]
 macros = ["linera-witty-macros"]
-test = ["linera-witty-macros?/mock-instance"]
+test = ["linera-witty-macros?/test"]
 wasmer = ["dep:wasmer", "linera-witty-macros?/wasmer", "wasmer-vm"]
-wasmtime = ["dep:wasmtime", "anyhow", "linera-witty-macros?/wasmtime"]
+wasmtime = ["dep:wasmtime", "linera-witty-macros?/wasmtime"]
 
 [dependencies]
-anyhow = { workspace = true, optional = true }
+anyhow.workspace = true
 either.workspace = true
 frunk.workspace = true
 linera-witty-macros = { workspace = true, optional = true }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -31,3 +31,6 @@ wasmtime = { workspace = true, optional = true }
 linera-witty = { workspace = true, features = ["macros", "test"] }
 test-case.workspace = true
 tracing.workspace = true
+
+[build-dependencies]
+cfg_aliases.workspace = true

--- a/linera-witty/build.rs
+++ b/linera-witty/build.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    cfg_aliases::cfg_aliases! {
+        with_testing: { any(test, feature = "test") },
+        with_wasmer: { feature = "wasmer" },
+        with_wasmtime: { feature = "wasmtime" },
+        with_macros: { feature = "macros" },
+        with_wit_export: {
+            all(
+                feature = "macros",
+                any(feature = "test", feature = "wasmer", feature = "wasmtime")
+            )
+        },
+    }
+}

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -22,11 +22,11 @@ mod runtime;
 mod type_traits;
 mod util;
 
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 pub use self::runtime::wasmer;
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 pub use self::runtime::wasmtime;
-#[cfg(any(test, feature = "test"))]
+#[cfg(with_testing)]
 pub use self::runtime::{MockExportedFunction, MockInstance, MockResults, MockRuntime};
 pub use self::{
     exported_function_interface::{ExportFunction, ExportTo, ExportedFunctionInterface},
@@ -40,10 +40,7 @@ pub use self::{
     util::{Merge, Split},
 };
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
-#[cfg(all(
-    feature = "macros",
-    any(feature = "test", feature = "wasmer", feature = "wasmtime")
-))]
+#[cfg(with_wit_export)]
 pub use linera_witty_macros::wit_export;
-#[cfg(feature = "macros")]
+#[cfg(with_macros)]
 pub use linera_witty_macros::{wit_import, WitLoad, WitStore, WitType};

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -50,22 +50,22 @@ pub enum RuntimeError {
     InvalidVariant,
 
     /// Wasmer runtime error.
-    #[cfg(feature = "wasmer")]
+    #[cfg(with_wasmer)]
     #[error(transparent)]
     Wasmer(#[from] wasmer::RuntimeError),
 
     /// Attempt to access an invalid memory address using Wasmer.
-    #[cfg(feature = "wasmer")]
+    #[cfg(with_wasmer)]
     #[error(transparent)]
     WasmerMemory(#[from] wasmer::MemoryAccessError),
 
     /// Wasmtime error.
-    #[cfg(feature = "wasmtime")]
+    #[cfg(with_wasmtime)]
     #[error(transparent)]
     Wasmtime(#[from] anyhow::Error),
 
     /// Wasmtime trap during execution.
-    #[cfg(feature = "wasmtime")]
+    #[cfg(with_wasmtime)]
     #[error(transparent)]
     WasmtimeTrap(#[from] wasmtime::Trap),
 }

--- a/linera-witty/src/runtime/mod.rs
+++ b/linera-witty/src/runtime/mod.rs
@@ -6,15 +6,15 @@
 mod borrowed_instance;
 mod error;
 mod memory;
-#[cfg(any(test, feature = "test"))]
+#[cfg(with_testing)]
 mod test;
 mod traits;
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 pub mod wasmer;
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 pub mod wasmtime;
 
-#[cfg(any(test, feature = "test"))]
+#[cfg(with_testing)]
 pub use self::test::{MockExportedFunction, MockInstance, MockResults, MockRuntime};
 pub use self::{
     error::RuntimeError,

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -4,9 +4,9 @@
 //! Helper code for testing using different runtimes.
 
 use frunk::{hlist, hlist_pat, HList};
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 use linera_witty::wasmer;
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 use linera_witty::wasmtime;
 use linera_witty::{
     ExportTo, InstanceWithMemory, Layout, MockExportedFunction, MockInstance, RuntimeError,
@@ -46,11 +46,11 @@ pub trait TestInstanceFactory {
 }
 
 /// A factory of [`wasmtime::Entrypoint`] instances.
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 #[derive(Default)]
 pub struct WasmtimeInstanceFactory<UserData>(PhantomData<UserData>);
 
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 impl<UserData> TestInstanceFactory for WasmtimeInstanceFactory<UserData>
 where
     UserData: Default + 'static,
@@ -85,11 +85,11 @@ where
 }
 
 /// A factory of [`wasmer::EntrypointInstance`]s.
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 #[derive(Default)]
 pub struct WasmerInstanceFactory<UserData>(PhantomData<UserData>);
 
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 impl<UserData> TestInstanceFactory for WasmerInstanceFactory<UserData>
 where
     UserData: Default + Send + 'static,

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -6,9 +6,9 @@
 #[path = "common/test_instance.rs"]
 mod test_instance;
 
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 use self::test_instance::WasmerInstanceFactory;
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 use self::test_instance::WasmtimeInstanceFactory;
 use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
 use linera_witty::{
@@ -57,8 +57,8 @@ impl ExportedSimpleFunction {
 /// The host function is called from the guest, and calls the guest back through a function with
 /// the same name.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -155,8 +155,8 @@ where
 /// The host functions are called from the guest, and they return values obtained by calling back
 /// the guest through functions with the same names.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -247,8 +247,8 @@ where
 /// The host functions are called from the guest, and they forward the arguments back to the guest
 /// by calling guest functions with the same names.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -339,8 +339,8 @@ where
 /// The host functions are called from the guest, and they call the guest back through functions
 /// with the same names, forwarding the arguments and retrieving the final results.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -386,8 +386,8 @@ impl ExportedGlobalState {
 ///
 /// The final value returned from the guest must match the initial value the host sent in.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_global_state<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -433,8 +433,8 @@ where
 ///
 /// The final value returned from the guest must match the initial value the host sent in.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::default(); "with Wasmtime"))]
 #[allow(clippy::bool_assert_comparison)]
 fn test_user_data<InstanceFactory>(mut factory: InstanceFactory)
 where

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -6,9 +6,9 @@
 #[path = "common/test_instance.rs"]
 mod test_instance;
 
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 use self::test_instance::WasmerInstanceFactory;
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 use self::test_instance::WasmtimeInstanceFactory;
 use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
 use linera_witty::{wit_export, wit_import, ExportTo, Instance, Runtime, RuntimeMemory};
@@ -32,8 +32,8 @@ impl SimpleFunction {
 
 /// Test exporting a simple function without parameters or return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -105,8 +105,8 @@ impl Getters {
 
 /// Test exporting functions with return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -175,8 +175,8 @@ impl Setters {
 
 /// Test exporting functions with parameters.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -244,8 +244,8 @@ impl Operations {
 
 /// Test exporting functions with multiple parameters and return values.
 #[test_case(MockInstanceFactory::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -8,9 +8,9 @@
 #[path = "common/test_instance.rs"]
 mod test_instance;
 
-#[cfg(feature = "wasmer")]
+#[cfg(with_wasmer)]
 use self::test_instance::WasmerInstanceFactory;
-#[cfg(feature = "wasmtime")]
+#[cfg(with_wasmtime)]
 use self::test_instance::WasmtimeInstanceFactory;
 use self::test_instance::{MockInstanceFactory, TestInstanceFactory, WithoutExports};
 use linera_witty::{wit_import, Instance, Runtime, RuntimeMemory};
@@ -24,8 +24,8 @@ trait SimpleFunction {
 
 /// Test importing a simple function without parameters or return values.
 #[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_simple_function<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -59,8 +59,8 @@ trait Getters {
 
 /// Test importing functions with return values.
 #[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_getters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -164,8 +164,8 @@ trait Setters {
 
 /// Test importing functions with parameters.
 #[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_setters<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,
@@ -230,8 +230,8 @@ trait Operations {
 
 /// Test importing functions with multiple parameters and return values.
 #[test_case(MockInstanceFactory::<()>::default(); "with a mock instance")]
-#[cfg_attr(feature = "wasmer", test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
-#[cfg_attr(feature = "wasmtime", test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
+#[cfg_attr(with_wasmer, test_case(WasmerInstanceFactory::<()>::default(); "with Wasmer"))]
+#[cfg_attr(with_wasmtime, test_case(WasmtimeInstanceFactory::<()>::default(); "with Wasmtime"))]
 fn test_operations<InstanceFactory>(mut factory: InstanceFactory)
 where
     InstanceFactory: TestInstanceFactory,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `mock-instance` feature flag used in Witty were a little inconsistent, because it represented an instance that's only used for testing, and should therefore be enabled by a `test` feature flag instead. There was also an inconsistency with other crates which have started to use `cfg_aliases`, while Witty did not.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Replace the `mock-instance` feature flag with the `test` feature flag, and use some `cfg` aliases to improve readability.

## Test Plan

<!-- How to test that the changes are correct. -->
Nothing new was added, so no new tests are needed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
