### PR TITLE
Address the test of existence of child storage service server

### DIFF
--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::client::create_shared_test_store;
+use crate::client::storage_service_check_endpoint;
 use anyhow::Result;
 use linera_service::util::CommandExt;
 use std::time::Duration;
@@ -33,7 +33,6 @@ impl StorageServiceSpanner {
         command.kill_on_drop(true);
         Ok(command)
     }
-
     pub async fn run_service(&self) -> Result<StorageServiceGuard> {
         let mut command = self.command().await?;
         let _child = command.spawn_into()?;
@@ -42,9 +41,8 @@ impl StorageServiceSpanner {
         // We add an additional waiting period to avoid problems.
         let mut wait_period = 1;
         loop {
-            let result = create_shared_test_store(self.endpoint.clone()).await;
+            let result = storage_service_check_endpoint(self.endpoint.clone()).await;
             if result.is_ok() {
-                tokio::time::sleep(Duration::from_secs(1)).await;
                 return Ok(guard);
             }
             tokio::time::sleep(Duration::from_secs(wait_period)).await;

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::client::storage_service_check_endpoint;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use linera_service::util::CommandExt;
 use std::time::Duration;
 use tokio::process::{Child, Command};
@@ -27,26 +27,25 @@ impl StorageServiceSpanner {
         Self { endpoint, binary }
     }
 
-    async fn command(&self) -> Result<Command> {
+    async fn command(&self) -> Command {
         let mut command = Command::new(&self.binary);
         command.args(["memory", "--endpoint", &self.endpoint]);
         command.kill_on_drop(true);
-        Ok(command)
+        command
     }
     pub async fn run_service(&self) -> Result<StorageServiceGuard> {
-        let mut command = self.command().await?;
+        let mut command = self.command().await;
         let _child = command.spawn_into()?;
         let guard = StorageServiceGuard { _child };
         // We iterate until the child is spanned and can be accessed.
         // We add an additional waiting period to avoid problems.
-        let mut wait_period = 1;
-        loop {
+        for i in 1..10 {
             let result = storage_service_check_endpoint(self.endpoint.clone()).await;
             if result.is_ok() {
                 return Ok(guard);
             }
-            tokio::time::sleep(Duration::from_secs(wait_period)).await;
-            wait_period += 1;
+            tokio::time::sleep(Duration::from_secs(i)).await;
         }
+        bail!("Failed to start child server");
     }
 }

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -226,3 +226,12 @@ pub async fn create_shared_test_store(
     };
     SharedStoreClient::new(store_config).await
 }
+
+#[cfg(any(test, feature = "test"))]
+pub(crate) async fn storage_service_check_endpoint(
+    endpoint: String,
+) -> Result<(), SharedContextError> {
+    let store = create_shared_test_store(endpoint).await?;
+    let _value = store.read_value_bytes(&[0]).await?;
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

The existing code for the storage service server still had some waiting period. It has now changed
to a better check of existence.

## Proposal

The following was done:
* Introduce a function for testing existence.
* Remove the `Result<Command>` that was not needed.
* Put the loop structure as in other such similar test in the code.

## Test Plan

CI should do it.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
