### PR TITLE
Root chains are subscribed to admin chain from the start.

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -246,12 +246,12 @@ where
         .with_operation(subscribe_operation);
     let subscribe_block_height = subscribe_block.height;
     let mut creator_system_state = SystemExecutionState {
-        subscriptions: [publisher_channel].into_iter().collect(),
         committees: [(Epoch::ZERO, committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(creator_key_pair.public()),
         timestamp: Timestamp::from(2),
         ..make_state(Epoch::ZERO, creator_chain, admin_id)
     };
+    creator_system_state.subscriptions.insert(publisher_channel);
     let creator_state = ExecutionStateView::from_system_state(
         creator_system_state.clone(),
         ExecutionRuntimeConfig::default(),

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -485,12 +485,14 @@ impl GenesisConfig {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
+        let committee = self.create_committee();
         for (chain_number, (public_key, balance)) in (0..).zip(&self.chains) {
+            let description = ChainDescription::Root(chain_number);
             storage
                 .create_chain(
-                    self.create_committee(),
+                    committee.clone(),
                     self.admin_id,
-                    ChainDescription::Root(chain_number),
+                    description,
                     *public_key,
                     *balance,
                     self.timestamp,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -450,16 +450,11 @@ impl Runnable for Job {
 
                 // Make sure genesis chains are subscribed to the admin chain.
                 let context = Arc::new(Mutex::new(context));
-                let certificates =
-                    ClientContext::ensure_admin_subscription(context.clone(), &storage).await;
                 let mut context = context.lock().await;
                 let mut chain_client = context.make_chain_client(
                     storage.clone(),
                     context.wallet_state().genesis_admin_chain(),
                 );
-                for cert in certificates {
-                    chain_client.receive_certificate(cert).await.unwrap();
-                }
                 let n = context
                     .process_inbox(&mut chain_client)
                     .await


### PR DESCRIPTION
## Motivation

Child chains automatically get subscribed to the admin chain, but root chains currently are not.
In general, all chains that aren't closed will usually want to be subscribed, so they get notified about new committees.

## Proposal

Make root chains be subscribed on initialization.

## Test Plan

The tests were updated.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/1671.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
