### PR TITLE
Native Fungible Token App

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,6 +3349,7 @@ dependencies = [
  "linera-version",
  "linera-views",
  "matching-engine",
+ "native-fungible",
  "pathdiff",
  "port-selector",
  "prometheus",
@@ -3939,6 +3940,19 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-fungible"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "bcs",
+ "fungible",
+ "linera-sdk",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ linera-service-graphql-client = { version = "0.9.0", path = "./linera-service-gr
 counter = { path = "./examples/counter" }
 meta-counter = { path = "./examples/meta-counter" }
 fungible = { path = "./examples/fungible" }
+native-fungible = { path = "./examples/native-fungible" }
 crowd-funding = { path = "./examples/crowd-funding" }
 matching-engine = { path = "./examples/matching-engine" }
 social = { path = "./examples/social" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2234,6 +2234,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-fungible"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "bcs",
+ "fungible",
+ "linera-sdk",
+ "native-fungible",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "fungible",
     "matching-engine",
     "meta-counter",
+    "native-fungible",
     "social",
 ]
 
@@ -32,6 +33,7 @@ num-traits = "0.2.16"
 counter = { path = "./counter" }
 crowd-funding = { path = "./crowd-funding" }
 fungible = { path = "./fungible" }
+native-fungible = { path = "./native-fungible" }
 amm = { path = "./amm" }
 matching-engine = { path = "./matching-engine" }
 

--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -235,7 +235,7 @@ You can check that the 200 tokens have arrived:
 
 ```gql,uri=$TOKEN1
 query {
-    accounts { entry(key: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd") { value } }
+    balance(owner: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd")
 }
 ```
 
@@ -268,13 +268,7 @@ check that we have received 110 tokens, in addition to the
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0
 query {
-    accounts {
-        entry(
-            key: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f"
-        ) {
-            value
-        }
-    }
+    balance(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
 }
 ```
 

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -241,7 +241,7 @@ You can check that the 200 tokens have arrived:
 
 ```gql,uri=$TOKEN1
 query {
-    accounts { entry(key: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd") { value } }
+    balance(owner: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd")
 }
 ```
 
@@ -274,13 +274,7 @@ check that we have received 110 tokens, in addition to the
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0
 query {
-    accounts {
-        entry(
-            key: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f"
-        ) {
-            value
-        }
-    }
+    balance(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
 }
 ```
 */

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -412,12 +412,9 @@ impl FungibleTokenAbi {
         chain: &ActiveChain,
         account_owner: AccountOwner,
     ) -> Option<Amount> {
-        let query = format!(
-            "query {{ accounts {{ entry(key: {}) {{ value }} }} }}",
-            account_owner.to_value()
-        );
+        let query = format!("query {{ balance(owner: {}) }}", account_owner.to_value());
         let response = chain.graphql_query(application_id, query).await;
-        let balance = response.pointer("/accounts/entry/value")?.as_str()?;
+        let balance = response.pointer("/balance")?.as_str()?;
 
         Some(
             balance

--- a/examples/fungible/web-frontend/src/App.js
+++ b/examples/fungible/web-frontend/src/App.js
@@ -9,11 +9,7 @@ import tw from "tailwind-styled-components";
 
 const GET_BALANCE = gql`
   query Accounts($owner: AccountOwner) {
-    accounts {
-      entry(key: $owner) {
-        value
-      }
-    }
+    balance(owner: $owner)
   }
 `;
 
@@ -137,7 +133,7 @@ function App({ chainId, owner }) {
         <h1 className="text-2xl font-bold mb-2">Your Balance</h1>
         {balanceData ? (
           <p className="text-3xl font-bold">
-            {parseInt(balanceData.accounts.entry.value ?? '0').toLocaleString()}
+            {parseInt(balanceData.balance ?? '0').toLocaleString()}
             {tickerSymbolData && ' ' + tickerSymbolData.tickerSymbol}
           </p>
         ) : (

--- a/examples/native-fungible/Cargo.toml
+++ b/examples/native-fungible/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "native-fungible"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[features]
+test = []
+
+[dependencies]
+async-graphql.workspace = true
+async-trait.workspace = true
+bcs.workspace = true
+fungible.workspace = true
+linera-sdk.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+native-fungible = { workspace = true, features = ["test"] }
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true }
+
+[[bin]]
+name = "native_fungible_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "native_fungible_service"
+path = "src/service.rs"

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -1,0 +1,324 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use self::state::NativeFungibleToken;
+use async_trait::async_trait;
+use fungible::{ApplicationCall, FungibleResponse, Message, Operation};
+use linera_sdk::{
+    base::{Account, AccountOwner, Amount, Owner, SessionId, WithContractAbi},
+    contract::system_api,
+    ApplicationCallOutcome, CalleeContext, Contract, ExecutionOutcome, MessageContext,
+    OperationContext, SessionCallOutcome, ViewStateStorage,
+};
+use native_fungible::TICKER_SYMBOL;
+use thiserror::Error;
+
+linera_sdk::contract!(NativeFungibleToken);
+
+impl WithContractAbi for NativeFungibleToken {
+    type Abi = fungible::FungibleTokenAbi;
+}
+
+#[async_trait]
+impl Contract for NativeFungibleToken {
+    type Error = Error;
+    type Storage = ViewStateStorage<Self>;
+
+    async fn initialize(
+        &mut self,
+        _context: &OperationContext,
+        state: Self::InitializationArgument,
+    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(
+            Self::parameters().is_ok_and(|param| param.ticker_symbol == "NAT"),
+            "Only NAT is accepted as ticker symbol"
+        );
+        for (owner, amount) in state.accounts {
+            let owner = self.normalize_owner(owner);
+            let account = Account {
+                chain_id: system_api::current_chain_id(),
+                owner: Some(owner),
+            };
+            system_api::transfer(None, account, amount);
+        }
+        Ok(ExecutionOutcome::default())
+    }
+
+    async fn execute_operation(
+        &mut self,
+        context: &OperationContext,
+        operation: Self::Operation,
+    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+        match operation {
+            Operation::Transfer {
+                owner,
+                amount,
+                target_account,
+            } => {
+                Self::check_account_authentication(context.authenticated_signer, owner)?;
+                let account_owner = owner;
+                let owner = self.normalize_owner(owner);
+
+                let fungible_target_account = target_account;
+                let target_account = self.normalize_account(target_account);
+
+                system_api::transfer(Some(owner), target_account, amount);
+
+                Ok(self.get_transfer_outcome(account_owner, fungible_target_account, amount))
+            }
+
+            Operation::Claim {
+                source_account,
+                amount,
+                target_account,
+            } => {
+                Self::check_account_authentication(
+                    context.authenticated_signer,
+                    source_account.owner,
+                )?;
+
+                let fungible_source_account = source_account;
+                let fungible_target_account = target_account;
+
+                let source_account = self.normalize_account(source_account);
+                let target_account = self.normalize_account(target_account);
+
+                system_api::claim(source_account, target_account, amount);
+                Ok(
+                    self.get_claim_outcome(
+                        fungible_source_account,
+                        fungible_target_account,
+                        amount,
+                    ),
+                )
+            }
+        }
+    }
+
+    // TODO(#1721): After message is separated from the Abi, create an empty Notify message
+    // to be the only message used here, simple message (no authentication, not tracked)
+    async fn execute_message(
+        &mut self,
+        context: &MessageContext,
+        message: Self::Message,
+    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+        // Messages for now don't do anything, just pass messages around
+        match message {
+            Message::Credit {
+                amount: _,
+                target: _,
+                source: _,
+            } => {
+                // If we ever actually implement this, we need to remember
+                // to check if it's a bouncing message like in the fungible app
+                Ok(ExecutionOutcome::default())
+            }
+            Message::Withdraw {
+                owner,
+                amount,
+                target_account,
+            } => {
+                Self::check_account_authentication(context.authenticated_signer, owner)?;
+                Ok(self.get_transfer_outcome(owner, target_account, amount))
+            }
+        }
+    }
+
+    async fn handle_application_call(
+        &mut self,
+        context: &CalleeContext,
+        call: ApplicationCall,
+        _forwarded_sessions: Vec<SessionId>,
+    ) -> Result<
+        ApplicationCallOutcome<Self::Message, Self::Response, Self::SessionState>,
+        Self::Error,
+    > {
+        match call {
+            ApplicationCall::Balance { owner } => {
+                let owner = self.normalize_owner(owner);
+
+                let mut outcome = ApplicationCallOutcome::default();
+                let balance = system_api::current_owner_balance(owner);
+                outcome.value = FungibleResponse::Balance(balance);
+                Ok(outcome)
+            }
+
+            ApplicationCall::Transfer {
+                owner,
+                amount,
+                destination,
+            } => {
+                Self::check_account_authentication(context.authenticated_signer, owner)?;
+                let account_owner = owner;
+                let owner = self.normalize_owner(owner);
+
+                let fungible_target_account = self.destination_to_account(destination);
+                let target_account = self.normalize_account(fungible_target_account);
+
+                system_api::transfer(Some(owner), target_account, amount);
+                let execution_outcome =
+                    self.get_transfer_outcome(account_owner, fungible_target_account, amount);
+                Ok(ApplicationCallOutcome {
+                    execution_outcome,
+                    ..Default::default()
+                })
+            }
+
+            ApplicationCall::Claim {
+                source_account,
+                amount,
+                target_account,
+            } => {
+                Self::check_account_authentication(
+                    context.authenticated_signer,
+                    source_account.owner,
+                )?;
+
+                let fungible_source_account = source_account;
+                let fungible_target_account = target_account;
+
+                let source_account = self.normalize_account(source_account);
+                let target_account = self.normalize_account(target_account);
+
+                system_api::claim(source_account, target_account, amount);
+                let execution_outcome = self.get_claim_outcome(
+                    fungible_source_account,
+                    fungible_target_account,
+                    amount,
+                );
+                Ok(ApplicationCallOutcome {
+                    execution_outcome,
+                    ..Default::default()
+                })
+            }
+
+            ApplicationCall::TickerSymbol => {
+                let outcome = ApplicationCallOutcome {
+                    value: FungibleResponse::TickerSymbol(String::from(TICKER_SYMBOL)),
+                    ..Default::default()
+                };
+                Ok(outcome)
+            }
+        }
+    }
+
+    async fn handle_session_call(
+        &mut self,
+        _context: &CalleeContext,
+        _state: Self::SessionState,
+        _request: Self::SessionCall,
+        _forwarded_sessions: Vec<SessionId>,
+    ) -> Result<SessionCallOutcome<Self::Message, Self::Response, Self::SessionState>, Self::Error>
+    {
+        Err(Error::SessionsNotSupported)
+    }
+}
+
+impl NativeFungibleToken {
+    fn get_transfer_outcome(
+        &self,
+        source: AccountOwner,
+        target: fungible::Account,
+        amount: Amount,
+    ) -> ExecutionOutcome<Message> {
+        if target.chain_id == system_api::current_chain_id() {
+            ExecutionOutcome::default()
+        } else {
+            let message = Message::Credit {
+                target: target.owner,
+                amount,
+                source,
+            };
+
+            ExecutionOutcome::default().with_message(target.chain_id, message)
+        }
+    }
+
+    fn get_claim_outcome(
+        &self,
+        source: fungible::Account,
+        target: fungible::Account,
+        amount: Amount,
+    ) -> ExecutionOutcome<Message> {
+        if source.chain_id == system_api::current_chain_id() {
+            self.get_transfer_outcome(source.owner, target, amount)
+        } else {
+            // If different chain, send message that will be ignored so the app gets auto-deployed
+            let message = Message::Withdraw {
+                owner: source.owner,
+                amount,
+                target_account: target,
+            };
+            ExecutionOutcome::default().with_message(source.chain_id, message)
+        }
+    }
+
+    fn normalize_owner(&self, account_owner: AccountOwner) -> Owner {
+        match account_owner {
+            AccountOwner::User(owner) => owner,
+            AccountOwner::Application(_) => panic!("Applications not supported yet!"),
+        }
+    }
+
+    fn normalize_account(&self, account: fungible::Account) -> Account {
+        let owner = self.normalize_owner(account.owner);
+        Account {
+            chain_id: account.chain_id,
+            owner: Some(owner),
+        }
+    }
+
+    fn destination_to_account(&self, destination: fungible::Destination) -> fungible::Account {
+        match destination {
+            fungible::Destination::Account(account) => account,
+            fungible::Destination::NewSession => panic!("Sessions not supported yet!"),
+        }
+    }
+
+    /// Verifies that a transfer is authenticated for this local account.
+    fn check_account_authentication(
+        authenticated_signer: Option<Owner>,
+        owner: AccountOwner,
+    ) -> Result<(), Error> {
+        match owner {
+            AccountOwner::User(address) if authenticated_signer == Some(address) => Ok(()),
+            AccountOwner::Application(_) => Err(Error::ApplicationsNotSupported),
+            _ => Err(Error::IncorrectAuthentication),
+        }
+    }
+}
+
+/// An error that can occur during the contract execution.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Insufficient balance in source account.
+    #[error("Source account does not have sufficient balance for transfer")]
+    InsufficientBalance(#[from] state::InsufficientBalanceError),
+
+    /// Insufficient balance in session.
+    #[error("Session does not have sufficient balance for transfer")]
+    InsufficientSessionBalance,
+
+    /// Requested transfer does not have permission on this account.
+    #[error("The requested transfer is not correctly authenticated.")]
+    IncorrectAuthentication,
+
+    /// Failed to deserialize BCS bytes
+    #[error("Failed to deserialize BCS bytes")]
+    BcsError(#[from] bcs::Error),
+
+    /// Failed to deserialize JSON string
+    #[error("Failed to deserialize JSON string")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("Native Fungible application doesn't support any cross-application sessions")]
+    SessionsNotSupported,
+
+    #[error("Applications not supported yet")]
+    ApplicationsNotSupported,
+}

--- a/examples/native-fungible/src/lib.rs
+++ b/examples/native-fungible/src/lib.rs
@@ -1,0 +1,4 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+pub const TICKER_SYMBOL: &str = "NAT";

--- a/examples/native-fungible/src/service.rs
+++ b/examples/native-fungible/src/service.rs
@@ -5,26 +5,28 @@
 
 mod state;
 
-use self::state::FungibleToken;
+use self::state::NativeFungibleToken;
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use async_trait::async_trait;
 use fungible::Operation;
 use linera_sdk::{
     base::{AccountOwner, Amount, WithServiceAbi},
     graphql::GraphQLMutationRoot,
+    service::system_api,
     QueryContext, Service, ViewStateStorage,
 };
+use native_fungible::TICKER_SYMBOL;
 use std::sync::Arc;
 use thiserror::Error;
 
-linera_sdk::service!(FungibleToken);
+linera_sdk::service!(NativeFungibleToken);
 
-impl WithServiceAbi for FungibleToken {
+impl WithServiceAbi for NativeFungibleToken {
     type Abi = fungible::FungibleTokenAbi;
 }
 
 #[async_trait]
-impl Service for FungibleToken {
+impl Service for NativeFungibleToken {
     type Error = Error;
     type Storage = ViewStateStorage<Self>;
 
@@ -33,31 +35,27 @@ impl Service for FungibleToken {
         _context: &QueryContext,
         request: Request,
     ) -> Result<Response, Self::Error> {
-        let schema = Schema::build(
-            QueryRoot {
-                fungible_token: self.clone(),
-            },
-            Operation::mutation_root(),
-            EmptySubscription,
-        )
-        .finish();
+        let schema =
+            Schema::build(QueryRoot, Operation::mutation_root(), EmptySubscription).finish();
         let response = schema.execute(request).await;
         Ok(response)
     }
 }
 
-struct QueryRoot {
-    fungible_token: Arc<FungibleToken>,
-}
+struct QueryRoot;
 
 #[Object]
 impl QueryRoot {
-    async fn balance(&self, owner: AccountOwner) -> Result<Option<Amount>, async_graphql::Error> {
-        Ok(self.fungible_token.balance(&owner).await)
+    async fn balance(&self, owner: AccountOwner) -> Result<Amount, async_graphql::Error> {
+        let owner = match owner {
+            AccountOwner::User(owner) => owner,
+            AccountOwner::Application(_) => panic!("Applications not supported yet!"),
+        };
+        Ok(system_api::current_owner_balance(owner))
     }
 
     async fn ticker_symbol(&self) -> Result<String, async_graphql::Error> {
-        Ok(FungibleToken::parameters()?.ticker_symbol)
+        Ok(String::from(TICKER_SYMBOL))
     }
 }
 
@@ -66,7 +64,7 @@ impl QueryRoot {
 pub enum Error {
     /// Invalid query argument; could not deserialize GraphQL request.
     #[error(
-        "Invalid query argument; Fungible application only supports JSON encoded GraphQL queries"
+        "Invalid query argument; Native Fungible application only supports JSON encoded GraphQL queries"
     )]
     InvalidQuery(#[from] serde_json::Error),
 }

--- a/examples/native-fungible/src/state.rs
+++ b/examples/native-fungible/src/state.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
+use thiserror::Error;
+
+/// The application state.
+#[derive(RootView)]
+#[view(context = "ViewStorageContext")]
+pub struct NativeFungibleToken {
+    // TODO(#968): We should support stateless applications/empty user views
+    pub _dummy: RegisterView<u8>,
+}
+
+/// Attempts to debit from an account with insufficient funds.
+#[derive(Clone, Copy, Debug, Error)]
+#[error("Insufficient balance for transfer")]
+pub struct InsufficientBalanceError;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -130,6 +130,8 @@ pub enum ExecutionError {
     MissingRuntimeResponse,
     #[error("Bytecode ID {0:?} is invalid")]
     InvalidBytecodeId(BytecodeId),
+    #[error("Owner is None")]
+    OwnerIsNone,
 }
 
 impl ExecutionError {
@@ -334,6 +336,9 @@ pub trait BaseRuntime {
     /// Reads the balance of the chain.
     fn read_chain_balance(&mut self) -> Result<Amount, ExecutionError>;
 
+    /// Reads the owner balance.
+    fn read_owner_balance(&mut self, owner: Owner) -> Result<Amount, ExecutionError>;
+
     /// Reads the system timestamp.
     fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError>;
 
@@ -456,6 +461,22 @@ pub trait ContractRuntime: BaseRuntime {
 
     /// Consumes some of the execution fuel.
     fn consume_fuel(&mut self, fuel: u64) -> Result<(), ExecutionError>;
+
+    /// Transfers amount from source to destination.
+    fn transfer(
+        &mut self,
+        source: Option<Owner>,
+        destination: Account,
+        amount: Amount,
+    ) -> Result<(), ExecutionError>;
+
+    /// Claims amount from source to destination.
+    fn claim(
+        &mut self,
+        source: Account,
+        destination: Account,
+        amount: Amount,
+    ) -> Result<(), ExecutionError>;
 
     /// Calls another application. Forwarded sessions will now be visible to
     /// `callee_id` (but not to the caller any more).

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -15,8 +15,8 @@ use crate::{
 };
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, Resources},
-    identifiers::{BytecodeId, ChainId, MessageId},
+    data_types::{Amount, BlockHeight, Resources},
+    identifiers::{Account, BytecodeId, ChainId, MessageId, Owner},
 };
 
 impl From<contract::SessionCallOutcome> for (SessionCallOutcome, Vec<u8>) {
@@ -180,6 +180,29 @@ impl From<contract_system_api::CryptoHash> for CryptoHash {
     }
 }
 
+impl From<contract_system_api::CryptoHash> for Owner {
+    fn from(guest: contract_system_api::CryptoHash) -> Self {
+        let integers = [guest.part1, guest.part2, guest.part3, guest.part4];
+        Owner(CryptoHash::from(integers))
+    }
+}
+
+impl From<contract_system_api::Account> for Account {
+    fn from(account: contract_system_api::Account) -> Self {
+        Account {
+            chain_id: account.chain_id.into(),
+            owner: account.owner.map(|owner| owner.into()),
+        }
+    }
+}
+
+impl From<contract_system_api::Amount> for Amount {
+    fn from(amount: contract_system_api::Amount) -> Self {
+        let value = ((amount.upper_half as u128) << 64) | (amount.lower_half as u128);
+        Amount::from_attos(value)
+    }
+}
+
 impl From<service_system_api::ApplicationId> for UserApplicationId {
     fn from(guest: service_system_api::ApplicationId) -> Self {
         UserApplicationId {
@@ -215,5 +238,12 @@ impl From<service_system_api::CryptoHash> for CryptoHash {
     fn from(guest: service_system_api::CryptoHash) -> Self {
         let integers = [guest.part1, guest.part2, guest.part3, guest.part4];
         CryptoHash::from(integers)
+    }
+}
+
+impl From<service_system_api::CryptoHash> for Owner {
+    fn from(guest: service_system_api::CryptoHash) -> Self {
+        let integers = [guest.part1, guest.part2, guest.part3, guest.part4];
+        Owner(CryptoHash::from(integers))
     }
 }

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -13,7 +13,11 @@ use crate::{
     CallOutcome, CalleeContext, MessageContext, MessageId, OperationContext, QueryContext,
     SessionId, UserApplicationId,
 };
-use linera_base::{crypto::CryptoHash, data_types::Amount, identifiers::ChainId};
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::Amount,
+    identifiers::{Account, ChainId, Owner},
+};
 
 impl From<OperationContext> for contract::OperationContext {
     fn from(host: OperationContext) -> Self {
@@ -233,5 +237,20 @@ impl From<Amount> for contract_system_api::Amount {
             lower_half: host.lower_half(),
             upper_half: host.upper_half(),
         }
+    }
+}
+
+impl From<Account> for contract_system_api::Account {
+    fn from(account: Account) -> Self {
+        contract_system_api::Account {
+            chain_id: account.chain_id.into(),
+            owner: account.owner.map(|owner| owner.into()),
+        }
+    }
+}
+
+impl From<Owner> for contract_system_api::CryptoHash {
+    fn from(owner: Owner) -> Self {
+        contract_system_api::CryptoHash::from(owner.0)
     }
 }

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -33,6 +33,36 @@ macro_rules! impl_contract_system_api {
                 BaseRuntime::read_chain_balance(self).map(|balance| balance.into())
             }
 
+            fn read_owner_balance(
+                &mut self,
+                owner: contract_system_api::Owner,
+            ) -> Result<contract_system_api::Amount, Self::Error> {
+                BaseRuntime::read_owner_balance(self, owner.into()).map(|balance| balance.into())
+            }
+
+            fn transfer(
+                &mut self,
+                source: Option<contract_system_api::Owner>,
+                destination: contract_system_api::Account,
+                amount: contract_system_api::Amount,
+            ) -> Result<(), Self::Error> {
+                ContractRuntime::transfer(
+                    self,
+                    source.map(|source| source.into()),
+                    destination.into(),
+                    amount.into(),
+                )
+            }
+
+            fn claim(
+                &mut self,
+                source: contract_system_api::Account,
+                destination: contract_system_api::Account,
+                amount: contract_system_api::Amount,
+            ) -> Result<(), Self::Error> {
+                ContractRuntime::claim(self, source.into(), destination.into(), amount.into())
+            }
+
             fn read_system_timestamp(
                 &mut self,
             ) -> Result<contract_system_api::Timestamp, Self::Error> {
@@ -131,6 +161,13 @@ macro_rules! impl_service_system_api {
 
             fn read_chain_balance(&mut self) -> Result<service_system_api::Amount, Self::Error> {
                 BaseRuntime::read_chain_balance(self).map(|balance| balance.into())
+            }
+
+            fn read_owner_balance(
+                &mut self,
+                owner: service_system_api::Owner,
+            ) -> Result<service_system_api::Amount, Self::Error> {
+                BaseRuntime::read_owner_balance(self, owner.into()).map(|balance| balance.into())
             }
 
             fn read_system_timestamp(

--- a/linera-sdk/contract_system_api.wit
+++ b/linera-sdk/contract_system_api.wit
@@ -2,6 +2,9 @@ chain-id: func() -> chain-id
 application-id: func() -> application-id
 application-parameters: func() -> list<u8>
 read-chain-balance: func() -> amount
+read-owner-balance: func(owner: owner) -> amount
+transfer: func(source: option<owner>, destination: account, amount: amount)
+claim: func(source: account, destination: account, amount: amount)
 read-system-timestamp: func() -> timestamp
 
 log: func(message: string, level: log-level)
@@ -43,6 +46,7 @@ record application-id {
     creation: message-id,
 }
 
+type owner = crypto-hash
 type bytecode-id = message-id
 
 record message-id {
@@ -65,4 +69,9 @@ record crypto-hash {
 record amount {
     lower-half: u64,
     upper-half: u64,
+}
+
+record account {
+    chain-id: chain-id,
+    owner: option<owner>,
 }

--- a/linera-sdk/mock_system_api.wit
+++ b/linera-sdk/mock_system_api.wit
@@ -2,6 +2,7 @@ mocked-chain-id: func() -> chain-id
 mocked-application-id: func() -> application-id
 mocked-application-parameters: func() -> list<u8>
 mocked-read-chain-balance: func() -> amount
+mocked-read-owner-balance: func() -> amount
 mocked-read-system-timestamp: func() -> timestamp
 
 mocked-log: func(message: string, level: log-level)

--- a/linera-sdk/service_system_api.wit
+++ b/linera-sdk/service_system_api.wit
@@ -2,6 +2,7 @@ chain-id: func() -> chain-id
 application-id: func() -> application-id
 application-parameters: func() -> list<u8>
 read-chain-balance: func() -> amount
+read-owner-balance: func(owner: owner) -> amount
 read-system-timestamp: func() -> timestamp
 
 log: func(message: string, level: log-level)
@@ -29,6 +30,7 @@ record message-id {
     index: u32,
 }
 
+type owner = crypto-hash
 type chain-id = crypto-hash
 type block-height = u64
 type timestamp = u64

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -8,8 +8,8 @@ use super::{contract_system_api as wit_system_api, wit_types};
 use crate::{ApplicationCallOutcome, ExecutionOutcome, OutgoingMessage, SessionCallOutcome};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::Resources,
-    identifiers::{ApplicationId, ChannelName, Destination, MessageId, SessionId},
+    data_types::{Amount, Resources},
+    identifiers::{Account, ApplicationId, ChannelName, Destination, MessageId, Owner, SessionId},
 };
 
 impl From<CryptoHash> for wit_system_api::CryptoHash {
@@ -25,6 +25,21 @@ impl From<CryptoHash> for wit_system_api::CryptoHash {
     }
 }
 
+impl From<Owner> for wit_system_api::CryptoHash {
+    fn from(owner: Owner) -> Self {
+        wit_system_api::CryptoHash::from(owner.0)
+    }
+}
+
+impl From<Amount> for wit_system_api::Amount {
+    fn from(host: Amount) -> Self {
+        wit_system_api::Amount {
+            lower_half: host.lower_half(),
+            upper_half: host.upper_half(),
+        }
+    }
+}
+
 impl From<CryptoHash> for wit_types::CryptoHash {
     fn from(crypto_hash: CryptoHash) -> Self {
         let parts = <[u64; 4]>::from(crypto_hash);
@@ -34,6 +49,15 @@ impl From<CryptoHash> for wit_types::CryptoHash {
             part2: parts[1],
             part3: parts[2],
             part4: parts[3],
+        }
+    }
+}
+
+impl From<Account> for wit_system_api::Account {
+    fn from(account: Account) -> Self {
+        wit_system_api::Account {
+            chain_id: account.chain_id.0.into(),
+            owner: account.owner.map(|owner| owner.into()),
         }
     }
 }

--- a/linera-sdk/src/contract/system_api/mod.rs
+++ b/linera-sdk/src/contract/system_api/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use self::private::{
 use super::contract_system_api as wit;
 use linera_base::{
     data_types::{Amount, Timestamp},
-    identifiers::{ApplicationId, ChainId},
+    identifiers::{Account, ApplicationId, ChainId, Owner},
 };
 use std::fmt;
 
@@ -31,6 +31,25 @@ pub fn current_application_id() -> ApplicationId {
 /// Retrieves the current chain balance.
 pub fn current_chain_balance() -> Amount {
     wit::read_chain_balance().into()
+}
+
+/// Retrieves the current balance for a given owner.
+pub fn current_owner_balance(owner: Owner) -> Amount {
+    wit::read_owner_balance(owner.into()).into()
+}
+
+/// Transfers amount from source to destination
+pub fn transfer(source: Option<Owner>, destination: Account, amount: Amount) {
+    wit::transfer(
+        source.map(|source| source.into()),
+        destination.into(),
+        amount.into(),
+    )
+}
+
+/// Claims amount from source to destination
+pub fn claim(source: Account, destination: Account, amount: Amount) {
+    wit::claim(source.into(), destination.into(), amount.into())
 }
 
 /// Retrieves the current system time, i.e. the timestamp of the block in which this is called.

--- a/linera-sdk/src/service/conversions_to_wit.rs
+++ b/linera-sdk/src/service/conversions_to_wit.rs
@@ -6,7 +6,7 @@
 use super::{service_system_api as wit_system_api, wit_types};
 use linera_base::{
     crypto::CryptoHash,
-    identifiers::{ApplicationId, MessageId},
+    identifiers::{ApplicationId, MessageId, Owner},
 };
 
 impl From<log::Level> for wit_system_api::LogLevel {
@@ -63,5 +63,11 @@ impl From<MessageId> for wit_system_api::MessageId {
             height: message_id.height.0,
             index: message_id.index,
         }
+    }
+}
+
+impl From<Owner> for wit_system_api::CryptoHash {
+    fn from(owner: Owner) -> Self {
+        wit_system_api::CryptoHash::from(owner.0)
     }
 }

--- a/linera-sdk/src/service/system_api/mod.rs
+++ b/linera-sdk/src/service/system_api/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use self::private::{current_application_parameters, load_view, query_
 use super::service_system_api as wit;
 use linera_base::{
     data_types::{Amount, Timestamp},
-    identifiers::{ApplicationId, ChainId},
+    identifiers::{ApplicationId, ChainId, Owner},
 };
 use std::fmt;
 
@@ -29,6 +29,11 @@ pub fn current_application_id() -> ApplicationId {
 /// Retrieves the current chain balance.
 pub fn current_chain_balance() -> Amount {
     wit::read_chain_balance().into()
+}
+
+/// Retrieves the current balance for a given owner.
+pub fn current_owner_balance(owner: Owner) -> Amount {
+    wit::read_owner_balance(owner.into()).into()
 }
 
 /// Retrieves the current system time, i.e. the timestamp of the latest block in this chain.

--- a/linera-sdk/src/test/unit/mod.rs
+++ b/linera-sdk/src/test/unit/mod.rs
@@ -33,6 +33,7 @@ static mut MOCK_CHAIN_ID: Option<ChainId> = None;
 static mut MOCK_APPLICATION_ID: Option<ApplicationId> = None;
 static mut MOCK_APPLICATION_PARAMETERS: Option<Vec<u8>> = None;
 static mut MOCK_SYSTEM_BALANCE: Option<Amount> = None;
+static mut MOCK_OWNER_BALANCE: Option<Amount> = None;
 static mut MOCK_SYSTEM_TIMESTAMP: Option<Timestamp> = None;
 static mut MOCK_LOG_COLLECTOR: Vec<(log::Level, String)> = Vec::new();
 static mut MOCK_KEY_VALUE_STORE: Option<MemoryContext<()>> = None;
@@ -60,6 +61,11 @@ pub fn mock_application_parameters(application_parameters: &impl Serialize) {
 /// Sets the mocked chain balance.
 pub fn mock_chain_balance(chain_balance: impl Into<Option<Amount>>) {
     unsafe { MOCK_SYSTEM_BALANCE = chain_balance.into() };
+}
+
+/// Sets the mocked owner balance.
+pub fn mock_owner_balance(owner_balance: impl Into<Option<Amount>>) {
+    unsafe { MOCK_OWNER_BALANCE = owner_balance.into() };
 }
 
 /// Sets the mocked system timestamp.
@@ -121,6 +127,15 @@ impl wit::MockSystemApi for MockSystemApi {
             .expect(
                 "Unexpected call to the `read_chain_balance` system API. \
                 Please call `mock_chain_balance` first",
+            )
+            .into()
+    }
+
+    fn mocked_read_owner_balance() -> wit::Amount {
+        unsafe { MOCK_OWNER_BALANCE }
+            .expect(
+                "Unexpected call to the `read_owner_balance` system API. \
+                Please call `mock_owner_balance` first",
             )
             .into()
     }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -96,6 +96,7 @@ linera-service = { path = ".", features = ["test"] }
 linera-storage = { workspace = true, features = ["test"] }
 linera-views = { workspace = true, features = ["test"] }
 matching-engine.workspace = true
+native-fungible.workspace = true
 proptest.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 social.workspace = true

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -275,13 +275,9 @@ struct FungibleApp(ApplicationWrapper<fungible::FungibleTokenAbi>);
 
 impl FungibleApp {
     async fn get_amount(&self, account_owner: &AccountOwner) -> Amount {
-        let query = format!(
-            "accounts {{ entry(key: {}) {{ value }} }}",
-            account_owner.to_value()
-        );
+        let query = format!("balance(owner: {})", account_owner.to_value());
         let response_body = self.0.query(&query).await.unwrap();
-        serde_json::from_value(response_body["accounts"]["entry"]["value"].clone())
-            .unwrap_or_default()
+        serde_json::from_value(response_body["balance"].clone()).unwrap_or_default()
     }
 
     async fn transfer(


### PR DESCRIPTION
## Motivation

We need a Native Fungible app

## Proposal

Implement a few system API calls:
- Created a `balance` query for the `fungible` app, so that both `fungible` and `native-fungible` share the same queries and mutations
- Renamed the `balance` function in `fungible` to `balance_or_default`, because it better describes what it does, and we needed a `balance` that would return None if the account wasn't found
- Created a native fungible app that reuses the fungible abi, has the same queries and mutations
    - Messages are disabled because all the messaging we need will happen on the system side
    - Sessions are not implemented, but will be implemented in a following PR
    - Application owners not supported yet, see follow up items
    - Ticker symbol on native fungible is fixed to `LIN`
- Created 3 contract system API calls: owner balance, transfer and claim
    - Transfer and claim internally call `SystemOperation`s
- And 1 service system API call: owner balance
- Reused and generalized existing `fungible` e2e tests to also test `native fungible`

## Test Plan

e2e tests
Tested fungible UI also

## Follow up items
- Implement support for sessions within native fungible
- Write simple README that will mostly point to the `fungible` README
- Double check that the `fungible` UI also works with `native fungible`, adapt what is needed
- Change codebase to use AccountOwner instead of Owner, and then as a follow up add support to Application owners to native fungible

