### PR TITLE
Improve InsufficientRound error message.

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -114,6 +114,8 @@ pub enum ChainError {
     InvalidBlockProposal,
     #[error("Round number should be at least {0:?}")]
     InsufficientRound(Round),
+    #[error("Round number should greater than {0:?}")]
+    InsufficientRoundStrict(Round),
     #[error("Round number should be {0:?}")]
     WrongRound(Round),
     #[error("A different block for height {0:?} was already locked at round number {1:?}")]

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -242,10 +242,11 @@ impl ChainManager {
             if old_proposal.content == proposal.content {
                 return Ok(Outcome::Skip); // We already voted for this proposal; nothing to do.
             }
-            if new_round <= old_proposal.content.round {
+            ensure!(
+                new_round > old_proposal.content.round,
                 // We already accepted a proposal in this round or in a higher round.
-                return Err(ChainError::InsufficientRound(old_proposal.content.round));
-            }
+                ChainError::InsufficientRoundStrict(old_proposal.content.round)
+            );
             // Any proposal in the fast round is considered locked, because validators vote to
             // confirm it immediately.
             if old_proposal.content.round.is_fast() && validated.is_none() {
@@ -335,7 +336,7 @@ impl ChainManager {
             }
             ensure!(
                 new_round > locked.round,
-                ChainError::InsufficientRound(locked.round)
+                ChainError::InsufficientRoundStrict(locked.round)
             );
         }
         Ok(Outcome::Accept)


### PR DESCRIPTION
## Motivation

We use `ChainError::InsufficientRound(round)` both if the round is expected to be _at least_ and _strictly greater than_ `round`. The error message only describes the first case.

## Proposal

Add a new error variant for the strict inequality.

## Test Plan

This only distinguishes more error variants.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
