### PR TITLE
`scripts/linera_net_helper.sh`: stop littering the current directory with temp files

### DIFF
--- a/scripts/linera_net_helper.sh
+++ b/scripts/linera_net_helper.sh
@@ -4,7 +4,7 @@
 # - Then executes the bash command recorded from stdout
 # - Returns without killing the process
 function linera_spawn_and_read_wallet_variables() {
-    LINERA_TMP_DIR=$(mktemp -d "${TMPDIR:-.}tmp-XXXXX") || exit 1
+    LINERA_TMP_DIR=$(mktemp -d) || exit 1
 
     # When the shell exits, we will clean up the top-level jobs (if any), the temporary
     # directory, and the main process. Handling future top-level jobs here is useful


### PR DESCRIPTION
## Motivation

`.tmp` files in the current directory are annoying, and also the current formulation breaks if `TMPDIR` is set without a trailing slash (as it often is).

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

We don't need to prepend the argument to `mktemp -d` with `$TMPDIR`, as it's respected by default, so let's just remove it. 

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

Should be invisible to users, [unless they have a really weird workflow](https://xkcd.com/1172/).

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
