### PR TITLE
Assert admin chains before other root chains and blocks

### DIFF
--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -485,6 +485,10 @@ where
         description: ChainDescription,
         balance: Amount,
     ) -> Result<ChainClient<NodeProvider<B::Storage>, B::Storage>, anyhow::Error> {
+        // If this is the first chain, make it the admin chain.
+        if self.genesis_storage_builder.accounts.is_empty() {
+            self.admin_id = ChainId::from(description);
+        }
         let key_pair = KeyPair::generate();
         let public_key = key_pair.public();
         // Remember what's in the genesis store for future clients to join.

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -193,6 +193,10 @@ pub trait Storage: Sized {
                 admin_chain.tip_state.get().is_first_block(),
                 "Attempting to add root chains after blocks have already been created"
             );
+            assert!(
+                admin_chain.is_active(),
+                "Attempting to add root chains without the admin chain being active"
+            );
             let full_name = ChannelFullName {
                 application_id: GenericApplicationId::System,
                 name: SystemChannel::Admin.name(),

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -189,6 +189,10 @@ pub trait Storage: Sized {
                 name: SystemChannel::Admin.name(),
             })?;
             let mut admin_chain = self.load_chain(admin_id).await?;
+            assert!(
+                admin_chain.tip_state.get().is_first_block(),
+                "Attempting to add root chains after blocks have already been created"
+            );
             let full_name = ChannelFullName {
                 application_id: GenericApplicationId::System,
                 name: SystemChannel::Admin.name(),


### PR DESCRIPTION
## Motivation

The system is expected to always have the admin chain initialized before anything else, especially now that we add admin channel subscriptions for each additional root chain. In the client tests, this is currently not always the case; in fact, some of them don't initialize a root chain at all.

## Proposal

In the `TestBuilder`, make the first initialized chain the admin chain.

## Test Plan

I added assertions about the root chain to `initialize_storage` that would fail. With the fixed `TestBuilder`, they pass.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
