### PR TITLE
Print weights in CommunicationError::Sample

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -70,9 +70,9 @@ pub enum CommunicationError<E: fmt::Debug> {
     #[error("Failed to communicate with a quorum of validators: {0}")]
     Trusted(E),
     /// No single error reached the validity threshold so we're returning a sample of
-    /// errors for debugging purposes.
+    /// errors for debugging purposes, together with their weight.
     #[error("Failed to communicate with a quorum of validators:\n{:#?}", .0)]
-    Sample(Vec<E>),
+    Sample(Vec<(E, u64)>),
 }
 
 /// Executes a sequence of actions in parallel for all validators.
@@ -161,7 +161,7 @@ where
     // No specific error is available to report reliably.
     let mut sample = error_scores.into_iter().collect::<Vec<_>>();
     sample.sort_by_key(|(_, score)| std::cmp::Reverse(*score));
-    let sample = sample.into_iter().map(|(error, _)| error).take(4).collect();
+    sample.truncate(4);
     Err(CommunicationError::Sample(sample))
 }
 


### PR DESCRIPTION
## Motivation

`communicate_with_quorum` returns a `CommunicationError::Sample` with the ≤ 4 errors returned by the most validators (by weight), but doesn't print the weight.

Printing the weight helps a lot with debugging; e.g. if two errors are returned in a test with four equal-weight validators, we don't even know whether three or four errors were returned in total, or whether e.g. one validator timed out.

## Proposal

Include the weights in the error.

## Test Plan

Doesn't change any logic, apart from what is included in an error.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
