### PR TITLE
Simplify ValidatorUpdater.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -8,7 +8,7 @@ mod wasm;
 use crate::{
     client::{
         client_test_utils::{FaultType, MakeMemoryStorage, StorageBuilder, TestBuilder},
-        ChainClient, ChainClientError, ClientOutcome, CommunicateAction, MessageAction,
+        ChainClient, ChainClientError, ClientOutcome, MessageAction,
     },
     local_node::LocalNodeError,
     node::{
@@ -1416,11 +1416,8 @@ where
         .communicate_chain_updates(
             &builder.initial_committee,
             client1.chain_id,
-            CommunicateAction::AdvanceToNextBlockHeight {
-                height: client1.next_block_height,
-                delivery: CrossChainMessageDelivery::NonBlocking,
-            },
-            None,
+            client1.next_block_height,
+            CrossChainMessageDelivery::NonBlocking,
         )
         .await
         .unwrap();

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1420,6 +1420,7 @@ where
                 height: client1.next_block_height,
                 delivery: CrossChainMessageDelivery::NonBlocking,
             },
+            None,
         )
         .await
         .unwrap();

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -31,7 +31,7 @@ const GRACE_PERIOD: f64 = 0.2;
 /// The maximum timeout for `communicate_with_quorum` if no quorum is reached.
 const MAX_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24); // 1 day.
 
-/// Used for `communicate_chain_updates`
+/// Used for `communicate_chain_action`
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum CommunicateAction {
@@ -42,11 +42,8 @@ pub enum CommunicateAction {
         certificate: Certificate,
         delivery: CrossChainMessageDelivery,
     },
-    AdvanceToNextBlockHeight {
-        height: BlockHeight,
-        delivery: CrossChainMessageDelivery,
-    },
     RequestLeaderTimeout {
+        chain_id: ChainId,
         height: BlockHeight,
         round: Round,
     },
@@ -269,7 +266,7 @@ where
         Ok(response.info)
     }
 
-    async fn send_chain_information(
+    pub async fn send_chain_information(
         &mut self,
         chain_id: ChainId,
         target_block_height: BlockHeight,
@@ -348,71 +345,50 @@ where
 
     pub async fn send_chain_update(
         &mut self,
-        chain_id: ChainId,
         action: CommunicateAction,
-    ) -> Result<Option<LiteVote>, NodeError> {
-        let (target_block_height, first_delivery) = {
-            use CrossChainMessageDelivery::NonBlocking;
-            match &action {
-                CommunicateAction::SubmitBlock { proposal } => {
-                    (proposal.content.block.height, NonBlocking)
-                }
-                CommunicateAction::FinalizeBlock { certificate, .. } => {
-                    (certificate.value().height(), NonBlocking)
-                }
-                CommunicateAction::AdvanceToNextBlockHeight { height, delivery } => {
-                    (*height, *delivery)
-                }
-                CommunicateAction::RequestLeaderTimeout { height, .. } => (*height, NonBlocking),
+    ) -> Result<LiteVote, NodeError> {
+        let (target_block_height, chain_id) = match &action {
+            CommunicateAction::SubmitBlock { proposal } => {
+                let block = &proposal.content.block;
+                (block.height, block.chain_id)
             }
+            CommunicateAction::FinalizeBlock { certificate, .. } => {
+                let value = certificate.value();
+                (value.height(), value.chain_id())
+            }
+            CommunicateAction::RequestLeaderTimeout {
+                height, chain_id, ..
+            } => (*height, *chain_id),
         };
         // Update the validator with missing information, if needed.
-        self.send_chain_information(chain_id, target_block_height, first_delivery)
+        let delivery = CrossChainMessageDelivery::NonBlocking;
+        self.send_chain_information(chain_id, target_block_height, delivery)
             .await?;
         // Send the block proposal, certificate or timeout request and return a vote.
-        match action {
+        let vote = match action {
             CommunicateAction::SubmitBlock { proposal } => {
                 let info = self.send_block_proposal(proposal.clone()).await?;
-                match info.manager.pending {
-                    Some(vote) if vote.validator == self.name => {
-                        vote.check()?;
-                        return Ok(Some(vote.clone()));
-                    }
-                    Some(_) | None => {
-                        return Err(NodeError::MissingVoteInValidatorResponse);
-                    }
-                }
+                info.manager.pending
             }
             CommunicateAction::FinalizeBlock {
                 certificate,
                 delivery,
             } => {
                 let info = self.send_certificate(certificate, delivery).await?;
-                match info.manager.pending {
-                    Some(vote) if vote.validator == self.name => {
-                        vote.check()?;
-                        return Ok(Some(vote.clone()));
-                    }
-                    Some(_) | None => {
-                        return Err(NodeError::MissingVoteInValidatorResponse);
-                    }
-                }
+                info.manager.pending
             }
             CommunicateAction::RequestLeaderTimeout { .. } => {
                 let query = ChainInfoQuery::new(chain_id).with_leader_timeout();
                 let info = self.node.handle_chain_info_query(query).await?.info;
-                match info.manager.timeout_vote {
-                    Some(vote) if vote.validator == self.name => {
-                        vote.check()?;
-                        return Ok(Some(vote.clone()));
-                    }
-                    Some(_) | None => {
-                        return Err(NodeError::MissingVoteInValidatorResponse);
-                    }
-                }
+                info.manager.timeout_vote
             }
-            CommunicateAction::AdvanceToNextBlockHeight { .. } => (),
+        };
+        match vote {
+            Some(vote) if vote.validator == self.name => {
+                vote.check()?;
+                Ok(vote)
+            }
+            Some(_) | None => Err(NodeError::MissingVoteInValidatorResponse),
         }
-        Ok(None)
     }
 }


### PR DESCRIPTION
## Motivation

`CommunicateAction` always tries to put together a `Certificate`, except if it's `AdvanceToNextBlockHeight`. That requires a lot of case distinctions and optional values in the code, since almost all of what happens in `communicate_chain_updates` applies only to the other variants. We also have several unreachable errors.

## Proposal

Separate the code; replace `AdvanceToNextBlockHeight` by a new function. Call the new function `communicate_chain_updates` and rename the other one to `communicate_chain_action`. Remove unreachable errors.

## Test Plan

The protocol logic was not changed.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
