### PR TITLE
Use configured cross-chain message delivery in FinalizeBlock.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -719,7 +719,7 @@ where
             .clone();
         let finalize_action = CommunicateAction::FinalizeBlock {
             certificate,
-            delivery: CrossChainMessageDelivery::NonBlocking,
+            delivery: self.cross_chain_message_delivery,
         };
         let certificate = self
             .communicate_chain_updates(committee, block.chain_id, finalize_action)


### PR DESCRIPTION
## Motivation

Currently `CommunicateAction::FinalizeBlock`'s `delivery` field is always `CrossChainMessageDelivery::NonBlocking`.

## Proposal

Set it to the configured `self.cross_chain_message_delivery`.

## Test Plan

The tests pass either way, but this might have been making some tests more flaky.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
