### PR TITLE
Don't skip if locked block is from different round.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -331,7 +331,7 @@ impl ChainManager {
         // even if it is older than the current round. Validators will only sign in the current
         // round, though. (See `create_final_vote` below.)
         if let Some(locked) = &self.locked {
-            if locked.hash() == certificate.hash() {
+            if locked.hash() == certificate.hash() && locked.round == certificate.round {
                 return Ok(Outcome::Skip);
             }
             ensure!(


### PR DESCRIPTION
## Motivation

`check_validated_block` returns `Skip` if the block matches the locked one, even if the locked one is from an earlier round.

## Proposal

In that case we still need to make a new signature, with the new round.

## Test Plan

A test was extended; it would fail without this fix.


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
