### PR TITLE
Make linera-execution test utilities public.

### DIFF
--- a/linera-execution/build.rs
+++ b/linera-execution/build.rs
@@ -4,6 +4,7 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
         web: { all(target_arch = "wasm32", target_os = "unknown") },
+        with_testing: { any(test, feature = "test") },
         with_metrics: { all(not(web), feature = "metrics") },
         with_wasmtime: { all(not(web), feature = "wasmtime") },
         with_wasmer: { all(not(web), feature = "wasmer") },

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -13,6 +13,8 @@ mod policy;
 mod resources;
 mod runtime;
 pub mod system;
+#[cfg(any(test, feature = "test"))]
+pub mod test_utils;
 mod util;
 mod wasm;
 

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -5,12 +5,12 @@
 
 #![allow(dead_code)]
 
-use linera_base::identifiers::SessionId;
-use linera_execution::{
+use crate::{
     ApplicationCallOutcome, CalleeContext, ContractSyncRuntime, ExecutionError, MessageContext,
     OperationContext, QueryContext, RawExecutionOutcome, ServiceSyncRuntime, SessionCallOutcome,
     UserContract, UserContractModule, UserService, UserServiceModule,
 };
+use linera_base::identifiers::SessionId;
 use std::{
     collections::VecDeque,
     fmt::{self, Display, Formatter},

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -7,7 +7,7 @@
 
 mod mock_application;
 
-pub use self::mock_application::{ExpectedCall, MockApplication};
+pub use self::mock_application::{ExpectedCall, MockApplication, MockApplicationInstance};
 use crate::{
     ApplicationRegistryView, BytecodeLocation, ExecutionRuntimeContext, ExecutionStateView,
     TestExecutionRuntimeContext, UserApplicationDescription, UserApplicationId,

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -8,14 +8,14 @@
 mod mock_application;
 
 pub use self::mock_application::{ExpectedCall, MockApplication};
+use crate::{
+    ApplicationRegistryView, BytecodeLocation, ExecutionRuntimeContext, ExecutionStateView,
+    TestExecutionRuntimeContext, UserApplicationDescription, UserApplicationId,
+};
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
     data_types::BlockHeight,
     identifiers::{BytecodeId, ChainId, MessageId},
-};
-use linera_execution::{
-    ApplicationRegistryView, BytecodeLocation, ExecutionRuntimeContext, ExecutionStateView,
-    TestExecutionRuntimeContext, UserApplicationDescription, UserApplicationId,
 };
 use linera_views::{
     common::Context,

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -5,15 +5,13 @@
 
 #![allow(clippy::items_after_test_module)]
 
-mod utils;
-
-use self::utils::{register_mock_applications, ExpectedCall};
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, BlockHeight},
     identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
+    test_utils::{register_mock_applications, ExpectedCall},
     ContractRuntime, ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionStateView,
     Message, MessageContext, RawExecutionOutcome, ResourceControlPolicy, ResourceController,
     SystemExecutionState, TestExecutionRuntimeContext,

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -3,11 +3,6 @@
 
 #![allow(clippy::field_reassign_with_default)]
 
-mod utils;
-
-use self::utils::{
-    create_dummy_user_application_registrations, register_mock_applications, ExpectedCall,
-};
 use assert_matches::assert_matches;
 use linera_base::{
     crypto::PublicKey,
@@ -15,11 +10,14 @@ use linera_base::{
     identifiers::{Account, ChainDescription, ChainId, Destination, Owner},
 };
 use linera_execution::{
-    system::SystemMessage, ApplicationCallOutcome, BaseRuntime, ContractRuntime, ExecutionError,
-    ExecutionOutcome, ExecutionRuntimeConfig, ExecutionStateView, MessageKind, Operation,
-    OperationContext, Query, QueryContext, RawExecutionOutcome, RawOutgoingMessage,
-    ResourceController, Response, SessionCallOutcome, SystemExecutionState,
-    TestExecutionRuntimeContext,
+    system::SystemMessage,
+    test_utils::{
+        create_dummy_user_application_registrations, register_mock_applications, ExpectedCall,
+    },
+    ApplicationCallOutcome, BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome,
+    ExecutionRuntimeConfig, ExecutionStateView, MessageKind, Operation, OperationContext, Query,
+    QueryContext, RawExecutionOutcome, RawOutgoingMessage, ResourceController, Response,
+    SessionCallOutcome, SystemExecutionState, TestExecutionRuntimeContext,
 };
 use linera_views::{batch::Batch, memory::MemoryContext};
 use std::vec;

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -3,18 +3,15 @@
 
 #![cfg(any(feature = "wasmer", with_wasmtime))]
 
-#[allow(dead_code)]
-mod utils;
-
-use self::utils::create_dummy_user_application_description;
 use counter::CounterAbi;
 use linera_base::{
     data_types::{Amount, BlockHeight},
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
-    ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView,
-    Operation, OperationContext, Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy,
+    test_utils::create_dummy_user_application_description, ExecutionOutcome,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView, Operation,
+    OperationContext, Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy,
     ResourceController, ResourceTracker, Response, SystemExecutionState,
     TestExecutionRuntimeContext, WasmContractModule, WasmRuntime, WasmServiceModule,
 };

--- a/linera-views/README.md
+++ b/linera-views/README.md
@@ -1,7 +1,7 @@
 <!-- cargo-rdme start -->
 
 This module is used in the Linera protocol to map complex data structures onto a
-key-value store. The central notion is a [`views::View`](https://docs.rs/linera-views/latest/linera_views/views/trait.View.html) which can
+key-value store. The central notion is a [`views::View`] which can
 be loaded from storage, modified in memory, then committed (i.e. the changes are
 atomically persisted in storage).
 

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module is used in the Linera protocol to map complex data structures onto a
-//! key-value store. The central notion is a [`views::View`](crate::views::View) which can
+//! key-value store. The central notion is a [`views::View`] which can
 //! be loaded from storage, modified in memory, then committed (i.e. the changes are
 //! atomically persisted in storage).
 //!


### PR DESCRIPTION
## Motivation

Mock applications are useful for `linera-chain` tests, too.

## Proposal

Make the `linera-execution` test utilities available for other crates.

## Test Plan

Tests that make use of this will be added in an upcoming PR.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
