### PR TITLE
Add TestSignable and CryptoHash::debug.

### DIFF
--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -18,7 +18,7 @@ fn test_signed_values() {
         block,
         messages: Vec::new(),
         message_counts: vec![1],
-        state_hash: CryptoHash::new(&Dummy),
+        state_hash: CryptoHash::debug("state"),
     };
     let value = HashedValue::new_confirmed(executed_block);
 
@@ -46,7 +46,7 @@ fn test_certificates() {
         block,
         messages: Vec::new(),
         message_counts: vec![1],
-        state_hash: CryptoHash::new(&Dummy),
+        state_hash: CryptoHash::debug("state"),
     };
     let value = HashedValue::new_confirmed(executed_block);
 
@@ -71,8 +71,3 @@ fn test_certificates() {
         .is_none());
     assert!(builder.append(v3.validator, v3.signature).is_err());
 }
-
-#[derive(Serialize, Deserialize)]
-struct Dummy;
-
-impl BcsSignable for Dummy {}

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -5,19 +5,10 @@
 use super::*;
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{BcsSignable, CryptoHash},
+    crypto::CryptoHash,
     data_types::{Amount, Timestamp},
 };
 use linera_execution::{Message, MessageKind, UserApplicationId};
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize)]
-struct Dummy;
-#[derive(Serialize, Deserialize)]
-struct Dummy2;
-
-impl BcsSignable for Dummy {}
-impl BcsSignable for Dummy2 {}
 
 fn make_event(
     certificate_hash: CryptoHash,
@@ -54,7 +45,7 @@ fn make_unskippable_event(
 
 #[tokio::test]
 async fn test_inbox_add_then_remove_skippable() {
-    let hash = CryptoHash::new(&Dummy);
+    let hash = CryptoHash::debug("1");
     let mut view = InboxStateView::new().await;
     // Add one event.
     view.add_event(make_event(hash, 0, 0, [0])).await.unwrap();
@@ -82,7 +73,7 @@ async fn test_inbox_add_then_remove_skippable() {
     );
     // Fail to remove non-matching even (hash).
     assert_matches!(
-        view.remove_event(&make_event(CryptoHash::new(&Dummy2), 0, 1, [1]))
+        view.remove_event(&make_event(CryptoHash::debug("2"), 0, 1, [1]))
             .await,
         Err(InboxError::UnexpectedEvent { .. })
     );
@@ -97,7 +88,7 @@ async fn test_inbox_add_then_remove_skippable() {
 
 #[tokio::test]
 async fn test_inbox_remove_then_add_skippable() {
-    let hash = CryptoHash::new(&Dummy);
+    let hash = CryptoHash::debug("1");
     let mut view = InboxStateView::new().await;
     // Remove one event by anticipation.
     view.remove_event(&make_event(hash, 0, 0, [0]))
@@ -129,7 +120,7 @@ async fn test_inbox_remove_then_add_skippable() {
     );
     // Fail to add non-matching event (hash).
     assert_matches!(
-        view.add_event(make_event(CryptoHash::new(&Dummy2), 0, 1, [1]))
+        view.add_event(make_event(CryptoHash::debug("2"), 0, 1, [1]))
             .await,
         Err(InboxError::UnexpectedEvent { .. })
     );
@@ -155,7 +146,7 @@ async fn test_inbox_remove_then_add_skippable() {
 
 #[tokio::test]
 async fn test_inbox_add_then_remove_unskippable() {
-    let hash = CryptoHash::new(&Dummy);
+    let hash = CryptoHash::debug("1");
     let mut view = InboxStateView::new().await;
     // Add one event.
     view.add_event(make_unskippable_event(hash, 0, 0, [0]))
@@ -192,7 +183,7 @@ async fn test_inbox_add_then_remove_unskippable() {
     );
     // Fail to remove non-matching event (hash).
     assert_matches!(
-        view.remove_event(&make_unskippable_event(CryptoHash::new(&Dummy2), 0, 1, [1]))
+        view.remove_event(&make_unskippable_event(CryptoHash::debug("2"), 0, 1, [1]))
             .await,
         Err(InboxError::UnexpectedEvent { .. })
     );
@@ -215,7 +206,7 @@ async fn test_inbox_add_then_remove_unskippable() {
 
 #[tokio::test]
 async fn test_inbox_remove_then_add_unskippable() {
-    let hash = CryptoHash::new(&Dummy);
+    let hash = CryptoHash::debug("1");
     let mut view = InboxStateView::new().await;
     // Remove one event by anticipation.
     view.remove_event(&make_unskippable_event(hash, 0, 0, [0]))
@@ -252,7 +243,7 @@ async fn test_inbox_remove_then_add_unskippable() {
     );
     // Fail to add non-matching event (hash).
     assert_matches!(
-        view.add_event(make_unskippable_event(CryptoHash::new(&Dummy2), 0, 1, [1]))
+        view.add_event(make_unskippable_event(CryptoHash::debug("2"), 0, 1, [1]))
             .await,
         Err(InboxError::UnexpectedEvent { .. })
     );
@@ -282,7 +273,7 @@ async fn test_inbox_remove_then_add_unskippable() {
 
 #[tokio::test]
 async fn test_inbox_add_then_remove_mixed() {
-    let hash = CryptoHash::new(&Dummy);
+    let hash = CryptoHash::debug("1");
     let mut view = InboxStateView::new().await;
     // Add two events.
     view.add_event(make_unskippable_event(hash, 0, 1, [1]))
@@ -296,7 +287,7 @@ async fn test_inbox_add_then_remove_mixed() {
     );
     // Fail to remove non-matching event (hash).
     assert_matches!(
-        view.remove_event(&make_unskippable_event(CryptoHash::new(&Dummy2), 0, 1, [1]))
+        view.remove_event(&make_unskippable_event(CryptoHash::debug("2"), 0, 1, [1]))
             .await,
         Err(InboxError::UnexpectedEvent { .. })
     );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use assert_matches::assert_matches;
 use linera_base::{
-    crypto::{BcsSignable, CryptoHash, *},
+    crypto::{CryptoHash, *},
     data_types::*,
     identifiers::{Account, ChainDescription, ChainId, ChannelName, Destination, MessageId, Owner},
 };
@@ -42,7 +42,6 @@ use linera_views::{
     value_splitting::DatabaseConsistencyError,
     views::{CryptoHashView, ViewError},
 };
-use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
@@ -58,11 +57,6 @@ use linera_storage::DynamoDbStorage;
 
 #[cfg(feature = "scylladb")]
 use linera_storage::ScyllaDbStorage;
-
-#[derive(Serialize, Deserialize)]
-struct Dummy;
-
-impl BcsSignable for Dummy {}
 
 async fn make_state_hash(state: SystemExecutionState) -> CryptoHash {
     ExecutionStateView::from_system_state(state, ExecutionRuntimeConfig::default())
@@ -1528,7 +1522,7 @@ where
     let open_chain_message = IncomingMessage {
         origin: Origin::chain(ChainId::root(3)),
         event: Event {
-            certificate_hash: CryptoHash::new(&Dummy),
+            certificate_hash: CryptoHash::debug("certificate"),
             height: BlockHeight::ZERO,
             index: 0,
             authenticated_signer: None,
@@ -1748,7 +1742,7 @@ where
         vec![IncomingMessage {
             origin: Origin::chain(ChainId::root(3)),
             event: Event {
-                certificate_hash: CryptoHash::new(&Dummy),
+                certificate_hash: CryptoHash::debug("certificate"),
                 height: BlockHeight::ZERO,
                 index: 0,
                 authenticated_signer: None,
@@ -1807,7 +1801,7 @@ where
             kind: MessageKind::Tracked,
             timestamp,
             message: Message::System(SystemMessage::Credit { amount, .. }),
-        } if certificate_hash == CryptoHash::new(&Dummy)
+        } if certificate_hash == CryptoHash::debug("certificate")
             && height == BlockHeight::ZERO
             && timestamp == Timestamp::from(0)
             && amount == Amount::from_tokens(995),

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -986,17 +986,8 @@ where
 mod tests {
     use super::*;
     use crate::{ExecutionRuntimeConfig, ExecutionStateView, TestExecutionRuntimeContext};
-    use linera_base::{
-        crypto::{BcsSignable, KeyPair},
-        data_types::BlockHeight,
-        identifiers::ApplicationId,
-    };
+    use linera_base::{crypto::KeyPair, data_types::BlockHeight, identifiers::ApplicationId};
     use linera_views::memory::MemoryContext;
-
-    #[derive(Deserialize, Serialize)]
-    pub struct Dummy;
-
-    impl BcsSignable for Dummy {}
 
     /// Returns an execution state view and a matching operation context, for epoch 1, with root
     /// chain 0 as the admin ID and one empty committee.
@@ -1053,7 +1044,7 @@ mod tests {
             index: 0,
         });
         let location = BytecodeLocation {
-            certificate_hash: CryptoHash::new(&Dummy),
+            certificate_hash: CryptoHash::debug("certificate"),
             operation_index: 1,
         };
         view.system

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -6,11 +6,10 @@ use super::{
     UserApplicationId,
 };
 use linera_base::{
-    crypto::{BcsSignable, CryptoHash},
+    crypto::CryptoHash,
     data_types::BlockHeight,
     identifiers::{BytecodeId, ChainId, MessageId},
 };
-use serde::{Deserialize, Serialize};
 
 fn message_id(index: u32) -> MessageId {
     MessageId {
@@ -42,13 +41,8 @@ fn app_description(index: u32, deps: Vec<u32>) -> UserApplicationDescription {
 }
 
 fn location(operation_index: u32) -> BytecodeLocation {
-    #[derive(Serialize, Deserialize)]
-    struct Dummy;
-
-    impl BcsSignable for Dummy {}
-
     BytecodeLocation {
-        certificate_hash: CryptoHash::new(&Dummy),
+        certificate_hash: CryptoHash::debug("certificate"),
         operation_index,
     }
 }

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::field_reassign_with_default)]
 
 use linera_base::{
-    crypto::{BcsSignable, CryptoHash},
+    crypto::CryptoHash,
     data_types::{Amount, BlockHeight},
     identifiers::{Account, ChainDescription, ChainId, MessageId},
 };
@@ -15,7 +15,6 @@ use linera_execution::{
     SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
-use serde::{Deserialize, Serialize};
 
 #[tokio::test]
 async fn test_simple_system_operation() -> anyhow::Result<()> {
@@ -60,11 +59,6 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[derive(Serialize, Deserialize)]
-struct Dummy;
-
-impl BcsSignable for Dummy {}
-
 #[tokio::test]
 async fn test_simple_system_message() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
@@ -84,7 +78,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         is_bouncing: false,
         height: BlockHeight(0),
-        certificate_hash: CryptoHash::new(&Dummy),
+        certificate_hash: CryptoHash::debug("certificate"),
         message_id: MessageId {
             chain_id: ChainId::root(1),
             height: BlockHeight(0),

--- a/linera-rpc/src/conversions.rs
+++ b/linera-rpc/src/conversions.rs
@@ -520,7 +520,7 @@ impl TryFrom<grpc::Owner> for Owner {
 pub mod tests {
     use super::*;
     use linera_base::{
-        crypto::{BcsSignable, CryptoHash, KeyPair},
+        crypto::{CryptoHash, KeyPair, TestSignable},
         data_types::{Amount, Round, Timestamp},
     };
     use linera_chain::{
@@ -528,13 +528,7 @@ pub mod tests {
         test::make_first_block,
     };
     use linera_core::data_types::ChainInfo;
-    use serde::{Deserialize, Serialize};
     use std::{borrow::Cow, fmt::Debug};
-
-    #[derive(Debug, Serialize, Deserialize)]
-    struct Foo(String);
-
-    impl BcsSignable for Foo {}
 
     fn get_block() -> Block {
         make_first_block(ChainId::root(0))
@@ -562,7 +556,7 @@ pub mod tests {
     #[test]
     pub fn test_signature() {
         let key_pair = KeyPair::generate();
-        let signature = Signature::new(&Foo("test".into()), &key_pair);
+        let signature = Signature::new(&TestSignable::new("test"), &key_pair);
         round_trip_check::<_, grpc::Signature>(signature);
     }
 
@@ -624,7 +618,10 @@ pub mod tests {
         let chain_info_response_some = ChainInfoResponse {
             // `info` is bincode so no need to test conversions extensively
             info: chain_info,
-            signature: Some(Signature::new(&Foo("test".into()), &KeyPair::generate())),
+            signature: Some(Signature::new(
+                &TestSignable::new("test"),
+                &KeyPair::generate(),
+            )),
         };
         round_trip_check::<_, grpc::ChainInfoResponse>(chain_info_response_some);
     }
@@ -657,13 +654,13 @@ pub mod tests {
         let key_pair = KeyPair::generate();
         let certificate = LiteCertificate {
             value: LiteValue {
-                value_hash: CryptoHash::new(&Foo("value".into())),
+                value_hash: CryptoHash::debug("value"),
                 chain_id: ChainId::root(0),
             },
             round: Round::MultiLeader(2),
             signatures: Cow::Owned(vec![(
                 ValidatorName::from(key_pair.public()),
-                Signature::new(&Foo("test".into()), &key_pair),
+                Signature::new(&TestSignable::new("test"), &key_pair),
             )]),
         };
         let request = HandleLiteCertificateRequest {
@@ -682,19 +679,19 @@ pub mod tests {
                 block: get_block(),
                 messages: vec![],
                 message_counts: vec![],
-                state_hash: CryptoHash::new(&Foo("test".into())),
+                state_hash: CryptoHash::debug("test"),
             }),
             Round::MultiLeader(3),
             vec![(
                 ValidatorName::from(key_pair.public()),
-                Signature::new(&Foo("test".into()), &key_pair),
+                Signature::new(&TestSignable::new("test"), &key_pair),
             )],
         );
         let blobs = vec![HashedValue::new_validated(ExecutedBlock {
             block: get_block(),
             messages: vec![],
             message_counts: vec![],
-            state_hash: CryptoHash::new(&Foo("also test".into())),
+            state_hash: CryptoHash::debug("also test"),
         })];
         let request = HandleCertificateRequest {
             certificate,
@@ -737,24 +734,24 @@ pub mod tests {
                 round: Round::SingleLeader(4),
             },
             owner: Owner::from(KeyPair::generate().public()),
-            signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),
+            signature: Signature::new(&TestSignable::new("test"), &KeyPair::generate()),
             blobs: vec![HashedValue::new_confirmed(ExecutedBlock {
                 block: get_block(),
                 messages: vec![],
                 message_counts: vec![],
-                state_hash: CryptoHash::new(&Foo("execution state".into())),
+                state_hash: CryptoHash::debug("execution state"),
             })],
             validated: Some(Certificate::new(
                 HashedValue::new_validated(ExecutedBlock {
                     block: get_block(),
                     messages: vec![],
                     message_counts: vec![],
-                    state_hash: CryptoHash::new(&Foo("validated".into())),
+                    state_hash: CryptoHash::debug("validated"),
                 }),
                 Round::SingleLeader(2),
                 vec![(
                     ValidatorName::from(key_pair.public()),
-                    Signature::new(&Foo("signed".into()), &key_pair),
+                    Signature::new(&TestSignable::new("signed"), &key_pair),
                 )],
             )),
         };
@@ -768,7 +765,7 @@ pub mod tests {
             chain_id: ChainId::root(0),
             reason: linera_core::worker::Reason::NewBlock {
                 height: BlockHeight(0),
-                hash: CryptoHash::new(&Foo("".into())),
+                hash: CryptoHash::debug(""),
             },
         };
         round_trip_check::<_, grpc::Notification>(notification);


### PR DESCRIPTION
## Motivation

We have multiple test-only `impl BcsSignable for Foo` (or `Dummy` etc.).

## Proposal

Replace them with a single `TestSignable` defined in `crypto.rs`.

Also add `CryptoHash::debug` as a shortcut for a hash of a `TestSignable`.

## Test Plan

This only refactors the tests.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
