### PR TITLE
Add redundant target exemption to config.toml.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,7 @@ runner = "target/release/linera-wasm-test-runner"
 
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
+
+[build]
+# We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
+rustdocflags = ["-Arustdoc::redundant_explicit_links"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,8 +25,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
-  # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
-  RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
+  RUSTDOCFLAGS: -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,8 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
-  RUSTDOCFLAGS: -D warnings
+  # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
+  RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn


### PR DESCRIPTION
## Motivation

The redundant target in the documentation is required for `cargo-rdme` to create a link. I broke this in one case in #1694 to fix a `cargo doc` warning.

## Proposal

~Revert the change~ (already done in https://github.com/linera-io/linera-protocol/pull/1659); move the exemption from `rust.yml` to `config.toml` so we don't see that warning locally.

## Test Plan

CI, and I ran `cargo doc` locally again.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
