### PR TITLE
Add `linera-storage-service` to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,7 @@ COPY linera-sdk-derive linera-sdk-derive
 COPY linera-service linera-service
 COPY linera-service-graphql-client linera-service-graphql-client
 COPY linera-storage linera-storage
+COPY linera-storage-service linera-storage-service
 COPY linera-version linera-version
 COPY linera-views linera-views
 COPY linera-views-derive linera-views-derive


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
While deploying devnet, we ran into an issue with the container images. Building our crates failed because the `linera-storage-service` crate's files were missing.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Ensure `linera-storage-service` is copied into the container images.

## Test Plan

<!-- How to test that the changes are correct. -->
Source code not affected, so nothing is needed.

## Release Plan

- This is required for the smooth deployment of the devnet

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
