### PR TITLE
Chain applications

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -38,6 +38,10 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(test)]
+#[path = "unit_tests/chain_tests.rs"]
+mod chain_tests;
+
 #[cfg(with_metrics)]
 use {
     linera_base::{
@@ -784,6 +788,12 @@ where
         }
         // Second, execute the operations in the block and remember the recipients to notify.
         for (index, operation) in block.operations.iter().enumerate() {
+            if let Some(app_id) = self.execution_state.system.chain_application.get() {
+                ensure!(
+                    operation.application_id() == GenericApplicationId::User(*app_id),
+                    ChainError::ChainApplication(*app_id)
+                );
+            }
             #[cfg(with_metrics)]
             let _operation_latency = OPERATION_EXECUTION_LATENCY.measure_latency();
             let index = u32::try_from(index).map_err(|_| ArithmeticError::Overflow)?;

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -18,7 +18,7 @@ use data_types::{Event, Origin};
 use linera_base::{
     crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
-    identifiers::ChainId,
+    identifiers::{ApplicationId, ChainId},
 };
 use linera_execution::ExecutionError;
 use linera_views::views::ViewError;
@@ -136,6 +136,8 @@ pub enum ChainError {
     OwnerWeightError(#[from] WeightedError),
     #[error("Closed chains cannot have operations, accepted messages or empty blocks")]
     ClosedChain,
+    #[error("All operations on this chain must be from application {0}")]
+    ChainApplication(ApplicationId),
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -1,0 +1,150 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    data_types::HashedValue,
+    test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt},
+    ChainError, ChainStateView,
+};
+use assert_matches::assert_matches;
+use linera_base::{
+    crypto::{CryptoHash, PublicKey},
+    data_types::{Amount, BlockHeight, Timestamp},
+    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId},
+};
+use linera_execution::{
+    committee::{Committee, Epoch},
+    system::OpenChainConfig,
+    test_utils::{ExpectedCall, MockApplication},
+    BytecodeLocation, ChainOwnership, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation,
+    RawExecutionOutcome, SystemMessage, TestExecutionRuntimeContext, UserApplicationDescription,
+};
+use linera_views::{
+    memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    views::{View, ViewError},
+};
+use std::{iter, sync::Arc};
+
+impl ChainStateView<MemoryContext<TestExecutionRuntimeContext>>
+where
+    MemoryContext<TestExecutionRuntimeContext>:
+        linera_views::common::Context + Clone + Send + Sync + 'static,
+    ViewError:
+        From<<MemoryContext<TestExecutionRuntimeContext> as linera_views::common::Context>::Error>,
+{
+    pub async fn new(chain_id: ChainId) -> Self {
+        let exec_runtime_context =
+            TestExecutionRuntimeContext::new(chain_id, ExecutionRuntimeConfig::Synchronous);
+        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, exec_runtime_context);
+        Self::load(context)
+            .await
+            .expect("Loading from memory should work")
+    }
+}
+
+fn make_app_description() -> UserApplicationDescription {
+    UserApplicationDescription {
+        bytecode_id: BytecodeId::new(make_admin_message_id(BlockHeight(1))),
+        bytecode_location: BytecodeLocation {
+            certificate_hash: CryptoHash::test_hash("bytecode certificate"),
+            operation_index: 0,
+        },
+        creation: make_admin_message_id(BlockHeight(2)),
+        required_application_ids: vec![],
+        parameters: vec![],
+    }
+}
+
+fn admin_id() -> ChainId {
+    ChainId::root(0)
+}
+
+fn make_admin_message_id(height: BlockHeight) -> MessageId {
+    MessageId {
+        chain_id: admin_id(),
+        height,
+        index: 0,
+    }
+}
+
+fn make_open_chain_config() -> OpenChainConfig {
+    let committee = Committee::make_simple(vec![PublicKey::test_key(1).into()]);
+    OpenChainConfig {
+        ownership: ChainOwnership::single(PublicKey::test_key(0)),
+        admin_id: admin_id(),
+        epoch: Epoch::ZERO,
+        committees: iter::once((Epoch::ZERO, committee)).collect(),
+        balance: Amount::from_tokens(10),
+        chain_application: None,
+    }
+}
+
+#[tokio::test]
+async fn test_chain_application() {
+    let time = Timestamp::from(0);
+    let message_id = make_admin_message_id(BlockHeight(3));
+    let chain_id = ChainId::child(message_id);
+    let mut chain = ChainStateView::new(chain_id).await;
+
+    // Create a mock application.
+    let app_description = make_app_description();
+    let application_id = ApplicationId::from(&app_description);
+    let application = Arc::new(MockApplication::default());
+    let extra = &chain.context().extra;
+    extra
+        .user_contracts()
+        .insert(application_id, application.clone());
+
+    // Initialize the chain, with a chain application.
+    let config = OpenChainConfig {
+        chain_application: Some(application_id),
+        ..make_open_chain_config()
+    };
+    let message = SystemMessage::OpenChain(config).into();
+    chain
+        .execute_init_message(message_id, &message, time, time)
+        .await
+        .unwrap();
+
+    // The OpenChain message must be included in the first block. Also register the app.
+    let open_chain_message = message.to_simple_incoming(admin_id(), BlockHeight(1));
+    let register_app_message = SystemMessage::RegisterApplications {
+        applications: vec![app_description],
+    }
+    .to_simple_incoming(admin_id(), BlockHeight(2));
+
+    // An operation that doesn't belong to the app isn't allowed.
+    let invalid_block = make_first_block(chain_id)
+        .with_incoming_message(open_chain_message.clone())
+        .with_incoming_message(register_app_message.clone())
+        .with_simple_transfer(chain_id, Amount::ONE);
+    let result = chain.execute_block(&invalid_block, time).await;
+    assert_matches!(result, Err(ChainError::ChainApplication(app_id)) if app_id == application_id);
+
+    // After registering, an app operation can already be used in the first block.
+    application.expect_call(ExpectedCall::execute_operation(|_, _, _| {
+        Ok(RawExecutionOutcome::default())
+    }));
+    let app_operation = Operation::User {
+        application_id,
+        bytes: b"foo".to_vec(),
+    };
+    let valid_block = make_first_block(chain_id)
+        .with_incoming_message(open_chain_message)
+        .with_incoming_message(register_app_message.clone())
+        .with_operation(app_operation.clone());
+    let outcome = chain.execute_block(&valid_block, time).await.unwrap();
+    let value = HashedValue::new_confirmed(outcome.with(valid_block));
+
+    // In the second block, other operations are still not allowed.
+    let invalid_block = make_child_block(&value).with_simple_transfer(chain_id, Amount::ONE);
+    let result = chain.execute_block(&invalid_block, time).await;
+    assert_matches!(result, Err(ChainError::ChainApplication(app_id)) if app_id == application_id);
+
+    // But app operations continue to work.
+    application.expect_call(ExpectedCall::execute_operation(|_, _, _| {
+        Ok(RawExecutionOutcome::default())
+    }));
+    let valid_block = make_child_block(&value).with_operation(app_operation);
+    chain.execute_block(&valid_block, time).await.unwrap();
+}

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1882,6 +1882,7 @@ where
                 admin_id: self.admin_id,
                 epoch,
                 balance,
+                chain_application: None,
             };
             let operation = Operation::System(SystemOperation::OpenChain(config));
             let certificate = match self.execute_block(messages, vec![operation]).await? {

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1566,6 +1566,7 @@ where
                 epoch,
                 committees,
                 balance,
+                chain_application: None,
             })),
         },
         action: MessageAction::Accept,
@@ -2904,6 +2905,7 @@ where
                     committees: committees.clone(),
                     admin_id,
                     balance: Amount::ZERO,
+                    chain_application: None,
                 },
             )),
             messages: vec![
@@ -2916,6 +2918,7 @@ where
                         committees: committees.clone(),
                         admin_id,
                         balance: Amount::ZERO,
+                        chain_application: None,
                     }),
                 ),
                 direct_outgoing_message(
@@ -3147,6 +3150,7 @@ where
                             committees: committees.clone(),
                             admin_id,
                             balance: Amount::ZERO,
+                            chain_application: None,
                         })),
                     },
                     action: MessageAction::Accept,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -67,6 +67,7 @@ where
             timestamp,
             registry,
             closed,
+            chain_application,
         } = state;
         let extra = TestExecutionRuntimeContext::new(
             description.expect("Chain description should be set").into(),
@@ -100,6 +101,7 @@ where
             .import(registry)
             .expect("serialization of registry components should not fail");
         view.system.closed.set(closed);
+        view.system.chain_application.set(chain_application);
         view
     }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -719,7 +719,7 @@ pub struct TestExecutionRuntimeContext {
 
 #[cfg(any(test, feature = "test"))]
 impl TestExecutionRuntimeContext {
-    fn new(chain_id: ChainId, execution_runtime_config: ExecutionRuntimeConfig) -> Self {
+    pub fn new(chain_id: ChainId, execution_runtime_config: ExecutionRuntimeConfig) -> Self {
         Self {
             chain_id,
             execution_runtime_config,

--- a/linera-rpc/tests/staged/formats.yaml
+++ b/linera-rpc/tests/staged/formats.yaml
@@ -582,6 +582,9 @@ OpenChainConfig:
             TYPENAME: Committee
     - balance:
         TYPENAME: Amount
+    - chain_application:
+        OPTION:
+          TYPENAME: ApplicationId
 Operation:
   ENUM:
     0:

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -470,6 +470,7 @@ impl ClientContext {
                 admin_id: self.wallet_state.genesis_admin_chain(),
                 epoch,
                 balance,
+                chain_application: None,
             };
             let operations = iter::repeat(Operation::System(SystemOperation::OpenChain(config)))
                 .take(num_new_chains)


### PR DESCRIPTION
## Motivation

To implement e.g. atomic swaps, applications will need to create temporary chains that can only be used for a single purpose.

## Proposal

A "chain application" can optionally be configured, and then only operations belonging to that chain are allowed.

## Test Plan

A unit test was added.

## Links

- Will look simpler once rebased on top of https://github.com/linera-io/linera-protocol/pull/1696.
- Closes https://github.com/linera-io/linera-protocol/issues/1652.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
