### PR TITLE
Generate wit type declarations

### DIFF
--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -34,7 +34,7 @@ pub fn derive_wit_type(input: TokenStream) -> TokenStream {
     let specializations = apply_specialization_attribute(&mut input);
 
     let body = match &input.data {
-        Data::Struct(struct_item) => wit_type::derive_for_struct(&struct_item.fields),
+        Data::Struct(struct_item) => wit_type::derive_for_struct(&input.ident, &struct_item.fields),
         Data::Enum(enum_item) => wit_type::derive_for_enum(&input.ident, enum_item.variants.iter()),
         Data::Union(_union_item) => {
             abort!(input.ident, "Can't derive `WitType` for `union`s")

--- a/linera-witty-macros/src/unit_tests/wit_type.rs
+++ b/linera-witty-macros/src/unit_tests/wit_type.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Unit tests for the `WitLoad` derive macro.
+//! Unit tests for the `WitType` derive macro.
 
 #![cfg(test)]
 
@@ -9,7 +9,7 @@ use super::{derive_for_enum, derive_for_struct};
 use quote::quote;
 use syn::{parse_quote, Fields, ItemEnum, ItemStruct};
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a unit struct.
+/// Check the generated code for the body of the implementation of `WitType` for a unit struct.
 #[test]
 fn zero_sized_type() {
     let input = Fields::Unit;
@@ -24,7 +24,7 @@ fn zero_sized_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a named struct.
+/// Check the generated code for the body of the implementation of `WitType` for a named struct.
 #[test]
 fn named_struct() {
     let input: ItemStruct = parse_quote! {
@@ -44,7 +44,7 @@ fn named_struct() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a tuple struct.
+/// Check the generated code for the body of the implementation of `WitType` for a tuple struct.
 #[test]
 fn tuple_struct() {
     let input: ItemStruct = parse_quote! {
@@ -131,7 +131,7 @@ fn enum_type() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a named struct
+/// Check the generated code for the body of the implementation of `WitType` for a named struct
 /// with some ignored fields.
 #[test]
 fn named_struct_with_skipped_fields() {
@@ -160,7 +160,7 @@ fn named_struct_with_skipped_fields() {
     assert_eq!(output.to_string(), expected.to_string());
 }
 
-/// Check the generated code for the body of the implementation of `WitLoad` for a tuple struct
+/// Check the generated code for the body of the implementation of `WitType` for a tuple struct
 /// with some ignored fields.
 #[test]
 fn tuple_struct_with_skipped_fields() {

--- a/linera-witty-macros/src/unit_tests/wit_type.rs
+++ b/linera-witty-macros/src/unit_tests/wit_type.rs
@@ -19,6 +19,7 @@ fn zero_sized_type() {
         const SIZE: u32 = <linera_witty::HList![] as linera_witty::WitType>::SIZE;
 
         type Layout = <linera_witty::HList![] as linera_witty::WitType>::Layout;
+        type Dependencies = linera_witty::HList![];
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "zero-sized-type".into()
@@ -50,6 +51,7 @@ fn named_struct() {
         const SIZE: u32 = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::SIZE;
 
         type Layout = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::Layout;
+        type Dependencies = linera_witty::HList![u8, CustomType];
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
@@ -92,6 +94,8 @@ fn tuple_struct() {
 
         type Layout =
             <linera_witty::HList![String, Vec<CustomType>, i64] as linera_witty::WitType>::Layout;
+
+        type Dependencies = linera_witty::HList![String, Vec<CustomType>, i64];
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
@@ -190,6 +194,8 @@ fn enum_type() {
                 >>::Output
             >>::Output>;
 
+        type Dependencies = linera_witty::HList![i8, CustomType, (), String];
+
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "enum".into()
         }
@@ -261,6 +267,7 @@ fn named_struct_with_skipped_fields() {
         const SIZE: u32 = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::SIZE;
 
         type Layout = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::Layout;
+        type Dependencies = linera_witty::HList![u8, CustomType];
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
@@ -312,6 +319,8 @@ fn tuple_struct_with_skipped_fields() {
 
         type Layout =
             <linera_witty::HList![String, Vec<CustomType>, i64] as linera_witty::WitType>::Layout;
+
+        type Dependencies = linera_witty::HList![String, Vec<CustomType>, i64];
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
@@ -416,6 +425,8 @@ fn enum_type_with_skipped_fields() {
                     <linera_witty::HList![(), String] as linera_witty::WitType>::Layout
                 >>::Output
             >>::Output>;
+
+        type Dependencies = linera_witty::HList![i8, CustomType, (), String];
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "enum".into()

--- a/linera-witty-macros/src/unit_tests/wit_type.rs
+++ b/linera-witty-macros/src/unit_tests/wit_type.rs
@@ -6,19 +6,23 @@
 #![cfg(test)]
 
 use super::{derive_for_enum, derive_for_struct};
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{parse_quote, Fields, ItemEnum, ItemStruct};
 
 /// Check the generated code for the body of the implementation of `WitType` for a unit struct.
 #[test]
 fn zero_sized_type() {
     let input = Fields::Unit;
-    let output = derive_for_struct(&input);
+    let output = derive_for_struct(&format_ident!("ZeroSizedType"), &input);
 
     let expected = quote! {
         const SIZE: u32 = <linera_witty::HList![] as linera_witty::WitType>::SIZE;
 
         type Layout = <linera_witty::HList![] as linera_witty::WitType>::Layout;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            "zero-sized-type".into()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -33,12 +37,16 @@ fn named_struct() {
             second: CustomType,
         }
     };
-    let output = derive_for_struct(&input.fields);
+    let output = derive_for_struct(&input.ident, &input.fields);
 
     let expected = quote! {
         const SIZE: u32 = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::SIZE;
 
         type Layout = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::Layout;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            "type".into()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -50,7 +58,7 @@ fn tuple_struct() {
     let input: ItemStruct = parse_quote! {
         struct Type(String, Vec<CustomType>, i64);
     };
-    let output = derive_for_struct(&input.fields);
+    let output = derive_for_struct(&input.ident, &input.fields);
 
     let expected = quote! {
         const SIZE: u32 =
@@ -58,6 +66,10 @@ fn tuple_struct() {
 
         type Layout =
             <linera_witty::HList![String, Vec<CustomType>, i64] as linera_witty::WitType>::Layout;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            "type".into()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -126,6 +138,10 @@ fn enum_type() {
                     <linera_witty::HList![(), String] as linera_witty::WitType>::Layout
                 >>::Output
             >>::Output>;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            "enum".into()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -149,12 +165,16 @@ fn named_struct_with_skipped_fields() {
             ignored4: Vec<()>,
         }
     };
-    let output = derive_for_struct(&input.fields);
+    let output = derive_for_struct(&input.ident, &input.fields);
 
     let expected = quote! {
         const SIZE: u32 = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::SIZE;
 
         type Layout = <linera_witty::HList![u8, CustomType] as linera_witty::WitType>::Layout;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            "type".into()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -175,7 +195,7 @@ fn tuple_struct_with_skipped_fields() {
             i64,
         );
     };
-    let output = derive_for_struct(&input.fields);
+    let output = derive_for_struct(&input.ident, &input.fields);
 
     let expected = quote! {
         const SIZE: u32 =
@@ -183,6 +203,10 @@ fn tuple_struct_with_skipped_fields() {
 
         type Layout =
             <linera_witty::HList![String, Vec<CustomType>, i64] as linera_witty::WitType>::Layout;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            "type".into()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -258,6 +282,10 @@ fn enum_type_with_skipped_fields() {
                     <linera_witty::HList![(), String] as linera_witty::WitType>::Layout
                 >>::Output
             >>::Output>;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            "enum".into()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());

--- a/linera-witty-macros/src/unit_tests/wit_type.rs
+++ b/linera-witty-macros/src/unit_tests/wit_type.rs
@@ -23,6 +23,13 @@ fn zero_sized_type() {
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "zero-sized-type".into()
         }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration =
+                String::from(concat!("    record " , "zero-sized-type" , " {\n"));
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into ()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -47,6 +54,25 @@ fn named_struct() {
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
         }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(concat!("    record " , "type" , " {\n"));
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("first");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<u8 as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("second");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<CustomType as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into ()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -69,6 +95,31 @@ fn tuple_struct() {
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
+        }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(concat!("    record " , "type" , " {\n"));
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("inner0");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<String as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("inner1");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<Vec<CustomType> as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("inner2");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<i64 as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into ()
         }
     };
 
@@ -142,6 +193,45 @@ fn enum_type() {
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "enum".into()
         }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(
+                concat!("    ", "variant", " ", "enum" , " {\n"),
+            );
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("empty");
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("tuple");
+            wit_declaration.push_str("(tuple<");
+            wit_declaration.push_str(
+                &<i8 as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(", ");
+            wit_declaration.push_str(
+                &<CustomType as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(">)");
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("struct");
+            wit_declaration.push_str("(tuple<");
+            wit_declaration.push_str(
+                &<() as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(", ");
+            wit_declaration.push_str(
+                &<String as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(">)");
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into ()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -175,6 +265,25 @@ fn named_struct_with_skipped_fields() {
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
         }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(concat!("    record " , "type" , " {\n"));
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("first");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<u8 as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("second");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<CustomType as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into ()
+        }
     };
 
     assert_eq!(output.to_string(), expected.to_string());
@@ -206,6 +315,31 @@ fn tuple_struct_with_skipped_fields() {
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "type".into()
+        }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(concat!("    record " , "type" , " {\n"));
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("inner1");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<String as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("inner2");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<Vec<CustomType> as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("inner4");
+            wit_declaration.push_str(": ");
+            wit_declaration.push_str(&*<i64 as linera_witty::WitType>::wit_type_name());
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into ()
         }
     };
 
@@ -285,6 +419,45 @@ fn enum_type_with_skipped_fields() {
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             "enum".into()
+        }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(
+                concat!("    ", "variant", " ", "enum" , " {\n"),
+            );
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("empty");
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("tuple");
+            wit_declaration.push_str("(tuple<");
+            wit_declaration.push_str(
+                &<i8 as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(", ");
+            wit_declaration.push_str(
+                &<CustomType as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(">)");
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("        ");
+            wit_declaration.push_str("struct");
+            wit_declaration.push_str("(tuple<");
+            wit_declaration.push_str(
+                &<() as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(", ");
+            wit_declaration.push_str(
+                &<String as linera_witty::WitType>::wit_type_name(),
+            );
+            wit_declaration.push_str(">)");
+            wit_declaration.push_str(",\n");
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into ()
         }
     };
 

--- a/linera-witty-macros/src/wit_type.rs
+++ b/linera-witty-macros/src/wit_type.rs
@@ -4,23 +4,32 @@
 //! Derivation of the `WitType` trait.
 
 use crate::util::FieldsInformation;
+use heck::ToKebabCase;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::quote;
-use syn::{Ident, Variant};
+use syn::{Ident, LitStr, Variant};
 
 #[path = "unit_tests/wit_type.rs"]
 mod tests;
 
 /// Returns the body of the `WitType` implementation for the Rust `struct` with the specified
 /// `fields`.
-pub fn derive_for_struct<'input>(fields: impl Into<FieldsInformation<'input>>) -> TokenStream {
+pub fn derive_for_struct<'input>(
+    name: &Ident,
+    fields: impl Into<FieldsInformation<'input>>,
+) -> TokenStream {
+    let wit_name = LitStr::new(&name.to_string().to_kebab_case(), name.span());
     let fields_hlist = fields.into().hlist_type();
 
     quote! {
         const SIZE: u32 = <#fields_hlist as linera_witty::WitType>::SIZE;
 
         type Layout = <#fields_hlist as linera_witty::WitType>::Layout;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            #wit_name.into()
+        }
     }
 }
 
@@ -30,6 +39,8 @@ pub fn derive_for_enum<'variants>(
     name: &Ident,
     variants: impl DoubleEndedIterator<Item = &'variants Variant> + Clone,
 ) -> TokenStream {
+    let wit_name = LitStr::new(&name.to_string().to_kebab_case(), name.span());
+
     let variant_count = variants.clone().count();
     let variant_hlists =
         variants.map(|variant| FieldsInformation::from(&variant.fields).hlist_type());
@@ -79,5 +90,9 @@ pub fn derive_for_enum<'variants>(
         };
 
         type Layout = linera_witty::HCons<#discriminant_type, #variant_layouts>;
+
+        fn wit_type_name() -> std::borrow::Cow<'static, str> {
+            #wit_name.into()
+        }
     }
 }

--- a/linera-witty-macros/src/wit_type.rs
+++ b/linera-witty-macros/src/wit_type.rs
@@ -29,6 +29,7 @@ pub fn derive_for_struct<'input>(
         const SIZE: u32 = <#fields_hlist as linera_witty::WitType>::SIZE;
 
         type Layout = <#fields_hlist as linera_witty::WitType>::Layout;
+        type Dependencies = #fields_hlist;
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             #wit_name.into()
@@ -163,6 +164,7 @@ pub fn derive_for_enum<'variants>(
         };
 
         type Layout = linera_witty::HCons<#discriminant_type, #variant_layouts>;
+        type Dependencies = linera_witty::HList![#( #dependencies ),*];
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             #wit_name.into()

--- a/linera-witty-macros/src/wit_type.rs
+++ b/linera-witty-macros/src/wit_type.rs
@@ -20,7 +20,10 @@ pub fn derive_for_struct<'input>(
     fields: impl Into<FieldsInformation<'input>>,
 ) -> TokenStream {
     let wit_name = LitStr::new(&name.to_string().to_kebab_case(), name.span());
-    let fields_hlist = fields.into().hlist_type();
+    let fields = fields.into();
+    let fields_hlist = fields.hlist_type();
+    let field_wit_names = fields.wit_names();
+    let field_wit_type_names = fields.wit_type_names();
 
     quote! {
         const SIZE: u32 = <#fields_hlist as linera_witty::WitType>::SIZE;
@@ -29,6 +32,21 @@ pub fn derive_for_struct<'input>(
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             #wit_name.into()
+        }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(concat!("    record ", #wit_name, " {\n"));
+
+            #(
+                wit_declaration.push_str("        ");
+                wit_declaration.push_str(#field_wit_names);
+                wit_declaration.push_str(": ");
+                wit_declaration.push_str(&*#field_wit_type_names);
+                wit_declaration.push_str(",\n");
+            )*
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into()
         }
     }
 }
@@ -42,8 +60,14 @@ pub fn derive_for_enum<'variants>(
     let wit_name = LitStr::new(&name.to_string().to_kebab_case(), name.span());
 
     let variant_count = variants.clone().count();
-    let variant_hlists =
-        variants.map(|variant| FieldsInformation::from(&variant.fields).hlist_type());
+    let variant_fields: Vec<_> = variants
+        .clone()
+        .map(|variant| FieldsInformation::from(&variant.fields))
+        .collect();
+    let variant_hlists: Vec<_> = variant_fields
+        .iter()
+        .map(FieldsInformation::hlist_type)
+        .collect();
 
     let discriminant_type = if variant_count <= u8::MAX.into() {
         quote! { u8 }
@@ -57,7 +81,7 @@ pub fn derive_for_enum<'variants>(
 
     let discriminant_size = quote! { std::mem::size_of::<#discriminant_type>() as u32 };
 
-    let variant_sizes = variant_hlists.clone().map(|variant_hlist| {
+    let variant_sizes = variant_hlists.iter().map(|variant_hlist| {
         quote! {
             let variant_size =
                 discriminant_size + padding + <#variant_hlist as linera_witty::WitType>::SIZE;
@@ -69,6 +93,7 @@ pub fn derive_for_enum<'variants>(
     });
 
     let variant_layouts = variant_hlists
+        .iter()
         .map(|variant_hlist| quote! { <#variant_hlist as linera_witty::WitType>::Layout })
         .rev()
         .reduce(|current, variant_layout| {
@@ -76,6 +101,54 @@ pub fn derive_for_enum<'variants>(
                 <#variant_layout as linera_witty::Merge<#current>>::Output
             }
         });
+
+    let variant_field_types = variant_fields.iter().map(FieldsInformation::types);
+    let dependencies = variant_field_types.clone().flatten();
+
+    let enum_or_variant = if dependencies.clone().count() == 0 {
+        LitStr::new("enum", name.span())
+    } else {
+        LitStr::new("variant", name.span())
+    };
+
+    let variant_wit_names = variants.map(|variant| {
+        LitStr::new(
+            &variant.ident.to_string().to_kebab_case(),
+            variant.ident.span(),
+        )
+    });
+
+    let variant_wit_payloads = variant_field_types.map(|field_types| {
+        let mut field_types = field_types.peekable();
+        let first_field_type = field_types.next();
+        let has_second_field_type = field_types.peek().is_some();
+
+        match (first_field_type, has_second_field_type) {
+            (None, _) => quote! {},
+            (Some(only_field_type), false) => quote! {
+                wit_declaration.push('(');
+                wit_declaration.push_str(
+                    &<#only_field_type as linera_witty::WitType>::wit_type_name(),
+                );
+                wit_declaration.push(')');
+            },
+            (Some(first_field_type), true) => quote! {
+                wit_declaration.push_str("(tuple<");
+                wit_declaration.push_str(
+                    &<#first_field_type as linera_witty::WitType>::wit_type_name(),
+                );
+
+                #(
+                    wit_declaration.push_str(", ");
+                    wit_declaration.push_str(
+                        &<#field_types as linera_witty::WitType>::wit_type_name(),
+                    );
+                )*
+
+                wit_declaration.push_str(">)");
+            },
+        }
+    });
 
     quote! {
         const SIZE: u32 = {
@@ -93,6 +166,22 @@ pub fn derive_for_enum<'variants>(
 
         fn wit_type_name() -> std::borrow::Cow<'static, str> {
             #wit_name.into()
+        }
+
+        fn wit_type_declaration() -> std::borrow::Cow<'static, str> {
+            let mut wit_declaration = String::from(
+                concat!("    ", #enum_or_variant, " ", #wit_name, " {\n"),
+            );
+
+            #(
+                wit_declaration.push_str("        ");
+                wit_declaration.push_str(#variant_wit_names);
+                #variant_wit_payloads
+                wit_declaration.push_str(",\n");
+            )*
+
+            wit_declaration.push_str("    }\n");
+            wit_declaration.into()
         }
     }
 }

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -36,7 +36,7 @@ pub use self::{
         GuestPointer, Instance, InstanceWithFunction, InstanceWithMemory, Memory, Runtime,
         RuntimeError, RuntimeMemory,
     },
-    type_traits::{WitLoad, WitStore, WitType},
+    type_traits::{RegisterWitTypes, WitLoad, WitStore, WitType},
     util::{Merge, Split},
 };
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};

--- a/linera-witty/src/type_traits/implementations/custom_types.rs
+++ b/linera-witty/src/type_traits/implementations/custom_types.rs
@@ -8,11 +8,16 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HList};
+use std::borrow::Cow;
 
 impl WitType for GuestPointer {
     const SIZE: u32 = u32::SIZE;
 
     type Layout = HList![i32];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "guest-pointer".into()
+    }
 }
 
 impl WitLoad for GuestPointer {

--- a/linera-witty/src/type_traits/implementations/custom_types.rs
+++ b/linera-witty/src/type_traits/implementations/custom_types.rs
@@ -14,6 +14,7 @@ impl WitType for GuestPointer {
     const SIZE: u32 = u32::SIZE;
 
     type Layout = HList![i32];
+    type Dependencies = HList![];
 
     fn wit_type_name() -> Cow<'static, str> {
         "guest-pointer".into()

--- a/linera-witty/src/type_traits/implementations/custom_types.rs
+++ b/linera-witty/src/type_traits/implementations/custom_types.rs
@@ -18,6 +18,10 @@ impl WitType for GuestPointer {
     fn wit_type_name() -> Cow<'static, str> {
         "guest-pointer".into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        "type guest-pointer = i32".into()
+    }
 }
 
 impl WitLoad for GuestPointer {

--- a/linera-witty/src/type_traits/implementations/frunk.rs
+++ b/linera-witty/src/type_traits/implementations/frunk.rs
@@ -18,6 +18,10 @@ impl WitType for HNil {
     fn wit_type_name() -> Cow<'static, str> {
         "hnil".into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        "type hnil = unit".into()
+    }
 }
 
 impl WitLoad for HNil {
@@ -80,6 +84,13 @@ where
 
     fn wit_type_name() -> Cow<'static, str> {
         format!("hcons-{}-{}", Head::wit_type_name(), Tail::wit_type_name()).into()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        let head = Head::wit_type_name();
+        let tail = Tail::wit_type_name();
+
+        format!("type hcons-{head}-{tail} = tuple<{head}, {tail}>").into()
     }
 }
 

--- a/linera-witty/src/type_traits/implementations/frunk.rs
+++ b/linera-witty/src/type_traits/implementations/frunk.rs
@@ -8,12 +8,16 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{HCons, HNil};
-use std::ops::Add;
+use std::{borrow::Cow, ops::Add};
 
 impl WitType for HNil {
     const SIZE: u32 = 0;
 
     type Layout = HNil;
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "hnil".into()
+    }
 }
 
 impl WitLoad for HNil {
@@ -73,6 +77,10 @@ where
     const SIZE: u32 = Self::SIZE_STARTING_AT_BYTE_BOUNDARIES[0];
 
     type Layout = <Head::Layout as Add<Tail::Layout>>::Output;
+
+    fn wit_type_name() -> Cow<'static, str> {
+        format!("hcons-{}-{}", Head::wit_type_name(), Tail::wit_type_name()).into()
+    }
 }
 
 impl<Head, Tail> WitLoad for HCons<Head, Tail>

--- a/linera-witty/src/type_traits/implementations/frunk.rs
+++ b/linera-witty/src/type_traits/implementations/frunk.rs
@@ -7,13 +7,14 @@ use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory, Split,
     WitLoad, WitStore, WitType,
 };
-use frunk::{HCons, HNil};
+use frunk::{HCons, HList, HNil};
 use std::{borrow::Cow, ops::Add};
 
 impl WitType for HNil {
     const SIZE: u32 = 0;
 
     type Layout = HNil;
+    type Dependencies = HNil;
 
     fn wit_type_name() -> Cow<'static, str> {
         "hnil".into()
@@ -81,6 +82,7 @@ where
     const SIZE: u32 = Self::SIZE_STARTING_AT_BYTE_BOUNDARIES[0];
 
     type Layout = <Head::Layout as Add<Tail::Layout>>::Output;
+    type Dependencies = HList![Head, Tail];
 
     fn wit_type_name() -> Cow<'static, str> {
         format!("hcons-{}-{}", Head::wit_type_name(), Tail::wit_type_name()).into()

--- a/linera-witty/src/type_traits/implementations/std/floats.rs
+++ b/linera-witty/src/type_traits/implementations/std/floats.rs
@@ -16,6 +16,7 @@ macro_rules! impl_wit_traits {
             const SIZE: u32 = $size;
 
             type Layout = HList![$float];
+            type Dependencies = HList![];
 
             fn wit_type_name() -> Cow<'static, str> {
                 $wit_name.into()

--- a/linera-witty/src/type_traits/implementations/std/floats.rs
+++ b/linera-witty/src/type_traits/implementations/std/floats.rs
@@ -20,6 +20,11 @@ macro_rules! impl_wit_traits {
             fn wit_type_name() -> Cow<'static, str> {
                 $wit_name.into()
             }
+
+            fn wit_type_declaration() -> Cow<'static, str> {
+                // Primitive types don't need to be declared
+                "".into()
+            }
         }
 
         impl WitLoad for $float {

--- a/linera-witty/src/type_traits/implementations/std/floats.rs
+++ b/linera-witty/src/type_traits/implementations/std/floats.rs
@@ -8,13 +8,18 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HList};
+use std::borrow::Cow;
 
 macro_rules! impl_wit_traits {
-    ($float:ty, $size:expr) => {
+    ($float:ty, $wit_name:literal, $size:expr) => {
         impl WitType for $float {
             const SIZE: u32 = $size;
 
             type Layout = HList![$float];
+
+            fn wit_type_name() -> Cow<'static, str> {
+                $wit_name.into()
+            }
         }
 
         impl WitLoad for $float {
@@ -71,5 +76,5 @@ macro_rules! impl_wit_traits {
     };
 }
 
-impl_wit_traits!(f32, 4);
-impl_wit_traits!(f64, 8);
+impl_wit_traits!(f32, "float32", 4);
+impl_wit_traits!(f64, "float64", 8);

--- a/linera-witty/src/type_traits/implementations/std/integers.rs
+++ b/linera-witty/src/type_traits/implementations/std/integers.rs
@@ -20,6 +20,10 @@ macro_rules! impl_wit_traits {
             fn wit_type_name() -> Cow<'static, str> {
                 $wit_name.into()
             }
+
+            fn wit_type_declaration() -> Cow<'static, str> {
+                "".into()
+            }
         }
 
         impl WitLoad for $integer {
@@ -77,6 +81,7 @@ macro_rules! impl_wit_traits {
         impl_wit_traits!(
             $integer,
             $wit_name,
+            "",
             $size,
             ($integer),
             ($flat_type),
@@ -88,6 +93,7 @@ macro_rules! impl_wit_traits {
     (
         $integer:ty,
         $wit_name:literal,
+        $wit_declaration:literal,
         $size:expr,
         ($( $simple_types:ty ),*),
         ($( $flat_types:ty ),*),
@@ -101,6 +107,10 @@ macro_rules! impl_wit_traits {
 
             fn wit_type_name() -> Cow<'static, str> {
                 $wit_name.into()
+            }
+
+            fn wit_type_declaration() -> Cow<'static, str> {
+                $wit_declaration.into()
             }
         }
 
@@ -179,6 +189,7 @@ macro_rules! x128_lower {
 impl_wit_traits!(
     u128,
     "u128",
+    "    type u128 = tuple<u64, u64>;\n",
     16,
     (u64, u64),
     (i64, i64),
@@ -192,6 +203,7 @@ impl_wit_traits!(
 impl_wit_traits!(
     i128,
     "s128",
+    "    type s128 = tuple<s64, s64>;\n",
     16,
     (i64, i64),
     (i64, i64),

--- a/linera-witty/src/type_traits/implementations/std/integers.rs
+++ b/linera-witty/src/type_traits/implementations/std/integers.rs
@@ -16,6 +16,7 @@ macro_rules! impl_wit_traits {
             const SIZE: u32 = 1;
 
             type Layout = HList![$integer];
+            type Dependencies = HList![];
 
             fn wit_type_name() -> Cow<'static, str> {
                 $wit_name.into()
@@ -104,6 +105,7 @@ macro_rules! impl_wit_traits {
             const SIZE: u32 = $size;
 
             type Layout = HList![$( $simple_types ),*];
+            type Dependencies = HList![];
 
             fn wit_type_name() -> Cow<'static, str> {
                 $wit_name.into()

--- a/linera-witty/src/type_traits/implementations/std/integers.rs
+++ b/linera-witty/src/type_traits/implementations/std/integers.rs
@@ -8,13 +8,18 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HList};
+use std::borrow::Cow;
 
 macro_rules! impl_wit_traits {
-    ($integer:ty, 1) => {
+    ($integer:ty, $wit_name:literal, 1) => {
         impl WitType for $integer {
             const SIZE: u32 = 1;
 
             type Layout = HList![$integer];
+
+            fn wit_type_name() -> Cow<'static, str> {
+                $wit_name.into()
+            }
         }
 
         impl WitLoad for $integer {
@@ -68,9 +73,10 @@ macro_rules! impl_wit_traits {
         }
     };
 
-    ($integer:ty, $size:expr, $flat_type:ty) => {
+    ($integer:ty, $wit_name:literal, $size:expr, $flat_type:ty) => {
         impl_wit_traits!(
             $integer,
+            $wit_name,
             $size,
             ($integer),
             ($flat_type),
@@ -81,6 +87,7 @@ macro_rules! impl_wit_traits {
 
     (
         $integer:ty,
+        $wit_name:literal,
         $size:expr,
         ($( $simple_types:ty ),*),
         ($( $flat_types:ty ),*),
@@ -91,6 +98,10 @@ macro_rules! impl_wit_traits {
             const SIZE: u32 = $size;
 
             type Layout = HList![$( $simple_types ),*];
+
+            fn wit_type_name() -> Cow<'static, str> {
+                $wit_name.into()
+            }
         }
 
         impl WitLoad for $integer {
@@ -147,14 +158,14 @@ macro_rules! impl_wit_traits {
     };
 }
 
-impl_wit_traits!(u8, 1);
-impl_wit_traits!(i8, 1);
-impl_wit_traits!(u16, 2, i32);
-impl_wit_traits!(i16, 2, i32);
-impl_wit_traits!(u32, 4, i32);
-impl_wit_traits!(i32, 4, i32);
-impl_wit_traits!(u64, 8, i64);
-impl_wit_traits!(i64, 8, i64);
+impl_wit_traits!(u8, "u8", 1);
+impl_wit_traits!(i8, "s8", 1);
+impl_wit_traits!(u16, "u16", 2, i32);
+impl_wit_traits!(i16, "s16", 2, i32);
+impl_wit_traits!(u32, "u32", 4, i32);
+impl_wit_traits!(i32, "s32", 4, i32);
+impl_wit_traits!(u64, "u64", 8, i64);
+impl_wit_traits!(i64, "s64", 8, i64);
 
 macro_rules! x128_lower {
     ($this:ident) => {
@@ -167,6 +178,7 @@ macro_rules! x128_lower {
 
 impl_wit_traits!(
     u128,
+    "u128",
     16,
     (u64, u64),
     (i64, i64),
@@ -179,6 +191,7 @@ impl_wit_traits!(
 
 impl_wit_traits!(
     i128,
+    "s128",
     16,
     (i64, i64),
     (i64, i64),

--- a/linera-witty/src/type_traits/implementations/std/option.rs
+++ b/linera-witty/src/type_traits/implementations/std/option.rs
@@ -7,7 +7,7 @@ use crate::{
     GuestPointer, InstanceWithMemory, JoinFlatLayouts, Layout, Memory, Merge, Runtime,
     RuntimeError, RuntimeMemory, WitLoad, WitStore, WitType,
 };
-use frunk::{hlist, hlist_pat, HCons, HNil};
+use frunk::{hlist, hlist_pat, HCons, HList, HNil};
 use std::borrow::Cow;
 
 impl<T> WitType for Option<T>
@@ -23,6 +23,7 @@ where
     };
 
     type Layout = HCons<i8, <HNil as Merge<T::Layout>>::Output>;
+    type Dependencies = HList![T];
 
     fn wit_type_name() -> Cow<'static, str> {
         format!("option<{}>", T::wit_type_name()).into()

--- a/linera-witty/src/type_traits/implementations/std/option.rs
+++ b/linera-witty/src/type_traits/implementations/std/option.rs
@@ -8,6 +8,7 @@ use crate::{
     RuntimeError, RuntimeMemory, WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HCons, HNil};
+use std::borrow::Cow;
 
 impl<T> WitType for Option<T>
 where
@@ -22,6 +23,10 @@ where
     };
 
     type Layout = HCons<i8, <HNil as Merge<T::Layout>>::Output>;
+
+    fn wit_type_name() -> Cow<'static, str> {
+        format!("option<{}>", T::wit_type_name()).into()
+    }
 }
 
 impl<T> WitLoad for Option<T>

--- a/linera-witty/src/type_traits/implementations/std/option.rs
+++ b/linera-witty/src/type_traits/implementations/std/option.rs
@@ -27,6 +27,11 @@ where
     fn wit_type_name() -> Cow<'static, str> {
         format!("option<{}>", T::wit_type_name()).into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        // The native `option` type doesn't need to be declared
+        "".into()
+    }
 }
 
 impl<T> WitLoad for Option<T>

--- a/linera-witty/src/type_traits/implementations/std/phantom_data.rs
+++ b/linera-witty/src/type_traits/implementations/std/phantom_data.rs
@@ -14,6 +14,7 @@ impl<T> WitType for PhantomData<T> {
     const SIZE: u32 = 0;
 
     type Layout = HList![];
+    type Dependencies = HList![];
 
     fn wit_type_name() -> Cow<'static, str> {
         "unit".into()

--- a/linera-witty/src/type_traits/implementations/std/phantom_data.rs
+++ b/linera-witty/src/type_traits/implementations/std/phantom_data.rs
@@ -8,12 +8,16 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, HList};
-use std::marker::PhantomData;
+use std::{borrow::Cow, marker::PhantomData};
 
 impl<T> WitType for PhantomData<T> {
     const SIZE: u32 = 0;
 
     type Layout = HList![];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "unit".into()
+    }
 }
 
 impl<T> WitLoad for PhantomData<T> {

--- a/linera-witty/src/type_traits/implementations/std/phantom_data.rs
+++ b/linera-witty/src/type_traits/implementations/std/phantom_data.rs
@@ -18,6 +18,11 @@ impl<T> WitType for PhantomData<T> {
     fn wit_type_name() -> Cow<'static, str> {
         "unit".into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        // The `unit` type used doesn't need to be declared
+        "".into()
+    }
 }
 
 impl<T> WitLoad for PhantomData<T> {

--- a/linera-witty/src/type_traits/implementations/std/primitives.rs
+++ b/linera-witty/src/type_traits/implementations/std/primitives.rs
@@ -8,11 +8,16 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HList};
+use std::borrow::Cow;
 
 impl WitType for bool {
     const SIZE: u32 = 1;
 
     type Layout = HList![i8];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "bool".into()
+    }
 }
 
 impl WitLoad for bool {
@@ -72,6 +77,10 @@ where
     const SIZE: u32 = T::SIZE;
 
     type Layout = T::Layout;
+
+    fn wit_type_name() -> Cow<'static, str> {
+        panic!("Borrowed values can't be used in WIT files generated with Witty");
+    }
 }
 
 impl<'t, T> WitStore for &'t T

--- a/linera-witty/src/type_traits/implementations/std/primitives.rs
+++ b/linera-witty/src/type_traits/implementations/std/primitives.rs
@@ -18,6 +18,11 @@ impl WitType for bool {
     fn wit_type_name() -> Cow<'static, str> {
         "bool".into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        // Primitive types don't need to be declared
+        "".into()
+    }
 }
 
 impl WitLoad for bool {
@@ -79,6 +84,10 @@ where
     type Layout = T::Layout;
 
     fn wit_type_name() -> Cow<'static, str> {
+        panic!("Borrowed values can't be used in WIT files generated with Witty");
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
         panic!("Borrowed values can't be used in WIT files generated with Witty");
     }
 }

--- a/linera-witty/src/type_traits/implementations/std/primitives.rs
+++ b/linera-witty/src/type_traits/implementations/std/primitives.rs
@@ -14,6 +14,7 @@ impl WitType for bool {
     const SIZE: u32 = 1;
 
     type Layout = HList![i8];
+    type Dependencies = HList![];
 
     fn wit_type_name() -> Cow<'static, str> {
         "bool".into()
@@ -82,6 +83,7 @@ where
     const SIZE: u32 = T::SIZE;
 
     type Layout = T::Layout;
+    type Dependencies = HList![];
 
     fn wit_type_name() -> Cow<'static, str> {
         panic!("Borrowed values can't be used in WIT files generated with Witty");

--- a/linera-witty/src/type_traits/implementations/std/result.rs
+++ b/linera-witty/src/type_traits/implementations/std/result.rs
@@ -7,7 +7,7 @@ use crate::{
     GuestPointer, InstanceWithMemory, JoinFlatLayouts, Layout, Memory, Merge, Runtime,
     RuntimeError, RuntimeMemory, WitLoad, WitStore, WitType,
 };
-use frunk::{hlist, hlist_pat, HCons};
+use frunk::{hlist, hlist_pat, HCons, HList};
 use std::borrow::Cow;
 
 impl<T, E> WitType for Result<T, E>
@@ -35,6 +35,7 @@ where
     };
 
     type Layout = HCons<i8, <T::Layout as Merge<E::Layout>>::Output>;
+    type Dependencies = HList![T, E];
 
     fn wit_type_name() -> Cow<'static, str> {
         format!("result<{}, {}>", T::wit_type_name(), E::wit_type_name()).into()

--- a/linera-witty/src/type_traits/implementations/std/result.rs
+++ b/linera-witty/src/type_traits/implementations/std/result.rs
@@ -8,6 +8,7 @@ use crate::{
     RuntimeError, RuntimeMemory, WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HCons};
+use std::borrow::Cow;
 
 impl<T, E> WitType for Result<T, E>
 where
@@ -34,6 +35,10 @@ where
     };
 
     type Layout = HCons<i8, <T::Layout as Merge<E::Layout>>::Output>;
+
+    fn wit_type_name() -> Cow<'static, str> {
+        format!("result<{}, {}>", T::wit_type_name(), E::wit_type_name()).into()
+    }
 }
 
 impl<T, E> WitLoad for Result<T, E>

--- a/linera-witty/src/type_traits/implementations/std/result.rs
+++ b/linera-witty/src/type_traits/implementations/std/result.rs
@@ -39,6 +39,11 @@ where
     fn wit_type_name() -> Cow<'static, str> {
         format!("result<{}, {}>", T::wit_type_name(), E::wit_type_name()).into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        // The native `result` type doesn't need to be declared
+        "".into()
+    }
 }
 
 impl<T, E> WitLoad for Result<T, E>

--- a/linera-witty/src/type_traits/implementations/std/string.rs
+++ b/linera-witty/src/type_traits/implementations/std/string.rs
@@ -14,6 +14,7 @@ impl WitType for String {
     const SIZE: u32 = 8;
 
     type Layout = HList![i32, i32];
+    type Dependencies = HList![];
 
     fn wit_type_name() -> Cow<'static, str> {
         "string".into()

--- a/linera-witty/src/type_traits/implementations/std/string.rs
+++ b/linera-witty/src/type_traits/implementations/std/string.rs
@@ -18,6 +18,11 @@ impl WitType for String {
     fn wit_type_name() -> Cow<'static, str> {
         "string".into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        // Primitive types don't need to be declared
+        "".into()
+    }
 }
 
 impl WitLoad for String {

--- a/linera-witty/src/type_traits/implementations/std/string.rs
+++ b/linera-witty/src/type_traits/implementations/std/string.rs
@@ -8,11 +8,16 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HList};
+use std::borrow::Cow;
 
 impl WitType for String {
     const SIZE: u32 = 8;
 
     type Layout = HList![i32, i32];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "string".into()
+    }
 }
 
 impl WitLoad for String {

--- a/linera-witty/src/type_traits/implementations/std/tuples.rs
+++ b/linera-witty/src/type_traits/implementations/std/tuples.rs
@@ -8,6 +8,7 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HList};
+use std::borrow::Cow;
 
 /// Implement [`WitType`], [`WitLoad`] and [`WitStore`].
 ///
@@ -48,6 +49,18 @@ macro_rules! impl_wit_traits_with_borrow_store_clause {
             const SIZE: u32 = <HList![$( $types ),*] as WitType>::SIZE;
 
             type Layout = <HList![$( $types ),*] as WitType>::Layout;
+
+            fn wit_type_name() -> Cow<'static, str> {
+                let elements: &[Cow<'static, str>] = &[
+                    $( $types::wit_type_name(), )*
+                ];
+
+                if elements.is_empty() {
+                    "unit".into()
+                } else {
+                    format!("tuple<{}>", elements.join(", ")).into()
+                }
+            }
         }
 
         impl<$( $types ),*> WitLoad for ($( $types, )*)

--- a/linera-witty/src/type_traits/implementations/std/tuples.rs
+++ b/linera-witty/src/type_traits/implementations/std/tuples.rs
@@ -61,6 +61,11 @@ macro_rules! impl_wit_traits_with_borrow_store_clause {
                     format!("tuple<{}>", elements.join(", ")).into()
                 }
             }
+
+            fn wit_type_declaration() -> Cow<'static, str> {
+                // The native `tuple` type doesn't need to be declared
+                "".into()
+            }
         }
 
         impl<$( $types ),*> WitLoad for ($( $types, )*)

--- a/linera-witty/src/type_traits/implementations/std/tuples.rs
+++ b/linera-witty/src/type_traits/implementations/std/tuples.rs
@@ -49,6 +49,7 @@ macro_rules! impl_wit_traits_with_borrow_store_clause {
             const SIZE: u32 = <HList![$( $types ),*] as WitType>::SIZE;
 
             type Layout = <HList![$( $types ),*] as WitType>::Layout;
+            type Dependencies = HList![$( $types ),*];
 
             fn wit_type_name() -> Cow<'static, str> {
                 let elements: &[Cow<'static, str>] = &[

--- a/linera-witty/src/type_traits/implementations/std/vec.rs
+++ b/linera-witty/src/type_traits/implementations/std/vec.rs
@@ -8,6 +8,7 @@ use crate::{
     WitLoad, WitStore, WitType,
 };
 use frunk::{hlist, hlist_pat, HList};
+use std::borrow::Cow;
 
 impl<T> WitType for Vec<T>
 where
@@ -16,6 +17,10 @@ where
     const SIZE: u32 = 8;
 
     type Layout = HList![i32, i32];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        format!("list<{}>", T::wit_type_name()).into()
+    }
 }
 
 impl<T> WitLoad for Vec<T>

--- a/linera-witty/src/type_traits/implementations/std/vec.rs
+++ b/linera-witty/src/type_traits/implementations/std/vec.rs
@@ -17,6 +17,7 @@ where
     const SIZE: u32 = 8;
 
     type Layout = HList![i32, i32];
+    type Dependencies = HList![T];
 
     fn wit_type_name() -> Cow<'static, str> {
         format!("list<{}>", T::wit_type_name()).into()

--- a/linera-witty/src/type_traits/implementations/std/vec.rs
+++ b/linera-witty/src/type_traits/implementations/std/vec.rs
@@ -21,6 +21,11 @@ where
     fn wit_type_name() -> Cow<'static, str> {
         format!("list<{}>", T::wit_type_name()).into()
     }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        // The native `list` type doesn't need to be declared
+        "".into()
+    }
 }
 
 impl<T> WitLoad for Vec<T>

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -4,6 +4,7 @@
 //! Traits used to allow complex types to be sent and received between hosts and guests using WIT.
 
 mod implementations;
+mod register_wit_types;
 
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -8,6 +8,7 @@ mod implementations;
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
 };
+use std::borrow::Cow;
 
 /// A type that is representable by fundamental WIT types.
 pub trait WitType: Sized {
@@ -16,6 +17,9 @@ pub trait WitType: Sized {
 
     /// The layout of the type as fundamental types.
     type Layout: Layout;
+
+    /// Generates the WIT type name for this type.
+    fn wit_type_name() -> Cow<'static, str>;
 }
 
 /// A type that can be loaded from a guest Wasm module.

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -6,6 +6,8 @@
 mod implementations;
 mod register_wit_types;
 
+pub use self::register_wit_types::RegisterWitTypes;
+
 use crate::{
     GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
 };
@@ -18,6 +20,9 @@ pub trait WitType: Sized {
 
     /// The layout of the type as fundamental types.
     type Layout: Layout;
+
+    /// Other [`WitType`]s that this type depends on.
+    type Dependencies: RegisterWitTypes;
 
     /// Generates the WIT type name for this type.
     fn wit_type_name() -> Cow<'static, str>;

--- a/linera-witty/src/type_traits/mod.rs
+++ b/linera-witty/src/type_traits/mod.rs
@@ -20,6 +20,9 @@ pub trait WitType: Sized {
 
     /// Generates the WIT type name for this type.
     fn wit_type_name() -> Cow<'static, str>;
+
+    /// Generates the WIT type declaration for this type.
+    fn wit_type_declaration() -> Cow<'static, str>;
 }
 
 /// A type that can be loaded from a guest Wasm module.

--- a/linera-witty/src/type_traits/register_wit_types.rs
+++ b/linera-witty/src/type_traits/register_wit_types.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Trait and helper types allow registering a compile-time list of [`WitType`]s.
+
+use super::WitType;
+use frunk::{HCons, HNil};
+use std::collections::HashMap;
+
+/// Marker trait to prevent [`RegisterWitTypes`] to be implemented for other types.
+pub trait Sealed {}
+
+/// Trait to register a compile-time list of [`WitType`]s into a [`HashMap`].
+pub trait RegisterWitTypes: Sealed {
+    /// Registers this list of [`WitType`]s into `wit_types`.
+    fn register_wit_types(wit_types: &mut HashMap<String, String>);
+}
+
+impl Sealed for HNil {}
+impl<Head, Tail> Sealed for HCons<Head, Tail>
+where
+    Head: WitType,
+    Tail: Sealed,
+{
+}
+
+impl RegisterWitTypes for HNil {
+    fn register_wit_types(_wit_types: &mut HashMap<String, String>) {}
+}
+
+impl<Head, Tail> RegisterWitTypes for HCons<Head, Tail>
+where
+    Head: WitType,
+    Tail: RegisterWitTypes,
+{
+    fn register_wit_types(wit_types: &mut HashMap<String, String>) {
+        let head_name = Head::wit_type_name();
+
+        if !wit_types.contains_key(&*head_name) {
+            wit_types.insert(
+                head_name.into_owned(),
+                Head::wit_type_declaration().into_owned(),
+            );
+        }
+
+        Tail::register_wit_types(wit_types);
+    }
+}

--- a/linera-witty/src/type_traits/register_wit_types.rs
+++ b/linera-witty/src/type_traits/register_wit_types.rs
@@ -41,6 +41,8 @@ where
                 head_name.into_owned(),
                 Head::wit_type_declaration().into_owned(),
             );
+
+            Head::Dependencies::register_wit_types(wit_types);
         }
 
         Tail::register_wit_types(wit_types);

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -10,18 +10,23 @@ use self::types::{
     Branch, Enum, Leaf, RecordWithDoublePadding, SimpleWrapper, SpecializedGenericEnum,
     SpecializedGenericStruct, TupleWithPadding, TupleWithoutPadding,
 };
-use linera_witty::{HList, Layout, WitType};
+use linera_witty::{HList, Layout, RegisterWitTypes, WitType};
+use std::collections::{BTreeMap, HashMap};
 
-/// Check the memory size and layout derived for a wrapper type.
+/// Check the memory size, layout and WIT type declaration derived for a wrapper type.
 #[test]
 fn test_simple_bool_wrapper() {
     assert_eq!(SimpleWrapper::SIZE, 1);
     assert_eq!(<SimpleWrapper as WitType>::Layout::ALIGNMENT, 1);
     assert_eq!(<<SimpleWrapper as WitType>::Layout as Layout>::Flat::LEN, 1);
+    assert_eq!(
+        wit_type_declaration_of::<SimpleWrapper>(),
+        "    record simple-wrapper {\n        inner0: bool,\n    }\n"
+    );
 }
 
-/// Check the memory size and layout derived for a type with multiple fields ordered in a way that
-/// doesn't require any padding.
+/// Check the memory size, layout and WIT type declaration derived for a type with multiple fields
+/// ordered in a way that doesn't require any padding.
 #[test]
 fn test_tuple_struct_without_padding() {
     assert_eq!(TupleWithoutPadding::SIZE, 14);
@@ -30,10 +35,20 @@ fn test_tuple_struct_without_padding() {
         <<TupleWithoutPadding as WitType>::Layout as Layout>::Flat::LEN,
         3
     );
+    assert_eq!(
+        wit_type_declaration_of::<TupleWithoutPadding>(),
+        concat!(
+            "    record tuple-without-padding {\n",
+            "        inner0: u64,\n",
+            "        inner1: s32,\n",
+            "        inner2: s16,\n",
+            "    }\n"
+        )
+    );
 }
 
-/// Check the memory size and layout derived for a type with multiple fields ordered in a way that
-/// requires padding between all fields.
+/// Check the memory size, layout and WIT type declaration derived for a type with multiple fields
+/// ordered in a way that requires padding between all fields.
 #[test]
 fn test_tuple_struct_with_padding() {
     assert_eq!(TupleWithPadding::SIZE, 16);
@@ -42,10 +57,20 @@ fn test_tuple_struct_with_padding() {
         <<TupleWithPadding as WitType>::Layout as Layout>::Flat::LEN,
         3
     );
+    assert_eq!(
+        wit_type_declaration_of::<TupleWithPadding>(),
+        concat!(
+            "    record tuple-with-padding {\n",
+            "        inner0: u16,\n",
+            "        inner1: u32,\n",
+            "        inner2: s64,\n",
+            "    }\n"
+        )
+    );
 }
 
-/// Check the memory size and layout derived for a type with multiple named fields ordered in a way
-/// that requires padding before two fields.
+/// Check the memory size, layout and WIT type declaration derived for a type with multiple named
+/// fields ordered in a way that requires padding before two fields.
 #[test]
 fn test_named_struct_with_double_padding() {
     assert_eq!(RecordWithDoublePadding::SIZE, 24);
@@ -54,30 +79,79 @@ fn test_named_struct_with_double_padding() {
         <<RecordWithDoublePadding as WitType>::Layout as Layout>::Flat::LEN,
         4
     );
+    assert_eq!(
+        wit_type_declaration_of::<RecordWithDoublePadding>(),
+        concat!(
+            "    record record-with-double-padding {\n",
+            "        first: u16,\n",
+            "        second: u32,\n",
+            "        third: s8,\n",
+            "        fourth: s64,\n",
+            "    }\n"
+        )
+    );
 }
 
-/// Check the memory size and layout derived for a type that contains a field with a type that also
-/// has `WitType` derived for it.
+/// Check the memory size, layout and WIT type declarations derived for a type that contains a
+/// field with a type that also has `WitType` derived for it.
 #[test]
 fn test_nested_types() {
     assert_eq!(Leaf::SIZE, 24);
     assert_eq!(<Leaf as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Leaf as WitType>::Layout as Layout>::Flat::LEN, 3);
+    assert_eq!(
+        wit_type_declaration_of::<Leaf>(),
+        concat!(
+            "    record leaf {\n",
+            "        first: bool,\n",
+            "        second: u128,\n",
+            "    }\n\n",
+            "    type u128 = tuple<u64, u64>;\n"
+        )
+    );
 
     assert_eq!(Branch::SIZE, 56);
     assert_eq!(<Branch as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Branch as WitType>::Layout as Layout>::Flat::LEN, 7);
+    assert_eq!(
+        wit_type_declaration_of::<Branch>(),
+        concat!(
+            "    record branch {\n",
+            "        tag: u16,\n",
+            "        first-leaf: leaf,\n",
+            "        second-leaf: leaf,\n",
+            "    }\n\n",
+            "    record leaf {\n",
+            "        first: bool,\n",
+            "        second: u128,\n",
+            "    }\n\n",
+            "    type u128 = tuple<u64, u64>;\n"
+        )
+    );
 }
 
-/// Check the memory size and layout derived for an `enum` type.
+/// Check the memory size, layout and WIT type declaration derived for an `enum` type.
 #[test]
 fn test_enum_type() {
     assert_eq!(Enum::SIZE, 18);
     assert_eq!(<Enum as WitType>::Layout::ALIGNMENT, 8);
     assert_eq!(<<Enum as WitType>::Layout as Layout>::Flat::LEN, 11);
+    assert_eq!(
+        wit_type_declaration_of::<Enum>(),
+        concat!(
+            "    variant enum {\n",
+            "        empty,\n",
+            "        large-variant-with-loose-alignment(\
+                        tuple<s8, s8, s8, s8, s8, s8, s8, s8, s8, s8>\
+                     ),\n",
+            "        smaller-variant-with-strict-alignment(u64),\n",
+            "    }\n",
+        )
+    );
 }
 
-/// Check the memory size and layout derived for a specialized generic `struct` type.
+/// Check the memory size, layout and WIT type declaration derived for a specialized generic
+/// `struct` type.
 #[test]
 fn test_specialized_generic_struct() {
     assert_eq!(SpecializedGenericStruct::SIZE, 12);
@@ -89,9 +163,20 @@ fn test_specialized_generic_struct() {
         <<SpecializedGenericStruct<u8, i16> as WitType>::Layout as Layout>::Flat::LEN,
         4
     );
+    assert_eq!(
+        wit_type_declaration_of::<SpecializedGenericStruct<u8, i16>>(),
+        concat!(
+            "    record specialized-generic-struct {\n",
+            "        first: u8,\n",
+            "        second: s16,\n",
+            "        both: list<tuple<u8, s16>>,\n",
+            "    }\n",
+        )
+    );
 }
 
-/// Check the memory size and layout derived for a specialized generic `enum` type.
+/// Check the memory size, layout and WIT type declaration derived for a specialized generic `enum`
+/// type.
 #[test]
 fn test_specialized_generic_enum_type() {
     assert_eq!(SpecializedGenericEnum::SIZE, 12);
@@ -103,4 +188,34 @@ fn test_specialized_generic_enum_type() {
         <<SpecializedGenericEnum<Option<bool>, u32> as WitType>::Layout as Layout>::Flat::LEN,
         3
     );
+    assert_eq!(
+        wit_type_declaration_of::<SpecializedGenericEnum<Option<bool>, u32>>(),
+        concat!(
+            "    variant specialized-generic-enum {\n",
+            "        none,\n",
+            "        first(option<bool>),\n",
+            "        maybe-second(option<u32>),\n",
+            "    }\n",
+        )
+    );
+}
+
+/// Returns the WIT snippet with the type declarations for `T`.
+fn wit_type_declaration_of<T>() -> String
+where
+    T: WitType,
+{
+    let mut wit_types = HashMap::new();
+
+    <HList![T] as RegisterWitTypes>::register_wit_types(&mut wit_types);
+
+    let sorted_wit_types = wit_types
+        .into_iter()
+        .filter(|(_, declaration)| !declaration.is_empty())
+        .collect::<BTreeMap<_, _>>();
+
+    sorted_wit_types
+        .into_values()
+        .collect::<Vec<_>>()
+        .join("\n")
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
One of the goals of Witty is to allow the Rust code to be the source of truth. Therefore, the Rust code should be able to generate WIT files.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
This is the first step to generate WIT files. This only allows types that implement `WitType` to be able to generate WIT snippets with the necessary type declarations.

## Test Plan

<!-- How to test that the changes are correct. -->
Unit tests were updated to check the generated WIT snippets and the derived WIT snippet generators.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

This is a part of #906, but does _not_ close it.
