### PR TITLE
Move ChainOwnership to linera-base.

### DIFF
--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -12,6 +12,7 @@ pub mod crypto;
 pub mod data_types;
 mod graphql;
 pub mod identifiers;
+pub mod ownership;
 #[cfg(with_metrics)]
 pub mod prometheus_util;
 pub mod sync;

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -76,8 +76,9 @@ use linera_base::{
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
     doc_scalar, ensure,
     identifiers::{ChainId, Owner},
+    ownership::ChainOwnership,
 };
-use linera_execution::{committee::Epoch, ChainOwnership};
+use linera_execution::committee::Epoch;
 use rand_chacha::{rand_core::SeedableRng, ChaCha8Rng};
 use rand_distr::{Distribution, WeightedAliasIndex};
 use serde::{Deserialize, Serialize};

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -11,12 +11,13 @@ use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId},
+    ownership::ChainOwnership,
 };
 use linera_execution::{
     committee::{Committee, Epoch},
     system::OpenChainConfig,
     test_utils::{ExpectedCall, MockApplication},
-    BytecodeLocation, ChainOwnership, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation,
+    BytecodeLocation, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation,
     RawExecutionOutcome, SystemMessage, TestExecutionRuntimeContext, UserApplicationDescription,
 };
 use linera_views::{

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -28,6 +28,7 @@ use linera_base::{
     data_types::{Amount, ArithmeticError, BlockHeight, Round, Timestamp},
     ensure,
     identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
     data_types::{
@@ -42,9 +43,8 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemOperation, UserData,
         CREATE_APPLICATION_MESSAGE_INDEX, OPEN_CHAIN_MESSAGE_INDEX, PUBLISH_BYTECODE_MESSAGE_INDEX,
     },
-    Bytecode, ChainOwnership, ExecutionError, Message, Operation, Query, Response,
-    SystemExecutionError, SystemMessage, SystemQuery, SystemResponse, TimeoutConfig,
-    UserApplicationId,
+    Bytecode, ExecutionError, Message, Operation, Query, Response, SystemExecutionError,
+    SystemMessage, SystemQuery, SystemResponse, UserApplicationId,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -24,6 +24,7 @@ use linera_base::{
     crypto::*,
     data_types::*,
     identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
+    ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
     data_types::{CertificateValue, Event, ExecutedBlock, IncomingMessage, Medium, Origin},
@@ -32,8 +33,8 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::{Recipient, SystemOperation, UserData},
-    ChainOwnership, ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy,
-    SystemExecutionError, SystemMessage, SystemQuery, SystemResponse, TimeoutConfig,
+    ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy, SystemExecutionError,
+    SystemMessage, SystemQuery, SystemResponse,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -16,6 +16,7 @@ use linera_base::{
     crypto::KeyPair,
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{BytecodeId, ChainDescription, ChainId, Destination, MessageId},
+    ownership::ChainOwnership,
 };
 use linera_chain::{
     data_types::{
@@ -27,10 +28,10 @@ use linera_chain::{
 use linera_execution::{
     committee::Epoch,
     system::{SystemChannel, SystemMessage, SystemOperation},
-    Bytecode, BytecodeLocation, ChainOwnership, ChannelSubscription, ExecutionRuntimeConfig,
-    ExecutionStateView, GenericApplicationId, Message, MessageKind, Operation, OperationContext,
-    ResourceController, SystemExecutionState, UserApplicationDescription, UserApplicationId,
-    WasmContractModule, WasmRuntime,
+    Bytecode, BytecodeLocation, ChannelSubscription, ExecutionRuntimeConfig, ExecutionStateView,
+    GenericApplicationId, Message, MessageKind, Operation, OperationContext, ResourceController,
+    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmContractModule,
+    WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage};
 use linera_views::views::{CryptoHashView, ViewError};

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -18,6 +18,7 @@ use linera_base::{
     crypto::{CryptoHash, *},
     data_types::*,
     identifiers::{Account, ChainDescription, ChainId, ChannelName, Destination, MessageId, Owner},
+    ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
     data_types::{
@@ -33,9 +34,9 @@ use linera_execution::{
     system::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
-    ChainOwnership, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
-    ExecutionStateView, GenericApplicationId, Message, MessageKind, Query, Response,
-    SystemExecutionError, SystemExecutionState, SystemQuery, SystemResponse, TimeoutConfig,
+    ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionStateView,
+    GenericApplicationId, Message, MessageKind, Query, Response, SystemExecutionError,
+    SystemExecutionState, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, MemoryStorage, Storage, TestClock};
 use linera_views::{

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -4,7 +4,7 @@
 use crate::{
     committee::{Committee, Epoch, ValidatorName, ValidatorState},
     system::{Recipient, UserData},
-    Bytecode, ChainOwnership, ChannelSubscription, ExecutionStateView, GenericApplicationId,
+    Bytecode, ChannelSubscription, ExecutionStateView, GenericApplicationId,
     SystemExecutionStateView, UserApplicationDescription,
 };
 use async_graphql::{Error, Object};
@@ -12,6 +12,7 @@ use linera_base::{
     data_types::{Amount, Timestamp},
     doc_scalar,
     identifiers::{ChainDescription, ChainId, Owner},
+    ownership::ChainOwnership,
 };
 use linera_views::{common::Context, map_view::MapView, views::ViewError};
 use std::collections::BTreeMap;
@@ -21,7 +22,6 @@ doc_scalar!(
     "A unique identifier for a user application or for the system application"
 );
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
-doc_scalar!(ChainOwnership, "Represents the owner(s) of a chain");
 doc_scalar!(
     Epoch,
     "A number identifying the configuration of the chain (aka the committee)"

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -8,7 +8,6 @@ pub mod committee;
 mod execution;
 mod execution_state_actor;
 mod graphql;
-mod ownership;
 mod policy;
 mod resources;
 mod runtime;
@@ -24,7 +23,6 @@ pub use applications::{
     UserApplicationId,
 };
 pub use execution::ExecutionStateView;
-pub use ownership::{ChainOwnership, TimeoutConfig};
 pub use policy::ResourceControlPolicy;
 pub use resources::{ResourceController, ResourceTracker};
 pub use system::{

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -4,10 +4,9 @@
 
 use crate::{
     committee::{Committee, Epoch},
-    ownership::TimeoutConfig,
-    ApplicationRegistryView, Bytecode, BytecodeLocation, ChainOwnership, ChannelName,
-    ChannelSubscription, Destination, MessageContext, MessageKind, OperationContext, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, UserApplicationDescription, UserApplicationId,
+    ApplicationRegistryView, Bytecode, BytecodeLocation, ChannelName, ChannelSubscription,
+    Destination, MessageContext, MessageKind, OperationContext, QueryContext, RawExecutionOutcome,
+    RawOutgoingMessage, UserApplicationDescription, UserApplicationId,
 };
 use async_graphql::Enum;
 use custom_debug_derive::Debug;
@@ -18,6 +17,7 @@ use linera_base::{
     identifiers::{
         Account, ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId, Owner,
     },
+    ownership::{ChainOwnership, TimeoutConfig},
 };
 
 #[cfg(with_metrics)]

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -8,6 +8,7 @@
 use linera_base::{
     data_types::Round,
     identifiers::{ChainDescription, Destination},
+    ownership::ChainOwnership,
 };
 use linera_chain::{
     data_types::{CertificateValue, HashedValue, Medium, MessageAction},
@@ -16,7 +17,7 @@ use linera_chain::{
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
     system::{AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
-    ChainOwnership, GenericApplicationId, Message, MessageKind, Operation,
+    GenericApplicationId, Message, MessageKind, Operation,
 };
 use linera_rpc::RpcMessage;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -56,14 +56,14 @@ mod types {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod types {
+    pub use linera_base::ownership::ChainOwnership;
     pub use linera_chain::{
         data_types::{ChannelFullName, Event, MessageAction, Origin, Target},
         ChainManager,
     };
     pub use linera_core::worker::{Notification, Reason};
     pub use linera_execution::{
-        committee::Epoch, ChainOwnership, Message, MessageKind, Operation,
-        UserApplicationDescription,
+        committee::Epoch, Message, MessageKind, Operation, UserApplicationDescription,
     };
 }
 

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -9,13 +9,14 @@ use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, Timestamp},
     identifiers::{ChainId, MessageId},
+    ownership::ChainOwnership,
 };
 use linera_core::{
     client::{ChainClient, ChainClientError},
     data_types::ClientOutcome,
     node::ValidatorNodeProvider,
 };
-use linera_execution::{committee::ValidatorName, ChainOwnership};
+use linera_execution::committee::ValidatorName;
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use serde::Deserialize;

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -38,6 +38,7 @@ use {
         crypto::PublicKey,
         data_types::Amount,
         identifiers::{AccountOwner, ApplicationId, Owner},
+        ownership::ChainOwnership,
     },
     linera_chain::data_types::{Block, BlockAndRound, BlockProposal, SignatureAggregator, Vote},
     linera_core::{
@@ -47,7 +48,7 @@ use {
     linera_execution::{
         committee::Epoch,
         system::{OpenChainConfig, Recipient, SystemOperation, UserData, OPEN_CHAIN_MESSAGE_INDEX},
-        ChainOwnership, Operation,
+        Operation,
     },
     linera_rpc::{
         config::NetworkProtocol, grpc_network::GrpcClient, mass::MassClient, simple_network,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -13,6 +13,7 @@ use linera_base::{
     crypto::{CryptoHash, CryptoRng, PublicKey},
     data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId, MessageId, Owner},
+    ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::data_types::{CertificateValue, ExecutedBlock};
 use linera_core::{
@@ -26,7 +27,7 @@ use linera_core::{
 use linera_execution::{
     committee::{Committee, ValidatorName, ValidatorState},
     system::{SystemChannel, UserData},
-    ChainOwnership, Message, ResourceControlPolicy, SystemMessage, TimeoutConfig,
+    Message, ResourceControlPolicy, SystemMessage,
 };
 use linera_service::{
     chain_listener::ClientContext as _,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -24,6 +24,7 @@ use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
     data_types::{Amount, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner},
+    ownership::{ChainOwnership, TimeoutConfig},
     BcsHexParseError,
 };
 use linera_chain::{data_types::HashedValue, ChainStateView};
@@ -36,8 +37,8 @@ use linera_core::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::{AdminOperation, Recipient, SystemChannel, UserData},
-    Bytecode, ChainOwnership, Operation, Query, Response, SystemOperation, TimeoutConfig,
-    UserApplicationDescription, UserApplicationId,
+    Bytecode, Operation, Query, Response, SystemOperation, UserApplicationDescription,
+    UserApplicationId,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -39,6 +39,7 @@ use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{ChainDescription, ChainId},
+    ownership::ChainOwnership,
 };
 use linera_chain::{
     data_types::{Certificate, ChannelFullName, HashedValue},
@@ -47,9 +48,9 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch},
     system::SystemChannel,
-    ChainOwnership, ChannelSubscription, ExecutionError, ExecutionRuntimeConfig,
-    ExecutionRuntimeContext, GenericApplicationId, UserApplicationDescription, UserApplicationId,
-    UserContractCode, UserServiceCode, WasmRuntime,
+    ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
+    GenericApplicationId, UserApplicationDescription, UserApplicationId, UserContractCode,
+    UserServiceCode, WasmRuntime,
 };
 use linera_views::{
     common::Context,


### PR DESCRIPTION
## Motivation

For https://github.com/linera-io/linera-protocol/issues/305 applications will need to be able to open new chains, so we will add a `contract_abi` function in `linera-sdk`.

## Proposal

Move `ChainOwnership` and `TimeoutConfig` to `linera-base`, so they are available in `linera-sdk`.

## Test Plan

This only moves two types.

## Links

- Preparation for https://github.com/linera-io/linera-protocol/issues/1650.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
