### PR TITLE
Extract open_chain from execute_operation.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -568,7 +568,7 @@ where
         // Initialize ourself.
         self.execution_state
             .system
-            .open_chain(message_id, timestamp, config.clone());
+            .initialize_chain(message_id, timestamp, config.clone());
         // Recompute the state hash.
         let hash = self.execution_state.crypto_hash().await?;
         self.execution_state_hash.set(Some(hash));

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -932,7 +932,7 @@ where
     }
 
     /// Initializes the system application state on a newly opened chain.
-    pub fn open_chain(
+    pub fn initialize_chain(
         &mut self,
         message_id: MessageId,
         timestamp: Timestamp,


### PR DESCRIPTION
## Motivation

For https://github.com/linera-io/linera-protocol/issues/1650, the `OpenChain` `match` arm in `SystemExecutionStateView::execute_operation` will need to be called without such an operation being present in the block.

## Proposal

Extract that code into an `open_chain` method.

Rename the existing `open_chain` to `initialize_chain`; it is called when the `OpenChain` message is handled in the receiving chain, to initialize the state.

## Test Plan

This is only a refactoring.

## Links

- Preparation for https://github.com/linera-io/linera-protocol/issues/1650.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
