### PR TITLE
Fix parameter order in WIT proxy function

### DIFF
--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -200,8 +200,8 @@ extern "Rust" {
 
     fn __contract_handle_session_call(
         context: CalleeContext,
-        argument: Vec<u8>,
         session_state: Vec<u8>,
+        argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
     ) -> Result<SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, String>;
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The signature definition of the `__contract_handle_session_call` WIT proxy function had incorrectly swapped the `session_state` parameter with the `argument` parameter.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use the correct order of parameters in the proxy function signature, swapping the `argument` parameter with the `session_state` parameter.

## Test Plan

<!-- How to test that the changes are correct. -->
Since both parameters have the same type and this is only in an external function signature, the behavior with the different order is exactly the same, which is why this wasn't caught before.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because in practice this only changes the parameter name.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
