### PR TITLE
Move SystemExecutionState to test_utils.

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -9,9 +9,7 @@
 
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
-use crate::worker::worker_tests::make_state;
-
-use super::{init_worker_with_chains, make_certificate, make_state_hash};
+use super::{init_worker_with_chains, make_certificate};
 use linera_base::{
     crypto::KeyPair,
     data_types::{Amount, BlockHeight, Timestamp},
@@ -134,9 +132,9 @@ where
         committees: [(Epoch::ZERO, committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(publisher_key_pair.public()),
         timestamp: Timestamp::from(1),
-        ..make_state(Epoch::ZERO, publisher_chain, admin_id)
+        ..SystemExecutionState::make(Epoch::ZERO, publisher_chain, admin_id)
     };
-    let publisher_state_hash = make_state_hash(publisher_system_state.clone()).await;
+    let publisher_state_hash = publisher_system_state.clone().into_hash().await;
     let publish_block_proposal = HashedValue::new_confirmed(ExecutedBlock {
         block: publish_block,
         messages: vec![OutgoingMessage {
@@ -201,7 +199,7 @@ where
         .registry
         .published_bytecodes
         .insert(bytecode_id, bytecode_location);
-    let publisher_state_hash = make_state_hash(publisher_system_state.clone()).await;
+    let publisher_state_hash = publisher_system_state.clone().into_hash().await;
     let broadcast_block_proposal = HashedValue::new_confirmed(ExecutedBlock {
         block: broadcast_block,
         messages: vec![OutgoingMessage {
@@ -250,7 +248,7 @@ where
         committees: [(Epoch::ZERO, committee.clone())].into_iter().collect(),
         ownership: ChainOwnership::single(creator_key_pair.public()),
         timestamp: Timestamp::from(2),
-        ..make_state(Epoch::ZERO, creator_chain, admin_id)
+        ..SystemExecutionState::make(Epoch::ZERO, creator_chain, admin_id)
     };
     creator_system_state.subscriptions.insert(publisher_channel);
     let creator_state = ExecutionStateView::from_system_state(
@@ -305,7 +303,7 @@ where
         .with_timestamp(3)
         .with_incoming_message(accept_message);
     publisher_system_state.timestamp = Timestamp::from(3);
-    let publisher_state_hash = make_state_hash(publisher_system_state).await;
+    let publisher_state_hash = publisher_system_state.into_hash().await;
     let accept_block_proposal = HashedValue::new_confirmed(ExecutedBlock {
         block: accept_block,
         messages: vec![OutgoingMessage {

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -28,10 +28,10 @@ use linera_chain::{
 use linera_execution::{
     committee::Epoch,
     system::{SystemChannel, SystemMessage, SystemOperation},
+    test_utils::SystemExecutionState,
     Bytecode, BytecodeLocation, ChannelSubscription, ExecutionRuntimeConfig, ExecutionStateView,
     GenericApplicationId, Message, MessageKind, Operation, OperationContext, ResourceController,
-    SystemExecutionState, UserApplicationDescription, UserApplicationId, WasmContractModule,
-    WasmRuntime,
+    UserApplicationDescription, UserApplicationId, WasmContractModule, WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage};
 use linera_views::views::{CryptoHashView, ViewError};

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -34,9 +34,10 @@ use linera_execution::{
     system::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
+    test_utils::SystemExecutionState,
     ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionStateView,
-    GenericApplicationId, Message, MessageKind, Query, Response, SystemExecutionError,
-    SystemExecutionState, SystemQuery, SystemResponse,
+    GenericApplicationId, Message, MessageKind, Query, Response, SystemExecutionError, SystemQuery,
+    SystemResponse,
 };
 use linera_storage::{DbStorage, MemoryStorage, Storage, TestClock};
 use linera_views::{

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -35,16 +35,13 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
     test_utils::SystemExecutionState,
-    ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionStateView,
-    GenericApplicationId, Message, MessageKind, Query, Response, SystemExecutionError, SystemQuery,
-    SystemResponse,
+    ChannelSubscription, ExecutionError, GenericApplicationId, Message, MessageKind, Query,
+    Response, SystemExecutionError, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, MemoryStorage, Storage, TestClock};
 use linera_views::{
-    common::KeyValueStore,
-    memory::TEST_MEMORY_MAX_STREAM_QUERIES,
-    value_splitting::DatabaseConsistencyError,
-    views::{CryptoHashView, ViewError},
+    common::KeyValueStore, memory::TEST_MEMORY_MAX_STREAM_QUERIES,
+    value_splitting::DatabaseConsistencyError, views::ViewError,
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -61,38 +58,6 @@ use linera_storage::DynamoDbStorage;
 
 #[cfg(feature = "scylladb")]
 use linera_storage::ScyllaDbStorage;
-
-async fn make_state_hash(state: SystemExecutionState) -> CryptoHash {
-    ExecutionStateView::from_system_state(state, ExecutionRuntimeConfig::default())
-        .await
-        .crypto_hash()
-        .await
-        .expect("hashing from memory should not fail")
-}
-
-fn make_state(
-    epoch: Epoch,
-    description: ChainDescription,
-    admin_id: impl Into<ChainId>,
-) -> SystemExecutionState {
-    let admin_id = admin_id.into();
-    let subscriptions = if ChainId::from(description) == admin_id {
-        BTreeSet::new()
-    } else {
-        iter::once(ChannelSubscription {
-            chain_id: admin_id,
-            name: SystemChannel::Admin.name(),
-        })
-        .collect()
-    };
-    SystemExecutionState {
-        epoch: Some(epoch),
-        description: Some(description),
-        admin_id: Some(admin_id),
-        subscriptions,
-        ..SystemExecutionState::default()
-    }
-}
 
 /// The test worker accepts blocks with a timestamp this far in the future.
 const TEST_GRACE_PERIOD_MICROS: u64 = 500_000;
@@ -255,7 +220,7 @@ async fn make_transfer_certificate_for_epoch<S>(
         ownership: ChainOwnership::single(key_pair.public()),
         balance,
         balances,
-        ..make_state(epoch, chain_description, ChainId::root(0))
+        ..SystemExecutionState::make(epoch, chain_description, ChainId::root(0))
     };
     let block_template = match &previous_confirmed_block {
         None => make_first_block(chain_id),
@@ -305,7 +270,7 @@ async fn make_transfer_certificate_for_epoch<S>(
         Recipient::Burn => (),
     }
     message_counts.push(message_count);
-    let state_hash = make_state_hash(system_state).await;
+    let state_hash = system_state.into_hash().await;
     let value = HashedValue::new_confirmed(ExecutedBlock {
         block,
         messages,
@@ -605,9 +570,9 @@ where
             ownership: ChainOwnership::single(key_pair.public()),
             balance,
             timestamp: block_0_time,
-            ..make_state(epoch, ChainDescription::Root(1), ChainId::root(0))
+            ..SystemExecutionState::make(epoch, ChainDescription::Root(1), ChainId::root(0))
         };
-        let state_hash = make_state_hash(system_state).await;
+        let state_hash = system_state.into_hash().await;
         let value = HashedValue::new_confirmed(ExecutedBlock {
             block,
             messages: vec![],
@@ -868,6 +833,7 @@ where
     .await;
 
     let epoch = Epoch::ZERO;
+    let admin_id = ChainId::root(0);
     let certificate0 = make_certificate(
         &committee,
         &worker,
@@ -880,12 +846,13 @@ where
                 direct_credit_message(ChainId::root(2), Amount::from_tokens(2)),
             ],
             message_counts: vec![1, 2],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: [(epoch, committee.clone())].into_iter().collect(),
                 ownership: ChainOwnership::single(sender_key_pair.public()),
                 balance: Amount::from_tokens(3),
-                ..make_state(epoch, ChainDescription::Root(1), ChainId::root(0))
-            })
+                ..SystemExecutionState::make(epoch, ChainDescription::Root(1), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -901,11 +868,12 @@ where
                 Amount::from_tokens(3),
             )],
             message_counts: vec![1],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: [(epoch, committee.clone())].into_iter().collect(),
                 ownership: ChainOwnership::single(sender_key_pair.public()),
-                ..make_state(epoch, ChainDescription::Root(1), ChainId::root(0))
-            })
+                ..SystemExecutionState::make(epoch, ChainDescription::Root(1), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -980,7 +948,9 @@ where
                 ) if matches!(
                     *error,
                     ChainError::ExecutionError(
-                        ExecutionError::SystemError(SystemExecutionError::InsufficientFunding { .. }),
+                        ExecutionError::SystemError(
+                            SystemExecutionError::InsufficientFunding { .. }
+                        ),
                         ChainExecutionContext::Operation(_)
                     )
                 )
@@ -1155,11 +1125,12 @@ where
                 block: block_proposal.content.block,
                 messages: vec![direct_credit_message(ChainId::root(3), Amount::ONE)],
                 message_counts: vec![0, 1],
-                state_hash: make_state_hash(SystemExecutionState {
+                state_hash: SystemExecutionState {
                     committees: [(epoch, committee.clone())].into_iter().collect(),
                     ownership: ChainOwnership::single(recipient_key_pair.public()),
-                    ..make_state(epoch, ChainDescription::Root(2), ChainId::root(0))
-                })
+                    ..SystemExecutionState::make(epoch, ChainDescription::Root(2), admin_id)
+                }
+                .into_hash()
                 .await,
             }),
         );
@@ -1549,7 +1520,7 @@ where
         ownership: ownership.clone(),
         balance,
         subscriptions,
-        ..make_state(epoch, description, admin_id)
+        ..SystemExecutionState::make(epoch, description, admin_id)
     };
     let open_chain_message = IncomingMessage {
         origin: Origin::chain(ChainId::root(3)),
@@ -1577,7 +1548,7 @@ where
         block: make_first_block(chain_id).with_incoming_message(open_chain_message),
         messages: vec![],
         message_counts: vec![0],
-        state_hash: make_state_hash(state).await,
+        state_hash: state.into_hash().await,
     });
     let certificate = make_certificate(&committee, &worker, value);
     let info = worker
@@ -2933,12 +2904,13 @@ where
                 ),
             ],
             message_counts: vec![2],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: committees.clone(),
                 ownership: ChainOwnership::single(key_pair.public()),
                 balance: Amount::from_tokens(2),
-                ..make_state(Epoch::ZERO, ChainDescription::Root(0), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::ZERO, ChainDescription::Root(0), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -2990,12 +2962,13 @@ where
                 direct_credit_message(user_id, Amount::from_tokens(2)),
             ],
             message_counts: vec![1, 2],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 // The root chain knows both committees at the end.
                 committees: committees2.clone(),
                 ownership: ChainOwnership::single(key_pair.public()),
-                ..make_state(Epoch::from(1), ChainDescription::Root(0), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::from(1), ChainDescription::Root(0), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -3035,12 +3008,13 @@ where
                 SystemMessage::Notify { id: user_id },
             )],
             message_counts: vec![1],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 // The root chain knows both committees at the end.
                 committees: committees2.clone(),
                 ownership: ChainOwnership::single(key_pair.public()),
-                ..make_state(Epoch::from(1), ChainDescription::Root(0), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::from(1), ChainDescription::Root(0), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -3207,7 +3181,7 @@ where
                 }),
             messages: Vec::new(),
             message_counts: vec![0, 0, 0, 0],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 subscriptions: [ChannelSubscription {
                     chain_id: admin_id,
                     name: SystemChannel::Admin.name(),
@@ -3218,8 +3192,9 @@ where
                 committees: committees2.clone(),
                 ownership: ChainOwnership::single(key_pair.public()),
                 balance: Amount::from_tokens(2),
-                ..make_state(Epoch::from(1), user_description, admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::from(1), user_description, admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -3339,12 +3314,13 @@ where
             block: make_first_block(user_id).with_simple_transfer(admin_id, Amount::ONE),
             messages: vec![direct_credit_message(admin_id, Amount::ONE)],
             message_counts: vec![1],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: committees.clone(),
                 ownership: ChainOwnership::single(key_pair1.public()),
                 balance: Amount::from_tokens(2),
-                ..make_state(Epoch::ZERO, ChainDescription::Root(1), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::ZERO, ChainDescription::Root(1), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -3368,11 +3344,12 @@ where
                 committees: committees2.clone(),
             })],
             message_counts: vec![1],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: committees2.clone(),
                 ownership: ChainOwnership::single(key_pair0.public()),
-                ..make_state(Epoch::from(1), ChainDescription::Root(0), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::from(1), ChainDescription::Root(0), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -3482,12 +3459,13 @@ where
             block: make_first_block(user_id).with_simple_transfer(admin_id, Amount::ONE),
             messages: vec![direct_credit_message(admin_id, Amount::ONE)],
             message_counts: vec![1],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: committees.clone(),
                 ownership: ChainOwnership::single(key_pair1.public()),
                 balance: Amount::from_tokens(2),
-                ..make_state(Epoch::ZERO, ChainDescription::Root(1), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::ZERO, ChainDescription::Root(1), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -3520,11 +3498,12 @@ where
                 }),
             ],
             message_counts: vec![1, 2],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: committees3.clone(),
                 ownership: ChainOwnership::single(key_pair0.public()),
-                ..make_state(Epoch::from(1), ChainDescription::Root(0), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::from(1), ChainDescription::Root(0), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );
@@ -3584,12 +3563,13 @@ where
                 }),
             messages: Vec::new(),
             message_counts: vec![0],
-            state_hash: make_state_hash(SystemExecutionState {
+            state_hash: SystemExecutionState {
                 committees: committees3.clone(),
                 ownership: ChainOwnership::single(key_pair0.public()),
                 balance: Amount::ONE,
-                ..make_state(Epoch::from(1), ChainDescription::Root(0), admin_id)
-            })
+                ..SystemExecutionState::make(Epoch::from(1), ChainDescription::Root(0), admin_id)
+            }
+            .into_hash()
             .await,
         }),
     );

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -12,12 +12,14 @@ mod policy;
 mod resources;
 mod runtime;
 pub mod system;
-#[cfg(any(test, feature = "test"))]
+#[cfg(with_testing)]
 pub mod test_utils;
 mod util;
 mod wasm;
 
 pub use crate::runtime::{ContractSyncRuntime, ServiceSyncRuntime};
+#[cfg(with_testing)]
+pub use applications::ApplicationRegistry;
 pub use applications::{
     ApplicationRegistryView, BytecodeLocation, GenericApplicationId, UserApplicationDescription,
     UserApplicationId,
@@ -29,12 +31,10 @@ pub use system::{
     SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation, SystemQuery,
     SystemResponse,
 };
-#[cfg(all(any(test, feature = "test"), any(with_wasmer, with_wasmtime)))]
+#[cfg(all(with_testing, any(with_wasmer, with_wasmtime)))]
 pub use wasm::test as wasm_test;
 #[cfg(with_wasm_runtime)]
 pub use wasm::{WasmContractModule, WasmExecutionError, WasmServiceModule};
-#[cfg(any(test, feature = "test"))]
-pub use {applications::ApplicationRegistry, system::SystemExecutionState};
 
 use async_graphql::SimpleObject;
 use async_trait::async_trait;

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -20,9 +20,8 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 
-#[cfg(with_metrics)]
-use linera_base::{prometheus_util, sync::Lazy};
-
+#[cfg(test)]
+use crate::test_utils::SystemExecutionState;
 use linera_views::{
     common::Context,
     map_view::MapView,
@@ -30,8 +29,6 @@ use linera_views::{
     set_view::SetView,
     views::{HashableView, View, ViewError},
 };
-#[cfg(with_metrics)]
-use prometheus::IntCounterVec;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -39,9 +36,11 @@ use std::{
     iter,
 };
 use thiserror::Error;
-
-#[cfg(any(test, feature = "test"))]
-use crate::applications::ApplicationRegistry;
+#[cfg(with_metrics)]
+use {
+    linera_base::{prometheus_util, sync::Lazy},
+    prometheus::IntCounterVec,
+};
 
 /// The relative index of the `OpenChain` message created by the `OpenChain` operation.
 pub static OPEN_CHAIN_MESSAGE_INDEX: u32 = 0;
@@ -94,24 +93,6 @@ pub struct SystemExecutionStateView<C> {
     /// An optional set of authorized applications. If set, operations are restricted to these
     /// applications.
     pub authorized_applications: RegisterView<C, Option<BTreeSet<ApplicationId>>>,
-}
-
-/// For testing only.
-#[cfg(with_testing)]
-#[derive(Default, Debug, PartialEq, Eq, Clone)]
-pub struct SystemExecutionState {
-    pub description: Option<ChainDescription>,
-    pub epoch: Option<Epoch>,
-    pub admin_id: Option<ChainId>,
-    pub subscriptions: BTreeSet<ChannelSubscription>,
-    pub committees: BTreeMap<Epoch, Committee>,
-    pub ownership: ChainOwnership,
-    pub balance: Amount,
-    pub balances: BTreeMap<Owner, Amount>,
-    pub timestamp: Timestamp,
-    pub registry: ApplicationRegistry,
-    pub closed: bool,
-    pub authorized_applications: Option<BTreeSet<ApplicationId>>,
 }
 
 /// The configuration for a new chain.

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -6,8 +6,12 @@
 #![allow(unused_imports)]
 
 mod mock_application;
+mod system_execution_state;
 
-pub use self::mock_application::{ExpectedCall, MockApplication, MockApplicationInstance};
+pub use self::{
+    mock_application::{ExpectedCall, MockApplication, MockApplicationInstance},
+    system_execution_state::SystemExecutionState,
+};
 use crate::{
     ApplicationRegistryView, BytecodeLocation, ExecutionRuntimeContext, ExecutionStateView,
     TestExecutionRuntimeContext, UserApplicationDescription, UserApplicationId,

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -1,0 +1,108 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    applications::ApplicationRegistry,
+    committee::{Committee, Epoch},
+    execution::UserAction,
+    ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
+    ExecutionStateView, OperationContext, ResourceControlPolicy, ResourceController,
+    ResourceTracker, TestExecutionRuntimeContext, UserApplicationDescription, UserContractCode,
+};
+use linera_base::{
+    data_types::{Amount, Timestamp},
+    identifiers::{ApplicationId, ChainDescription, ChainId, Owner},
+    ownership::ChainOwnership,
+};
+use linera_views::{
+    common::Context,
+    memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    views::{View, ViewError},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+/// A system execution state, not represented as a view but as a simple struct.
+#[derive(Default, Debug, PartialEq, Eq, Clone)]
+pub struct SystemExecutionState {
+    pub description: Option<ChainDescription>,
+    pub epoch: Option<Epoch>,
+    pub admin_id: Option<ChainId>,
+    pub subscriptions: BTreeSet<ChannelSubscription>,
+    pub committees: BTreeMap<Epoch, Committee>,
+    pub ownership: ChainOwnership,
+    pub balance: Amount,
+    pub balances: BTreeMap<Owner, Amount>,
+    pub timestamp: Timestamp,
+    pub registry: ApplicationRegistry,
+    pub closed: bool,
+    pub authorized_applications: Option<BTreeSet<ApplicationId>>,
+}
+
+impl ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>
+where
+    MemoryContext<TestExecutionRuntimeContext>: Context + Clone + Send + Sync + 'static,
+    ViewError:
+        From<<MemoryContext<TestExecutionRuntimeContext> as linera_views::common::Context>::Error>,
+{
+    /// Creates an in-memory view where the system state is set. This is used notably to
+    /// generate state hashes in tests.
+    pub async fn from_system_state(
+        state: SystemExecutionState,
+        execution_runtime_config: ExecutionRuntimeConfig,
+    ) -> Self {
+        // Destructure, to make sure we don't miss any fields.
+        let SystemExecutionState {
+            description,
+            epoch,
+            admin_id,
+            subscriptions,
+            committees,
+            ownership,
+            balance,
+            balances,
+            timestamp,
+            registry,
+            closed,
+            authorized_applications,
+        } = state;
+        let extra = TestExecutionRuntimeContext::new(
+            description.expect("Chain description should be set").into(),
+            execution_runtime_config,
+        );
+        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, extra);
+        let mut view = Self::load(context)
+            .await
+            .expect("Loading from memory should work");
+        view.system.description.set(description);
+        view.system.epoch.set(epoch);
+        view.system.admin_id.set(admin_id);
+        for subscription in subscriptions {
+            view.system
+                .subscriptions
+                .insert(&subscription)
+                .expect("serialization of subscription should not fail");
+        }
+        view.system.committees.set(committees);
+        view.system.ownership.set(ownership);
+        view.system.balance.set(balance);
+        for (owner, balance) in balances {
+            view.system
+                .balances
+                .insert(&owner, balance)
+                .expect("insertion of balances should not fail");
+        }
+        view.system.timestamp.set(timestamp);
+        view.system
+            .registry
+            .import(registry)
+            .expect("serialization of registry components should not fail");
+        view.system.closed.set(closed);
+        view.system
+            .authorized_applications
+            .set(authorized_applications);
+        view
+    }
+}

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -11,10 +11,10 @@ use linera_base::{
     identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
-    test_utils::{register_mock_applications, ExpectedCall},
+    test_utils::{register_mock_applications, ExpectedCall, SystemExecutionState},
     ContractRuntime, ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionStateView,
     Message, MessageContext, RawExecutionOutcome, ResourceControlPolicy, ResourceController,
-    SystemExecutionState, TestExecutionRuntimeContext,
+    TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
 use std::{sync::Arc, vec};

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -13,11 +13,12 @@ use linera_execution::{
     system::SystemMessage,
     test_utils::{
         create_dummy_user_application_registrations, register_mock_applications, ExpectedCall,
+        SystemExecutionState,
     },
     ApplicationCallOutcome, BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome,
     ExecutionRuntimeConfig, ExecutionStateView, MessageKind, Operation, OperationContext, Query,
     QueryContext, RawExecutionOutcome, RawOutgoingMessage, ResourceController, Response,
-    SessionCallOutcome, SystemExecutionState, TestExecutionRuntimeContext,
+    SessionCallOutcome, TestExecutionRuntimeContext,
 };
 use linera_views::{batch::Batch, memory::MemoryContext};
 use std::vec;

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -10,9 +10,10 @@ use linera_base::{
 };
 use linera_execution::{
     system::{Recipient, UserData},
+    test_utils::SystemExecutionState,
     ExecutionOutcome, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionOutcome, ResourceController, Response, SystemExecutionState,
-    SystemMessage, SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
+    Query, QueryContext, RawExecutionOutcome, ResourceController, Response, SystemMessage,
+    SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_views::memory::MemoryContext;
 

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -9,11 +9,11 @@ use linera_base::{
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
-    test_utils::create_dummy_user_application_description, ExecutionOutcome,
-    ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView, Operation,
-    OperationContext, Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy,
-    ResourceController, ResourceTracker, Response, SystemExecutionState,
-    TestExecutionRuntimeContext, WasmContractModule, WasmRuntime, WasmServiceModule,
+    test_utils::{create_dummy_user_application_description, SystemExecutionState},
+    ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView,
+    Operation, OperationContext, Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy,
+    ResourceController, ResourceTracker, Response, TestExecutionRuntimeContext, WasmContractModule,
+    WasmRuntime, WasmServiceModule,
 };
 use linera_views::{memory::MemoryContext, views::View};
 use serde_json::json;


### PR DESCRIPTION
## Motivation

`make_state` and `make_state_hash` are currently only defined locally in `worker_tests`, but these will be useful for other crates, too.

## Proposal

Move `SystemExecutionState` to `test_utils` and turn the two functions into methods.

## Test Plan

(Only refactoring.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
