### PR TITLE
Improve invalid discriminant error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,6 +3655,7 @@ name = "linera-witty"
 version = "0.9.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "cfg_aliases",
  "either",
  "frunk",

--- a/linera-witty-macros/src/unit_tests/wit_load.rs
+++ b/linera-witty-macros/src/unit_tests/wit_load.rs
@@ -208,7 +208,10 @@ fn enum_type() {
 
                     Ok(Enum::Struct { first, second })
                 }
-                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+                discriminant => Err(linera_witty::RuntimeError::InvalidVariant {
+                    type_name: ::std::any::type_name::<Self>(),
+                    discriminant: discriminant.into(),
+                }),
             }
         }
 
@@ -255,7 +258,10 @@ fn enum_type() {
 
                     Ok(Enum::Struct { first, second })
                 }
-                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+                discriminant => Err(linera_witty::RuntimeError::InvalidVariant {
+                    type_name: ::std::any::type_name::<Self>(),
+                    discriminant: discriminant.into(),
+                }),
             }
         }
     };
@@ -488,7 +494,10 @@ fn enum_type_with_skipped_fields() {
                         ignored3
                     })
                 }
-                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+                discriminant => Err(linera_witty::RuntimeError::InvalidVariant {
+                    type_name: ::std::any::type_name::<Self>(),
+                    discriminant: discriminant.into(),
+                }),
             }
         }
 
@@ -547,7 +556,10 @@ fn enum_type_with_skipped_fields() {
                         ignored3
                     })
                 }
-                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+                discriminant => Err(linera_witty::RuntimeError::InvalidVariant {
+                    type_name: ::std::any::type_name::<Self>(),
+                    discriminant: discriminant.into(),
+                }),
             }
         }
     };

--- a/linera-witty-macros/src/wit_load.rs
+++ b/linera-witty-macros/src/wit_load.rs
@@ -148,7 +148,10 @@ pub fn derive_for_enum<'variants>(
 
             match discriminant {
                 #( #load_variants )*
-                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+                discriminant => Err(linera_witty::RuntimeError::InvalidVariant {
+                    type_name: ::std::any::type_name::<Self>(),
+                    discriminant: discriminant.into(),
+                }),
             }
         }
 
@@ -169,7 +172,10 @@ pub fn derive_for_enum<'variants>(
 
             match discriminant {
                 #( #lift_variants )*
-                _ => Err(linera_witty::RuntimeError::InvalidVariant),
+                discriminant => Err(linera_witty::RuntimeError::InvalidVariant {
+                    type_name: ::std::any::type_name::<Self>(),
+                    discriminant: discriminant.into(),
+                }),
             }
         }
     }

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -28,6 +28,7 @@ wasmer-vm = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
 
 [dev-dependencies]
+assert_matches.workspace = true
 linera-witty = { workspace = true, features = ["macros", "test"] }
 test-case.workspace = true
 tracing.workspace = true

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -46,8 +46,13 @@ pub enum RuntimeError {
     InvalidNumber(#[from] TryFromIntError),
 
     /// Attempt to load an `enum` type but the discriminant doesn't match any of the variants.
-    #[error("Unexpected variant discriminant")]
-    InvalidVariant,
+    #[error("Unexpected variant discriminant {discriminant} for `{type_name}`")]
+    InvalidVariant {
+        /// The `enum` type that failed being loaded.
+        type_name: &'static str,
+        /// The invalid discriminant that was received.
+        discriminant: i64,
+    },
 
     /// Wasmer runtime error.
     #[cfg(with_wasmer)]


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
While debugging the issue fixed by #1716, I ran into the `linera_witty::RuntimeError::InvalidVariant` error. However, it wasn't as useful as it could be, because it didn't show what invalid value it read nor which type is was trying to load.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add some more information to the error variant, so that it can show what type was being loaded and what the invalid discriminant was.

## Test Plan

<!-- How to test that the changes are correct. -->
A unit test was added for the error scenario.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because Witty isn't used yet.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
