### PR TITLE
Turn from_system_state into into_view.

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -27,9 +27,9 @@ use linera_execution::{
     committee::Epoch,
     system::{SystemChannel, SystemMessage, SystemOperation},
     test_utils::SystemExecutionState,
-    Bytecode, BytecodeLocation, ChannelSubscription, ExecutionRuntimeConfig, ExecutionStateView,
-    GenericApplicationId, Message, MessageKind, Operation, OperationContext, ResourceController,
-    UserApplicationDescription, UserApplicationId, WasmContractModule, WasmRuntime,
+    Bytecode, BytecodeLocation, ChannelSubscription, GenericApplicationId, Message, MessageKind,
+    Operation, OperationContext, ResourceController, UserApplicationDescription, UserApplicationId,
+    WasmContractModule, WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage};
 use linera_views::views::{CryptoHashView, ViewError};
@@ -251,11 +251,7 @@ where
         ..SystemExecutionState::new(Epoch::ZERO, creator_chain, admin_id)
     };
     creator_system_state.subscriptions.insert(publisher_channel);
-    let creator_state = ExecutionStateView::from_system_state(
-        creator_system_state.clone(),
-        ExecutionRuntimeConfig::default(),
-    )
-    .await;
+    let creator_state = creator_system_state.clone().into_view().await;
     let subscribe_block_proposal = HashedValue::new_confirmed(ExecutedBlock {
         block: subscribe_block,
         messages: vec![OutgoingMessage {
@@ -389,11 +385,7 @@ where
         .known_applications
         .insert(application_id, application_description.clone());
     creator_system_state.timestamp = Timestamp::from(4);
-    let mut creator_state = ExecutionStateView::from_system_state(
-        creator_system_state,
-        ExecutionRuntimeConfig::default(),
-    )
-    .await;
+    let mut creator_state = creator_system_state.into_view().await;
     creator_state
         .simulate_initialization(
             contract,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -976,7 +976,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ExecutionRuntimeConfig, ExecutionStateView, TestExecutionRuntimeContext};
+    use crate::{ExecutionStateView, TestExecutionRuntimeContext};
     use linera_base::{data_types::BlockHeight, identifiers::ApplicationId};
     use linera_views::memory::MemoryContext;
 
@@ -1001,8 +1001,7 @@ mod tests {
             committees: BTreeMap::new(),
             ..SystemExecutionState::default()
         };
-        let view =
-            ExecutionStateView::from_system_state(state, ExecutionRuntimeConfig::default()).await;
+        let view = state.into_view().await;
         (view, context)
     }
 

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -12,11 +12,9 @@ use linera_base::{
 };
 use linera_execution::{
     test_utils::{register_mock_applications, ExpectedCall, SystemExecutionState},
-    ContractRuntime, ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionStateView,
-    Message, MessageContext, RawExecutionOutcome, ResourceControlPolicy, ResourceController,
-    TestExecutionRuntimeContext,
+    ContractRuntime, ExecutionError, ExecutionOutcome, Message, MessageContext,
+    RawExecutionOutcome, ResourceControlPolicy, ResourceController,
 };
-use linera_views::memory::MemoryContext;
 use std::{sync::Arc, vec};
 use test_case::test_case;
 
@@ -122,12 +120,7 @@ async fn test_fee_consumption(
         description: Some(ChainDescription::Root(0)),
         ..SystemExecutionState::default()
     };
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let owner = Owner::from(PublicKey::test_key(0));
     view.system.balance.set(chain_balance);

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -16,23 +16,17 @@ use linera_execution::{
         SystemExecutionState,
     },
     ApplicationCallOutcome, BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome,
-    ExecutionRuntimeConfig, ExecutionStateView, MessageKind, Operation, OperationContext, Query,
-    QueryContext, RawExecutionOutcome, RawOutgoingMessage, ResourceController, Response,
-    SessionCallOutcome, TestExecutionRuntimeContext,
+    MessageKind, Operation, OperationContext, Query, QueryContext, RawExecutionOutcome,
+    RawOutgoingMessage, ResourceController, Response, SessionCallOutcome,
 };
-use linera_views::{batch::Batch, memory::MemoryContext};
+use linera_views::batch::Batch;
 use std::vec;
 
 #[tokio::test]
 async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            Default::default(),
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let (app_id, app_desc) =
         &create_dummy_user_application_registrations(&mut view.system.registry, 1).await?[0];
@@ -68,12 +62,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
 async fn test_simple_user_operation() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
@@ -224,12 +213,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
 async fn test_leaking_session() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
@@ -283,12 +267,7 @@ async fn test_leaking_session() -> anyhow::Result<()> {
 async fn test_simple_session() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
@@ -377,12 +356,7 @@ async fn test_simple_session() -> anyhow::Result<()> {
 async fn test_cross_application_error() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
@@ -442,12 +416,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
 async fn test_simple_message() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 1).await?;
     let (application_id, application) = applications
@@ -533,12 +502,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
 async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 2).await?;
     let (caller_id, caller_application) = applications
@@ -642,12 +606,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
 async fn test_message_from_session_call() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 3).await?;
     let (caller_id, caller_application) = applications
@@ -795,12 +754,7 @@ async fn test_message_from_session_call() -> anyhow::Result<()> {
 async fn test_multiple_messages_from_different_applications() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            ExecutionRuntimeConfig::Synchronous,
-        )
-        .await;
+    let mut view = state.into_view().await;
 
     let mut applications = register_mock_applications(&mut view, 3).await?;
     // The entrypoint application, which sends a message and calls other applications

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -11,23 +11,17 @@ use linera_base::{
 use linera_execution::{
     system::{Recipient, UserData},
     test_utils::SystemExecutionState,
-    ExecutionOutcome, ExecutionStateView, Message, MessageContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionOutcome, ResourceController, Response, SystemMessage,
-    SystemOperation, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
+    ExecutionOutcome, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
+    RawExecutionOutcome, ResourceController, Response, SystemMessage, SystemOperation, SystemQuery,
+    SystemResponse,
 };
-use linera_views::memory::MemoryContext;
 
 #[tokio::test]
 async fn test_simple_system_operation() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
     state.balance = Amount::from_tokens(4);
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            Default::default(),
-        )
-        .await;
+    let mut view = state.into_view().await;
     let operation = SystemOperation::Transfer {
         owner: None,
         amount: Amount::from_tokens(4),
@@ -64,12 +58,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
 async fn test_simple_system_message() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            Default::default(),
-        )
-        .await;
+    let mut view = state.into_view().await;
     let message = SystemMessage::Credit {
         amount: Amount::from_tokens(4),
         target: None,
@@ -106,12 +95,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
     let mut state = SystemExecutionState::default();
     state.description = Some(ChainDescription::Root(0));
     state.balance = Amount::from_tokens(4);
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            Default::default(),
-        )
-        .await;
+    let mut view = state.into_view().await;
     let context = QueryContext {
         chain_id: ChainId::root(0),
     };

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -10,12 +10,11 @@ use linera_base::{
 };
 use linera_execution::{
     test_utils::{create_dummy_user_application_description, SystemExecutionState},
-    ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, ExecutionStateView,
-    Operation, OperationContext, Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy,
-    ResourceController, ResourceTracker, Response, TestExecutionRuntimeContext, WasmContractModule,
-    WasmRuntime, WasmServiceModule,
+    ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext,
+    Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy, ResourceController,
+    ResourceTracker, Response, WasmContractModule, WasmRuntime, WasmServiceModule,
 };
-use linera_views::{memory::MemoryContext, views::View};
+use linera_views::views::View;
 use serde_json::json;
 use std::sync::Arc;
 use test_case::test_case;
@@ -38,12 +37,7 @@ async fn test_fuel_for_counter_wasm_application(
         description: Some(ChainDescription::Root(0)),
         ..Default::default()
     };
-    let mut view =
-        ExecutionStateView::<MemoryContext<TestExecutionRuntimeContext>>::from_system_state(
-            state,
-            execution_runtime_config,
-        )
-        .await;
+    let mut view = state.into_view_with_runtime(execution_runtime_config).await;
     let app_desc = create_dummy_user_application_description(1);
     let app_id = view
         .system


### PR DESCRIPTION
## Motivation

A lot of tests call `ExecutionStateView::from_system_state(state, config)`. The `config` is always the default anyway. Also, this is an `ExecutionStateView` message defined in the `system_execution_state` module.

## Proposal

Make it a method `SystemExecutionState::into_view`, without the config argument.

## Test Plan

(Only refactoring.)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
