### PR TITLE
Remove unused ChainManager::is_active.

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -133,11 +133,6 @@ impl ChainManager {
         Ok(())
     }
 
-    /// Whether this chain is active, i.e. has any owners.
-    pub fn is_active(&self) -> bool {
-        self.ownership.is_active()
-    }
-
     /// Creates a new `ChainManager`, and starts the first round.
     fn new(
         ownership: ChainOwnership,


### PR DESCRIPTION
## Motivation

This function is unused; it didn't cause a warning because it's public.

## Proposal

Remove it.

## Test Plan

N/A

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
