### PR TITLE
Support accounts query on native fungible as well

### DIFF
--- a/examples/crowd-funding/README.md
+++ b/examples/crowd-funding/README.md
@@ -235,7 +235,7 @@ You can check that the 200 tokens have arrived:
 
 ```gql,uri=$TOKEN1
 query {
-    balance(owner: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd")
+    accounts { entry(key: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd") { value } }
 }
 ```
 
@@ -268,7 +268,7 @@ check that we have received 110 tokens, in addition to the
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0
 query {
-    balance(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
+    accounts { entry(key: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f") { value } }
 }
 ```
 

--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -241,7 +241,7 @@ You can check that the 200 tokens have arrived:
 
 ```gql,uri=$TOKEN1
 query {
-    balance(owner: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd")
+    accounts { entry(key: "User:b4f8586041a07323bd4f4ed2d758bf1b9a977eabfd4c00e2f12d08a0899485fd") { value } }
 }
 ```
 
@@ -274,7 +274,7 @@ check that we have received 110 tokens, in addition to the
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_0/applications/$APP_ID_0
 query {
-    balance(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
+    accounts { entry(key: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f") { value } }
 }
 ```
 */

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -308,6 +308,10 @@ impl FungibleToken {
     }
 }
 
+// Dummy ComplexObject implementation, required by the graphql(complex) attribute in state.rs.
+#[async_graphql::ComplexObject]
+impl FungibleToken {}
+
 /// An error that can occur during the contract execution.
 #[derive(Debug, Error)]
 pub enum Error {

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -412,9 +412,12 @@ impl FungibleTokenAbi {
         chain: &ActiveChain,
         account_owner: AccountOwner,
     ) -> Option<Amount> {
-        let query = format!("query {{ balance(owner: {}) }}", account_owner.to_value());
+        let query = format!(
+            "query {{ accounts {{ entry(key: {}) {{ value }} }} }}",
+            account_owner.to_value()
+        );
         let response = chain.graphql_query(application_id, query).await;
-        let balance = response.pointer("/balance")?.as_str()?;
+        let balance = response.pointer("/accounts/entry/value")?.as_str()?;
 
         Some(
             balance

--- a/examples/fungible/src/state.rs
+++ b/examples/fungible/src/state.rs
@@ -10,6 +10,11 @@ use thiserror::Error;
 
 /// The application state.
 #[derive(RootView, async_graphql::SimpleObject)]
+// In the service we also want a tickerSymbol query, which is not derived from a struct member.
+// This attribute requires having a ComplexObject implementation that adds such fields.
+// The implementation with tickerSymbol is in service.rs. Since a ComplexObject impl is required,
+// there is also an empty one in contract.rs.
+#[graphql(complex)]
 #[view(context = "ViewStorageContext")]
 pub struct FungibleToken {
     accounts: MapView<AccountOwner, Amount>,

--- a/examples/fungible/web-frontend/src/App.js
+++ b/examples/fungible/web-frontend/src/App.js
@@ -9,7 +9,11 @@ import tw from "tailwind-styled-components";
 
 const GET_BALANCE = gql`
   query Accounts($owner: AccountOwner) {
-    balance(owner: $owner)
+    accounts {
+      entry(key: $owner) {
+        value
+      }
+    }
   }
 `;
 
@@ -133,7 +137,7 @@ function App({ chainId, owner }) {
         <h1 className="text-2xl font-bold mb-2">Your Balance</h1>
         {balanceData ? (
           <p className="text-3xl font-bold">
-            {parseInt(balanceData.balance ?? '0').toLocaleString()}
+            {parseInt(balanceData.accounts.entry.value ?? '0').toLocaleString()}
             {tickerSymbolData && ' ' + tickerSymbolData.tickerSymbol}
           </p>
         ) : (

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -293,6 +293,10 @@ impl NativeFungibleToken {
     }
 }
 
+// Dummy ComplexObject implementation, required by the graphql(complex) attribute in state.rs.
+#[async_graphql::ComplexObject]
+impl NativeFungibleToken {}
+
 /// An error that can occur during the contract execution.
 #[derive(Debug, Error)]
 pub enum Error {

--- a/examples/native-fungible/src/service.rs
+++ b/examples/native-fungible/src/service.rs
@@ -6,7 +6,9 @@
 mod state;
 
 use self::state::NativeFungibleToken;
-use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use async_graphql::{
+    ComplexObject, EmptySubscription, Object, Request, Response, Schema, SimpleObject,
+};
 use async_trait::async_trait;
 use fungible::Operation;
 use linera_sdk::{
@@ -36,26 +38,43 @@ impl Service for NativeFungibleToken {
         request: Request,
     ) -> Result<Response, Self::Error> {
         let schema =
-            Schema::build(QueryRoot, Operation::mutation_root(), EmptySubscription).finish();
+            Schema::build(self.clone(), Operation::mutation_root(), EmptySubscription).finish();
         let response = schema.execute(request).await;
         Ok(response)
     }
 }
 
-struct QueryRoot;
+#[derive(SimpleObject)]
+struct AccountEntry {
+    value: Amount,
+}
+
+#[derive(Default)]
+struct Accounts;
 
 #[Object]
-impl QueryRoot {
-    async fn balance(&self, owner: AccountOwner) -> Result<Amount, async_graphql::Error> {
-        let owner = match owner {
+impl Accounts {
+    // Define a field that lets you query by key
+    async fn entry(&self, key: AccountOwner) -> Result<AccountEntry, Error> {
+        let owner = match key {
             AccountOwner::User(owner) => owner,
-            AccountOwner::Application(_) => panic!("Applications not supported yet!"),
+            AccountOwner::Application(_) => return Err(Error::ApplicationsNotSupported),
         };
-        Ok(system_api::current_owner_balance(owner))
-    }
 
+        let balance = system_api::current_owner_balance(owner);
+        Ok(AccountEntry { value: balance })
+    }
+}
+
+// Implements additional fields not derived from struct members of FungibleToken.
+#[ComplexObject]
+impl NativeFungibleToken {
     async fn ticker_symbol(&self) -> Result<String, async_graphql::Error> {
         Ok(String::from(TICKER_SYMBOL))
+    }
+
+    async fn accounts(&self) -> Result<Accounts, async_graphql::Error> {
+        Ok(Accounts)
     }
 }
 
@@ -67,4 +86,7 @@ pub enum Error {
         "Invalid query argument; Native Fungible application only supports JSON encoded GraphQL queries"
     )]
     InvalidQuery(#[from] serde_json::Error),
+
+    #[error("Applications not supported yet")]
+    ApplicationsNotSupported,
 }

--- a/examples/native-fungible/src/state.rs
+++ b/examples/native-fungible/src/state.rs
@@ -5,7 +5,12 @@ use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext
 use thiserror::Error;
 
 /// The application state.
-#[derive(RootView)]
+#[derive(RootView, async_graphql::SimpleObject)]
+// In the service we also want a tickerSymbol query, which is not derived from a struct member.
+// This attribute requires having a ComplexObject implementation that adds such fields.
+// The implementation with tickerSymbol is in service.rs. Since a ComplexObject impl is required,
+// there is also an empty one in contract.rs.
+#[graphql(complex)]
 #[view(context = "ViewStorageContext")]
 pub struct NativeFungibleToken {
     // TODO(#968): We should support stateless applications/empty user views

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -304,3 +304,9 @@ impl From<Owner> for contract_system_api::CryptoHash {
         contract_system_api::CryptoHash::from(owner.0)
     }
 }
+
+impl From<Owner> for service_system_api::CryptoHash {
+    fn from(owner: Owner) -> Self {
+        service_system_api::CryptoHash::from(owner.0)
+    }
+}

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -11,7 +11,7 @@ use crate::QueryContext;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight},
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId},
+    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
 
 impl From<wit_types::QueryContext> for QueryContext {
@@ -42,6 +42,13 @@ impl From<wit_system_api::CryptoHash> for CryptoHash {
             hash_value.part3,
             hash_value.part4,
         ])
+    }
+}
+
+impl From<wit_system_api::CryptoHash> for Owner {
+    fn from(guest: wit_system_api::CryptoHash) -> Self {
+        let integers = [guest.part1, guest.part2, guest.part3, guest.part4];
+        Owner(CryptoHash::from(integers))
     }
 }
 

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -275,9 +275,13 @@ struct FungibleApp(ApplicationWrapper<fungible::FungibleTokenAbi>);
 
 impl FungibleApp {
     async fn get_amount(&self, account_owner: &AccountOwner) -> Amount {
-        let query = format!("balance(owner: {})", account_owner.to_value());
+        let query = format!(
+            "accounts {{ entry(key: {}) {{ value }} }}",
+            account_owner.to_value()
+        );
         let response_body = self.0.query(&query).await.unwrap();
-        serde_json::from_value(response_body["balance"].clone()).unwrap_or_default()
+        serde_json::from_value(response_body["accounts"]["entry"]["value"].clone())
+            .unwrap_or_default()
     }
 
     async fn transfer(

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -41,9 +41,13 @@ struct FungibleApp(ApplicationWrapper<fungible::FungibleTokenAbi>);
 
 impl FungibleApp {
     async fn get_amount(&self, account_owner: &AccountOwner) -> Amount {
-        let query = format!("balance(owner: {})", account_owner.to_value());
+        let query = format!(
+            "accounts {{ entry(key: {}) {{ value }} }}",
+            account_owner.to_value()
+        );
         let response_body = self.0.query(&query).await.unwrap();
-        serde_json::from_value(response_body["balance"].clone()).unwrap_or_default()
+        serde_json::from_value(response_body["accounts"]["entry"]["value"].clone())
+            .unwrap_or_default()
     }
 
     async fn assert_balances(&self, accounts: impl IntoIterator<Item = (AccountOwner, Amount)>) {


### PR DESCRIPTION
## Motivation

It was raised during #1675 that we might want to revert everything to use that `accounts` abstraction instead

## Proposal

Revert `fungible` back to using `accounts`, implement that for `native-fungible` using a new system API

## Test Plan

CI

