### PR TITLE
Merge duplicate types from `linera-sdk` and `linera-execution`

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -13,7 +13,7 @@ use linera_sdk::{
     base::{AccountOwner, Amount, ApplicationId, Owner, SessionId, WithContractAbi},
     contract::system_api,
     ensure, ApplicationCallOutcome, CalleeContext, Contract, ExecutionOutcome, MessageContext,
-    OperationContext, OutgoingMessage, Resources, SessionCallOutcome, ViewStateStorage,
+    OperationContext, SessionCallOutcome, ViewStateStorage,
 };
 use num_bigint::BigUint;
 use num_traits::{cast::FromPrimitive, ToPrimitive};
@@ -317,13 +317,7 @@ impl Amm {
                     input_token_idx,
                     input_amount,
                 };
-                outcome.messages.push(OutgoingMessage {
-                    destination: chain_id.into(),
-                    authenticated: true,
-                    is_tracked: false,
-                    resources: Resources::default(),
-                    message,
-                });
+                outcome.add_authenticated_message(chain_id, message);
             }
             Operation::AddLiquidity {
                 owner: _,
@@ -361,13 +355,7 @@ impl Amm {
                     input_token_idx,
                     input_amount,
                 };
-                outcome.messages.push(OutgoingMessage {
-                    destination: chain_id.into(),
-                    authenticated: true,
-                    is_tracked: false,
-                    resources: Resources::default(),
-                    message,
-                });
+                outcome.add_authenticated_message(chain_id, message);
             }
         }
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -14,7 +14,7 @@ use linera_sdk::{
     ensure,
     views::View,
     ApplicationCallOutcome, CalleeContext, Contract, ExecutionOutcome, MessageContext,
-    OperationContext, OutgoingMessage, Resources, SessionCallOutcome, ViewStateStorage,
+    OperationContext, SessionCallOutcome, ViewStateStorage,
 };
 use state::{CrowdFunding, Status};
 use thiserror::Error;
@@ -164,13 +164,7 @@ impl CrowdFunding {
         )?;
         // Second, schedule the attribution of the funds to the (remote) campaign.
         let message = Message::PledgeWithAccount { owner, amount };
-        outcome.messages.push(OutgoingMessage {
-            destination: chain_id.into(),
-            authenticated: true,
-            is_tracked: false,
-            resources: Resources::default(),
-            message,
-        });
+        outcome.add_authenticated_message(chain_id, message);
         Ok(())
     }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -17,7 +17,7 @@ use linera_sdk::{
     base::{AccountOwner, Amount, ApplicationId, Owner, SessionId, WithContractAbi},
     contract::system_api,
     ensure, ApplicationCallOutcome, CalleeContext, Contract, ExecutionOutcome, MessageContext,
-    OperationContext, OutgoingMessage, Resources, SessionCallOutcome, ViewStateStorage,
+    OperationContext, SessionCallOutcome, ViewStateStorage,
 };
 
 linera_sdk::contract!(MatchingEngine);
@@ -313,13 +313,7 @@ impl MatchingEngine {
             let (amount, token_idx) = Self::get_amount_idx(&nature, &price, &amount);
             self.transfer(owner, amount, destination, token_idx)?;
         }
-        outcome.messages.push(OutgoingMessage {
-            destination: chain_id.into(),
-            authenticated: true,
-            is_tracked: false,
-            resources: Resources::default(),
-            message,
-        });
+        outcome.add_authenticated_message(chain_id, message);
         Ok(())
     }
 

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -9,7 +9,7 @@ use self::state::MetaCounter;
 use async_trait::async_trait;
 use linera_sdk::{
     base::{ApplicationId, SessionId, WithContractAbi},
-    ApplicationCallOutcome, CalleeContext, Contract, ExecutionOutcome, MessageContext,
+    ApplicationCallOutcome, CalleeContext, Contract, ExecutionOutcome, MessageContext, MessageKind,
     OperationContext, OutgoingMessage, Resources, SessionCallOutcome, SimpleStateStorage,
 };
 use meta_counter::{Message, Operation};
@@ -59,11 +59,15 @@ impl Contract for MetaCounter {
             fuel_grant,
             message,
         } = operation;
+        // Formatting the `if-else` makes it more noisy and therefore harder to read
+        #[allow(clippy::obfuscated_if_else)]
         let message = OutgoingMessage {
             destination: recipient_id.into(),
             authenticated,
-            is_tracked,
-            resources: Resources {
+            kind: is_tracked
+                .then_some(MessageKind::Tracked)
+                .unwrap_or(MessageKind::Simple),
+            grant: Resources {
                 fuel: fuel_grant,
                 ..Default::default()
             },

--- a/linera-base/src/execution.rs
+++ b/linera-base/src/execution.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Data-types used in the execution of Linera applications.
+
+use crate::{
+    data_types::BlockHeight,
+    identifiers::{Account, ChainId, MessageId, Owner},
+};
+
+/// The context of an application when it is executing an operation.
+#[derive(Clone, Copy, Debug)]
+pub struct OperationContext {
+    /// The current chain id.
+    pub chain_id: ChainId,
+    /// The authenticated signer of the operation, if any.
+    pub authenticated_signer: Option<Owner>,
+    /// The current block height.
+    pub height: BlockHeight,
+    /// The current index of the operation.
+    pub index: u32,
+    /// The index of the next message to be created.
+    pub next_message_index: u32,
+}
+
+impl OperationContext {
+    /// Returns the [`Account`] that should receive the refund of a grant provided for the
+    /// execution of this context.
+    pub fn refund_grant_to(&self) -> Option<Account> {
+        Some(Account {
+            chain_id: self.chain_id,
+            owner: self.authenticated_signer,
+        })
+    }
+
+    /// Returns the next [`MessageId`] to use for the next message to be sent.
+    pub fn next_message_id(&self) -> MessageId {
+        MessageId {
+            chain_id: self.chain_id,
+            height: self.height,
+            index: self.next_message_index,
+        }
+    }
+}

--- a/linera-base/src/execution.rs
+++ b/linera-base/src/execution.rs
@@ -7,7 +7,7 @@
 use crate::{
     crypto::CryptoHash,
     data_types::BlockHeight,
-    identifiers::{Account, ChainId, MessageId, Owner},
+    identifiers::{Account, ApplicationId, ChainId, MessageId, Owner},
 };
 
 /// The context of an application when it is executing an operation.
@@ -65,4 +65,16 @@ pub struct MessageContext {
     pub message_id: MessageId,
     /// The index of the next message to be created.
     pub next_message_index: u32,
+}
+
+/// The context of an application when it is executing a cross-application call or a session call.
+#[derive(Clone, Copy, Debug)]
+pub struct CalleeContext {
+    /// The current chain id.
+    pub chain_id: ChainId,
+    /// The authenticated signer of the operation, if any.
+    pub authenticated_signer: Option<Owner>,
+    /// `None` if the caller doesn't want this particular call to be authenticated (e.g.
+    /// for safety reasons).
+    pub authenticated_caller_id: Option<ApplicationId>,
 }

--- a/linera-base/src/execution.rs
+++ b/linera-base/src/execution.rs
@@ -5,6 +5,7 @@
 //! Data-types used in the execution of Linera applications.
 
 use crate::{
+    crypto::CryptoHash,
     data_types::BlockHeight,
     identifiers::{Account, ChainId, MessageId, Owner},
 };
@@ -42,4 +43,26 @@ impl OperationContext {
             index: self.next_message_index,
         }
     }
+}
+
+/// The context of an application when it is executing an incoming message.
+#[derive(Clone, Copy, Debug)]
+pub struct MessageContext {
+    /// The current chain id.
+    pub chain_id: ChainId,
+    /// Whether the message was rejected by the original receiver and is now bouncing back.
+    pub is_bouncing: bool,
+    /// The authenticated signer of the operation that created the message, if any.
+    pub authenticated_signer: Option<Owner>,
+    /// Where to send a refund for the unused part of each grant after execution, if any.
+    pub refund_grant_to: Option<Account>,
+    /// The current block height.
+    pub height: BlockHeight,
+    /// The hash of the remote certificate that created the message.
+    pub certificate_hash: CryptoHash,
+    /// The id of the message (based on the operation height and index in the remote
+    /// certificate).
+    pub message_id: MessageId,
+    /// The index of the next message to be created.
+    pub next_message_index: u32,
 }

--- a/linera-base/src/execution.rs
+++ b/linera-base/src/execution.rs
@@ -78,3 +78,12 @@ pub struct CalleeContext {
     /// for safety reasons).
     pub authenticated_caller_id: Option<ApplicationId>,
 }
+
+/// The context of an application service when it is handling a query.
+#[derive(Clone, Copy, Debug)]
+pub struct QueryContext {
+    /// The current chain id.
+    pub chain_id: ChainId,
+    /// The height of the next block on this chain.
+    pub next_block_height: BlockHeight,
+}

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod abi;
 pub mod crypto;
 pub mod data_types;
+pub mod execution;
 mod graphql;
 pub mod identifiers;
 pub mod ownership;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -27,7 +27,7 @@ pub use applications::{
 pub use execution::ExecutionStateView;
 pub use linera_base::execution::{
     ApplicationCallOutcome, CalleeContext, MessageContext, MessageKind, OperationContext,
-    QueryContext, RawExecutionOutcome, RawOutgoingMessage,
+    QueryContext, RawExecutionOutcome, RawOutgoingMessage, SessionCallOutcome,
 };
 pub use policy::{IntoPriced, ResourceControlPolicy};
 pub use resources::{ResourceController, ResourceTracker};
@@ -186,13 +186,14 @@ pub trait UserContract {
     ) -> Result<ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError>;
 
     /// Executes a call from another application into a session created by this application.
+    #[allow(clippy::type_complexity)]
     fn handle_session_call(
         &mut self,
         context: CalleeContext,
         session_state: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallOutcome, ExecutionError>;
+    ) -> Result<SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError>;
 }
 
 /// The public entry points provided by the service part of an application.
@@ -203,15 +204,6 @@ pub trait UserService {
         context: QueryContext,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
-}
-
-/// The result of calling into a session.
-#[derive(Default)]
-pub struct SessionCallOutcome {
-    /// The application result.
-    pub inner: ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>,
-    /// The new state of the session, if any. `None` means that the session should be terminated.
-    pub new_state: Option<Vec<u8>>,
 }
 
 /// System runtime implementation in use.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -192,7 +192,7 @@ pub trait UserContract {
         session_state: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<(SessionCallOutcome, Vec<u8>), ExecutionError>;
+    ) -> Result<SessionCallOutcome, ExecutionError>;
 }
 
 /// The public entry points provided by the service part of an application.
@@ -210,8 +210,8 @@ pub trait UserService {
 pub struct SessionCallOutcome {
     /// The application result.
     pub inner: ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>,
-    /// If true, the session should be terminated.
-    pub close_session: bool,
+    /// The new state of the session, if any. `None` means that the session should be terminated.
+    pub new_state: Option<Vec<u8>>,
 }
 
 /// System runtime implementation in use.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -25,7 +25,7 @@ pub use applications::{
     UserApplicationId,
 };
 pub use execution::ExecutionStateView;
-pub use linera_base::execution::{CalleeContext, MessageContext, OperationContext};
+pub use linera_base::execution::{CalleeContext, MessageContext, OperationContext, QueryContext};
 pub use policy::ResourceControlPolicy;
 pub use resources::{ResourceController, ResourceTracker};
 pub use system::{
@@ -44,7 +44,7 @@ use dashmap::DashMap;
 use derive_more::Display;
 use linera_base::{
     abi::Abi,
-    data_types::{Amount, ArithmeticError, BlockHeight, Resources, Timestamp},
+    data_types::{Amount, ArithmeticError, Resources, Timestamp},
     doc_scalar, hex_debug,
     identifiers::{Account, BytecodeId, ChainId, ChannelName, Destination, Owner, SessionId},
     ownership::ChainOwnership,
@@ -263,14 +263,6 @@ pub trait ExecutionRuntimeContext {
         &self,
         description: &UserApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError>;
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct QueryContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// The height of the next block on this chain.
-    pub next_block_height: BlockHeight,
 }
 
 pub trait BaseRuntime {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -25,6 +25,7 @@ pub use applications::{
     UserApplicationId,
 };
 pub use execution::ExecutionStateView;
+pub use linera_base::execution::OperationContext;
 pub use policy::ResourceControlPolicy;
 pub use resources::{ResourceController, ResourceTracker};
 pub use system::{
@@ -265,20 +266,6 @@ pub trait ExecutionRuntimeContext {
         &self,
         description: &UserApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError>;
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct OperationContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// The authenticated signer of the operation, if any.
-    pub authenticated_signer: Option<Owner>,
-    /// The current block height.
-    pub height: BlockHeight,
-    /// The current index of the operation.
-    pub index: u32,
-    /// The index of the next message to be created.
-    pub next_message_index: u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -722,23 +709,6 @@ impl<Message> RawExecutionOutcome<Message, Resources> {
             subscribe,
             unsubscribe,
         })
-    }
-}
-
-impl OperationContext {
-    fn refund_grant_to(&self) -> Option<Account> {
-        Some(Account {
-            chain_id: self.chain_id,
-            owner: self.authenticated_signer,
-        })
-    }
-
-    fn next_message_id(&self) -> MessageId {
-        MessageId {
-            chain_id: self.chain_id,
-            height: self.height,
-            index: self.next_message_index,
-        }
     }
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -25,7 +25,7 @@ pub use applications::{
     UserApplicationId,
 };
 pub use execution::ExecutionStateView;
-pub use linera_base::execution::{MessageContext, OperationContext};
+pub use linera_base::execution::{CalleeContext, MessageContext, OperationContext};
 pub use policy::ResourceControlPolicy;
 pub use resources::{ResourceController, ResourceTracker};
 pub use system::{
@@ -263,17 +263,6 @@ pub trait ExecutionRuntimeContext {
         &self,
         description: &UserApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError>;
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct CalleeContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// The authenticated signer for the execution thread, if any.
-    pub authenticated_signer: Option<Owner>,
-    /// `None` if the caller doesn't want this particular call to be authenticated (e.g.
-    /// for safety reasons).
-    pub authenticated_caller_id: Option<UserApplicationId>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -25,7 +25,7 @@ pub use applications::{
     UserApplicationId,
 };
 pub use execution::ExecutionStateView;
-pub use linera_base::execution::OperationContext;
+pub use linera_base::execution::{MessageContext, OperationContext};
 pub use policy::ResourceControlPolicy;
 pub use resources::{ResourceController, ResourceTracker};
 pub use system::{
@@ -44,12 +44,9 @@ use dashmap::DashMap;
 use derive_more::Display;
 use linera_base::{
     abi::Abi,
-    crypto::CryptoHash,
     data_types::{Amount, ArithmeticError, BlockHeight, Resources, Timestamp},
     doc_scalar, hex_debug,
-    identifiers::{
-        Account, BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner, SessionId,
-    },
+    identifiers::{Account, BytecodeId, ChainId, ChannelName, Destination, Owner, SessionId},
     ownership::ChainOwnership,
 };
 use linera_views::{batch::Batch, views::ViewError};
@@ -266,27 +263,6 @@ pub trait ExecutionRuntimeContext {
         &self,
         description: &UserApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError>;
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct MessageContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// Whether the message was rejected by the original receiver and is now bouncing back.
-    pub is_bouncing: bool,
-    /// The authenticated signer of the operation that created the message, if any.
-    pub authenticated_signer: Option<Owner>,
-    /// Where to send a refund for the unused part of each grant after execution, if any.
-    pub refund_grant_to: Option<Account>,
-    /// The current block height.
-    pub height: BlockHeight,
-    /// The hash of the remote certificate that created the message.
-    pub certificate_hash: CryptoHash,
-    /// The id of the message (based on the operation height and index in the remote
-    /// certificate).
-    pub message_id: MessageId,
-    /// The index of the next message to be created.
-    pub next_message_index: u32,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -4,6 +4,7 @@
 use crate::{
     execution::UserAction,
     execution_state_actor::{ExecutionStateSender, Request},
+    policy::IntoPriced,
     resources::ResourceController,
     util::{ReceiverExt, UnboundedSenderExt},
     ApplicationCallOutcome, BaseRuntime, CallOutcome, CalleeContext, ContractRuntime,
@@ -1132,8 +1133,8 @@ impl ContractRuntime for ContractSyncRuntime {
             })?
             .recv_response()?;
         let outcome = RawExecutionOutcome::default()
-            .with_message(open_chain_message)
-            .with_message(subscribe_message);
+            .with_raw_message(open_chain_message)
+            .with_raw_message(subscribe_message);
         this.execution_outcomes
             .push(ExecutionOutcome::System(outcome));
         Ok(chain_id)

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -392,7 +392,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
     /// Cleans up the runtime after the execution of a call to a different contract.
     fn finish_call(
         &mut self,
-        raw_outcome: ApplicationCallOutcome,
+        raw_outcome: ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>,
     ) -> Result<CallOutcome, ExecutionError> {
         let ApplicationStatus {
             id: callee_id,

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -100,7 +100,7 @@ type HandleSessionCallHandler = Box<
             Vec<u8>,
             Vec<u8>,
             Vec<SessionId>,
-        ) -> Result<(SessionCallOutcome, Vec<u8>), ExecutionError>
+        ) -> Result<SessionCallOutcome, ExecutionError>
         + Send
         + Sync,
 >;
@@ -217,7 +217,7 @@ impl ExpectedCall {
                 Vec<u8>,
                 Vec<u8>,
                 Vec<SessionId>,
-            ) -> Result<(SessionCallOutcome, Vec<u8>), ExecutionError>
+            ) -> Result<SessionCallOutcome, ExecutionError>
             + Send
             + Sync
             + 'static,
@@ -338,7 +338,7 @@ impl UserContract for MockApplicationInstance<ContractSyncRuntime> {
         session_state: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<(SessionCallOutcome, Vec<u8>), ExecutionError> {
+    ) -> Result<SessionCallOutcome, ExecutionError> {
         match self.next_expected_call() {
             Some(ExpectedCall::HandleSessionCall(handler)) => {
                 handler(&mut self.runtime, context, session_state, argument, forwarded_sessions)

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -100,7 +100,7 @@ type HandleSessionCallHandler = Box<
             Vec<u8>,
             Vec<u8>,
             Vec<SessionId>,
-        ) -> Result<SessionCallOutcome, ExecutionError>
+        ) -> Result<SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError>
         + Send
         + Sync,
 >;
@@ -217,7 +217,8 @@ impl ExpectedCall {
                 Vec<u8>,
                 Vec<u8>,
                 Vec<SessionId>,
-            ) -> Result<SessionCallOutcome, ExecutionError>
+            )
+                -> Result<SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError>
             + Send
             + Sync
             + 'static,
@@ -338,7 +339,7 @@ impl UserContract for MockApplicationInstance<ContractSyncRuntime> {
         session_state: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallOutcome, ExecutionError> {
+    ) -> Result<SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError> {
         match self.next_expected_call() {
             Some(ExpectedCall::HandleSessionCall(handler)) => {
                 handler(&mut self.runtime, context, session_state, argument, forwarded_sessions)

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -89,7 +89,7 @@ type HandleApplicationCallHandler = Box<
             CalleeContext,
             Vec<u8>,
             Vec<SessionId>,
-        ) -> Result<ApplicationCallOutcome, ExecutionError>
+        ) -> Result<ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError>
         + Send
         + Sync,
 >;
@@ -198,7 +198,8 @@ impl ExpectedCall {
                 CalleeContext,
                 Vec<u8>,
                 Vec<SessionId>,
-            ) -> Result<ApplicationCallOutcome, ExecutionError>
+            )
+                -> Result<ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError>
             + Send
             + Sync
             + 'static,
@@ -319,7 +320,7 @@ impl UserContract for MockApplicationInstance<ContractSyncRuntime> {
         context: CalleeContext,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallOutcome, ExecutionError> {
+    ) -> Result<ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError> {
         match self.next_expected_call() {
             Some(ExpectedCall::HandleApplicationCall(handler)) => {
                 handler(&mut self.runtime, context, argument, forwarded_sessions)

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -22,16 +22,12 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 
-impl From<contract::SessionCallOutcome> for (SessionCallOutcome, Vec<u8>) {
+impl From<contract::SessionCallOutcome> for SessionCallOutcome {
     fn from(outcome: contract::SessionCallOutcome) -> Self {
-        let session_call_outcome = SessionCallOutcome {
+        SessionCallOutcome {
             inner: outcome.inner.into(),
-            close_session: outcome.new_state.is_some(),
-        };
-
-        let updated_session_state = outcome.new_state.unwrap_or_default();
-
-        (session_call_outcome, updated_session_state)
+            new_state: outcome.new_state,
+        }
     }
 }
 

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -22,7 +22,7 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 
-impl From<contract::SessionCallOutcome> for SessionCallOutcome {
+impl From<contract::SessionCallOutcome> for SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>> {
     fn from(outcome: contract::SessionCallOutcome) -> Self {
         SessionCallOutcome {
             inner: outcome.inner.into(),

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -65,13 +65,20 @@ impl From<contract::OutgoingMessage> for RawOutgoingMessage<Vec<u8>, Resources> 
         Self {
             destination: message.destination.into(),
             authenticated: message.authenticated,
-            grant: message.resources.into(),
-            kind: if message.is_tracked {
-                MessageKind::Tracked
-            } else {
-                MessageKind::Simple
-            },
+            grant: message.grant.into(),
+            kind: message.kind.into(),
             message: message.message,
+        }
+    }
+}
+
+impl From<contract::MessageKind> for MessageKind {
+    fn from(kind: contract::MessageKind) -> Self {
+        match kind {
+            contract::MessageKind::Simple => MessageKind::Simple,
+            contract::MessageKind::Protected => MessageKind::Protected,
+            contract::MessageKind::Tracked => MessageKind::Tracked,
+            contract::MessageKind::Bouncing => MessageKind::Bouncing,
         }
     }
 }

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -35,7 +35,7 @@ impl From<contract::SessionCallOutcome> for (SessionCallOutcome, Vec<u8>) {
     }
 }
 
-impl From<contract::ApplicationCallOutcome> for ApplicationCallOutcome {
+impl From<contract::ApplicationCallOutcome> for ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>> {
     fn from(outcome: contract::ApplicationCallOutcome) -> Self {
         ApplicationCallOutcome {
             create_sessions: outcome.create_sessions,

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -10,13 +10,13 @@
 
 use super::{contract, contract_system_api, service, service_system_api};
 use crate::{
-    CallOutcome, CalleeContext, MessageContext, MessageId, OperationContext, QueryContext,
-    SessionId, UserApplicationId,
+    CallOutcome, CalleeContext, MessageContext, OperationContext, QueryContext, SessionId,
+    UserApplicationId,
 };
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::Amount,
-    identifiers::{Account, ChainId, Owner},
+    identifiers::{Account, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 
@@ -38,8 +38,11 @@ impl From<MessageContext> for contract::MessageContext {
             chain_id: host.chain_id.into(),
             is_bouncing: host.is_bouncing,
             authenticated_signer: host.authenticated_signer.map(|owner| owner.0.into()),
+            refund_grant_to: host.refund_grant_to.map(|account| account.into()),
             height: host.height.0,
+            certificate_hash: host.certificate_hash.into(),
             message_id: host.message_id.into(),
+            next_message_index: host.next_message_index,
         }
     }
 }
@@ -136,6 +139,15 @@ impl From<UserApplicationId> for contract_system_api::ApplicationId {
         contract_system_api::ApplicationId {
             bytecode_id: host.bytecode_id.message_id.into(),
             creation: host.creation.into(),
+        }
+    }
+}
+
+impl From<Account> for contract::Account {
+    fn from(host: Account) -> Self {
+        contract::Account {
+            chain_id: host.chain_id.into(),
+            owner: host.owner.map(|owner| owner.0.into()),
         }
     }
 }

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -27,6 +27,7 @@ impl From<OperationContext> for contract::OperationContext {
             authenticated_signer: host.authenticated_signer.map(|owner| owner.0.into()),
             height: host.height.0,
             index: host.index,
+            next_message_index: host.next_message_index,
         }
     }
 }

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -278,7 +278,7 @@ where
         context: CalleeContext,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallOutcome, ExecutionError> {
+    ) -> Result<ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError> {
         let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -303,7 +303,7 @@ where
         session: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallOutcome, ExecutionError> {
+    ) -> Result<SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError> {
         let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -303,7 +303,7 @@ where
         session: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<(SessionCallOutcome, Vec<u8>), ExecutionError> {
+    ) -> Result<SessionCallOutcome, ExecutionError> {
         let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)
@@ -318,7 +318,7 @@ where
             &argument,
             &forwarded_sessions,
         )
-        .map(|inner| inner.map(<(SessionCallOutcome, Vec<u8>)>::from));
+        .map(|inner| inner.map(SessionCallOutcome::from));
         self.persist_remaining_fuel()?;
         result?.map_err(ExecutionError::UserError)
     }

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -340,7 +340,7 @@ where
         context: CalleeContext,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<ApplicationCallOutcome, ExecutionError> {
+    ) -> Result<ApplicationCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError> {
         let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -365,7 +365,7 @@ where
         session: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<(SessionCallOutcome, Vec<u8>), ExecutionError> {
+    ) -> Result<SessionCallOutcome, ExecutionError> {
         let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)
@@ -380,7 +380,7 @@ where
             &argument,
             &forwarded_sessions,
         )
-        .map(|inner| inner.map(<(SessionCallOutcome, Vec<u8>)>::from));
+        .map(|inner| inner.map(SessionCallOutcome::from));
         self.persist_remaining_fuel()?;
         result?.map_err(ExecutionError::UserError)
     }

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -365,7 +365,7 @@ where
         session: Vec<u8>,
         argument: Vec<u8>,
         forwarded_sessions: Vec<SessionId>,
-    ) -> Result<SessionCallOutcome, ExecutionError> {
+    ) -> Result<SessionCallOutcome<Vec<u8>, Vec<u8>, Vec<u8>>, ExecutionError> {
         let forwarded_sessions = forwarded_sessions
             .into_iter()
             .map(contract::SessionId::from)

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -139,13 +139,10 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
             assert_eq!(session_state, dummy_session_state);
             assert!(argument.is_empty());
             assert!(forwarded_sessions.is_empty());
-            Ok((
-                SessionCallOutcome {
-                    inner: ApplicationCallOutcome::default(),
-                    close_session: true,
-                },
-                session_state,
-            ))
+            Ok(SessionCallOutcome {
+                inner: ApplicationCallOutcome::default(),
+                new_state: None,
+            })
         },
     ));
 
@@ -297,13 +294,7 @@ async fn test_simple_session() -> anyhow::Result<()> {
 
     target_application.expect_call(ExpectedCall::handle_session_call(
         |_runtime, _context, _session_state, _argument, _forwarded_sessions| {
-            Ok((
-                SessionCallOutcome {
-                    close_session: true,
-                    ..SessionCallOutcome::default()
-                },
-                vec![],
-            ))
+            Ok(SessionCallOutcome::default())
         },
     ));
 
@@ -648,13 +639,10 @@ async fn test_message_from_session_call() -> anyhow::Result<()> {
         let dummy_message = dummy_message.clone();
         move |_runtime, _context, session_state, _argument, _forwarded_sessions| {
             assert_eq!(session_state, dummy_session);
-            Ok((
-                SessionCallOutcome {
-                    inner: ApplicationCallOutcome::default().with_message(dummy_message),
-                    close_session: true,
-                },
-                session_state,
-            ))
+            Ok(SessionCallOutcome {
+                inner: ApplicationCallOutcome::default().with_message(dummy_message),
+                new_state: None,
+            })
         }
     }));
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -424,7 +424,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
     application.expect_call(ExpectedCall::execute_operation({
         let dummy_message = dummy_message.clone();
         move |_runtime, _context, _operation| {
-            Ok(RawExecutionOutcome::default().with_message(dummy_message))
+            Ok(RawExecutionOutcome::default().with_raw_message(dummy_message))
         }
     }));
 
@@ -465,12 +465,12 @@ async fn test_simple_message() -> anyhow::Result<()> {
         outcomes,
         &[
             ExecutionOutcome::System(
-                RawExecutionOutcome::default().with_message(registration_message)
+                RawExecutionOutcome::default().with_raw_message(registration_message)
             ),
             ExecutionOutcome::User(
                 application_id,
                 RawExecutionOutcome::default()
-                    .with_message(dummy_message)
+                    .with_raw_message(dummy_message)
                     .with_refund_grant_to(Some(account))
             )
         ]
@@ -521,7 +521,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
         |_runtime, _context, _argument, _forwarded_sessions| {
             Ok(ApplicationCallOutcome {
                 value: vec![],
-                execution_outcome: RawExecutionOutcome::default().with_message(dummy_message),
+                execution_outcome: RawExecutionOutcome::default().with_raw_message(dummy_message),
                 create_sessions: vec![],
             })
         }
@@ -560,12 +560,12 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
         outcomes,
         &[
             ExecutionOutcome::System(
-                RawExecutionOutcome::default().with_message(registration_message)
+                RawExecutionOutcome::default().with_raw_message(registration_message)
             ),
             ExecutionOutcome::User(
                 target_id,
                 RawExecutionOutcome::default()
-                    .with_message(dummy_message)
+                    .with_raw_message(dummy_message)
                     .with_refund_grant_to(Some(account))
             ),
             ExecutionOutcome::User(
@@ -690,7 +690,7 @@ async fn test_message_from_session_call() -> anyhow::Result<()> {
         outcomes,
         &[
             ExecutionOutcome::System(
-                RawExecutionOutcome::default().with_message(registration_message)
+                RawExecutionOutcome::default().with_raw_message(registration_message)
             ),
             ExecutionOutcome::User(
                 target_id,
@@ -699,7 +699,7 @@ async fn test_message_from_session_call() -> anyhow::Result<()> {
             ExecutionOutcome::User(
                 target_id,
                 RawExecutionOutcome::default()
-                    .with_message(dummy_message)
+                    .with_raw_message(dummy_message)
                     .with_refund_grant_to(Some(account))
             ),
             ExecutionOutcome::User(
@@ -772,7 +772,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
                 vec![],
                 vec![],
             )?;
-            Ok(RawExecutionOutcome::default().with_message(first_message))
+            Ok(RawExecutionOutcome::default().with_raw_message(first_message))
         }
     }));
 
@@ -798,8 +798,8 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
             Ok(ApplicationCallOutcome {
                 value: vec![],
                 execution_outcome: RawExecutionOutcome::default()
-                    .with_message(first_message)
-                    .with_message(second_message),
+                    .with_raw_message(first_message)
+                    .with_raw_message(second_message),
                 create_sessions: vec![],
             })
         }
@@ -886,14 +886,14 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
             ExecutionOutcome::User(
                 sending_target_id,
                 RawExecutionOutcome::default()
-                    .with_message(first_message.clone())
-                    .with_message(second_message)
+                    .with_raw_message(first_message.clone())
+                    .with_raw_message(second_message)
                     .with_refund_grant_to(Some(account))
             ),
             ExecutionOutcome::User(
                 caller_id,
                 RawExecutionOutcome::default()
-                    .with_message(first_message)
+                    .with_raw_message(first_message)
                     .with_refund_grant_to(Some(account))
             ),
         ]

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -18,7 +18,7 @@ use linera_execution::{
         SystemExecutionState,
     },
     ApplicationCallOutcome, BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome,
-    MessageKind, Operation, OperationContext, Query, QueryContext, RawExecutionOutcome,
+    IntoPriced, MessageKind, Operation, OperationContext, Query, QueryContext, RawExecutionOutcome,
     RawOutgoingMessage, ResourceController, Response, SessionCallOutcome,
 };
 use linera_views::batch::Batch;

--- a/linera-sdk/contract.wit
+++ b/linera-sdk/contract.wit
@@ -35,8 +35,11 @@ record message-context {
     chain-id: chain-id,
     is-bouncing: bool,
     authenticated-signer: option<owner>,
+    refund-grant-to: option<account>,
     height: block-height,
+    certificate-hash: crypto-hash,
     message-id: message-id,
+    next-message-index: u32,
 }
 
 record message-id {
@@ -54,6 +57,11 @@ record callee-context {
 record application-id {
     bytecode-id: bytecode-id,
     creation: message-id,
+}
+
+record account {
+    chain-id: chain-id,
+    owner: option<owner>
 }
 
 type chain-id = crypto-hash

--- a/linera-sdk/contract.wit
+++ b/linera-sdk/contract.wit
@@ -28,6 +28,7 @@ record operation-context {
     authenticated-signer: option<owner>,
     height: block-height,
     index: u32,
+    next-message-index: u32,
 }
 
 record message-context {

--- a/linera-sdk/contract.wit
+++ b/linera-sdk/contract.wit
@@ -88,9 +88,16 @@ record session-call-outcome {
 record outgoing-message {
     destination: destination,
     authenticated: bool,
-    is-tracked: bool,
-    resources: resources,
+    kind: message-kind,
+    grant: resources,
     message: list<u8>,
+}
+
+enum message-kind {
+    simple,
+    protected,
+    tracked,
+    bouncing,
 }
 
 record resources {

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -11,7 +11,7 @@ use crate::{CalleeContext, MessageContext, OperationContext};
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, BlockHeight},
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner, SessionId},
+    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner, SessionId},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use std::time::Duration;
@@ -34,8 +34,11 @@ impl From<wit_types::MessageContext> for MessageContext {
             chain_id: ChainId(context.chain_id.into()),
             is_bouncing: context.is_bouncing,
             authenticated_signer: context.authenticated_signer.map(Owner::from),
+            refund_grant_to: context.refund_grant_to.map(Account::from),
             height: BlockHeight(context.height),
+            certificate_hash: context.certificate_hash.into(),
             message_id: context.message_id.into(),
+            next_message_index: context.next_message_index,
         }
     }
 }
@@ -56,6 +59,15 @@ impl From<wit_types::CalleeContext> for CalleeContext {
             chain_id: ChainId(context.chain_id.into()),
             authenticated_signer: context.authenticated_signer.map(Owner::from),
             authenticated_caller_id: context.authenticated_caller_id.map(ApplicationId::from),
+        }
+    }
+}
+
+impl From<wit_types::Account> for Account {
+    fn from(account: wit_types::Account) -> Self {
+        Account {
+            chain_id: account.chain_id.into(),
+            owner: account.owner.map(Owner::from),
         }
     }
 }
@@ -81,6 +93,12 @@ impl From<wit_types::SessionId> for SessionId {
 impl From<wit_types::CryptoHash> for Owner {
     fn from(crypto_hash: wit_types::CryptoHash) -> Self {
         Owner(crypto_hash.into())
+    }
+}
+
+impl From<wit_types::CryptoHash> for ChainId {
+    fn from(crypto_hash: wit_types::CryptoHash) -> Self {
+        ChainId(crypto_hash.into())
     }
 }
 

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -23,6 +23,7 @@ impl From<wit_types::OperationContext> for OperationContext {
             authenticated_signer: context.authenticated_signer.map(Owner::from),
             height: BlockHeight(context.height),
             index: context.index,
+            next_message_index: context.next_message_index,
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -9,6 +9,7 @@ use crate::{ApplicationCallOutcome, ExecutionOutcome, OutgoingMessage, SessionCa
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, Resources},
+    execution::MessageKind,
     identifiers::{Account, ApplicationId, ChannelName, Destination, MessageId, Owner, SessionId},
 };
 
@@ -126,9 +127,20 @@ impl From<OutgoingMessage<Vec<u8>>> for wit_types::OutgoingMessage {
         Self {
             destination: message.destination.into(),
             authenticated: message.authenticated,
-            is_tracked: message.is_tracked,
-            resources: message.resources.into(),
+            kind: message.kind.into(),
+            grant: message.grant.into(),
             message: message.message,
+        }
+    }
+}
+
+impl From<MessageKind> for wit_types::MessageKind {
+    fn from(kind: MessageKind) -> Self {
+        match kind {
+            MessageKind::Simple => wit_types::MessageKind::Simple,
+            MessageKind::Protected => wit_types::MessageKind::Protected,
+            MessageKind::Tracked => wit_types::MessageKind::Tracked,
+            MessageKind::Bouncing => wit_types::MessageKind::Bouncing,
         }
     }
 }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -41,7 +41,7 @@ macro_rules! contract {
                     application
                         .initialize(&context.into(), argument)
                         .await
-                        .map(|outcome| (application, outcome.into_raw()))
+                        .map(|outcome| (application, outcome.serialize_messages()))
                 },
             )
         }
@@ -60,7 +60,7 @@ macro_rules! contract {
                     application
                         .execute_operation(&context.into(), operation)
                         .await
-                        .map(|outcome| (application, outcome.into_raw()))
+                        .map(|outcome| (application, outcome.serialize_messages()))
                 },
             )
         }
@@ -79,7 +79,7 @@ macro_rules! contract {
                     application
                         .execute_message(&context.into(), message)
                         .await
-                        .map(|outcome| (application, outcome.into_raw()))
+                        .map(|outcome| (application, outcome.serialize_messages()))
                 },
             )
         }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -135,7 +135,7 @@ macro_rules! contract {
                             forwarded_sessions,
                         )
                         .await
-                        .map(|outcome| (application, outcome.into_raw()))
+                        .map(|outcome| (application, outcome.serialize_contents()))
                 },
             )
         }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -103,7 +103,7 @@ macro_rules! contract {
                     application
                         .handle_application_call(&context.into(), argument, forwarded_sessions)
                         .await
-                        .map(|outcome| (application, outcome.into_raw()))
+                        .map(|outcome| (application, outcome.serialize_contents()))
                 },
             )
         }

--- a/linera-sdk/src/contract/wit_types.rs
+++ b/linera-sdk/src/contract/wit_types.rs
@@ -9,8 +9,8 @@
 wit_bindgen_guest_rust::export!("contract.wit");
 
 pub use self::contract::{
-    ApplicationCallOutcome, ApplicationId, BlockHeight, BytecodeId, CalleeContext, ChainId,
-    ChannelName, CryptoHash, Destination, ExecutionOutcome, MessageContext, MessageId,
+    Account, ApplicationCallOutcome, ApplicationId, BlockHeight, BytecodeId, CalleeContext,
+    ChainId, ChannelName, CryptoHash, Destination, ExecutionOutcome, MessageContext, MessageId,
     OperationContext, OutgoingMessage, Owner, Resources, SessionCallOutcome, SessionId,
     SessionState,
 };

--- a/linera-sdk/src/contract/wit_types.rs
+++ b/linera-sdk/src/contract/wit_types.rs
@@ -11,8 +11,8 @@ wit_bindgen_guest_rust::export!("contract.wit");
 pub use self::contract::{
     Account, ApplicationCallOutcome, ApplicationId, BlockHeight, BytecodeId, CalleeContext,
     ChainId, ChannelName, CryptoHash, Destination, ExecutionOutcome, MessageContext, MessageId,
-    OperationContext, OutgoingMessage, Owner, Resources, SessionCallOutcome, SessionId,
-    SessionState,
+    MessageKind, OperationContext, OutgoingMessage, Owner, Resources, SessionCallOutcome,
+    SessionId, SessionState,
 };
 use super::{
     __contract_execute_message, __contract_execute_operation, __contract_handle_application_call,

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -65,7 +65,9 @@ pub use self::{
     log::{ContractLogger, ServiceLogger},
     service::ServiceStateStorage,
 };
-pub use linera_base::{abi, data_types::Resources, ensure, identifiers::SessionId};
+pub use linera_base::{
+    abi, data_types::Resources, ensure, execution::OperationContext, identifiers::SessionId,
+};
 #[doc(hidden)]
 pub use wit_bindgen_guest_rust;
 
@@ -316,19 +318,6 @@ pub trait Service: WithServiceAbi + ServiceAbi {
         let parameters = serde_json::from_slice(&bytes)?;
         Ok(parameters)
     }
-}
-
-/// The context of the execution of an application's operation.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct OperationContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// The authenticated signer of the operation, if any.
-    pub authenticated_signer: Option<Owner>,
-    /// The current block height.
-    pub height: BlockHeight,
-    /// The current index of the operation.
-    pub index: u32,
 }
 
 /// The context of the execution of an application's message.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -54,7 +54,6 @@ use self::contract::ContractStateStorage;
 use async_trait::async_trait;
 use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
-    data_types::BlockHeight,
     identifiers::{ApplicationId, ChainId, ChannelName, Destination},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -69,7 +68,7 @@ pub use linera_base::{
     abi,
     data_types::Resources,
     ensure,
-    execution::{CalleeContext, MessageContext, OperationContext},
+    execution::{CalleeContext, MessageContext, OperationContext, QueryContext},
     identifiers::SessionId,
 };
 #[doc(hidden)]
@@ -322,15 +321,6 @@ pub trait Service: WithServiceAbi + ServiceAbi {
         let parameters = serde_json::from_slice(&bytes)?;
         Ok(parameters)
     }
-}
-
-/// The context of the execution of an application's query.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct QueryContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// The height of the next block on this chain.
-    pub next_block_height: BlockHeight,
 }
 
 /// A message together with routing information.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -55,7 +55,7 @@ use async_trait::async_trait;
 use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
     data_types::BlockHeight,
-    identifiers::{ApplicationId, ChainId, ChannelName, Destination, MessageId, Owner},
+    identifiers::{ApplicationId, ChainId, ChannelName, Destination, Owner},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{error::Error, fmt::Debug, sync::Arc};
@@ -66,7 +66,11 @@ pub use self::{
     service::ServiceStateStorage,
 };
 pub use linera_base::{
-    abi, data_types::Resources, ensure, execution::OperationContext, identifiers::SessionId,
+    abi,
+    data_types::Resources,
+    ensure,
+    execution::{MessageContext, OperationContext},
+    identifiers::SessionId,
 };
 #[doc(hidden)]
 pub use wit_bindgen_guest_rust;
@@ -318,22 +322,6 @@ pub trait Service: WithServiceAbi + ServiceAbi {
         let parameters = serde_json::from_slice(&bytes)?;
         Ok(parameters)
     }
-}
-
-/// The context of the execution of an application's message.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct MessageContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// Whether the message was rejected by the original receiver and is now bouncing back.
-    pub is_bouncing: bool,
-    /// The authenticated signer of the operation, if any.
-    pub authenticated_signer: Option<Owner>,
-    /// The current block height.
-    pub height: BlockHeight,
-    /// The id of the message (based on the operation height and index in the remote
-    /// chain that created the message).
-    pub message_id: MessageId,
 }
 
 /// The context of the execution of an application's cross-application call or session call handler.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -55,7 +55,7 @@ use async_trait::async_trait;
 use linera_base::{
     abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
     data_types::BlockHeight,
-    identifiers::{ApplicationId, ChainId, ChannelName, Destination, Owner},
+    identifiers::{ApplicationId, ChainId, ChannelName, Destination},
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{error::Error, fmt::Debug, sync::Arc};
@@ -69,7 +69,7 @@ pub use linera_base::{
     abi,
     data_types::Resources,
     ensure,
-    execution::{MessageContext, OperationContext},
+    execution::{CalleeContext, MessageContext, OperationContext},
     identifiers::SessionId,
 };
 #[doc(hidden)]
@@ -322,18 +322,6 @@ pub trait Service: WithServiceAbi + ServiceAbi {
         let parameters = serde_json::from_slice(&bytes)?;
         Ok(parameters)
     }
-}
-
-/// The context of the execution of an application's cross-application call or session call handler.
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct CalleeContext {
-    /// The current chain id.
-    pub chain_id: ChainId,
-    /// The authenticated signer of the operation, if any.
-    pub authenticated_signer: Option<Owner>,
-    /// `None` if the caller doesn't want this particular call to be authenticated (e.g.
-    /// for safety reasons).
-    pub authenticated_caller_id: Option<ApplicationId>,
 }
 
 /// The context of the execution of an application's query.


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Some types were originally defined in `linera-execution`, but had to be used inside Wasm applications. Therefore they were duplicated in `linera-sdk`. This has led to some issues where one of the types could become out of date.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Move the duplicated types into `linera-base`, which is accessible both from `linera-sdk` and from `linera-execution`.

## Test Plan

<!-- How to test that the changes are correct. -->
Internal refactoring, so existing tests should catch regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Changes the public API of `linera-base`, so:
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
