### PR TITLE
Make open_chain return a result.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -237,11 +237,11 @@ where
             } => {
                 let app_permissions = self.system.application_permissions.get();
                 if !app_permissions.can_close_chain(&application_id) {
-                    callback.respond(Ok(false));
+                    callback.respond(Err(ExecutionError::UnauthorizedApplication(application_id)));
                 } else {
                     let chain_id = self.context().extra().chain_id();
                     self.system.close_chain(chain_id).await?;
-                    callback.respond(Ok(true));
+                    callback.respond(Ok(()));
                 }
             }
         }
@@ -341,7 +341,7 @@ pub enum Request {
 
     CloseChain {
         application_id: UserApplicationId,
-        callback: oneshot::Sender<Result<bool, ExecutionError>>,
+        callback: oneshot::Sender<Result<(), ExecutionError>>,
     },
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -516,7 +516,7 @@ pub trait ContractRuntime: BaseRuntime {
     ) -> Result<ChainId, ExecutionError>;
 
     /// Closes the current chain.
-    fn close_chain(&mut self) -> Result<bool, ExecutionError>;
+    fn close_chain(&mut self) -> Result<(), ExecutionError>;
 }
 
 /// An operation to be executed in a block.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1137,7 +1137,7 @@ impl ContractRuntime for ContractSyncRuntime {
         Ok(chain_id)
     }
 
-    fn close_chain(&mut self) -> Result<bool, ExecutionError> {
+    fn close_chain(&mut self) -> Result<(), ExecutionError> {
         let mut this = self.inner();
         let application_id = this.current_application().id;
         this.execution_state_sender

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -84,8 +84,20 @@ macro_rules! impl_contract_system_api {
                     .map(Into::into)
             }
 
-            fn close_chain(&mut self) -> Result<bool, Self::Error> {
+            fn close_chain(&mut self) -> Result<(), Self::Error> {
                 ContractRuntime::close_chain(self)
+            }
+
+            fn error_to_closechainerror(
+                &mut self,
+                error: Self::Error,
+            ) -> Result<contract_system_api::Closechainerror, $trap> {
+                match error {
+                    ExecutionError::UnauthorizedApplication(_) => {
+                        Ok(contract_system_api::Closechainerror::NotPermitted)
+                    }
+                    error => Err(error.into()),
+                }
             }
 
             fn try_call_application(

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -999,7 +999,10 @@ async fn test_close_chain() {
     let context = make_operation_context();
     application.expect_call(ExpectedCall::execute_operation(
         move |runtime, _context, _operation| {
-            assert!(!runtime.close_chain().unwrap());
+            assert_matches!(
+                runtime.close_chain(),
+                Err(ExecutionError::UnauthorizedApplication(_))
+            );
             Ok(RawExecutionOutcome::default())
         },
     ));
@@ -1019,7 +1022,7 @@ async fn test_close_chain() {
         .set(ApplicationPermissions::new_single(application_id));
     application.expect_call(ExpectedCall::execute_operation(
         move |runtime, _context, _operation| {
-            assert!(runtime.close_chain().unwrap());
+            runtime.close_chain().unwrap();
             Ok(RawExecutionOutcome::default())
         },
     ));

--- a/linera-sdk/contract_system_api.wit
+++ b/linera-sdk/contract_system_api.wit
@@ -36,7 +36,11 @@ open-chain: func(
     balance: amount
 ) -> chain-id
 
-close-chain: func() -> bool
+close-chain: func() -> result<tuple<>, closechainerror>
+
+variant closechainerror {
+    not-permitted
+}
 
 chain-ownership: func() -> chain-ownership
 


### PR DESCRIPTION
## Motivation

`close_chain` should return a `Result`; if the application is not authorized it should return `Err`.

## Proposal

Change the return type to `result<tuple<>, closechainerror>`.
Unfortunately we cannot use dashes in the error type due to a wit-bindgen bug.

## Test Plan

`test_close_chain` was updated.

## Release Plan

- Need to update the developer manual.

## Links

- #1722 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
