### PR TITLE
`.github`: continue on error in Rust lint workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,6 +109,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Motivation

Currently linting stops at the first failure.  This means that any future linting errors will be eclipsed by earlier ones, and the developer can push a fix to a linting error only for the job to fail at a later error. 

The lint step runs on a small machine, and is therefore free for us as an open-source project.  By continuing on error we can allow all lint feedback to be collected in one run, which will hopefully allow developers to run the CI less often. 

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Add `continue-on-error` to the Rust lint job, ensuring that it will run to completion even if one step continues.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

No user-visible changes.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [`continue-on-error` in the GitHub actions documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
