### PR TITLE
Web client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3293,6 +3293,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes",
+ "cfg-if",
  "cfg_aliases",
  "clap",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3321,6 +3321,7 @@ dependencies = [
  "tonic-build",
  "tonic-health",
  "tonic-reflection",
+ "tonic-web-wasm-client",
  "tower",
  "tracing",
 ]
@@ -6171,6 +6172,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-web-wasm-client"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79bb296fba9974fbc7ea2f1364a661c0e7acb7ebfca648343e5a4ac44ec9a0ec"
+dependencies = [
+ "base64 0.21.7",
+ "byteorder",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "js-sys",
+ "pin-project",
+ "thiserror",
+ "tonic",
+ "tower-service",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6586,9 +6611,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6663,6 +6688,19 @@ dependencies = [
  "serde",
  "wasm-encoder 0.29.0",
  "wasmparser 0.107.0",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,6 +3126,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "trait-variant",
 ]
 
 [[package]]
@@ -3324,6 +3325,7 @@ dependencies = [
  "tonic-web-wasm-client",
  "tower",
  "tracing",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -6327,6 +6329,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e1a477061e97925d81a2f89fb73b2b8038e6baa5a0023bad380ac23b5f4fa6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6649,6 +6662,31 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bf62a58e0780af3e852044583deee40983e5886da43a271dd772379987667b"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ custom_debug_derive = "0.6.1"
 dashmap = "5.5.3"
 derive_more = "0.99.17"
 dirs = "5.0.1"
-ed25519 = "2.2"
 ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
 either = "1.10.0"
 frunk = "0.4.2"
@@ -127,6 +126,8 @@ tower-http = "0.5.2"
 tower = "0.4.13"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = ["env-filter"] }
+trait-variant = "0.1.1"
+wasm-bindgen-test = "0.3.42"
 wasm-encoder = "0.24.1"
 wasmer = { version = "=3.1.1", features = ["singlepass"] }
 wasmer-middlewares = "=3.1.1"
@@ -143,7 +144,6 @@ linera-chain = { version = "0.9.0", path = "./linera-chain" }
 linera-core = { version = "0.9.0", path = "./linera-core", default-features = false }
 linera-execution = { version = "0.9.0", path = "./linera-execution", default-features = false }
 linera-indexer = { path = "./linera-indexer/lib" }
-linera-indexer-example = { path = "./linera-indexer/example" }
 linera-indexer-graphql-client = { path = "./linera-indexer/graphql-client" }
 linera-indexer-plugins = { path = "./linera-indexer/plugins" }
 linera-rpc = { version = "0.9.0", path = "./linera-rpc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ tonic-build = { version = "0.11", default-features = false }
 tonic-health = "0.11"
 tonic-reflection = "0.11"
 tonic-web = "0.11"
+tonic-web-wasm-client = "0.5.1"
 tokio = "1.36.0"
 tokio-stream = "0.1.14"
 tokio-test = "0.4.3"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1893,6 +1893,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "trait-variant",
 ]
 
 [[package]]
@@ -3890,6 +3891,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e1a477061e97925d81a2f89fb73b2b8038e6baa5a0023bad380ac23b5f4fa6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
 ]
 
 [[package]]

--- a/flake.nix
+++ b/flake.nix
@@ -18,11 +18,8 @@
       let
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         nonRustDeps = with pkgs; [
+          # for building
           clang
-          jq
-          kubernetes-helm
-          kind
-          kubectl
           libclang.lib
           libiconv
           nodejs
@@ -30,6 +27,17 @@
           protobuf
           pkg-config
           rocksdb
+
+          # for testing
+          jq
+          kubernetes-helm
+          kind
+          kubectl
+
+          # for Wasm testing
+          chromium
+          chromedriver
+          wasm-pack
         ];
         rustBuildToolchain = (pkgs.rust-bin.fromRustupToolchainFile
           ./toolchains/build/rust-toolchain.toml);

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -72,6 +72,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 tracing.workspace = true
+trait-variant.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 linera-storage-service.workspace = true

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2012,7 +2012,7 @@ impl<P, S> ArcChainClient<P, S> {
 impl<P, S> ArcChainClient<P, S>
 where
     P: ValidatorNodeProvider + Sync,
-    <P as ValidatorNodeProvider>::Node: Clone + 'static,
+    <<P as ValidatorNodeProvider>::Node as crate::node::ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -8,8 +8,8 @@ use crate::{
     },
     local_node::{LocalNodeClient, LocalNodeError},
     node::{
-        CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
-        ValidatorNodeProvider,
+        CrossChainMessageDelivery, LocalValidatorNode, LocalValidatorNodeProvider, NodeError,
+        NotificationStream, ValidatorNodeProvider,
     },
     notifier::Notifier,
     updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
@@ -272,7 +272,7 @@ enum ReceiveCertificateMode {
 
 impl<P, S> ChainClient<P, S>
 where
-    P: ValidatorNodeProvider + Sync,
+    P: LocalValidatorNodeProvider + Sync,
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
@@ -722,7 +722,7 @@ where
         mut node_client: LocalNodeClient<S>,
     ) -> Result<(ValidatorName, u64, Vec<Certificate>), NodeError>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         // Retrieve newly received certificates from this validator.
         let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_nth(tracker);
@@ -2003,16 +2003,19 @@ impl<P, S> Clone for ArcChainClient<P, S> {
     }
 }
 
-impl<P, S> ArcChainClient<P, S>
-where
-    P: ValidatorNodeProvider + Sync,
-    S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
-{
+impl<P, S> ArcChainClient<P, S> {
     pub fn new(client: ChainClient<P, S>) -> Self {
         Self(Arc::new(Mutex::new(client)))
     }
+}
 
+impl<P, S> ArcChainClient<P, S>
+where
+    P: ValidatorNodeProvider + Sync,
+    <P as ValidatorNodeProvider>::Node: Clone + 'static,
+    S: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
+{
     async fn local_chain_info(
         &self,
         chain_id: ChainId,
@@ -2040,7 +2043,7 @@ where
     async fn process_notification(
         &self,
         name: ValidatorName,
-        node: P::Node,
+        node: <P as ValidatorNodeProvider>::Node,
         mut local_node: LocalNodeClient<S>,
         notification: Notification,
     ) {
@@ -2198,7 +2201,7 @@ where
     pub async fn find_received_certificates_from_validator(
         &self,
         name: ValidatorName,
-        node: P::Node,
+        node: <P as ValidatorNodeProvider>::Node,
         node_client: LocalNodeClient<S>,
     ) -> Result<(), ChainClientError> {
         let ((committees, max_epoch), chain_id, current_tracker) = {

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery, ChainInfoResponse},
-    node::{NotificationStream, ValidatorNode},
+    node::{LocalValidatorNode, NotificationStream},
     notifier::Notifier,
     worker::{Notification, ValidatorWorker, WorkerError, WorkerState},
 };
@@ -182,7 +182,7 @@ where
         certificates: Vec<Certificate>,
     ) -> Option<Box<ChainInfo>>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         let mut info = None;
         for certificate in certificates {
@@ -268,7 +268,7 @@ where
         target_next_block_height: BlockHeight,
     ) -> Result<Box<ChainInfo>, LocalNodeError>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         // Sequentially try each validator in random order.
         validators.shuffle(&mut rand::thread_rng());
@@ -306,7 +306,7 @@ where
         blob_locations: impl IntoIterator<Item = (BytecodeLocation, ChainId)>,
     ) -> Result<Vec<HashedValue>, LocalNodeError>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         let mut blobs = vec![];
         let mut tasks = vec![];
@@ -344,7 +344,7 @@ where
         location: BytecodeLocation,
     ) -> Result<Option<HashedValue>, LocalNodeError>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         match storage.read_value(location.certificate_hash).await {
             Ok(blob) => return Ok(Some(blob)),
@@ -387,7 +387,7 @@ where
         stop: BlockHeight,
     ) -> Result<(), LocalNodeError>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         let limit = u64::from(stop)
             .checked_sub(u64::from(start))
@@ -421,7 +421,7 @@ where
         chain_id: ChainId,
     ) -> Result<Box<ChainInfo>, LocalNodeError>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         let futures = validators
             .into_iter()
@@ -446,7 +446,7 @@ where
         chain_id: ChainId,
     ) -> Result<(), LocalNodeError>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         let local_info = self.local_chain_info(chain_id).await?;
         let range = BlockHeightRange {
@@ -506,7 +506,7 @@ where
         location: BytecodeLocation,
     ) -> Option<HashedValue>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         // Sequentially try each validator in random order.
         validators.shuffle(&mut rand::thread_rng());
@@ -527,7 +527,7 @@ where
         location: BytecodeLocation,
     ) -> Option<HashedValue>
     where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
+        A: LocalValidatorNode + Clone + 'static,
     {
         let query = ChainInfoQuery::new(chain_id).with_blob(location.certificate_hash);
         if let Ok(response) = node.handle_chain_info_query(query).await {

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -39,7 +39,7 @@ pub enum CrossChainMessageDelivery {
 }
 
 /// How to communicate with a validator node.
-#[trait_variant::make(ValidatorNodeInner: Send)]
+#[trait_variant::make(ValidatorNode: Send)]
 pub trait LocalValidatorNode {
     type NotificationStream: Stream<Item = Notification> + Unpin;
 
@@ -78,20 +78,6 @@ pub trait LocalValidatorNode {
         &mut self,
         chains: Vec<ChainId>,
     ) -> Result<Self::NotificationStream, NodeError>;
-}
-
-/// How to communicate with a validator node.
-pub trait ValidatorNode:
-    ValidatorNodeInner<NotificationStream = <Self as ValidatorNode>::NotificationStream>
-{
-    type NotificationStream: Stream<Item = Notification> + Unpin + Send;
-}
-
-impl<T: ValidatorNodeInner> ValidatorNode for T
-where
-    T::NotificationStream: Send,
-{
-    type NotificationStream = <T as ValidatorNodeInner>::NotificationStream;
 }
 
 /// Turn an address into a validator node.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -6,8 +6,7 @@ use crate::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
     worker::{Notification, WorkerError},
 };
-use async_trait::async_trait;
-use futures::Stream;
+use futures::stream::{BoxStream, LocalBoxStream, Stream};
 use linera_base::{
     crypto::CryptoError,
     data_types::{ArithmeticError, BlockHeight},
@@ -24,11 +23,12 @@ use linera_execution::{
 use linera_version::VersionInfo;
 use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
-use std::pin::Pin;
 use thiserror::Error;
 
 /// A pinned [`Stream`] of Notifications.
-pub type NotificationStream = Pin<Box<dyn Stream<Item = Notification> + Send>>;
+pub type NotificationStream = BoxStream<'static, Notification>;
+/// A pinned [`Stream`] of Notifications, without the `Send` constraint.
+pub type LocalNotificationStream = LocalBoxStream<'static, Notification>;
 
 /// Whether to wait for the delivery of outgoing cross-chain messages.
 #[derive(Debug, Default, Clone, Copy)]
@@ -39,8 +39,10 @@ pub enum CrossChainMessageDelivery {
 }
 
 /// How to communicate with a validator node.
-#[async_trait]
-pub trait ValidatorNode {
+#[trait_variant::make(ValidatorNodeInner: Send)]
+pub trait LocalValidatorNode {
+    type NotificationStream: Stream<Item = Notification> + Unpin;
+
     /// Proposes a new block.
     async fn handle_block_proposal(
         &mut self,
@@ -72,13 +74,30 @@ pub trait ValidatorNode {
     async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError>;
 
     /// Subscribes to receiving notifications for a collection of chains.
-    async fn subscribe(&mut self, chains: Vec<ChainId>) -> Result<NotificationStream, NodeError>;
+    async fn subscribe(
+        &mut self,
+        chains: Vec<ChainId>,
+    ) -> Result<Self::NotificationStream, NodeError>;
+}
+
+/// How to communicate with a validator node.
+pub trait ValidatorNode:
+    ValidatorNodeInner<NotificationStream = <Self as ValidatorNode>::NotificationStream>
+{
+    type NotificationStream: Stream<Item = Notification> + Unpin + Send;
+}
+
+impl<T: ValidatorNodeInner> ValidatorNode for T
+where
+    T::NotificationStream: Send,
+{
+    type NotificationStream = <T as ValidatorNodeInner>::NotificationStream;
 }
 
 /// Turn an address into a validator node.
 #[allow(clippy::result_large_err)]
-pub trait ValidatorNodeProvider {
-    type Node: ValidatorNode + Clone + Send + Sync + 'static;
+pub trait LocalValidatorNodeProvider {
+    type Node: LocalValidatorNode + Clone + 'static;
 
     fn make_node(&self, address: &str) -> Result<Self::Node, NodeError>;
 
@@ -102,6 +121,19 @@ pub trait ValidatorNodeProvider {
             .map(|(name, address)| Ok((name, self.make_node(address.as_ref())?)))
             .collect()
     }
+}
+
+pub trait ValidatorNodeProvider:
+    LocalValidatorNodeProvider<Node = <Self as ValidatorNodeProvider>::Node>
+{
+    type Node: ValidatorNode + Send + Sync + Clone + 'static;
+}
+
+impl<T: LocalValidatorNodeProvider> ValidatorNodeProvider for T
+where
+    T::Node: ValidatorNode + Send + Sync + Clone + 'static,
+{
+    type Node = <T as LocalValidatorNodeProvider>::Node;
 }
 
 /// Error type for node queries.

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    client::{ChainClient, ChainClientBuilder, ValidatorNodeProvider},
+    client::{ChainClient, ChainClientBuilder},
     data_types::*,
-    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
+    node::{
+        CrossChainMessageDelivery, LocalValidatorNodeProvider, NodeError, NotificationStream,
+        ValidatorNodeInner,
+    },
     notifier::Notifier,
     worker::{Notification, ValidatorWorker, WorkerState},
 };
@@ -90,12 +93,13 @@ pub struct LocalValidatorClient<S> {
     client: Arc<Mutex<LocalValidator<S>>>,
 }
 
-#[async_trait]
-impl<S> ValidatorNode for LocalValidatorClient<S>
+impl<S> ValidatorNodeInner for LocalValidatorClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
+    type NotificationStream = NotificationStream;
+
     async fn handle_block_proposal(
         &mut self,
         proposal: BlockProposal,
@@ -316,7 +320,7 @@ where
 #[derive(Clone)]
 pub struct NodeProvider<S>(BTreeMap<ValidatorName, Arc<Mutex<LocalValidator<S>>>>);
 
-impl<S> ValidatorNodeProvider for NodeProvider<S>
+impl<S> LocalValidatorNodeProvider for NodeProvider<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -6,7 +6,7 @@ use crate::{
     data_types::*,
     node::{
         CrossChainMessageDelivery, LocalValidatorNodeProvider, NodeError, NotificationStream,
-        ValidatorNodeInner,
+        ValidatorNode,
     },
     notifier::Notifier,
     worker::{Notification, ValidatorWorker, WorkerState},
@@ -93,7 +93,7 @@ pub struct LocalValidatorClient<S> {
     client: Arc<Mutex<LocalValidator<S>>>,
 }
 
-impl<S> ValidatorNodeInner for LocalValidatorClient<S>
+impl<S> ValidatorNode for LocalValidatorClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -904,7 +904,7 @@ pub struct Bytecode {
 
 impl Bytecode {
     /// Creates a new [`Bytecode`] instance using the provided `bytes`.
-    #[cfg(any(test, with_wasm_runtime))]
+    #[allow(dead_code)]
     pub(crate) fn new(bytes: Vec<u8>) -> Self {
         Bytecode { bytes }
     }

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -80,7 +80,8 @@ test-strategy.workspace = true
 tonic = { workspace = true, features = ["prost", "codegen", "transport"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tonic = { workspace = true, features = ["prost", "codegen"] }
+tonic = { workspace = true, features = ["codegen", "prost"] }
+tonic-web-wasm-client.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -83,6 +83,9 @@ tonic = { workspace = true, features = ["prost", "codegen", "transport"] }
 tonic = { workspace = true, features = ["codegen", "prost"] }
 tonic-web-wasm-client.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test.workspace = true
+
 [build-dependencies]
 cfg_aliases.workspace = true
 tonic-build = { workspace = true, features = ["prost"] }

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -45,6 +45,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 bincode.workspace = true
 bytes.workspace = true
+cfg-if.workspace = true
 clap.workspace = true
 dashmap.workspace = true
 ed25519-dalek.workspace = true

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -12,9 +12,11 @@ use linera_core::{
 };
 
 #[cfg(web)]
-use linera_core::node::{LocalNotificationStream, LocalValidatorNode};
+use linera_core::node::{
+    LocalNotificationStream as NotificationStream, LocalValidatorNode as ValidatorNode,
+};
 #[cfg(not(web))]
-use linera_core::node::{NotificationStream, ValidatorNodeInner};
+use linera_core::node::{NotificationStream, ValidatorNodeInner as ValidatorNode};
 
 #[derive(Clone)]
 pub enum Client {
@@ -36,103 +38,7 @@ impl From<SimpleClient> for Client {
     }
 }
 
-// TODO(TODO): deduplicate
-
-#[cfg(web)]
-impl LocalValidatorNode for Client {
-    type NotificationStream = LocalNotificationStream;
-
-    async fn handle_block_proposal(
-        &mut self,
-        proposal: BlockProposal,
-    ) -> Result<ChainInfoResponse, NodeError> {
-        match self {
-            Client::Grpc(grpc_client) => grpc_client.handle_block_proposal(proposal).await,
-
-            #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => simple_client.handle_block_proposal(proposal).await,
-        }
-    }
-
-    async fn handle_lite_certificate(
-        &mut self,
-        certificate: LiteCertificate<'_>,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<ChainInfoResponse, NodeError> {
-        match self {
-            Client::Grpc(grpc_client) => {
-                grpc_client
-                    .handle_lite_certificate(certificate, delivery)
-                    .await
-            }
-
-            #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => {
-                simple_client
-                    .handle_lite_certificate(certificate, delivery)
-                    .await
-            }
-        }
-    }
-
-    async fn handle_certificate(
-        &mut self,
-        certificate: Certificate,
-        blobs: Vec<HashedValue>,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<ChainInfoResponse, NodeError> {
-        match self {
-            Client::Grpc(grpc_client) => {
-                grpc_client
-                    .handle_certificate(certificate, blobs, delivery)
-                    .await
-            }
-
-            #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => {
-                simple_client
-                    .handle_certificate(certificate, blobs, delivery)
-                    .await
-            }
-        }
-    }
-
-    async fn handle_chain_info_query(
-        &mut self,
-        query: ChainInfoQuery,
-    ) -> Result<ChainInfoResponse, NodeError> {
-        match self {
-            Client::Grpc(grpc_client) => grpc_client.handle_chain_info_query(query).await,
-
-            #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => simple_client.handle_chain_info_query(query).await,
-        }
-    }
-
-    async fn subscribe(
-        &mut self,
-        chains: Vec<ChainId>,
-    ) -> Result<Self::NotificationStream, NodeError> {
-        Ok(match self {
-            Client::Grpc(grpc_client) => Box::pin(grpc_client.subscribe(chains).await?),
-
-            #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => Box::pin(simple_client.subscribe(chains).await?),
-        })
-    }
-
-    async fn get_version_info(&mut self) -> Result<linera_version::VersionInfo, NodeError> {
-        Ok(match self {
-            Client::Grpc(grpc_client) => grpc_client.get_version_info().await?,
-
-            #[cfg(with_simple_network)]
-            Client::Simple(simple_client) => simple_client.get_version_info().await?,
-        })
-    }
-}
-
-#[cfg(not(web))]
-impl ValidatorNodeInner for Client {
+impl ValidatorNode for Client {
     type NotificationStream = NotificationStream;
 
     async fn handle_block_proposal(

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
-
 use crate::grpc::GrpcClient;
 #[cfg(with_simple_network)]
 use crate::simple::SimpleClient;
@@ -10,8 +8,13 @@ use linera_base::identifiers::ChainId;
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
-    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
+    node::{CrossChainMessageDelivery, NodeError},
 };
+
+#[cfg(web)]
+use linera_core::node::{LocalNotificationStream, LocalValidatorNode};
+#[cfg(not(web))]
+use linera_core::node::{NotificationStream, ValidatorNodeInner};
 
 #[derive(Clone)]
 pub enum Client {
@@ -33,8 +36,12 @@ impl From<SimpleClient> for Client {
     }
 }
 
-#[async_trait]
-impl ValidatorNode for Client {
+// TODO(TODO): deduplicate
+
+#[cfg(web)]
+impl LocalValidatorNode for Client {
+    type NotificationStream = LocalNotificationStream;
+
     async fn handle_block_proposal(
         &mut self,
         proposal: BlockProposal,
@@ -102,7 +109,103 @@ impl ValidatorNode for Client {
         }
     }
 
-    async fn subscribe(&mut self, chains: Vec<ChainId>) -> Result<NotificationStream, NodeError> {
+    async fn subscribe(
+        &mut self,
+        chains: Vec<ChainId>,
+    ) -> Result<Self::NotificationStream, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => Box::pin(grpc_client.subscribe(chains).await?),
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => Box::pin(simple_client.subscribe(chains).await?),
+        })
+    }
+
+    async fn get_version_info(&mut self) -> Result<linera_version::VersionInfo, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.get_version_info().await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.get_version_info().await?,
+        })
+    }
+}
+
+#[cfg(not(web))]
+impl ValidatorNodeInner for Client {
+    type NotificationStream = NotificationStream;
+
+    async fn handle_block_proposal(
+        &mut self,
+        proposal: BlockProposal,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        match self {
+            Client::Grpc(grpc_client) => grpc_client.handle_block_proposal(proposal).await,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.handle_block_proposal(proposal).await,
+        }
+    }
+
+    async fn handle_lite_certificate(
+        &mut self,
+        certificate: LiteCertificate<'_>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        match self {
+            Client::Grpc(grpc_client) => {
+                grpc_client
+                    .handle_lite_certificate(certificate, delivery)
+                    .await
+            }
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => {
+                simple_client
+                    .handle_lite_certificate(certificate, delivery)
+                    .await
+            }
+        }
+    }
+
+    async fn handle_certificate(
+        &mut self,
+        certificate: Certificate,
+        blobs: Vec<HashedValue>,
+        delivery: CrossChainMessageDelivery,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        match self {
+            Client::Grpc(grpc_client) => {
+                grpc_client
+                    .handle_certificate(certificate, blobs, delivery)
+                    .await
+            }
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => {
+                simple_client
+                    .handle_certificate(certificate, blobs, delivery)
+                    .await
+            }
+        }
+    }
+
+    async fn handle_chain_info_query(
+        &mut self,
+        query: ChainInfoQuery,
+    ) -> Result<ChainInfoResponse, NodeError> {
+        match self {
+            Client::Grpc(grpc_client) => grpc_client.handle_chain_info_query(query).await,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.handle_chain_info_query(query).await,
+        }
+    }
+
+    async fn subscribe(
+        &mut self,
+        chains: Vec<ChainId>,
+    ) -> Result<Self::NotificationStream, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => Box::pin(grpc_client.subscribe(chains).await?),
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -16,7 +16,7 @@ use linera_core::node::{
     LocalNotificationStream as NotificationStream, LocalValidatorNode as ValidatorNode,
 };
 #[cfg(not(web))]
-use linera_core::node::{NotificationStream, ValidatorNodeInner as ValidatorNode};
+use linera_core::node::{NotificationStream, ValidatorNode};
 
 #[derive(Clone)]
 pub enum Client {

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -27,7 +27,7 @@ use linera_core::node::{
 use {
     super::GrpcProtoConversionError,
     crate::{mass_client, RpcMessage},
-    linera_core::node::{NotificationStream, ValidatorNodeInner as ValidatorNode},
+    linera_core::node::{NotificationStream, ValidatorNode},
 };
 
 use linera_version::VersionInfo;

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -20,12 +20,14 @@ use linera_core::{
 };
 
 #[cfg(web)]
-use linera_core::node::{LocalNotificationStream, LocalValidatorNode};
+use linera_core::node::{
+    LocalNotificationStream as NotificationStream, LocalValidatorNode as ValidatorNode,
+};
 #[cfg(not(web))]
 use {
     super::GrpcProtoConversionError,
     crate::{mass_client, RpcMessage},
-    linera_core::node::{NotificationStream, ValidatorNodeInner},
+    linera_core::node::{NotificationStream, ValidatorNodeInner as ValidatorNode},
 };
 
 use linera_version::VersionInfo;
@@ -133,139 +135,7 @@ macro_rules! client_delegate {
     }};
 }
 
-// TODO(TODO): deduplicate this implementation
-
-#[cfg(web)]
-impl LocalValidatorNode for GrpcClient {
-    type NotificationStream = LocalNotificationStream;
-
-    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn handle_block_proposal(
-        &mut self,
-        proposal: data_types::BlockProposal,
-    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        client_delegate!(self, handle_block_proposal, proposal)
-    }
-
-    #[instrument(target = "grpc_client", skip_all, fields(address = self.address))]
-    async fn handle_lite_certificate(
-        &mut self,
-        certificate: data_types::LiteCertificate<'_>,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
-        let request = HandleLiteCertificateRequest {
-            certificate,
-            wait_for_outgoing_messages,
-        };
-        client_delegate!(self, handle_lite_certificate, request)
-    }
-
-    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn handle_certificate(
-        &mut self,
-        certificate: data_types::Certificate,
-        blobs: Vec<data_types::HashedValue>,
-        delivery: CrossChainMessageDelivery,
-    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
-        let request = HandleCertificateRequest {
-            certificate,
-            blobs,
-            wait_for_outgoing_messages,
-        };
-        client_delegate!(self, handle_certificate, request)
-    }
-
-    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn handle_chain_info_query(
-        &mut self,
-        query: linera_core::data_types::ChainInfoQuery,
-    ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
-        client_delegate!(self, handle_chain_info_query, query)
-    }
-
-    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn subscribe(
-        &mut self,
-        chains: Vec<ChainId>,
-    ) -> Result<Self::NotificationStream, NodeError> {
-        let notification_retry_delay = self.notification_retry_delay;
-        let notification_retries = self.notification_retries;
-        let mut retry_count = 0;
-        let subscription_request = SubscriptionRequest {
-            chain_ids: chains.into_iter().map(|chain| chain.into()).collect(),
-        };
-        let mut client = self.client.clone();
-
-        // Make the first connection attempt before returning from this method.
-        let mut stream = Some(
-            client
-                .subscribe(subscription_request.clone())
-                .await
-                .map_err(|status| NodeError::SubscriptionFailed {
-                    status: status.to_string(),
-                })?
-                .into_inner(),
-        );
-
-        // A stream of `Result<grpc::Notification, tonic::Status>` that keeps calling
-        // `client.subscribe(request)` endlessly and without delay.
-        let endlessly_retrying_notification_stream = stream::unfold((), move |()| {
-            let mut client = client.clone();
-            let subscription_request = subscription_request.clone();
-            let mut stream = stream.take();
-            async move {
-                let stream = if let Some(stream) = stream.take() {
-                    future::Either::Right(stream)
-                } else {
-                    match client.subscribe(subscription_request.clone()).await {
-                        Err(err) => future::Either::Left(stream::iter(iter::once(Err(err)))),
-                        Ok(response) => future::Either::Right(response.into_inner()),
-                    }
-                };
-                Some((stream, ()))
-            }
-        })
-        .flatten();
-
-        // The stream of `Notification`s that inserts increasing delays after retriable errors, and
-        // terminates after unexpected or fatal errors.
-        let notification_stream = endlessly_retrying_notification_stream
-            .map(|result| {
-                Notification::try_from(result?).map_err(|err| {
-                    let message = format!("Could not deserialize notification: {}", err);
-                    tonic::Status::new(Code::Internal, message)
-                })
-            })
-            .take_while(move |result| {
-                let Err(status) = result else {
-                    retry_count = 0;
-                    return future::Either::Left(future::ready(true));
-                };
-                if !Self::is_retryable(status) || retry_count >= notification_retries {
-                    return future::Either::Left(future::ready(false));
-                }
-                let delay = notification_retry_delay.saturating_mul(retry_count);
-                retry_count += 1;
-                future::Either::Right(async move {
-                    tokio::time::sleep(delay).await;
-                    true
-                })
-            })
-            .filter_map(|result| future::ready(result.ok()));
-
-        Ok(Box::pin(notification_stream))
-    }
-
-    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError> {
-        Ok(self.client.get_version_info(()).await?.into_inner().into())
-    }
-}
-
-#[cfg(not(web))]
-impl ValidatorNodeInner for GrpcClient {
+impl ValidatorNode for GrpcClient {
     type NotificationStream = NotificationStream;
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -5,9 +5,9 @@ mod client;
 mod conversions;
 mod node_provider;
 pub mod pool;
-
 #[cfg(with_server)]
 mod server;
+pub mod transport;
 
 pub use client::*;
 pub use conversions::*;
@@ -24,7 +24,7 @@ pub mod api {
 #[derive(thiserror::Error, Debug)]
 pub enum GrpcError {
     #[error("failed to connect to address: {0}")]
-    ConnectionFailed(#[from] tonic::transport::Error),
+    ConnectionFailed(#[from] transport::Error),
 
     #[error("failed to communicate cross-chain queries: {0}")]
     CrossChain(#[from] tonic::Status),

--- a/linera-rpc/src/grpc/node_provider.rs
+++ b/linera-rpc/src/grpc/node_provider.rs
@@ -5,8 +5,7 @@ use super::GrpcClient;
 
 use crate::{config::ValidatorPublicNetworkConfig, node_provider::NodeOptions};
 
-use linera_core::node::{NodeError, ValidatorNodeProvider};
-
+use linera_core::node::{LocalValidatorNodeProvider, NodeError};
 use std::str::FromStr as _;
 
 #[derive(Copy, Clone)]
@@ -18,7 +17,7 @@ impl GrpcNodeProvider {
     }
 }
 
-impl ValidatorNodeProvider for GrpcNodeProvider {
+impl LocalValidatorNodeProvider for GrpcNodeProvider {
     type Node = GrpcClient;
 
     fn make_node(&self, address: &str) -> anyhow::Result<Self::Node, NodeError> {

--- a/linera-rpc/src/grpc/pool.rs
+++ b/linera-rpc/src/grpc/pool.rs
@@ -1,48 +1,37 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::GrpcError;
+use super::{transport, GrpcError};
 
 use dashmap::DashMap;
 use std::time::Duration;
-use tonic::transport::{Channel, Endpoint};
 
-/// A pool of transport channels to be used by Grpc.
+/// A pool of transport channels to be used by gRPC.
 #[derive(Clone, Default)]
 pub struct GrpcConnectionPool {
-    connect_timeout: Option<Duration>,
-    timeout: Option<Duration>,
-    channels: DashMap<String, Channel>,
+    options: transport::Options,
+    channels: DashMap<String, transport::Channel>,
 }
 
 impl GrpcConnectionPool {
     pub fn with_connect_timeout(mut self, connect_timeout: impl Into<Option<Duration>>) -> Self {
-        self.connect_timeout = connect_timeout.into();
+        self.options.connect_timeout = connect_timeout.into();
         self
     }
 
     pub fn with_timeout(mut self, timeout: impl Into<Option<Duration>>) -> Self {
-        self.timeout = timeout.into();
+        self.options.timeout = timeout.into();
         self
     }
 
     /// Obtains a channel for the current address. Either clones an existing one (thereby
     /// reusing the connection), or creates one if needed. New channels do not create a
     /// connection immediately.
-    pub fn channel(&self, address: String) -> Result<Channel, GrpcError> {
-        let channel = self
+    pub fn channel(&self, address: String) -> Result<transport::Channel, GrpcError> {
+        Ok(self
             .channels
             .entry(address.clone())
-            .or_try_insert_with(|| {
-                let mut endpoint = Endpoint::from_shared(address)?;
-                if let Some(timeout) = self.connect_timeout {
-                    endpoint = endpoint.connect_timeout(timeout);
-                }
-                if let Some(timeout) = self.timeout {
-                    endpoint = endpoint.timeout(timeout);
-                }
-                Ok::<_, GrpcError>(endpoint.connect_lazy())
-            })?;
-        Ok(channel.clone())
+            .or_try_insert_with(|| transport::create_channel(address, &self.options))?
+            .clone())
     }
 }

--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -1,0 +1,54 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::NodeOptions;
+
+#[derive(Clone, Debug, Default)]
+pub struct Options {
+    pub connect_timeout: Option<std::time::Duration>,
+    pub timeout: Option<std::time::Duration>,
+}
+
+impl From<&'_ NodeOptions> for Options {
+    fn from(node_options: &NodeOptions) -> Self {
+        Self {
+            connect_timeout: Some(node_options.send_timeout),
+            timeout: Some(node_options.recv_timeout),
+        }
+    }
+}
+
+#[cfg(web)]
+pub mod transport {
+    use super::Options;
+
+    pub use tonic_web_wasm_client::{Client as Channel, Error};
+
+    pub fn create_channel(address: String, _options: &Options) -> Result<Channel, super::Error> {
+        // TODO this should respect `options`
+        Ok(tonic_web_wasm_client::Client::new(address))
+    }
+}
+
+#[cfg(not(web))]
+mod transport {
+    use super::Options;
+
+    pub use tonic::transport::{Channel, Error};
+
+    pub fn create_channel(
+        address: String,
+        options: &Options,
+    ) -> Result<Channel, super::super::GrpcError> {
+        let mut endpoint = tonic::transport::Endpoint::from_shared(address)?;
+        if let Some(timeout) = options.connect_timeout {
+            endpoint = endpoint.connect_timeout(timeout);
+        }
+        if let Some(timeout) = options.timeout {
+            endpoint = endpoint.timeout(timeout);
+        }
+        Ok(endpoint.connect_lazy())
+    }
+}
+
+pub use transport::*;

--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -19,7 +19,7 @@ impl From<&'_ NodeOptions> for Options {
 }
 
 #[cfg(web)]
-pub mod transport {
+mod implementation {
     use super::Options;
 
     pub use tonic_web_wasm_client::{Client as Channel, Error};
@@ -31,7 +31,7 @@ pub mod transport {
 }
 
 #[cfg(not(web))]
-mod transport {
+mod implementation {
     use super::Options;
 
     pub use tonic::transport::{Channel, Error};
@@ -51,4 +51,4 @@ mod transport {
     }
 }
 
-pub use transport::*;
+pub use implementation::*;

--- a/linera-rpc/src/grpc/transport.rs
+++ b/linera-rpc/src/grpc/transport.rs
@@ -23,7 +23,7 @@ cfg_if::cfg_if! {
         pub use tonic_web_wasm_client::{Client as Channel, Error};
 
         pub fn create_channel(address: String, _options: &Options) -> Result<Channel, Error> {
-            // TODO this should respect `options`
+            // TODO(#1817): this should respect `options`
             Ok(tonic_web_wasm_client::Client::new(address))
         }
     } else {

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -21,6 +21,7 @@ pub mod simple;
 pub mod grpc;
 
 pub use message::RpcMessage;
+pub use node_provider::NodeOptions;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]

--- a/linera-rpc/src/mass_client.rs
+++ b/linera-rpc/src/mass_client.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::RpcMessage;
+
+use async_trait::async_trait;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -16,7 +18,7 @@ pub enum MassClientError {
     Rpc(#[from] tonic::Status),
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 pub trait MassClient {
     async fn send(
         &mut self,

--- a/linera-rpc/src/mass_client.rs
+++ b/linera-rpc/src/mass_client.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::RpcMessage;
-use async_trait::async_trait;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -17,8 +16,8 @@ pub enum MassClientError {
     Rpc(#[from] tonic::Status),
 }
 
-#[async_trait]
-pub trait MassClient: Send + Sync {
+#[async_trait::async_trait]
+pub trait MassClient {
     async fn send(
         &mut self,
         requests: Vec<RpcMessage>,

--- a/linera-rpc/src/mass_client.rs
+++ b/linera-rpc/src/mass_client.rs
@@ -10,7 +10,7 @@ pub enum MassClientError {
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
     #[error("tonic transport: {0}")]
-    Tonic(#[from] tonic::transport::Error),
+    TonicTransport(#[from] crate::grpc::transport::Error),
     #[error("conversion error: {0}")]
     Conversion(#[from] crate::grpc::GrpcProtoConversionError),
     #[error("error while making a remote call: {0}")]

--- a/linera-rpc/src/node_provider.rs
+++ b/linera-rpc/src/node_provider.rs
@@ -5,7 +5,7 @@
 use crate::simple::SimpleNodeProvider;
 use crate::{client::Client, grpc::GrpcNodeProvider};
 
-use linera_core::node::{NodeError, ValidatorNodeProvider};
+use linera_core::node::{LocalValidatorNodeProvider, NodeError};
 
 use std::time::Duration;
 
@@ -28,7 +28,7 @@ impl NodeProvider {
     }
 }
 
-impl ValidatorNodeProvider for NodeProvider {
+impl LocalValidatorNodeProvider for NodeProvider {
     type Node = Client;
 
     fn make_node(&self, address: &str) -> anyhow::Result<Self::Node, NodeError> {

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -13,7 +13,7 @@ use linera_base::identifiers::ChainId;
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
-    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNodeInner},
+    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
 };
 use linera_version::VersionInfo;
 
@@ -70,7 +70,7 @@ impl SimpleClient {
     }
 }
 
-impl ValidatorNodeInner for SimpleClient {
+impl ValidatorNode for SimpleClient {
     type NotificationStream = NotificationStream;
 
     /// Initiates a new block.

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -3,22 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{codec, transport::TransportProtocol};
+
 use crate::{
     config::ValidatorPublicNetworkPreConfig, mass_client, HandleCertificateRequest,
     HandleLiteCertificateRequest, RpcMessage,
 };
-use futures::{sink::SinkExt, stream::StreamExt};
+
 use linera_base::identifiers::ChainId;
 use linera_chain::data_types::{BlockProposal, Certificate, HashedValue, LiteCertificate};
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNodeInner},
 };
-
 use linera_version::VersionInfo;
 
-use std::{future::Future, time::Duration};
+use async_trait::async_trait;
+use futures::{sink::SinkExt, stream::StreamExt};
 use tokio::time;
+
+use std::{future::Future, time::Duration};
 
 #[derive(Clone)]
 pub struct SimpleClient {
@@ -150,7 +153,7 @@ impl SimpleMassClient {
     }
 }
 
-#[async_trait::async_trait]
+#[async_trait]
 impl mass_client::MassClient for SimpleMassClient {
     async fn send(
         &mut self,

--- a/linera-rpc/src/simple/node_provider.rs
+++ b/linera-rpc/src/simple/node_provider.rs
@@ -5,7 +5,7 @@ use super::SimpleClient;
 
 use crate::{config::ValidatorPublicNetworkPreConfig, node_provider::NodeOptions};
 
-use linera_core::node::{NodeError, ValidatorNodeProvider};
+use linera_core::node::{LocalValidatorNodeProvider, NodeError};
 
 use std::str::FromStr as _;
 
@@ -19,7 +19,7 @@ impl SimpleNodeProvider {
     }
 }
 
-impl ValidatorNodeProvider for SimpleNodeProvider {
+impl LocalValidatorNodeProvider for SimpleNodeProvider {
     type Node = SimpleClient;
 
     fn make_node(&self, address: &str) -> Result<Self::Node, NodeError> {

--- a/linera-rpc/tests/transport.rs
+++ b/linera-rpc/tests/transport.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(web)]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+#[cfg_attr(web, wasm_bindgen_test::wasm_bindgen_test)]
+#[cfg_attr(not(web), tokio::test(flavor = "current_thread"))]
+#[ignore]
+// this test currently must be run manually, as it requires a Linera proxy to be running on 127.0.0.1:9000.
+async fn client() {
+    use linera_core::node::LocalValidatorNode as _;
+    use linera_rpc::config::*;
+    use std::time::Duration;
+
+    let network_config = ValidatorPublicNetworkPreConfig {
+        protocol: NetworkProtocol::Grpc(TlsConfig::ClearText),
+        host: "127.0.0.1".into(),
+        port: 9000,
+    };
+
+    let node_options = linera_rpc::node_provider::NodeOptions {
+        send_timeout: Duration::from_millis(100),
+        recv_timeout: Duration::from_millis(100),
+        notification_retry_delay: Duration::from_millis(100),
+        notification_retries: 5,
+    };
+
+    let _ = linera_rpc::grpc::GrpcClient::new(network_config, node_options)
+        .unwrap()
+        .get_version_info()
+        .await
+        .unwrap();
+}

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -12,7 +12,7 @@ use linera_base::{
 use linera_chain::data_types::OutgoingMessage;
 use linera_core::{
     client::{ArcChainClient, ChainClient},
-    node::ValidatorNodeProvider,
+    node::{ValidatorNode, ValidatorNodeProvider},
     worker::{Notification, Reason},
 };
 use linera_execution::{Message, SystemMessage};
@@ -61,6 +61,7 @@ pub struct ChainListener<P, S> {
 impl<P, S> ChainListener<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
+    <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -113,6 +113,7 @@ where
 impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
+    <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<P> + Send + 'static,
     ViewError: From<S::ContextError>,
@@ -126,6 +127,7 @@ where
 impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
+    <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<P> + Send + 'static,
     ViewError: From<S::ContextError>,

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -766,10 +766,10 @@ impl ClientContext {
         responses
     }
 
-    fn make_validator_mass_clients(&self) -> Vec<Box<dyn MassClient>> {
+    fn make_validator_mass_clients(&self) -> Vec<Box<dyn MassClient + Send>> {
         let mut validator_clients = Vec::new();
         for config in &self.wallet_state.genesis_config().committee.validators {
-            let client: Box<dyn MassClient> = match config.network.protocol {
+            let client: Box<dyn MassClient + Send> = match config.network.protocol {
                 NetworkProtocol::Simple(protocol) => {
                     let network = config.network.clone_with_protocol(protocol);
                     Box::new(SimpleMassClient::new(

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -20,7 +20,7 @@ use linera_core::{
     client::ChainClientError,
     data_types::{ChainInfoQuery, ClientOutcome},
     local_node::LocalNodeClient,
-    node::ValidatorNodeProvider,
+    node::LocalValidatorNodeProvider,
     notifier::Notifier,
     worker::WorkerState,
 };
@@ -430,7 +430,7 @@ impl Runnable for Job {
             }
 
             QueryValidators { chain_id } => {
-                use linera_core::node::ValidatorNode as _;
+                use linera_core::node::ValidatorNodeInner as _;
 
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 let mut chain_client = context.make_chain_client(storage, chain_id);

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -430,7 +430,7 @@ impl Runnable for Job {
             }
 
             QueryValidators { chain_id } => {
-                use linera_core::node::ValidatorNodeInner as _;
+                use linera_core::node::ValidatorNode as _;
 
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 let mut chain_client = context.make_chain_client(storage, chain_id);

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -29,7 +29,7 @@ use linera_chain::{data_types::HashedValue, ChainStateView};
 use linera_core::{
     client::{ArcChainClient, ChainClient, ChainClientError},
     data_types::{ClientOutcome, RoundTimeout},
-    node::{NotificationStream, ValidatorNodeProvider},
+    node::{NotificationStream, ValidatorNode, ValidatorNodeProvider},
     worker::{Notification, Reason},
 };
 use linera_execution::{
@@ -884,6 +884,7 @@ impl<P, S: Clone, C> Clone for NodeService<P, S, C> {
 impl<P, S, C> NodeService<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
+    <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<P> + Send + 'static,
     ViewError: From<S::ContextError>,

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -8,8 +8,8 @@ use linera_core::{
     client::ChainClient,
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{
-        CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
-        ValidatorNodeProvider,
+        CrossChainMessageDelivery, LocalValidatorNodeProvider, NodeError, NotificationStream,
+        ValidatorNodeInner,
     },
 };
 use linera_execution::committee::Committee;
@@ -28,8 +28,9 @@ use linera_views::{
 #[derive(Clone)]
 struct DummyValidatorNode;
 
-#[async_trait]
-impl ValidatorNode for DummyValidatorNode {
+impl ValidatorNodeInner for DummyValidatorNode {
+    type NotificationStream = NotificationStream;
+
     async fn handle_block_proposal(
         &mut self,
         _: BlockProposal,
@@ -72,7 +73,7 @@ impl ValidatorNode for DummyValidatorNode {
 
 struct DummyValidatorNodeProvider;
 
-impl ValidatorNodeProvider for DummyValidatorNodeProvider {
+impl LocalValidatorNodeProvider for DummyValidatorNodeProvider {
     type Node = DummyValidatorNode;
 
     fn make_node(&self, _: &str) -> Result<Self::Node, NodeError> {

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -9,7 +9,7 @@ use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{
         CrossChainMessageDelivery, LocalValidatorNodeProvider, NodeError, NotificationStream,
-        ValidatorNodeInner,
+        ValidatorNode,
     },
 };
 use linera_execution::committee::Committee;
@@ -28,7 +28,7 @@ use linera_views::{
 #[derive(Clone)]
 struct DummyValidatorNode;
 
-impl ValidatorNodeInner for DummyValidatorNode {
+impl ValidatorNode for DummyValidatorNode {
     type NotificationStream = NotificationStream;
 
     async fn handle_block_proposal(


### PR DESCRIPTION
Atop #1801, #1802.

## Motivation

The client half of https://github.com/linera-io/linera-protocol/issues/1609.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

When compiling with `web`, replace our existing gRPC client with a Wasm-compatible gRPC-Web–based client using `tonic-web-wasm-client`.

Since [browser objects are neither `Send` nor `Sync`](https://github.com/rustwasm/wasm-bindgen/issues/2753), a large part of this work is then to enable non–`Send` equivalents of various traits for structs containing non–`Send` objects.  `linera-core` in particular now never assumes that the client struct is `Send`.  `linera-service`, however, does.  In order to enable this, I have used [`trait-variant`](https://crates.io/crates/trait-variant) to construct, as automatically as possible, local and non-local variants of relevant traits.

Task list:
- [x] convert relevant traits to use AFIT and `trait-variant`
- [x] relax the `Send`ness bound that permeates `linera-core` and `linera-rpc`
- [x] implement a gRPC-Web client when compiling for the browser
- [x] deduplicate the implementations for the Web and non–Web clients
- [x] add tests in which the Wasm client connects to the gRPC-Web endpoint implemented in https://github.com/linera-io/linera-protocol/pull/1735

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

As part of this PR, I shall add tests to be run in a headless browser using `wasm-pack test`.

Due to https://github.com/linera-io/linera-protocol/issues/1799 and https://github.com/linera-io/linera-protocol/issues/1800 these are not currently part of the standard test `cargo test` test suite, but can be run manually:

```shellsession
$ eval "$(linera net helper)"
$ linera_spawn_and_read_wallet_variables linera net up
$ cd linera-rpc
$ wasm-pack test --chrome --headless --features web -- --include-ignored
```

The above assumes you are using the provided Nix flake for a development environment; if not, first you will need to install `wasm-pack`, `chromium`, and `chromedriver` through your usual package distribution channels.  Tests also pass on Firefox, if you have Firefox installed — substitute `--firefox` for `--chrome` above.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- Closes #1609.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
