### PR TITLE
Add Linera logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+
+![Linera_Red_White_H](https://github.com/papadritta/linera-protocol/assets/90826754/4513e5f7-b364-4fb4-9a43-c3b49c749f01)
+
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
 [![Build Status for Rust](https://github.com/linera-io/linera-protocol/actions/workflows/rust.yml/badge.svg)](https://github.com/linera-io/linera-protocol/actions/workflows/rust.yml)
 [![Build Status for Documentation](https://github.com/linera-io/linera-protocol/actions/workflows/documentation.yml/badge.svg)](https://github.com/linera-io/linera-protocol/actions/workflows/documentation.yml)


### PR DESCRIPTION
## Changes:

- Downloaded and added the official `Linera logo` from the `Linera brand-kit`.
- Updated `README.md` to include the `Linera logo` at the top of the page for enhanced project visibility and branding.

## Motivation

The motivation behind this PR is to improve the `Linera` project's `README` page by making it more visually appealing and immediately recognizable. Adding the official logo to the `README` is a step towards enhancing brand visibility and making a strong first impression on visitors.

## Proposal

#### This PR proposes to:
- Add the official `Linera logo` to the `README`.
- Place the logo at the top of the `README` to ensure it's the first element seen by visitors.

This approach is appropriate because it aligns with standard practices for open-source projects on GitHub, where the `README` page often serves as the front door to the project.

## Test Plan

- Logo displays correctly.
- The image link loads quickly and with high quality.

## Release Plan

These changes are do not affect the functionality of the `Linera` project itself.

## Links

[Linera_Red_White_H](https://github.com/papadritta/linera-protocol/assets/90826754/4513e5f7-b364-4fb4-9a43-c3b49c749f01)
