### PR TITLE
Move app permissions types to linera-base.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -131,6 +131,32 @@ pub struct ApplicationId<A = ()> {
     pub creation: MessageId,
 }
 
+/// A unique identifier for an application.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+pub enum GenericApplicationId {
+    /// The system application.
+    System,
+    /// A user application.
+    User(ApplicationId),
+}
+
+impl GenericApplicationId {
+    /// Returns the `ApplicationId`, or `None` if it is `System`.
+    pub fn user_application_id(&self) -> Option<&ApplicationId> {
+        if let GenericApplicationId::User(app_id) = self {
+            Some(app_id)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<ApplicationId> for GenericApplicationId {
+    fn from(user_application_id: ApplicationId) -> Self {
+        GenericApplicationId::User(user_application_id)
+    }
+}
+
 /// A unique identifier for an application bytecode.
 #[cfg_attr(with_testing, derive(Default))]
 pub struct BytecodeId<A = ()> {
@@ -766,6 +792,10 @@ impl ChainId {
 impl BcsHashable for ChainDescription {}
 
 bcs_scalar!(ApplicationId, "A unique identifier for a user application");
+doc_scalar!(
+    GenericApplicationId,
+    "A unique identifier for a user application or for the system application"
+);
 bcs_scalar!(
     BytecodeId,
     "A unique identifier for an application bytecode"

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -16,13 +16,12 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ArithmeticError, BlockHeight, Timestamp},
     ensure,
-    identifiers::{ChainId, Destination, MessageId},
+    identifiers::{ChainId, Destination, GenericApplicationId, MessageId},
 };
 use linera_execution::{
-    system::SystemMessage, ExecutionOutcome, ExecutionRuntimeContext, ExecutionStateView,
-    GenericApplicationId, Message, MessageContext, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker, Response,
-    UserApplicationDescription, UserApplicationId,
+    system::SystemMessage, ExecutionOutcome, ExecutionRuntimeContext, ExecutionStateView, Message,
+    MessageContext, OperationContext, Query, QueryContext, RawExecutionOutcome, RawOutgoingMessage,
+    ResourceController, ResourceTracker, Response, UserApplicationDescription, UserApplicationId,
 };
 use linera_views::{
     common::Context,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -8,11 +8,13 @@ use linera_base::{
     crypto::{BcsHashable, BcsSignable, CryptoHash, KeyPair, Signature},
     data_types::{Amount, BlockHeight, Round, Timestamp},
     doc_scalar, ensure,
-    identifiers::{Account, ChainId, ChannelName, Destination, MessageId, Owner},
+    identifiers::{
+        Account, ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner,
+    },
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    BytecodeLocation, GenericApplicationId, Message, MessageKind, Operation,
+    BytecodeLocation, Message, MessageKind, Operation,
 };
 use serde::{de::Deserializer, Deserialize, Serialize};
 use std::{

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -9,13 +9,13 @@ use crate::{
 use assert_matches::assert_matches;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, Timestamp},
+    data_types::{Amount, ApplicationPermissions, BlockHeight, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId},
     ownership::ChainOwnership,
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{ApplicationPermissions, OpenChainConfig},
+    system::OpenChainConfig,
     test_utils::{ExpectedCall, MockApplication},
     BytecodeLocation, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation,
     RawExecutionOutcome, SystemMessage, TestExecutionRuntimeContext, UserApplicationDescription,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -25,7 +25,7 @@ use futures::{
 use linera_base::{
     abi::{Abi, ContractAbi},
     crypto::{CryptoHash, KeyPair, PublicKey},
-    data_types::{Amount, ArithmeticError, BlockHeight, Round, Timestamp},
+    data_types::{Amount, ApplicationPermissions, ArithmeticError, BlockHeight, Round, Timestamp},
     ensure,
     identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
@@ -40,9 +40,8 @@ use linera_chain::{
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
     system::{
-        AdminOperation, ApplicationPermissions, OpenChainConfig, Recipient, SystemChannel,
-        SystemOperation, UserData, CREATE_APPLICATION_MESSAGE_INDEX, OPEN_CHAIN_MESSAGE_INDEX,
-        PUBLISH_BYTECODE_MESSAGE_INDEX,
+        AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemOperation, UserData,
+        CREATE_APPLICATION_MESSAGE_INDEX, OPEN_CHAIN_MESSAGE_INDEX, PUBLISH_BYTECODE_MESSAGE_INDEX,
     },
     Bytecode, ExecutionError, Message, Operation, Query, Response, SystemExecutionError,
     SystemMessage, SystemQuery, SystemResponse, UserApplicationId,

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -13,7 +13,9 @@ use super::{init_worker_with_chains, make_certificate};
 use linera_base::{
     crypto::KeyPair,
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{BytecodeId, ChainDescription, ChainId, Destination, MessageId},
+    identifiers::{
+        BytecodeId, ChainDescription, ChainId, Destination, GenericApplicationId, MessageId,
+    },
     ownership::ChainOwnership,
 };
 use linera_chain::{
@@ -27,8 +29,8 @@ use linera_execution::{
     committee::Epoch,
     system::{SystemChannel, SystemMessage, SystemOperation},
     test_utils::SystemExecutionState,
-    Bytecode, BytecodeLocation, ChannelSubscription, GenericApplicationId, Message, MessageKind,
-    Operation, OperationContext, ResourceController, UserApplicationDescription, UserApplicationId,
+    Bytecode, BytecodeLocation, ChannelSubscription, Message, MessageKind, Operation,
+    OperationContext, ResourceController, UserApplicationDescription, UserApplicationId,
     WasmContractModule, WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage};

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -17,7 +17,10 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::{CryptoHash, *},
     data_types::*,
-    identifiers::{Account, ChainDescription, ChainId, ChannelName, Destination, MessageId, Owner},
+    identifiers::{
+        Account, ChainDescription, ChainId, ChannelName, Destination, GenericApplicationId,
+        MessageId, Owner,
+    },
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -35,8 +38,8 @@ use linera_execution::{
         AdminOperation, OpenChainConfig, Recipient, SystemChannel, SystemMessage, SystemOperation,
     },
     test_utils::SystemExecutionState,
-    ChannelSubscription, ExecutionError, GenericApplicationId, Message, MessageKind, Query,
-    Response, SystemExecutionError, SystemQuery, SystemResponse,
+    ChannelSubscription, ExecutionError, Message, MessageKind, Query, Response,
+    SystemExecutionError, SystemQuery, SystemResponse,
 };
 use linera_storage::{DbStorage, MemoryStorage, Storage, TestClock};
 use linera_views::{

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -27,27 +27,8 @@ use {
 #[path = "unit_tests/applications_tests.rs"]
 mod applications_tests;
 
-/// A unique identifier for an application.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
-pub enum GenericApplicationId {
-    /// The system application.
-    System,
-    /// A user application.
-    User(UserApplicationId),
-}
-
-impl GenericApplicationId {
-    pub fn user_application_id(&self) -> Option<&UserApplicationId> {
-        if let GenericApplicationId::User(app_id) = self {
-            Some(app_id)
-        } else {
-            None
-        }
-    }
-}
-
 /// Alias for `linera_base::identifiers::ApplicationId`. Use this alias in the core
-/// protocol where the distinction with the more general enum [`GenericApplicationId`] matters.
+/// protocol where the distinction with the more general enum `GenericApplicationId` matters.
 pub type UserApplicationId<A = ()> = linera_base::identifiers::ApplicationId<A>;
 
 /// Description of the necessary information to run a user application.
@@ -74,12 +55,6 @@ impl From<&UserApplicationDescription> for UserApplicationId {
             bytecode_id: description.bytecode_id,
             creation: description.creation,
         }
-    }
-}
-
-impl From<UserApplicationId> for GenericApplicationId {
-    fn from(user_application_id: UserApplicationId) -> Self {
-        GenericApplicationId::User(user_application_id)
     }
 }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -4,7 +4,7 @@
 //! Handle requests from the synchronous execution thread of user applications.
 
 use crate::{
-    system::{ApplicationPermissions, OpenChainConfig, Recipient, UserData},
+    system::{OpenChainConfig, Recipient, UserData},
     util::RespondExt,
     ExecutionError, ExecutionRuntimeContext, ExecutionStateView, RawExecutionOutcome,
     RawOutgoingMessage, SystemExecutionError, SystemMessage, UserApplicationDescription,
@@ -12,7 +12,7 @@ use crate::{
 };
 use futures::channel::mpsc;
 use linera_base::{
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{Account, MessageId, Owner},
     ownership::ChainOwnership,
 };

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -4,8 +4,8 @@
 use crate::{
     committee::{Committee, Epoch, ValidatorName, ValidatorState},
     system::{Recipient, UserData},
-    Bytecode, ChannelSubscription, ExecutionStateView, GenericApplicationId,
-    SystemExecutionStateView, UserApplicationDescription,
+    Bytecode, ChannelSubscription, ExecutionStateView, SystemExecutionStateView,
+    UserApplicationDescription,
 };
 use async_graphql::{Error, Object};
 use linera_base::{
@@ -17,10 +17,6 @@ use linera_base::{
 use linera_views::{common::Context, map_view::MapView, views::ViewError};
 use std::collections::BTreeMap;
 
-doc_scalar!(
-    GenericApplicationId,
-    "A unique identifier for a user application or for the system application"
-);
 doc_scalar!(Bytecode, "A WebAssembly module's bytecode");
 doc_scalar!(
     Epoch,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -21,8 +21,7 @@ pub use crate::runtime::{ContractSyncRuntime, ServiceSyncRuntime};
 #[cfg(with_testing)]
 pub use applications::ApplicationRegistry;
 pub use applications::{
-    ApplicationRegistryView, BytecodeLocation, GenericApplicationId, UserApplicationDescription,
-    UserApplicationId,
+    ApplicationRegistryView, BytecodeLocation, UserApplicationDescription, UserApplicationId,
 };
 pub use execution::ExecutionStateView;
 pub use policy::ResourceControlPolicy;
@@ -47,7 +46,8 @@ use linera_base::{
     data_types::{Amount, ArithmeticError, BlockHeight, Resources, Timestamp},
     doc_scalar, hex_debug,
     identifiers::{
-        Account, BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner, SessionId,
+        Account, BytecodeId, ChainId, ChannelName, Destination, GenericApplicationId, MessageId,
+        Owner, SessionId,
     },
     ownership::ChainOwnership,
 };

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -5,7 +5,6 @@ use crate::{
     execution::UserAction,
     execution_state_actor::{ExecutionStateSender, Request},
     resources::ResourceController,
-    system::ApplicationPermissions,
     util::{ReceiverExt, UnboundedSenderExt},
     ApplicationCallOutcome, BaseRuntime, CallOutcome, CalleeContext, ContractRuntime,
     ExecutionError, ExecutionOutcome, RawExecutionOutcome, ServiceRuntime, SessionId,
@@ -14,7 +13,7 @@ use crate::{
 };
 use custom_debug_derive::Debug;
 use linera_base::{
-    data_types::{Amount, ArithmeticError, BlockHeight, Timestamp},
+    data_types::{Amount, ApplicationPermissions, ArithmeticError, BlockHeight, Timestamp},
     ensure,
     identifiers::{Account, ChainId, MessageId, Owner},
     ownership::ChainOwnership,

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -5,14 +5,14 @@ use crate::{
     applications::ApplicationRegistry,
     committee::{Committee, Epoch},
     execution::UserAction,
-    system::{ApplicationPermissions, SystemChannel},
+    system::SystemChannel,
     ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
     ExecutionStateView, OperationContext, ResourceControlPolicy, ResourceController,
     ResourceTracker, TestExecutionRuntimeContext, UserApplicationDescription, UserContractCode,
 };
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ApplicationId, ChainDescription, ChainId, Owner},
     ownership::ChainOwnership,
 };

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -6,13 +6,13 @@
 use assert_matches::assert_matches;
 use linera_base::{
     crypto::PublicKey,
-    data_types::{Amount, BlockHeight, Resources, Timestamp},
+    data_types::{Amount, ApplicationPermissions, BlockHeight, Resources, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, Destination, MessageId, Owner},
     ownership::ChainOwnership,
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{ApplicationPermissions, SystemMessage},
+    system::SystemMessage,
     test_utils::{
         create_dummy_user_application_registrations, register_mock_applications, ExpectedCall,
         SystemExecutionState,

--- a/linera-rpc/examples/generate-format.rs
+++ b/linera-rpc/examples/generate-format.rs
@@ -7,7 +7,7 @@
 
 use linera_base::{
     data_types::Round,
-    identifiers::{ChainDescription, Destination},
+    identifiers::{ChainDescription, Destination, GenericApplicationId},
     ownership::ChainOwnership,
 };
 use linera_chain::{
@@ -17,7 +17,7 @@ use linera_chain::{
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{
     system::{AdminOperation, Recipient, SystemChannel, SystemMessage, SystemOperation},
-    GenericApplicationId, Message, MessageKind, Operation,
+    Message, MessageKind, Operation,
 };
 use linera_rpc::RpcMessage;
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -11,7 +11,7 @@ use colored::Colorize;
 use futures::{lock::Mutex, StreamExt};
 use linera_base::{
     crypto::{CryptoHash, CryptoRng, PublicKey},
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ChainDescription, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -26,7 +26,7 @@ use linera_core::{
 };
 use linera_execution::{
     committee::{Committee, ValidatorName, ValidatorState},
-    system::{ApplicationPermissions, SystemChannel, UserData},
+    system::{SystemChannel, UserData},
     Message, ResourceControlPolicy, SystemMessage,
 };
 use linera_service::{

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -22,7 +22,7 @@ use futures::{
 };
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
     BcsHexParseError,
@@ -36,7 +36,7 @@ use linera_core::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    system::{AdminOperation, ApplicationPermissions, Recipient, SystemChannel, UserData},
+    system::{AdminOperation, Recipient, SystemChannel, UserData},
     Bytecode, Operation, Query, Response, SystemOperation, UserApplicationDescription,
     UserApplicationId,
 };

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -38,7 +38,7 @@ use futures::future;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{ChainDescription, ChainId},
+    identifiers::{ChainDescription, ChainId, GenericApplicationId},
     ownership::ChainOwnership,
 };
 use linera_chain::{
@@ -49,8 +49,7 @@ use linera_execution::{
     committee::{Committee, Epoch},
     system::SystemChannel,
     ChannelSubscription, ExecutionError, ExecutionRuntimeConfig, ExecutionRuntimeContext,
-    GenericApplicationId, UserApplicationDescription, UserApplicationId, UserContractCode,
-    UserServiceCode, WasmRuntime,
+    UserApplicationDescription, UserApplicationId, UserContractCode, UserServiceCode, WasmRuntime,
 };
 use linera_views::{
     common::Context,


### PR DESCRIPTION
## Motivation

I will need to use `ApplicationPermissions` in the Matching Engine integration test, which really should only depend on `linera-sdk` and not `linera-execution`. We might even add a system API function to get or change application permissions at some point, then it will be necessary anyway.

## Proposal

Move `ApplicationPermissions`, and therefore also `GenericApplicationId`, to `linera-base`, so that it gets re-exported in `linera-sdk`.

## Test Plan

Only types were moved.

## Links

- #305 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
