### PR TITLE
Remove empty fungible accounts.

### DIFF
--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -105,7 +105,7 @@ async fn collect_pledges() {
         );
         assert_eq!(
             FungibleTokenAbi::query_account(token_id, &campaign_chain, backer_account).await,
-            Some(Amount::ZERO),
+            None,
         );
     }
 }
@@ -194,7 +194,7 @@ async fn cancel_successful_campaign() {
 
     assert_eq!(
         FungibleTokenAbi::query_account(token_id, &campaign_chain, campaign_account).await,
-        Some(Amount::ZERO),
+        None,
     );
 
     for (backer_chain, backer_account, initial_amount) in backers {

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -180,11 +180,7 @@ async fn single_transaction() {
             amount
         );
     }
-    for (owner, amount) in [
-        (admin_account, None),
-        (owner_a, Some(Amount::ZERO)),
-        (owner_b, None),
-    ] {
+    for (owner, amount) in [(admin_account, None), (owner_a, None), (owner_b, None)] {
         assert_eq!(
             FungibleTokenAbi::query_account(token_id_a, &matching_chain, owner).await,
             amount

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -168,22 +168,20 @@ async fn single_transaction() {
     // Checking the values for token_a
     for (owner, amount) in [
         (admin_account, None),
-        (owner_a, Some(Amount::from_tokens(1))),
+        (owner_a, Some(Amount::ONE)),
         (owner_b, None),
     ] {
         let value = FungibleTokenAbi::query_account(token_id_a, &user_chain_a, owner).await;
         assert_eq!(value, amount);
     }
-    for (owner, amount) in [(admin_account, None), (owner_a, None), (owner_b, None)] {
+    for owner in [admin_account, owner_a, owner_b] {
         assert_eq!(
             FungibleTokenAbi::query_account(token_id_a, &user_chain_b, owner).await,
-            amount
+            None
         );
-    }
-    for (owner, amount) in [(admin_account, None), (owner_a, None), (owner_b, None)] {
         assert_eq!(
             FungibleTokenAbi::query_account(token_id_a, &matching_chain, owner).await,
-            amount
+            None
         );
     }
 


### PR DESCRIPTION
## Motivation

The fungible account leaves empty accounts in the map. This wastes space and makes it confusing to assert balances in tests, because there is an artificial difference between "zero" and "absent".

## Proposal

Always remove empty accounts.

## Test Plan

The affected tests have been updated.


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
