### PR TITLE
Send tokens back to owner chain when orders are filled or cancelled.

### DIFF
--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -224,7 +224,7 @@ transfer tokens from OWNER_1 to OWNER_2 at CHAIN_2 will instantly update the UI 
 second page.
 */
 
-use async_graphql::{scalar, InputObject, Request, Response};
+use async_graphql::{scalar, InputObject, Request, Response, SimpleObject};
 use linera_sdk::{
     base::{AccountOwner, Amount, ChainId, ContractAbi, ServiceAbi},
     graphql::GraphQLMutationRoot,
@@ -360,7 +360,17 @@ impl Parameters {
 
 /// An account.
 #[derive(
-    Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, InputObject,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    SimpleObject,
+    InputObject,
 )]
 pub struct Account {
     pub chain_id: ChainId,

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::SimpleObject;
+use fungible::Account;
 use linera_sdk::{
     base::{AccountOwner, Amount, ArithmeticError},
     views::{
@@ -62,7 +63,7 @@ pub struct OrderEntry {
     /// The number of token1 being bought or sold
     pub amount: Amount,
     /// The one who has created the order
-    pub owner: AccountOwner,
+    pub account: Account,
     /// The order_id (needed for possible cancel or modification)
     pub order_id: OrderId,
 }
@@ -76,7 +77,7 @@ pub struct KeyBook {
     /// The nature of the order
     pub nature: OrderNature,
     /// The owner used for checks
-    pub owner: AccountOwner,
+    pub account: Account,
 }
 
 /// The AccountInfo used for storing which order_id are owned by

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -268,23 +268,27 @@ async fn single_transaction() {
     user_chain_a.handle_received_messages().await;
     user_chain_b.handle_received_messages().await;
 
-    // Check balances on tha matching engine chain
-    for (owner, amount) in [
-        (owner_a, Amount::from_tokens(3)),
-        (owner_b, Amount::from_tokens(6)),
+    // Check owner balances
+    for (owner, user_chain, amount) in [
+        (owner_a, &matching_chain, None),
+        (owner_b, &matching_chain, None),
+        (owner_a, &user_chain_a, Some(Amount::from_tokens(4))),
+        (owner_b, &user_chain_b, Some(Amount::from_tokens(6))),
     ] {
         assert_eq!(
-            FungibleTokenAbi::query_account(token_id_a, &matching_chain, owner).await,
-            Some(amount)
+            FungibleTokenAbi::query_account(token_id_a, user_chain, owner).await,
+            amount
         );
     }
-    for (owner, amount) in [
-        (owner_a, Amount::from_tokens(3)),
-        (owner_b, Amount::from_tokens(5)),
+    for (owner, user_chain, amount) in [
+        (owner_a, &matching_chain, None),
+        (owner_b, &matching_chain, None),
+        (owner_a, &user_chain_a, Some(Amount::from_tokens(3))),
+        (owner_b, &user_chain_b, Some(Amount::from_tokens(6))),
     ] {
         assert_eq!(
-            FungibleTokenAbi::query_account(token_id_b, &matching_chain, owner).await,
-            Some(amount)
+            FungibleTokenAbi::query_account(token_id_b, user_chain, owner).await,
+            amount
         );
     }
 }


### PR DESCRIPTION
## Motivation

Currently the matching engine keeps all tokens on the order book chain. Owners have to claim them to get them back to their own chains.

This means the chain can't be used for atomic swaps: When closing the chain, the matching engine application does not have permissions to move those tokens back to their owners' chains. Users may also find it surprising or inconvenient in general.

## Proposal

Whenever an order is filled or cancelled, send the tokens to the owner's chain.

## Test Plan

The integration test was updated.

## Links

- #305 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
