### PR TITLE
Fix non-deterministic RegisterApplications messages.

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -179,7 +179,7 @@ pub struct SessionId<A = ()> {
 pub struct ChannelName(#[serde(with = "serde_bytes")] Vec<u8>);
 
 /// The destination of a message, relative to a particular application.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum Destination {
     /// Direct message to a chain.
     Recipient(ChainId),

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -20,7 +20,7 @@ use linera_views::{
     views::{View, ViewError},
 };
 use linera_views_derive::CryptoHashView;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 #[cfg(with_testing)]
 use {
@@ -218,7 +218,7 @@ where
             _ => None,
         });
 
-        let mut applications_to_register_per_destination = HashMap::<_, BTreeSet<_>>::new();
+        let mut applications_to_register_per_destination = BTreeMap::<_, BTreeSet<_>>::new();
 
         for (application_id, result) in user_application_outcomes {
             for message in &result.messages {


### PR DESCRIPTION
## Motivation

`update_execution_outcomes_with_app_registrations` iterates over a `HashMap`, which does not have the same order each time. That makes execution nondeterministic.

## Proposal

Use a `BTreeMap` instead.
Also include more information in the `IncorrectMessages` error to help debug problems like this in the future.

## Test Plan

I ran into this problem in an extended matching engine integration test, which I will add in an upcoming PR.

Also, the `test_multiple_messages_from_different_applications` was updated.

## Links

- Introduced in https://github.com/linera-io/linera-protocol/pull/1486.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
