### PR TITLE
Fail earlier in retrying CLI wrapper functions.

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -803,7 +803,7 @@ impl NodeService {
         application_id: &ApplicationId<A>,
     ) -> Result<ApplicationWrapper<A>> {
         let application_id = application_id.forget_abi().to_string();
-        let n_try = 30;
+        let n_try = 15;
         for i in 0..n_try {
             tokio::time::sleep(Duration::from_secs(i)).await;
             let values = self.try_get_applications_uri(chain_id).await?;
@@ -861,7 +861,7 @@ impl NodeService {
     }
 
     pub async fn query_node(&self, query: impl AsRef<str>) -> Result<Value> {
-        let n_try = 30;
+        let n_try = 15;
         let query = query.as_ref();
         for i in 0..n_try {
             tokio::time::sleep(Duration::from_secs(i)).await;


### PR DESCRIPTION
## Motivation

Some functions in the CLI wrappers keep retrying for almost seven minutes. That means that failing tests hang for that long until they finally print the line in which they failed.

## Proposal

Reduce this to 36 seconds.

## Test Plan

This should still be enough time to not make the tests flaky.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
