### PR TITLE
Remove deprecated NaiveDateTime::from_timestamp_opt.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -136,11 +136,11 @@ impl From<u64> for Timestamp {
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(date_time) = chrono::NaiveDateTime::from_timestamp_opt(
+        if let Some(date_time) = chrono::DateTime::from_timestamp(
             (self.0 / 1_000_000) as i64,
             ((self.0 % 1_000_000) * 1_000) as u32,
         ) {
-            return date_time.fmt(f);
+            return date_time.naive_utc().fmt(f);
         }
         self.0.fmt(f)
     }


### PR DESCRIPTION
## Motivation

`NaiveDateTime::from_timestamp_opt` is deprecated. This causes `test_project_new` to fail in CI now because of the warning.

## Proposal

Use `DateTime::from_timestamp`.

## Test Plan

The test passes now.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
