### PR TITLE
Add a CloseChain operation to the Matching Engine.

### DIFF
--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -332,6 +332,9 @@ scalar!(Parameters);
 pub enum Operation {
     /// The order that is going to be executed on the chain of the order book.
     ExecuteOrder { order: Order },
+    /// Close this chain, and cancel all orders.
+    /// Requires that this application is authorized to close the chain.
+    CloseChain,
 }
 
 /// Messages that can be processed by the application.

--- a/examples/matching-engine/src/state.rs
+++ b/examples/matching-engine/src/state.rs
@@ -55,6 +55,9 @@ pub enum MatchingEngineError {
 
     #[error(transparent)]
     BcsError(#[from] bcs::Error),
+
+    #[error("The application does not have permissions to close the chain.")]
+    CloseChainError,
 }
 
 /// The order entry in the order book

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -8,7 +8,7 @@
 use super::TestValidator;
 use crate::ToBcsBytes;
 use linera_base::{
-    data_types::{Round, Timestamp},
+    data_types::{ApplicationPermissions, Round, Timestamp},
     identifiers::{ApplicationId, ChainId, MessageId, Owner},
 };
 use linera_chain::data_types::{
@@ -91,6 +91,14 @@ impl BlockBuilder {
             chain_id: application.creation.chain_id,
             application_id: application.forget_abi(),
         })
+    }
+
+    /// Adds an application permissions change to this block.
+    pub fn with_change_application_permissions(
+        &mut self,
+        permissions: ApplicationPermissions,
+    ) -> &mut Self {
+        self.with_system_operation(SystemOperation::ChangeApplicationPermissions(permissions))
     }
 
     /// Adds a user `operation` to this block.


### PR DESCRIPTION
## Motivation

To use the matching engine as an atomic swap application we need to make sure that nobody can close the chain while there are still users' tokens on it.

## Proposal

Add a `CloseChain` operation to the matching engine: If the application has the permission to do so, it will close the chain, but first it will cancel all orders and send the tokens back to the users.

If the matching engine is also configured to be the only one authorized to execute operations, no chain owner can close the chain using the system operation. They have to go through the matching engine, ensuring that the tokens get sent back.

## Test Plan

The test was updated; instead of directly cancelling all remaining bids, some of them are only cancelled implicitly through `CloseChain`.

## Links

- #305 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
