### PR TITLE
Add a change-ownership command.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -241,7 +241,6 @@ Specify the complete set of new owners, by public key. Existing owners that are 
 * `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round
 
   Default value: `1000`
-* `-f`, `--force` — Perform the change even if it removes existing owners or has super owners
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -10,6 +10,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera subscribe`↴](#linera-subscribe)
 * [`linera unsubscribe`↴](#linera-unsubscribe)
 * [`linera open-multi-owner-chain`↴](#linera-open-multi-owner-chain)
+* [`linera change-ownership`↴](#linera-change-ownership)
 * [`linera change-application-permissions`↴](#linera-change-application-permissions)
 * [`linera close-chain`↴](#linera-close-chain)
 * [`linera local-balance`↴](#linera-local-balance)
@@ -57,6 +58,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `subscribe` — Subscribe to a system channel
 * `unsubscribe` — Unsubscribe from a system channel
 * `open-multi-owner-chain` — Open (i.e. activate) a new multi-owner chain deriving the UID from an existing one
+* `change-ownership` — Change who owns the chain, and how the owners work together proposing blocks
 * `change-application-permissions` — Changes the application permissions configuration
 * `close-chain` — Close an existing chain
 * `local-balance` — Read the current native-token balance of the given account directly from the local state
@@ -200,12 +202,10 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 ###### **Options:**
 
 * `--from <CHAIN_ID>` — Chain ID (must be one of our chains)
-* `--to-public-keys <PUBLIC_KEYS>` — Public keys of the new owners
-* `--weights <WEIGHTS>` — Weights for the new owners
+* `--super-owner-public-keys <SUPER_OWNER_PUBLIC_KEYS>` — Public keys of the new super owners
+* `--owner-public-keys <OWNER_PUBLIC_KEYS>` — Public keys of the new regular owners
+* `--owner-weights <OWNER_WEIGHTS>` — Weights for the new owners
 * `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks
-* `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
-
-  Default value: `0`
 * `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds
 * `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds
 
@@ -213,6 +213,35 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 * `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round
 
   Default value: `1000`
+* `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
+
+  Default value: `0`
+
+
+
+## `linera change-ownership`
+
+Change who owns the chain, and how the owners work together proposing blocks.
+
+Specify the complete set of new owners, by public key. Existing owners that are not included will be removed.
+
+**Usage:** `linera change-ownership [OPTIONS]`
+
+###### **Options:**
+
+* `--chain-id <CHAIN_ID>` — The ID of the chain whose owners will be changed
+* `--super-owner-public-keys <SUPER_OWNER_PUBLIC_KEYS>` — Public keys of the new super owners
+* `--owner-public-keys <OWNER_PUBLIC_KEYS>` — Public keys of the new regular owners
+* `--owner-weights <OWNER_WEIGHTS>` — Weights for the new owners
+* `--multi-leader-rounds <MULTI_LEADER_ROUNDS>` — The number of rounds in which every owner can propose blocks, i.e. the first round number in which only a single designated leader is allowed to propose blocks
+* `--fast-round-ms <FAST_ROUND_DURATION>` — The duration of the fast round, in milliseconds
+* `--base-timeout-ms <BASE_TIMEOUT>` — The duration of the first single-leader and all multi-leader rounds
+
+  Default value: `10000`
+* `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round
+
+  Default value: `1000`
+* `-f`, `--force` — Perform the change even if it removes existing owners or has super owners
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,6 +3382,7 @@ version = "0.9.0"
 dependencies = [
  "amm",
  "anyhow",
+ "assert_matches",
  "async-graphql",
  "async-graphql-axum",
  "async-trait",

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -50,7 +50,7 @@ use linera_storage::Storage;
 use linera_views::views::ViewError;
 use lru::LruCache;
 use std::{
-    collections::{hash_map, BTreeMap, HashMap, HashSet},
+    collections::{hash_map, BTreeMap, HashMap},
     convert::Infallible,
     iter,
     num::NonZeroUsize,
@@ -232,19 +232,6 @@ pub enum ChainClientError {
 
     #[error("Found several possible identities to interact with chain {0}")]
     FoundMultipleKeysForChain(ChainId),
-}
-
-/// Error type for [`ChainClient::change_ownership`].
-#[derive(Debug, Error)]
-pub enum ChangeOwnershipError {
-    #[error(transparent)]
-    ChainClient(#[from] ChainClientError),
-
-    #[error(
-        "This would remove the following existing owners: {:}",
-        .0.iter().map(Owner::to_string).collect::<Vec<_>>().join(", "))
-    ]
-    RemoveOwners(Vec<Owner>),
 }
 
 impl From<Infallible> for ChainClientError {
@@ -1883,48 +1870,14 @@ where
     pub async fn change_ownership(
         &mut self,
         ownership: ChainOwnership,
-        remove_owners: bool,
-    ) -> Result<ClientOutcome<Certificate>, ChangeOwnershipError> {
-        loop {
-            let old_ownership = self.prepare_chain().await?.manager.ownership;
-            ensure!(
-                old_ownership.is_active(),
-                ChainClientError::from(ChainError::InactiveChain(self.chain_id))
-            );
-            if !remove_owners {
-                let new_owners = ownership.all_owners().collect::<HashSet<_>>();
-                let removed_owners = old_ownership
-                    .all_owners()
-                    .filter(|owner| !new_owners.contains(owner))
-                    .cloned()
-                    .collect::<Vec<_>>();
-                ensure!(
-                    removed_owners.is_empty(),
-                    ChangeOwnershipError::RemoveOwners(removed_owners)
-                );
-            }
-            let messages = self.pending_messages().await?;
-            let operations = vec![Operation::System(SystemOperation::ChangeOwnership {
-                super_owners: ownership.super_owners.values().cloned().collect(),
-                owners: ownership.owners.values().cloned().collect(),
-                multi_leader_rounds: ownership.multi_leader_rounds,
-                timeout_config: ownership.timeout_config.clone(),
-            })];
-            match self.execute_block(messages, operations).await? {
-                ExecuteBlockOutcome::Executed(certificate) => {
-                    return Ok(ClientOutcome::Committed(certificate));
-                }
-                ExecuteBlockOutcome::Conflict(certificate) => {
-                    info!(
-                        height = %certificate.value().height(),
-                        "Another block was committed; retrying."
-                    );
-                }
-                ExecuteBlockOutcome::WaitForTimeout(timeout) => {
-                    return Ok(ClientOutcome::WaitForTimeout(timeout));
-                }
-            };
-        }
+    ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
+        self.execute_operation(Operation::System(SystemOperation::ChangeOwnership {
+            super_owners: ownership.super_owners.values().cloned().collect(),
+            owners: ownership.owners.values().cloned().collect(),
+            multi_leader_rounds: ownership.multi_leader_rounds,
+            timeout_config: ownership.timeout_config.clone(),
+        }))
+        .await
     }
 
     /// Changes the application permissions configuration on this chain.

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -32,6 +32,7 @@ remote_net = ["dep:k8s-openapi", "dep:kube"]
 
 [dependencies]
 anyhow.workspace = true
+assert_matches.workspace = true
 async-graphql.workspace = true
 async-graphql-axum.workspace = true
 async-trait.workspace = true

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -627,7 +627,6 @@ impl ClientWrapper {
         chain_id: ChainId,
         super_owner_public_keys: Vec<PublicKey>,
         owner_public_keys: Vec<PublicKey>,
-        force: bool,
     ) -> Result<()> {
         let mut command = self.command().await?;
         command
@@ -642,9 +641,6 @@ impl ClientWrapper {
             command
                 .arg("--owner-public-keys")
                 .args(owner_public_keys.iter().map(PublicKey::to_string));
-        }
-        if force {
-            command.arg("-f");
         }
         command.spawn_and_wait_for_stdout().await?;
         Ok(())

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -248,10 +248,6 @@ pub enum ClientCommand {
 
         #[clap(flatten)]
         ownership_config: ChainOwnershipConfig,
-
-        /// Perform the change even if it removes existing owners or has super owners.
-        #[clap(long, short = 'f')]
-        force: bool,
     },
 
     /// Changes the application permissions configuration.

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ClientContext;
+use crate::{ClientContext, Job};
 use anyhow::Error;
 use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::PublicKey,
     data_types::Amount,
-    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId},
+    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_execution::{
     committee::ValidatorName, system::SystemChannel, UserApplicationId, WasmRuntime,
@@ -19,9 +20,7 @@ use linera_service::{
     util,
 };
 use linera_views::common::CommonStoreConfig;
-use std::{env, num::NonZeroU16, path::PathBuf, time::Duration};
-
-use crate::Job;
+use std::{env, iter, num::NonZeroU16, path::PathBuf, time::Duration};
 
 #[derive(clap::Parser)]
 #[command(
@@ -229,44 +228,30 @@ pub enum ClientCommand {
         #[arg(long = "from")]
         chain_id: Option<ChainId>,
 
-        /// Public keys of the new owners
-        #[arg(long = "to-public-keys", num_args(0..))]
-        public_keys: Vec<PublicKey>,
-
-        /// Weights for the new owners
-        #[arg(long = "weights", num_args(0..))]
-        weights: Vec<u64>,
-
-        /// The number of rounds in which every owner can propose blocks, i.e. the first round
-        /// number in which only a single designated leader is allowed to propose blocks.
-        #[arg(long = "multi-leader-rounds")]
-        multi_leader_rounds: Option<u32>,
+        #[clap(flatten)]
+        ownership_config: ChainOwnershipConfig,
 
         /// The initial balance of the new chain. This is subtracted from the parent chain's
         /// balance.
         #[arg(long = "initial-balance", default_value = "0")]
         balance: Amount,
+    },
 
-        /// The duration of the fast round, in milliseconds.
-        #[arg(long = "fast-round-ms", value_parser = util::parse_millis)]
-        fast_round_duration: Option<Duration>,
+    /// Change who owns the chain, and how the owners work together proposing blocks.
+    ///
+    /// Specify the complete set of new owners, by public key. Existing owners that are
+    /// not included will be removed.
+    ChangeOwnership {
+        /// The ID of the chain whose owners will be changed.
+        #[clap(long)]
+        chain_id: Option<ChainId>,
 
-        /// The duration of the first single-leader and all multi-leader rounds.
-        #[arg(
-            long = "base-timeout-ms",
-            default_value = "10000",
-            value_parser = util::parse_millis
-        )]
-        base_timeout: Duration,
+        #[clap(flatten)]
+        ownership_config: ChainOwnershipConfig,
 
-        /// The number of milliseconds by which the timeout increases after each
-        /// single-leader round.
-        #[arg(
-            long = "timeout-increment-ms",
-            default_value = "1000",
-            value_parser = util::parse_millis
-        )]
-        timeout_increment: Duration,
+        /// Perform the change even if it removes existing owners or has super owners.
+        #[clap(long, short = 'f')]
+        force: bool,
     },
 
     /// Changes the application permissions configuration.
@@ -855,4 +840,91 @@ pub enum ProjectCommand {
         #[arg(long, num_args(0..))]
         required_application_ids: Option<Vec<UserApplicationId>>,
     },
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct ChainOwnershipConfig {
+    /// Public keys of the new super owners.
+    #[arg(long, num_args(0..))]
+    super_owner_public_keys: Vec<PublicKey>,
+
+    /// Public keys of the new regular owners.
+    #[arg(long, num_args(0..))]
+    owner_public_keys: Vec<PublicKey>,
+
+    /// Weights for the new owners.
+    ///
+    /// If they are specified there must be exactly one weight for each owner.
+    /// If no weights are given, every owner will have weight 100.
+    #[arg(long, num_args(0..))]
+    owner_weights: Vec<u64>,
+
+    /// The number of rounds in which every owner can propose blocks, i.e. the first round
+    /// number in which only a single designated leader is allowed to propose blocks.
+    #[arg(long)]
+    multi_leader_rounds: Option<u32>,
+
+    /// The duration of the fast round, in milliseconds.
+    #[arg(long = "fast-round-ms", value_parser = util::parse_millis)]
+    fast_round_duration: Option<Duration>,
+
+    /// The duration of the first single-leader and all multi-leader rounds.
+    #[arg(
+        long = "base-timeout-ms",
+        default_value = "10000",
+        value_parser = util::parse_millis
+    )]
+    base_timeout: Duration,
+
+    /// The number of milliseconds by which the timeout increases after each
+    /// single-leader round.
+    #[arg(
+        long = "timeout-increment-ms",
+        default_value = "1000",
+        value_parser = util::parse_millis
+    )]
+    timeout_increment: Duration,
+}
+
+impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
+    type Error = Error;
+
+    fn try_from(config: ChainOwnershipConfig) -> Result<ChainOwnership, Error> {
+        let ChainOwnershipConfig {
+            super_owner_public_keys,
+            owner_public_keys,
+            owner_weights,
+            multi_leader_rounds,
+            fast_round_duration,
+            base_timeout,
+            timeout_increment,
+        } = config;
+        anyhow::ensure!(
+            owner_weights.is_empty() || owner_weights.len() == owner_public_keys.len(),
+            "There are {} public keys but {} weights.",
+            owner_public_keys.len(),
+            owner_weights.len()
+        );
+        let super_owners = super_owner_public_keys
+            .into_iter()
+            .map(|pub_key| (Owner::from(pub_key), pub_key))
+            .collect();
+        let owners = owner_public_keys
+            .into_iter()
+            .zip(owner_weights.into_iter().chain(iter::repeat(100)))
+            .map(|(pub_key, weight)| (Owner::from(pub_key), (pub_key, weight)))
+            .collect();
+        let multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
+        let timeout_config = TimeoutConfig {
+            fast_round_duration,
+            base_timeout,
+            timeout_increment,
+        };
+        Ok(ChainOwnership {
+            super_owners,
+            owners,
+            multi_leader_rounds,
+            timeout_config,
+        })
+    }
 }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -13,7 +13,7 @@ use linera_base::{
     crypto::{CryptoHash, CryptoRng, PublicKey},
     data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ChainDescription, ChainId, MessageId, Owner},
-    ownership::{ChainOwnership, TimeoutConfig},
+    ownership::ChainOwnership,
 };
 use linera_chain::data_types::{CertificateValue, ExecutedBlock};
 use linera_core::{
@@ -48,7 +48,7 @@ use rand::Rng as _;
 use serde_json::Value;
 use std::{
     collections::HashMap,
-    env, iter,
+    env,
     path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
@@ -190,13 +190,8 @@ impl Runnable for Job {
 
             OpenMultiOwnerChain {
                 chain_id,
-                public_keys,
-                weights,
-                multi_leader_rounds,
                 balance,
-                fast_round_duration,
-                base_timeout,
-                timeout_increment,
+                ownership_config,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 let chain_client = context.make_chain_client(storage, chain_id);
@@ -205,33 +200,10 @@ impl Runnable for Job {
                     chain_id
                 );
                 let time_start = Instant::now();
-                let owners = if weights.is_empty() {
-                    public_keys
-                        .into_iter()
-                        .zip(iter::repeat(100))
-                        .collect::<Vec<_>>()
-                } else if weights.len() != public_keys.len() {
-                    bail!(
-                        "There are {} public keys but {} weights.",
-                        public_keys.len(),
-                        weights.len()
-                    );
-                } else {
-                    public_keys.into_iter().zip(weights).collect::<Vec<_>>()
-                };
-                let multi_leader_rounds = multi_leader_rounds.unwrap_or(u32::MAX);
-                let timeout_config = TimeoutConfig {
-                    fast_round_duration,
-                    base_timeout,
-                    timeout_increment,
-                };
+                let ownership = ChainOwnership::try_from(ownership_config)?;
                 let ((message_id, certificate), _) = context
                     .apply_client_command(chain_client, |mut chain_client| {
-                        let ownership = ChainOwnership::multiple(
-                            owners.clone(),
-                            multi_leader_rounds,
-                            timeout_config.clone(),
-                        );
+                        let ownership = ownership.clone();
                         async move {
                             let result = chain_client
                                 .open_chain(ownership, balance)
@@ -259,6 +231,16 @@ impl Runnable for Job {
                 // Print the new chain ID and message ID on stdout for scripting purposes.
                 println!("{}", message_id);
                 println!("{}", ChainId::child(message_id));
+            }
+
+            ChangeOwnership {
+                chain_id,
+                ownership_config,
+                force,
+            } => {
+                context
+                    .change_ownership(chain_id, ownership_config, force, storage)
+                    .await?
             }
 
             ChangeApplicationPermissions {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -236,10 +236,9 @@ impl Runnable for Job {
             ChangeOwnership {
                 chain_id,
                 ownership_config,
-                force,
             } => {
                 context
-                    .change_ownership(chain_id, ownership_config, force, storage)
+                    .change_ownership(chain_id, ownership_config, storage)
                     .await?
             }
 


### PR DESCRIPTION
## Motivation

Explaining how to use the matching engine example for atomic swaps in the README will be much easier if we can just change the ownership of the existing chain, rather than create a new chain and another application.

Also, changing a chain's ownership from the command line should be possible anyway.

## Proposal

Add a `change-ownership` command.

To make it more consistent with the `open-multi-owner-chain` command, a few parameters are renamed.

## Test Plan

A test was added.

## Release Plan

- Need to update the developer manual.

## Links

- #305 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
