### PR TITLE
Non Fungible Token App

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3387,6 +3387,7 @@ dependencies = [
  "async-graphql-axum",
  "async-trait",
  "axum 0.7.4",
+ "base64 0.22.0",
  "bcs",
  "cargo_toml",
  "chrono",
@@ -3419,6 +3420,7 @@ dependencies = [
  "linera-views",
  "matching-engine",
  "native-fungible",
+ "non-fungible",
  "pathdiff",
  "port-selector",
  "prometheus",
@@ -4036,6 +4038,22 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "non-fungible"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "base64 0.22.0",
+ "bcs",
+ "fungible",
+ "linera-sdk",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ counter = { path = "./examples/counter" }
 meta-counter = { path = "./examples/meta-counter" }
 fungible = { path = "./examples/fungible" }
 native-fungible = { path = "./examples/native-fungible" }
+non-fungible = { path = "./examples/non-fungible" }
 crowd-funding = { path = "./examples/crowd-funding" }
 matching-engine = { path = "./examples/matching-engine" }
 social = { path = "./examples/social" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2442,6 +2442,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "non-fungible"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "async-trait",
+ "base64 0.22.0",
+ "bcs",
+ "fungible",
+ "linera-sdk",
+ "non-fungible",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3960,9 +3978,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "valuable"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "matching-engine",
     "meta-counter",
     "native-fungible",
+    "non-fungible",
     "social",
 ]
 
@@ -15,6 +16,7 @@ members = [
 assert_matches = "1.5.0"
 async-graphql = { version = "7.0.2", default-features = false }
 async-trait = "0.1.58"
+base64 = "0.22.0"
 bcs = "0.1.3"
 futures = "0.3.24"
 futures-util = "0.3.26"
@@ -24,6 +26,7 @@ linera-views = { path = "../linera-views", default-features = false }
 log = "0.4.20"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
+sha3 = "0.10.8"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 webassembly-test = "0.1.0"
@@ -34,6 +37,7 @@ counter = { path = "./counter" }
 crowd-funding = { path = "./crowd-funding" }
 fungible = { path = "./fungible" }
 native-fungible = { path = "./native-fungible" }
+non-fungible = { path = "./non-fungible" }
 amm = { path = "./amm" }
 matching-engine = { path = "./matching-engine" }
 

--- a/examples/non-fungible/Cargo.toml
+++ b/examples/non-fungible/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "non-fungible"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[features]
+test = []
+
+[dependencies]
+async-graphql.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+bcs.workspace = true
+fungible.workspace = true
+linera-sdk.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha3.workspace = true
+thiserror.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+fungible = { workspace = true, features = ["test"] }
+non-fungible = { workspace = true, features = ["test"] }
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio.workspace = true
+
+[[bin]]
+name = "non_fungible_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "non_fungible_service"
+path = "src/service.rs"

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -1,0 +1,382 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use self::state::NonFungibleToken;
+use async_trait::async_trait;
+use fungible::Account;
+use linera_sdk::{
+    base::{AccountOwner, ApplicationId, Owner, SessionId, WithContractAbi},
+    contract::system_api,
+    ApplicationCallOutcome, Contract, ContractRuntime, ExecutionOutcome, SessionCallOutcome,
+    ViewStateStorage,
+};
+use non_fungible::{Message, Nft, Operation, TokenId};
+use std::collections::BTreeSet;
+use thiserror::Error;
+
+linera_sdk::contract!(NonFungibleToken);
+
+impl WithContractAbi for NonFungibleToken {
+    type Abi = non_fungible::NonFungibleTokenAbi;
+}
+
+#[async_trait]
+impl Contract for NonFungibleToken {
+    type Error = Error;
+    type Storage = ViewStateStorage<Self>;
+
+    async fn initialize(
+        &mut self,
+        _runtime: &mut ContractRuntime,
+        _state: Self::InitializationArgument,
+    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+        // Validate that the application parameters were configured correctly.
+        assert!(Self::parameters().is_ok());
+        Ok(ExecutionOutcome::default())
+    }
+
+    async fn execute_operation(
+        &mut self,
+        runtime: &mut ContractRuntime,
+        operation: Self::Operation,
+    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+        match operation {
+            Operation::Mint { name, payload } => Ok(self
+                .mint(
+                    AccountOwner::User(runtime.authenticated_signer().unwrap()),
+                    name,
+                    payload,
+                )
+                .await),
+
+            Operation::Transfer {
+                source_owner,
+                token_id,
+                target_account,
+            } => {
+                Self::check_account_authentication(
+                    None,
+                    runtime.authenticated_signer(),
+                    source_owner,
+                )?;
+
+                let nft = self.get_nft(&token_id).await;
+                Self::check_account_authentication(
+                    None,
+                    runtime.authenticated_signer(),
+                    nft.owner,
+                )?;
+
+                Ok(self.transfer(nft, target_account).await)
+            }
+
+            Operation::Claim {
+                source_account,
+                token_id,
+                target_account,
+            } => {
+                Self::check_account_authentication(
+                    None,
+                    runtime.authenticated_signer(),
+                    source_account.owner,
+                )?;
+
+                if source_account.chain_id == system_api::current_chain_id() {
+                    let nft = self.get_nft(&token_id).await;
+                    Self::check_account_authentication(
+                        None,
+                        runtime.authenticated_signer(),
+                        nft.owner,
+                    )?;
+
+                    Ok(self.transfer(nft, target_account).await)
+                } else {
+                    Ok(self.remote_claim(source_account, token_id, target_account))
+                }
+            }
+        }
+    }
+
+    async fn execute_message(
+        &mut self,
+        runtime: &mut ContractRuntime,
+        message: Message,
+    ) -> Result<ExecutionOutcome<Self::Message>, Self::Error> {
+        match message {
+            Message::Transfer {
+                mut nft,
+                target_account,
+            } => {
+                let is_bouncing = runtime
+                    .message_is_bouncing()
+                    .expect("Message delivery status has to be available when executing a message");
+                if !is_bouncing {
+                    nft.owner = target_account.owner;
+                }
+
+                self.add_nft(nft).await;
+                Ok(ExecutionOutcome::default())
+            }
+
+            Message::Claim {
+                source_account,
+                token_id,
+                target_account,
+            } => {
+                Self::check_account_authentication(
+                    None,
+                    runtime.authenticated_signer(),
+                    source_account.owner,
+                )?;
+
+                let nft = self.get_nft(&token_id).await;
+                Self::check_account_authentication(
+                    None,
+                    runtime.authenticated_signer(),
+                    nft.owner,
+                )?;
+
+                Ok(self.transfer(nft, target_account).await)
+            }
+        }
+    }
+
+    async fn handle_application_call(
+        &mut self,
+        runtime: &mut ContractRuntime,
+        call: Self::ApplicationCall,
+        _forwarded_sessions: Vec<SessionId>,
+    ) -> Result<
+        ApplicationCallOutcome<Self::Message, Self::Response, Self::SessionState>,
+        Self::Error,
+    > {
+        match call {
+            Self::ApplicationCall::Mint { name, payload } => {
+                let execution_outcome = self
+                    .mint(
+                        AccountOwner::Application(runtime.authenticated_caller_id().unwrap()),
+                        name,
+                        payload,
+                    )
+                    .await;
+
+                Ok(ApplicationCallOutcome {
+                    execution_outcome,
+                    ..Default::default()
+                })
+            }
+
+            Self::ApplicationCall::Transfer {
+                source_owner,
+                token_id,
+                target_account,
+            } => {
+                Self::check_account_authentication(
+                    runtime.authenticated_caller_id(),
+                    runtime.authenticated_signer(),
+                    source_owner,
+                )?;
+
+                let nft = self.get_nft(&token_id).await;
+                Self::check_account_authentication(
+                    runtime.authenticated_caller_id(),
+                    runtime.authenticated_signer(),
+                    nft.owner,
+                )?;
+
+                let execution_outcome = self.transfer(nft, target_account).await;
+                Ok(ApplicationCallOutcome {
+                    execution_outcome,
+                    ..Default::default()
+                })
+            }
+
+            Self::ApplicationCall::Claim {
+                source_account,
+                token_id,
+                target_account,
+            } => {
+                Self::check_account_authentication(
+                    runtime.authenticated_caller_id(),
+                    runtime.authenticated_signer(),
+                    source_account.owner,
+                )?;
+
+                let execution_outcome = if source_account.chain_id == system_api::current_chain_id()
+                {
+                    let nft = self.get_nft(&token_id).await;
+                    Self::check_account_authentication(
+                        runtime.authenticated_caller_id(),
+                        runtime.authenticated_signer(),
+                        nft.owner,
+                    )?;
+
+                    self.transfer(nft, target_account).await
+                } else {
+                    self.remote_claim(source_account, token_id, target_account)
+                };
+
+                Ok(ApplicationCallOutcome {
+                    execution_outcome,
+                    ..Default::default()
+                })
+            }
+        }
+    }
+
+    async fn handle_session_call(
+        &mut self,
+        _runtime: &mut ContractRuntime,
+        _state: Self::SessionState,
+        _request: Self::SessionCall,
+        _forwarded_sessions: Vec<SessionId>,
+    ) -> Result<SessionCallOutcome<Self::Message, Self::Response, Self::SessionState>, Self::Error>
+    {
+        Err(Error::SessionsNotSupported)
+    }
+}
+
+impl NonFungibleToken {
+    /// Verifies that a transfer is authenticated for this local account.
+    fn check_account_authentication(
+        authenticated_application_id: Option<ApplicationId>,
+        authenticated_signer: Option<Owner>,
+        owner: AccountOwner,
+    ) -> Result<(), Error> {
+        match owner {
+            AccountOwner::User(address) if authenticated_signer == Some(address) => Ok(()),
+            AccountOwner::Application(id) if authenticated_application_id == Some(id) => Ok(()),
+            _ => Err(Error::IncorrectAuthentication),
+        }
+    }
+
+    /// Transfers the specified NFT to another account.
+    /// Authentication needs to have happened already.
+    async fn transfer(
+        &mut self,
+        mut nft: Nft,
+        target_account: Account,
+    ) -> ExecutionOutcome<Message> {
+        self.remove_nft(&nft).await;
+        if target_account.chain_id == system_api::current_chain_id() {
+            nft.owner = target_account.owner;
+            self.add_nft(nft).await;
+            ExecutionOutcome::default()
+        } else {
+            let message = Message::Transfer {
+                nft,
+                target_account,
+            };
+
+            ExecutionOutcome::default().with_tracked_message(target_account.chain_id, message)
+        }
+    }
+
+    async fn get_nft(&self, token_id: &TokenId) -> Nft {
+        self.nfts
+            .get(token_id)
+            .await
+            .expect("Failure in retrieving NFT")
+            .expect("NFT should not be None")
+    }
+
+    async fn mint(
+        &mut self,
+        owner: AccountOwner,
+        name: String,
+        payload: Vec<u8>,
+    ) -> ExecutionOutcome<Message> {
+        let token_id = Nft::create_token_id(
+            &system_api::current_chain_id(),
+            &system_api::current_application_id(),
+            &name,
+            &owner,
+            &payload,
+        );
+
+        self.add_nft(Nft {
+            token_id,
+            owner,
+            name,
+            minter: owner,
+            payload,
+        })
+        .await;
+
+        ExecutionOutcome::default()
+    }
+
+    fn remote_claim(
+        &mut self,
+        source_account: Account,
+        token_id: TokenId,
+        target_account: Account,
+    ) -> ExecutionOutcome<Message> {
+        let message = Message::Claim {
+            source_account,
+            token_id,
+            target_account,
+        };
+        ExecutionOutcome::default().with_authenticated_message(source_account.chain_id, message)
+    }
+
+    async fn add_nft(&mut self, nft: Nft) {
+        let token_id = nft.token_id.clone();
+        let owner = nft.owner;
+
+        self.nfts
+            .insert(&token_id, nft)
+            .expect("Error in insert statement");
+        if let Some(owned_token_ids) = self
+            .owned_token_ids
+            .get_mut(&owner)
+            .await
+            .expect("Error in get_mut statement")
+        {
+            owned_token_ids.insert(token_id);
+        } else {
+            let mut owned_token_ids = BTreeSet::new();
+            owned_token_ids.insert(token_id);
+            self.owned_token_ids
+                .insert(&owner, owned_token_ids)
+                .expect("Error in insert statement");
+        }
+    }
+
+    async fn remove_nft(&mut self, nft: &Nft) {
+        self.nfts
+            .remove(&nft.token_id)
+            .expect("Failure removing NFT");
+        let owned_token_ids = self
+            .owned_token_ids
+            .get_mut(&nft.owner)
+            .await
+            .expect("Error in get_mut statement")
+            .expect("NFT set should be there!");
+
+        owned_token_ids.remove(&nft.token_id);
+    }
+}
+
+/// An error that can occur during the contract execution.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Requested transfer does not have permission on this account.
+    #[error("The requested transfer is not correctly authenticated.")]
+    IncorrectAuthentication,
+
+    /// Failed to deserialize BCS bytes
+    #[error("Failed to deserialize BCS bytes")]
+    BcsError(#[from] bcs::Error),
+
+    /// Failed to deserialize JSON string
+    #[error("Failed to deserialize JSON string")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("Non Fungible application doesn't support any cross-application sessions")]
+    SessionsNotSupported,
+}

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -1,0 +1,147 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::{InputObject, Request, Response, SimpleObject};
+use fungible::Account;
+use linera_sdk::{
+    base::{AccountOwner, ApplicationId, ChainId, ContractAbi, ServiceAbi},
+    graphql::GraphQLMutationRoot,
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+
+#[derive(
+    Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Ord, PartialOrd, SimpleObject, InputObject,
+)]
+#[graphql(input_name = "TokenIdInput")]
+pub struct TokenId {
+    pub id: Vec<u8>,
+}
+
+pub struct NonFungibleTokenAbi;
+
+impl ContractAbi for NonFungibleTokenAbi {
+    type InitializationArgument = ();
+    type Parameters = ();
+    type ApplicationCall = Operation;
+    type Operation = Operation;
+    type Message = Message;
+    type SessionCall = ();
+    type Response = ();
+    type SessionState = ();
+}
+
+impl ServiceAbi for NonFungibleTokenAbi {
+    type Query = Request;
+    type QueryResponse = Response;
+    type Parameters = ();
+}
+
+/// An operation.
+#[derive(Debug, Deserialize, Serialize, GraphQLMutationRoot)]
+pub enum Operation {
+    /// Mints a token
+    Mint { name: String, payload: Vec<u8> },
+    /// Transfers a token from a (locally owned) account to a (possibly remote) account.
+    Transfer {
+        source_owner: AccountOwner,
+        token_id: TokenId,
+        target_account: Account,
+    },
+    /// Same as `Transfer` but the source account may be remote. Depending on its
+    /// configuration, the target chain may take time or refuse to process
+    /// the message.
+    Claim {
+        source_account: Account,
+        token_id: TokenId,
+        target_account: Account,
+    },
+}
+
+/// A message.
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Message {
+    /// Transfers to the given `target` account, unless the message is bouncing, in which case
+    /// we transfer back to the `source`.
+    Transfer { nft: Nft, target_account: Account },
+
+    /// Claims from the given account and starts a transfer to the target account.
+    Claim {
+        source_account: Account,
+        token_id: TokenId,
+        target_account: Account,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, SimpleObject, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Nft {
+    pub token_id: TokenId,
+    pub owner: AccountOwner,
+    pub name: String,
+    pub minter: AccountOwner,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, SimpleObject, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct NftOutput {
+    pub token_id: String,
+    pub owner: AccountOwner,
+    pub name: String,
+    pub minter: AccountOwner,
+    pub payload: Vec<u8>,
+}
+
+impl NftOutput {
+    pub fn new(nft: Nft) -> Self {
+        use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
+        let token_id = STANDARD_NO_PAD.encode(nft.token_id.id);
+        Self {
+            token_id,
+            owner: nft.owner,
+            name: nft.name,
+            minter: nft.minter,
+            payload: nft.payload,
+        }
+    }
+
+    pub fn new_with_token_id(token_id: String, nft: Nft) -> Self {
+        Self {
+            token_id,
+            owner: nft.owner,
+            name: nft.name,
+            minter: nft.minter,
+            payload: nft.payload,
+        }
+    }
+}
+
+impl Display for TokenId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.id)
+    }
+}
+
+impl Nft {
+    pub fn create_token_id(
+        chain_id: &ChainId,
+        application_id: &ApplicationId,
+        name: &String,
+        minter: &AccountOwner,
+        payload: &Vec<u8>,
+    ) -> TokenId {
+        use sha3::Digest as _;
+
+        let mut hasher = sha3::Sha3_256::new();
+        hasher.update(chain_id.to_string());
+        hasher.update(application_id.to_string());
+        hasher.update(name);
+        hasher.update(minter.to_string());
+        hasher.update(payload);
+
+        TokenId {
+            id: hasher.finalize().to_vec(),
+        }
+    }
+}

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -1,0 +1,196 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use self::state::NonFungibleToken;
+use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use async_trait::async_trait;
+use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
+use fungible::Account;
+use linera_sdk::{
+    base::{AccountOwner, WithServiceAbi},
+    Service, ServiceRuntime, ViewStateStorage,
+};
+use non_fungible::{NftOutput, Operation, TokenId};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+use thiserror::Error;
+
+linera_sdk::service!(NonFungibleToken);
+
+impl WithServiceAbi for NonFungibleToken {
+    type Abi = non_fungible::NonFungibleTokenAbi;
+}
+
+#[async_trait]
+impl Service for NonFungibleToken {
+    type Error = Error;
+    type Storage = ViewStateStorage<Self>;
+
+    async fn handle_query(
+        self: Arc<Self>,
+        _runtime: &ServiceRuntime,
+        request: Request,
+    ) -> Result<Response, Self::Error> {
+        let schema = Schema::build(
+            QueryRoot {
+                non_fungible_token: self.clone(),
+            },
+            MutationRoot,
+            EmptySubscription,
+        )
+        .finish();
+        let response = schema.execute(request).await;
+        Ok(response)
+    }
+}
+
+struct QueryRoot {
+    non_fungible_token: Arc<NonFungibleToken>,
+}
+
+#[Object]
+impl QueryRoot {
+    async fn nft(&self, token_id: String) -> Option<NftOutput> {
+        let token_id_vec = STANDARD_NO_PAD.decode(&token_id).unwrap();
+        let nft = self
+            .non_fungible_token
+            .nfts
+            .get(&TokenId { id: token_id_vec })
+            .await
+            .unwrap();
+
+        if let Some(nft) = nft {
+            let nft_output = NftOutput::new_with_token_id(token_id, nft);
+            Some(nft_output)
+        } else {
+            None
+        }
+    }
+
+    async fn nfts(&self) -> BTreeMap<String, NftOutput> {
+        let mut nfts = BTreeMap::new();
+        self.non_fungible_token
+            .nfts
+            .for_each_index_value(|_token_id, nft| {
+                let nft_output = NftOutput::new(nft);
+                nfts.insert(nft_output.token_id.clone(), nft_output);
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        nfts
+    }
+
+    async fn owned_token_ids_by_owner(&self, owner: AccountOwner) -> BTreeSet<String> {
+        self.non_fungible_token
+            .owned_token_ids
+            .get(&owner)
+            .await
+            .unwrap()
+            .into_iter()
+            .flatten()
+            .map(|token_id| STANDARD_NO_PAD.encode(token_id.id))
+            .collect()
+    }
+
+    async fn owned_token_ids(&self) -> BTreeMap<AccountOwner, BTreeSet<String>> {
+        let mut owners = BTreeMap::new();
+        self.non_fungible_token
+            .owned_token_ids
+            .for_each_index_value(|owner, token_ids| {
+                let new_token_ids = token_ids
+                    .into_iter()
+                    .map(|token_id| STANDARD_NO_PAD.encode(token_id.id))
+                    .collect();
+
+                owners.insert(owner, new_token_ids);
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        owners
+    }
+
+    async fn owned_nfts(&self, owner: AccountOwner) -> BTreeMap<String, NftOutput> {
+        let mut result = BTreeMap::new();
+        let owned_token_ids = self
+            .non_fungible_token
+            .owned_token_ids
+            .get(&owner)
+            .await
+            .unwrap();
+
+        for token_id in owned_token_ids.into_iter().flatten() {
+            let nft = self
+                .non_fungible_token
+                .nfts
+                .get(&token_id)
+                .await
+                .unwrap()
+                .unwrap();
+            let nft_output = NftOutput::new(nft);
+            result.insert(nft_output.token_id.clone(), nft_output);
+        }
+
+        result
+    }
+}
+
+struct MutationRoot;
+
+#[Object]
+impl MutationRoot {
+    async fn mint(&self, name: String, payload: Vec<u8>) -> Vec<u8> {
+        bcs::to_bytes(&Operation::Mint { name, payload }).unwrap()
+    }
+
+    async fn transfer(
+        &self,
+        source_owner: AccountOwner,
+        token_id: String,
+        target_account: Account,
+    ) -> Vec<u8> {
+        bcs::to_bytes(&Operation::Transfer {
+            source_owner,
+            token_id: TokenId {
+                id: STANDARD_NO_PAD.decode(token_id).unwrap(),
+            },
+            target_account,
+        })
+        .unwrap()
+    }
+
+    async fn claim(
+        &self,
+        source_account: Account,
+        token_id: String,
+        target_account: Account,
+    ) -> Vec<u8> {
+        bcs::to_bytes(&Operation::Claim {
+            source_account,
+            token_id: TokenId {
+                id: STANDARD_NO_PAD.decode(token_id).unwrap(),
+            },
+            target_account,
+        })
+        .unwrap()
+    }
+}
+
+/// An error that can occur during the contract execution.
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Invalid query argument; could not deserialize GraphQL request.
+    #[error(
+        "Invalid query argument; Fungible application only supports JSON encoded GraphQL queries"
+    )]
+    InvalidQuery(#[from] serde_json::Error),
+}

--- a/examples/non-fungible/src/state.rs
+++ b/examples/non-fungible/src/state.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::SimpleObject;
+use linera_sdk::{
+    base::AccountOwner,
+    views::{linera_views, MapView, RootView, ViewStorageContext},
+};
+use non_fungible::{Nft, TokenId};
+use std::collections::BTreeSet;
+
+/// The application state.
+#[derive(RootView, SimpleObject)]
+#[view(context = "ViewStorageContext")]
+pub struct NonFungibleToken {
+    // Map from token ID to the NFT data
+    pub nfts: MapView<TokenId, Nft>,
+    // Map from owners to the set of NFT token IDs they own
+    pub owned_token_ids: MapView<AccountOwner, BTreeSet<TokenId>>,
+}

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -87,6 +87,7 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 
 [dev-dependencies]
 amm.workspace = true
+base64.workspace = true
 counter.workspace = true
 crowd-funding.workspace = true
 fungible.workspace = true
@@ -100,6 +101,7 @@ linera-storage = { workspace = true, features = ["test"] }
 linera-views = { workspace = true, features = ["test"] }
 matching-engine.workspace = true
 native-fungible.workspace = true
+non-fungible.workspace = true
 proptest.workspace = true
 reqwest = { workspace = true, features = ["json"] }
 social.workspace = true


### PR DESCRIPTION
## Motivation

We need an NFT app

## Proposal

* Created a new `NonFungibleTokenAbi`, it has `Mint`, `Transfer`, `Claim` operations, `Transfer`, `Claim` messages, `Mint`, `Transfer`, `Claim` application calls.
* No sessions support, specially as these are going away soon
* NFT app has a local state of the NFTs, keyed by token ID. Token ID is deterministically generated by hashing `chain_id`, `application_id`, and the NFT's metadata.

## Test Plan

Created an e2e test, so CI

## Follow ups

* Write `README`
* NFT UI?
