### PR TITLE
Several adjustments to accelerate the CI.

### DIFF
--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -6,6 +6,10 @@
 //! These tests only run if a Wasm runtime has been configured by enabling either the `wasmer` or
 //! the `wasmtime` feature flags.
 
+// Tests for `RocksDb`, `DynamoDb`, `ScyllaDb` and `Service` are currently disabled
+// because they are slow and their behavior appears to be correctly check by the
+// test with memory.
+
 #![cfg(any(feature = "wasmer", feature = "wasmtime"))]
 
 use crate::client::client_tests::{
@@ -44,6 +48,7 @@ async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(),
     run_test_create_application(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -56,6 +61,7 @@ async fn test_service_create_application(wasm_runtime: WasmRuntime) -> Result<()
     .await
 }
 
+#[ignore]
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -65,6 +71,7 @@ async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(
     run_test_create_application(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -73,6 +80,7 @@ async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<
     run_test_create_application(DynamoDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -167,6 +175,7 @@ async fn test_memory_run_application_with_dependency(
         .await
 }
 
+#[ignore]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -181,6 +190,7 @@ async fn test_service_run_application_with_dependency(
     .await
 }
 
+#[ignore]
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -193,6 +203,7 @@ async fn test_rocks_db_run_application_with_dependency(
         .await
 }
 
+#[ignore]
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -206,6 +217,7 @@ async fn test_dynamo_db_run_application_with_dependency(
     .await
 }
 
+#[ignore]
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -392,6 +404,7 @@ async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<()
     run_test_cross_chain_message(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
@@ -404,6 +417,7 @@ async fn test_service_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(
     .await
 }
 
+#[ignore]
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -413,6 +427,7 @@ async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<
     run_test_cross_chain_message(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -423,6 +438,7 @@ async fn test_dynamo_db_cross_chain_message(
     run_test_cross_chain_message(DynamoDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -604,6 +620,7 @@ async fn test_memory_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> Result<
     run_test_user_pub_sub_channels(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]
@@ -618,6 +635,7 @@ async fn test_service_user_pub_sub_channels(
     .await
 }
 
+#[ignore]
 #[cfg(feature = "rocksdb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
@@ -629,6 +647,7 @@ async fn test_rocks_db_user_pub_sub_channels(
     run_test_user_pub_sub_channels(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg(feature = "aws")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
@@ -639,6 +658,7 @@ async fn test_dynamo_db_user_pub_sub_channels(
     run_test_user_pub_sub_channels(DynamoDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
+#[ignore]
 #[cfg(feature = "scylladb")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -457,7 +457,7 @@ async fn run_test_batch_from_blank<C: KeyValueStore + Sync>(
 /// Run many operations on batches always starting from a blank state.
 pub async fn run_writes_from_blank<C: KeyValueStore + Sync>(key_value_store: &C) {
     let mut rng = make_deterministic_rng();
-    let n_oper = 1000;
+    let n_oper = 10;
     let batch_size = 500;
     // key space has size 4^4 = 256 so we necessarily encounter collisions
     // because the number of generated keys is about batch_size * n_oper = 800 > 256.

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -315,7 +315,7 @@ pub async fn run_reads<S: KeyValueStore + Sync>(store: S, key_values: Vec<(Vec<u
 
 fn get_random_key_values1(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let key_prefix = vec![0];
-    let n = 1000;
+    let n = 30;
     let mut rng = make_deterministic_rng();
     get_random_key_values_prefix(&mut rng, key_prefix, 8, len_value, n)
 }
@@ -323,7 +323,7 @@ fn get_random_key_values1(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
 fn get_random_key_values2(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut rng = make_deterministic_rng();
     let key_prefix = vec![0];
-    let n = 100;
+    let n = 30;
     let mut key_values = Vec::new();
     let mut key_set = HashSet::new();
     for _ in 0..n {

--- a/linera-views/tests/map_view_tests.rs
+++ b/linera-views/tests/map_view_tests.rs
@@ -23,7 +23,7 @@ async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) {
     let context = create_memory_context();
     let mut state_map = BTreeMap::new();
     let mut all_keys = BTreeSet::new();
-    let n = 200;
+    let n = 10;
     for _ in 0..n {
         let mut view = StateView::load(context.clone()).await.unwrap();
         let save = rng.gen::<bool>();
@@ -150,7 +150,7 @@ async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) {
 #[tokio::test]
 async fn map_view_mutability() {
     let mut rng = test_utils::make_deterministic_rng();
-    for _ in 0..10 {
+    for _ in 0..5 {
         run_map_view_mutability(&mut rng).await;
     }
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -66,7 +66,7 @@ async fn test_reads_key_value_store_view_memory() {
 }
 
 #[tokio::test]
-async fn test_reads_memory_specific() {
+async fn test_specific_reads_memory() {
     let key_value_store = create_memory_store();
     let key_values = vec![
         (vec![0, 1, 255], Vec::new()),


### PR DESCRIPTION
## Motivation

The CI is taking a lot of time. This costs money and also hinders development.

## Proposal

The following are done:
* The size of the scenarios in the `num_reads` is decreased which makes the test 10 times faster.
* The wasmer tests `create_application`, `run_application_with_dependency`, `user_pub_sub_channel` and `cross_chain_message` are all taking more than 60s. But they are very similar and the storage used is not key. Therefore they are marked as `#[ignore]`.
* The `map_view_mutability` test is reduced in size.

Random tests are useful of course and they are kept. However, the probability of catching a bug decreases as the size increases. Therefore it does not make sense to have such large test cases. They are useful in development but not in CI.

## Test Plan

That is precisely the point.

## Release Plan

Nothing relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
