### PR TITLE
Fix Wasmtime fuel consumption calculation

### DIFF
--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -83,6 +83,8 @@ where
     initial_fuel: u64,
 }
 
+// TODO(#1785): Simplify by using proper fuel getter and setter methods from Wasmtime once the
+// dependency is updated
 impl<Runtime> WasmtimeContractInstance<Runtime>
 where
     Runtime: ContractRuntime + Send + Sync,

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -78,6 +78,9 @@ where
 
     /// The application's memory state.
     store: Store<ContractState<Runtime>>,
+
+    /// The starting amount of fuel.
+    initial_fuel: u64,
 }
 
 impl<Runtime> WasmtimeContractInstance<Runtime>
@@ -88,21 +91,40 @@ where
         let runtime = &mut self.store.data_mut().runtime;
         let fuel = runtime.remaining_fuel()?;
 
+        self.initial_fuel = fuel;
+
         self.store
-            .add_fuel(fuel)
-            .expect("Fuel consumption wasn't properly enabled");
+            .add_fuel(1)
+            .expect("Fuel consumption should be enabled");
+
+        let existing_fuel = self
+            .store
+            .consume_fuel(0)
+            .expect("Fuel consumption should be enabled");
+
+        if existing_fuel > fuel {
+            self.store
+                .consume_fuel(existing_fuel - fuel)
+                .expect("Existing fuel was incorrectly calculated");
+        } else {
+            self.store
+                .add_fuel(fuel - existing_fuel)
+                .expect("Fuel consumption wasn't properly enabled");
+        }
 
         Ok(())
     }
 
     fn persist_remaining_fuel(&mut self) -> Result<(), ExecutionError> {
-        let consumed_fuel = self
+        let remaining_fuel = self
             .store
-            .fuel_consumed()
+            .consume_fuel(0)
             .expect("Failed to read consumed fuel");
         let runtime = &mut self.store.data_mut().runtime;
 
-        runtime.consume_fuel(consumed_fuel)
+        assert!(self.initial_fuel >= remaining_fuel);
+
+        runtime.consume_fuel(self.initial_fuel - remaining_fuel)
     }
 }
 
@@ -154,7 +176,11 @@ where
         )
         .map_err(WasmExecutionError::LoadContractModule)?;
 
-        Ok(Self { application, store })
+        Ok(Self {
+            application,
+            store,
+            initial_fuel: 0,
+        })
     }
 }
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Wasmtime's `consumed_fuel` returns the total amount of fuel consumed since execution started, instead of the amount of fuel consumed since the last time fuel was added. That value was incorrectly used to consume fuel from the runtime, so fuel consumption values in Wasmtime was incorrect for any application that performed system API calls.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Obtain the remaining fuel and manually calculate how much fuel was consumed.

Unfortunately we're currently using an old version of the `wasmtime` dependency, so there isn't any simple API to get the remaining fuel. The way to do it with the current version used is to call `consume_fuel(0)`, because it returns the amount of remaining fuel. However, if the fuel amount is zero, it returns an error instead, so a workaround is used to add one unit of fuel before checking. Issue #1785 was opened to improve this in the future.

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed besides resetting the Devnet state of validators running with Wasmtime.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
