### PR TITLE
Make the `linera-storage-service` handle requests and replies that have size higher than 4M.

### DIFF
--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -35,7 +35,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest-8-cores
-    timeout-minutes: 30
+    timeout-minutes: 40
 
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,6 +3511,7 @@ dependencies = [
  "port-selector",
  "proptest",
  "prost",
+ "serde",
  "serde-reflection",
  "serde_yaml 0.8.26",
  "similar-asserts",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2003,6 +2003,7 @@ dependencies = [
  "linera-views",
  "port-selector",
  "prost",
+ "serde",
  "thiserror",
  "tokio",
  "tonic",

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1067,8 +1067,8 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
 // #[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 // #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 // #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
-// #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
-#[cfg_attr(feature = "rocksdb", test_case(LocalNetConfig::new_test(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
+#[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
+// #[cfg_attr(feature = "rocksdb", test_case(LocalNetConfig::new_test(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
     use fungible::{FungibleTokenAbi, InitialState};

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -32,6 +32,7 @@ linera-version.workspace = true
 linera-views.workspace = true
 port-selector.workspace = true
 prost.workspace = true
+serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, features = ["codegen", "prost", "transport"] }

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -9,7 +9,7 @@ message KeyValue {
 message KeyValueAppend {
   bytes key = 1;
   bytes value = 2;
-  bool status = 3;
+  bool last = 3;
 }
 
 message Statement {

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -33,7 +33,7 @@ message RequestReadValue {
 message ReplyReadValue {
   optional bytes value = 1;
   int64 recover_key = 2;
-  int32 n_block = 3;
+  int32 num_chunks = 3;
 }
 
 
@@ -53,7 +53,7 @@ message RequestReadMultiValues {
 message ReplyReadMultiValues {
   repeated OptValue values = 1;
   int64 recover_key = 2;
-  int32 n_block = 3;
+  int32 num_chunks = 3;
 }
 
 
@@ -64,7 +64,7 @@ message RequestFindKeysByPrefix {
 message ReplyFindKeysByPrefix {
   repeated bytes keys = 1;
   int64 recover_key = 2;
-  int32 n_block = 3;
+  int32 num_chunks = 3;
 }
 
 
@@ -75,7 +75,7 @@ message RequestFindKeyValuesByPrefix {
 message ReplyFindKeyValuesByPrefix {
   repeated KeyValue key_values = 1;
   int64 recover_key = 2;
-  int32 n_block = 3;
+  int32 num_chunks = 3;
 }
 
 

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -32,6 +32,8 @@ message RequestReadValue {
 
 message ReplyReadValue {
   optional bytes value = 1;
+  int64 recover_key = 2;
+  int32 n_block = 3;
 }
 
 
@@ -50,6 +52,8 @@ message RequestReadMultiValues {
 
 message ReplyReadMultiValues {
   repeated OptValue values = 1;
+  int64 recover_key = 2;
+  int32 n_block = 3;
 }
 
 
@@ -59,6 +63,8 @@ message RequestFindKeysByPrefix {
 
 message ReplyFindKeysByPrefix {
   repeated bytes keys = 1;
+  int64 recover_key = 2;
+  int32 n_block = 3;
 }
 
 
@@ -68,6 +74,8 @@ message RequestFindKeyValuesByPrefix {
 
 message ReplyFindKeyValuesByPrefix {
   repeated KeyValue key_values = 1;
+  int64 recover_key = 2;
+  int32 n_block = 3;
 }
 
 
@@ -80,7 +88,7 @@ message ReplyWriteBatchExtended {
 
 
 message RequestSpecificBlock {
-  bytes key = 1;
+  int64 recover_key = 1;
   int32 index = 2;
 }
 
@@ -135,6 +143,7 @@ service StoreProcessor {
   rpc ProcessFindKeysByPrefix (RequestFindKeysByPrefix) returns (ReplyFindKeysByPrefix) {}
   rpc ProcessFindKeyValuesByPrefix (RequestFindKeyValuesByPrefix) returns (ReplyFindKeyValuesByPrefix) {}
   rpc ProcessWriteBatchExtended (RequestWriteBatchExtended) returns (ReplyWriteBatchExtended) {}
+  rpc ProcessSpecificBlock (RequestSpecificBlock) returns (ReplySpecificBlock) {}
   rpc ProcessCreateNamespace (RequestCreateNamespace) returns (ReplyCreateNamespace) {}
   rpc ProcessExistsNamespace (RequestExistsNamespace) returns (ReplyExistsNamespace) {}
   rpc ProcessDeleteNamespace (RequestDeleteNamespace) returns (ReplyDeleteNamespace) {}

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -71,11 +71,11 @@ message ReplyFindKeyValuesByPrefix {
 }
 
 
-message RequestWriteBatch {
+message RequestWriteBatchExtended {
   repeated Statement statements = 1;
 }
 
-message ReplyWriteBatch {
+message ReplyWriteBatchExtended {
 }
 
 
@@ -124,7 +124,7 @@ service StoreProcessor {
   rpc ProcessReadMultiValues (RequestReadMultiValues) returns (ReplyReadMultiValues) {}
   rpc ProcessFindKeysByPrefix (RequestFindKeysByPrefix) returns (ReplyFindKeysByPrefix) {}
   rpc ProcessFindKeyValuesByPrefix (RequestFindKeyValuesByPrefix) returns (ReplyFindKeyValuesByPrefix) {}
-  rpc ProcessWriteBatch (RequestWriteBatch) returns (ReplyWriteBatch) {}
+  rpc ProcessWriteBatchExtended (RequestWriteBatchExtended) returns (ReplyWriteBatchExtended) {}
   rpc ProcessCreateNamespace (RequestCreateNamespace) returns (ReplyCreateNamespace) {}
   rpc ProcessExistsNamespace (RequestExistsNamespace) returns (ReplyExistsNamespace) {}
   rpc ProcessDeleteNamespace (RequestDeleteNamespace) returns (ReplyDeleteNamespace) {}

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -6,11 +6,18 @@ message KeyValue {
   bytes value = 2;
 }
 
+message KeyValueAppend {
+  bytes key = 1;
+  bytes value = 2;
+  bool status = 3;
+}
+
 message Statement {
   oneof Operation {
     bytes delete = 1;
     KeyValue put = 2;
-    bytes delete_prefix = 3;
+    KeyValueAppend append = 3;
+    bytes delete_prefix = 4;
   }
 }
 

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -87,13 +87,13 @@ message ReplyWriteBatchExtended {
 }
 
 
-message RequestSpecificBlock {
+message RequestSpecificChunk {
   int64 recover_key = 1;
   int32 index = 2;
 }
 
-message ReplySpecificBlock {
-  bytes block = 1;
+message ReplySpecificChunk {
+  bytes chunk = 1;
 }
 
 
@@ -143,7 +143,7 @@ service StoreProcessor {
   rpc ProcessFindKeysByPrefix (RequestFindKeysByPrefix) returns (ReplyFindKeysByPrefix) {}
   rpc ProcessFindKeyValuesByPrefix (RequestFindKeyValuesByPrefix) returns (ReplyFindKeyValuesByPrefix) {}
   rpc ProcessWriteBatchExtended (RequestWriteBatchExtended) returns (ReplyWriteBatchExtended) {}
-  rpc ProcessSpecificBlock (RequestSpecificBlock) returns (ReplySpecificBlock) {}
+  rpc ProcessSpecificChunk (RequestSpecificChunk) returns (ReplySpecificChunk) {}
   rpc ProcessCreateNamespace (RequestCreateNamespace) returns (ReplyCreateNamespace) {}
   rpc ProcessExistsNamespace (RequestExistsNamespace) returns (ReplyExistsNamespace) {}
   rpc ProcessDeleteNamespace (RequestDeleteNamespace) returns (ReplyDeleteNamespace) {}

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -32,7 +32,7 @@ message RequestReadValue {
 
 message ReplyReadValue {
   optional bytes value = 1;
-  int64 recover_key = 2;
+  int64 message_index = 2;
   int32 num_chunks = 3;
 }
 
@@ -52,7 +52,7 @@ message RequestReadMultiValues {
 
 message ReplyReadMultiValues {
   repeated OptValue values = 1;
-  int64 recover_key = 2;
+  int64 message_index = 2;
   int32 num_chunks = 3;
 }
 
@@ -63,7 +63,7 @@ message RequestFindKeysByPrefix {
 
 message ReplyFindKeysByPrefix {
   repeated bytes keys = 1;
-  int64 recover_key = 2;
+  int64 message_index = 2;
   int32 num_chunks = 3;
 }
 
@@ -74,7 +74,7 @@ message RequestFindKeyValuesByPrefix {
 
 message ReplyFindKeyValuesByPrefix {
   repeated KeyValue key_values = 1;
-  int64 recover_key = 2;
+  int64 message_index = 2;
   int32 num_chunks = 3;
 }
 
@@ -88,7 +88,7 @@ message ReplyWriteBatchExtended {
 
 
 message RequestSpecificChunk {
-  int64 recover_key = 1;
+  int64 message_index = 1;
   int32 index = 2;
 }
 

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -73,18 +73,9 @@ message ReplyFindKeyValuesByPrefix {
 
 message RequestWriteBatch {
   repeated Statement statements = 1;
-  bytes base_key = 2;
 }
 
 message ReplyWriteBatch {
-}
-
-
-message RequestClearJournal {
-  bytes base_key = 1;
-}
-
-message ReplyClearJournal {
 }
 
 
@@ -134,7 +125,6 @@ service StoreProcessor {
   rpc ProcessFindKeysByPrefix (RequestFindKeysByPrefix) returns (ReplyFindKeysByPrefix) {}
   rpc ProcessFindKeyValuesByPrefix (RequestFindKeyValuesByPrefix) returns (ReplyFindKeyValuesByPrefix) {}
   rpc ProcessWriteBatch (RequestWriteBatch) returns (ReplyWriteBatch) {}
-  rpc ProcessClearJournal (RequestClearJournal) returns (ReplyClearJournal) {}
   rpc ProcessCreateNamespace (RequestCreateNamespace) returns (ReplyCreateNamespace) {}
   rpc ProcessExistsNamespace (RequestExistsNamespace) returns (ReplyExistsNamespace) {}
   rpc ProcessDeleteNamespace (RequestDeleteNamespace) returns (ReplyDeleteNamespace) {}

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -79,6 +79,16 @@ message ReplyWriteBatchExtended {
 }
 
 
+message RequestSpecificBlock {
+  bytes key = 1;
+  int32 index = 2;
+}
+
+message ReplySpecificBlock {
+  bytes block = 1;
+}
+
+
 message RequestCreateNamespace {
   bytes namespace = 1;
 }

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::{ServiceContextError, ServiceStoreConfig},
-    common::{KeyTag, MAX_PAYLOAD_SIZE},
+    common::{KeyTag, ServiceContextError, ServiceStoreConfig, MAX_PAYLOAD_SIZE},
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
         KeyValueAppend, ReplyContainsKey, ReplyExistsNamespace, ReplyFindKeyValuesByPrefix,
@@ -33,7 +32,6 @@ use linera_views::test_utils::generate_test_namespace;
 
 // The maximum key size is set to 1M rather arbitrarily.
 const MAX_KEY_SIZE: usize = 1000000;
-
 
 // The shared store client.
 // * Interior mutability is required for client because
@@ -139,7 +137,10 @@ impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
         &self,
         key_prefix: &[u8],
     ) -> Result<Vec<Vec<u8>>, ServiceContextError> {
-        ensure!(key_prefix.len() <= MAX_KEY_SIZE, ServiceContextError::KeyTooLong);
+        ensure!(
+            key_prefix.len() <= MAX_KEY_SIZE,
+            ServiceContextError::KeyTooLong
+        );
         let mut full_key_prefix = self.namespace.clone();
         full_key_prefix.extend(key_prefix);
         let query = RequestFindKeysByPrefix {
@@ -166,7 +167,10 @@ impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
         &self,
         key_prefix: &[u8],
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ServiceContextError> {
-        ensure!(key_prefix.len() <= MAX_KEY_SIZE, ServiceContextError::KeyTooLong);
+        ensure!(
+            key_prefix.len() <= MAX_KEY_SIZE,
+            ServiceContextError::KeyTooLong
+        );
         let mut full_key_prefix = self.namespace.clone();
         full_key_prefix.extend(key_prefix);
         let query = RequestFindKeyValuesByPrefix {
@@ -325,7 +329,10 @@ impl ServiceStoreClient {
     ) -> Result<S, ServiceContextError> {
         let mut value = Vec::new();
         for index in 0..num_chunks {
-            let query = RequestSpecificChunk { message_index, index };
+            let query = RequestSpecificChunk {
+                message_index,
+                index,
+            };
             let request = tonic::Request::new(query);
             let response = client.process_specific_chunk(request).await?;
             let response = response.into_inner();

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -203,10 +203,11 @@ impl WritableKeyValueStore<ServiceContextError> for ServiceStoreClient {
                     let value_blocks = value.chunks(MAX_GRPC_REQUEST_SIZE).collect::<Vec<_>>();
                     let n_block = value_blocks.len();
                     for i_block in 0..n_block {
-                        let last = i_block + 1 < n_block;
+                        let last = i_block + 1 == n_block;
+                        let value = value_blocks[i_block].to_vec();
                         let operation = Operation::Append(KeyValueAppend {
                             key: full_key.clone(),
-                            value: value_blocks[i_block].to_vec(),
+                            value,
                             last,
                         });
                         statements = vec![Statement {
@@ -250,6 +251,7 @@ impl ServiceStoreClient {
     }
 
     async fn submit_statements(&self, statements: Vec<Statement>) -> Result<(), ServiceContextError> {
+        println!("submit_statements |statements|={}", statements.len());
         if statements.len() > 0 {
             let query = RequestWriteBatchExtended {
                 statements,

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -85,7 +85,7 @@ impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
         let _guard = self.acquire().await;
         let response = client.process_read_value(request).await?;
         let response = response.get_ref();
-        let ReplyReadValue { value } = response;
+        let ReplyReadValue { value, recover_key, n_block } = response;
         Ok(value.clone())
     }
 
@@ -118,7 +118,7 @@ impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
         let _guard = self.acquire().await;
         let response = client.process_read_multi_values(request).await?;
         let response = response.into_inner();
-        let ReplyReadMultiValues { values } = response;
+        let ReplyReadMultiValues { values, recover_key, n_block } = response;
         let values = values.into_iter().map(|x| x.value).collect::<Vec<_>>();
         Ok(values)
     }
@@ -137,7 +137,7 @@ impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
         let _guard = self.acquire().await;
         let response = client.process_find_keys_by_prefix(request).await?;
         let response = response.into_inner();
-        let ReplyFindKeysByPrefix { keys } = response;
+        let ReplyFindKeysByPrefix { keys, recover_key, n_block } = response;
         Ok(keys)
     }
 
@@ -155,7 +155,7 @@ impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
         let _guard = self.acquire().await;
         let response = client.process_find_key_values_by_prefix(request).await?;
         let response = response.into_inner();
-        let ReplyFindKeyValuesByPrefix { key_values } = response;
+        let ReplyFindKeyValuesByPrefix { key_values, recover_key, n_block } = response;
         let key_values = key_values
             .into_iter()
             .map(|x| (x.key, x.value))

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -9,7 +9,7 @@ use crate::{
         ReplyListAll, ReplyReadMultiValues, ReplyReadValue,
         RequestContainsKey, RequestCreateNamespace, RequestDeleteAll, RequestDeleteNamespace,
         RequestExistsNamespace, RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix,
-        RequestListAll, RequestReadMultiValues, RequestReadValue, RequestWriteBatch, Statement,
+        RequestListAll, RequestReadMultiValues, RequestReadValue, RequestWriteBatchExtended, Statement,
     },
 };
 use async_lock::{RwLock, Semaphore, SemaphoreGuard};
@@ -251,13 +251,13 @@ impl ServiceStoreClient {
 
     async fn submit_statements(&self, statements: Vec<Statement>) -> Result<(), ServiceContextError> {
         if statements.len() > 0 {
-            let query = RequestWriteBatch {
+            let query = RequestWriteBatchExtended {
                 statements,
             };
             let request = tonic::Request::new(query);
             let mut client = self.client.write().await;
             let _guard = self.acquire().await;
-            let _response = client.process_write_batch(request).await?;
+            let _response = client.process_write_batch_extended(request).await?;
         }
         Ok(())
     }

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -25,7 +25,8 @@ const TEST_SHARED_STORE_MAX_STREAM_QUERIES: usize = 10;
 // That size occurs in almost every use of GRPC and in particular the
 // `tonic` library. In particular for the `tonic` library, the limit is
 // both for incoming and outgoing messages.
-// We decrease the 4194304 to 4000000 for safety reasons.
+// We decrease the 4194304 to 4000000 to leave space for the rest of the message
+// (that includes length prefixes)
 pub const MAX_PAYLOAD_SIZE: usize = 4000000;
 
 /// Key tags to create the sub keys used for storing data on storage.

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -3,6 +3,7 @@
 
 use linera_base::command::resolve_binary;
 use linera_views::{common::CommonStoreConfig, value_splitting::DatabaseConsistencyError};
+use linera_views::common::MIN_VIEW_TAG;
 use std::path::PathBuf;
 use thiserror::Error;
 use tonic::Status;
@@ -16,6 +17,23 @@ const TEST_SHARED_STORE_MAX_CONCURRENT_QUERIES: usize = 10;
 /// The number of entries in a stream of the tests can be controlled by this parameter for tests.
 #[cfg(any(test, feature = "test"))]
 const TEST_SHARED_STORE_MAX_STREAM_QUERIES: usize = 10;
+
+// The maximal block size on GRPC is 4M.
+//
+// That size occurs in almost every use of GRPC and in particular the
+// `tonic` library. In particular for the `tonic` library, the limit is
+// both for incoming and outgoing messages.
+// We decrease the 4194304 to 4000000 for safety reasons.
+pub const MAX_PAYLOAD_SIZE: usize = 4000000;
+
+/// Key tags to create the sub keys used for storing data on storage.
+#[repr(u8)]
+pub enum KeyTag {
+    /// Prefix for the storage of the keys of the map
+    Key = MIN_VIEW_TAG,
+    /// Prefix for the storage of existence or not of the namespaces.
+    Namespace,
+}
 
 #[derive(Debug, Error)]
 pub enum ServiceContextError {

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -49,6 +49,10 @@ pub enum ServiceContextError {
     #[error(transparent)]
     GrpcError(#[from] Status),
 
+    /// The key must have at most 1M
+    #[error("The key must have at most 1M")]
+    KeyTooLong,
+
     /// Transport error
     #[error(transparent)]
     TransportError(#[from] tonic::transport::Error),

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::command::resolve_binary;
-use linera_views::{common::CommonStoreConfig, value_splitting::DatabaseConsistencyError};
-use linera_views::common::MIN_VIEW_TAG;
+use linera_views::{
+    common::{CommonStoreConfig, MIN_VIEW_TAG},
+    value_splitting::DatabaseConsistencyError,
+};
 use std::path::PathBuf;
 use thiserror::Error;
 use tonic::Status;

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -51,8 +51,8 @@ pub enum ServiceContextError {
     #[error(transparent)]
     GrpcError(#[from] Status),
 
-    /// The key must have at most 1M
-    #[error("The key must have at most 1M")]
+    /// The key size must be at most 1 MB
+    #[error("The key size must be at most 1 MB")]
     KeyTooLong,
 
     /// Transport error

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -11,6 +11,8 @@ use crate::key_value_store::{
     RequestExistsNamespace, RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix, RequestListAll,
     RequestReadMultiValues, RequestReadValue, RequestWriteBatch,
 };
+use std::sync::Arc;
+use async_lock::RwLock;
 use linera_views::{
     batch::Batch,
     common::{
@@ -47,7 +49,7 @@ enum ServiceStoreServerInternal {
 
 struct ServiceStoreServer {
     store: ServiceStoreServerInternal,
-    pending_big_puts: BTreeMap<Vec<u8>, Vec<u8>>,
+    pending_big_puts: Arc<RwLock<BTreeMap<Vec<u8>, Vec<u8>>>>,
 }
 
 
@@ -400,7 +402,7 @@ async fn main() {
             (store, endpoint)
         }
     };
-    let pending_big_puts = BTreeMap::default();
+    let pending_big_puts = Arc::new(RwLock::new(BTreeMap::default()));
     let store = ServiceStoreServer { store, pending_big_puts };
     let endpoint = endpoint.parse().unwrap();
     Server::builder()

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -6,10 +6,10 @@ use crate::key_value_store::{
     store_processor_server::{StoreProcessor, StoreProcessorServer},
     KeyValue, OptValue, ReplyContainsKey, ReplyCreateNamespace, ReplyDeleteAll,
     ReplyDeleteNamespace, ReplyExistsNamespace, ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix,
-    ReplyListAll, ReplyReadMultiValues, ReplyReadValue, ReplyWriteBatch,
+    ReplyListAll, ReplyReadMultiValues, ReplyReadValue, ReplyWriteBatchExtended,
     RequestContainsKey, RequestCreateNamespace, RequestDeleteAll, RequestDeleteNamespace,
     RequestExistsNamespace, RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix, RequestListAll,
-    RequestReadMultiValues, RequestReadValue, RequestWriteBatch,
+    RequestReadMultiValues, RequestReadValue, RequestWriteBatchExtended,
 };
 use std::sync::Arc;
 use async_lock::RwLock;
@@ -271,12 +271,12 @@ impl StoreProcessor for ServiceStoreServer {
         Ok(Response::new(response))
     }
 
-    async fn process_write_batch(
+    async fn process_write_batch_extended(
         &self,
-        request: Request<RequestWriteBatch>,
-    ) -> Result<Response<ReplyWriteBatch>, Status> {
+        request: Request<RequestWriteBatchExtended>,
+    ) -> Result<Response<ReplyWriteBatchExtended>, Status> {
         let request = request.into_inner();
-        let RequestWriteBatch {
+        let RequestWriteBatchExtended {
             statements,
         } = request;
         let mut batch = Batch::default();
@@ -311,7 +311,7 @@ impl StoreProcessor for ServiceStoreServer {
         if batch.size() > 0 {
             self.write_batch(batch).await?;
         }
-        let response = ReplyWriteBatch {};
+        let response = ReplyWriteBatchExtended {};
         Ok(Response::new(response))
     }
 

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -37,7 +37,7 @@ pub(crate) enum KeyTag {
     Namespace,
 }
 
-pub enum ServiceStoreServer {
+enum ServiceStoreServer {
     Memory(MemoryStore),
     /// The RocksDb key value store
     #[cfg(feature = "rocksdb")]
@@ -293,6 +293,8 @@ impl StoreProcessor for ServiceStoreServer {
                 }
                 Operation::Put(key_value) => {
                     batch.put_key_value_bytes(key_value.key, key_value.value);
+                }
+                Operation::Append(_) => {
                 }
                 Operation::DeletePrefix(key_prefix) => {
                     batch.delete_key_prefix(key_prefix);

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -12,13 +12,11 @@ use crate::key_value_store::{
     RequestFindKeysByPrefix, RequestListAll, RequestReadMultiValues, RequestReadValue,
     RequestSpecificChunk, RequestWriteBatchExtended,
 };
-use linera_storage_service::common::{KeyTag, MAX_PAYLOAD_SIZE};
 use async_lock::RwLock;
+use linera_storage_service::common::{KeyTag, MAX_PAYLOAD_SIZE};
 use linera_views::{
     batch::Batch,
-    common::{
-        AdminKeyValueStore, CommonStoreConfig, ReadableKeyValueStore, WritableKeyValueStore,
-    },
+    common::{AdminKeyValueStore, CommonStoreConfig, ReadableKeyValueStore, WritableKeyValueStore},
     memory::{create_memory_store_stream_queries, MemoryStore},
     rocks_db::{RocksDbStore, RocksDbStoreConfig},
 };
@@ -399,7 +397,10 @@ impl StoreProcessor for ServiceStoreServer {
         request: Request<RequestSpecificChunk>,
     ) -> Result<Response<ReplySpecificChunk>, Status> {
         let request = request.into_inner();
-        let RequestSpecificChunk { message_index, index } = request;
+        let RequestSpecificChunk {
+            message_index,
+            index,
+        } = request;
         let mut pending_big_reads = self.pending_big_reads.write().await;
         let Some(entry) = pending_big_reads.chunks_by_index.get(&message_index) else {
             unreachable!();

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -323,7 +323,9 @@ impl StoreProcessor for ServiceStoreServer {
                 }
             }
         }
-        self.write_batch(batch, &base_key).await?;
+        if batch.size() > 0 {
+            self.write_batch(batch, &base_key).await?;
+        }
         let response = ReplyWriteBatch {};
         Ok(Response::new(response))
     }

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -184,10 +184,10 @@ impl ServiceStoreServer {
             .collect::<Vec<_>>();
         let num_chunks = chunks.len() as i32;
         let mut pending_big_reads = self.pending_big_reads.write().await;
-        let pos = pending_big_reads.index;
+        let message_index = pending_big_reads.index;
         pending_big_reads.index += 1;
-        pending_big_reads.chunks_by_index.insert(pos, chunks);
-        (pos, num_chunks)
+        pending_big_reads.chunks_by_index.insert(message_index, chunks);
+        (message_index, num_chunks)
     }
 }
 
@@ -403,7 +403,7 @@ impl StoreProcessor for ServiceStoreServer {
         } = request;
         let mut pending_big_reads = self.pending_big_reads.write().await;
         let Some(entry) = pending_big_reads.chunks_by_index.get(&message_index) else {
-            unreachable!();
+            return Err(Status::not_found("process_specific_chunk"))
         };
         let index = index as usize;
         let chunk = entry[index].clone();

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -186,7 +186,9 @@ impl ServiceStoreServer {
         let mut pending_big_reads = self.pending_big_reads.write().await;
         let message_index = pending_big_reads.index;
         pending_big_reads.index += 1;
-        pending_big_reads.chunks_by_index.insert(message_index, chunks);
+        pending_big_reads
+            .chunks_by_index
+            .insert(message_index, chunks);
         (message_index, num_chunks)
     }
 }
@@ -403,7 +405,7 @@ impl StoreProcessor for ServiceStoreServer {
         } = request;
         let mut pending_big_reads = self.pending_big_reads.write().await;
         let Some(entry) = pending_big_reads.chunks_by_index.get(&message_index) else {
-            return Err(Status::not_found("process_specific_chunk"))
+            return Err(Status::not_found("process_specific_chunk"));
         };
         let index = index as usize;
         let chunk = entry[index].clone();

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -5,13 +5,14 @@ use linera_storage_service::{
     child::{get_free_port, StorageService},
     client::{create_service_test_store, service_config_from_endpoint, ServiceStoreClient},
 };
-use linera_views::test_utils::{
-    admin_test, get_random_test_scenarios, run_reads, run_writes_from_blank, run_writes_from_state,
+use linera_views::{
+    batch::Batch,
+    test_utils,
+    test_utils::{
+        admin_test, get_random_byte_vector, get_random_test_scenarios, run_reads,
+        run_test_batch_from_blank, run_writes_from_blank, run_writes_from_state,
+    },
 };
-use linera_views::batch::Batch;
-use linera_views::test_utils;
-use linera_views::test_utils::get_random_byte_vector;
-use linera_views::test_utils::run_test_batch_from_blank;
 
 /// The endpoint used for the storage service tests.
 #[cfg(test)]

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -8,6 +8,10 @@ use linera_storage_service::{
 use linera_views::test_utils::{
     admin_test, get_random_test_scenarios, run_reads, run_writes_from_blank, run_writes_from_state,
 };
+use linera_views::batch::Batch;
+use linera_views::test_utils;
+use linera_views::test_utils::get_random_byte_vector;
+use linera_views::test_utils::run_test_batch_from_blank;
 
 /// The endpoint used for the storage service tests.
 #[cfg(test)]
@@ -48,4 +52,18 @@ async fn test_service_admin() {
     let _guard = get_storage_service_guard(&endpoint).run().await;
     let config = service_config_from_endpoint(&endpoint).expect("config");
     admin_test::<ServiceStoreClient>(&config).await;
+}
+
+#[tokio::test]
+async fn test_service_big_raw_write() {
+    let endpoint = get_free_port().await.unwrap();
+    let _guard = get_storage_service_guard(&endpoint).run_service().await;
+    let key_value_store = create_service_test_store(&endpoint).await.unwrap();
+    let n = 5000000;
+    let mut rng = test_utils::make_deterministic_rng();
+    let vector = get_random_byte_vector(&mut rng, &[], n);
+    let mut batch = Batch::new();
+    let key_prefix = vec![43];
+    batch.put_key_value_bytes(vec![43, 57], vector);
+    run_test_batch_from_blank(&key_value_store, key_prefix, batch).await;
 }

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -58,7 +58,7 @@ async fn test_service_admin() {
 #[tokio::test]
 async fn test_service_big_raw_write() {
     let endpoint = get_free_port().await.unwrap();
-    let _guard = get_storage_service_guard(&endpoint).run_service().await;
+    let _guard = get_storage_service_guard(&endpoint).run().await;
     let key_value_store = create_service_test_store(&endpoint).await.unwrap();
     let n = 5000000;
     let mut rng = test_utils::make_deterministic_rng();

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -442,7 +442,9 @@ async fn read_key_values_prefix<C: KeyValueStore + Sync>(
     key_values
 }
 
-async fn run_test_batch_from_blank<C: KeyValueStore + Sync>(
+/// Running from a prefix, we write the data in it and then
+/// we check that we have the correct result.
+pub async fn run_test_batch_from_blank<C: KeyValueStore + Sync>(
     key_value_store: &C,
     key_prefix: Vec<u8>,
     batch: Batch,

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -442,8 +442,7 @@ async fn read_key_values_prefix<C: KeyValueStore + Sync>(
     key_values
 }
 
-/// Running from a prefix, we write the data in it and then
-/// we check that we have the correct result.
+/// Writes and then reads data under a prefix, and verifies the result.
 pub async fn run_test_batch_from_blank<C: KeyValueStore + Sync>(
     key_value_store: &C,
     key_prefix: Vec<u8>,


### PR DESCRIPTION
## Motivation

The service store is limited to 4M in size which is a classic limit of GRPC server. This prevents
having the matching engine test working on `service`. Here we address this limitation.

## Proposal

The following steps were done:
* The submission of the write_batch was changed so that now we incrementally submit the batch. In the case of big values, we split into some blocks which are then put together.
* We did not use the value-splitting mechanism since we are in full control of both sides of the divide. The lack of use of the value-splitting gets us better speed.
* The limitation of 4M also applies to the returning values. That limitation is for tonic, which may be specific to tonic. This limits to the `read_value_bytes`, `read_multi_values_bytes`, `find_keys_by_prefix`, and `find_key_values_by_prefix`.

These modifications allow to make the end-to-end test of the matching_engine to work.

## Test Plan

The test for the matching_engine was switched from `rocksdb` to `service` which was the objective and an individual test for writing a single big value was introduced.

## Release Plan

Nothing relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
