### PR TITLE
`linera-service`: enable gRPC-Web on the right service

### DIFF
--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -212,7 +212,7 @@ impl GrpcProxy {
             .set_serving::<ValidatorNodeServer<GrpcProxy>>()
             .await;
         let internal_server = Server::builder()
-            .add_service(tonic_web::enable(self.as_notifier_service()))
+            .add_service(self.as_notifier_service())
             .serve(self.internal_address());
         let public_server = self
             .public_server()?
@@ -222,7 +222,7 @@ impl GrpcProxy {
                     .into_inner(),
             )
             .add_service(health_service)
-            .add_service(self.as_validator_node())
+            .add_service(tonic_web::enable(self.as_validator_node()))
             .serve(self.public_address());
 
         select! {


### PR DESCRIPTION
## Motivation

To my great embarrassment, in https://github.com/linera-io/linera-protocol/pull/1735 I in fact added gRPC-Web support to the wrong service on the proxy (the internal notifications service, instead of the external-facing validator node service).

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Fix it.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

As in the original PR.  The new test in https://github.com/linera-io/linera-protocol/pull/1738 would catch it. 

<!-- How to test that the changes are correct. -->

## Release Plan

No special handling required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
