### PR TITLE
`linera-service`: implement gRPC reflection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3319,6 +3319,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tonic-health",
+ "tonic-reflection",
  "tower",
  "tracing",
 ]
@@ -3442,6 +3443,7 @@ dependencies = [
  "toml 0.8.10",
  "tonic",
  "tonic-health",
+ "tonic-reflection",
  "tonic-web",
  "tower",
  "tower-http 0.5.2",
@@ -6124,6 +6126,19 @@ checksum = "2cef6e24bc96871001a7e48e820ab240b3de2201e59b517cf52835df2f1d2350"
 dependencies = [
  "async-stream",
  "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548c227bd5c0fae5925812c4ec6c66ffcfced23ea370cb823f4d18f0fc1cb6a7"
+dependencies = [
+ "prost",
+ "prost-types",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ thiserror = "1.0.57"
 tonic = { version = "0.11", default-features = false }
 tonic-build = { version = "0.11", default-features = false }
 tonic-health = "0.11"
+tonic-reflection = "0.11"
 tonic-web = "0.11"
 tokio = "1.36.0"
 tokio-stream = "0.1.14"

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -29,7 +29,7 @@ metrics = [
     "linera-views/metrics",
 ]
 
-server = ["tonic-health"]
+server = ["tonic-health", "tonic-reflection"]
 simple-network = ["tokio-util/net"]
 
 web = [
@@ -65,6 +65,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tokio-util = { workspace = true, optional = true, features = ["codec"] }
 tonic-health = { workspace = true, optional = true }
+tonic-reflection = { workspace = true, optional = true }
 tower.workspace = true
 tracing.workspace = true
 

--- a/linera-rpc/build.rs
+++ b/linera-rpc/build.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out_dir: std::path::PathBuf = std::env::var("OUT_DIR")?.into();
+
     let no_includes: &[&str] = &[];
     tonic_build::configure()
+        .file_descriptor_set_path(out_dir.join("file_descriptor_set.bin"))
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile(&["proto/rpc.proto"], no_includes)?;
 

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -37,6 +37,10 @@ pub enum GrpcError {
 
     #[error(transparent)]
     InvalidUri(#[from] tonic::codegen::http::uri::InvalidUri),
+
+    #[cfg(with_server)]
+    #[error(transparent)]
+    Reflection(#[from] tonic_reflection::server::Error),
 }
 
 const MEBIBYTE: usize = 1024 * 1024;

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -252,6 +252,10 @@ where
             .max_encoding_message_size(GRPC_MAX_MESSAGE_SIZE)
             .max_decoding_message_size(GRPC_MAX_MESSAGE_SIZE);
 
+        let reflection_service = tonic_reflection::server::Builder::configure()
+            .register_encoded_file_descriptor_set(crate::FILE_DESCRIPTOR_SET)
+            .build()?;
+
         let handle = tokio::spawn(
             tonic::transport::Server::builder()
                 .layer(
@@ -260,6 +264,7 @@ where
                         .into_inner(),
                 )
                 .add_service(health_service)
+                .add_service(reflection_service)
                 .add_service(worker_node)
                 .serve_with_shutdown(server_address, receiver.map(|_| ())),
         );

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -36,3 +36,5 @@ pub struct HandleCertificateRequest {
     pub wait_for_outgoing_messages: bool,
     pub blobs: Vec<linera_chain::data_types::HashedValue>,
 }
+
+pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("file_descriptor_set");

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -80,6 +80,7 @@ tokio-stream.workspace = true
 toml.workspace = true
 tonic = { workspace = true, features = ["transport", "tls", "tls-roots"] }
 tonic-health.workspace = true
+tonic-reflection.workspace = true
 tonic-web.workspace = true
 tower.workspace = true
 tower-http = { workspace = true, features = ["cors"] }


### PR DESCRIPTION
## Motivation

In debugging and developing against gRPC services, reflection is very helpful.  For example, it allows for much easier use of tools like `grpcurl` when the correctness of implementation of the relevant services is unknown. 

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Use the `tonic-reflection` crate to add reflection to both the internal validator node service and the `linera-service` gRPC proxy.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI for regressions.

<!-- How to test that the changes are correct. -->

## Release Plan

Technically adds API (backwards-compatible but forwards-incompatible), so we could bump the minor version number. 

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
