### PR TITLE
Add an ArcChainClient wrapper

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -483,187 +483,6 @@ where
         Ok(self.key_pair().await?.public())
     }
 
-    async fn local_chain_info(
-        this: Arc<Mutex<Self>>,
-        chain_id: ChainId,
-        local_node: &mut LocalNodeClient<S>,
-    ) -> Option<Box<ChainInfo>> {
-        let mut guard = this.lock().await;
-        let Ok(info) = local_node.local_chain_info(chain_id).await else {
-            error!("Fail to read local chain info for {chain_id}");
-            return None;
-        };
-        // Useful in case `chain_id` is the same as the local chain.
-        guard.update_from_info(&info);
-        Some(info)
-    }
-
-    async fn local_next_block_height(
-        this: Arc<Mutex<Self>>,
-        chain_id: ChainId,
-        local_node: &mut LocalNodeClient<S>,
-    ) -> Option<BlockHeight> {
-        let info = Self::local_chain_info(this, chain_id, local_node).await?;
-        Some(info.next_block_height)
-    }
-
-    async fn process_notification<A>(
-        this: Arc<Mutex<Self>>,
-        name: ValidatorName,
-        node: A,
-        mut local_node: LocalNodeClient<S>,
-        notification: Notification,
-    ) where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
-    {
-        match notification.reason {
-            Reason::NewIncomingMessage { origin, height } => {
-                if Self::local_next_block_height(this.clone(), origin.sender, &mut local_node).await
-                    > Some(height)
-                {
-                    debug!("Accepting redundant notification for new message");
-                }
-                if let Err(e) = Self::find_received_certificates_from_validator(
-                    this.clone(),
-                    name,
-                    node,
-                    local_node.clone(),
-                )
-                .await
-                {
-                    error!("Fail to process notification: {e}");
-                }
-                if Self::local_next_block_height(this, origin.sender, &mut local_node).await
-                    <= Some(height)
-                {
-                    error!("Fail to synchronize new message after notification");
-                }
-            }
-            Reason::NewBlock { height, .. } => {
-                let chain_id = notification.chain_id;
-                if Self::local_next_block_height(this.clone(), chain_id, &mut local_node).await
-                    > Some(height)
-                {
-                    debug!("Accepting redundant notification for new block");
-                }
-                match local_node
-                    .try_synchronize_chain_state_from(name, node, chain_id)
-                    .await
-                {
-                    Ok(()) => {
-                        if Self::local_next_block_height(this, chain_id, &mut local_node).await
-                            <= Some(height)
-                        {
-                            error!("Fail to synchronize new block after notification");
-                        }
-                    }
-                    Err(e) => {
-                        error!("Fail to process notification: {e}");
-                    }
-                }
-            }
-            Reason::NewRound { height, round } => {
-                let chain_id = notification.chain_id;
-                if let Some(info) =
-                    Self::local_chain_info(this.clone(), chain_id, &mut local_node).await
-                {
-                    if (info.next_block_height, info.manager.current_round) >= (height, round) {
-                        debug!("Accepting redundant notification for new round");
-                    }
-                }
-                if let Err(error) = local_node
-                    .try_synchronize_chain_state_from(name, node, chain_id)
-                    .await
-                {
-                    error!("Fail to process notification: {error}");
-                }
-                let Some(info) =
-                    Self::local_chain_info(this.clone(), chain_id, &mut local_node).await
-                else {
-                    error!("Fail to read local chain info for {chain_id}");
-                    return;
-                };
-                if (info.next_block_height, info.manager.current_round) < (height, round) {
-                    error!("Fail to synchronize new block after notification");
-                }
-            }
-        }
-    }
-
-    /// Spawns a thread that listens to notifications about the current chain from all validators,
-    /// and synchronizes the local state accordingly.
-    pub async fn listen(this: Arc<Mutex<Self>>) -> Result<(), ChainClientError>
-    where
-        P: Send + 'static,
-    {
-        let mut senders = HashMap::new(); // Senders to cancel notification streams.
-        let mut notifications = this.lock().await.subscribe().await?;
-        if let Err(err) = Self::update_streams(&this, &mut senders).await {
-            error!("Failed to update committee: {}", err);
-        }
-        tokio::spawn(async move {
-            while let Some(notification) = notifications.next().await {
-                if matches!(notification.reason, Reason::NewBlock { .. }) {
-                    if let Err(err) = Self::update_streams(&this, &mut senders).await {
-                        error!("Failed to update committee: {}", err);
-                    }
-                }
-            }
-        });
-        Ok(())
-    }
-
-    async fn update_streams(
-        this: &Arc<Mutex<Self>>,
-        senders: &mut HashMap<ValidatorName, AbortHandle>,
-    ) -> Result<(), ChainClientError>
-    where
-        P: Send + 'static,
-    {
-        let (chain_id, nodes, local_node) = {
-            let mut guard = this.lock().await;
-            let committee = guard.local_committee().await?;
-            let nodes: HashMap<_, _> = guard.validator_node_provider.make_nodes(&committee)?;
-            (guard.chain_id, nodes, guard.node_client.clone())
-        };
-        // Drop removed validators.
-        senders.retain(|name, abort| {
-            if !nodes.contains_key(name) {
-                abort.abort();
-            }
-            !abort.is_aborted()
-        });
-        // Add tasks for new validators.
-        for (name, mut node) in nodes {
-            let hash_map::Entry::Vacant(entry) = senders.entry(name) else {
-                continue;
-            };
-            let (mut stream, abort) = match node.subscribe(vec![chain_id]).await {
-                Err(error) => {
-                    info!(?error, "Could not connect to validator {name}");
-                    continue;
-                }
-                Ok(stream) => stream::abortable(stream),
-            };
-            let this = this.clone();
-            let local_node = local_node.clone();
-            tokio::spawn(async move {
-                while let Some(notification) = stream.next().await {
-                    Self::process_notification(
-                        this.clone(),
-                        name,
-                        node.clone(),
-                        local_node.clone(),
-                        notification,
-                    )
-                    .await;
-                }
-            });
-            entry.insert(abort);
-        }
-        Ok(())
-    }
-
     /// Prepares the chain for the next operation.
     async fn prepare_chain(&mut self) -> Result<Box<ChainInfo>, ChainClientError> {
         // Verify that our local storage contains enough history compared to the
@@ -1060,47 +879,6 @@ where
             self.receive_certificates_from_validator(name, tracker, certificates)
                 .await;
         }
-        Ok(())
-    }
-
-    /// Attempts to download new received certificates from a particular validator.
-    ///
-    /// This is similar to `find_received_certificates` but for only one validator.
-    /// We also don't try to synchronize the admin chain.
-    pub async fn find_received_certificates_from_validator<A>(
-        this: Arc<Mutex<Self>>,
-        name: ValidatorName,
-        node: A,
-        node_client: LocalNodeClient<S>,
-    ) -> Result<(), ChainClientError>
-    where
-        A: ValidatorNode + Send + Sync + 'static + Clone,
-    {
-        let ((committees, max_epoch), chain_id, current_tracker) = {
-            let mut guard = this.lock().await;
-            (
-                guard.known_committees().await?,
-                guard.chain_id(),
-                *guard.received_certificate_trackers.get(&name).unwrap_or(&0),
-            )
-        };
-        // Proceed to downloading received certificates.
-        let (name, tracker, certificates) = Self::synchronize_received_certificates_from_validator(
-            chain_id,
-            name,
-            current_tracker,
-            committees,
-            max_epoch,
-            node,
-            node_client,
-        )
-        .await?;
-        // Process received certificates. If the client state has changed during the
-        // network calls, we should still be fine.
-        this.lock()
-            .await
-            .receive_certificates_from_validator(name, tracker, certificates)
-            .await;
         Ok(())
     }
 
@@ -2199,4 +1977,233 @@ enum ExecuteBlockOutcome {
     /// We are not the round leader and cannot do anything. Try again at the specified time or
     /// or whenever the round or block height changes.
     WaitForTimeout(RoundTimeout),
+}
+
+impl<P, S> ChainClient<P, S>
+where
+    P: ValidatorNodeProvider + Sync,
+    S: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
+{
+    async fn local_chain_info(
+        this: Arc<Mutex<Self>>,
+        chain_id: ChainId,
+        local_node: &mut LocalNodeClient<S>,
+    ) -> Option<Box<ChainInfo>> {
+        let mut guard = this.lock().await;
+        let Ok(info) = local_node.local_chain_info(chain_id).await else {
+            error!("Fail to read local chain info for {chain_id}");
+            return None;
+        };
+        // Useful in case `chain_id` is the same as the local chain.
+        guard.update_from_info(&info);
+        Some(info)
+    }
+
+    async fn local_next_block_height(
+        this: Arc<Mutex<Self>>,
+        chain_id: ChainId,
+        local_node: &mut LocalNodeClient<S>,
+    ) -> Option<BlockHeight> {
+        let info = Self::local_chain_info(this, chain_id, local_node).await?;
+        Some(info.next_block_height)
+    }
+
+    async fn process_notification<A>(
+        this: Arc<Mutex<Self>>,
+        name: ValidatorName,
+        node: A,
+        mut local_node: LocalNodeClient<S>,
+        notification: Notification,
+    ) where
+        A: ValidatorNode + Send + Sync + 'static + Clone,
+    {
+        match notification.reason {
+            Reason::NewIncomingMessage { origin, height } => {
+                if Self::local_next_block_height(this.clone(), origin.sender, &mut local_node).await
+                    > Some(height)
+                {
+                    debug!("Accepting redundant notification for new message");
+                }
+                if let Err(e) = Self::find_received_certificates_from_validator(
+                    this.clone(),
+                    name,
+                    node,
+                    local_node.clone(),
+                )
+                .await
+                {
+                    error!("Fail to process notification: {e}");
+                }
+                if Self::local_next_block_height(this, origin.sender, &mut local_node).await
+                    <= Some(height)
+                {
+                    error!("Fail to synchronize new message after notification");
+                }
+            }
+            Reason::NewBlock { height, .. } => {
+                let chain_id = notification.chain_id;
+                if Self::local_next_block_height(this.clone(), chain_id, &mut local_node).await
+                    > Some(height)
+                {
+                    debug!("Accepting redundant notification for new block");
+                }
+                match local_node
+                    .try_synchronize_chain_state_from(name, node, chain_id)
+                    .await
+                {
+                    Ok(()) => {
+                        if Self::local_next_block_height(this, chain_id, &mut local_node).await
+                            <= Some(height)
+                        {
+                            error!("Fail to synchronize new block after notification");
+                        }
+                    }
+                    Err(e) => {
+                        error!("Fail to process notification: {e}");
+                    }
+                }
+            }
+            Reason::NewRound { height, round } => {
+                let chain_id = notification.chain_id;
+                if let Some(info) =
+                    Self::local_chain_info(this.clone(), chain_id, &mut local_node).await
+                {
+                    if (info.next_block_height, info.manager.current_round) >= (height, round) {
+                        debug!("Accepting redundant notification for new round");
+                    }
+                }
+                if let Err(error) = local_node
+                    .try_synchronize_chain_state_from(name, node, chain_id)
+                    .await
+                {
+                    error!("Fail to process notification: {error}");
+                }
+                let Some(info) =
+                    Self::local_chain_info(this.clone(), chain_id, &mut local_node).await
+                else {
+                    error!("Fail to read local chain info for {chain_id}");
+                    return;
+                };
+                if (info.next_block_height, info.manager.current_round) < (height, round) {
+                    error!("Fail to synchronize new block after notification");
+                }
+            }
+        }
+    }
+
+    /// Spawns a thread that listens to notifications about the current chain from all validators,
+    /// and synchronizes the local state accordingly.
+    pub async fn listen(this: Arc<Mutex<Self>>) -> Result<(), ChainClientError>
+    where
+        P: Send + 'static,
+    {
+        let mut senders = HashMap::new(); // Senders to cancel notification streams.
+        let mut notifications = this.lock().await.subscribe().await?;
+        if let Err(err) = Self::update_streams(&this, &mut senders).await {
+            error!("Failed to update committee: {}", err);
+        }
+        tokio::spawn(async move {
+            while let Some(notification) = notifications.next().await {
+                if matches!(notification.reason, Reason::NewBlock { .. }) {
+                    if let Err(err) = Self::update_streams(&this, &mut senders).await {
+                        error!("Failed to update committee: {}", err);
+                    }
+                }
+            }
+        });
+        Ok(())
+    }
+
+    async fn update_streams(
+        this: &Arc<Mutex<Self>>,
+        senders: &mut HashMap<ValidatorName, AbortHandle>,
+    ) -> Result<(), ChainClientError>
+    where
+        P: Send + 'static,
+    {
+        let (chain_id, nodes, local_node) = {
+            let mut guard = this.lock().await;
+            let committee = guard.local_committee().await?;
+            let nodes: HashMap<_, _> = guard.validator_node_provider.make_nodes(&committee)?;
+            (guard.chain_id, nodes, guard.node_client.clone())
+        };
+        // Drop removed validators.
+        senders.retain(|name, abort| {
+            if !nodes.contains_key(name) {
+                abort.abort();
+            }
+            !abort.is_aborted()
+        });
+        // Add tasks for new validators.
+        for (name, mut node) in nodes {
+            let hash_map::Entry::Vacant(entry) = senders.entry(name) else {
+                continue;
+            };
+            let (mut stream, abort) = match node.subscribe(vec![chain_id]).await {
+                Err(error) => {
+                    info!(?error, "Could not connect to validator {name}");
+                    continue;
+                }
+                Ok(stream) => stream::abortable(stream),
+            };
+            let this = this.clone();
+            let local_node = local_node.clone();
+            tokio::spawn(async move {
+                while let Some(notification) = stream.next().await {
+                    Self::process_notification(
+                        this.clone(),
+                        name,
+                        node.clone(),
+                        local_node.clone(),
+                        notification,
+                    )
+                    .await;
+                }
+            });
+            entry.insert(abort);
+        }
+        Ok(())
+    }
+
+    /// Attempts to download new received certificates from a particular validator.
+    ///
+    /// This is similar to `find_received_certificates` but for only one validator.
+    /// We also don't try to synchronize the admin chain.
+    pub async fn find_received_certificates_from_validator<A>(
+        this: Arc<Mutex<Self>>,
+        name: ValidatorName,
+        node: A,
+        node_client: LocalNodeClient<S>,
+    ) -> Result<(), ChainClientError>
+    where
+        A: ValidatorNode + Send + Sync + 'static + Clone,
+    {
+        let ((committees, max_epoch), chain_id, current_tracker) = {
+            let mut guard = this.lock().await;
+            (
+                guard.known_committees().await?,
+                guard.chain_id(),
+                *guard.received_certificate_trackers.get(&name).unwrap_or(&0),
+            )
+        };
+        // Proceed to downloading received certificates.
+        let (name, tracker, certificates) = Self::synchronize_received_certificates_from_validator(
+            chain_id,
+            name,
+            current_tracker,
+            committees,
+            max_epoch,
+            node,
+            node_client,
+        )
+        .await?;
+        // Process received certificates. If the client state has changed during the
+        // network calls, we should still be fine.
+        this.lock()
+            .await
+            .receive_certificates_from_validator(name, tracker, certificates)
+            .await;
+        Ok(())
+    }
 }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -11,7 +11,7 @@ use linera_base::{
 };
 use linera_chain::data_types::OutgoingMessage;
 use linera_core::{
-    client::ChainClient,
+    client::{ArcChainClient, ChainClient},
     node::ValidatorNodeProvider,
     worker::{Notification, Reason},
 };
@@ -124,11 +124,11 @@ where
                 return Ok(());
             };
             let client = context_guard.make_chain_client(storage.clone(), chain_id);
-            let client = Arc::new(Mutex::new(client));
+            let client = ArcChainClient::new(client);
             entry.insert(client.clone());
             client
         };
-        ChainClient::listen(client.clone()).await?;
+        client.listen().await?;
         let mut local_stream = {
             let mut guard = client.lock().await;
             let stream = guard.subscribe().await?;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -17,7 +17,7 @@ use linera_base::{
 };
 use linera_chain::data_types::{CertificateValue, ExecutedBlock};
 use linera_core::{
-    client::{ChainClient, ChainClientError},
+    client::{ArcChainClient, ChainClientError},
     data_types::{ChainInfoQuery, ClientOutcome},
     local_node::LocalNodeClient,
     node::ValidatorNodeProvider,
@@ -767,7 +767,7 @@ impl Runnable for Job {
                 let chain_id = chain_client.chain_id();
                 info!("Watching for notifications for chain {:?}", chain_id);
                 let mut notification_stream = chain_client.subscribe().await?;
-                ChainClient::listen(Arc::new(Mutex::new(chain_client))).await?;
+                ArcChainClient::new(chain_client).listen().await?;
                 while let Some(notification) = notification_stream.next().await {
                     if raw {
                         println!("{}", serde_json::to_string(&notification)?);


### PR DESCRIPTION
## Motivation

We are using `Arc<Mutex<ChainClient<_, _>>>` like an object in several places, but have to use `Self::foo(this)` syntax because `Mutex` is not defined in our own crates. Some of these functions also have unnecessarily complicated trait bounds.

## Proposal

Create an `ArcChainClient` wrapper and make these functions methods of it. Simplify the trait bounds.

## Test Plan

(Only refactoring.)


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
