### PR TITLE
Adding minter to mint mutation for NFTs

### DIFF
--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -89,6 +89,7 @@ linera service --port $PORT &
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         mint(
+            minter: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
             name: "nft1",
             payload: [1, 2, 3, 4]
         )

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -91,6 +91,7 @@ linera service --port $PORT &
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         mint(
+            minter: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
             name: "nft1",
             payload: [1, 2, 3, 4]
         )
@@ -192,7 +193,11 @@ impl ServiceAbi for NonFungibleTokenAbi {
 #[derive(Debug, Deserialize, Serialize, GraphQLMutationRoot)]
 pub enum Operation {
     /// Mints a token
-    Mint { name: String, payload: Vec<u8> },
+    Mint {
+        minter: AccountOwner,
+        name: String,
+        payload: Vec<u8>,
+    },
     /// Transfers a token from a (locally owned) account to a (possibly remote) account.
     Transfer {
         source_owner: AccountOwner,

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -153,8 +153,13 @@ struct MutationRoot;
 
 #[Object]
 impl MutationRoot {
-    async fn mint(&self, name: String, payload: Vec<u8>) -> Vec<u8> {
-        bcs::to_bytes(&Operation::Mint { name, payload }).unwrap()
+    async fn mint(&self, minter: AccountOwner, name: String, payload: Vec<u8>) -> Vec<u8> {
+        bcs::to_bytes(&Operation::Mint {
+            minter,
+            name,
+            payload,
+        })
+        .unwrap()
     }
 
     async fn transfer(

--- a/examples/non-fungible/web-frontend/src/App.js
+++ b/examples/non-fungible/web-frontend/src/App.js
@@ -13,8 +13,8 @@ const GET_OWNED_NFTS = gql`
 `;
 
 const MINT_NFT = gql`
-  mutation Mint($name: String!, $payload: [Int!]!) {
-    mint(name: $name, payload: $payload)
+  mutation Mint($minter: AccountOwner!, $name: String!, $payload: [Int!]!) {
+    mint(minter: $minter, name: $name, payload: $payload)
   }
 `;
 
@@ -129,6 +129,7 @@ function App({ chainId, owner }) {
 
     mintNft({
       variables: {
+        minter: `User:${owner}`,
         name: name,
         payload: Array.from(byteArrayFile),
       },

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -115,9 +115,10 @@ impl NonFungibleApp {
         )?)
     }
 
-    async fn mint(&self, name: &String, payload: &Vec<u8>) -> Value {
+    async fn mint(&self, minter: &AccountOwner, name: &String, payload: &Vec<u8>) -> Value {
         let mutation = format!(
-            "mint(name: {}, payload: {})",
+            "mint(minter: {}, name: {}, payload: {})",
+            minter.to_value(),
             name.to_value(),
             payload.to_value(),
         );
@@ -712,7 +713,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) {
         &nft1_payload,
     );
 
-    app1.mint(&nft1_name, &nft1_payload).await;
+    app1.mint(&account_owner1, &nft1_name, &nft1_payload).await;
 
     let mut expected_nft1 = NftOutput {
         token_id: nft1_id.clone(),
@@ -841,7 +842,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) {
     );
 
     // Minting NFT from chain2
-    app2.mint(&nft2_name, &nft2_payload).await;
+    app2.mint(&account_owner2, &nft2_name, &nft2_payload).await;
 
     let expected_nft2 = NftOutput {
         token_id: nft2_id.clone(),


### PR DESCRIPTION
## Motivation

This was an oversight on the initial implementation, we need to make sure that we're authenticated as who we expect to be authenticated as

## Proposal

Add `minter` to the `mint` mutation, and check authentication

## Test Plan

e2e tests + I've also tested in the web UI to make sure that if we're connected to just one node service, mutations from a different account will fail authentication

