### PR TITLE
Return an abort handle from listen.

### DIFF
--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -108,7 +108,7 @@ where
     let sender = ArcChainClient::new(sender);
     // Listen to the notifications on the sender chain.
     let mut notifications = sender.lock().await.subscribe().await?;
-    sender.listen().await?;
+    let _listen_handle = sender.listen().await?;
     {
         let mut sender = sender.lock().await;
         let certificate = sender

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -128,7 +128,7 @@ where
             entry.insert(client.clone());
             client
         };
-        client.listen().await?;
+        let _listen_handle = client.listen().await?;
         let mut local_stream = {
             let mut guard = client.lock().await;
             let stream = guard.subscribe().await?;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -17,7 +17,7 @@ use linera_base::{
 };
 use linera_chain::data_types::{CertificateValue, ExecutedBlock};
 use linera_core::{
-    client::{ArcChainClient, ChainClientError},
+    client::ChainClientError,
     data_types::{ChainInfoQuery, ClientOutcome},
     local_node::LocalNodeClient,
     node::ValidatorNodeProvider,
@@ -765,10 +765,9 @@ impl Runnable for Job {
             Watch { chain_id, raw } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 let mut chain_client = context.make_chain_client(storage, chain_id);
-                let chain_id = chain_client.chain_id();
                 info!("Watching for notifications for chain {:?}", chain_id);
                 let mut notification_stream = chain_client.subscribe().await?;
-                ArcChainClient::new(chain_client).listen().await?;
+                let _listen_handle = chain_client.into_arc().listen().await?;
                 while let Some(notification) = notification_stream.next().await {
                     if raw {
                         println!("{}", serde_json::to_string(&notification)?);


### PR DESCRIPTION
## Motivation

Currently `listen` starts a background task that's impossible to kill and that keeps handling notifications from validators.

## Proposal

Return a handle that kills the background task when dropped.

## Test Plan

This doesn't change anything yet. The existing tests should make sure we don't drop the handle too early anywhere.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
