### PR TITLE
Remove redundant to_string call.

### DIFF
--- a/linera-service/src/cli_wrappers/docker.rs
+++ b/linera-service/src/cli_wrappers/docker.rs
@@ -69,7 +69,7 @@ impl DockerImage {
                 &format!(
                     "build_date={}",
                     // Same format as $(TZ=UTC date)
-                    chrono::Utc::now().format("%a %b %d %T UTC %Y").to_string()
+                    chrono::Utc::now().format("%a %b %d %T UTC %Y")
                 ),
             ]);
 


### PR DESCRIPTION
## Motivation

```
warning: `to_string` applied to a type that implements `Display` in `format!` args
```

## Proposal

Remove the redundant `.to_string()`.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
