### PR TITLE
Refactor guest runtime API to send messages

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -299,7 +299,7 @@ impl AmmContract {
                     input_amount,
                 };
                 self.runtime
-                    .send_message(chain_id, message)
+                    .prepare_message(chain_id, message)
                     .with_authentication();
             }
             Operation::AddLiquidity {
@@ -338,7 +338,7 @@ impl AmmContract {
                     input_amount,
                 };
                 self.runtime
-                    .send_message(chain_id, message)
+                    .prepare_message(chain_id, message)
                     .with_authentication();
             }
         }

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -299,8 +299,9 @@ impl AmmContract {
                     input_amount,
                 };
                 self.runtime
-                    .prepare_message(chain_id, message)
-                    .with_authentication();
+                    .prepare_message(message)
+                    .with_authentication()
+                    .send_to(chain_id);
             }
             Operation::AddLiquidity {
                 owner: _,
@@ -338,8 +339,9 @@ impl AmmContract {
                     input_amount,
                 };
                 self.runtime
-                    .prepare_message(chain_id, message)
-                    .with_authentication();
+                    .prepare_message(message)
+                    .with_authentication()
+                    .send_to(chain_id);
             }
         }
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -132,8 +132,9 @@ impl CrowdFundingContract {
             .call_application(/* authenticated by owner */ true, fungible_id, &call);
         // Second, schedule the attribution of the funds to the (remote) campaign.
         self.runtime
-            .prepare_message(chain_id, Message::PledgeWithAccount { owner, amount })
-            .with_authentication();
+            .prepare_message(Message::PledgeWithAccount { owner, amount })
+            .with_authentication()
+            .send_to(chain_id);
         Ok(())
     }
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -132,7 +132,7 @@ impl CrowdFundingContract {
             .call_application(/* authenticated by owner */ true, fungible_id, &call);
         // Second, schedule the attribution of the funds to the (remote) campaign.
         self.runtime
-            .send_message(chain_id, Message::PledgeWithAccount { owner, amount })
+            .prepare_message(chain_id, Message::PledgeWithAccount { owner, amount })
             .with_authentication();
         Ok(())
     }

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -199,8 +199,9 @@ impl FungibleTokenContract {
                 target_account,
             };
             self.runtime
-                .prepare_message(source_account.chain_id, message)
-                .with_authentication();
+                .prepare_message(message)
+                .with_authentication()
+                .send_to(source_account.chain_id);
         }
 
         Ok(())
@@ -222,8 +223,9 @@ impl FungibleTokenContract {
                 source,
             };
             self.runtime
-                .prepare_message(target_account.chain_id, message)
-                .with_authentication();
+                .prepare_message(message)
+                .with_authentication()
+                .send_to(target_account.chain_id);
         }
     }
 }

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -199,7 +199,7 @@ impl FungibleTokenContract {
                 target_account,
             };
             self.runtime
-                .send_message(source_account.chain_id, message)
+                .prepare_message(source_account.chain_id, message)
                 .with_authentication();
         }
 
@@ -222,7 +222,7 @@ impl FungibleTokenContract {
                 source,
             };
             self.runtime
-                .send_message(target_account.chain_id, message)
+                .prepare_message(target_account.chain_id, message)
                 .with_authentication();
         }
     }

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -321,8 +321,9 @@ impl MatchingEngineContract {
             self.transfer(owner, amount, destination, token_idx);
         }
         self.runtime
-            .prepare_message(chain_id, message)
-            .with_authentication();
+            .prepare_message(message)
+            .with_authentication()
+            .send_to(chain_id);
         Ok(())
     }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -321,7 +321,7 @@ impl MatchingEngineContract {
             self.transfer(owner, amount, destination, token_idx);
         }
         self.runtime
-            .send_message(chain_id, message)
+            .prepare_message(chain_id, message)
             .with_authentication();
         Ok(())
     }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -66,19 +66,17 @@ impl Contract for MetaCounterContract {
             message,
         } = operation;
 
-        let mut message = self
-            .runtime
-            .prepare_message(recipient_id, message)
-            .with_grant(Resources {
-                fuel: fuel_grant,
-                ..Resources::default()
-            });
+        let mut message = self.runtime.prepare_message(message).with_grant(Resources {
+            fuel: fuel_grant,
+            ..Resources::default()
+        });
         if authenticated {
             message = message.with_authentication();
         }
         if is_tracked {
-            message.with_tracking();
+            message = message.with_tracking();
         }
+        message.send_to(recipient_id);
 
         Ok(())
     }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -66,18 +66,18 @@ impl Contract for MetaCounterContract {
             message,
         } = operation;
 
-        let mut send_message =
-            self.runtime
-                .send_message(recipient_id, message)
-                .with_grant(Resources {
-                    fuel: fuel_grant,
-                    ..Resources::default()
-                });
+        let mut message = self
+            .runtime
+            .prepare_message(recipient_id, message)
+            .with_grant(Resources {
+                fuel: fuel_grant,
+                ..Resources::default()
+            });
         if authenticated {
-            send_message = send_message.with_authentication();
+            message = message.with_authentication();
         }
         if is_tracked {
-            send_message.with_tracking();
+            message.with_tracking();
         }
 
         Ok(())

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -189,7 +189,7 @@ impl NativeFungibleTokenContract {
                 source,
             };
             self.runtime
-                .send_message(target.chain_id, message)
+                .prepare_message(target.chain_id, message)
                 .with_authentication();
         }
     }
@@ -205,7 +205,7 @@ impl NativeFungibleTokenContract {
                 target_account: target,
             };
             self.runtime
-                .send_message(source.chain_id, message)
+                .prepare_message(source.chain_id, message)
                 .with_authentication();
         }
     }

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -189,8 +189,9 @@ impl NativeFungibleTokenContract {
                 source,
             };
             self.runtime
-                .prepare_message(target.chain_id, message)
-                .with_authentication();
+                .prepare_message(message)
+                .with_authentication()
+                .send_to(target.chain_id);
         }
     }
 
@@ -205,8 +206,9 @@ impl NativeFungibleTokenContract {
                 target_account: target,
             };
             self.runtime
-                .prepare_message(source.chain_id, message)
-                .with_authentication();
+                .prepare_message(message)
+                .with_authentication()
+                .send_to(source.chain_id);
         }
     }
 

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -220,8 +220,9 @@ impl NonFungibleTokenContract {
             };
 
             self.runtime
-                .prepare_message(target_account.chain_id, message)
-                .with_tracking();
+                .prepare_message(message)
+                .with_tracking()
+                .send_to(target_account.chain_id);
         }
     }
 
@@ -278,8 +279,9 @@ impl NonFungibleTokenContract {
             target_account,
         };
         self.runtime
-            .prepare_message(source_account.chain_id, message)
-            .with_authentication();
+            .prepare_message(message)
+            .with_authentication()
+            .send_to(source_account.chain_id);
     }
 
     async fn add_nft(&mut self, nft: Nft) {

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -220,7 +220,7 @@ impl NonFungibleTokenContract {
             };
 
             self.runtime
-                .send_message(target_account.chain_id, message)
+                .prepare_message(target_account.chain_id, message)
                 .with_tracking();
         }
     }
@@ -278,7 +278,7 @@ impl NonFungibleTokenContract {
             target_account,
         };
         self.runtime
-            .send_message(source_account.chain_id, message)
+            .prepare_message(source_account.chain_id, message)
             .with_authentication();
     }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -136,16 +136,15 @@ where
         destination: impl Into<Destination>,
         message: Application::Message,
     ) {
-        MessageBuilder::new(destination.into(), message);
+        self.prepare_message(message).send_to(destination)
     }
 
     /// Returns a `MessageBuilder` to prepare a message to be sent.
     pub fn prepare_message(
         &mut self,
-        destination: impl Into<Destination>,
         message: Application::Message,
     ) -> MessageBuilder<Application::Message> {
-        MessageBuilder::new(destination.into(), message)
+        MessageBuilder::new(message)
     }
 
     /// Subscribes to a message channel from another chain.
@@ -208,7 +207,10 @@ pub struct MessageBuilder<Message>
 where
     Message: Serialize,
 {
-    message: SendMessageRequest<Message>,
+    authenticated: bool,
+    is_tracked: bool,
+    grant: Resources,
+    message: Message,
 }
 
 impl<Message> MessageBuilder<Message>
@@ -216,51 +218,44 @@ where
     Message: Serialize,
 {
     /// Creates a new [`MessageBuilder`] instance to send the `message` to the `destination`.
-    pub(crate) fn new(destination: Destination, message: Message) -> Self {
+    pub(crate) fn new(message: Message) -> Self {
         MessageBuilder {
-            message: SendMessageRequest {
-                destination,
-                authenticated: false,
-                is_tracked: false,
-                grant: Resources::default(),
-                message,
-            },
+            authenticated: false,
+            is_tracked: false,
+            grant: Resources::default(),
+            message,
         }
     }
 
     /// Marks the message to be tracked, so that the sender receives the message back if it is
     /// rejected by the receiver.
     pub fn with_tracking(mut self) -> Self {
-        self.message.is_tracked = true;
+        self.is_tracked = true;
         self
     }
 
     /// Forwards the authenticated signer with the message.
     pub fn with_authentication(mut self) -> Self {
-        self.message.authenticated = true;
+        self.authenticated = true;
         self
     }
 
     /// Forwards a grant of resources so the receiver can use it to pay for receiving the message.
     pub fn with_grant(mut self, grant: Resources) -> Self {
-        self.message.grant = grant;
+        self.grant = grant;
         self
     }
-}
 
-impl<Message> Drop for MessageBuilder<Message>
-where
-    Message: Serialize,
-{
-    fn drop(&mut self) {
+    /// Schedules this `Message` to be sent to the `destination`.
+    pub fn send_to(self, destination: impl Into<Destination>) {
         let serialized_message =
-            bcs::to_bytes(&self.message.message).expect("Failed to serialize message to be sent");
+            bcs::to_bytes(&self.message).expect("Failed to serialize message to be sent");
 
         let raw_message = SendMessageRequest {
-            destination: self.message.destination.clone(),
-            authenticated: self.message.authenticated,
-            is_tracked: self.message.is_tracked,
-            grant: self.message.grant,
+            destination: destination.into(),
+            authenticated: self.authenticated,
+            is_tracked: self.is_tracked,
+            grant: self.grant,
             message: serialized_message,
         };
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -135,8 +135,8 @@ where
         &mut self,
         destination: impl Into<Destination>,
         message: Application::Message,
-    ) -> MessageSender<Application::Message> {
-        MessageSender::new(destination.into(), message)
+    ) -> MessageBuilder<Application::Message> {
+        MessageBuilder::new(destination.into(), message)
     }
 
     /// Subscribes to a message channel from another chain.
@@ -195,20 +195,20 @@ where
 
 /// A helper type that uses the builder pattern to configure how a message is sent, and then
 /// sends the message once it is dropped.
-pub struct MessageSender<Message>
+pub struct MessageBuilder<Message>
 where
     Message: Serialize,
 {
     message: SendMessageRequest<Message>,
 }
 
-impl<Message> MessageSender<Message>
+impl<Message> MessageBuilder<Message>
 where
     Message: Serialize,
 {
-    /// Creates a new [`MessageSender`] instance to send the `message` to the `destination`.
+    /// Creates a new [`MessageBuilder`] instance to send the `message` to the `destination`.
     pub(crate) fn new(destination: Destination, message: Message) -> Self {
-        MessageSender {
+        MessageBuilder {
             message: SendMessageRequest {
                 destination,
                 authenticated: false,
@@ -239,7 +239,7 @@ where
     }
 }
 
-impl<Message> Drop for MessageSender<Message>
+impl<Message> Drop for MessageBuilder<Message>
 where
     Message: Serialize,
 {

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -135,6 +135,15 @@ where
         &mut self,
         destination: impl Into<Destination>,
         message: Application::Message,
+    ) {
+        MessageBuilder::new(destination.into(), message);
+    }
+
+    /// Returns a `MessageBuilder` to prepare a message to be sent.
+    pub fn prepare_message(
+        &mut self,
+        destination: impl Into<Destination>,
+        message: Application::Message,
     ) -> MessageBuilder<Application::Message> {
         MessageBuilder::new(destination.into(), message)
     }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -203,6 +203,7 @@ where
 
 /// A helper type that uses the builder pattern to configure how a message is sent, and then
 /// sends the message once it is dropped.
+#[must_use]
 pub struct MessageBuilder<Message>
 where
     Message: Serialize,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Having side-effects from `Drop` is not idiomatic Rust, so sending should be made explicit.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Split the original `send_message` API in two: the original that sends the message immediately without any extra configuration, and a new `prepare_message` that returns the builder but requires a call to `send_to` in order to send the message.

## Test Plan

<!-- How to test that the changes are correct. -->
API refactor, so existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Changes the SDK API, so
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
