### PR TITLE
Fix round notification handling for CLI commands.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2153,6 +2153,9 @@ where
         let mut guard = self.lock().await;
         let notifications = guard.subscribe().await?;
         let notifications2 = guard.subscribe().await?;
+        if let Err(error) = guard.synchronize_from_validators().await {
+            error!("Failed to synchronize from validators: {}", error);
+        }
         drop(guard);
         let (mut notifications, abort) = stream::abortable(notifications);
         if let Err(error) = self.update_streams(&mut senders).await {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -106,7 +106,7 @@ where
     let sender = ArcChainClient::new(sender);
     // Listen to the notifications on the sender chain.
     let mut notifications = sender.lock().await.subscribe().await?;
-    let _listen_handle = sender.listen().await?;
+    let (_listen_handle, _) = sender.listen().await?;
     {
         let mut sender = sender.lock().await;
         let certificate = sender

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -132,15 +132,9 @@ where
             client
         };
         let (_listen_handle, mut local_stream) = client.listen().await?;
-        {
-            let mut guard = client.lock().await;
-            // Process the inbox: For messages that are already there we won't receive a
-            // notification.
-            guard.synchronize_from_validators().await?;
-            if let Err(error) = guard.process_inbox_if_owned().await {
-                warn!(%error, "Failed to process inbox after starting stream.");
-            }
-        };
+        if let Err(error) = client.lock().await.process_inbox_if_owned().await {
+            warn!(%error, "Failed to process inbox after starting stream.");
+        }
         while let Some(notification) = local_stream.next().await {
             info!("Received new notification: {:?}", notification);
             if config.delay_before_ms > 0 {

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -131,17 +131,15 @@ where
             entry.insert(client.clone());
             client
         };
-        let _listen_handle = client.listen().await?;
-        let mut local_stream = {
+        let (_listen_handle, mut local_stream) = client.listen().await?;
+        {
             let mut guard = client.lock().await;
-            let stream = guard.subscribe().await?;
             // Process the inbox: For messages that are already there we won't receive a
             // notification.
             guard.synchronize_from_validators().await?;
             if let Err(error) = guard.process_inbox_if_owned().await {
                 warn!(%error, "Failed to process inbox after starting stream.");
             }
-            stream
         };
         while let Some(notification) = local_stream.next().await {
             info!("Received new notification: {:?}", notification);

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -603,13 +603,15 @@ impl ClientWrapper {
         weights: Vec<u64>,
         multi_leader_rounds: u32,
         balance: Amount,
+        base_timeout: Duration,
     ) -> Result<(MessageId, ChainId)> {
         let mut command = self.command().await?;
         command
             .arg("open-multi-owner-chain")
             .args(["--from", &from.to_string()])
             .arg("--owner-public-keys")
-            .args(to_public_keys.iter().map(PublicKey::to_string));
+            .args(to_public_keys.iter().map(PublicKey::to_string))
+            .args(["--base-timeout-ms", &base_timeout.as_millis().to_string()]);
         if !weights.is_empty() {
             command
                 .arg("--owner-weights")

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -403,9 +403,9 @@ impl ClientContext {
         Fut: Future<Output = Result<ClientOutcome<T>, E>>,
         anyhow::Error: From<E>,
     {
+        // Start listening for notifications, so we learn about new rounds and blocks.
+        let (_listen_handle, mut notification_stream) = client.listen().await?;
         loop {
-            // Subscribe to the local node, so we learn about new rounds.
-            let mut notification_stream = client.lock().await.subscribe().await?;
             // Try applying f. Return if committed.
             let result = f(client.0.clone().lock_owned().await).await;
             self.update_and_save_wallet(&mut *client.lock().await).await;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -748,11 +748,10 @@ impl Runnable for Job {
 
             Watch { chain_id, raw } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let mut chain_client = context.make_chain_client(storage, chain_id);
+                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
                 info!("Watching for notifications for chain {:?}", chain_id);
-                let mut notification_stream = chain_client.subscribe().await?;
-                let _listen_handle = chain_client.into_arc().listen().await?;
-                while let Some(notification) = notification_stream.next().await {
+                let (_listen_handle, mut notifications) = chain_client.listen().await?;
+                while let Some(notification) = notifications.next().await {
                     if raw {
                         println!("{}", serde_json::to_string(&notification)?);
                     }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -403,11 +403,10 @@ impl Runnable for Job {
 
             ProcessInbox { chain_id } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let mut chain_client = context.make_chain_client(storage, chain_id);
+                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
                 info!("Processing the inbox of chain {}", chain_id);
                 let time_start = Instant::now();
-                let certificates = context.process_inbox(&mut chain_client).await?;
-                context.update_and_save_wallet(&mut chain_client).await;
+                let certificates = context.process_inbox(&chain_client).await?;
                 let time_total = time_start.elapsed();
                 info!(
                     "Processed incoming messages with {} blocks in {} ms",
@@ -461,18 +460,19 @@ impl Runnable for Job {
                 // Make sure genesis chains are subscribed to the admin chain.
                 let context = Arc::new(Mutex::new(context));
                 let mut context = context.lock().await;
-                let mut chain_client = context.make_chain_client(
-                    storage.clone(),
-                    context.wallet_state().genesis_admin_chain(),
-                );
+                let chain_client = context
+                    .make_chain_client(
+                        storage.clone(),
+                        context.wallet_state().genesis_admin_chain(),
+                    )
+                    .into_arc();
                 let n = context
-                    .process_inbox(&mut chain_client)
+                    .process_inbox(&chain_client)
                     .await
                     .unwrap()
                     .into_iter()
                     .filter_map(|c| c.value().executed_block().map(|e| e.messages.len()))
                     .sum::<usize>();
-                let chain_client = chain_client.into_arc();
                 info!("Subscribed {} chains to new committees", n);
                 let maybe_certificate = context
                     .apply_client_command(&chain_client, |mut chain_client| {
@@ -830,8 +830,8 @@ impl Runnable for Job {
 
                 info!("Synchronizing");
                 chain_client.synchronize_from_validators().await?;
-                context.process_inbox(&mut chain_client).await?;
                 let chain_client = chain_client.into_arc();
+                context.process_inbox(&chain_client).await?;
 
                 let (application_id, _) = context
                     .apply_client_command(&chain_client, move |mut chain_client| {

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -9,6 +9,7 @@ use std::{collections::BTreeMap, env, path::PathBuf, time::Duration};
 use assert_matches::assert_matches;
 use async_graphql::InputType;
 use common::INTEGRATION_TEST_GUARD;
+use futures::{channel::mpsc, SinkExt, StreamExt};
 use linera_base::{
     command::resolve_binary,
     crypto::{KeyPair, PublicKey},
@@ -27,6 +28,7 @@ use linera_service::cli_wrappers::{
 };
 use serde_json::{json, Value};
 use test_case::test_case;
+use tokio::task::JoinHandle;
 use tracing::{info, warn};
 
 fn get_fungible_account_owner(client: &ClientWrapper) -> AccountOwner {
@@ -2289,6 +2291,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
             vec![100, 100],
             u32::MAX,
             Amount::from_tokens(6),
+            Duration::from_secs(10),
         )
         .await
         .unwrap();
@@ -2645,4 +2648,65 @@ impl Drop for RestoreVarOnDrop {
     fn drop(&mut self) {
         env::set_var("RUSTFLAGS", "-D warnings");
     }
+}
+
+#[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) {
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+
+    // Create runner and two clients.
+    let (mut net, client1) = config.instantiate().await.unwrap();
+    let client2 = net.make_client().await;
+    client2.wallet_init(&[], FaucetOption::None).await.unwrap();
+    let chain1 = *client1.get_wallet().unwrap().chain_ids().first().unwrap();
+
+    // Open a chain owned by both clients, with only single-leader rounds.
+    let client1_key = client1.keygen().await.unwrap();
+    let client2_key = client2.keygen().await.unwrap();
+    let (message_id, chain2) = client1
+        .open_multi_owner_chain(
+            chain1,
+            vec![client1_key, client2_key],
+            vec![100, 100],
+            0,
+            Amount::from_tokens(9),
+            Duration::from_secs(60 * 60 * 24),
+        )
+        .await
+        .unwrap();
+    client1.assign(client1_key, message_id).await.unwrap();
+    client2.assign(client2_key, message_id).await.unwrap();
+    client2.sync(chain2).await.unwrap();
+
+    let (mut tx1, mut rx) = mpsc::channel(8);
+    let mut tx2 = tx1.clone();
+    let handle1: JoinHandle<Result<(), anyhow::Error>> = tokio::spawn(async move {
+        loop {
+            client1.transfer(Amount::ONE, chain2, chain1).await?;
+            tx1.send(()).await.unwrap();
+        }
+    });
+    let handle2: JoinHandle<Result<(), anyhow::Error>> = tokio::spawn(async move {
+        loop {
+            client2.transfer(Amount::ONE, chain2, chain1).await?;
+            tx2.send(()).await.unwrap();
+        }
+    });
+
+    for _ in 0..8 {
+        let () = rx.next().await.unwrap();
+    }
+    drop(rx);
+
+    let (result1, result2) = futures::join!(handle1, handle2);
+    assert!(result1.unwrap().is_err());
+    assert!(result2.unwrap().is_err());
+
+    net.ensure_is_running().await.unwrap();
+    net.terminate().await.unwrap();
 }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -235,7 +235,7 @@ impl AmmApp {
             max_token1_amount,
         };
 
-        let mutation = format!("operation(operation: {})", operation.to_value(),);
+        let mutation = format!("operation(operation: {})", operation.to_value());
         self.0.mutate(mutation).await.unwrap();
     }
 
@@ -251,7 +251,7 @@ impl AmmApp {
             token_to_remove_amount,
         };
 
-        let mutation = format!("operation(operation: {})", operation.to_value(),);
+        let mutation = format!("operation(operation: {})", operation.to_value());
         self.0.mutate(mutation).await.unwrap();
     }
 
@@ -262,7 +262,7 @@ impl AmmApp {
             input_amount,
         };
 
-        let mutation = format!("operation(operation: {})", operation.to_value(),);
+        let mutation = format!("operation(operation: {})", operation.to_value());
         self.0.mutate(mutation).await.unwrap();
     }
 }
@@ -2281,7 +2281,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
     let client1_key = client1.keygen().await.unwrap();
     let client2_key = client2.keygen().await.unwrap();
 
-    // Open chain on behalf of Client 2.
+    // Open a chain owned by both clients.
     let (message_id, chain2) = client1
         .open_multi_owner_chain(
             chain1,
@@ -2326,8 +2326,8 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
     client1.sync(chain1).await.unwrap();
     client2.sync(chain2).await.unwrap();
 
-    assert!(client1.query_balance(account2).await.unwrap() <= Amount::from_tokens(3),);
-    assert!(client2.query_balance(account2).await.unwrap() <= Amount::from_tokens(3),);
+    assert!(client1.query_balance(account2).await.unwrap() <= Amount::from_tokens(3));
+    assert!(client2.query_balance(account2).await.unwrap() <= Amount::from_tokens(3));
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
@@ -2342,7 +2342,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
 async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
-    // Create runner and two clients.
+    // Create runner and client.
     let (mut net, client) = config.instantiate().await.unwrap();
 
     let chain = client.get_wallet().unwrap().default_chain().unwrap();
@@ -2567,7 +2567,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) {
         .await;
     assert!(result.is_err());
     // The transfer didn't get confirmed.
-    assert_eq!(client.local_balance(account).await.unwrap(), balance,);
+    assert_eq!(client.local_balance(account).await.unwrap(), balance);
     // Restart validators.
     for i in 0..4 {
         net.start_validator(i).await.unwrap();


### PR DESCRIPTION
## Motivation

CLI commands don't work in all cases in single-leader mode.

## Proposal

Add an end-to-end test and fix the issues:
* `process_pending_block_without_prepare` should not fail with a "conflicting proposal" error if there is a timeout for the current round. Instead, it should return `WaitForTimeout`.
* `process_inbox` and `apply_client_command` need to actually listen for notifications from the validators, so that they know when a new round begins. Currently they only listen to the local node, but the local node doesn't get updated automatically.
* Synchronize from the validators and return a notification stream from `ChainClient::listen`: Aside from test code, this is what we want at all call sites.
* Update the wallet when `watch`ing if we get notifications about new blocks.
* When we try to finalize a validated block we learned about from the validators, and fail with a communication error, it's probably because someone else finalized the block first. We should return `WaitForTimeout` rather than an error.

## Test Plan

An end-to-end test was added.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/1796.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
