### PR TITLE
Fix certificate value caching.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -767,16 +767,15 @@ impl HashedValue {
         }
     }
 
+    /// Returns the corresponding `ConfirmedBlock`, if this is a `ValidatedBlock`.
     pub fn into_confirmed(self) -> Option<HashedValue> {
         match self.value {
-            value @ CertificateValue::ConfirmedBlock { .. } => Some(HashedValue {
-                hash: self.hash,
-                value,
-            }),
             CertificateValue::ValidatedBlock { executed_block } => {
                 Some(CertificateValue::ConfirmedBlock { executed_block }.into())
             }
-            CertificateValue::LeaderTimeout { .. } => None,
+            CertificateValue::ConfirmedBlock { .. } | CertificateValue::LeaderTimeout { .. } => {
+                None
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

Some tests produce warning messages that a validator `forgot a certificate value that they signed`. This is because `handle_block_proposal` only caches the `ValidatedBlock` value, and then `process_validated_block` thinks it already knows the block and fails to cache the `ConfirmedBlock` when signing it.

## Proposal

Save both in `handle_block_proposal`.

Also avoid some unnecessary cloning: Make `into_confirmed` return `None` if it's already a `ConfirmedBlock` (this is fine at all call sites), and don't clone the certificate at the end in `process_validated_block`.

## Test Plan

`test_end_to_end_change_ownership` now doesn't print the warnings anymore.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
