### PR TITLE
change protocol version to 0.10.0 on the main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "linera-base"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3087,7 +3087,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3131,7 +3131,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "linera-explorer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -3201,7 +3201,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -3229,7 +3229,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-example"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-graphql-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "graphql_client",
  "linera-base",
@@ -3269,7 +3269,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-plugins"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3287,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "linera-rpc"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-wasm-tests"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3386,7 +3386,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "amm",
  "anyhow",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service-graphql-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "fungible",
  "graphql_client",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage-service"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "linera-version"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-graphql",
  "base64 0.22.0",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cfg_aliases",
  "insta",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -3758,7 +3758,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cfg_aliases",
  "heck 0.4.1",
@@ -3770,7 +3770,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-test-modules"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "wit-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,25 +139,25 @@ wit-bindgen-guest-rust = { version = "0.2.0", package = "linera-wit-bindgen-gues
 wit-bindgen-host-wasmer-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmer-rust" }
 wit-bindgen-host-wasmtime-rust = { version = "0.2.0", package = "linera-wit-bindgen-host-wasmtime-rust" }
 
-linera-base = { version = "0.9.0", path = "./linera-base" }
-linera-chain = { version = "0.9.0", path = "./linera-chain" }
-linera-core = { version = "0.9.0", path = "./linera-core", default-features = false }
-linera-execution = { version = "0.9.0", path = "./linera-execution", default-features = false }
+linera-base = { version = "0.10.0", path = "./linera-base" }
+linera-chain = { version = "0.10.0", path = "./linera-chain" }
+linera-core = { version = "0.10.0", path = "./linera-core", default-features = false }
+linera-execution = { version = "0.10.0", path = "./linera-execution", default-features = false }
 linera-indexer = { path = "./linera-indexer/lib" }
 linera-indexer-graphql-client = { path = "./linera-indexer/graphql-client" }
 linera-indexer-plugins = { path = "./linera-indexer/plugins" }
-linera-rpc = { version = "0.9.0", path = "./linera-rpc" }
-linera-sdk = { version = "0.9.0", path = "./linera-sdk" }
-linera-storage = { version = "0.9.0", path = "./linera-storage", default-features = false }
-linera-storage-service = { version = "0.9.0", path = "./linera-storage-service", default-features = false }
-linera-version = { version = "0.9.0", path = "./linera-version" }
-linera-views = { version = "0.9.0", path = "./linera-views", default-features = false }
-linera-views-derive = { version = "0.9.0", path = "./linera-views-derive" }
-linera-witty = { version = "0.9.0", path = "./linera-witty" }
-linera-witty-macros = { version = "0.9.0", path = "./linera-witty-macros" }
-linera-sdk-derive = { version = "0.9.0", path = "./linera-sdk-derive" }
-linera-service = { version = "0.9.0", path = "./linera-service" }
-linera-service-graphql-client = { version = "0.9.0", path = "./linera-service-graphql-client" }
+linera-rpc = { version = "0.10.0", path = "./linera-rpc" }
+linera-sdk = { version = "0.10.0", path = "./linera-sdk" }
+linera-storage = { version = "0.10.0", path = "./linera-storage", default-features = false }
+linera-storage-service = { version = "0.10.0", path = "./linera-storage-service", default-features = false }
+linera-version = { version = "0.10.0", path = "./linera-version" }
+linera-views = { version = "0.10.0", path = "./linera-views", default-features = false }
+linera-views-derive = { version = "0.10.0", path = "./linera-views-derive" }
+linera-witty = { version = "0.10.0", path = "./linera-witty" }
+linera-witty-macros = { version = "0.10.0", path = "./linera-witty-macros" }
+linera-sdk-derive = { version = "0.10.0", path = "./linera-sdk-derive" }
+linera-service = { version = "0.10.0", path = "./linera-service" }
+linera-service-graphql-client = { version = "0.10.0", path = "./linera-service-graphql-client" }
 
 counter = { path = "./examples/counter" }
 meta-counter = { path = "./examples/meta-counter" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "linera-base"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "bcs",
@@ -1994,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage-service"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "linera-version"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-graphql",
  "base64 0.22.0",
@@ -2033,7 +2033,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cfg_aliases",
  "proc-macro2",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-base"
-version = "0.9.0"
+version = "0.10.0"
 description = "Base definitions, including cryptography, used by the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-chain"
-version = "0.9.0"
+version = "0.10.0"
 description = "Persistent data and the corresponding logics used by the Linera protocol for chains of blocks, certificates, and cross-chain messaging."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-core"
-version = "0.9.0"
+version = "0.10.0"
 description = "The core Linera protocol, including client and server logic, node synchronization, etc."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-execution"
-version = "0.9.0"
+version = "0.10.0"
 description = "Persistent data and the corresponding logics used by the Linera protocol for runtime and execution of smart contracts / applications."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-explorer/Cargo.toml
+++ b/linera-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-explorer"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Block explorer for the Linera network"
 readme = "README.md"

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer-example"
-version = "0.9.0"
+version = "0.10.0"
 description = "Indexer example."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-indexer/graphql-client/Cargo.toml
+++ b/linera-indexer/graphql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer-graphql-client"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "GraphQL client for the indexer"
 readme = "README.md"

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer"
-version = "0.9.0"
+version = "0.10.0"
 description = "Indexer for Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-indexer/plugins/Cargo.toml
+++ b/linera-indexer/plugins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-indexer-plugins"
-version = "0.9.0"
+version = "0.10.0"
 description = "Indexer plugins."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-rpc"
-version = "0.9.0"
+version = "0.10.0"
 description = "RPC schemas and networking library for the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-sdk-derive/Cargo.toml
+++ b/linera-sdk-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk-derive"
-version = "0.9.0"
+version = "0.10.0"
 description = "The procedural macros for the crate `linera-sdk`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk"
-version = "0.9.0"
+version = "0.10.0"
 description = "Library to support developping Linera applications in Rust."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-sdk/wasm-tests/Cargo.toml
+++ b/linera-sdk/wasm-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-sdk-wasm-tests"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Linera <contact@linera.io>"]
 edition = "2021"
 

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-service-graphql-client"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "A GraphQL client for Linera node service"
 readme = "README.md"

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-service"
-version = "0.9.0"
+version = "0.10.0"
 description = "Executable for clients (aka CLI wallets), proxy (aka validator frontend) and servers of the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-storage-service"
-version = "0.9.0"
+version = "0.10.0"
 description = "RPC shared key value store."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-storage"
-version = "0.9.0"
+version = "0.10.0"
 description = "Storage abstractions for the Linera protocol."
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-version/Cargo.toml
+++ b/linera-version/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-version"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-views-derive/Cargo.toml
+++ b/linera-views-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-views-derive"
-version = "0.9.0"
+version = "0.10.0"
 description = "The procedural macros for the crate `linera-views`"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-views"
-version = "0.9.0"
+version = "0.10.0"
 description = "A library mapping complex data structures onto a key-value store, used by the Linera protocol"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-witty-macros"
-version = "0.9.0"
+version = "0.10.0"
 description = "Procedural macros for generation of WIT compatible host code from Rust code"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-witty"
-version = "0.9.0"
+version = "0.10.0"
 description = "Generation of WIT compatible host code from Rust code"
 authors = ["Linera <contact@linera.io>"]
 readme = "README.md"

--- a/linera-witty/test-modules/Cargo.toml
+++ b/linera-witty/test-modules/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"
 homepage = "https://linera.dev"
 license = "Apache-2.0"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Motivation

We want to upgrade Devnet.

## Proposal

Set the crate versions to 0.10.0, so we can publish them and deploy the upgraded Devnet.

## Test Plan

Only version changed.

## Release Plan

- Need to update the developer manual.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
