### PR TITLE
Removal of the INTEGRATION_TEST_GUARD

### DIFF
--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -91,7 +91,7 @@ async fn test_end_to_end_operations_indexer(config: impl LineraNetConfig) {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client) = config.instantiate().await.unwrap();
-    let mut node_service = client.run_node_service(None).await.unwrap();
+    let mut node_service = client.run_node_service(8080).await.unwrap();
     let mut indexer = run_indexer(&client.path_provider).await;
 
     // check operations plugin

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -66,7 +66,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
         .await
         .unwrap();
 
-    let mut node_service = client.run_node_service(None).await.unwrap();
+    let mut node_service = client.run_node_service(8080).await.unwrap();
     let req_client = &reqwest_client();
     let url = &format!("http://localhost:{}/", node_service.port());
 

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -154,7 +154,7 @@ impl LineraNetConfig for LocalKubernetesNetConfig {
 }
 
 #[cfg(with_testing)]
-pub struct LocalKubernetesTestNet {
+pub struct SharedLocalKubernetesTestingNet {
     net: Arc<Mutex<LocalKubernetesNet>>,
     _guard: OwnedMutexGuard<()>,
 }
@@ -162,7 +162,7 @@ pub struct LocalKubernetesTestNet {
 #[cfg(with_testing)]
 #[async_trait]
 impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
-    type Net = LocalKubernetesTestNet;
+    type Net = SharedLocalKubernetesTestingNet;
 
     async fn instantiate(self) -> Result<(Self::Net, ClientWrapper)> {
         let guard = KUBERNETES_TEST_GUARD.clone().lock_owned().await;
@@ -177,7 +177,7 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
             })
             .await;
 
-        let mut net = LocalKubernetesTestNet {
+        let mut net = SharedLocalKubernetesTestingNet {
             net: net.clone(),
             _guard: guard,
         };
@@ -201,7 +201,7 @@ impl LineraNetConfig for SharedLocalKubernetesNetTestingConfig {
 }
 
 #[async_trait]
-impl LineraNet for LocalKubernetesTestNet {
+impl LineraNet for SharedLocalKubernetesTestingNet {
     async fn ensure_is_running(&mut self) -> Result<()> {
         let self_clone = self.net.clone();
         let mut self_lock = self_clone.lock().await;

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -181,10 +181,10 @@ impl PortShifts {
 
 /// The number of simultaneous sets of validators
 #[cfg(any(test, feature = "test"))]
-const N_SIMULTANEOUS_VALIDATOR: usize = 5;
+const N_SIMULTANEOUS_VALIDATOR: usize = 2;
 
 /// The maximal number of shards used for local_net
-static MAX_N_CLIENT: usize = 3;
+static MAX_N_CLIENT: usize = 10;
 
 /// The maximal number of shards used for local_net
 static MAX_N_SHARD: usize = 9;

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -197,7 +197,7 @@ static MAX_N_TEST: usize = 30;
 /// The maximum number of validators used.
 static MAX_N_VALIDATOR: usize = 10;
 
-/// The shift in ports froom one set of validators to the next
+/// The shift in ports from one set of validators to the next
 static SHIFT_PORT: usize = MAX_N_VALIDATOR * (MAX_N_SHARD + 1);
 
 /// The basic port used

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -41,7 +41,9 @@ use linera_service::{
     chain_listener::ClientContext as _,
     cli_wrappers::{
         self,
-        local_net::{Database, LocalNetConfig, PathProvider, StorageConfigBuilder},
+        local_net::{
+            Database, IndexPortChoice, LocalNetConfig, PathProvider, StorageConfigBuilder,
+        },
         ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
     },
     config::{CommitteeConfig, Export, GenesisConfig, Import, UserChain},
@@ -1515,6 +1517,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                     let storage_config_builder =
                         StorageConfigBuilder::ExistingConfig { storage_config };
                     let path_provider = PathProvider::new(path);
+                    let index_port_choice = IndexPortChoice::IndexPort { index: 0 };
                     let config = LocalNetConfig {
                         network: Network::Grpc,
                         database: Database::RocksDb,
@@ -1527,6 +1530,7 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                         policy: ResourceControlPolicy::default(),
                         storage_config_builder,
                         path_provider,
+                        index_port_choice,
                     };
                     let (mut net, client1) = config.instantiate().await?;
                     let result = Ok(net_up(extra_wallets, &mut net, client1).await?);

--- a/linera-service/tests/end_to_end_serial_tests.rs
+++ b/linera-service/tests/end_to_end_serial_tests.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    env,
+    io::{BufRead, BufReader},
+    process::{Command, Stdio},
+};
+mod common;
+use common::INTEGRATION_TEST_GUARD;
+
+#[test_log::test(tokio::test)]
+async fn test_linera_net_up_simple() {
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_linera"));
+    command.args(["net", "up"]);
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    let stdout = BufReader::new(child.stdout.take().unwrap());
+    let stderr = BufReader::new(child.stderr.take().unwrap());
+
+    for line in stderr.lines() {
+        let line = line.unwrap();
+        if line.starts_with("READY!") {
+            let mut exports = stdout.lines();
+            assert!(exports
+                .next()
+                .unwrap()
+                .unwrap()
+                .starts_with("export LINERA_WALLET="));
+            assert!(exports
+                .next()
+                .unwrap()
+                .unwrap()
+                .starts_with("export LINERA_STORAGE="));
+            assert_eq!(exports.next().unwrap().unwrap(), "");
+
+            // Send SIGINT to the child process.
+            Command::new("kill")
+                .args(["-s", "INT", &child.id().to_string()])
+                .output()
+                .unwrap();
+
+            assert!(exports.next().is_none());
+            assert!(child.wait().unwrap().success());
+            return;
+        }
+    }
+    panic!("Unexpected EOF for stderr");
+}

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -12,6 +12,7 @@ use linera_base::{
     crypto::{KeyPair, PublicKey},
     data_types::{Amount, Timestamp},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId, Owner},
+    sync::Lazy,
 };
 #[cfg(feature = "remote_net")]
 use linera_service::cli_wrappers::remote_net::RemoteNetTestingConfig;
@@ -25,11 +26,8 @@ use linera_service::cli_wrappers::{
 };
 use serde_json::{json, Value};
 use test_case::test_case;
-use tokio::task::JoinHandle;
+use tokio::{sync::Mutex, task::JoinHandle};
 use tracing::{info, warn};
-
-use linera_base::sync::Lazy;
-use tokio::sync::Mutex;
 
 /// The `counter` directory should be accessed only once at the same time.
 static COUNTER_DIRECTORY_TEST_GUARD: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -3,9 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![cfg(feature = "rocksdb")]
-
 mod common;
-
 use common::INTEGRATION_TEST_GUARD;
 use linera_service::util::QuotedBashAndGraphQlScript;
 use tokio::{process::Command, time::Duration};


### PR DESCRIPTION
## Motivation

The tests in CI take a lot of resource and a big chunk of that is in the end-to-end tests for the applications.
Particularly, the parallelism of the tests is not exploited which is unfortunate.

## Proposal

One line of approach was to have a global validator which is used for everything but while this line
of programming has merits it requires significant work. Instead the proposition here is to shift the
ports used so that each test creates its own sets of validators.

Following was done:
* Move the `linera net up` in a separate `command.rs`file. This is because it does not use the local_net called via tests.
* Enable the functionality of port shift which can be used for testing and for normal usage.
* Use Semaphore to limit the number of test framework running at the same time.

## Test Plan

No change in the functionality of the tests.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
