### PR TITLE
`linera-version`: use `CARGO_MANIFEST_DIR` instead of `PWD`

### DIFF
--- a/linera-version/build.rs
+++ b/linera-version/build.rs
@@ -23,10 +23,16 @@ fn main() {
         wit_hash,
     } = {
         let mut paths = vec![];
-        let version_info = VersionInfo::trace_get(&mut paths).unwrap();
+        let version_info = VersionInfo::trace_get(
+            std::path::Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()),
+            &mut paths,
+        )
+        .unwrap();
+
         for path in paths {
             println!("cargo:rerun-if-changed={}", path.display());
         }
+
         version_info
     };
 

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -158,12 +158,12 @@ fn get_package_root<'r>(
 
 impl VersionInfo {
     pub fn get() -> Result<Self, Error> {
-        Self::trace_get(&mut vec![])
+        Self::trace_get(&std::env::current_dir()?, &mut vec![])
     }
 
-    fn trace_get(paths: &mut Vec<PathBuf>) -> Result<Self, Error> {
+    fn trace_get(crate_dir: &std::path::Path, paths: &mut Vec<PathBuf>) -> Result<Self, Error> {
         let metadata = cargo_metadata::MetadataCommand::new()
-            .current_dir(env!("PWD"))
+            .current_dir(crate_dir)
             .exec()?;
 
         let crate_version = Pretty::new(


### PR DESCRIPTION
## Motivation

I think that `PWD`, when building a build script, used to be set to the directory containing `build.rs`.  We used this fact to run `cargo manifest`, getting information about the current package for `linera-version`.  However, it seems that if this was ever the case, it no longer is, breaking `cargo install`.  We should probably be relying on `CARGO_MANIFEST_DIR` instead.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Replace `PWD` with `CARGO_MANIFEST_DIR` when building `linera-version`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

`(cd /tmp; cargo install --path /path/to/linera-protocol/linera-service)`

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

This is a hotfix.  It shouldn't break any working flows.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [old discussion about the behaviour of `PWD` vs `CARGO_MANIFEST_DIR`](https://internals.rust-lang.org/t/build-scripts-pwd-and-cargo-manifest-dir-strangeness/16833)
- [documentation about Cargo environment variables for build scripts](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
