### PR TITLE
`linera-views`: add local variants of store traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3513,7 +3513,6 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-lock",
- "async-trait",
  "bcs",
  "cfg_aliases",
  "clap",
@@ -3586,6 +3585,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+ "trait-variant",
 ]
 
 [[package]]
@@ -7142,9 +7142,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1998,7 +1998,6 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-lock",
- "async-trait",
  "bcs",
  "cfg_aliases",
  "clap",
@@ -2057,6 +2056,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "trait-variant",
 ]
 
 [[package]]

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -3,7 +3,6 @@
 
 //! Functions and types to interface with the system API available to application views.
 
-use async_trait::async_trait;
 use linera_base::ensure;
 use linera_views::{
     batch::{Batch, WriteOperation},
@@ -40,7 +39,6 @@ impl AppStateStore {
     }
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<ViewError> for AppStateStore {
     // The AppStateStore of the system_api does not have limits
     // on the size of its values.
@@ -101,7 +99,6 @@ impl ReadableKeyValueStore<ViewError> for AppStateStore {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<ViewError> for AppStateStore {
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
@@ -135,7 +132,6 @@ impl WritableKeyValueStore<ViewError> for AppStateStore {
     }
 }
 
-#[async_trait]
 impl KeyValueStore for AppStateStore {
     type Error = ViewError;
 }

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -24,7 +24,6 @@ path = "src/server.rs"
 [dependencies]
 anyhow.workspace = true
 async-lock.workspace = true
-async-trait.workspace = true
 bcs.workspace = true
 clap.workspace = true
 linera-base.workspace = true

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -4,7 +4,6 @@
 use std::{mem, sync::Arc};
 
 use async_lock::{RwLock, RwLockWriteGuard, Semaphore, SemaphoreGuard};
-use async_trait::async_trait;
 use linera_base::ensure;
 #[cfg(with_testing)]
 use linera_views::test_utils::generate_test_namespace;
@@ -58,7 +57,6 @@ pub struct ServiceStoreClient {
     namespace: Vec<u8>,
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
@@ -199,14 +197,10 @@ impl ReadableKeyValueStore<ServiceContextError> for ServiceStoreClient {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<ServiceContextError> for ServiceStoreClient {
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch, _base_key: &[u8]) -> Result<(), ServiceContextError> {
-        use linera_views::batch::WriteOperation;
-
-        use crate::client::Operation;
         let mut statements = Vec::new();
         let mut chunk_size = 0;
         for operation in batch.operations {
@@ -345,7 +339,6 @@ impl ServiceStoreClient {
     }
 }
 
-#[async_trait]
 impl AdminKeyValueStore for ServiceStoreClient {
     type Error = ServiceContextError;
     type Config = ServiceStoreConfig;

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -52,6 +52,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "sync"] }
 tracing.workspace = true
+trait-variant.workspace = true
 
 [dev-dependencies]
 linera-views = { path = ".", features = ["test"] }

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -348,8 +348,8 @@ impl Batch {
 /// Certain databases (e.g. DynamoDB) do not support the deletion by prefix.
 /// Thus we need to access the databases in order to replace a `DeletePrefix`
 /// by a vector of the keys to be removed.
-#[async_trait]
-pub trait DeletePrefixExpander {
+#[trait_variant::make(DeletePrefixExpander: Send)]
+pub trait LocalDeletePrefixExpander {
     /// The error type that can happen when expanding the key_prefix.
     type Error: Debug;
 

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -324,7 +324,6 @@ pub struct DynamoDbStoreConfig {
     pub common_config: CommonStoreConfig,
 }
 
-#[async_trait]
 impl AdminKeyValueStore for DynamoDbStoreInternal {
     type Error = DynamoDbContextError;
     type Config = DynamoDbStoreConfig;
@@ -785,7 +784,6 @@ impl KeyValueIterable<DynamoDbContextError> for DynamoDbKeyValues {
     }
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = DynamoDbKeys;
@@ -818,8 +816,10 @@ impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStoreInternal {
             let handle = self.read_value_bytes_general(key_db);
             handles.push(handle);
         }
-        let result = join_all(handles).await;
-        Ok(result.into_iter().collect::<Result<_, _>>()?)
+        join_all(handles)
+            .await
+            .into_iter()
+            .collect::<Result<_, _>>()
     }
 
     async fn find_keys_by_prefix(
@@ -890,7 +890,6 @@ pub struct DynamoDbStore {
     store: LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<DynamoDbStoreInternal>>>,
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE - 4;
     type Keys = Vec<Vec<u8>>;
@@ -930,7 +929,6 @@ impl ReadableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
     const MAX_VALUE_SIZE: usize = DynamoDbStoreInternal::MAX_VALUE_SIZE;
 
@@ -943,12 +941,10 @@ impl WritableKeyValueStore<DynamoDbContextError> for DynamoDbStore {
     }
 }
 
-#[async_trait]
 impl KeyValueStore for DynamoDbStore {
     type Error = DynamoDbContextError;
 }
 
-#[async_trait]
 impl AdminKeyValueStore for DynamoDbStore {
     type Error = DynamoDbContextError;
     type Config = DynamoDbStoreConfig;

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -102,7 +102,6 @@ pub struct JournalingKeyValueStore<K> {
     pub store: K,
 }
 
-#[async_trait]
 impl<K> DeletePrefixExpander for &JournalingKeyValueStore<K>
 where
     K: DirectKeyValueStore + Send + Sync,
@@ -117,7 +116,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K> ReadableKeyValueStore<K::Error> for JournalingKeyValueStore<K>
 where
     K: DirectKeyValueStore + Send + Sync,
@@ -161,7 +159,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K> AdminKeyValueStore for JournalingKeyValueStore<K>
 where
     K: AdminKeyValueStore + Send + Sync,
@@ -195,7 +192,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K> WritableKeyValueStore<K::Error> for JournalingKeyValueStore<K>
 where
     K: DirectKeyValueStore + Send + Sync,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -1017,7 +1017,6 @@ pub struct ViewContainer<C> {
 }
 
 #[cfg(with_testing)]
-#[async_trait]
 impl<C> ReadableKeyValueStore<ViewError> for ViewContainer<C>
 where
     C: Context + Sync + Send + Clone,
@@ -1062,8 +1061,8 @@ where
         view.find_key_values_by_prefix(key_prefix).await
     }
 }
+
 #[cfg(with_testing)]
-#[async_trait]
 impl<C> WritableKeyValueStore<ViewError> for ViewContainer<C>
 where
     C: Context + Sync + Send + Clone,

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -4,7 +4,6 @@
 use std::{collections::BTreeMap, fmt::Debug, sync::Arc};
 
 use async_lock::{Mutex, MutexGuardArc, RwLock};
-use async_trait::async_trait;
 use futures::FutureExt;
 use thiserror::Error;
 
@@ -53,7 +52,6 @@ pub struct MemoryStore {
     pub max_stream_queries: usize,
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<MemoryContextError> for MemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
@@ -113,7 +111,6 @@ impl ReadableKeyValueStore<MemoryContextError> for MemoryStore {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<MemoryContextError> for MemoryStore {
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
@@ -146,7 +143,6 @@ impl WritableKeyValueStore<MemoryContextError> for MemoryStore {
     }
 }
 
-#[async_trait]
 impl AdminKeyValueStore for MemoryStore {
     type Error = MemoryContextError;
     type Config = MemoryStoreConfig;
@@ -263,7 +259,6 @@ impl From<MemoryContextError> for ViewError {
     }
 }
 
-#[async_trait]
 impl DeletePrefixExpander for MemoryContext<()> {
     type Error = MemoryContextError;
 

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use async_trait::async_trait;
 use convert_case::{Case, Casing};
 use linera_base::{
     prometheus_util::{register_histogram_vec, MeasureLatency},
@@ -116,7 +115,6 @@ pub struct MeteredStore<K> {
     pub store: K,
 }
 
-#[async_trait]
 impl<K, E> ReadableKeyValueStore<E> for MeteredStore<K>
 where
     K: ReadableKeyValueStore<E> + Send + Sync,
@@ -155,7 +153,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K, E> WritableKeyValueStore<E> for MeteredStore<K>
 where
     K: WritableKeyValueStore<E> + Send + Sync,

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -8,7 +8,6 @@ use std::{
     sync::Arc,
 };
 
-use async_trait::async_trait;
 use linera_base::ensure;
 use thiserror::Error;
 #[cfg(with_testing)]
@@ -74,7 +73,6 @@ impl RocksDbStoreInternal {
     }
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
@@ -180,7 +178,6 @@ impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
 
@@ -245,7 +242,6 @@ impl WritableKeyValueStore<RocksDbContextError> for RocksDbStoreInternal {
     }
 }
 
-#[async_trait]
 impl AdminKeyValueStore for RocksDbStoreInternal {
     type Error = RocksDbContextError;
     type Config = RocksDbStoreConfig;
@@ -391,7 +387,6 @@ pub async fn create_rocks_db_test_store() -> (RocksDbStore, TempDir) {
 /// An implementation of [`crate::common::Context`] based on RocksDB
 pub type RocksDbContext<E> = ContextFromStore<E, RocksDbStore>;
 
-#[async_trait]
 impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStore {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
@@ -431,7 +426,6 @@ impl ReadableKeyValueStore<RocksDbContextError> for RocksDbStore {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<RocksDbContextError> for RocksDbStore {
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
@@ -444,7 +438,6 @@ impl WritableKeyValueStore<RocksDbContextError> for RocksDbStore {
     }
 }
 
-#[async_trait]
 impl AdminKeyValueStore for RocksDbStore {
     type Error = RocksDbContextError;
     type Config = RocksDbStoreConfig;
@@ -484,7 +477,6 @@ impl AdminKeyValueStore for RocksDbStore {
     }
 }
 
-#[async_trait]
 impl KeyValueStore for RocksDbStore {
     type Error = RocksDbContextError;
 }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -344,7 +344,6 @@ impl From<ScyllaDbContextError> for crate::views::ViewError {
     }
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
@@ -373,8 +372,10 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
         let store = self.store.deref();
         let _guard = self.acquire().await;
         let handles = keys.into_iter().map(|key| store.read_value_internal(key));
-        let result = join_all(handles).await;
-        Ok(result.into_iter().collect::<Result<_, _>>()?)
+        join_all(handles)
+            .await
+            .into_iter()
+            .collect::<Result<_, _>>()
     }
 
     async fn find_keys_by_prefix(
@@ -426,7 +427,6 @@ impl DirectWritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal
     }
 }
 
-#[async_trait]
 impl AdminKeyValueStore for ScyllaDbStoreInternal {
     type Error = ScyllaDbContextError;
     type Config = ScyllaDbStoreConfig;
@@ -589,7 +589,6 @@ impl DirectKeyValueStore for ScyllaDbStoreInternal {
     type Error = ScyllaDbContextError;
 }
 
-#[async_trait]
 impl DeletePrefixExpander for ScyllaDbClient {
     type Error = ScyllaDbContextError;
 
@@ -645,7 +644,6 @@ pub struct ScyllaDbStoreConfig {
     pub common_config: CommonStoreConfig,
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
     const MAX_KEY_SIZE: usize = ScyllaDbStoreInternal::MAX_KEY_SIZE;
 
@@ -688,7 +686,6 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
     const MAX_VALUE_SIZE: usize = ScyllaDbStoreInternal::MAX_VALUE_SIZE;
 
@@ -701,7 +698,6 @@ impl WritableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
     }
 }
 
-#[async_trait]
 impl AdminKeyValueStore for ScyllaDbStore {
     type Error = ScyllaDbContextError;
     type Config = ScyllaDbStoreConfig;

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         Batch, WriteOperation,
         WriteOperation::{Delete, Put},
     },
-    common::{AdminKeyValueStore, KeyIterable, KeyValueIterable, KeyValueStore},
+    common::{KeyIterable, KeyValueIterable, LocalAdminKeyValueStore, LocalKeyValueStore},
 };
 
 // The following seed is chosen to have equal numbers of 1s and 0s, as advised by
@@ -237,7 +237,7 @@ pub fn span_random_reordering_put_delete<R: Rng>(
 /// * `read_multi_values_bytes`
 /// * `find_keys_by_prefix` / `find_key_values_by_prefix`
 /// * The ordering of keys returned by `find_keys_by_prefix` and `find_key_values_by_prefix`
-pub async fn run_reads<S: KeyValueStore + Sync>(store: S, key_values: Vec<(Vec<u8>, Vec<u8>)>) {
+pub async fn run_reads<S: LocalKeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec<u8>)>) {
     // We need a nontrivial key_prefix because dynamo requires a non-trivial prefix
     let mut batch = Batch::new();
     let mut keys = Vec::new();
@@ -426,7 +426,7 @@ fn realize_batch(batch: &Batch) -> BTreeMap<Vec<u8>, Vec<u8>> {
     kv_state
 }
 
-async fn read_key_values_prefix<C: KeyValueStore + Sync>(
+async fn read_key_values_prefix<C: LocalKeyValueStore>(
     key_value_store: &C,
     key_prefix: &[u8],
 ) -> BTreeMap<Vec<u8>, Vec<u8>> {
@@ -446,7 +446,7 @@ async fn read_key_values_prefix<C: KeyValueStore + Sync>(
 }
 
 /// Writes and then reads data under a prefix, and verifies the result.
-pub async fn run_test_batch_from_blank<C: KeyValueStore + Sync>(
+pub async fn run_test_batch_from_blank<C: LocalKeyValueStore>(
     key_value_store: &C,
     key_prefix: Vec<u8>,
     batch: Batch,
@@ -459,7 +459,7 @@ pub async fn run_test_batch_from_blank<C: KeyValueStore + Sync>(
 }
 
 /// Run many operations on batches always starting from a blank state.
-pub async fn run_writes_from_blank<C: KeyValueStore + Sync>(key_value_store: &C) {
+pub async fn run_writes_from_blank<C: LocalKeyValueStore>(key_value_store: &C) {
     let mut rng = make_deterministic_rng();
     let n_oper = 10;
     let batch_size = 500;
@@ -487,7 +487,7 @@ pub async fn run_writes_from_blank<C: KeyValueStore + Sync>(key_value_store: &C)
 /// Then we select half of them at random and delete them. By the random
 /// selection, Scylla is forced to introduce around 100000 tombstones
 /// which triggers the crash with the default settings.
-pub async fn tombstone_triggering_test<C: KeyValueStore + Sync>(key_value_store: C) {
+pub async fn tombstone_triggering_test<C: LocalKeyValueStore>(key_value_store: C) {
     let mut rng = make_deterministic_rng();
     let value_size = 100;
     let n_entry = 200000;
@@ -525,7 +525,7 @@ pub async fn tombstone_triggering_test<C: KeyValueStore + Sync>(key_value_store:
 /// must handle that.
 ///
 /// The size of the value vary as each size has its own issues.
-pub async fn run_big_write_read<C: KeyValueStore + Sync>(
+pub async fn run_big_write_read<C: LocalKeyValueStore>(
     key_value_store: C,
     target_size: usize,
     value_sizes: Vec<usize>,
@@ -547,7 +547,7 @@ pub async fn run_big_write_read<C: KeyValueStore + Sync>(
 
 type StateBatch = (Vec<(Vec<u8>, Vec<u8>)>, Batch);
 
-async fn run_test_batch_from_state<C: KeyValueStore + Sync>(
+async fn run_test_batch_from_state<C: LocalKeyValueStore>(
     key_value_store: &C,
     key_prefix: Vec<u8>,
     state_and_batch: StateBatch,
@@ -642,7 +642,7 @@ fn generate_specific_state_batch(key_prefix: &[u8], option: usize) -> StateBatch
 
 /// Run some deterministic and random batches operation and check their
 /// correctness
-pub async fn run_writes_from_state<C: KeyValueStore + Sync>(key_value_store: &C) {
+pub async fn run_writes_from_state<C: LocalKeyValueStore>(key_value_store: &C) {
     for option in 0..7 {
         let key_prefix = if option == 6 {
             vec![255, 255, 255]
@@ -654,7 +654,7 @@ pub async fn run_writes_from_state<C: KeyValueStore + Sync>(key_value_store: &C)
     }
 }
 
-async fn namespaces_with_prefix<S: AdminKeyValueStore>(
+async fn namespaces_with_prefix<S: LocalAdminKeyValueStore>(
     config: &S::Config,
     prefix: &str,
 ) -> BTreeSet<String>
@@ -671,7 +671,7 @@ where
 /// Exercises the functionalities of the `AdminKeyValueStore`.
 /// This tests everything except the `delete_all` which would
 /// interact with other namespaces.
-pub async fn admin_test<S: AdminKeyValueStore>(config: &S::Config)
+pub async fn admin_test<S: LocalAdminKeyValueStore>(config: &S::Config)
 where
     S::Error: Debug,
 {

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -3,7 +3,6 @@
 
 use std::fmt::Debug;
 
-use async_trait::async_trait;
 use futures::FutureExt;
 use linera_base::ensure;
 use thiserror::Error;
@@ -45,7 +44,6 @@ pub struct ValueSplittingStore<K> {
     pub store: K,
 }
 
-#[async_trait]
 impl<K> ReadableKeyValueStore<K::Error> for ValueSplittingStore<K>
 where
     K: KeyValueStore + Send + Sync,
@@ -196,7 +194,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K> WritableKeyValueStore<K::Error> for ValueSplittingStore<K>
 where
     K: KeyValueStore + Send + Sync,
@@ -242,7 +239,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K> AdminKeyValueStore for ValueSplittingStore<K>
 where
     K: AdminKeyValueStore + Send + Sync,
@@ -343,7 +339,6 @@ impl Default for TestMemoryStoreInternal {
     }
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
@@ -383,7 +378,6 @@ impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<MemoryContextError> for TestMemoryStoreInternal {
     // We set up the MAX_VALUE_SIZE to the artificially low value of 100
     // purely for testing purposes.
@@ -430,7 +424,6 @@ pub struct TestMemoryStore {
     store: ValueSplittingStore<TestMemoryStoreInternal>,
 }
 
-#[async_trait]
 impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
@@ -470,7 +463,6 @@ impl ReadableKeyValueStore<MemoryContextError> for TestMemoryStore {
     }
 }
 
-#[async_trait]
 impl WritableKeyValueStore<MemoryContextError> for TestMemoryStore {
     const MAX_VALUE_SIZE: usize = usize::MAX;
 


### PR DESCRIPTION
## Motivation

In order to support non-`Send` Linera view stores on the Web, we need local variants of the store traits that don't require `Send`.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Replace `async-trait` with native AFIT, and use `trait-variant` to automatically create local and non-local variants.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI build should catch regressions.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.

This changes the trait interfaces, which is a backward-incompatible change (for people using `linera-views` directly).

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
