### PR TITLE
quick fix for #1841

### DIFF
--- a/linera-views/src/graphql.rs
+++ b/linera-views/src/graphql.rs
@@ -23,7 +23,11 @@ impl<K: async_graphql::OutputType, V: async_graphql::OutputType> async_graphql::
     for Entry<K, V>
 {
     fn type_name() -> Cow<'static, str> {
-        format!("Entry_{}_{}", K::type_name(), V::type_name()).into()
+        format!("Entry_{}_{}", K::type_name(), V::type_name())
+            .replace('!', "_NonNull")
+            .replace('[', "")
+            .replace(']', "_Array")
+            .into()
     }
 }
 


### PR DESCRIPTION
## Motivation

attempt to fix #1841

## Proposal

It looks like there are only two GraphQL type constructors and they are unary. Therefore we could replace
* `[` with the empty string,
* `]` with the `_Array`, and
* `!` with `_Nonnull`.

## Test Plan

CI + TBD
