### PR TITLE
chore: add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Use `git config blame.ignorerevsfile .git-blame-ignore-revs` to make `git blame` ignore the following commits.
+
+# upload node_modules
+f0a4fad16b59fdf726f03eed9d523dbabd610402
+# remove node_modules
+359c74a60671e54cd017eda7b0622e3c4a5c6c0b


### PR DESCRIPTION
## Motivation

It's really confusing for new contributors when they see commits bulking adding and removing useless files.

## Proposal

Add a .git-blame-ignore-revs file for git blame to ignore #1852 and #1789.

`.git-blame-ignore-revs` is not enabled by default, but it's the de facto standard for ignoring revs (many projects such as [Rust](https://github.com/rust-lang/rust/blob/master/.git-blame-ignore-revs) has this file). Git users basically need to run `git config --globalblame.ignoreRevsFile .git-blame-ignore-revs` to use this file.

## Links

#1852
#1789