### PR TITLE
`linera-views`: avoid generating duplicate GraphQL type names

### DIFF
--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -63,9 +63,9 @@ query ChainInbox($chainId: ChainId!, $origin: Origin!) {
 
 query Chain(
   $chainId: ChainId!,
-  $inboxesInput: MapInput_Origin,
-  $outboxesInput: MapInput_Target,
-  $channelsInput: MapInput_ChannelFullName,
+  $inboxesInput: MapInput_Origin_08662377,
+  $outboxesInput: MapInput_Target_16f15470,
+  $channelsInput: MapInput_ChannelFullName_3aa4320a,
 ) {
   chain(chainId: $chainId) {
     chainId

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -140,19 +140,19 @@ type ChainStateExtendedView {
 	Hashes of all certified blocks for this sender.
 	This ends with `block_hash` and has length `usize::from(next_block_height)`.
 	"""
-	confirmedLog: LogView_CryptoHash!
+	confirmedLog: LogView_CryptoHash_b0541e41!
 	"""
 	Sender chain and height of all certified blocks known as a receiver (local ordering).
 	"""
-	receivedLog: LogView_ChainAndHeight!
+	receivedLog: LogView_ChainAndHeight_de85b393!
 	"""
 	Mailboxes used to receive messages indexed by their origin.
 	"""
-	inboxes: ReentrantCollectionView_Origin_InboxStateView!
+	inboxes: ReentrantCollectionView_Origin_InboxStateView_2059505700!
 	"""
 	Mailboxes used to send messages, indexed by their target.
 	"""
-	outboxes: ReentrantCollectionView_Target_OutboxStateView!
+	outboxes: ReentrantCollectionView_Target_OutboxStateView_3775022202!
 	"""
 	Number of outgoing messages in flight for each block height.
 	We use a `RegisterView` to prioritize speed for small maps.
@@ -161,7 +161,7 @@ type ChainStateExtendedView {
 	"""
 	Channels able to multicast messages to subscribers.
 	"""
-	channels: ReentrantCollectionView_ChannelFullName_ChannelStateView!
+	channels: ReentrantCollectionView_ChannelFullName_ChannelStateView_1259684418!
 }
 
 """
@@ -282,7 +282,7 @@ scalar Destination
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_ChannelFullName_ChannelStateView {
+type Entry_ChannelFullName_ChannelStateView_3a04511c {
 	key: ChannelFullName!
 	value: ChannelStateView!
 }
@@ -290,7 +290,7 @@ type Entry_ChannelFullName_ChannelStateView {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_Origin_InboxStateView {
+type Entry_Origin_InboxStateView_79f3e1f3 {
 	key: Origin!
 	value: InboxStateView!
 }
@@ -298,7 +298,7 @@ type Entry_Origin_InboxStateView {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_Owner_Amount {
+type Entry_Owner_Amount_771b9c6c {
 	key: Owner!
 	value: Amount
 }
@@ -306,7 +306,7 @@ type Entry_Owner_Amount {
 """
 A GraphQL-visible map item, complete with key.
 """
-type Entry_Target_OutboxStateView {
+type Entry_Target_OutboxStateView_f3778d1a {
 	key: Target!
 	value: OutboxStateView!
 }
@@ -372,12 +372,12 @@ type InboxStateView {
 	"""
 	These events have been added and are waiting to be removed.
 	"""
-	addedEvents: QueueView_Event!
+	addedEvents: QueueView_Event_fd202526!
 	"""
 	These events have been removed by anticipation and are waiting to be added.
 	At least one of `added_events` and `removed_events` should be empty.
 	"""
-	removedEvents: QueueView_Event!
+	removedEvents: QueueView_Event_fd202526!
 }
 
 """
@@ -405,50 +405,50 @@ A scalar that can represent any JSON Object value.
 """
 scalar JSONObject
 
-type LogView_ChainAndHeight {
+type LogView_ChainAndHeight_de85b393 {
 	entries(start: Int, end: Int): [ChainAndHeight!]!
 }
 
-type LogView_CryptoHash {
+type LogView_CryptoHash_b0541e41 {
 	entries(start: Int, end: Int): [CryptoHash!]!
 }
 
-input MapFilters_ChannelFullName {
+input MapFilters_ChannelFullName_39361e62 {
 	keys: [ChannelFullName!]
 }
 
-input MapFilters_Origin {
+input MapFilters_Origin_7201976d {
 	keys: [Origin!]
 }
 
-input MapFilters_Owner {
+input MapFilters_Owner_7b1d3281 {
 	keys: [Owner!]
 }
 
-input MapFilters_Target {
+input MapFilters_Target_6fda9ea4 {
 	keys: [Target!]
 }
 
-input MapInput_ChannelFullName {
-	filters: MapFilters_ChannelFullName
+input MapInput_ChannelFullName_3aa4320a {
+	filters: MapFilters_ChannelFullName_39361e62
 }
 
-input MapInput_Origin {
-	filters: MapFilters_Origin
+input MapInput_Origin_08662377 {
+	filters: MapFilters_Origin_7201976d
 }
 
-input MapInput_Owner {
-	filters: MapFilters_Owner
+input MapInput_Owner_2b9cd89a {
+	filters: MapFilters_Owner_7b1d3281
 }
 
-input MapInput_Target {
-	filters: MapFilters_Target
+input MapInput_Target_16f15470 {
+	filters: MapFilters_Target_6fda9ea4
 }
 
-type MapView_Owner_Amount {
+type MapView_Owner_Amount_0d73ec3f {
 	keys(count: Int): [Owner!]!
-	entry(key: Owner!): Entry_Owner_Amount!
-	entries(input: MapInput_Owner): [Entry_Owner_Amount!]!
+	entry(key: Owner!): Entry_Owner_Amount_771b9c6c!
+	entries(input: MapInput_Owner_2b9cd89a): [Entry_Owner_Amount_771b9c6c!]!
 }
 
 """
@@ -606,7 +606,7 @@ type OutboxStateView {
 	Keep sending these certified blocks of ours until they are acknowledged by
 	receivers.
 	"""
-	queue: QueueView_BlockHeight!
+	queue: QueueView_BlockHeight_f5d50b5f!
 }
 
 """
@@ -661,11 +661,11 @@ type QueryRoot {
 	version: VersionInfo!
 }
 
-type QueueView_BlockHeight {
+type QueueView_BlockHeight_f5d50b5f {
 	entries(count: Int): [BlockHeight!]!
 }
 
-type QueueView_Event {
+type QueueView_Event_fd202526 {
 	entries(count: Int): [Event!]!
 }
 
@@ -674,22 +674,22 @@ The recipient of a transfer
 """
 scalar Recipient
 
-type ReentrantCollectionView_ChannelFullName_ChannelStateView {
+type ReentrantCollectionView_ChannelFullName_ChannelStateView_1259684418 {
 	keys: [ChannelFullName!]!
-	entry(key: ChannelFullName!): Entry_ChannelFullName_ChannelStateView!
-	entries(input: MapInput_ChannelFullName): [Entry_ChannelFullName_ChannelStateView!]!
+	entry(key: ChannelFullName!): Entry_ChannelFullName_ChannelStateView_3a04511c!
+	entries(input: MapInput_ChannelFullName_3aa4320a): [Entry_ChannelFullName_ChannelStateView_3a04511c!]!
 }
 
-type ReentrantCollectionView_Origin_InboxStateView {
+type ReentrantCollectionView_Origin_InboxStateView_2059505700 {
 	keys: [Origin!]!
-	entry(key: Origin!): Entry_Origin_InboxStateView!
-	entries(input: MapInput_Origin): [Entry_Origin_InboxStateView!]!
+	entry(key: Origin!): Entry_Origin_InboxStateView_79f3e1f3!
+	entries(input: MapInput_Origin_08662377): [Entry_Origin_InboxStateView_79f3e1f3!]!
 }
 
-type ReentrantCollectionView_Target_OutboxStateView {
+type ReentrantCollectionView_Target_OutboxStateView_3775022202 {
 	keys: [Target!]!
-	entry(key: Target!): Entry_Target_OutboxStateView!
-	entries(input: MapInput_Target): [Entry_Target_OutboxStateView!]!
+	entry(key: Target!): Entry_Target_OutboxStateView_f3778d1a!
+	entries(input: MapInput_Target_16f15470): [Entry_Target_OutboxStateView_f3778d1a!]!
 }
 
 """
@@ -780,7 +780,7 @@ type SystemExecutionStateView {
 	committees: JSONObject!
 	ownership: ChainOwnership!
 	balance: Amount!
-	balances: MapView_Owner_Amount!
+	balances: MapView_Owner_Amount_0d73ec3f!
 	timestamp: Timestamp!
 }
 

--- a/linera-views/src/graphql.rs
+++ b/linera-views/src/graphql.rs
@@ -11,6 +11,21 @@ use crate::{
 // TODO(#1326): fix the proliferation of constraints from this module
 
 // TODO(#1858): come up with a better name-mangling scheme
+/// Mangle a GraphQL type into something that can be interpolated into a GraphQL type name
+fn mangle(type_name: impl AsRef<str>) -> String {
+    let mut mangled = String::new();
+
+    for c in type_name.as_ref().chars() {
+        match c {
+            '!' | '[' => (),
+            ']' => mangled.push_str("_Array"),
+            c => mangled.push(c),
+        }
+    }
+
+    mangled
+}
+
 fn hash_name<T: ?Sized>() -> u32 {
     use sha3::Digest as _;
     u32::from_le_bytes(
@@ -35,8 +50,8 @@ impl<K: async_graphql::OutputType, V: async_graphql::OutputType> async_graphql::
     fn type_name() -> Cow<'static, str> {
         format!(
             "Entry_{}_{}_{:08x}",
-            K::type_name(),
-            V::type_name(),
+            mangle(K::type_name()),
+            mangle(V::type_name()),
             hash_name::<Self>(),
         )
         .into()
@@ -58,7 +73,7 @@ impl<K: async_graphql::InputType> async_graphql::InputType for MapFilters<K> {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!(
             "MapFilters_{}_{:08x}",
-            K::type_name(),
+            mangle(K::type_name()),
             hash_name::<Self>(),
         ))
     }
@@ -133,7 +148,7 @@ impl<K: async_graphql::InputType> async_graphql::InputType for MapInput<K> {
     fn type_name() -> Cow<'static, str> {
         Cow::Owned(format!(
             "MapInput_{}_{:08x}",
-            K::type_name(),
+            mangle(K::type_name()),
             hash_name::<Self>(),
         ))
     }
@@ -206,7 +221,12 @@ impl<K: async_graphql::InputType> async_graphql::InputType for MapInput<K> {
 use crate::map_view::ByteMapView;
 impl<C: Send + Sync, V: async_graphql::OutputType> async_graphql::TypeName for ByteMapView<C, V> {
     fn type_name() -> Cow<'static, str> {
-        format!("ByteMapView_{}_{:08x}", V::type_name(), hash_name::<Self>()).into()
+        format!(
+            "ByteMapView_{}_{:08x}",
+            mangle(V::type_name()),
+            hash_name::<Self>()
+        )
+        .into()
     }
 }
 #[async_graphql::Object(name_type)]
@@ -272,8 +292,8 @@ impl<C: Send + Sync, I: async_graphql::OutputType, V: async_graphql::OutputType>
     fn type_name() -> Cow<'static, str> {
         format!(
             "MapView_{}_{}_{:08x}",
-            I::type_name(),
-            V::type_name(),
+            mangle(I::type_name()),
+            mangle(V::type_name()),
             hash_name::<Self>(),
         )
         .into()
@@ -467,8 +487,8 @@ impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
     fn type_name() -> Cow<'static, str> {
         format!(
             "CollectionView_{}_{}_{:08x}",
-            K::type_name(),
-            V::type_name(),
+            mangle(K::type_name()),
+            mangle(V::type_name()),
             hash_name::<Self>(),
         )
         .into()
@@ -534,8 +554,8 @@ impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
     fn type_name() -> Cow<'static, str> {
         format!(
             "CustomCollectionView_{}_{}_{:08x}",
-            K::type_name(),
-            V::type_name(),
+            mangle(K::type_name()),
+            mangle(V::type_name()),
             hash_name::<Self>(),
         )
         .into()
@@ -618,8 +638,8 @@ impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
     fn type_name() -> Cow<'static, str> {
         format!(
             "ReentrantCollectionView_{}_{}_{}",
-            K::type_name(),
-            V::type_name(),
+            mangle(K::type_name()),
+            mangle(V::type_name()),
             hash_name::<Self>(),
         )
         .into()
@@ -697,8 +717,8 @@ impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
     fn type_name() -> Cow<'static, str> {
         format!(
             "ReentrantCustomCollectionView_{}_{}_{:08x}",
-            K::type_name(),
-            V::type_name(),
+            mangle(K::type_name()),
+            mangle(V::type_name()),
             hash_name::<Self>(),
         )
         .into()
@@ -830,7 +850,12 @@ where
 use crate::log_view::LogView;
 impl<C: Send + Sync, T: async_graphql::OutputType> async_graphql::TypeName for LogView<C, T> {
     fn type_name() -> Cow<'static, str> {
-        format!("LogView_{}_{:08x}", T::type_name(), hash_name::<Self>()).into()
+        format!(
+            "LogView_{}_{:08x}",
+            mangle(T::type_name()),
+            hash_name::<Self>()
+        )
+        .into()
     }
 }
 #[async_graphql::Object(name_type)]
@@ -882,7 +907,12 @@ where
 use crate::queue_view::QueueView;
 impl<C: Send + Sync, T: async_graphql::OutputType> async_graphql::TypeName for QueueView<C, T> {
     fn type_name() -> Cow<'static, str> {
-        format!("QueueView_{}_{:08x}", T::type_name(), hash_name::<Self>()).into()
+        format!(
+            "QueueView_{}_{:08x}",
+            mangle(T::type_name()),
+            hash_name::<Self>()
+        )
+        .into()
     }
 }
 #[async_graphql::Object(name_type)]


### PR DESCRIPTION
## Motivation

When we added the ability to do more complex queries on our `linera-views` data structures, we introduced several intermediate data types in the GraphQL that need unique type names.  GraphQL type names are a lot more syntactically restrictive than Rust type names, so we introduced a very basic name mangling scheme that is sufficient to cover all the cases originally covered by the `GraphQlView` derive macro and preserves human-readability. 

However, recently, we've seen an influx of issues in which people want to use more complex types in their `async_graphql::SimpleObject` types that cause these GraphQL type names to collide, resulting in a build error.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Introduce a more unique naming scheme by appending a hash of the Rust type name to the generated GraphQL type name.  This mangling scheme [isn't perfect](https://github.com/linera-io/linera-protocol/issues/1858), but should suffice for now until we get time to design something more appropriate.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates. (This is a breaking change to our GraphQL APIs.)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
