### PR TITLE
Use `tuple<>` for the unit type

### DIFF
--- a/linera-witty/src/type_traits/implementations/std/tuples.rs
+++ b/linera-witty/src/type_traits/implementations/std/tuples.rs
@@ -58,11 +58,7 @@ macro_rules! impl_wit_traits_with_borrow_store_clause {
                     $( $types::wit_type_name(), )*
                 ];
 
-                if elements.is_empty() {
-                    "unit".into()
-                } else {
-                    format!("tuple<{}>", elements.join(", ")).into()
-                }
+                format!("tuple<{}>", elements.join(", ")).into()
             }
 
             fn wit_type_declaration() -> Cow<'static, str> {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The previous `unit` native type was removed from the Component Model.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
It is still possible to represent a unit type using an empty tuple type `tuple<>`.

## Test Plan

<!-- How to test that the changes are correct. -->
Not currently used, but was manually tested while getting `linera-execution` to work with Witty.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
