### PR TITLE
`linera-views::dynamodb`: box `aws-sdk-dynamodb` futures

### DIFF
--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -24,7 +24,7 @@ use aws_sdk_dynamodb::{
     Client,
 };
 use aws_smithy_types::error::operation::BuildError;
-use futures::future::join_all;
+use futures::future::{join_all, FutureExt as _};
 use linera_base::ensure;
 use thiserror::Error;
 #[cfg(with_testing)]
@@ -539,6 +539,7 @@ impl DynamoDbStoreInternal {
             .expression_attribute_values(":prefix", AttributeValue::B(Blob::new(key_prefix)))
             .set_exclusive_start_key(start_key_map)
             .send()
+            .boxed()
             .await?;
         Ok(response)
     }
@@ -554,6 +555,7 @@ impl DynamoDbStoreInternal {
             .table_name(&self.namespace)
             .set_key(Some(key_db))
             .send()
+            .boxed()
             .await?;
 
         match response.item {
@@ -577,6 +579,7 @@ impl DynamoDbStoreInternal {
             .set_key(Some(key_db))
             .projection_expression(PARTITION_ATTRIBUTE)
             .send()
+            .boxed()
             .await?;
 
         Ok(response.item.is_some())


### PR DESCRIPTION
## Motivation

The futures returned by `aws-sdk-dynamodb` are large, and frequently lead to stack overflow in `linera-views::dynamodb`.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Box them using `futures::FutureExt::boxed` to move them to the heap before `await`ing them.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

No user-visible changes.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
