### PR TITLE
Fix `Credit` message tracking in Fungible Token

### DIFF
--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -200,6 +200,7 @@ impl FungibleTokenContract {
             self.runtime
                 .prepare_message(message)
                 .with_authentication()
+                .with_tracking()
                 .send_to(target_account.chain_id);
         }
     }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `Credit` message was being sent from the Fungible Token application without tracking. This meant that if the message failed to be delivered, the transferred tokens would not be returned to the sender.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Track the sent `Credit` message.

## Test Plan

<!-- How to test that the changes are correct. -->
TODO

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
