### PR TITLE
Add a configurable policy for incoming messages.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -115,6 +115,18 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
+* `--message-policy <MESSAGE_POLICY>` — The policy for handling incoming messages
+
+  Default value: `accept`
+
+  Possible values:
+  - `accept`:
+    Automatically accept all incoming messages. Reject them only if execution fails
+  - `reject`:
+    Automatically reject tracked messages, ignore or skip untracked messages, but accept protected ones
+  - `ignore`:
+    Don't include any messages in blocks, and don't make any decision whether to accept or reject
+
 
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,6 +3095,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "cfg_aliases",
+ "clap",
  "counter",
  "criterion",
  "dashmap",

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -50,6 +50,7 @@ anyhow = { workspace = true, optional = true }
 async-graphql.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
+clap = { workspace = true, optional = true }
 dashmap.workspace = true
 futures.workspace = true
 linera-base.workspace = true

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -58,7 +58,7 @@ k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 linera-base = { workspace = true, features = ["metrics"] }
 linera-chain = { workspace = true, features = ["metrics"] }
-linera-core = { workspace = true, features = ["metrics", "rocksdb", "wasmer"] }
+linera-core = { workspace = true, features = ["metrics", "rocksdb", "wasmer", "clap"] }
 linera-execution = { workspace = true, features = ["fs", "metrics", "wasmer"] }
 linera-rpc = { workspace = true, features = ["server", "simple-network"] }
 linera-sdk = { workspace = true, optional = true }

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -11,6 +11,7 @@ use linera_base::{
     identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
+use linera_core::client::MessagePolicy;
 use linera_execution::{
     committee::ValidatorName, system::SystemChannel, UserApplicationId, WasmRuntime,
     WithWasmDefault,
@@ -96,6 +97,10 @@ pub struct ClientOptions {
     /// The number of Tokio worker threads to use.
     #[arg(long, env = "LINERA_CLIENT_TOKIO_THREADS")]
     pub tokio_threads: Option<usize>,
+
+    /// The policy for handling incoming messages.
+    #[arg(long, default_value = "accept")]
+    pub message_policy: MessagePolicy,
 }
 
 impl ClientOptions {


### PR DESCRIPTION
## Motivation

Users may not always want to automatically accept all incoming messages when running a CLI command. Once fallback owners are implement, validators will also use `linera service` to act as chain owners, and they will want to reject most messages.

## Proposal

Add a configurable message policy to the client options, so you can choose to:
* ignore all messages (except `OpenChain`),
* reject and skip as much as possible, or
* accept all messages (the default).

## Test Plan

A client test was added.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/1842.
- See also: https://github.com/linera-io/linera-protocol/issues/1621
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
