### PR TITLE
Make clap non-optional in linera-core.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "cfg_aliases",
+ "clap",
  "dashmap",
  "futures",
  "linera-base",

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -50,7 +50,7 @@ anyhow = { workspace = true, optional = true }
 async-graphql.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
-clap = { workspace = true, optional = true }
+clap.workspace = true
 dashmap.workspace = true
 futures.workspace = true
 linera-base.workspace = true

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -163,8 +163,7 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
 /// Policies for automatically handling incoming messages.
 ///
 /// These apply to all messages except for the initial `OpenChain`, which is always accepted.
-#[derive(Copy, Clone)]
-#[cfg_attr(feature = "clap", derive(clap::ValueEnum))]
+#[derive(Copy, Clone, clap::ValueEnum)]
 pub enum MessagePolicy {
     /// Automatically accept all incoming messages. Reject them only if execution fails.
     Accept,

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -58,7 +58,7 @@ k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 linera-base = { workspace = true, features = ["metrics"] }
 linera-chain = { workspace = true, features = ["metrics"] }
-linera-core = { workspace = true, features = ["metrics", "rocksdb", "wasmer", "clap"] }
+linera-core = { workspace = true, features = ["metrics", "rocksdb", "wasmer"] }
 linera-execution = { workspace = true, features = ["fs", "metrics", "wasmer"] }
 linera-rpc = { workspace = true, features = ["server", "simple-network"] }
 linera-sdk = { workspace = true, optional = true }


### PR DESCRIPTION
## Motivation

`linera-execution` already depends on `clap` and works fine with Wasm and in the browser. `linera-core` depends on `linera-execution` anway, so `clap` is always a dependency.

## Proposal

Remove the `clap` feature and unconditionally derive `clap::ValueEnum` for `MessagePolicy`.

## Test Plan

Doesn't change any logic.

## Links

- #1842
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
