### PR TITLE
`.github/workflows/documentation`: supersede in-progress publishes

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,7 +14,7 @@ on:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.head_ref || github.run_id }}'
+  group: '${{ github.workflow }} ${{ github.ref }}'
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Motivation

Sometimes if we merge two PRs quickly they will race to push to our GitHub pages, causing one to fail.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Make the concurrency group on the job coarser so that if a job is already running, cancel it before attempting a publish. 

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI on `main`.  We could deliberately merge two PRs in quick succession?

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

Shouldn't change anything from the outside.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [GitHub workflow concurrency reference](https://docs.github.com/en/actions/using-jobs/using-concurrency)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
