### PR TITLE
Implement Witty traits for `BTreeMap` and `Duration`

### DIFF
--- a/linera-witty/src/type_traits/implementations/std/collections.rs
+++ b/linera-witty/src/type_traits/implementations/std/collections.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for the Rust collection types.
+
+use std::{borrow::Cow, collections::BTreeMap};
+
+use frunk::HList;
+
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitStore, WitType,
+};
+
+impl<K, V> WitType for BTreeMap<K, V>
+where
+    K: WitType,
+    V: WitType,
+    (K, V): WitType,
+{
+    const SIZE: u32 = <Vec<(K, V)> as WitType>::SIZE;
+
+    type Layout = <Vec<(K, V)> as WitType>::Layout;
+    type Dependencies = HList![K, V];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        <Vec<(K, V)> as WitType>::wit_type_name()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        <Vec<(K, V)> as WitType>::wit_type_declaration()
+    }
+}
+
+impl<K, V> WitLoad for BTreeMap<K, V>
+where
+    K: WitType + Ord,
+    V: WitType,
+    (K, V): WitLoad,
+{
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = <Vec<(K, V)> as WitLoad>::load(memory, location)?;
+        Ok(entries.into_iter().collect())
+    }
+
+    fn lift_from<Instance>(
+        flat_layout: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = <Vec<(K, V)> as WitLoad>::lift_from(flat_layout, memory)?;
+        Ok(entries.into_iter().collect())
+    }
+}
+
+impl<K, V> WitStore for BTreeMap<K, V>
+where
+    K: WitType,
+    V: WitType,
+    (K, V): WitStore,
+    for<'a> (&'a K, &'a V): WitStore,
+{
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = self.iter().collect::<Vec<(&K, &V)>>();
+        entries.store(memory, location)
+    }
+
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<Self::Layout, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let entries = self.iter().collect::<Vec<(&K, &V)>>();
+        entries.lower(memory)
+    }
+}

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -11,5 +11,6 @@ mod phantom_data;
 mod primitives;
 mod result;
 mod string;
+mod time;
 mod tuples;
 mod vec;

--- a/linera-witty/src/type_traits/implementations/std/mod.rs
+++ b/linera-witty/src/type_traits/implementations/std/mod.rs
@@ -3,6 +3,7 @@
 
 //! Implementations of the custom traits for types from the standard library.
 
+mod collections;
 mod floats;
 mod integers;
 mod option;

--- a/linera-witty/src/type_traits/implementations/std/time.rs
+++ b/linera-witty/src/type_traits/implementations/std/time.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implementations of the custom traits for the Rust time types.
+
+use std::{borrow::Cow, time::Duration};
+
+use frunk::HList;
+
+use crate::{
+    GuestPointer, InstanceWithMemory, Layout, Memory, Runtime, RuntimeError, RuntimeMemory,
+    WitLoad, WitStore, WitType,
+};
+
+impl WitType for Duration {
+    const SIZE: u32 = <HList![u64, u32] as WitType>::SIZE;
+
+    type Layout = <HList![u64, u32] as WitType>::Layout;
+    type Dependencies = HList![];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "duration".into()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        "    type duration = tuple<u64, u32>;".into()
+    }
+}
+
+impl WitLoad for Duration {
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let (secs, nanos) = <(u64, u32) as WitLoad>::load(memory, location)?;
+        Ok(Duration::new(secs, nanos))
+    }
+
+    fn lift_from<Instance>(
+        flat_layout: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let (secs, nanos) = <(u64, u32) as WitLoad>::lift_from(flat_layout, memory)?;
+        Ok(Duration::new(secs, nanos))
+    }
+}
+
+impl WitStore for Duration {
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let secs = self.as_secs();
+        let nanos = self.subsec_nanos();
+
+        (secs, nanos).store(memory, location)
+    }
+
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let secs = self.as_secs();
+        let nanos = self.subsec_nanos();
+
+        (secs, nanos).lower(memory)
+    }
+}

--- a/linera-witty/src/type_traits/implementations/tests.rs
+++ b/linera-witty/src/type_traits/implementations/tests.rs
@@ -22,7 +22,7 @@ fn hlist_without_padding() {
     ];
 
     test_memory_roundtrip(
-        input,
+        &input,
         &[
             0x1f, 0x1e, 0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x18, 0x17, 0x16, 0x15, 0x14, 0x13, 0x12,
             0x11, 0x10, 0x27, 0x26, 0x25, 0x24, 0x23, 0x22, 0x21, 0x20, 0x33, 0x32, 0x31, 0x30,
@@ -31,7 +31,7 @@ fn hlist_without_padding() {
         &[],
     );
     test_flattening_roundtrip(
-        input,
+        &input,
         hlist![
             0x1819_1a1b_1c1d_1e1f_i64,
             0x1011_1213_1415_1617_i64,
@@ -52,14 +52,14 @@ fn hlist_with_padding_at_the_end_for_size_alignment() {
     let input = hlist![0x8081_8283_8485_8687_u64, true];
 
     test_memory_roundtrip(
-        input,
+        &input,
         &[
             0x87, 0x86, 0x85, 0x84, 0x83, 0x82, 0x81, 0x80, 0x01, 0, 0, 0, 0, 0, 0, 0,
         ],
         &[],
     );
     test_flattening_roundtrip(
-        input,
+        &input,
         hlist![0x8081_8283_8485_8687_u64 as i64, 0x0000_0001_i32],
         &[],
     );
@@ -77,7 +77,7 @@ fn hlist_with_padding() {
     ];
 
     test_memory_roundtrip(
-        input,
+        &input,
         &[
             0x01, 0, 0x11, 0x10, 0x21, 0x20, 0, 0, 0x33, 0x32, 0x31, 0x30, 0, 0, 0, 0, 0x47, 0x46,
             0x45, 0x44, 0x43, 0x42, 0x41, 0x40,
@@ -85,7 +85,7 @@ fn hlist_with_padding() {
         &[],
     );
     test_flattening_roundtrip(
-        input,
+        &input,
         hlist![
             0x0000_0001_i32,
             0x0000_1011_i32,
@@ -102,8 +102,8 @@ fn hlist_with_padding() {
 fn none() {
     let input = None::<i8>;
 
-    test_memory_roundtrip(input, &[0x00, 0], &[]);
-    test_flattening_roundtrip(input, hlist![0_i32, 0_i32], &[]);
+    test_memory_roundtrip(&input, &[0x00, 0], &[]);
+    test_flattening_roundtrip(&input, hlist![0_i32, 0_i32], &[]);
 }
 
 /// Test roundtrip of `Some::<i8>`.
@@ -111,8 +111,8 @@ fn none() {
 fn some_byte() {
     let input = Some(-100_i8);
 
-    test_memory_roundtrip(input, &[0x01, 0x9c], &[]);
-    test_flattening_roundtrip(input, hlist![1_i32, -100_i32], &[]);
+    test_memory_roundtrip(&input, &[0x01, 0x9c], &[]);
+    test_flattening_roundtrip(&input, hlist![1_i32, -100_i32], &[]);
 }
 
 /// Test roundtrip of `Ok::<i16, u128>`.
@@ -125,13 +125,13 @@ fn ok_two_bytes_but_large_err() {
         8
     );
     test_memory_roundtrip(
-        input,
+        &input,
         &[
             0x00, 0, 0, 0, 0, 0, 0, 0, 0x34, 0x12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         ],
         &[],
     );
-    test_flattening_roundtrip(input, hlist![0_i32, 0x0000_1234_i64, 0_i64], &[]);
+    test_flattening_roundtrip(&input, hlist![0_i32, 0x0000_1234_i64, 0_i64], &[]);
 }
 
 /// Test roundtrip of `Err::<i16, u128>`.
@@ -140,7 +140,7 @@ fn large_err() {
     let input = Err::<i16, _>(0x0001_0203_0405_0607_0809_0a0b_0c0d_0e0f_u128);
 
     test_memory_roundtrip(
-        input,
+        &input,
         &[
             0x01, 0, 0, 0, 0, 0, 0, 0, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06,
             0x05, 0x04, 0x03, 0x02, 0x01, 0x00,
@@ -148,7 +148,7 @@ fn large_err() {
         &[],
     );
     test_flattening_roundtrip(
-        input,
+        &input,
         hlist![1_i32, 0x0809_0a0b_0c0d_0e0f_i64, 0x0001_0203_0405_0607_i64],
         &[],
     );
@@ -166,19 +166,19 @@ fn duration() {
 
     assert_eq!(<<Duration as WitType>::Layout as Layout>::ALIGNMENT, 8);
     test_memory_roundtrip(
-        input,
+        &input,
         &[
             0xbb, 0xba, 0xaf, 0xae, 0xad, 0xac, 0xab, 0x4a, 0x35, 0x36, 0x37, 0x38, 0, 0, 0, 0,
         ],
         &[],
     );
-    test_flattening_roundtrip(input, hlist![seconds as i64, nanos as i32], &[]);
+    test_flattening_roundtrip(&input, hlist![seconds as i64, nanos as i32], &[]);
 }
 
 /// Test storing an instance of `T` to memory, checking that the `layout_data` bytes followed by
 /// the `heap_data` bytes are correctly written, and check that the instance can be loaded from
 /// those bytes.
-fn test_memory_roundtrip<T>(input: T, layout_data: &[u8], heap_data: &[u8])
+fn test_memory_roundtrip<T>(input: &T, layout_data: &[u8], heap_data: &[u8])
 where
     T: Debug + Eq + WitLoad + WitStore,
 {
@@ -206,7 +206,7 @@ where
 /// Test lowering an instance of `T`, checking that the resulting flat layout matches the expected
 /// `flat_layout`, and check that the instance can be lifted from that flat layout.
 fn test_flattening_roundtrip<T>(
-    input: T,
+    input: &T,
     flat_layout: <T::Layout as Layout>::Flat,
     heap_data: &[u8],
 ) where
@@ -223,5 +223,5 @@ fn test_flattening_roundtrip<T>(
 
     assert_eq!(lowered_layout, flat_layout);
     assert_eq!(memory.read(heap_address, heap_length).unwrap(), heap_data);
-    assert_eq!(T::lift_from(lowered_layout, &memory).unwrap(), input);
+    assert_eq!(&T::lift_from(lowered_layout, &memory).unwrap(), input);
 }

--- a/linera-witty/src/type_traits/implementations/tests.rs
+++ b/linera-witty/src/type_traits/implementations/tests.rs
@@ -3,7 +3,7 @@
 
 //! Unit tests for implementations of the custom traits for existing types.
 
-use std::{fmt::Debug, time::Duration};
+use std::{collections::BTreeMap, fmt::Debug, time::Duration};
 
 use frunk::hlist;
 
@@ -173,6 +173,33 @@ fn duration() {
         &[],
     );
     test_flattening_roundtrip(&input, hlist![seconds as i64, nanos as i32], &[]);
+}
+
+/// Test roundtrip of `BTreeMap<u8, i32>`.
+#[test]
+fn btree_map() {
+    let input = [(0xaa, 0x1122_3344), (0xbb, 0x7788_99aa)]
+        .into_iter()
+        .collect::<BTreeMap<u8, i32>>();
+
+    assert_eq!(
+        <<BTreeMap<u8, i32> as WitType>::Layout as Layout>::ALIGNMENT,
+        4
+    );
+    test_memory_roundtrip(
+        &input,
+        &[0x08, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00],
+        &[
+            0xaa, 0, 0, 0, 0x44, 0x33, 0x22, 0x11, 0xbb, 0, 0, 0, 0xaa, 0x99, 0x88, 0x77,
+        ],
+    );
+    test_flattening_roundtrip(
+        &input,
+        hlist![0_i32, 2_i32],
+        &[
+            0xaa, 0, 0, 0, 0x44, 0x33, 0x22, 0x11, 0xbb, 0, 0, 0, 0xaa, 0x99, 0x88, 0x77,
+        ],
+    );
 }
 
 /// Test storing an instance of `T` to memory, checking that the `layout_data` bytes followed by


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
As part of recent additions to the system API, we need to send `std::time::Duration` and `std::collections::BTreeMap` through the WIT interface.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Implement the Witty types (`WitType`, `WitLoad` and `WitStore`) for those types.

## Test Plan

<!-- How to test that the changes are correct. -->
Added some round-trip unit tests for the new types.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
