### PR TITLE
linera wallet forget-keys command

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -37,6 +37,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera wallet show`↴](#linera-wallet-show)
 * [`linera wallet set-default`↴](#linera-wallet-set-default)
 * [`linera wallet init`↴](#linera-wallet-init)
+* [`linera wallet forget-keys`↴](#linera-wallet-forget-keys)
 * [`linera project`↴](#linera-project)
 * [`linera project new`↴](#linera-project-new)
 * [`linera project test`↴](#linera-project-test)
@@ -651,6 +652,7 @@ Show the contents of the wallet
 * `show` — Show the contents of the wallet
 * `set-default` — Change the wallet default chain
 * `init` — Initialize a wallet from the genesis configuration
+* `forget-keys` — Forgets the specified chain's keys
 
 
 
@@ -691,6 +693,18 @@ Initialize a wallet from the genesis configuration
 * `--with-new-chain` — Request a new chain from the faucet, credited with tokens. This requires `--faucet`
 * `--with-other-chains <WITH_OTHER_CHAINS>` — Other chains to follow
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
+
+
+
+## `linera wallet forget-keys`
+
+Forgets the specified chain's keys
+
+**Usage:** `linera wallet forget-keys <CHAIN_ID>`
+
+###### **Arguments:**
+
+* `<CHAIN_ID>`
 
 
 

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -169,6 +169,15 @@ impl WalletState {
         self.inner.chains.insert(chain.chain_id, chain);
     }
 
+    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<KeyPair, anyhow::Error> {
+        let chain = self
+            .inner
+            .chains
+            .get_mut(chain_id)
+            .context(format!("Failed to get chain for chain id: {}", chain_id))?;
+        chain.key_pair.take().context("Failed to take keypair")
+    }
+
     pub fn default_chain(&self) -> Option<ChainId> {
         self.inner.default
     }

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -786,6 +786,9 @@ pub enum WalletCommand {
         #[arg(long)]
         testing_prng_seed: Option<u64>,
     },
+
+    /// Forgets the specified chain's keys.
+    ForgetKeys { chain_id: ChainId },
 }
 
 #[derive(Clone, clap::Parser)]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1549,9 +1549,17 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 context.wallet_state().pretty_print(*chain_id);
                 Ok(())
             }
+
             WalletCommand::SetDefault { chain_id } => {
                 let mut context = ClientContext::from_options(&options)?;
                 context.wallet_state_mut().set_default_chain(*chain_id)?;
+                context.save_wallet();
+                Ok(())
+            }
+
+            WalletCommand::ForgetKeys { chain_id } => {
+                let mut context = ClientContext::from_options(&options)?;
+                context.wallet_state_mut().forget_keys(chain_id)?;
                 context.save_wallet();
                 Ok(())
             }


### PR DESCRIPTION
## Motivation

We need a way to forget the keys from a chain

## Proposal

Create a `linera wallet forget-keys` command

## Test Plan

`linera wallet show` before:

![Screenshot 2024-04-05 at 13.31.03.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/946e68b0-aa28-4f69-881c-0d06e72232d5.png)

`linera wallet show` after:

![Screenshot 2024-04-05 at 13.31.12.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/262f2e14-4b2e-45c7-9676-c9b5c53b32c8.png)

