### PR TITLE
linera wallet forget-chain command

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -38,6 +38,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera wallet set-default`↴](#linera-wallet-set-default)
 * [`linera wallet init`↴](#linera-wallet-init)
 * [`linera wallet forget-keys`↴](#linera-wallet-forget-keys)
+* [`linera wallet forget-chain`↴](#linera-wallet-forget-chain)
 * [`linera project`↴](#linera-project)
 * [`linera project new`↴](#linera-project-new)
 * [`linera project test`↴](#linera-project-test)
@@ -653,6 +654,7 @@ Show the contents of the wallet
 * `set-default` — Change the wallet default chain
 * `init` — Initialize a wallet from the genesis configuration
 * `forget-keys` — Forgets the specified chain's keys
+* `forget-chain` — Forgets the specified chain, including the associated key pair
 
 
 
@@ -701,6 +703,18 @@ Initialize a wallet from the genesis configuration
 Forgets the specified chain's keys
 
 **Usage:** `linera wallet forget-keys <CHAIN_ID>`
+
+###### **Arguments:**
+
+* `<CHAIN_ID>`
+
+
+
+## `linera wallet forget-chain`
+
+Forgets the specified chain, including the associated key pair
+
+**Usage:** `linera wallet forget-chain <CHAIN_ID>`
 
 ###### **Arguments:**
 

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -178,6 +178,13 @@ impl WalletState {
         chain.key_pair.take().context("Failed to take keypair")
     }
 
+    pub fn forget_chain(&mut self, chain_id: &ChainId) -> Result<UserChain, anyhow::Error> {
+        self.inner
+            .chains
+            .remove(chain_id)
+            .context(format!("Failed to remove chain: {}", chain_id))
+    }
+
     pub fn default_chain(&self) -> Option<ChainId> {
         self.inner.default
     }

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -789,6 +789,9 @@ pub enum WalletCommand {
 
     /// Forgets the specified chain's keys.
     ForgetKeys { chain_id: ChainId },
+
+    /// Forgets the specified chain, including the associated key pair.
+    ForgetChain { chain_id: ChainId },
 }
 
 #[derive(Clone, clap::Parser)]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1564,6 +1564,13 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 Ok(())
             }
 
+            WalletCommand::ForgetChain { chain_id } => {
+                let mut context = ClientContext::from_options(&options)?;
+                context.wallet_state_mut().forget_chain(chain_id)?;
+                context.save_wallet();
+                Ok(())
+            }
+
             WalletCommand::Init {
                 genesis_config_path,
                 faucet,


### PR DESCRIPTION
## Motivation

We need a way to forget a chain from a wallet

## Proposal

Create a `linera wallet forget-chain` command

## Test Plan

`linera wallet show` before:

![Screenshot 2024-04-05 at 13.31.45.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/4e33dc1d-c5da-4cad-ade2-0a3e7a240ef2.png)

`linera wallet show` after (chain not there anymore):

![Screenshot 2024-04-05 at 13.32.23.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/HlciHFAoHZW62zn13apJ/886e399c-d46e-4ea3-8ed7-a00527e2a219.png)

