### PR TITLE
Wait for refund messages before final assertions in Matching Engine end-to-end test

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1045,6 +1045,38 @@ impl NodeService {
             invalid_data => bail!("Expected a tip hash string, but got {invalid_data:?} instead"),
         }
     }
+
+    /// Waits until this node service has the certificate with the provided `certificate_hash` in
+    /// storage.
+    ///
+    /// This is usually used to check that the block from the `certificate_hash` has been
+    /// processed, and consequently its messages have been placed in the inbox of the
+    /// `receiver_chain`. Note that if the sender chain does not send a message to the
+    /// `receiver_chain` in the block referenced by the `certificate_hash` (or to any of the chains
+    /// tracked by this node service) the node service will never receive a notification for the
+    /// block, and consequently wait forever.
+    ///
+    /// In practice, the `receiver_chain` is only used by the node service to access the storage.
+    pub async fn wait_for_messages(
+        &self,
+        receiver_chain: ChainId,
+        certificate_hash: CryptoHash,
+    ) -> Result<()> {
+        let query = format!(
+            r#"query {{
+                block(hash: "{certificate_hash}", chainId: "{receiver_chain}") {{ hash }}
+            }}"#
+        );
+
+        let data = self.query_node(query).await?;
+
+        assert_eq!(
+            data["block"]["hash"].as_str(),
+            Some(&*certificate_hash.to_string())
+        );
+
+        Ok(())
+    }
 }
 
 /// A running faucet service.


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The Matching Engine end-to-end test would sometimes fail in CI. This was caused by a race condition in the test, where some queries to node services to obtain token balances for the final assertions raced the notifications to the node services about the blocks that send the final tokens.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Wait until the node services receive the blocks that send the messages, so that they can execute them and receive the remaining tokens.

## Test Plan

<!-- How to test that the changes are correct. -->
I managed to increase the frequency of the race condition significantly by adding a delay when proxying the notification to the node service, just before the following line:

https://github.com/linera-io/linera-protocol/blob/538ce38b3f9a1c41c9dcd4a957f959b66fa2b5cf/linera-service/src/grpc_proxy.rs#L398

After the fix, I could not reproduce the error.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Fixes #1854
- Future work:
  - #1874 
  - #1888
