### PR TITLE
Use `anyhow::Error` in end-to-end tests

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -6,6 +6,7 @@ mod common;
 
 use std::{collections::BTreeMap, env, path::PathBuf, time::Duration};
 
+use anyhow::Result;
 use assert_matches::assert_matches;
 use async_graphql::InputType;
 use common::INTEGRATION_TEST_GUARD;
@@ -144,7 +145,7 @@ impl NonFungibleApp {
         STANDARD_NO_PAD.encode(token_id_vec.id)
     }
 
-    async fn get_nft(&self, token_id: &String) -> anyhow::Result<non_fungible::NftOutput> {
+    async fn get_nft(&self, token_id: &String) -> Result<non_fungible::NftOutput> {
         let query = format!(
             "nft(tokenId: {}) {{ tokenId, owner, name, minter, payload }}",
             token_id.to_value()
@@ -153,7 +154,7 @@ impl NonFungibleApp {
         Ok(serde_json::from_value(response_body["nft"].clone())?)
     }
 
-    async fn get_owned_nfts(&self, owner: &AccountOwner) -> anyhow::Result<Vec<String>> {
+    async fn get_owned_nfts(&self, owner: &AccountOwner) -> Result<Vec<String>> {
         let query = format!("ownedTokenIdsByOwner(owner: {})", owner.to_value());
         let response_body = self.0.query(&query).await?;
         Ok(serde_json::from_value(
@@ -2717,13 +2718,13 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) {
 
     let (mut tx1, mut rx) = mpsc::channel(8);
     let mut tx2 = tx1.clone();
-    let handle1: JoinHandle<Result<(), anyhow::Error>> = tokio::spawn(async move {
+    let handle1: JoinHandle<Result<()>> = tokio::spawn(async move {
         loop {
             client1.transfer(Amount::ONE, chain2, chain1).await?;
             tx1.send(()).await.unwrap();
         }
     });
-    let handle2: JoinHandle<Result<(), anyhow::Error>> = tokio::spawn(async move {
+    let handle2: JoinHandle<Result<()>> = tokio::spawn(async move {
         loop {
             client2.transfer(Amount::ONE, chain2, chain1).await?;
             tx2.send(()).await.unwrap();

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -280,7 +280,7 @@ impl AmmApp {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) {
+async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
@@ -323,6 +323,8 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -331,7 +333,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfig) {
+async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -372,6 +374,8 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -380,7 +384,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) {
+async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) -> Result<()> {
     use social::SocialAbi;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
@@ -467,6 +471,8 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "service_grpc")]
@@ -480,7 +486,10 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None), "fungible" ; "remote_net_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None), "native-fungible" ; "native_remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig, example_name: &str) {
+async fn test_wasm_end_to_end_fungible(
+    config: impl LineraNetConfig,
+    example_name: &str,
+) -> Result<()> {
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -621,6 +630,8 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig, example_nam
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "service_grpc")]
@@ -637,7 +648,7 @@ async fn test_wasm_end_to_end_fungible(config: impl LineraNetConfig, example_nam
 async fn test_wasm_end_to_end_same_wallet_fungible(
     config: impl LineraNetConfig,
     example_name: &str,
-) {
+) -> Result<()> {
     use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -739,6 +750,8 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -747,7 +760,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) {
+async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Result<()> {
     use non_fungible::{NftOutput, NonFungibleTokenAbi};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1014,6 +1027,8 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -1022,7 +1037,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
+async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Result<()> {
     use crowd_funding::{CrowdFundingAbi, InitializationArgument};
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
 
@@ -1146,6 +1161,8 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 // TODO(#1159): We should enable the matching engine on other storages.
@@ -1156,7 +1173,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) {
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
 // #[cfg_attr(feature = "rocksdb", test_case(LocalNetConfig::new_test(Database::RocksDb, Network::Grpc) ; "rocksdb_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
+async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> Result<()> {
     use matching_engine::{MatchingEngineAbi, OrderNature, Parameters, Price};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -1448,6 +1465,8 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -1456,7 +1475,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
+async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     use amm::{AmmAbi, Parameters};
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
@@ -1777,10 +1796,12 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
-async fn test_resolve_binary() {
+async fn test_resolve_binary() -> Result<()> {
     resolve_binary("linera", env!("CARGO_PKG_NAME"))
         .await
         .unwrap();
@@ -1790,6 +1811,8 @@ async fn test_resolve_binary() {
     assert!(resolve_binary("linera-spaceship", env!("CARGO_PKG_NAME"))
         .await
         .is_err());
+
+    Ok(())
 }
 
 // TODO(#1655): Make the scylladb_udp / rocksdb_udp test work.
@@ -1802,7 +1825,7 @@ async fn test_resolve_binary() {
 #[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Tcp) ; "aws_tcp"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Udp) ; "aws_udp"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_reconfiguration(config: LocalNetConfig) {
+async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let network = config.network;
     let (mut net, client) = config.instantiate().await.unwrap();
@@ -1910,6 +1933,8 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -1918,7 +1943,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_open_chain_node_service(config: impl LineraNetConfig) {
+async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client) = config.instantiate().await.unwrap();
 
@@ -2018,7 +2043,7 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) {
         if balance1 == Amount::from_tokens(6) && balance2 == Amount::from_tokens(4) {
             net.ensure_is_running().await.unwrap();
             net.terminate().await.unwrap();
-            return;
+            return Ok(());
         }
     }
     panic!("Failed to receive new block");
@@ -2028,7 +2053,7 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) {
+async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client1) = config.instantiate().await.unwrap();
@@ -2085,6 +2110,8 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -2093,7 +2120,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
+async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create net and two clients.
@@ -2131,10 +2158,12 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
-async fn test_project_new() {
+async fn test_project_new() -> Result<()> {
     let _rustflags_override = override_disable_warnings_as_errors();
     let path_provider = PathProvider::create_temporary_directory().unwrap();
     let client = ClientWrapper::new(path_provider, Network::Grpc, None, 0);
@@ -2148,23 +2177,27 @@ async fn test_project_new() {
         .build_application(project_dir.as_path(), "init-test", false)
         .await
         .unwrap();
+
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
-async fn test_project_test() {
+async fn test_project_test() -> Result<()> {
     let path_provider = PathProvider::create_temporary_directory().unwrap();
     let client = ClientWrapper::new(path_provider, Network::Grpc, None, 0);
     client
         .project_test(&ClientWrapper::example_path("counter").unwrap())
         .await
         .unwrap();
+
+    Ok(())
 }
 
 #[test_case(Database::Service, Network::Grpc ; "service_grpc")]
 #[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(Database::DynamoDb, Network::Grpc ; "aws_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_project_publish(database: Database, network: Network) {
+async fn test_project_publish(database: Database, network: Network) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let _rustflags_override = override_disable_warnings_as_errors();
     let config = LocalNetConfig {
@@ -2201,10 +2234,12 @@ async fn test_project_publish(database: Database, network: Network) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_log::test(tokio::test)]
-async fn test_linera_net_up_simple() {
+async fn test_linera_net_up_simple() -> Result<()> {
     use std::{
         io::{BufRead, BufReader},
         process::{Command, Stdio},
@@ -2247,7 +2282,7 @@ async fn test_linera_net_up_simple() {
 
             assert!(exports.next().is_none());
             assert!(child.wait().unwrap().success());
-            return;
+            return Ok(());
         }
     }
     panic!("Unexpected EOF for stderr");
@@ -2257,7 +2292,7 @@ async fn test_linera_net_up_simple() {
 #[cfg_attr(feature = "scylladb", test_case(Database::ScyllaDb, Network::Grpc ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(Database::DynamoDb, Network::Grpc ; "aws_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_example_publish(database: Database, network: Network) {
+async fn test_example_publish(database: Database, network: Network) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let config = LocalNetConfig {
         num_initial_validators: 1,
@@ -2286,6 +2321,8 @@ async fn test_example_publish(database: Database, network: Network) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -2294,7 +2331,7 @@ async fn test_example_publish(database: Database, network: Network) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
+async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -2360,6 +2397,8 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -2368,7 +2407,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) {
+async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and client.
@@ -2400,6 +2439,8 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -2408,7 +2449,7 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConfig) {
+async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -2448,6 +2489,8 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
@@ -2456,7 +2499,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
+async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -2529,6 +2572,8 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
     assert!(client3.query_balance(Account::chain(chain3)).await.unwrap() <= Amount::ONE);
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[cfg(feature = "benchmark")]
@@ -2538,7 +2583,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) {
+async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::command::CommandExt;
     use tokio::process::Command;
 
@@ -2574,13 +2619,15 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) {
     faucet_service.terminate().await.unwrap();
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) {
+async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     // Create runner and client.
     let (mut net, client) = config.instantiate().await.unwrap();
@@ -2611,6 +2658,8 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 #[cfg(feature = "benchmark")]
@@ -2621,7 +2670,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) {
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Tcp) ; "scylladb_tcp"))]
 #[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Tcp) ; "aws_tcp"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_benchmark(mut config: LocalNetConfig) {
+async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
 
     config.num_other_initial_chains = 2;
@@ -2658,6 +2707,8 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }
 
 /// Clears the `RUSTFLAGS` environment variable, if it was configured to make warnings fail as
@@ -2689,7 +2740,7 @@ impl Drop for RestoreVarOnDrop {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) {
+async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -2742,4 +2793,6 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) {
 
     net.ensure_is_running().await.unwrap();
     net.terminate().await.unwrap();
+
+    Ok(())
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Many of the `async` tests panic when an error occurs instead of propagating the error using the try operator (`?`). The reasoning for this was that panics preserve the backtrace. However, if `anyhow::Error` is used, it automatically captures and displays a backtrace as well.

If the try operator (`?`) is used instead of panics, the code becomes slightly less noisy.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Change the end-to-end tests to return `anyhow::Result<()>` and replace `Result::unwrap` calls with the try operator.

## Test Plan

<!-- How to test that the changes are correct. -->
Two tests were temporarily changed to fail, to test if CI shows the backtrace even if the try operator is used.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Only affects tests, so nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
