### PR TITLE
Derive Witty traits for `linera-base` types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,6 +3102,7 @@ dependencies = [
  "getrandom",
  "hex",
  "linera-base",
+ "linera-witty",
  "prometheus",
  "proptest",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,7 @@ dependencies = [
  "serde-name",
  "serde_bytes",
  "sha3",
+ "test-case",
  "test-strategy",
  "thiserror",
  "tokio",

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -25,6 +25,7 @@ ed25519-dalek.workspace = true
 generic-array.workspace = true
 getrandom = { workspace = true, optional = true }
 hex.workspace = true
+linera-witty = { workspace = true, features = ["macros"] }
 prometheus = { workspace = true, optional = true }
 proptest = { workspace = true, optional = true, features = ["alloc"] }
 rand.workspace = true

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -46,6 +46,8 @@ prometheus.workspace = true
 [dev-dependencies]
 custom_debug_derive.workspace = true
 linera-base = { path = ".", features = ["test"] }
+linera-witty = { workspace = true, features = ["test"] }
+test-case.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true

--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -598,6 +598,81 @@ impl WitStore for CryptoHash {
     }
 }
 
+impl WitType for PublicKey {
+    const SIZE: u32 = <(u64, u64, u64, u64) as WitType>::SIZE;
+    type Layout = <(u64, u64, u64, u64) as WitType>::Layout;
+    type Dependencies = HList![];
+
+    fn wit_type_name() -> Cow<'static, str> {
+        "public-key".into()
+    }
+
+    fn wit_type_declaration() -> Cow<'static, str> {
+        concat!(
+            "    record public-key {\n",
+            "        part1: u64,\n",
+            "        part2: u64,\n",
+            "        part3: u64,\n",
+            "        part4: u64,\n",
+            "    }\n",
+        )
+        .into()
+    }
+}
+
+impl WitLoad for PublicKey {
+    fn load<Instance>(
+        memory: &Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let (part1, part2, part3, part4) = WitLoad::load(memory, location)?;
+        Ok(PublicKey::from([part1, part2, part3, part4]))
+    }
+
+    fn lift_from<Instance>(
+        flat_layout: <Self::Layout as Layout>::Flat,
+        memory: &Memory<'_, Instance>,
+    ) -> Result<Self, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let (part1, part2, part3, part4) = WitLoad::lift_from(flat_layout, memory)?;
+        Ok(PublicKey::from([part1, part2, part3, part4]))
+    }
+}
+
+impl WitStore for PublicKey {
+    fn store<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+        location: GuestPointer,
+    ) -> Result<(), RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let [part1, part2, part3, part4] = (*self).into();
+        (part1, part2, part3, part4).store(memory, location)
+    }
+
+    fn lower<Instance>(
+        &self,
+        memory: &mut Memory<'_, Instance>,
+    ) -> Result<<Self::Layout as Layout>::Flat, RuntimeError>
+    where
+        Instance: InstanceWithMemory,
+        <Instance::Runtime as Runtime>::Memory: RuntimeMemory<Instance>,
+    {
+        let [part1, part2, part3, part4] = (*self).into();
+        (part1, part2, part3, part4).lower(memory)
+    }
+}
+
 #[cfg(with_testing)]
 impl Arbitrary for CryptoHash {
     type Parameters = ();

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -9,6 +9,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -21,7 +22,9 @@ use crate::{
 ///
 /// This is a fixed-point fraction, with [`Amount::DECIMAL_PLACES`] digits after the point.
 /// [`Amount::ONE`] is one whole token, divisible into `10.pow(Amount::DECIMAL_PLACES)` parts.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug)]
+#[derive(
+    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, WitType, WitLoad, WitStore,
+)]
 pub struct Amount(u128);
 
 #[derive(Serialize, Deserialize)]
@@ -55,7 +58,20 @@ impl<'de> Deserialize<'de> for Amount {
 
 /// A block height to identify blocks in a chain.
 #[derive(
-    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitType,
+    WitLoad,
+    WitStore,
 )]
 #[cfg_attr(with_testing, derive(test_strategy::Arbitrary))]
 pub struct BlockHeight(pub u64);
@@ -76,7 +92,20 @@ pub enum Round {
 
 /// A timestamp, in microseconds since the Unix epoch.
 #[derive(
-    Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Default, Debug, Serialize, Deserialize,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitType,
+    WitLoad,
+    WitStore,
 )]
 pub struct Timestamp(u64);
 
@@ -149,7 +178,9 @@ impl fmt::Display for Timestamp {
 
 /// Resources that an application may spend during the execution of transaction or an
 /// application call.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize, WitLoad, WitStore, WitType,
+)]
 pub struct Resources {
     /// An amount of execution fuel.
     pub fuel: u64,
@@ -173,8 +204,9 @@ pub struct Resources {
 }
 
 /// A request to send a message.
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, WitLoad, WitType)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
+#[witty_specialize_with(Message = Vec<u8>)]
 pub struct SendMessageRequest<Message> {
     /// The destination of the message.
     pub destination: Destination,

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -205,7 +205,7 @@ pub struct Resources {
 
 /// A request to send a message.
 #[derive(Clone, Debug, Deserialize, Serialize, WitLoad, WitType)]
-#[cfg_attr(with_testing, derive(Eq, PartialEq))]
+#[cfg_attr(with_testing, derive(Eq, PartialEq, WitStore))]
 #[witty_specialize_with(Message = Vec<u8>)]
 pub struct SendMessageRequest<Message> {
     /// The destination of the message.

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -21,7 +22,21 @@ use crate::{
 
 /// The owner of a chain. This is currently the hash of the owner's public key used to
 /// verify signatures.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
 #[cfg_attr(with_testing, derive(Default, test_strategy::Arbitrary))]
 pub struct Owner(pub CryptoHash);
 
@@ -35,7 +50,9 @@ pub enum AccountOwner {
 }
 
 /// A system account.
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(
+    Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize, WitLoad, WitStore, WitType,
+)]
 pub struct Account {
     /// The chain of the account.
     pub chain_id: ChainId,
@@ -107,13 +124,40 @@ impl ChainDescription {
 
 /// The unique identifier (UID) of a chain. This is currently computed as the hash value
 /// of a [`ChainDescription`].
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize)]
+#[derive(
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
 #[cfg_attr(with_testing, derive(test_strategy::Arbitrary))]
 #[cfg_attr(with_testing, derive(Default))]
 pub struct ChainId(pub CryptoHash);
 
 /// The index of a message in a chain.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
 #[cfg_attr(with_testing, derive(Default))]
 pub struct MessageId {
     /// The chain ID that created the message.
@@ -125,6 +169,7 @@ pub struct MessageId {
 }
 
 /// A unique identifier for a user application.
+#[derive(WitLoad, WitStore, WitType)]
 #[cfg_attr(with_testing, derive(Default))]
 pub struct ApplicationId<A = ()> {
     /// The bytecode to use for the application.
@@ -160,19 +205,47 @@ impl From<ApplicationId> for GenericApplicationId {
 }
 
 /// A unique identifier for an application bytecode.
+#[derive(WitLoad, WitStore, WitType)]
 #[cfg_attr(with_testing, derive(Default))]
 pub struct BytecodeId<Abi = (), Parameters = (), InitializationArgument = ()> {
     /// The message ID that published the bytecode.
     pub message_id: MessageId,
+    #[witty(skip)]
     _phantom: std::marker::PhantomData<(Abi, Parameters, InitializationArgument)>,
 }
 
 /// The name of a subscription channel.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
 pub struct ChannelName(#[serde(with = "serde_bytes")] Vec<u8>);
 
 /// The destination of a message, relative to a particular application.
-#[derive(Debug, PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
 pub enum Destination {
     /// Direct message to a chain.
     Recipient(ChainId),

--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -21,6 +21,8 @@ pub mod ownership;
 #[cfg(with_metrics)]
 pub mod prometheus_util;
 pub mod sync;
+#[cfg(test)]
+mod unit_tests;
 
 pub use graphql::BcsHexParseError;
 #[doc(hidden)]

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -6,14 +6,14 @@
 
 use std::{collections::BTreeMap, iter, time::Duration};
 
-use linera_witty::{WitStore, WitType};
+use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{crypto::PublicKey, data_types::Round, doc_scalar, identifiers::Owner};
 
 /// The timeout configuration: how long fast, multi-leader and single-leader rounds last.
-#[derive(PartialEq, Eq, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Hash, Debug, Serialize, Deserialize, WitLoad, WitStore, WitType)]
 pub struct TimeoutConfig {
     /// The duration of the fast round.
     pub fast_round_duration: Option<Duration>,
@@ -34,7 +34,9 @@ impl Default for TimeoutConfig {
 }
 
 /// Represents the owner(s) of a chain.
-#[derive(PartialEq, Eq, Clone, Hash, Debug, Default, Serialize, Deserialize)]
+#[derive(
+    PartialEq, Eq, Clone, Hash, Debug, Default, Serialize, Deserialize, WitLoad, WitStore, WitType,
+)]
 pub struct ChainOwnership {
     /// Super owners can propose fast blocks in the first round, and regular blocks in any round.
     pub super_owners: BTreeMap<Owner, PublicKey>,

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -6,7 +6,9 @@
 
 use std::{collections::BTreeMap, iter, time::Duration};
 
+use linera_witty::{WitStore, WitType};
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use crate::{crypto::PublicKey, data_types::Round, doc_scalar, identifiers::Owner};
 
@@ -166,6 +168,14 @@ impl ChainOwnership {
         };
         Some(previous_round)
     }
+}
+
+/// Errors that can happen when attempting to close a chain.
+#[derive(Clone, Copy, Debug, Error, WitStore, WitType)]
+pub enum CloseChainError {
+    /// Authenticated signer wasn't allowed to close the chain.
+    #[error("Unauthorized attempt to close the chain")]
+    NotPermitted,
 }
 
 #[cfg(test)]

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -19,6 +19,8 @@ mod imported_function_interface;
 mod memory_layout;
 mod primitive_types;
 mod runtime;
+#[cfg(with_testing)]
+pub mod test;
 mod type_traits;
 mod util;
 

--- a/linera-witty/src/test.rs
+++ b/linera-witty/src/test.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Functions and types useful for writing tests.
+
+use std::fmt::Debug;
+
+use crate::{InstanceWithMemory, Layout, MockInstance, WitLoad, WitStore};
+
+/// Test storing an instance of `T` to memory, checking that the instance can be loaded from those
+/// bytes.
+///
+/// Also checks if storing the loaded instance results in exactly the same bytes in
+/// memory.
+pub fn test_memory_roundtrip<T>(input: &T) -> anyhow::Result<()>
+where
+    T: Debug + Eq + WitLoad + WitStore,
+{
+    let mut first_instance = MockInstance::<()>::default();
+    let mut first_memory = first_instance.memory()?;
+
+    let first_address = first_memory.allocate(T::SIZE)?;
+
+    input.store(&mut first_memory, first_address)?;
+
+    let loaded_instance = T::load(&first_memory, first_address)?;
+
+    assert_eq!(&loaded_instance, input);
+
+    // Create a clean separate memory instance
+    let mut second_instance = MockInstance::<()>::default();
+    let mut second_memory = second_instance.memory()?;
+
+    let second_address = second_memory.allocate(T::SIZE)?;
+
+    loaded_instance.store(&mut second_memory, second_address)?;
+
+    let total_allocated_memory = first_memory.allocate(0)?.0;
+
+    assert_eq!(
+        first_memory.read(first_address, total_allocated_memory)?,
+        second_memory.read(second_address, total_allocated_memory)?
+    );
+
+    Ok(())
+}
+
+/// Test lowering an instance of `T`, checking that the resulting flat layout matches the expected
+/// `flat_layout`, and check that the instance can be lifted from that flat layout.
+pub fn test_flattening_roundtrip<T>(input: &T) -> anyhow::Result<()>
+where
+    T: Debug + Eq + WitLoad + WitStore,
+    <T::Layout as Layout>::Flat: Copy + Debug + Eq,
+{
+    let mut first_instance = MockInstance::<()>::default();
+    let mut first_memory = first_instance.memory()?;
+    let first_start_address = first_memory.allocate(0)?;
+
+    let first_lowered_layout = input.lower(&mut first_memory)?;
+    let lifted_instance = T::lift_from(first_lowered_layout, &first_memory)?;
+
+    assert_eq!(&lifted_instance, input);
+
+    // Create a clean separate memory instance
+    let mut second_instance = MockInstance::<()>::default();
+    let mut second_memory = second_instance.memory()?;
+    let second_start_address = second_memory.allocate(0)?;
+
+    let second_lowered_layout = lifted_instance.lower(&mut second_memory)?;
+
+    assert_eq!(first_lowered_layout, second_lowered_layout);
+
+    let total_allocated_memory = first_memory.allocate(0)?.0;
+
+    assert_eq!(
+        first_memory.read(first_start_address, total_allocated_memory)?,
+        second_memory.read(second_start_address, total_allocated_memory)?
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Some types from `linera-base` are used in the WIT interface. For them to be used with Witty, they need to have some traits implemented.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Implement the traits manually for `CryptoHash` and `PublicKey`, which have non-direct WIT representations, and derive the traits for the other needed types.

## Test Plan

<!-- How to test that the changes are correct. -->
A unit test was added to check that the types can be stored and loaded using Witty.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because the Witty trait implementations aren't used yet.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
