### PR TITLE
Simplify current_round computation; remove previous_round.

### DIFF
--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -147,34 +147,6 @@ impl ChainOwnership {
         };
         Some(next_round)
     }
-
-    /// Returns the round preceding the specified one, if any.
-    pub fn previous_round(&self, round: Round) -> Option<Round> {
-        let previous_round = match round {
-            Round::Fast => return None,
-            Round::MultiLeader(r) => {
-                if let Some(prev_r) = r.checked_sub(1) {
-                    Round::MultiLeader(prev_r)
-                } else if self.super_owners.is_empty() {
-                    return None;
-                } else {
-                    Round::Fast
-                }
-            }
-            Round::SingleLeader(r) => {
-                if let Some(prev_r) = r.checked_sub(1) {
-                    Round::SingleLeader(prev_r)
-                } else if let Some(last_multi_r) = self.multi_leader_rounds.checked_sub(1) {
-                    Round::MultiLeader(last_multi_r)
-                } else if self.super_owners.is_empty() {
-                    return None;
-                } else {
-                    Round::Fast
-                }
-            }
-        };
-        Some(previous_round)
-    }
 }
 
 /// Errors that can happen when attempting to close a chain.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -788,7 +788,7 @@ where
             ));
         }
         self.cache_validated(&certificate.value).await;
-        let old_round = chain.manager.get().current_round();
+        let old_round = chain.manager.get().current_round;
         chain.manager.get_mut().create_final_vote(
             certificate,
             self.key_pair(),
@@ -796,7 +796,7 @@ where
         );
         let info = ChainInfoResponse::new(&chain, self.key_pair());
         chain.save().await?;
-        let round = chain.manager.get().current_round();
+        let round = chain.manager.get().current_round;
         if round > old_round {
             actions.notifications.push(Notification {
                 chain_id,
@@ -841,18 +841,16 @@ where
         if chain.tip_state.get().already_validated_block(height)? {
             return Ok((ChainInfoResponse::new(&chain, self.key_pair()), actions));
         }
-        let current_round = chain.manager.get().current_round();
+        let old_round = chain.manager.get().current_round;
         chain
             .manager
             .get_mut()
             .handle_timeout_certificate(certificate.clone(), self.storage.current_time());
-        if chain.manager.get().current_round() > current_round {
+        let round = chain.manager.get().current_round;
+        if round > old_round {
             actions.notifications.push(Notification {
                 chain_id,
-                reason: Reason::NewRound {
-                    height,
-                    round: chain.manager.get().current_round(),
-                },
+                reason: Reason::NewRound { height, round },
             })
         }
         let info = ChainInfoResponse::new(&chain, self.key_pair());


### PR DESCRIPTION
## Motivation

In the chain manager, whenever `leader_timeout`, `locked` or `proposed` changes, that potentially starts a new round, in which case the round timeout resets. We pass into `update_timeout` the round that is ending and then check whether that is actually at least the current one.

In some cases this requires computing the "previous round"—or rather the highest round that _could_ have been the previous one. This is confusing and unnecessarily complicated, and would be further complicated by the new `Round` type we will need for fallback owners.

## Proposal

Add a `current_round` field to the `ChainManager`. After each change to one of the mentioned fields, call `update_current_round` to update that and the timeout. Remove `previous_round`.

## Test Plan

The current round is already checked in and relied on by several tests.

## Links

- #1621 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
