### PR TITLE
Increase the gRPC message size limit to 16 MiB.

### DIFF
--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -44,4 +44,4 @@ pub enum GrpcError {
 }
 
 const MEBIBYTE: usize = 1024 * 1024;
-pub const GRPC_MAX_MESSAGE_SIZE: usize = 8 * MEBIBYTE;
+pub const GRPC_MAX_MESSAGE_SIZE: usize = 16 * MEBIBYTE;


### PR DESCRIPTION
## Motivation

Some applications in practice are already limited by the gRPC message size.

This will be addressed by implementing pagination for chain infos, and splitting out bytecodes in the future.

## Proposal

Increase the gRPC message size for now.

## Test Plan

No logic was changed.

## Links

- https://github.com/linera-io/linera-protocol/issues/1850
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
