### PR TITLE
Service engine uses Cranelift instead of Singlepass

### DIFF
--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -38,8 +38,8 @@ use bytes::Bytes;
 use linera_base::sync::Lazy;
 use tokio::sync::Mutex;
 use wasmer::{
-    imports, wasmparser::Operator, CompilerConfig, Engine, EngineBuilder, Instance, Module,
-    Singlepass, Store,
+    imports, wasmparser::Operator, CompilerConfig, Cranelift, Engine, EngineBuilder, Instance,
+    Module, Singlepass, Store,
 };
 use wasmer_middlewares::metering::{self, Metering, MeteringPoints};
 
@@ -52,7 +52,7 @@ use crate::{
 
 /// An [`Engine`] instance configured to run application services.
 static SERVICE_ENGINE: Lazy<Engine> = Lazy::new(|| {
-    let compiler_config = Singlepass::default();
+    let compiler_config = Cranelift::new();
     EngineBuilder::new(compiler_config).into()
 });
 


### PR DESCRIPTION
## Motivation

Running AI models in WASM requires simd128 instructions. The `Singlepass` compiler does not support this.

## Proposal

Change to the `Cranelift` compiler backend for services.

## Test Plan

Existing tests should capture any potential regressions.