### PR TITLE
Display error in WasmExecutionError::ExecuteModuleInWasmer

### DIFF
--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -223,7 +223,7 @@ pub enum WasmExecutionError {
     CreateWasmtimeEngine(#[source] anyhow::Error),
     #[cfg(with_wasmer)]
     #[error(
-        "Failed to execute Wasm module in Wasmer. This may be caused by panics or insufficient fuel."
+        "Failed to execute Wasm module in Wasmer. This may be caused by panics or insufficient fuel. {0}"
     )]
     ExecuteModuleInWasmer(#[from] ::wasmer::RuntimeError),
     #[cfg(with_wasmtime)]


### PR DESCRIPTION
## Motivation

Wasmer errors were not being displayed resulting in making debugging applications difficult.

## Proposal

Display Wasmer error in the error message.

## Test Plan

Has been tested manually.