### PR TITLE
Added a Service API to fetch a blob of bytes from a URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3210,6 +3210,7 @@ dependencies = [
  "once_cell",
  "oneshot",
  "prometheus",
+ "reqwest",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -626,6 +626,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
 name = "corosensei"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,6 +1653,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.11",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1697,6 +1727,12 @@ name = "io-lifetimes"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
@@ -1921,6 +1957,7 @@ dependencies = [
  "once_cell",
  "oneshot",
  "prometheus",
+ "reqwest",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3098,6 +3135,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.11",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,6 +3262,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3191,6 +3315,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "seahash"
@@ -3533,6 +3667,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,6 +3836,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3979,6 +4144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4074,6 +4245,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4529,6 +4712,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4871,6 +5060,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -49,6 +49,7 @@ lru.workspace = true
 once_cell.workspace = true
 oneshot.workspace = true
 prometheus = { workspace = true, optional = true }
+reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -261,6 +261,11 @@ where
                     callback.respond(Ok(()));
                 }
             }
+            #[cfg(not(target_arch = "wasm32"))]
+            FetchUrl { url, callback } => {
+                let bytes = reqwest::get(url).await?.bytes().await?.to_vec();
+                callback.respond(bytes);
+            }
         }
 
         Ok(())
@@ -367,6 +372,12 @@ pub enum Request {
     CloseChain {
         application_id: UserApplicationId,
         callback: oneshot::Sender<Result<(), ExecutionError>>,
+    },
+
+    #[cfg(not(target_arch = "wasm32"))]
+    FetchUrl {
+        url: String,
+        callback: Sender<Vec<u8>>,
     },
 }
 
@@ -480,6 +491,11 @@ impl Debug for Request {
             Request::CloseChain { application_id, .. } => formatter
                 .debug_struct("Request::CloseChain")
                 .field("application_id", application_id)
+                .finish_non_exhaustive(),
+            #[cfg(not(target_arch = "wasm32"))]
+            Request::FetchUrl { url, .. } => formatter
+                .debug_struct("Request::FetchUrl")
+                .field("url", url)
                 .finish_non_exhaustive(),
         }
     }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -129,6 +129,10 @@ pub enum ExecutionError {
     OwnerIsNone,
     #[error("Application is not authorized to perform system operations on this chain: {0:}")]
     UnauthorizedApplication(UserApplicationId),
+    #[error("Failed to make network reqwest")]
+    ReqwestError(#[from] reqwest::Error),
+    #[error("Encountered IO error")]
+    IoError(#[from] std::io::Error),
 }
 
 /// The public entry points provided by the contract part of an application.
@@ -414,6 +418,10 @@ pub trait ServiceRuntime: BaseRuntime {
         queried_id: UserApplicationId,
         argument: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Fetches blob of bytes from an arbitrary URL.
+    fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, ExecutionError>;
 }
 
 pub trait ContractRuntime: BaseRuntime {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1223,6 +1223,16 @@ impl ServiceRuntime for ServiceSyncRuntime {
         self.inner().pop_application();
         Ok(response)
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    /// Get a blob of bytes from an arbitrary URL.
+    fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, ExecutionError> {
+        let this = self.inner();
+        let url = url.to_string();
+        this.execution_state_sender
+            .send_request(|callback| Request::FetchUrl { url, callback })?
+            .recv_response()
+    }
 }
 
 /// The origin of the execution.

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -260,6 +260,11 @@ macro_rules! impl_service_system_api {
                 ServiceRuntime::try_query_application(self, application.into(), argument.to_vec())
             }
 
+            /// Fetches a blob of bytes from an arbitrary URL.
+            fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, Self::Error> {
+                ServiceRuntime::fetch_url(self, url)
+            }
+
             fn log(
                 &mut self,
                 message: &str,

--- a/linera-sdk/service_system_api.wit
+++ b/linera-sdk/service_system_api.wit
@@ -7,6 +7,7 @@ read-owner-balance: func(owner: owner) -> amount
 read-owner-balances: func() -> list<tuple<owner, amount>>
 read-balance-owners: func() -> list<owner>
 read-system-timestamp: func() -> timestamp
+fetch-url: func(url: url) -> list<u8>
 
 log: func(message: string, level: log-level)
 
@@ -24,6 +25,8 @@ record application-id {
     bytecode-id: bytecode-id,
     creation: message-id,
 }
+
+type url = string
 
 type bytecode-id = message-id
 

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -123,6 +123,11 @@ where
             .expect("Failed to deserialize query response from application")
     }
 
+    /// Fetches a blob of bytes from a given URL.
+    pub fn fetch_url(&self, url: &str) -> Vec<u8> {
+        wit::fetch_url(url)
+    }
+
     /// Loads a value from the `cell` cache or fetches it and stores it in the cache.
     fn fetch_value_through_cache<T>(cell: &Cell<Option<T>>, fetch: impl FnOnce() -> T) -> T
     where


### PR DESCRIPTION
## Motivation

We would the Service to download blobs from the internet.

## Proposal

Add a `fetch_url` API which will return a vector of bytes given a URL string. Here are some extra considerations:

1. How can we make this API more general?
    i.   Should we take arbitrary `reqwests`
    ii.  Should we provide our own comprehensive HTTP API?
2. Use `url::Url` instead?