### PR TITLE
Remove newline incorrectly added between the test and its attributes

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -623,7 +623,6 @@ async fn test_wasm_end_to_end_fungible(
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None), "fungible" ; "remote_net_grpc"))]
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None), "native-fungible" ; "native_remote_net_grpc"))]
 #[test_log::test(tokio::test)]
-
 async fn test_wasm_end_to_end_same_wallet_fungible(
     config: impl LineraNetConfig,
     example_name: &str,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
#1878 incorrectly added a newline typo between one of the end-to-end tests and its attributes, deviating from the formatting convention.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Fix the formatting so that there isn't a newline separating the test function and its attributes.

## Test Plan

<!-- How to test that the changes are correct. -->
Whitespace change, so no new coverage is needed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
