### PR TITLE
Ensure WIT types are registered in a deterministic order

### DIFF
--- a/linera-witty/src/type_traits/register_wit_types.rs
+++ b/linera-witty/src/type_traits/register_wit_types.rs
@@ -3,7 +3,7 @@
 
 //! Trait and helper types allow registering a compile-time list of [`WitType`]s.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use frunk::{HCons, HNil};
 
@@ -12,10 +12,10 @@ use super::WitType;
 /// Marker trait to prevent [`RegisterWitTypes`] to be implemented for other types.
 pub trait Sealed {}
 
-/// Trait to register a compile-time list of [`WitType`]s into a [`HashMap`].
+/// Trait to register a compile-time list of [`WitType`]s into a [`BTreeMap`].
 pub trait RegisterWitTypes: Sealed {
     /// Registers this list of [`WitType`]s into `wit_types`.
-    fn register_wit_types(wit_types: &mut HashMap<String, String>);
+    fn register_wit_types(wit_types: &mut BTreeMap<String, String>);
 }
 
 impl Sealed for HNil {}
@@ -27,7 +27,7 @@ where
 }
 
 impl RegisterWitTypes for HNil {
-    fn register_wit_types(_wit_types: &mut HashMap<String, String>) {}
+    fn register_wit_types(_wit_types: &mut BTreeMap<String, String>) {}
 }
 
 impl<Head, Tail> RegisterWitTypes for HCons<Head, Tail>
@@ -35,7 +35,7 @@ where
     Head: WitType,
     Tail: RegisterWitTypes,
 {
-    fn register_wit_types(wit_types: &mut HashMap<String, String>) {
+    fn register_wit_types(wit_types: &mut BTreeMap<String, String>) {
         let head_name = Head::wit_type_name();
 
         if !wit_types.contains_key(&*head_name) {

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -6,7 +6,7 @@
 #[path = "common/types.rs"]
 mod types;
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use linera_witty::{HList, Layout, RegisterWitTypes, WitType};
 
@@ -207,7 +207,7 @@ fn wit_type_declaration_of<T>() -> String
 where
     T: WitType,
 {
-    let mut wit_types = HashMap::new();
+    let mut wit_types = BTreeMap::new();
 
     <HList![T] as RegisterWitTypes>::register_wit_types(&mut wit_types);
 

--- a/linera-witty/tests/wit_type.rs
+++ b/linera-witty/tests/wit_type.rs
@@ -211,13 +211,9 @@ where
 
     <HList![T] as RegisterWitTypes>::register_wit_types(&mut wit_types);
 
-    let sorted_wit_types = wit_types
-        .into_iter()
-        .filter(|(_, declaration)| !declaration.is_empty())
-        .collect::<BTreeMap<_, _>>();
-
-    sorted_wit_types
+    wit_types
         .into_values()
+        .filter(|declaration| !declaration.is_empty())
         .collect::<Vec<_>>()
         .join("\n")
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When generating WIT snippets, the necessary types need to be collected from a dependency graph. To prevent cycles and repeated declarations, a `HashMap` was used to ensure every WIT type is only declared once. However, `HashMap` has a random order, so regenerating the same snippet would lead to a different order of WIT types inside it. This made it hard to see if the WIT file was up-to-date, which would make it hard to use in tests for example.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use a `BTreeMap` instead of a `HashMap` to ensure that multiple runs registering the same types have the same order.

## Test Plan

<!-- How to test that the changes are correct. -->
Some tests already sorted the declarations using a `BTreeMap`, so the extra sorting was removed and the test should now cover the generated order of the types.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal changes, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
