### PR TITLE
Use test_case in worker_tests.

### DIFF
--- a/examples/matching-engine/README.md
+++ b/examples/matching-engine/README.md
@@ -168,7 +168,7 @@ owners, allow only Matching Engine operations on the chain, and allow only the M
 Engine to close the chain.
 
 ```bash
-kill %%    # Kill the service so we can use CLI commands for chain 1.
+kill %% && sleep 1    # Kill the service so we can use CLI commands for chain 1.
 
 linera --wait-for-outgoing-messages change-ownership \
     --owner-public-keys $PUB_KEY_1 $PUB_KEY_2

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -170,7 +170,7 @@ owners, allow only Matching Engine operations on the chain, and allow only the M
 Engine to close the chain.
 
 ```bash
-kill %%    # Kill the service so we can use CLI commands for chain 1.
+kill %% && sleep 1    # Kill the service so we can use CLI commands for chain 1.
 
 linera --wait-for-outgoing-messages change-ownership \
     --owner-public-keys $PUB_KEY_1 $PUB_KEY_2

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -8,9 +8,9 @@ use linera_base::{
     data_types::Amount,
     identifiers::{Account, ChainDescription},
 };
-use linera_core::client::{
-    self,
-    client_test_utils::{MemoryStorageBuilder, NodeProvider, StorageBuilder, TestBuilder},
+use linera_core::{
+    client,
+    test_utils::{MemoryStorageBuilder, NodeProvider, StorageBuilder, TestBuilder},
 };
 use linera_execution::system::{Recipient, UserData};
 use linera_storage::{

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -63,10 +63,6 @@ use crate::{
     },
 };
 
-#[cfg(with_testing)]
-#[path = "unit_tests/client_test_utils.rs"]
-pub mod client_test_utils;
-
 #[cfg(test)]
 #[path = "unit_tests/client_tests.rs"]
 mod client_tests;

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -9,6 +9,9 @@ pub mod data_types;
 pub mod local_node;
 pub mod node;
 pub mod notifier;
+#[cfg(with_testing)]
+#[path = "unit_tests/test_utils.rs"]
+pub mod test_utils;
 pub mod worker;
 
 pub(crate) mod updater;

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -21,6 +21,7 @@ use linera_execution::{
     ResourceControlPolicy, WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage, TestClock};
+use linera_storage_service::child::get_free_port;
 use linera_version::VersionInfo;
 use linera_views::{memory::TEST_MEMORY_MAX_STREAM_QUERIES, views::ViewError};
 use tokio::sync::oneshot;
@@ -33,8 +34,10 @@ use {
 };
 #[cfg(feature = "rocksdb")]
 use {
-    linera_storage::RocksDbStorage, linera_views::rocks_db::create_rocks_db_common_config,
-    linera_views::rocks_db::RocksDbStoreConfig, tokio::sync::Semaphore,
+    linera_storage::RocksDbStorage,
+    linera_views::rocks_db::create_rocks_db_common_config,
+    linera_views::rocks_db::RocksDbStoreConfig,
+    tokio::sync::{Semaphore, SemaphorePermit},
 };
 #[cfg(feature = "scylladb")]
 use {
@@ -641,7 +644,7 @@ where
 }
 
 #[cfg(feature = "rocksdb")]
-/// Limit concurrency for rocksdb tests to avoid "too many open files" errors.
+/// Limit concurrency for RocksDB tests to avoid "too many open files" errors.
 pub static ROCKS_DB_SEMAPHORE: Semaphore = Semaphore::const_new(5);
 
 #[derive(Default)]
@@ -681,22 +684,31 @@ impl MemoryStorageBuilder {
 }
 
 #[cfg(feature = "rocksdb")]
-#[derive(Default)]
 pub struct RocksDbStorageBuilder {
     temp_dirs: Vec<tempfile::TempDir>,
     wasm_runtime: Option<WasmRuntime>,
     clock: TestClock,
+    _permit: SemaphorePermit<'static>,
 }
 
 #[cfg(feature = "rocksdb")]
 impl RocksDbStorageBuilder {
+    pub async fn new() -> Self {
+        RocksDbStorageBuilder {
+            temp_dirs: Vec::new(),
+            wasm_runtime: None,
+            clock: TestClock::default(),
+            _permit: ROCKS_DB_SEMAPHORE.acquire().await.unwrap(),
+        }
+    }
+
     /// Creates a [`RocksDbStorageBuilder`] that uses the specified [`WasmRuntime`] to run Wasm
     /// applications.
-    #[allow(dead_code)]
-    pub fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
+    #[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+    pub async fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
         RocksDbStorageBuilder {
             wasm_runtime: wasm_runtime.into(),
-            ..RocksDbStorageBuilder::default()
+            ..RocksDbStorageBuilder::new().await
         }
     }
 }
@@ -743,36 +755,16 @@ pub struct ServiceStorageBuilder {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl Default for ServiceStorageBuilder {
-    fn default() -> ServiceStorageBuilder {
-        let _guard = None;
-        let clock = TestClock::default();
-        let endpoint = "127.0.0.1:8742".to_string();
-        let namespace = generate_test_namespace();
-        let use_child = true;
-        Self {
-            _guard,
-            endpoint,
-            namespace,
-            use_child,
-            instance_counter: 0,
-            wasm_runtime: None,
-            clock,
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 impl ServiceStorageBuilder {
-    /// Creates a `ServiceStorage` from just an endpoint
-    pub fn new(endpoint: &str) -> Self {
-        Self::with_wasm_runtime(endpoint, None)
+    /// Creates a `ServiceStorage`.
+    pub async fn new() -> Self {
+        Self::with_wasm_runtime(None).await
     }
 
-    /// Creates a `ServiceStorage` from an endpoint and the wasm runtime.
-    pub fn with_wasm_runtime(endpoint: &str, wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
+    /// Creates a `ServiceStorage` with the given Wasm runtime.
+    pub async fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
         let _guard = None;
-        let endpoint = endpoint.to_string();
+        let endpoint = get_free_port().await.unwrap();
         let clock = TestClock::default();
         let namespace = generate_test_namespace();
         let use_child = true;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -25,7 +25,7 @@ use linera_execution::{
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use test_log::test;
+use test_case::test_case;
 
 #[cfg(feature = "aws")]
 use crate::client::client_test_utils::DynamoDbStorageBuilder;
@@ -49,42 +49,15 @@ use crate::{
     worker::{Notification, Reason, WorkerError},
 };
 
-#[test(tokio::test)]
-pub async fn test_memory_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
-{
-    run_test_initiating_valid_transfer_with_notifications(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-pub async fn test_service_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
-{
-    run_test_initiating_valid_transfer_with_notifications(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_with_notifications(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
-{
-    run_test_initiating_valid_transfer_with_notifications(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
-{
-    run_test_initiating_valid_transfer_with_notifications(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_initiating_valid_transfer_with_notifications<B>(
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_initiating_valid_transfer_with_notifications<B>(
     storage_builder: B,
-) -> Result<(), anyhow::Error>
+) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -136,36 +109,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_claim_amount() -> Result<(), anyhow::Error> {
-    run_test_claim_amount(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_claim_amount() -> Result<(), anyhow::Error> {
-    run_test_claim_amount(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_claim_amount() -> Result<(), anyhow::Error> {
-    run_test_claim_amount(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_claim_amount() -> Result<(), anyhow::Error> {
-    run_test_claim_amount(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_claim_amount() -> Result<(), anyhow::Error> {
-    run_test_claim_amount(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_claim_amount<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_claim_amount<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -286,36 +236,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_rotate_key_pair() -> Result<(), anyhow::Error> {
-    run_test_rotate_key_pair(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_rotate_key_pair() -> Result<(), anyhow::Error> {
-    run_test_rotate_key_pair(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_rotate_key_pair() -> Result<(), anyhow::Error> {
-    run_test_rotate_key_pair(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_rotate_key_pair() -> Result<(), anyhow::Error> {
-    run_test_rotate_key_pair(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_rotate_key_pair() -> Result<(), anyhow::Error> {
-    run_test_rotate_key_pair(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_rotate_key_pair<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_rotate_key_pair<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -358,36 +285,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_transfer_ownership() -> Result<(), anyhow::Error> {
-    run_test_transfer_ownership(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_transfer_ownership() -> Result<(), anyhow::Error> {
-    run_test_transfer_ownership(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_transfer_ownership() -> Result<(), anyhow::Error> {
-    run_test_transfer_ownership(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_transfer_ownership() -> Result<(), anyhow::Error> {
-    run_test_transfer_ownership(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_transfer_ownership() -> Result<(), anyhow::Error> {
-    run_test_transfer_ownership(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_transfer_ownership<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_transfer_ownership<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -439,36 +343,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_share_ownership() -> Result<(), anyhow::Error> {
-    run_test_share_ownership(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_share_ownership() -> Result<(), anyhow::Error> {
-    run_test_share_ownership(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_share_ownership() -> Result<(), anyhow::Error> {
-    run_test_share_ownership(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_share_ownership() -> Result<(), anyhow::Error> {
-    run_test_share_ownership(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_share_ownership() -> Result<(), anyhow::Error> {
-    run_test_share_ownership(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_share_ownership<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_share_ownership<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -607,36 +488,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_close_it(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_close_it(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_close_it(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_close_it(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_close_it(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_open_chain_then_close_it<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_open_chain_then_close_it<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -670,36 +528,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    run_test_transfer_then_open_chain(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    run_test_transfer_then_open_chain(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    run_test_transfer_then_open_chain(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    run_test_transfer_then_open_chain(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    run_test_transfer_then_open_chain(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_transfer_then_open_chain<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_transfer_then_open_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -793,36 +628,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_open_chain_must_be_first() -> Result<(), anyhow::Error> {
-    run_test_open_chain_must_be_first(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_open_chain_must_be_first() -> Result<(), anyhow::Error> {
-    run_test_open_chain_must_be_first(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_open_chain_must_be_first() -> Result<(), anyhow::Error> {
-    run_test_open_chain_must_be_first(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_open_chain_must_be_first() -> Result<(), anyhow::Error> {
-    run_test_open_chain_must_be_first(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_open_chain_must_be_first() -> Result<(), anyhow::Error> {
-    run_test_open_chain_must_be_first(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_open_chain_must_be_first<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_open_chain_must_be_first<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -902,36 +714,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_transfer(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_transfer(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_transfer(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_transfer(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    run_test_open_chain_then_transfer(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_open_chain_then_transfer<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_open_chain_then_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -999,36 +788,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_close_chain() -> Result<(), anyhow::Error> {
-    run_test_close_chain(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_close_chain() -> Result<(), anyhow::Error> {
-    run_test_close_chain(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_close_chain() -> Result<(), anyhow::Error> {
-    run_test_close_chain(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_close_chain() -> Result<(), anyhow::Error> {
-    run_test_close_chain(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_close_chain() -> Result<(), anyhow::Error> {
-    run_test_close_chain(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_close_chain<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_close_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1138,38 +904,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_too_many_faults(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_too_many_faults(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_too_many_faults(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_too_many_faults(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    run_test_initiating_valid_transfer_too_many_faults(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_initiating_valid_transfer_too_many_faults<B>(
-    storage_builder: B,
-) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_initiating_valid_transfer_too_many_faults<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1202,36 +943,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    run_test_bidirectional_transfer(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    run_test_bidirectional_transfer(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    run_test_bidirectional_transfer(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    run_test_bidirectional_transfer(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylla")]
-#[test(tokio::test)]
-async fn test_scylla_db_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    run_test_bidirectional_transfer(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_bidirectional_transfer<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_bidirectional_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1328,36 +1046,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_receiving_unconfirmed_transfer<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_receiving_unconfirmed_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1400,58 +1095,15 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-) -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        MemoryStorageBuilder::default(),
-    )
-    .await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-) -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        ServiceStorageBuilder::new().await,
-    )
-    .await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-) -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        RocksDbStorageBuilder::new().await,
-    )
-    .await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-) -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        DynamoDbStorageBuilder::default(),
-    )
-    .await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-) -> Result<(), anyhow::Error> {
-    run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        ScyllaDbStorageBuilder::default(),
-    )
-    .await
-}
-
-async fn run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances<B>(
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_receiving_unconfirmed_transfer_with_lagging_sender_balances<B>(
     storage_builder: B,
-) -> Result<(), anyhow::Error>
+) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1547,36 +1199,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_change_voting_rights() -> Result<(), anyhow::Error> {
-    run_test_change_voting_rights(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_change_voting_rights() -> Result<(), anyhow::Error> {
-    run_test_change_voting_rights(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_change_voting_rights() -> Result<(), anyhow::Error> {
-    run_test_change_voting_rights(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_change_voting_rights() -> Result<(), anyhow::Error> {
-    run_test_change_voting_rights(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_change_voting_rights() -> Result<(), anyhow::Error> {
-    run_test_change_voting_rights(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_change_voting_rights<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_change_voting_rights<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1702,18 +1331,10 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-pub async fn test_memory_insufficient_balance() -> Result<(), anyhow::Error> {
-    run_test_insufficient_balance(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-pub async fn test_service_insufficient_balance() -> Result<(), anyhow::Error> {
-    run_test_insufficient_balance(ServiceStorageBuilder::new().await).await
-}
-
-async fn run_test_insufficient_balance<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[test_log::test(tokio::test)]
+async fn test_insufficient_balance<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1763,36 +1384,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_request_leader_timeout() -> Result<(), anyhow::Error> {
-    run_test_request_leader_timeout(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_request_leader_timeout() -> Result<(), anyhow::Error> {
-    run_test_request_leader_timeout(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_request_leader_timeout() -> Result<(), anyhow::Error> {
-    run_test_request_leader_timeout(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_request_leader_timeout() -> Result<(), anyhow::Error> {
-    run_test_request_leader_timeout(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_request_leader_timeout() -> Result<(), anyhow::Error> {
-    run_test_request_leader_timeout(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_request_leader_timeout<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_request_leader_timeout<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1912,36 +1510,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_propose_validated() -> Result<(), anyhow::Error> {
-    run_test_propose_validated(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_propose_validated() -> Result<(), anyhow::Error> {
-    run_test_propose_validated(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_propose_validated() -> Result<(), anyhow::Error> {
-    run_test_propose_validated(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_propose_validated() -> Result<(), anyhow::Error> {
-    run_test_propose_validated(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_propose_validated() -> Result<(), anyhow::Error> {
-    run_test_propose_validated(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_propose_validated<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_propose_validated<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -2030,36 +1605,13 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-async fn test_memory_propose_pending_block() -> Result<(), anyhow::Error> {
-    run_test_propose_pending_block(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-async fn test_service_propose_pending_block() -> Result<(), anyhow::Error> {
-    run_test_propose_pending_block(ServiceStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "rocksdb")]
-#[test(tokio::test)]
-async fn test_rocks_db_propose_pending_block() -> Result<(), anyhow::Error> {
-    run_test_propose_pending_block(RocksDbStorageBuilder::new().await).await
-}
-
-#[cfg(feature = "aws")]
-#[test(tokio::test)]
-async fn test_dynamo_db_propose_pending_block() -> Result<(), anyhow::Error> {
-    run_test_propose_pending_block(DynamoDbStorageBuilder::default()).await
-}
-
-#[cfg(feature = "scylladb")]
-#[test(tokio::test)]
-async fn test_scylla_db_propose_pending_block() -> Result<(), anyhow::Error> {
-    run_test_propose_pending_block(ScyllaDbStorageBuilder::default()).await
-}
-
-async fn run_test_propose_pending_block<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "aws", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test)]
+async fn test_propose_pending_block<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -2098,18 +1650,10 @@ where
     Ok(())
 }
 
-#[test(tokio::test)]
-pub async fn test_memory_message_policy() -> Result<(), anyhow::Error> {
-    run_test_message_policy(MemoryStorageBuilder::default()).await
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-#[test(tokio::test)]
-pub async fn test_service_message_policy() -> Result<(), anyhow::Error> {
-    run_test_message_policy(ServiceStorageBuilder::new().await).await
-}
-
-async fn run_test_message_policy<B>(storage_builder: B) -> Result<(), anyhow::Error>
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[test_log::test(tokio::test)]
+async fn test_message_policy<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -28,23 +28,21 @@ use linera_views::views::ViewError;
 use test_case::test_case;
 
 #[cfg(feature = "aws")]
-use crate::client::client_test_utils::DynamoDbStorageBuilder;
+use crate::test_utils::DynamoDbStorageBuilder;
 #[cfg(feature = "rocksdb")]
-use crate::client::client_test_utils::RocksDbStorageBuilder;
+use crate::test_utils::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
-use crate::client::client_test_utils::ScyllaDbStorageBuilder;
+use crate::test_utils::ScyllaDbStorageBuilder;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::client::client_test_utils::ServiceStorageBuilder;
+use crate::test_utils::ServiceStorageBuilder;
 use crate::{
-    client::{
-        client_test_utils::{FaultType, MemoryStorageBuilder, StorageBuilder, TestBuilder},
-        ArcChainClient, ChainClientError, ClientOutcome, MessageAction, MessagePolicy,
-    },
+    client::{ArcChainClient, ChainClientError, ClientOutcome, MessageAction, MessagePolicy},
     local_node::LocalNodeError,
     node::{
         CrossChainMessageDelivery,
         NodeError::{self, ClientIoError},
     },
+    test_utils::{FaultType, MemoryStorageBuilder, StorageBuilder, TestBuilder},
     updater::CommunicationError,
     worker::{Notification, Reason, WorkerError},
 };

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -26,18 +26,15 @@ use linera_execution::{
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use test_log::test;
-#[cfg(not(target_arch = "wasm32"))]
-use {
-    crate::client::client_test_utils::ServiceStorageBuilder,
-    linera_storage_service::child::get_free_port,
-};
 
 #[cfg(feature = "aws")]
 use crate::client::client_test_utils::DynamoDbStorageBuilder;
+#[cfg(feature = "rocksdb")]
+use crate::client::client_test_utils::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
 use crate::client::client_test_utils::ScyllaDbStorageBuilder;
-#[cfg(feature = "rocksdb")]
-use crate::client::client_test_utils::{RocksDbStorageBuilder, ROCKS_DB_SEMAPHORE};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::client::client_test_utils::ServiceStorageBuilder;
 use crate::{
     client::{
         client_test_utils::{FaultType, MemoryStorageBuilder, StorageBuilder, TestBuilder},
@@ -62,16 +59,13 @@ pub async fn test_memory_initiating_valid_transfer_with_notifications() -> Resul
 #[test(tokio::test)]
 pub async fn test_service_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error>
 {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_initiating_valid_transfer_with_notifications(ServiceStorageBuilder::new(&endpoint))
-        .await
+    run_test_initiating_valid_transfer_with_notifications(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_initiating_valid_transfer_with_notifications() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_initiating_valid_transfer_with_notifications(RocksDbStorageBuilder::default()).await
+    run_test_initiating_valid_transfer_with_notifications(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -150,15 +144,13 @@ async fn test_memory_claim_amount() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_claim_amount() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_claim_amount(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_claim_amount(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_claim_amount() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_claim_amount(RocksDbStorageBuilder::default()).await
+    run_test_claim_amount(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -302,15 +294,13 @@ async fn test_memory_rotate_key_pair() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_rotate_key_pair() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_rotate_key_pair(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_rotate_key_pair(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_rotate_key_pair() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_rotate_key_pair(RocksDbStorageBuilder::default()).await
+    run_test_rotate_key_pair(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -376,15 +366,13 @@ async fn test_memory_transfer_ownership() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_transfer_ownership() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_transfer_ownership(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_transfer_ownership(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_transfer_ownership() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_transfer_ownership(RocksDbStorageBuilder::default()).await
+    run_test_transfer_ownership(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -459,15 +447,13 @@ async fn test_memory_share_ownership() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_share_ownership() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_share_ownership(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_share_ownership(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_share_ownership() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_share_ownership(RocksDbStorageBuilder::default()).await
+    run_test_share_ownership(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -629,15 +615,13 @@ async fn test_memory_open_chain_then_close_it() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_open_chain_then_close_it(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_open_chain_then_close_it(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_open_chain_then_close_it() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_open_chain_then_close_it(RocksDbStorageBuilder::default()).await
+    run_test_open_chain_then_close_it(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -694,15 +678,13 @@ async fn test_memory_transfer_then_open_chain() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_transfer_then_open_chain(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_transfer_then_open_chain(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_transfer_then_open_chain() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_transfer_then_open_chain(RocksDbStorageBuilder::default()).await
+    run_test_transfer_then_open_chain(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -819,15 +801,13 @@ async fn test_memory_open_chain_must_be_first() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_open_chain_must_be_first() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_open_chain_must_be_first(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_open_chain_must_be_first(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_open_chain_must_be_first() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_open_chain_must_be_first(RocksDbStorageBuilder::default()).await
+    run_test_open_chain_must_be_first(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -930,15 +910,13 @@ async fn test_memory_open_chain_then_transfer() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_open_chain_then_transfer(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_open_chain_then_transfer(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_open_chain_then_transfer() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_open_chain_then_transfer(RocksDbStorageBuilder::default()).await
+    run_test_open_chain_then_transfer(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -1029,15 +1007,13 @@ async fn test_memory_close_chain() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_close_chain() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_close_chain(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_close_chain(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_close_chain() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_close_chain(RocksDbStorageBuilder::default()).await
+    run_test_close_chain(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -1170,15 +1146,13 @@ async fn test_memory_initiating_valid_transfer_too_many_faults() -> Result<(), a
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_initiating_valid_transfer_too_many_faults(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_initiating_valid_transfer_too_many_faults(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_initiating_valid_transfer_too_many_faults() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_initiating_valid_transfer_too_many_faults(RocksDbStorageBuilder::default()).await
+    run_test_initiating_valid_transfer_too_many_faults(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -1236,15 +1210,13 @@ async fn test_memory_bidirectional_transfer() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_bidirectional_transfer(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_bidirectional_transfer(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_bidirectional_transfer() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_bidirectional_transfer(RocksDbStorageBuilder::default()).await
+    run_test_bidirectional_transfer(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -1364,15 +1336,13 @@ async fn test_memory_receiving_unconfirmed_transfer() -> Result<(), anyhow::Erro
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_receiving_unconfirmed_transfer(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_receiving_unconfirmed_transfer(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_receiving_unconfirmed_transfer() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_receiving_unconfirmed_transfer(RocksDbStorageBuilder::default()).await
+    run_test_receiving_unconfirmed_transfer(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -1443,9 +1413,8 @@ async fn test_memory_receiving_unconfirmed_transfer_with_lagging_sender_balances
 #[test(tokio::test)]
 async fn test_service_receiving_unconfirmed_transfer_with_lagging_sender_balances(
 ) -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
     run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        ServiceStorageBuilder::new(&endpoint),
+        ServiceStorageBuilder::new().await,
     )
     .await
 }
@@ -1454,9 +1423,8 @@ async fn test_service_receiving_unconfirmed_transfer_with_lagging_sender_balance
 #[test(tokio::test)]
 async fn test_rocks_db_receiving_unconfirmed_transfer_with_lagging_sender_balances(
 ) -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
     run_test_receiving_unconfirmed_transfer_with_lagging_sender_balances(
-        RocksDbStorageBuilder::default(),
+        RocksDbStorageBuilder::new().await,
     )
     .await
 }
@@ -1587,15 +1555,13 @@ async fn test_memory_change_voting_rights() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_change_voting_rights() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_change_voting_rights(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_change_voting_rights(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_change_voting_rights() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_change_voting_rights(RocksDbStorageBuilder::default()).await
+    run_test_change_voting_rights(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -1744,8 +1710,7 @@ pub async fn test_memory_insufficient_balance() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 pub async fn test_service_insufficient_balance() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_insufficient_balance(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_insufficient_balance(ServiceStorageBuilder::new().await).await
 }
 
 async fn run_test_insufficient_balance<B>(storage_builder: B) -> Result<(), anyhow::Error>
@@ -1806,15 +1771,13 @@ async fn test_memory_request_leader_timeout() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_request_leader_timeout() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_request_leader_timeout(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_request_leader_timeout(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_request_leader_timeout() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_request_leader_timeout(RocksDbStorageBuilder::default()).await
+    run_test_request_leader_timeout(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -1957,15 +1920,13 @@ async fn test_memory_propose_validated() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_propose_validated() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_propose_validated(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_propose_validated(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_propose_validated() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_propose_validated(RocksDbStorageBuilder::default()).await
+    run_test_propose_validated(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -2077,15 +2038,13 @@ async fn test_memory_propose_pending_block() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 async fn test_service_propose_pending_block() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_propose_pending_block(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_propose_pending_block(ServiceStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "rocksdb")]
 #[test(tokio::test)]
 async fn test_rocks_db_propose_pending_block() -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_propose_pending_block(RocksDbStorageBuilder::default()).await
+    run_test_propose_pending_block(RocksDbStorageBuilder::new().await).await
 }
 
 #[cfg(feature = "aws")]
@@ -2147,8 +2106,7 @@ pub async fn test_memory_message_policy() -> Result<(), anyhow::Error> {
 #[cfg(not(target_arch = "wasm32"))]
 #[test(tokio::test)]
 pub async fn test_service_message_policy() -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_message_policy(ServiceStorageBuilder::new(&endpoint)).await
+    run_test_message_policy(ServiceStorageBuilder::new().await).await
 }
 
 async fn run_test_message_policy<B>(storage_builder: B) -> Result<(), anyhow::Error>

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -21,7 +21,6 @@ use linera_execution::{
     ResourceControlPolicy, WasmRuntime,
 };
 use linera_storage::{MemoryStorage, Storage, TestClock};
-use linera_storage_service::child::get_free_port;
 use linera_version::VersionInfo;
 use linera_views::{memory::TEST_MEMORY_MAX_STREAM_QUERIES, views::ViewError};
 use tokio::sync::oneshot;
@@ -645,7 +644,7 @@ where
 
 #[cfg(feature = "rocksdb")]
 /// Limit concurrency for RocksDB tests to avoid "too many open files" errors.
-pub static ROCKS_DB_SEMAPHORE: Semaphore = Semaphore::const_new(5);
+static ROCKS_DB_SEMAPHORE: Semaphore = Semaphore::const_new(5);
 
 #[derive(Default)]
 pub struct MemoryStorageBuilder {
@@ -764,7 +763,9 @@ impl ServiceStorageBuilder {
     /// Creates a `ServiceStorage` with the given Wasm runtime.
     pub async fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
         let _guard = None;
-        let endpoint = get_free_port().await.unwrap();
+        let endpoint = linera_storage_service::child::get_free_port()
+            .await
+            .unwrap();
         let clock = TestClock::default();
         let namespace = generate_test_namespace();
         let use_child = true;

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -44,7 +44,7 @@ use crate::client::client_tests::{
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_create_application(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
@@ -52,7 +52,7 @@ async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(),
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_service_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_service_create_application(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_create_application(ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
@@ -61,7 +61,7 @@ async fn test_service_create_application(wasm_runtime: WasmRuntime) -> Result<()
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_create_application(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
@@ -70,7 +70,7 @@ async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_create_application(DynamoDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
@@ -79,11 +79,11 @@ async fn test_dynamo_db_create_application(wasm_runtime: WasmRuntime) -> Result<
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_scylla_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_scylla_db_create_application(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_create_application(ScyllaDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
-async fn run_test_create_application<B>(storage_builder: B) -> Result<(), anyhow::Error>
+async fn run_test_create_application<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -164,7 +164,7 @@ where
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     run_test_run_application_with_dependency(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime))
         .await
 }
@@ -175,7 +175,7 @@ async fn test_memory_run_application_with_dependency(
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_service_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     run_test_run_application_with_dependency(
         ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await,
     )
@@ -189,7 +189,7 @@ async fn test_service_run_application_with_dependency(
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     run_test_run_application_with_dependency(
         RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await,
     )
@@ -203,7 +203,7 @@ async fn test_rocks_db_run_application_with_dependency(
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_dynamo_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     run_test_run_application_with_dependency(DynamoDbStorageBuilder::with_wasm_runtime(
         wasm_runtime,
     ))
@@ -217,16 +217,14 @@ async fn test_dynamo_db_run_application_with_dependency(
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_scylla_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     run_test_run_application_with_dependency(ScyllaDbStorageBuilder::with_wasm_runtime(
         wasm_runtime,
     ))
     .await
 }
 
-async fn run_test_run_application_with_dependency<B>(
-    storage_builder: B,
-) -> Result<(), anyhow::Error>
+async fn run_test_run_application_with_dependency<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -394,7 +392,7 @@ where
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_cross_chain_message(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
@@ -402,7 +400,7 @@ async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<()
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_service_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_service_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_cross_chain_message(ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
@@ -411,7 +409,7 @@ async fn test_service_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_cross_chain_message(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
@@ -420,9 +418,7 @@ async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_cross_chain_message(
-    wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+async fn test_dynamo_db_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_cross_chain_message(DynamoDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
@@ -431,13 +427,11 @@ async fn test_dynamo_db_cross_chain_message(
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_cross_chain_message(
-    wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+async fn test_scylla_db_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_cross_chain_message(ScyllaDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
-async fn run_test_cross_chain_message<B>(storage_builder: B) -> Result<(), anyhow::Error>
+async fn run_test_cross_chain_message<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -605,7 +599,7 @@ where
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_memory_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
+async fn test_memory_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_user_pub_sub_channels(MemoryStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
@@ -613,9 +607,7 @@ async fn test_memory_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> Result<
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_service_user_pub_sub_channels(
-    wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+async fn test_service_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_user_pub_sub_channels(ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await)
         .await
 }
@@ -625,9 +617,7 @@ async fn test_service_user_pub_sub_channels(
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_rocks_db_user_pub_sub_channels(
-    wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+async fn test_rocks_db_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_user_pub_sub_channels(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await)
         .await
 }
@@ -637,9 +627,7 @@ async fn test_rocks_db_user_pub_sub_channels(
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_dynamo_db_user_pub_sub_channels(
-    wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+async fn test_dynamo_db_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_user_pub_sub_channels(DynamoDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
@@ -648,13 +636,11 @@ async fn test_dynamo_db_user_pub_sub_channels(
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]
-async fn test_scylla_db_user_pub_sub_channels(
-    wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+async fn test_scylla_db_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyhow::Result<()> {
     run_test_user_pub_sub_channels(ScyllaDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
 }
 
-async fn run_test_user_pub_sub_channels<B>(storage_builder: B) -> Result<(), anyhow::Error>
+async fn run_test_user_pub_sub_channels<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -33,13 +33,13 @@ use test_case::test_case;
 
 #[cfg(feature = "aws")]
 use crate::client::client_tests::DynamoDbStorageBuilder;
+#[cfg(feature = "rocksdb")]
+use crate::client::client_tests::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
 use crate::client::client_tests::ScyllaDbStorageBuilder;
 use crate::client::client_tests::{
-    get_free_port, MemoryStorageBuilder, ServiceStorageBuilder, StorageBuilder, TestBuilder,
+    MemoryStorageBuilder, ServiceStorageBuilder, StorageBuilder, TestBuilder,
 };
-#[cfg(feature = "rocksdb")]
-use crate::client::client_tests::{RocksDbStorageBuilder, ROCKS_DB_SEMAPHORE};
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -53,12 +53,7 @@ async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> Result<(),
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_service_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_create_application(ServiceStorageBuilder::with_wasm_runtime(
-        &endpoint,
-        wasm_runtime,
-    ))
-    .await
+    run_test_create_application(ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
 #[ignore]
@@ -67,8 +62,7 @@ async fn test_service_create_application(wasm_runtime: WasmRuntime) -> Result<()
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_create_application(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_create_application(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
+    run_test_create_application(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
 #[ignore]
@@ -182,11 +176,9 @@ async fn test_memory_run_application_with_dependency(
 async fn test_service_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_run_application_with_dependency(ServiceStorageBuilder::with_wasm_runtime(
-        &endpoint,
-        wasm_runtime,
-    ))
+    run_test_run_application_with_dependency(
+        ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await,
+    )
     .await
 }
 
@@ -198,9 +190,10 @@ async fn test_service_run_application_with_dependency(
 async fn test_rocks_db_run_application_with_dependency(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_run_application_with_dependency(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime))
-        .await
+    run_test_run_application_with_dependency(
+        RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await,
+    )
+    .await
 }
 
 #[ignore]
@@ -410,12 +403,7 @@ async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<()
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_service_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_cross_chain_message(ServiceStorageBuilder::with_wasm_runtime(
-        &endpoint,
-        wasm_runtime,
-    ))
-    .await
+    run_test_cross_chain_message(ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
 #[ignore]
@@ -424,8 +412,7 @@ async fn test_service_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
 async fn test_rocks_db_cross_chain_message(wasm_runtime: WasmRuntime) -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_cross_chain_message(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
+    run_test_cross_chain_message(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await).await
 }
 
 #[ignore]
@@ -629,12 +616,8 @@ async fn test_memory_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> Result<
 async fn test_service_user_pub_sub_channels(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let endpoint = get_free_port().await.unwrap();
-    run_test_user_pub_sub_channels(ServiceStorageBuilder::with_wasm_runtime(
-        &endpoint,
-        wasm_runtime,
-    ))
-    .await
+    run_test_user_pub_sub_channels(ServiceStorageBuilder::with_wasm_runtime(wasm_runtime).await)
+        .await
 }
 
 #[ignore]
@@ -645,8 +628,8 @@ async fn test_service_user_pub_sub_channels(
 async fn test_rocks_db_user_pub_sub_channels(
     wasm_runtime: WasmRuntime,
 ) -> Result<(), anyhow::Error> {
-    let _lock = ROCKS_DB_SEMAPHORE.acquire().await;
-    run_test_user_pub_sub_channels(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime)).await
+    run_test_user_pub_sub_channels(RocksDbStorageBuilder::with_wasm_runtime(wasm_runtime).await)
+        .await
 }
 
 #[ignore]

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -51,7 +51,7 @@ use super::{init_worker_with_chains, make_certificate};
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_memory_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     let storage = MemoryStorage::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
@@ -62,7 +62,7 @@ async fn test_memory_handle_certificates_to_create_application(
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     let (storage, _dir) = RocksDbStorage::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
@@ -73,7 +73,7 @@ async fn test_rocks_db_handle_certificates_to_create_application(
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_dynamo_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     let storage = DynamoDbStorage::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
@@ -84,7 +84,7 @@ async fn test_dynamo_db_handle_certificates_to_create_application(
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_scylla_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<()> {
     let storage = ScyllaDbStorage::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
@@ -92,7 +92,7 @@ async fn test_scylla_db_handle_certificates_to_create_application(
 async fn run_test_handle_certificates_to_create_application<S>(
     storage: S,
     wasm_runtime: WasmRuntime,
-) -> Result<(), anyhow::Error>
+) -> anyhow::Result<()>
 where
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -10,11 +10,9 @@ use linera_base::{
     data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
-use linera_core::client::{
-    client_test_utils::{
-        FaultType, MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder,
-    },
-    ChainClient,
+use linera_core::{
+    client::ChainClient,
+    test_utils::{FaultType, MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
 };
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{memory::MemoryStore, views::ViewError};


### PR DESCRIPTION
## Motivation

We use `test_case` in some places, but not in `worker_tests`, which has a lot of boiler plate. We also use `unwrap()` in lots of tests where we could use `anyhow`, which also supports backtraces.

## Proposal

Use `test_case` and `anyhow`. Move `client::client_test_utils` to `test_utils`.

## Test Plan

I tried it locally for the memory and RocksDB cases. Let's double-check that the tests are still executed in the CI logs once they're done.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
