### PR TITLE
Use Account instead of AccountOwner in fungible's InitialState

### DIFF
--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -250,6 +250,14 @@ pub enum Message {
         source: AccountOwner,
     },
 
+    /// Credits the given `target` account with an initial balance amount
+    CreditInitialBalance {
+        /// Target account to credit amount to
+        target: AccountOwner,
+        /// Amount to be credited
+        amount: Amount,
+    },
+
     /// Withdraws from the given account and starts a transfer to the target account.
     Withdraw {
         /// Account to withdraw from
@@ -285,8 +293,14 @@ pub async fn create_with_accounts(
         .collect::<Vec<_>>()
         .await;
 
-    for (_chain, account, initial_amount) in &accounts {
-        initial_state = initial_state.with_account(*account, *initial_amount);
+    for (chain, account, initial_amount) in &accounts {
+        initial_state = initial_state.with_account(
+            Account {
+                chain_id: chain.id(),
+                owner: *account,
+            },
+            *initial_amount,
+        );
     }
 
     let params = Parameters::new("FUN");

--- a/examples/fungible/src/state.rs
+++ b/examples/fungible/src/state.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use fungible::InitialState;
 use linera_sdk::{
     base::{AccountOwner, Amount},
     views::{linera_views, MapView, RootView, ViewStorageContext},
@@ -17,17 +16,6 @@ pub struct FungibleToken {
 
 #[allow(dead_code)]
 impl FungibleToken {
-    /// Initializes the application state with some accounts with initial balances.
-    pub(crate) async fn initialize_accounts(&mut self, state: InitialState) {
-        for (k, v) in state.accounts {
-            if v != Amount::ZERO {
-                self.accounts
-                    .insert(&k, v)
-                    .expect("Error in insert statement");
-            }
-        }
-    }
-
     /// Obtains the balance for an `account`, returning None if there's no entry for the account.
     pub(crate) async fn balance(&self, account: &AccountOwner) -> Option<Amount> {
         self.accounts

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -32,7 +32,13 @@ async fn test_cross_chain_transfer() {
     let mut sender_chain = validator.new_chain().await;
     let sender_account = AccountOwner::from(sender_chain.public_key());
 
-    let initial_state = InitialStateBuilder::default().with_account(sender_account, initial_amount);
+    let initial_state = InitialStateBuilder::default().with_account(
+        fungible::Account {
+            chain_id: sender_chain.id(),
+            owner: sender_account,
+        },
+        initial_amount,
+    );
     let params = Parameters::new("FUN");
     let application_id = sender_chain
         .create_application(bytecode_id, params, initial_state.build(), vec![])
@@ -86,7 +92,13 @@ async fn test_bouncing_tokens() {
     let mut sender_chain = validator.new_chain().await;
     let sender_account = AccountOwner::from(sender_chain.public_key());
 
-    let initial_state = InitialStateBuilder::default().with_account(sender_account, initial_amount);
+    let initial_state = InitialStateBuilder::default().with_account(
+        Account {
+            owner: sender_account,
+            chain_id: sender_chain.id(),
+        },
+        initial_amount,
+    );
     let params = Parameters::new("RET");
     let application_id = sender_chain
         .create_application(bytecode_id, params, initial_state.build(), vec![])

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -83,8 +83,13 @@ async fn single_transaction() {
         .publish_bytecodes_in::<fungible::FungibleTokenAbi, fungible::Parameters, fungible::InitialState>("../fungible")
         .await;
 
-    let initial_state_a =
-        fungible::InitialStateBuilder::default().with_account(owner_a, Amount::from_tokens(10));
+    let initial_state_a = fungible::InitialStateBuilder::default().with_account(
+        fungible::Account {
+            owner: owner_a,
+            chain_id: user_chain_a.id(),
+        },
+        Amount::from_tokens(10),
+    );
     let params_a = fungible::Parameters::new("A");
     let token_id_a = user_chain_a
         .create_application(
@@ -94,8 +99,13 @@ async fn single_transaction() {
             vec![],
         )
         .await;
-    let initial_state_b =
-        fungible::InitialStateBuilder::default().with_account(owner_b, Amount::from_tokens(9));
+    let initial_state_b = fungible::InitialStateBuilder::default().with_account(
+        fungible::Account {
+            owner: owner_b,
+            chain_id: user_chain_b.id(),
+        },
+        Amount::from_tokens(9),
+    );
     let params_b = fungible::Parameters::new("B");
     let token_id_b = user_chain_b
         .create_application(

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -53,8 +53,8 @@ impl Contract for NativeFungibleTokenContract {
             self.runtime.application_parameters().ticker_symbol == "NAT",
             "Only NAT is accepted as ticker symbol"
         );
-        for (owner, amount) in state.accounts {
-            let owner = self.normalize_owner(owner);
+        for (account, amount) in state.accounts {
+            let owner = self.normalize_owner(account.owner);
             let account = Account {
                 chain_id: self.runtime.chain_id(),
                 owner: Some(owner),

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -488,7 +488,13 @@ where
     let sender_owner = AccountOwner::User(Owner::from(sender.key_pair().await?.public()));
     let receiver_owner = AccountOwner::User(Owner::from(receiver.key_pair().await?.public()));
 
-    let accounts = BTreeMap::from_iter([(sender_owner, Amount::from_tokens(1_000_000))]);
+    let accounts = BTreeMap::from_iter([(
+        fungible::Account {
+            owner: sender_owner,
+            chain_id: sender.chain_id,
+        },
+        Amount::from_tokens(1_000_000),
+    )]);
     let state = fungible::InitialState { accounts };
     let params = fungible::Parameters::new("FUN");
     let (application_id, _cert) = sender

--- a/linera-sdk/src/abis/fungible.rs
+++ b/linera-sdk/src/abis/fungible.rs
@@ -75,7 +75,7 @@ pub enum FungibleResponse {
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct InitialState {
     /// Accounts and their respective initial balances
-    pub accounts: BTreeMap<AccountOwner, Amount>,
+    pub accounts: BTreeMap<Account, Amount>,
 }
 
 /// The parameters to initialize fungible with
@@ -118,12 +118,12 @@ pub struct Account {
 #[derive(Debug, Default)]
 pub struct InitialStateBuilder {
     /// Accounts and their respective initial balances
-    account_balances: BTreeMap<AccountOwner, Amount>,
+    account_balances: BTreeMap<Account, Amount>,
 }
 
 impl InitialStateBuilder {
     /// Adds an account to the initial state of the application.
-    pub fn with_account(mut self, account: AccountOwner, balance: impl Into<Amount>) -> Self {
+    pub fn with_account(mut self, account: Account, balance: impl Into<Amount>) -> Self {
         self.account_balances.insert(account, balance.into());
         self
     }

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -150,7 +150,10 @@ async fn benchmark_with_fungible(
             let default_chain = client.default_chain().context("missing default chain")?;
             let initial_state = InitialState {
                 accounts: BTreeMap::from([(
-                    AccountOwner::User(owner),
+                    fungible::Account {
+                        owner: AccountOwner::User(owner),
+                        chain_id: default_chain,
+                    },
                     Amount::from_tokens(num_transactions as u128),
                 )]),
             };

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -474,7 +474,7 @@ async fn test_wasm_end_to_end_fungible(
     config: impl LineraNetConfig,
     example_name: &str,
 ) -> Result<()> {
-    use fungible::{FungibleTokenAbi, InitialState, Parameters};
+    use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
@@ -491,8 +491,20 @@ async fn test_wasm_end_to_end_fungible(
     let account_owner2 = get_fungible_account_owner(&client2);
     // The initial accounts on chain1
     let accounts = BTreeMap::from([
-        (account_owner1, Amount::from_tokens(5)),
-        (account_owner2, Amount::from_tokens(2)),
+        (
+            Account {
+                owner: account_owner1,
+                chain_id: chain1,
+            },
+            Amount::from_tokens(5),
+        ),
+        (
+            Account {
+                owner: account_owner2,
+                chain_id: chain2,
+            },
+            Amount::from_tokens(2),
+        ),
     ]);
     let state = InitialState { accounts };
     // Setting up the application and verifying
@@ -651,8 +663,20 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     };
     // The initial accounts on chain1
     let accounts = BTreeMap::from([
-        (account_owner1, Amount::from_tokens(5)),
-        (account_owner2, Amount::from_tokens(2)),
+        (
+            Account {
+                owner: account_owner1,
+                chain_id: chain1,
+            },
+            Amount::from_tokens(5),
+        ),
+        (
+            Account {
+                owner: account_owner2,
+                chain_id: chain2,
+            },
+            Amount::from_tokens(2),
+        ),
     ]);
     let state = InitialState { accounts };
     // Setting up the application and verifying
@@ -995,7 +1019,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Result<()> {
     use crowd_funding::{CrowdFundingAbi, InitializationArgument};
-    use fungible::{FungibleTokenAbi, InitialState, Parameters};
+    use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
 
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
@@ -1012,7 +1036,13 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     let account_owner2 = get_fungible_account_owner(&client2); // contributor
 
     // The initial accounts on chain1
-    let accounts = BTreeMap::from([(account_owner1, Amount::from_tokens(6))]);
+    let accounts = BTreeMap::from([(
+        Account {
+            owner: account_owner1,
+            chain_id: chain1,
+        },
+        Amount::from_tokens(6),
+    )]);
     let state_fungible = InitialState { accounts };
 
     // Setting up the application fungible
@@ -1148,11 +1178,23 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let owner_a = get_fungible_account_owner(&client_a);
     let owner_b = get_fungible_account_owner(&client_b);
     // The initial accounts on chain_a and chain_b
-    let accounts0 = BTreeMap::from([(owner_a, Amount::from_tokens(10))]);
+    let accounts0 = BTreeMap::from([(
+        fungible::Account {
+            owner: owner_a,
+            chain_id: chain_a,
+        },
+        Amount::from_tokens(10),
+    )]);
     let state_fungible0 = fungible::InitialState {
         accounts: accounts0,
     };
-    let accounts1 = BTreeMap::from([(owner_b, Amount::from_tokens(9))]);
+    let accounts1 = BTreeMap::from([(
+        fungible::Account {
+            owner: owner_b,
+            chain_id: chain_b,
+        },
+        Amount::from_tokens(9),
+    )]);
     let state_fungible1 = fungible::InitialState {
         accounts: accounts1,
     };
@@ -1408,18 +1450,54 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     // Amounts of token0 that will be owned by each user
     let state_fungible0 = fungible::InitialState {
         accounts: BTreeMap::from([
-            (owner0, Amount::ZERO),
-            (owner1, Amount::from_tokens(50)),
-            (owner_admin, Amount::from_tokens(200)),
+            (
+                fungible::Account {
+                    owner: owner0,
+                    chain_id: chain0,
+                },
+                Amount::ZERO,
+            ),
+            (
+                fungible::Account {
+                    owner: owner1,
+                    chain_id: chain1,
+                },
+                Amount::from_tokens(50),
+            ),
+            (
+                fungible::Account {
+                    owner: owner_admin,
+                    chain_id: chain_admin,
+                },
+                Amount::from_tokens(200),
+            ),
         ]),
     };
 
     // Amounts of token1 that will be owned by each user
     let state_fungible1 = fungible::InitialState {
         accounts: BTreeMap::from([
-            (owner0, Amount::from_tokens(50)),
-            (owner1, Amount::ZERO),
-            (owner_admin, Amount::from_tokens(200)),
+            (
+                fungible::Account {
+                    owner: owner0,
+                    chain_id: chain0,
+                },
+                Amount::from_tokens(50),
+            ),
+            (
+                fungible::Account {
+                    owner: owner1,
+                    chain_id: chain1,
+                },
+                Amount::ZERO,
+            ),
+            (
+                fungible::Account {
+                    owner: owner_admin,
+                    chain_id: chain_admin,
+                },
+                Amount::from_tokens(200),
+            ),
         ]),
     };
 
@@ -1820,7 +1898,13 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
 
     // Create a fungible token application with 10 tokens for owner 1.
     let owner = get_fungible_account_owner(&client);
-    let accounts = BTreeMap::from([(owner, Amount::from_tokens(10))]);
+    let accounts = BTreeMap::from([(
+        fungible::Account {
+            owner,
+            chain_id: chain1,
+        },
+        Amount::from_tokens(10),
+    )]);
     let state = fungible::InitialState { accounts };
     let (contract, service) = client.build_example("fungible").await?;
     let params = fungible::Parameters::new("FUN");
@@ -2478,7 +2562,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
 #[cfg_attr(feature = "aws", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Tcp) ; "aws_tcp"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
-    use fungible::{FungibleTokenAbi, InitialState, Parameters};
+    use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
 
     config.num_other_initial_chains = 2;
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
@@ -2492,7 +2576,13 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     // Now we run the benchmark again, with the fungible token application instead of the
     // native token.
     let account_owner = get_fungible_account_owner(&client);
-    let accounts = BTreeMap::from([(account_owner, Amount::from_tokens(1_000_000))]);
+    let accounts = BTreeMap::from([(
+        Account {
+            owner: account_owner,
+            chain_id: client.get_wallet()?.default_chain().unwrap(),
+        },
+        Amount::from_tokens(1_000_000),
+    )]);
     let state = InitialState { accounts };
     let (contract, service) = client.build_example("fungible").await?;
     let params = Parameters::new("FUN");


### PR DESCRIPTION
## Motivation

It makes sense to have chain information with the accounts, since we can communicate with other chains via cross chain messages

## Proposal

Have the `InitialState` in `fungible` use `Account`, and send messages to other chains to initialize the state there too if needed

## Test Plan

CI

