### PR TITLE
Add fallback/public mode to the chain manager.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -227,6 +227,9 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 * `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round
 
   Default value: `1000`
+* `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds
+
+  Default value: `86400000`
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
 
   Default value: `0`
@@ -255,6 +258,9 @@ Specify the complete set of new owners, by public key. Existing owners that are 
 * `--timeout-increment-ms <TIMEOUT_INCREMENT>` — The number of milliseconds by which the timeout increases after each single-leader round
 
   Default value: `1000`
+* `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds
+
+  Default value: `86400000`
 
 
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -88,6 +88,8 @@ pub enum Round {
     MultiLeader(u32),
     /// The N-th single-leader round.
     SingleLeader(u32),
+    /// The N-th round where the validators rotate as leaders.
+    Validator(u32),
 }
 
 /// A duration in microseconds.
@@ -547,6 +549,7 @@ impl fmt::Display for Round {
             Round::Fast => write!(f, "fast round"),
             Round::MultiLeader(r) => write!(f, "multi-leader round {}", r),
             Round::SingleLeader(r) => write!(f, "single-leader round {}", r),
+            Round::Validator(r) => write!(f, "validator round {}", r),
         }
     }
 }
@@ -566,7 +569,7 @@ impl Round {
     pub fn number(&self) -> u32 {
         match self {
             Round::Fast => 0,
-            Round::MultiLeader(r) | Round::SingleLeader(r) => *r,
+            Round::MultiLeader(r) | Round::SingleLeader(r) | Round::Validator(r) => *r,
         }
     }
 
@@ -576,6 +579,7 @@ impl Round {
             Round::Fast => "fast",
             Round::MultiLeader(_) => "multi",
             Round::SingleLeader(_) => "single",
+            Round::Validator(_) => "validator",
         }
     }
 }

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -121,6 +121,10 @@ impl ChainOwnership {
                 let increment = tc.timeout_increment.saturating_mul(u64::from(r));
                 Some(tc.base_timeout.saturating_add(increment))
             }
+            Round::Validator(r) => {
+                let increment = tc.timeout_increment.saturating_mul(u64::from(r));
+                Some(tc.base_timeout.saturating_add(increment))
+            }
         }
     }
 
@@ -128,6 +132,8 @@ impl ChainOwnership {
     pub fn first_round(&self) -> Round {
         if !self.super_owners.is_empty() {
             Round::Fast
+        } else if self.owners.is_empty() {
+            Round::Validator(0)
         } else if self.multi_leader_rounds > 0 {
             Round::MultiLeader(0)
         } else {
@@ -145,11 +151,14 @@ impl ChainOwnership {
         let next_round = match round {
             Round::Fast if self.multi_leader_rounds == 0 => Round::SingleLeader(0),
             Round::Fast => Round::MultiLeader(0),
-            Round::MultiLeader(r) if r >= self.multi_leader_rounds.saturating_sub(1) => {
-                Round::SingleLeader(0)
-            }
-            Round::MultiLeader(r) => Round::MultiLeader(r.checked_add(1)?),
-            Round::SingleLeader(r) => Round::SingleLeader(r.checked_add(1)?),
+            Round::MultiLeader(r) => r
+                .checked_add(1)
+                .filter(|r| *r < self.multi_leader_rounds)
+                .map_or(Round::SingleLeader(0), Round::MultiLeader),
+            Round::SingleLeader(r) => r
+                .checked_add(1)
+                .map_or(Round::Validator(0), Round::SingleLeader),
+            Round::Validator(r) => Round::Validator(r.checked_add(1)?),
         };
         Some(next_round)
     }

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -92,9 +92,11 @@ impl ChainOwnership {
         self
     }
 
-    /// Returns whether there are any owners or super owners.
+    /// Returns whether there are any owners or super owners or it is a public chain.
     pub fn is_active(&self) -> bool {
-        !self.super_owners.is_empty() || !self.owners.is_empty()
+        !self.super_owners.is_empty()
+            || !self.owners.is_empty()
+            || self.timeout_config.fallback_duration == TimeDelta::ZERO
     }
 
     /// Returns the given owner's public key, if they are an owner or super owner.

--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -26,6 +26,9 @@ pub struct TimeoutConfig {
     pub base_timeout: TimeDelta,
     /// The duration by which the timeout increases after each single-leader round.
     pub timeout_increment: TimeDelta,
+    /// The age of an incoming tracked or protected message after which the validators start
+    /// transitioning the chain to fallback mode.
+    pub fallback_duration: TimeDelta,
 }
 
 impl Default for TimeoutConfig {
@@ -34,6 +37,7 @@ impl Default for TimeoutConfig {
             fast_round_duration: None,
             base_timeout: TimeDelta::from_secs(10),
             timeout_increment: TimeDelta::from_secs(1),
+            fallback_duration: TimeDelta::from_secs(60 * 60 * 24),
         }
     }
 }
@@ -178,6 +182,7 @@ mod tests {
                 fast_round_duration: Some(TimeDelta::from_secs(5)),
                 base_timeout: TimeDelta::from_secs(10),
                 timeout_increment: TimeDelta::from_secs(1),
+                fallback_duration: TimeDelta::from_secs(60 * 60),
             },
         };
 

--- a/linera-base/src/unit_tests.rs
+++ b/linera-base/src/unit_tests.rs
@@ -127,6 +127,7 @@ fn timeout_config_test_case() -> TimeoutConfig {
         fast_round_duration: Some(TimeDelta::from_micros(20)),
         base_timeout: TimeDelta::from_secs(4),
         timeout_increment: TimeDelta::from_millis(125),
+        fallback_duration: TimeDelta::from_secs(1_000),
     }
 }
 
@@ -165,6 +166,7 @@ fn chain_ownership_test_case() -> ChainOwnership {
             fast_round_duration: None,
             base_timeout: TimeDelta::ZERO,
             timeout_increment: TimeDelta::from_secs(3_600),
+            fallback_duration: TimeDelta::from_secs(10_000),
         },
     }
 }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -616,11 +616,13 @@ where
         // Recompute the state hash.
         let hash = self.execution_state.crypto_hash().await?;
         self.execution_state_hash.set(Some(hash));
+        let maybe_committee = self.execution_state.system.current_committee().into_iter();
         // Last, reset the consensus state based on the current ownership.
         self.manager.get_mut().reset(
             self.execution_state.system.ownership.get(),
             BlockHeight(0),
             local_time,
+            maybe_committee.flat_map(|(_, committee)| committee.keys_and_weights()),
         )?;
         Ok(true)
     }
@@ -922,10 +924,12 @@ where
         };
         self.execution_state_hash.set(Some(state_hash));
         // Last, reset the consensus state based on the current ownership.
+        let maybe_committee = self.execution_state.system.current_committee().into_iter();
         self.manager.get_mut().reset(
             self.execution_state.system.ownership.get(),
             block.height.try_add_one()?,
             local_time,
+            maybe_committee.flat_map(|(_, committee)| committee.keys_and_weights()),
         )?;
 
         #[cfg(with_metrics)]

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -736,17 +736,17 @@ impl BlockExecutionOutcome {
 }
 
 impl HashedValue {
-    /// Creates a `ConfirmedBlock` value.
+    /// Creates a [`ConfirmedBlock`](CertificateValue::ConfirmedBlock) value.
     pub fn new_confirmed(executed_block: ExecutedBlock) -> HashedValue {
         CertificateValue::ConfirmedBlock { executed_block }.into()
     }
 
-    /// Creates a new `ValidatedBlock` value.
+    /// Creates a [`ValidatedBlock`](CertificateValue::ValidatedBlock) value.
     pub fn new_validated(executed_block: ExecutedBlock) -> HashedValue {
         CertificateValue::ValidatedBlock { executed_block }.into()
     }
 
-    /// Creates a new `Timeout` value.
+    /// Creates a [`Timeout`](CertificateValue::Timeout) value.
     pub fn new_timeout(chain_id: ChainId, height: BlockHeight, epoch: Epoch) -> HashedValue {
         CertificateValue::Timeout {
             chain_id,

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -293,7 +293,7 @@ pub enum CertificateValue {
     ConfirmedBlock {
         executed_block: ExecutedBlock,
     },
-    LeaderTimeout {
+    Timeout {
         chain_id: ChainId,
         height: BlockHeight,
         epoch: Epoch,
@@ -311,7 +311,7 @@ impl CertificateValue {
         match self {
             CertificateValue::ValidatedBlock { .. } => "validated".to_string(),
             CertificateValue::ConfirmedBlock { .. } => "confirmed".to_string(),
-            CertificateValue::LeaderTimeout { .. } => "timeout".to_string(),
+            CertificateValue::Timeout { .. } => "timeout".to_string(),
         }
     }
 }
@@ -573,7 +573,7 @@ impl CertificateValue {
             | CertificateValue::ValidatedBlock { executed_block, .. } => {
                 executed_block.block.chain_id
             }
-            CertificateValue::LeaderTimeout { chain_id, .. } => *chain_id,
+            CertificateValue::Timeout { chain_id, .. } => *chain_id,
         }
     }
 
@@ -583,7 +583,7 @@ impl CertificateValue {
             | CertificateValue::ValidatedBlock { executed_block, .. } => {
                 executed_block.block.height
             }
-            CertificateValue::LeaderTimeout { height, .. } => *height,
+            CertificateValue::Timeout { height, .. } => *height,
         }
     }
 
@@ -591,7 +591,7 @@ impl CertificateValue {
         match self {
             CertificateValue::ConfirmedBlock { executed_block, .. }
             | CertificateValue::ValidatedBlock { executed_block, .. } => executed_block.block.epoch,
-            CertificateValue::LeaderTimeout { epoch, .. } => *epoch,
+            CertificateValue::Timeout { epoch, .. } => *epoch,
         }
     }
 
@@ -622,7 +622,7 @@ impl CertificateValue {
     }
 
     pub fn is_timeout(&self) -> bool {
-        matches!(self, CertificateValue::LeaderTimeout { .. })
+        matches!(self, CertificateValue::Timeout { .. })
     }
 
     #[cfg(with_testing)]
@@ -634,7 +634,7 @@ impl CertificateValue {
         match self {
             CertificateValue::ConfirmedBlock { executed_block, .. }
             | CertificateValue::ValidatedBlock { executed_block, .. } => Some(executed_block),
-            CertificateValue::LeaderTimeout { .. } => None,
+            CertificateValue::Timeout { .. } => None,
         }
     }
 
@@ -647,7 +647,7 @@ impl CertificateValue {
         match self {
             CertificateValue::ConfirmedBlock { .. } => "confirmed_block",
             CertificateValue::ValidatedBlock { .. } => "validated_block",
-            CertificateValue::LeaderTimeout { .. } => "leader_timeout",
+            CertificateValue::Timeout { .. } => "timeout",
         }
     }
 }
@@ -746,9 +746,9 @@ impl HashedValue {
         CertificateValue::ValidatedBlock { executed_block }.into()
     }
 
-    /// Creates a new `LeaderTimeout` value.
-    pub fn new_leader_timeout(chain_id: ChainId, height: BlockHeight, epoch: Epoch) -> HashedValue {
-        CertificateValue::LeaderTimeout {
+    /// Creates a new `Timeout` value.
+    pub fn new_timeout(chain_id: ChainId, height: BlockHeight, epoch: Epoch) -> HashedValue {
+        CertificateValue::Timeout {
             chain_id,
             height,
             epoch,
@@ -776,9 +776,7 @@ impl HashedValue {
                 }
                 .into(),
             ),
-            CertificateValue::ConfirmedBlock { .. } | CertificateValue::LeaderTimeout { .. } => {
-                None
-            }
+            CertificateValue::ConfirmedBlock { .. } | CertificateValue::Timeout { .. } => None,
         }
     }
 

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -57,6 +57,7 @@ where
     Default,
     Clone,
     Copy,
+    Hash,
     Eq,
     PartialEq,
     Ord,

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -21,7 +21,7 @@
 //! * In leader rotation mode (`Round::SingleLeader`), chain owners take turns at proposing blocks.
 //!   It can make progress as long as at least one owner is honest, even if other owners try to
 //!   prevent it.
-//! * In fallback/publich mode (`Round::Validator`), validators take turns at proposing blocks.
+//! * In fallback/public mode (`Round::Validator`), validators take turns at proposing blocks.
 //!   It can always make progress under the standard assumption that there is a quorum of honest
 //!   validators.
 //!

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1612,7 +1612,7 @@ where
         let can_propose = match round {
             Round::Fast => manager.ownership.super_owners.contains_key(&identity),
             Round::MultiLeader(_) => true,
-            Round::SingleLeader(_) => manager.leader == Some(identity),
+            Round::SingleLeader(_) | Round::Validator(_) => manager.leader == Some(identity),
         };
         if can_propose {
             let certificate = self.propose_block(block.clone(), round).await?;

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -994,7 +994,7 @@ where
 
     /// Requests a leader timeout vote from all validators. If a quorum signs it, creates a
     /// certificate and sends it to all validators, to make them enter the next round.
-    pub async fn request_timeout(&mut self) -> Result<Certificate, ChainClientError> {
+    pub async fn request_leader_timeout(&mut self) -> Result<Certificate, ChainClientError> {
         let chain_id = self.chain_id;
         let query = ChainInfoQuery::new(chain_id).with_committees();
         let info = self.node_client.handle_chain_info_query(query).await?.info;
@@ -1534,7 +1534,7 @@ where
         // the next round.
         if let Some(round_timeout) = info.manager.round_timeout {
             if round_timeout <= self.storage_client().await.current_time() {
-                self.request_timeout().await?;
+                self.request_leader_timeout().await?;
                 info = self.chain_info_with_manager_values().await?;
             }
         }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -508,6 +508,7 @@ where
         let mut identities = manager
             .ownership
             .all_owners()
+            .chain(&manager.leader)
             .filter(|owner| self.known_key_pairs.contains_key(owner));
         let Some(identity) = identities.next() else {
             return Err(ChainClientError::CannotFindKeyForChain(self.chain_id));

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -65,7 +65,7 @@ pub struct ChainInfoQuery {
     /// Query values from the chain manager, not just votes.
     pub request_manager_values: bool,
     /// Include a timeout vote for the current round, if appropriate.
-    pub request_timeout: bool,
+    pub request_leader_timeout: bool,
     /// Include a vote to switch to fallback mode, if appropriate.
     pub request_fallback: bool,
     /// Query a value that contains a binary blob (e.g. bytecode) required by this chain.
@@ -83,7 +83,7 @@ impl ChainInfoQuery {
             request_sent_certificates_in_range: None,
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
-            request_timeout: false,
+            request_leader_timeout: false,
             request_fallback: false,
             request_blob: None,
         }
@@ -125,7 +125,7 @@ impl ChainInfoQuery {
     }
 
     pub fn with_timeout(mut self) -> Self {
-        self.request_timeout = true;
+        self.request_leader_timeout = true;
         self
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -65,7 +65,7 @@ pub struct ChainInfoQuery {
     /// Query values from the chain manager, not just votes.
     pub request_manager_values: bool,
     /// Include a timeout vote for the current round, if appropriate.
-    pub request_leader_timeout: bool,
+    pub request_timeout: bool,
     /// Include a vote to switch to fallback mode, if appropriate.
     pub request_fallback: bool,
     /// Query a value that contains a binary blob (e.g. bytecode) required by this chain.
@@ -83,7 +83,7 @@ impl ChainInfoQuery {
             request_sent_certificates_in_range: None,
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
-            request_leader_timeout: false,
+            request_timeout: false,
             request_fallback: false,
             request_blob: None,
         }
@@ -124,8 +124,8 @@ impl ChainInfoQuery {
         self
     }
 
-    pub fn with_leader_timeout(mut self) -> Self {
-        self.request_leader_timeout = true;
+    pub fn with_timeout(mut self) -> Self {
+        self.request_timeout = true;
         self
     }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -66,6 +66,8 @@ pub struct ChainInfoQuery {
     pub request_manager_values: bool,
     /// Include a timeout vote for the current round, if appropriate.
     pub request_leader_timeout: bool,
+    /// Include a vote to switch to fallback mode, if appropriate.
+    pub request_fallback: bool,
     /// Query a value that contains a binary blob (e.g. bytecode) required by this chain.
     pub request_blob: Option<CryptoHash>,
 }
@@ -82,6 +84,7 @@ impl ChainInfoQuery {
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
             request_leader_timeout: false,
+            request_fallback: false,
             request_blob: None,
         }
     }
@@ -123,6 +126,11 @@ impl ChainInfoQuery {
 
     pub fn with_leader_timeout(mut self) -> Self {
         self.request_leader_timeout = true;
+        self
+    }
+
+    pub fn with_fallback(mut self) -> Self {
+        self.request_fallback = true;
         self
     }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1388,7 +1388,7 @@ where
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
 #[test_log::test(tokio::test)]
-async fn test_request_leader_timeout<B>(storage_builder: B) -> anyhow::Result<()>
+async fn test_request_timeout<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,
@@ -1417,7 +1417,7 @@ where
     // If the malicious and one honest validator happen to be much faster than the other
     // two honest validators, only those two samples may be returned. Otherwise we get
     // a trusted MissingVoteInValidatorResponse, because at least two returned that.
-    let result = client.request_leader_timeout().await;
+    let result = client.request_timeout().await;
     if !matches!(
         result,
         Err(ChainClientError::CommunicationError(
@@ -1433,10 +1433,10 @@ where
     clock.set(manager.round_timeout.unwrap());
 
     // After the timeout they will.
-    let certificate = client.request_leader_timeout().await.unwrap();
+    let certificate = client.request_timeout().await.unwrap();
     assert_eq!(
         *certificate.value(),
-        CertificateValue::LeaderTimeout {
+        CertificateValue::Timeout {
             chain_id,
             height: BlockHeight::from(1),
             epoch: Epoch::ZERO
@@ -1455,7 +1455,7 @@ where
             break manager.current_round;
         }
         clock.set(manager.round_timeout.unwrap());
-        assert!(client.request_leader_timeout().await.is_ok());
+        assert!(client.request_timeout().await.is_ok());
     };
     let round_number = match round {
         Round::SingleLeader(round_number) => round_number,
@@ -1472,9 +1472,9 @@ where
         ClientOutcome::WaitForTimeout(timeout) => timeout,
     };
     client.clear_pending_block();
-    assert!(client.request_leader_timeout().await.is_err());
+    assert!(client.request_timeout().await.is_err());
     clock.set(timeout.timestamp);
-    client.request_leader_timeout().await.unwrap();
+    client.request_timeout().await.unwrap();
     let expected_round = Round::SingleLeader(round_number + 1);
     builder
         .check_that_validators_are_in_round(chain_id, BlockHeight::from(1), expected_round, 3)
@@ -1486,7 +1486,7 @@ where
             break;
         }
         clock.set(manager.round_timeout.unwrap());
-        assert!(client.request_leader_timeout().await.is_ok());
+        assert!(client.request_timeout().await.is_ok());
     }
 
     // Now we are the leader, and the transfer should succeed.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1585,12 +1585,7 @@ where
         .await?;
     assert_eq!(BlockHeight::from(1), inbox.next_block_height_to_receive()?);
     assert_matches!(
-        inbox
-            .added_events
-            .front()
-            .await
-            ?
-            .unwrap(),
+        inbox.added_events.front().await?.unwrap(),
         Event {
             certificate_hash,
             height,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -474,7 +474,7 @@ where
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
     let key_pair = KeyPair::generate();
-    let balance: Amount = Amount::from_tokens(5);
+    let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public(), balance)];
     let epoch = Epoch::ZERO;
     let (committee, mut worker) = init_worker_with_chains(storage, balances).await;
@@ -3550,7 +3550,7 @@ where
     let clock = storage_builder.clock();
     let chain_id = ChainId::root(1);
     let key_pair = KeyPair::generate();
-    let balance: Amount = Amount::from_tokens(5);
+    let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public(), balance)];
     let (committee, mut worker) = init_worker_with_chains(storage, balances).await;
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -44,7 +44,7 @@ pub enum CommunicateAction {
         certificate: Certificate,
         delivery: CrossChainMessageDelivery,
     },
-    RequestLeaderTimeout {
+    RequestTimeout {
         chain_id: ChainId,
         height: BlockHeight,
         round: Round,
@@ -210,7 +210,7 @@ where
                 | CertificateValue::ValidatedBlock { executed_block, .. } => {
                     executed_block.block.bytecode_locations()
                 }
-                CertificateValue::LeaderTimeout { .. } => HashMap::new(),
+                CertificateValue::Timeout { .. } => HashMap::new(),
             };
             for location in locations {
                 if !required.contains_key(location) {
@@ -313,7 +313,7 @@ where
                     .await?;
             }
         }
-        if let Some(cert) = manager.leader_timeout {
+        if let Some(cert) = manager.timeout {
             if cert.value().is_timeout() && cert.value().chain_id() == chain_id {
                 self.send_certificate(cert, CrossChainMessageDelivery::NonBlocking)
                     .await?;
@@ -359,7 +359,7 @@ where
                 let value = certificate.value();
                 (value.height(), value.chain_id())
             }
-            CommunicateAction::RequestLeaderTimeout {
+            CommunicateAction::RequestTimeout {
                 height, chain_id, ..
             } => (*height, *chain_id),
         };
@@ -380,8 +380,8 @@ where
                 let info = self.send_certificate(certificate, delivery).await?;
                 info.manager.pending
             }
-            CommunicateAction::RequestLeaderTimeout { .. } => {
-                let query = ChainInfoQuery::new(chain_id).with_leader_timeout();
+            CommunicateAction::RequestTimeout { .. } => {
+                let query = ChainInfoQuery::new(chain_id).with_timeout();
                 let info = self.node.handle_chain_info_query(query).await?.info;
                 info.manager.timeout_vote
             }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -807,12 +807,12 @@ where
     }
 
     /// Processes a leader timeout issued from a multi-owner chain.
-    async fn process_leader_timeout(
+    async fn process_timeout(
         &mut self,
         certificate: Certificate,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let (chain_id, height, epoch) = match certificate.value() {
-            CertificateValue::LeaderTimeout {
+            CertificateValue::Timeout {
                 chain_id,
                 height,
                 epoch,
@@ -1201,9 +1201,9 @@ where
                 )
                 .await?
             }
-            CertificateValue::LeaderTimeout { .. } => {
+            CertificateValue::Timeout { .. } => {
                 // Handle the leader timeout.
-                self.process_leader_timeout(certificate).await?
+                self.process_timeout(certificate).await?
             }
         };
 
@@ -1231,9 +1231,9 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);
         let mut chain = self.storage.load_chain(query.chain_id).await?;
-        if query.request_leader_timeout {
+        if query.request_timeout {
             if let Some(epoch) = chain.execution_state.system.epoch.get() {
-                if chain.manager.get_mut().vote_leader_timeout(
+                if chain.manager.get_mut().vote_timeout(
                     query.chain_id,
                     chain.tip_state.get().next_block_height,
                     *epoch,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1231,7 +1231,7 @@ where
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);
         let mut chain = self.storage.load_chain(query.chain_id).await?;
-        if query.request_timeout {
+        if query.request_leader_timeout {
             if let Some(epoch) = chain.execution_state.system.epoch.get() {
                 if chain.manager.get_mut().vote_timeout(
                     query.chain_id,

--- a/linera-execution/src/committee.rs
+++ b/linera-execution/src/committee.rs
@@ -334,6 +334,12 @@ impl Committee {
         }
     }
 
+    pub fn keys_and_weights(&self) -> impl Iterator<Item = (PublicKey, u64)> + '_ {
+        self.validators
+            .iter()
+            .map(|(name, validator)| (name.0, validator.votes))
+    }
+
     pub fn network_address(&self, author: &ValidatorName) -> Option<&str> {
         self.validators
             .get(author)

--- a/linera-execution/src/wasm/conversions_from_wit.rs
+++ b/linera-execution/src/wasm/conversions_from_wit.rs
@@ -74,11 +74,13 @@ impl From<contract_system_api::TimeoutConfig> for TimeoutConfig {
             fast_round_duration_us,
             base_timeout_us,
             timeout_increment_us,
+            fallback_duration_us,
         } = guest;
         TimeoutConfig {
             fast_round_duration: fast_round_duration_us.map(TimeDelta::from_micros),
             base_timeout: TimeDelta::from_micros(base_timeout_us),
             timeout_increment: TimeDelta::from_micros(timeout_increment_us),
+            fallback_duration: TimeDelta::from_micros(fallback_duration_us),
         }
     }
 }

--- a/linera-execution/src/wasm/conversions_to_wit.rs
+++ b/linera-execution/src/wasm/conversions_to_wit.rs
@@ -128,11 +128,13 @@ impl From<TimeoutConfig> for contract_system_api::TimeoutConfig {
             fast_round_duration,
             base_timeout,
             timeout_increment,
+            fallback_duration,
         } = host;
         Self {
             fast_round_duration_us: fast_round_duration.map(|duration| duration.as_micros()),
             base_timeout_us: base_timeout.as_micros(),
             timeout_increment_us: timeout_increment.as_micros(),
+            fallback_duration_us: fallback_duration.as_micros(),
         }
     }
 }

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -144,6 +144,9 @@ message ChainInfoQuery {
 
   // Query the balance of a given owner.
   optional Owner request_owner_balance = 10;
+
+  // Request a signed vote for fallback mode.
+  bool request_fallback = 11;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -137,7 +137,7 @@ message ChainInfoQuery {
   bool request_manager_values = 7;
 
   // Request a signed vote for a leader timeout.
-  bool request_leader_timeout = 8;
+  bool request_timeout = 8;
 
   // Query a value that contains a binary blob (e.g. bytecode) required by this chain.
   optional bytes request_blob = 9;

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -137,7 +137,7 @@ message ChainInfoQuery {
   bool request_manager_values = 7;
 
   // Request a signed vote for a leader timeout.
-  bool request_timeout = 8;
+  bool request_leader_timeout = 8;
 
   // Query a value that contains a binary blob (e.g. bytecode) required by this chain.
   optional bytes request_blob = 9;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -356,7 +356,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
                 .request_received_log_excluding_first_nth,
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
-            request_leader_timeout: chain_info_query.request_leader_timeout,
+            request_timeout: chain_info_query.request_timeout,
             request_fallback: chain_info_query.request_fallback,
             request_blob,
         })
@@ -386,7 +386,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_received_log_excluding_first_nth: chain_info_query
                 .request_received_log_excluding_first_nth,
             request_manager_values: chain_info_query.request_manager_values,
-            request_leader_timeout: chain_info_query.request_leader_timeout,
+            request_timeout: chain_info_query.request_timeout,
             request_fallback: chain_info_query.request_fallback,
             request_blob,
         })
@@ -643,7 +643,7 @@ pub mod tests {
             }),
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
-            request_leader_timeout: false,
+            request_timeout: false,
             request_fallback: true,
             request_blob: None,
         };

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -356,7 +356,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
                 .request_received_log_excluding_first_nth,
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
-            request_timeout: chain_info_query.request_timeout,
+            request_leader_timeout: chain_info_query.request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
             request_blob,
         })
@@ -386,7 +386,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_received_log_excluding_first_nth: chain_info_query
                 .request_received_log_excluding_first_nth,
             request_manager_values: chain_info_query.request_manager_values,
-            request_timeout: chain_info_query.request_timeout,
+            request_leader_timeout: chain_info_query.request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
             request_blob,
         })
@@ -643,7 +643,7 @@ pub mod tests {
             }),
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
-            request_timeout: false,
+            request_leader_timeout: false,
             request_fallback: true,
             request_blob: None,
         };

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -357,6 +357,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout: chain_info_query.request_leader_timeout,
+            request_fallback: chain_info_query.request_fallback,
             request_blob,
         })
     }
@@ -386,6 +387,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
                 .request_received_log_excluding_first_nth,
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout: chain_info_query.request_leader_timeout,
+            request_fallback: chain_info_query.request_fallback,
             request_blob,
         })
     }
@@ -642,6 +644,7 @@ pub mod tests {
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
             request_leader_timeout: false,
+            request_fallback: true,
             request_blob: None,
         };
         round_trip_check::<_, api::ChainInfoQuery>(chain_info_query_some);

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -217,7 +217,7 @@ ChainInfoQuery:
     - request_received_log_excluding_first_nth:
         OPTION: U64
     - request_manager_values: BOOL
-    - request_timeout: BOOL
+    - request_leader_timeout: BOOL
     - request_blob:
         OPTION:
           TYPENAME: CryptoHash

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -126,7 +126,7 @@ CertificateValue:
           - executed_block:
               TYPENAME: ExecutedBlock
     2:
-      LeaderTimeout:
+      Timeout:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
@@ -217,7 +217,7 @@ ChainInfoQuery:
     - request_received_log_excluding_first_nth:
         OPTION: U64
     - request_manager_values: BOOL
-    - request_leader_timeout: BOOL
+    - request_timeout: BOOL
     - request_blob:
         OPTION:
           TYPENAME: CryptoHash
@@ -238,7 +238,7 @@ ChainManagerInfo:
     - requested_locked:
         OPTION:
           TYPENAME: Certificate
-    - leader_timeout:
+    - timeout:
         OPTION:
           TYPENAME: Certificate
     - pending:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -218,6 +218,7 @@ ChainInfoQuery:
         OPTION: U64
     - request_manager_values: BOOL
     - request_leader_timeout: BOOL
+    - request_fallback: BOOL
     - request_blob:
         OPTION:
           TYPENAME: CryptoHash
@@ -245,6 +246,9 @@ ChainManagerInfo:
         OPTION:
           TYPENAME: LiteVote
     - timeout_vote:
+        OPTION:
+          TYPENAME: LiteVote
+    - fallback_vote:
         OPTION:
           TYPENAME: LiteVote
     - requested_pending_value:
@@ -678,6 +682,9 @@ Round:
     2:
       SingleLeader:
         NEWTYPE: U32
+    3:
+      Validator:
+        NEWTYPE: U32
 RpcMessage:
   ENUM:
     0:
@@ -914,6 +921,8 @@ TimeoutConfig:
     - base_timeout:
         TYPENAME: TimeDelta
     - timeout_increment:
+        TYPENAME: TimeDelta
+    - fallback_duration:
         TYPENAME: TimeDelta
 Timestamp:
   NEWTYPESTRUCT: U64

--- a/linera-sdk/contract_system_api.wit
+++ b/linera-sdk/contract_system_api.wit
@@ -129,4 +129,5 @@ record timeout-config {
     fast-round-duration-us: option<duration>,
     base-timeout-us: duration,
     timeout-increment-us: duration,
+    fallback-duration-us: duration,
 }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -79,11 +79,13 @@ impl From<wit_system_api::TimeoutConfig> for TimeoutConfig {
             fast_round_duration_us,
             base_timeout_us,
             timeout_increment_us,
+            fallback_duration_us,
         } = guest;
         TimeoutConfig {
             fast_round_duration: fast_round_duration_us.map(TimeDelta::from_micros),
             base_timeout: TimeDelta::from_micros(base_timeout_us),
             timeout_increment: TimeDelta::from_micros(timeout_increment_us),
+            fallback_duration: TimeDelta::from_micros(fallback_duration_us),
         }
     }
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -507,7 +507,11 @@ type MutationRoot {
 		"""
 		The number of milliseconds by which the timeout increases after each single-leader round
 		"""
-		timeoutIncrementMs: Int! = 1000
+		timeoutIncrementMs: Int! = 1000,
+		"""
+		The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds.
+		"""
+		fallbackDurationMs: Int! = 86400000
 	): ChainId!
 	"""
 	Closes the chain.
@@ -532,7 +536,11 @@ type MutationRoot {
 		"""
 		The number of milliseconds by which the timeout increases after each single-leader round
 		"""
-		timeoutIncrementMs: Int! = 1000
+		timeoutIncrementMs: Int! = 1000,
+		"""
+		The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds.
+		"""
+		fallbackDurationMs: Int! = 86400000
 	): CryptoHash!
 	"""
 	Changes the application permissions configuration on this chain.

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -150,6 +150,14 @@ type ChainStateExtendedView {
 	"""
 	inboxes: ReentrantCollectionView_Origin_InboxStateView_2059505700!
 	"""
+	A queue of unskippable events, with the timestamp when we added them to the inbox.
+	"""
+	unskippable: QueueView_TimestampedInboxEntry_ce4d8b86!
+	"""
+	Non-skippable events that have been removed but are still in the queue.
+	"""
+	removedUnskippable: [InboxEntry!]!
+	"""
 	Mailboxes used to send messages, indexed by their target.
 	"""
 	outboxes: ReentrantCollectionView_Target_OutboxStateView_3775022202!
@@ -346,6 +354,20 @@ type HashedValue {
 	value: CertificateValue!
 }
 
+
+"""
+An origin and cursor of a unskippable message that is no longer in our inbox.
+"""
+type InboxEntry {
+	"""
+	The origin from which we received the message.
+	"""
+	origin: Origin!
+	"""
+	The cursor of the message in the inbox.
+	"""
+	cursor: Cursor!
+}
 
 """
 The state of a inbox.
@@ -677,6 +699,10 @@ type QueueView_Event_fd202526 {
 	entries(count: Int): [Event!]!
 }
 
+type QueueView_TimestampedInboxEntry_ce4d8b86 {
+	entries(count: Int): [TimestampedInboxEntry!]!
+}
+
 """
 The recipient of a transfer
 """
@@ -801,6 +827,20 @@ scalar Target
 A timestamp, in microseconds since the Unix epoch
 """
 scalar Timestamp
+
+"""
+An origin, cursor and timestamp of a unskippable message in our inbox.
+"""
+type TimestampedInboxEntry {
+	"""
+	The origin and cursor of the message.
+	"""
+	entry: InboxEntry!
+	"""
+	The timestamp when the message was added to the inbox.
+	"""
+	seen: Timestamp!
+}
 
 """
 Description of the necessary information to run a user application

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -893,6 +893,15 @@ pub struct ChainOwnershipConfig {
         value_parser = util::parse_millis_delta
     )]
     timeout_increment: TimeDelta,
+
+    /// The age of an incoming tracked or protected message after which the validators start
+    /// transitioning the chain to fallback mode, in milliseconds.
+    #[arg(
+        long = "fallback-duration-ms",
+        default_value = "86400000", // 1 day
+        value_parser = util::parse_millis_delta
+    )]
+    pub fallback_duration: TimeDelta,
 }
 
 impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
@@ -907,6 +916,7 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
             fast_round_duration,
             base_timeout,
             timeout_increment,
+            fallback_duration,
         } = config;
         anyhow::ensure!(
             owner_weights.is_empty() || owner_weights.len() == owner_public_keys.len(),
@@ -928,6 +938,7 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
             fast_round_duration,
             base_timeout,
             timeout_increment,
+            fallback_duration,
         };
         Ok(ChainOwnership {
             super_owners,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -419,6 +419,12 @@ where
             default = 1_000
         )]
         timeout_increment_ms: u64,
+        #[graphql(
+            desc = "The age of an incoming tracked or protected message after which the \
+                    validators start transitioning the chain to fallback mode, in milliseconds.",
+            default = 86_400_000
+        )]
+        fallback_duration_ms: u64,
     ) -> Result<ChainId, Error> {
         let owners = if let Some(weights) = weights {
             if weights.len() != public_keys.len() {
@@ -440,6 +446,7 @@ where
             fast_round_duration: fast_round_ms.map(TimeDelta::from_millis),
             base_timeout: TimeDelta::from_millis(base_timeout_ms),
             timeout_increment: TimeDelta::from_millis(timeout_increment_ms),
+            fallback_duration: TimeDelta::from_millis(fallback_duration_ms),
         };
         let ownership = ChainOwnership::multiple(owners, multi_leader_rounds, timeout_config);
         let balance = balance.unwrap_or(Amount::ZERO);
@@ -506,6 +513,12 @@ where
             default = 1_000
         )]
         timeout_increment_ms: u64,
+        #[graphql(
+            desc = "The age of an incoming tracked or protected message after which the \
+                    validators start transitioning the chain to fallback mode, in milliseconds.",
+            default = 86_400_000
+        )]
+        fallback_duration_ms: u64,
     ) -> Result<CryptoHash, Error> {
         let operation = SystemOperation::ChangeOwnership {
             super_owners: Vec::new(),
@@ -515,6 +528,7 @@ where
                 fast_round_duration: fast_round_ms.map(TimeDelta::from_millis),
                 base_timeout: TimeDelta::from_millis(base_timeout_ms),
                 timeout_increment: TimeDelta::from_millis(timeout_increment_ms),
+                fallback_duration: TimeDelta::from_millis(fallback_duration_ms),
             },
         };
         self.execute_system_operation(operation, chain_id).await

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -5,11 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use linera_base::{
-    crypto::CryptoHash,
-    data_types::{TimeDelta, Timestamp},
-    identifiers::ChainId,
-};
+use linera_base::{crypto::CryptoHash, data_types::Timestamp, identifiers::ChainId};
 use linera_chain::{
     data_types::{Certificate, CertificateValue, HashedValue, LiteCertificate},
     ChainStateView,
@@ -240,7 +236,7 @@ impl TestClock {
     }
 
     /// Advances the current time by the specified delta.
-    pub fn add(&self, delta: TimeDelta) {
+    pub fn add(&self, delta: linera_base::data_types::TimeDelta) {
         self.0
             .fetch_add(delta.as_micros(), std::sync::atomic::Ordering::SeqCst);
     }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -5,7 +5,11 @@ use std::{fmt::Debug, sync::Arc};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use linera_base::{crypto::CryptoHash, data_types::Timestamp, identifiers::ChainId};
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::{TimeDelta, Timestamp},
+    identifiers::ChainId,
+};
 use linera_chain::{
     data_types::{Certificate, CertificateValue, HashedValue, LiteCertificate},
     ChainStateView,
@@ -235,10 +239,10 @@ impl TestClock {
             .store(timestamp.micros(), std::sync::atomic::Ordering::SeqCst);
     }
 
-    /// Advances the current time by the specified number of microseconds.
-    pub fn add_micros(&self, micros: u64) {
+    /// Advances the current time by the specified delta.
+    pub fn add(&self, delta: TimeDelta) {
         self.0
-            .fetch_add(micros, std::sync::atomic::Ordering::SeqCst);
+            .fetch_add(delta.as_micros(), std::sync::atomic::Ordering::SeqCst);
     }
 }
 


### PR DESCRIPTION
## Motivation

We plan to support both public chains—where the validators are always the block proposers—and a fallback mode—where the validators take over proposing blocks if the chain owners fail to include an unskippable (i.e. tracked or protected) message for a long time.

## Proposal

Add a `Round::Validator(u32)` variant for rounds in which a validator is the leader. These come after all other round types.

If an unskippable message is in the inbox for longer than `fallback_duration`, the validators will sign a timeout certificate for the last non-`Validator` round, and effectively make themselves the leaders. If `fallback_duration` is zero, they are always leaders.

## Test Plan

A worker test was added.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- #1621 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
