### PR TITLE
Fix the build without RocksDB.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -184,7 +184,8 @@ jobs:
         cargo clippy --all-targets --all-features --target x86_64-unknown-linux-gnu --locked
     - name: Run clippy
       run: |
-        cargo clippy --all-targets --all-features --tests --locked
+        cargo clippy --all-targets --all-features --locked
+        cargo clippy --no-default-features --features kubernetes --locked
     - name: Run cargo doc
       run: |
         cargo doc --locked --all-features

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -28,7 +28,7 @@ use linera_service::{
     chain_listener,
     config::{GenesisConfig, UserChain, WalletState},
     node_service::wait_for_next_round,
-    storage::{StorageConfig, StorageConfigNamespace},
+    storage::StorageConfigNamespace,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -189,7 +189,7 @@ impl ClientContext {
             Some(config) => config.parse(),
             #[cfg(feature = "rocksdb")]
             None => {
-                let storage_config = StorageConfig::RocksDb {
+                let storage_config = linera_service::storage::StorageConfig::RocksDb {
                     path: Self::create_default_config_path()?.join("wallet.db"),
                 };
                 let namespace = "default".to_string();

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -37,6 +37,8 @@ use linera_execution::{
     system::{SystemChannel, UserData},
     Message, ResourceControlPolicy, SystemMessage,
 };
+#[cfg(any(feature = "kubernetes", feature = "rocksdb"))]
+use linera_service::cli_wrappers::{LineraNetConfig, Network};
 use linera_service::{
     chain_listener::ClientContext as _,
     cli_wrappers::{self, ClientWrapper, FaucetOption, LineraNet},
@@ -45,6 +47,11 @@ use linera_service::{
     node_service::NodeService,
     project::{self, Project},
     storage::Runnable,
+};
+#[cfg(feature = "rocksdb")]
+use linera_service::{
+    cli_wrappers::local_net::{Database, LocalNetConfig, PathProvider, StorageConfigBuilder},
+    storage::StorageConfig,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -1465,8 +1472,6 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 kubernetes: true,
                 binaries,
             } => {
-                use linera_service::cli_wrappers::{LineraNetConfig, Network};
-
                 if *validators < 1 {
                     panic!("The local test network must have at least one validator.");
                 }
@@ -1504,14 +1509,6 @@ async fn run(options: ClientOptions) -> Result<(), anyhow::Error> {
                 table_name,
                 ..
             } => {
-                use linera_service::{
-                    cli_wrappers::{
-                        local_net::{Database, LocalNetConfig, PathProvider, StorageConfigBuilder},
-                        LineraNetConfig, Network,
-                    },
-                    storage::StorageConfig,
-                };
-
                 if *validators < 1 {
                     panic!("The local test network must have at least one validator.");
                 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -21,9 +21,7 @@ use linera_service::{
     config::{
         CommitteeConfig, Export, GenesisConfig, Import, ValidatorConfig, ValidatorServerConfig,
     },
-    storage::{
-        full_initialize_storage, run_with_storage, Runnable, StorageConfig, StorageConfigNamespace,
-    },
+    storage::{full_initialize_storage, run_with_storage, Runnable, StorageConfigNamespace},
     util,
 };
 use linera_storage::Storage;
@@ -437,7 +435,7 @@ async fn run(options: ServerOptions) {
 
             #[cfg(feature = "rocksdb")]
             if server_config.internal_network.shards.len() > 1
-                && matches!(storage_config.storage_config, StorageConfig::RocksDb { .. })
+                && storage_config.storage_config.is_rocks_db()
             {
                 panic!("Multiple shards not supported with RocksDB");
             }

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -87,6 +87,13 @@ pub enum StorageConfig {
     },
 }
 
+impl StorageConfig {
+    #[cfg(feature = "rocksdb")]
+    pub fn is_rocks_db(&self) -> bool {
+        matches!(self, StorageConfig::RocksDb { .. })
+    }
+}
+
 /// The description of a storage implementation.
 #[derive(Clone, Debug)]
 #[cfg_attr(any(test), derive(Eq, PartialEq))]

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -7,8 +7,12 @@ use async_lock::RwLock;
 use linera_storage_service::common::{KeyTag, MAX_PAYLOAD_SIZE};
 use linera_views::{
     batch::Batch,
-    common::{AdminKeyValueStore, CommonStoreConfig, ReadableKeyValueStore, WritableKeyValueStore},
+    common::{CommonStoreConfig, ReadableKeyValueStore, WritableKeyValueStore},
     memory::{create_memory_store_stream_queries, MemoryStore},
+};
+#[cfg(feature = "rocksdb")]
+use linera_views::{
+    common::AdminKeyValueStore,
     rocks_db::{RocksDbStore, RocksDbStoreConfig},
 };
 use serde::Serialize;
@@ -208,6 +212,7 @@ enum ServiceStoreServerOptions {
         endpoint: String,
     },
 
+    #[cfg(feature = "rocksdb")]
     #[command(name = "rocksdb")]
     RocksDb {
         #[arg(long = "endpoint")]
@@ -480,6 +485,7 @@ async fn main() {
             let store = ServiceStoreServerInternal::Memory(store);
             (store, endpoint)
         }
+        #[cfg(feature = "rocksdb")]
         ServiceStoreServerOptions::RocksDb { path, endpoint } => {
             let path_buf = path.into();
             let config = RocksDbStoreConfig {


### PR DESCRIPTION
## Motivation

`rocksdb` is an optional flag, but the build fails without it.

## Proposal

Fix it.
There are still a few warnings if neither `rocksdb` nor `kubernetes` are enabled, but with `kubernetes` alone there are no warnings, and the build succeeds now.

## Test Plan

I added this to CI:
```bash
cargo clippy --no-default-features --features kubernetes --locked
```

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
