### PR TITLE
Create a `WitInterface` trait to allow creating of WIT interface snippets

### DIFF
--- a/linera-witty-macros/src/lib.rs
+++ b/linera-witty-macros/src/lib.rs
@@ -10,6 +10,7 @@
 mod util;
 mod wit_export;
 mod wit_import;
+mod wit_interface;
 mod wit_load;
 mod wit_store;
 mod wit_type;

--- a/linera-witty-macros/src/wit_export/function_information.rs
+++ b/linera-witty-macros/src/wit_export/function_information.rs
@@ -15,11 +15,11 @@ use syn::{
 
 /// Pieces of information extracted from a function's definition.
 pub struct FunctionInformation<'input> {
-    function: &'input ImplItemFn,
+    pub(crate) function: &'input ImplItemFn,
+    pub(crate) is_reentrant: bool,
+    pub(crate) call_early_return: Option<Token![?]>,
     wit_name: String,
-    is_reentrant: bool,
     parameter_bindings: TokenStream,
-    call_early_return: Option<Token![?]>,
     interface_type: TokenStream,
 }
 
@@ -61,10 +61,10 @@ impl<'input> FunctionInformation<'input> {
 
         FunctionInformation {
             function,
-            wit_name,
             is_reentrant,
-            parameter_bindings,
             call_early_return: is_fallible.then(|| Token![?](Span::call_site())),
+            wit_name,
+            parameter_bindings,
             interface_type,
         }
     }
@@ -301,7 +301,7 @@ impl<'input> FunctionInformation<'input> {
 /// Returns the type inside the `Ok` variant of the `maybe_result_type`.
 ///
 /// The type is only considered if it's a [`Result`] type with `RuntimeError` as its error variant.
-fn ok_type_inside_result(maybe_result_type: &Type) -> Option<&Type> {
+pub(crate) fn ok_type_inside_result(maybe_result_type: &Type) -> Option<&Type> {
     let Type::Path(TypePath { qself: None, path }) = maybe_result_type else {
         return None;
     };

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -35,6 +35,7 @@ pub fn generate(implementation: &ItemImpl, parameters: AttributeParameters) -> T
 /// Code generating is done in two phases. First the necessary pieces are collected and stored in
 /// this type. Then, they are used to generate the final code.
 pub struct WitExportGenerator<'input> {
+    parameters: AttributeParameters,
     namespace: LitStr,
     type_name: &'input Ident,
     caller_type_parameter: Option<CallerTypeParameter<'input>>,
@@ -59,6 +60,7 @@ impl<'input> WitExportGenerator<'input> {
             .collect();
 
         WitExportGenerator {
+            parameters,
             namespace,
             type_name,
             caller_type_parameter,

--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -17,7 +17,8 @@ use syn::{
     TypePath, TypeTuple,
 };
 
-use self::{caller_type_parameter::CallerTypeParameter, function_information::FunctionInformation};
+use self::caller_type_parameter::CallerTypeParameter;
+pub(crate) use self::function_information::{ok_type_inside_result, FunctionInformation};
 use crate::util::AttributeParameters;
 
 /// Returns the code generated for exporting host functions to guest Wasm instances.

--- a/linera-witty-macros/src/wit_import.rs
+++ b/linera-witty-macros/src/wit_import.rs
@@ -27,6 +27,7 @@ pub fn generate(trait_definition: ItemTrait, parameters: AttributeParameters) ->
 /// Code generating is done in two phases. First the necessary pieces are collected and stored in
 /// this type. Then, they are used to generate the final code.
 pub struct WitImportGenerator<'input> {
+    parameters: AttributeParameters,
     trait_name: &'input Ident,
     namespace: LitStr,
     functions: Vec<FunctionInformation<'input>>,
@@ -55,6 +56,7 @@ impl<'input> WitImportGenerator<'input> {
 
         WitImportGenerator {
             trait_name,
+            parameters,
             namespace,
             functions,
         }

--- a/linera-witty-macros/src/wit_import.rs
+++ b/linera-witty-macros/src/wit_import.rs
@@ -33,8 +33,8 @@ pub struct WitImportGenerator<'input> {
 }
 
 /// Pieces of information extracted from a function's definition.
-struct FunctionInformation<'input> {
-    function: &'input TraitItemFn,
+pub(crate) struct FunctionInformation<'input> {
+    pub(crate) function: &'input TraitItemFn,
     parameter_definitions: TokenStream,
     parameter_bindings: TokenStream,
     return_type: TokenStream,

--- a/linera-witty-macros/src/wit_interface.rs
+++ b/linera-witty-macros/src/wit_interface.rs
@@ -1,0 +1,215 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generation of code to generate WIT snippets for an interface.
+
+use std::iter;
+
+use heck::ToKebabCase;
+use proc_macro2::TokenStream;
+use proc_macro_error::abort;
+use quote::quote;
+use syn::{FnArg, Ident, LitStr, Pat, PatIdent, PatType, ReturnType, Type};
+
+#[cfg(with_wit_export)]
+use super::wit_export;
+use super::wit_import;
+
+/// Returns the code generated for implementing `WitInterface` to generate WIT snippets for an
+/// interface.
+pub fn generate<'input, Functions>(
+    wit_package: &LitStr,
+    wit_name: LitStr,
+    functions: Functions,
+) -> TokenStream
+where
+    Functions: IntoIterator,
+    Functions::IntoIter: Clone,
+    FunctionInformation<'input>: From<Functions::Item>,
+{
+    let functions = functions.into_iter().map(FunctionInformation::from);
+
+    let dependencies = functions
+        .clone()
+        .flat_map(|function| function.dependencies().cloned().collect::<Vec<_>>());
+
+    let wit_functions = functions.map(|function| function.wit_declaration());
+
+    quote! {
+        type Dependencies = linera_witty::HList![#( #dependencies ),*];
+
+        fn wit_package() -> &'static str {
+            #wit_package
+        }
+
+        fn wit_name() -> &'static str {
+            #wit_name
+        }
+
+        fn wit_functions() -> Vec<String> {
+            vec![
+                #( #wit_functions ),*
+            ]
+        }
+    }
+}
+
+/// Information from a function relevant to deriving the [`WitInterface`] trait.
+pub struct FunctionInformation<'input> {
+    name: &'input Ident,
+    parameter_names: Vec<&'input Ident>,
+    parameter_types: Vec<&'input Type>,
+    output_type: Option<Type>,
+}
+
+impl<'input> FunctionInformation<'input> {
+    /// Creates a new [`FunctionInformation`] instance from its signature.
+    pub fn new(
+        name: &'input Ident,
+        inputs: impl IntoIterator<Item = &'input FnArg>,
+        output: ReturnType,
+    ) -> Self {
+        let (parameter_names, parameter_types) = inputs
+            .into_iter()
+            .map(|argument| {
+                let FnArg::Typed(PatType { pat, ty, .. }) = argument else {
+                    abort!(argument, "`self` is not supported in imported functions");
+                };
+
+                let Pat::Ident(PatIdent { ident, .. }) = pat.as_ref() else {
+                    abort!(
+                        pat,
+                        "Only named parameters are supported in imported functions"
+                    );
+                };
+
+                (ident, ty.as_ref())
+            })
+            .unzip();
+
+        let output_type = match output {
+            ReturnType::Default => None,
+            ReturnType::Type(_arrow, return_type) => Some(*return_type),
+        };
+
+        FunctionInformation {
+            name,
+            parameter_names,
+            parameter_types,
+            output_type,
+        }
+    }
+
+    /// Returns the types used in the function signature.
+    pub fn dependencies(&self) -> impl Iterator<Item = &'_ Type> {
+        self.parameter_types
+            .clone()
+            .into_iter()
+            .chain(&self.output_type)
+    }
+
+    /// Returns a [`LitStr`] with the kebab-case WIT name of the function.
+    pub fn wit_name(&self) -> LitStr {
+        LitStr::new(&self.name.to_string().to_kebab_case(), self.name.span())
+    }
+
+    /// Returns the code to generate a [`String`] with the WIT declaration of the function.
+    pub fn wit_declaration(&self) -> TokenStream {
+        let wit_name = self.wit_name();
+
+        let parameters = self.parameter_names.iter().zip(&self.parameter_types).map(
+            |(parameter_name, parameter_type)| {
+                let parameter_wit_name = LitStr::new(
+                    &parameter_name.to_string().to_kebab_case(),
+                    parameter_name.span(),
+                );
+
+                quote! {
+                    #parameter_wit_name.into(),
+                    ": ".into(),
+                    <#parameter_type as linera_witty::WitType>::wit_type_name()
+                }
+            },
+        );
+
+        let commas = iter::repeat(Some(quote! { ", ".into(), }))
+            .take(self.parameter_names.len().saturating_sub(1))
+            .chain(Some(None));
+
+        let output = self
+            .output_type
+            .as_ref()
+            .map(|output_type| {
+                quote! { " -> ".into(), <#output_type as linera_witty::WitType>::wit_type_name() }
+            })
+            .into_iter();
+
+        quote! {
+            [
+                std::borrow::Cow::Borrowed("    "),
+                #wit_name.into(),
+                ": func(".into(),
+                #( #parameters, #commas )*
+                ")".into(),
+                #( #output, )*
+                ";".into(),
+            ]
+            .as_slice()
+            .join("")
+        }
+    }
+}
+
+impl<'input> From<&'_ wit_import::FunctionInformation<'input>> for FunctionInformation<'input> {
+    fn from(imported_function: &'_ wit_import::FunctionInformation<'input>) -> Self {
+        let signature = &imported_function.function.sig;
+
+        FunctionInformation::new(
+            &signature.ident,
+            &signature.inputs,
+            signature.output.clone(),
+        )
+    }
+}
+
+#[cfg(with_wit_export)]
+impl<'input> From<&'_ wit_export::FunctionInformation<'input>> for FunctionInformation<'input> {
+    fn from(exported_function: &'_ wit_export::FunctionInformation<'input>) -> Self {
+        let signature = &exported_function.function.sig;
+
+        let inputs = signature
+            .inputs
+            .iter()
+            .skip(if exported_function.is_reentrant { 1 } else { 0 });
+
+        let mut output = signature.output.clone();
+
+        if exported_function.call_early_return.is_some() {
+            let ReturnType::Type(_arrow, return_type) = &mut output else {
+                abort!(output, "Missing `Result` in fallible function return type");
+            };
+
+            let Some(actual_output) = wit_export::ok_type_inside_result(&*return_type).cloned()
+            else {
+                abort!(
+                    output,
+                    "Missing `Ok` result type in fallible function return type"
+                );
+            };
+
+            if is_unit_type(&actual_output) {
+                output = ReturnType::Default;
+            } else {
+                *return_type = Box::new(actual_output);
+            }
+        }
+
+        FunctionInformation::new(&signature.ident, inputs, output)
+    }
+}
+
+/// Returns `true` if `the_type` is the unit `()` type.
+#[cfg(with_wit_export)]
+pub fn is_unit_type(the_type: &Type) -> bool {
+    matches!(the_type, Type::Tuple(tuple) if tuple.elems.is_empty())
+}

--- a/linera-witty/src/lib.rs
+++ b/linera-witty/src/lib.rs
@@ -23,6 +23,7 @@ mod runtime;
 pub mod test;
 mod type_traits;
 mod util;
+pub mod wit_generation;
 
 pub use frunk::{hlist, hlist::HList, hlist_pat, HCons, HList, HNil};
 #[cfg(with_wit_export)]

--- a/linera-witty/src/test.rs
+++ b/linera-witty/src/test.rs
@@ -3,9 +3,12 @@
 
 //! Functions and types useful for writing tests.
 
-use std::fmt::Debug;
+use std::{collections::BTreeMap, fmt::Debug};
 
-use crate::{InstanceWithMemory, Layout, MockInstance, WitLoad, WitStore};
+use crate::{
+    wit_generation::WitInterface, InstanceWithMemory, Layout, MockInstance, RegisterWitTypes,
+    WitLoad, WitStore,
+};
 
 /// Test storing an instance of `T` to memory, checking that the instance can be loaded from those
 /// bytes.
@@ -78,4 +81,23 @@ where
     );
 
     Ok(())
+}
+
+/// Asserts that the WIT type dependencies of the `Interface` are the `expected_types`.
+pub fn assert_interface_dependencies<'i, Interface>(
+    expected_types: impl IntoIterator<Item = (&'i str, &'i str)>,
+) where
+    Interface: WitInterface,
+{
+    let mut wit_types = BTreeMap::new();
+
+    Interface::Dependencies::register_wit_types(&mut wit_types);
+
+    assert_eq!(
+        wit_types
+            .iter()
+            .map(|(name, declaration)| (name.as_str(), declaration.as_str()))
+            .collect::<Vec<_>>(),
+        expected_types.into_iter().collect::<Vec<_>>(),
+    );
 }

--- a/linera-witty/src/test.rs
+++ b/linera-witty/src/test.rs
@@ -101,3 +101,19 @@ pub fn assert_interface_dependencies<'i, Interface>(
         expected_types.into_iter().collect::<Vec<_>>(),
     );
 }
+
+/// Asserts that the function declarations of the `Interface` are the `expected_declarations`.
+pub fn assert_interface_functions<Interface>(expected_declarations: &[impl AsRef<str>])
+where
+    Interface: WitInterface,
+{
+    let wit_functions = Interface::wit_functions();
+
+    assert_eq!(
+        wit_functions.iter().map(String::as_str).collect::<Vec<_>>(),
+        expected_declarations
+            .iter()
+            .map(AsRef::as_ref)
+            .collect::<Vec<_>>()
+    );
+}

--- a/linera-witty/src/wit_generation/mod.rs
+++ b/linera-witty/src/wit_generation/mod.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generation of WIT files.
+
+pub use crate::type_traits::RegisterWitTypes;
+
+/// Generates WIT snippets for an interface.
+pub trait WitInterface {
+    /// The [`WitType`][`crate::WitType`]s that this interface uses.
+    type Dependencies: RegisterWitTypes;
+
+    /// The name of the package the interface belongs to.
+    fn wit_package() -> &'static str;
+
+    /// The name of the interface.
+    fn wit_name() -> &'static str;
+
+    /// The WIT definitions of each function in this interface.
+    fn wit_functions() -> Vec<String>;
+}

--- a/linera-witty/tests/common/wit_interface_test.rs
+++ b/linera-witty/tests/common/wit_interface_test.rs
@@ -9,6 +9,12 @@ use linera_witty::{
     wit_generation::WitInterface,
 };
 
+/// Expected snippets for the `entryoint` interface.
+// The `wit_import` integration test does not use an `Entrypoint` interface
+#[allow(dead_code)]
+pub const ENTRYPOINT: (&str, &[&str], &[(&str, &str)]) =
+    ("entrypoint", &["    entrypoint: func();"], &[]);
+
 /// Expected snippets for the `simple-function` interface.
 pub const SIMPLE_FUNCTION: (&str, &[&str], &[(&str, &str)]) =
     ("simple-function", &["    simple: func();"], &[]);

--- a/linera-witty/tests/common/wit_interface_test.rs
+++ b/linera-witty/tests/common/wit_interface_test.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared code to test generated [`WitInterface`] implementations for the interfaces used
+//! in the tests.
+
+use linera_witty::{
+    test::{assert_interface_dependencies, assert_interface_functions},
+    wit_generation::WitInterface,
+};
+
+/// Expected snippets for the `simple-function` interface.
+pub const SIMPLE_FUNCTION: (&str, &[&str], &[(&str, &str)]) =
+    ("simple-function", &["    simple: func();"], &[]);
+
+/// Expected snippets for the `getters` interface.
+pub const GETTERS: (&str, &[&str], &[(&str, &str)]) = (
+    "getters",
+    &[
+        "    get-true: func() -> bool;",
+        "    get-false: func() -> bool;",
+        "    get-s8: func() -> s8;",
+        "    get-u8: func() -> u8;",
+        "    get-s16: func() -> s16;",
+        "    get-u16: func() -> u16;",
+        "    get-s32: func() -> s32;",
+        "    get-u32: func() -> u32;",
+        "    get-s64: func() -> s64;",
+        "    get-u64: func() -> u64;",
+        "    get-float32: func() -> float32;",
+        "    get-float64: func() -> float64;",
+    ],
+    &[
+        ("bool", ""),
+        ("float32", ""),
+        ("float64", ""),
+        ("s16", ""),
+        ("s32", ""),
+        ("s64", ""),
+        ("s8", ""),
+        ("u16", ""),
+        ("u32", ""),
+        ("u64", ""),
+        ("u8", ""),
+    ],
+);
+
+/// Expected snippets for the `setters` interface.
+pub const SETTERS: (&str, &[&str], &[(&str, &str)]) = (
+    "setters",
+    &[
+        "    set-bool: func(value: bool);",
+        "    set-s8: func(value: s8);",
+        "    set-u8: func(value: u8);",
+        "    set-s16: func(value: s16);",
+        "    set-u16: func(value: u16);",
+        "    set-s32: func(value: s32);",
+        "    set-u32: func(value: u32);",
+        "    set-s64: func(value: s64);",
+        "    set-u64: func(value: u64);",
+        "    set-float32: func(value: float32);",
+        "    set-float64: func(value: float64);",
+    ],
+    &[
+        ("bool", ""),
+        ("float32", ""),
+        ("float64", ""),
+        ("s16", ""),
+        ("s32", ""),
+        ("s64", ""),
+        ("s8", ""),
+        ("u16", ""),
+        ("u32", ""),
+        ("u64", ""),
+        ("u8", ""),
+    ],
+);
+
+/// Expected snippets for the `operations` interface.
+pub const OPERATIONS: (&str, &[&str], &[(&str, &str)]) = (
+    "operations",
+    &[
+        "    and-bool: func(first: bool, second: bool) -> bool;",
+        "    add-s8: func(first: s8, second: s8) -> s8;",
+        "    add-u8: func(first: u8, second: u8) -> u8;",
+        "    add-s16: func(first: s16, second: s16) -> s16;",
+        "    add-u16: func(first: u16, second: u16) -> u16;",
+        "    add-s32: func(first: s32, second: s32) -> s32;",
+        "    add-u32: func(first: u32, second: u32) -> u32;",
+        "    add-s64: func(first: s64, second: s64) -> s64;",
+        "    add-u64: func(first: u64, second: u64) -> u64;",
+        "    add-float32: func(first: float32, second: float32) -> float32;",
+        "    add-float64: func(first: float64, second: float64) -> float64;",
+    ],
+    &[
+        ("bool", ""),
+        ("float32", ""),
+        ("float64", ""),
+        ("s16", ""),
+        ("s32", ""),
+        ("s64", ""),
+        ("s8", ""),
+        ("u16", ""),
+        ("u32", ""),
+        ("u64", ""),
+        ("u8", ""),
+    ],
+);
+
+/// Tests the [`WitInterface`] of a specified type, checking that its WIT snippets match
+/// the `expected_snippets`.
+pub fn test_wit_interface<Interface>(expected_snippets: (&str, &[&str], &[(&str, &str)]))
+where
+    Interface: WitInterface,
+{
+    let (expected_name, expected_functions, expected_dependencies) = expected_snippets;
+
+    assert_eq!(Interface::wit_package(), "witty-macros:test-modules");
+    assert_eq!(Interface::wit_name(), expected_name);
+    assert_interface_functions::<Interface>(expected_functions);
+    assert_interface_dependencies::<Interface>(expected_dependencies.iter().copied());
+}

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -471,7 +471,7 @@ where
 #[test_case(PhantomData::<Entrypoint<MockInstance<()>>>, ENTRYPOINT; "of_entrypoint")]
 #[test_case(
     PhantomData::<ImportedSimpleFunction<MockInstance<()>>>, SIMPLE_FUNCTION;
-    "of_imported_simple_funciton"
+    "of_imported_simple_function"
 )]
 #[test_case(PhantomData::<ImportedGetters<MockInstance<()>>>, GETTERS; "of_imported_getters")]
 #[test_case(PhantomData::<ImportedSetters<MockInstance<()>>>, SETTERS; "of_imported_setters")]
@@ -479,7 +479,7 @@ where
     PhantomData::<ImportedOperations<MockInstance<()>>>, OPERATIONS;
     "of_imported_operations"
 )]
-#[test_case(PhantomData::<ExportedSimpleFunction>, SIMPLE_FUNCTION; "of_exported_simple_funciton")]
+#[test_case(PhantomData::<ExportedSimpleFunction>, SIMPLE_FUNCTION; "of_exported_simple_function")]
 #[test_case(PhantomData::<ExportedGetters<MockInstance<()>>>, GETTERS; "of_exported_getters")]
 #[test_case(PhantomData::<ExportedSetters<MockInstance<()>>>, SETTERS; "of_exported_setters")]
 #[test_case(

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -28,7 +28,7 @@ use self::test_instance::WasmerInstanceFactory;
 use self::test_instance::WasmtimeInstanceFactory;
 use self::{
     test_instance::{MockInstanceFactory, TestInstanceFactory},
-    wit_interface_test::{GETTERS, OPERATIONS, SETTERS, SIMPLE_FUNCTION},
+    wit_interface_test::{ENTRYPOINT, GETTERS, OPERATIONS, SETTERS, SIMPLE_FUNCTION},
 };
 
 /// An interface to call into the test modules.
@@ -468,6 +468,7 @@ where
 }
 
 /// Test the generated [`WitInterface`] implementations for the types used in this test.
+#[test_case(PhantomData::<Entrypoint<MockInstance<()>>>, ENTRYPOINT; "of_entrypoint")]
 #[test_case(
     PhantomData::<ImportedSimpleFunction<MockInstance<()>>>, SIMPLE_FUNCTION;
     "of_imported_simple_funciton"

--- a/linera-witty/tests/reentrancy.rs
+++ b/linera-witty/tests/reentrancy.rs
@@ -5,6 +5,8 @@
 
 #[path = "common/test_instance.rs"]
 mod test_instance;
+#[path = "common/wit_interface_test.rs"]
+mod wit_interface_test;
 
 use std::{
     marker::PhantomData,
@@ -15,7 +17,8 @@ use std::{
 };
 
 use linera_witty::{
-    wit_export, wit_import, ExportTo, Instance, Runtime, RuntimeError, RuntimeMemory,
+    wit_export, wit_generation::WitInterface, wit_import, ExportTo, Instance, MockInstance,
+    Runtime, RuntimeError, RuntimeMemory,
 };
 use test_case::test_case;
 
@@ -23,7 +26,10 @@ use test_case::test_case;
 use self::test_instance::WasmerInstanceFactory;
 #[cfg(with_wasmtime)]
 use self::test_instance::WasmtimeInstanceFactory;
-use self::test_instance::{MockInstanceFactory, TestInstanceFactory};
+use self::{
+    test_instance::{MockInstanceFactory, TestInstanceFactory},
+    wit_interface_test::{GETTERS, OPERATIONS, SETTERS, SIMPLE_FUNCTION},
+};
 
 /// An interface to call into the test modules.
 #[wit_import(package = "witty-macros:test-modules")]
@@ -459,4 +465,31 @@ where
         .expect("Failed to call guest's `entrypoint` function");
 
     assert_eq!(user_data.load(Ordering::Relaxed), true);
+}
+
+/// Test the generated [`WitInterface`] implementations for the types used in this test.
+#[test_case(
+    PhantomData::<ImportedSimpleFunction<MockInstance<()>>>, SIMPLE_FUNCTION;
+    "of_imported_simple_funciton"
+)]
+#[test_case(PhantomData::<ImportedGetters<MockInstance<()>>>, GETTERS; "of_imported_getters")]
+#[test_case(PhantomData::<ImportedSetters<MockInstance<()>>>, SETTERS; "of_imported_setters")]
+#[test_case(
+    PhantomData::<ImportedOperations<MockInstance<()>>>, OPERATIONS;
+    "of_imported_operations"
+)]
+#[test_case(PhantomData::<ExportedSimpleFunction>, SIMPLE_FUNCTION; "of_exported_simple_funciton")]
+#[test_case(PhantomData::<ExportedGetters<MockInstance<()>>>, GETTERS; "of_exported_getters")]
+#[test_case(PhantomData::<ExportedSetters<MockInstance<()>>>, SETTERS; "of_exported_setters")]
+#[test_case(
+    PhantomData::<ExportedOperations<MockInstance<()>>>, OPERATIONS;
+    "of_exported_operations"
+)]
+fn test_wit_interface<Interface>(
+    _: PhantomData<Interface>,
+    expected_snippets: (&str, &[&str], &[(&str, &str)]),
+) where
+    Interface: WitInterface,
+{
+    wit_interface_test::test_wit_interface::<Interface>(expected_snippets);
 }

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -274,7 +274,7 @@ where
 
 /// Test the generated [`WitInterface`] implementations for the types used in this test.
 #[test_case(PhantomData::<Entrypoint<MockInstance<()>>>, ENTRYPOINT; "of_entrypoint")]
-#[test_case(PhantomData::<SimpleFunction>, SIMPLE_FUNCTION; "of_simple_funciton")]
+#[test_case(PhantomData::<SimpleFunction>, SIMPLE_FUNCTION; "of_simple_function")]
 #[test_case(PhantomData::<Getters>, GETTERS; "of_getters")]
 #[test_case(PhantomData::<Setters>, SETTERS; "of_setters")]
 #[test_case(PhantomData::<Operations>, OPERATIONS; "of_operations")]

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -11,8 +11,8 @@ mod wit_interface_test;
 use std::marker::PhantomData;
 
 use linera_witty::{
-    wit_export, wit_generation::WitInterface, wit_import, ExportTo, Instance, Runtime,
-    RuntimeMemory,
+    wit_export, wit_generation::WitInterface, wit_import, ExportTo, Instance, MockInstance,
+    Runtime, RuntimeMemory,
 };
 use test_case::test_case;
 
@@ -22,7 +22,7 @@ use self::test_instance::WasmerInstanceFactory;
 use self::test_instance::WasmtimeInstanceFactory;
 use self::{
     test_instance::{MockInstanceFactory, TestInstanceFactory},
-    wit_interface_test::{GETTERS, OPERATIONS, SETTERS, SIMPLE_FUNCTION},
+    wit_interface_test::{ENTRYPOINT, GETTERS, OPERATIONS, SETTERS, SIMPLE_FUNCTION},
 };
 
 /// An interface to call into the test modules.
@@ -273,6 +273,7 @@ where
 }
 
 /// Test the generated [`WitInterface`] implementations for the types used in this test.
+#[test_case(PhantomData::<Entrypoint<MockInstance<()>>>, ENTRYPOINT; "of_entrypoint")]
 #[test_case(PhantomData::<SimpleFunction>, SIMPLE_FUNCTION; "of_simple_funciton")]
 #[test_case(PhantomData::<Getters>, GETTERS; "of_getters")]
 #[test_case(PhantomData::<Setters>, SETTERS; "of_setters")]

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -327,7 +327,7 @@ where
     );
 }
 
-/// Test the generated [`WitInterface`] implementations for the types used in this test.
+/// Tests the generated [`WitInterface`] implementations for the types used in this test.
 #[test_case(PhantomData::<SimpleFunction<MockInstance<()>>>, SIMPLE_FUNCTION; "of_simple_funciton")]
 #[test_case(PhantomData::<Getters<MockInstance<()>>>, GETTERS; "of_getters")]
 #[test_case(PhantomData::<Setters<MockInstance<()>>>, SETTERS; "of_setters")]

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -328,7 +328,7 @@ where
 }
 
 /// Tests the generated [`WitInterface`] implementations for the types used in this test.
-#[test_case(PhantomData::<SimpleFunction<MockInstance<()>>>, SIMPLE_FUNCTION; "of_simple_funciton")]
+#[test_case(PhantomData::<SimpleFunction<MockInstance<()>>>, SIMPLE_FUNCTION; "of_simple_function")]
 #[test_case(PhantomData::<Getters<MockInstance<()>>>, GETTERS; "of_getters")]
 #[test_case(PhantomData::<Setters<MockInstance<()>>>, SETTERS; "of_setters")]
 #[test_case(PhantomData::<Operations<MockInstance<()>>>, OPERATIONS; "of_operations")]

--- a/linera-witty/tests/wit_import.rs
+++ b/linera-witty/tests/wit_import.rs
@@ -7,15 +7,24 @@
 
 #[path = "common/test_instance.rs"]
 mod test_instance;
+#[path = "common/wit_interface_test.rs"]
+mod wit_interface_test;
 
-use linera_witty::{wit_import, Instance, Runtime, RuntimeMemory};
+use std::marker::PhantomData;
+
+use linera_witty::{
+    wit_generation::WitInterface, wit_import, Instance, MockInstance, Runtime, RuntimeMemory,
+};
 use test_case::test_case;
 
 #[cfg(with_wasmer)]
 use self::test_instance::WasmerInstanceFactory;
 #[cfg(with_wasmtime)]
 use self::test_instance::WasmtimeInstanceFactory;
-use self::test_instance::{MockInstanceFactory, TestInstanceFactory, WithoutExports};
+use self::{
+    test_instance::{MockInstanceFactory, TestInstanceFactory, WithoutExports},
+    wit_interface_test::{GETTERS, OPERATIONS, SETTERS, SIMPLE_FUNCTION},
+};
 
 /// An interface to import a single function without parameters or return values.
 #[wit_import(package = "witty-macros:test-modules")]
@@ -316,4 +325,18 @@ where
             .expect("Failed to run guest's `add-f64` function"),
         128.25
     );
+}
+
+/// Test the generated [`WitInterface`] implementations for the types used in this test.
+#[test_case(PhantomData::<SimpleFunction<MockInstance<()>>>, SIMPLE_FUNCTION; "of_simple_funciton")]
+#[test_case(PhantomData::<Getters<MockInstance<()>>>, GETTERS; "of_getters")]
+#[test_case(PhantomData::<Setters<MockInstance<()>>>, SETTERS; "of_setters")]
+#[test_case(PhantomData::<Operations<MockInstance<()>>>, OPERATIONS; "of_operations")]
+fn test_wit_interface<Interface>(
+    _: PhantomData<Interface>,
+    expected_snippets: (&str, &[&str], &[(&str, &str)]),
+) where
+    Interface: WitInterface,
+{
+    wit_interface_test::test_wit_interface::<Interface>(expected_snippets);
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Witty will allow generating WIT files from Rust items. To achieve that goal, it needs to generate WIT interfaces.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a `WitInterface` trait that provides the WIT snippets and type dependencies necessary for the interface. Automatically generate the implementation of this trait from `#[wit_export]` and `#[wit_import]` macros.

## Test Plan

<!-- How to test that the changes are correct. -->
The expected snippets are now checked in the integration tests.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Only affects Witty, so nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- This is part of #906 but does not close it.
