### PR TITLE
Make linera_chain::manager public, so the docs get published.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -35,8 +35,9 @@ use crate::{
         MessageAction, MessageBundle, Origin, OutgoingMessage, Target,
     },
     inbox::{InboxError, InboxStateView},
+    manager::ChainManager,
     outbox::OutboxStateView,
-    ChainError, ChainExecutionContext, ChainManager,
+    ChainError, ChainExecutionContext,
 };
 
 #[cfg(test)]

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -6,7 +6,7 @@
 mod chain;
 pub mod data_types;
 mod inbox;
-mod manager;
+pub mod manager;
 mod outbox;
 #[cfg(with_testing)]
 pub mod test;
@@ -20,7 +20,6 @@ use linera_base::{
 };
 use linera_execution::ExecutionError;
 use linera_views::views::ViewError;
-pub use manager::{ChainManager, ChainManagerInfo, Outcome as ChainManagerOutcome};
 use rand_distr::WeightedError;
 use thiserror::Error;
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -13,7 +13,8 @@ use linera_chain::{
     data_types::{
         Certificate, ChainAndHeight, HashedValue, IncomingMessage, Medium, MessageBundle,
     },
-    ChainManagerInfo, ChainStateView,
+    manager::ChainManagerInfo,
+    ChainStateView,
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -24,7 +24,7 @@ use linera_chain::{
         HashedValue, IncomingMessage, LiteCertificate, Medium, MessageAction, MessageBundle,
         Origin, OutgoingMessage, Target,
     },
-    ChainError, ChainManagerOutcome, ChainStateView,
+    manager, ChainError, ChainStateView,
 };
 use linera_execution::{
     committee::{Committee, Epoch},
@@ -778,7 +778,7 @@ where
         certificate.check(committee)?;
         let mut actions = NetworkActions::default();
         if chain.tip_state.get().already_validated_block(height)?
-            || chain.manager.get().check_validated_block(&certificate)? == ChainManagerOutcome::Skip
+            || chain.manager.get().check_validated_block(&certificate)? == manager::Outcome::Skip
         {
             // If we just processed the same pending block, return the chain info unchanged.
             return Ok((
@@ -1081,7 +1081,7 @@ where
         // Check if the chain is ready for this new block proposal.
         // This should always pass for nodes without voting key.
         chain.tip_state.get().verify_block_chaining(block)?;
-        if chain.manager.get().check_proposed_block(&proposal)? == ChainManagerOutcome::Skip {
+        if chain.manager.get().check_proposed_block(&proposal)? == manager::Outcome::Skip {
             // If we just processed the same pending block, return the chain info unchanged.
             return Ok((
                 ChainInfoResponse::new(&chain, self.key_pair()),

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -9,7 +9,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{CertificateValue, HashedValue, Medium, MessageAction},
-    ChainManagerInfo,
+    manager::ChainManagerInfo,
 };
 use linera_core::{data_types::CrossChainRequest, node::NodeError};
 use linera_execution::{

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -60,7 +60,7 @@ mod types {
     pub use linera_base::ownership::ChainOwnership;
     pub use linera_chain::{
         data_types::{ChannelFullName, Event, MessageAction, Origin, Target},
-        ChainManager,
+        manager::ChainManager,
     };
     pub use linera_core::worker::{Notification, Reason};
     pub use linera_execution::{


### PR DESCRIPTION
## Motivation

The `linera_chain::manager` module has a lot of documentation, which doesn't appear e.g. on docs.rs, because the module is private.

## Proposal

Make the module public.

## Test Plan

(no new logic)

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
