### PR TITLE
Fix warnings when building with --no-default-features.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -186,6 +186,7 @@ jobs:
       run: |
         cargo clippy --all-targets --all-features --locked
         cargo clippy --no-default-features --features kubernetes --locked
+        cargo clippy --no-default-features --locked
     - name: Run cargo doc
       run: |
         cargo doc --locked --all-features


### PR DESCRIPTION
## Motivation

There are some warnings when building with `--no-default-features`.

## Proposal

Move the functions that are used only with the `kubernetes` or `rocksdb` feature to a separate module.

## Test Plan

I added this to CI:

```bash
cargo clippy --no-default-features --locked
```

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
