### PR TITLE
Use Witty to declare the application interfaces

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,9 @@ jobs:
     - name: Compile the workspace with the default features (build)
       run: |
         cargo build --locked
+    - name: Compile Wasm test modules for Witty integration tests
+      run: |
+        cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
     - name: Run all tests using the default features
       run: |
         cargo test --locked
@@ -107,7 +110,6 @@ jobs:
         cargo test --locked --target x86_64-unknown-linux-gnu
     - name: Run Witty integration tests
       run: |
-        cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
         cargo test -p linera-witty --features wasmer,wasmtime
     - name: Check for outdated CLI.md
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,6 +3208,7 @@ dependencies = [
  "linera-views-derive",
  "linera-wit-bindgen-host-wasmer-rust",
  "linera-wit-bindgen-host-wasmtime-rust",
+ "linera-witty",
  "lru",
  "once_cell",
  "oneshot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3627,6 +3627,7 @@ dependencies = [
  "linera-base",
  "linera-views",
  "linera-views-derive",
+ "linera-witty",
  "linked-hash-map",
  "prometheus",
  "rand",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "hex",
  "linera-base",
  "linera-views-derive",
+ "linera-witty",
  "linked-hash-map",
  "prometheus",
  "rand",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2273,7 +2273,10 @@ dependencies = [
  "either",
  "frunk",
  "linera-witty-macros",
+ "log",
  "thiserror",
+ "wasmer",
+ "wasmer-vm",
 ]
 
 [[package]]
@@ -3918,6 +3921,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "linera-views",
  "linera-views-derive",
  "linera-wit-bindgen-host-wasmer-rust",
+ "linera-witty",
  "lru",
  "once_cell",
  "oneshot",

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -45,6 +45,7 @@ futures.workspace = true
 linera-base.workspace = true
 linera-views.workspace = true
 linera-views-derive.workspace = true
+linera-witty = { workspace = true, features = ["macros"] }
 lru.workspace = true
 once_cell.workspace = true
 oneshot.workspace = true

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -17,6 +17,7 @@ metrics = ["prometheus", "linera-views/metrics"]
 wasmer = [
     "bytes",
     "dep:wasmer",
+    "linera-witty/wasmer",
     "wasm-encoder",
     "wasmer-middlewares",
     "wasmparser",
@@ -24,6 +25,7 @@ wasmer = [
 ]
 wasmtime = [
     "dep:wasmtime",
+    "linera-witty/wasmtime",
     "wasm-encoder",
     "wasmparser",
     "wit-bindgen-host-wasmtime-rust",
@@ -45,7 +47,7 @@ futures.workspace = true
 linera-base.workspace = true
 linera-views.workspace = true
 linera-views-derive.workspace = true
-linera-witty = { workspace = true, features = ["macros"] }
+linera-witty = { workspace = true, features = ["log", "macros"] }
 lru.workspace = true
 once_cell.workspace = true
 oneshot.workspace = true
@@ -54,7 +56,7 @@ serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
+tracing = { workspace = true, features = ["log"] }
 wasm-encoder = { workspace = true, optional = true }
 wasmer = { workspace = true, optional = true }
 wasmer-middlewares = { workspace = true, optional = true }
@@ -76,6 +78,7 @@ bcs.workspace = true
 counter.workspace = true
 linera-base = { workspace = true, features = ["test"] }
 linera-execution = { path = ".", features = ["test"] }
+linera-witty = { workspace = true, features = ["log", "macros", "test"] }
 test-case.workspace = true
 test-log = { workspace = true, features = ["trace"] }
 tokio = { workspace = true, features = ["rt", "test-util"] }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -274,12 +274,12 @@ pub struct QueryContext {
 }
 
 pub trait BaseRuntime {
-    type Read: fmt::Debug + Send;
-    type ContainsKey: fmt::Debug + Send;
-    type ReadMultiValuesBytes: fmt::Debug + Send;
-    type ReadValueBytes: fmt::Debug + Send;
-    type FindKeysByPrefix: fmt::Debug + Send;
-    type FindKeyValuesByPrefix: fmt::Debug + Send;
+    type Read: fmt::Debug + Send + Sync;
+    type ContainsKey: fmt::Debug + Send + Sync;
+    type ReadMultiValuesBytes: fmt::Debug + Send + Sync;
+    type ReadValueBytes: fmt::Debug + Send + Sync;
+    type FindKeysByPrefix: fmt::Debug + Send + Sync;
+    type FindKeyValuesByPrefix: fmt::Debug + Send + Sync;
 
     /// The current chain ID.
     fn chain_id(&mut self) -> Result<ChainId, ExecutionError>;

--- a/linera-execution/src/wasm/entrypoints.rs
+++ b/linera-execution/src/wasm/entrypoints.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Wasm entrypoints for contracts and services.
+
+use linera_witty::wit_import;
+
+/// WIT entrypoints for application contracts.
+#[wit_import(package = "linera:app")]
+pub trait ContractEntrypoints {
+    fn initialize(argument: Vec<u8>) -> Result<(), String>;
+    fn execute_operation(operation: Vec<u8>) -> Result<Vec<u8>, String>;
+    fn execute_message(message: Vec<u8>) -> Result<(), String>;
+    fn finalize() -> Result<(), String>;
+}
+
+/// WIT entrypoints for application services.
+#[wit_import(package = "linera:app")]
+pub trait ServiceEntrypoints {
+    fn handle_query(argument: Vec<u8>) -> Result<Vec<u8>, String>;
+}

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -35,6 +35,7 @@ use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 #[cfg(with_wasmtime)]
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
 
+#[allow(unused_imports)]
 pub use self::entrypoints::{ContractEntrypoints, ServiceEntrypoints};
 use self::sanitizer::sanitize;
 use crate::{

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -231,6 +231,10 @@ pub enum WasmExecutionError {
     #[cfg(with_wasmtime)]
     #[error("Failed to execute Wasm module in Wasmtime: {0}")]
     ExecuteModuleInWasmtime(#[from] ::wasmtime::Trap),
+    #[error("Attempt to wait for an unknown promise")]
+    UnknownPromise,
+    #[error("Attempt to call incorrect `wait` function for a promise")]
+    IncorrectPromise,
 }
 
 /// This assumes that the current directory is one of the crates.

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -10,6 +10,7 @@
 
 #![cfg(with_wasm_runtime)]
 
+mod entrypoints;
 mod module_cache;
 mod sanitizer;
 #[macro_use]
@@ -34,6 +35,7 @@ use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 #[cfg(with_wasmtime)]
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
 
+pub use self::entrypoints::{ContractEntrypoints, ServiceEntrypoints};
 use self::sanitizer::sanitize;
 use crate::{
     Bytecode, ContractSyncRuntime, ExecutionError, ServiceSyncRuntime, UserContractInstance,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -154,7 +154,7 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Returns the authenticated caller ID, if the caller configured it and if the current context
+    /// Returns the authenticated caller ID, if the caller configured it and if the current context.
     fn authenticated_caller_id(caller: &mut Caller) -> Result<Option<ApplicationId>, RuntimeError> {
         caller
             .user_data_mut()

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -22,6 +22,7 @@ pub struct SystemApiData<Runtime> {
     promise_counter: u32,
 }
 
+#[allow(dead_code)]
 impl<Runtime> SystemApiData<Runtime> {
     /// Creates a new [`SystemApiData`] using the provided `runtime` to execute the system APIs.
     pub fn new(runtime: Runtime) -> Self {

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -41,6 +41,7 @@ generic-array.workspace = true
 hex = { workspace = true, optional = true }
 linera-base.workspace = true
 linera-views-derive.workspace = true
+linera-witty.workspace = true
 linked-hash-map.workspace = true
 prometheus.workspace = true
 rand = { workspace = true, optional = true, features = ["small_rng"] }

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -25,6 +25,7 @@ use std::{
 
 use async_trait::async_trait;
 use bcs::serialized_size;
+use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -37,7 +38,7 @@ use crate::{
 /// * Deletion of a specific key.
 /// * Deletion of all keys matching a specific prefix.
 /// * Insertion or replacement of a key with a value.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, WitType, WitLoad, WitStore)]
 pub enum WriteOperation {
     /// Delete the given key.
     Delete {

--- a/linera-witty/src/runtime/error.rs
+++ b/linera-witty/src/runtime/error.rs
@@ -55,6 +55,10 @@ pub enum RuntimeError {
         discriminant: i64,
     },
 
+    /// A custom error reported by one of the Wasm host's function handlers.
+    #[error("Error reported by host function handler: {_0}")]
+    Custom(#[source] anyhow::Error),
+
     /// Wasmer runtime error.
     #[cfg(with_wasmer)]
     #[error(transparent)]
@@ -68,7 +72,7 @@ pub enum RuntimeError {
     /// Wasmtime error.
     #[cfg(with_wasmtime)]
     #[error(transparent)]
-    Wasmtime(#[from] anyhow::Error),
+    Wasmtime(anyhow::Error),
 
     /// Wasmtime trap during execution.
     #[cfg(with_wasmtime)]

--- a/linera-witty/src/runtime/wasmtime/export_function.rs
+++ b/linera-witty/src/runtime/wasmtime/export_function.rs
@@ -41,7 +41,8 @@ macro_rules! export_function {
                             .map_err(|error| Trap::new(error.to_string()))?;
                         Ok(response)
                     },
-                )?;
+                )
+                .map_err(RuntimeError::Wasmtime)?;
                 Ok(())
             }
         }

--- a/linera-witty/src/runtime/wasmtime/function.rs
+++ b/linera-witty/src/runtime/wasmtime/function.rs
@@ -28,7 +28,11 @@ macro_rules! impl_instance_with_function {
                 export: <Self::Runtime as Runtime>::Export,
             ) -> Result<Option<Self::Function>, RuntimeError> {
                 Ok(match export {
-                    Extern::Func(function) => Some(function.typed(self.as_context())?),
+                    Extern::Func(function) => Some(
+                        function
+                            .typed(self.as_context())
+                            .map_err(RuntimeError::Wasmtime)?,
+                    ),
                     _ => None,
                 })
             }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Witty allows specifying WIT interfaces using Rust code, and supports different host Wasm runtimes. We are currently migrating our code to use Witty.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create the system API interfaces for contracts and services (and the view system APIs, which will later be refactored to more closely follow how the host divides the system APIs) and create the contract and service entrypoints.

## Test Plan

<!-- How to test that the changes are correct. -->
The added functionality is not used yet, but the intention is to replace existing functionality later one, and existing tests should catch regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
For now, only new (and temporarily unused) functionality is added, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
