### PR TITLE
Replace `file-lock` dependency with `fs4` in order to support non-POSIX operating systems

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,16 +2058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
 
 [[package]]
-name = "file-lock"
-version = "2.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "040b48f80a749da50292d0f47a1e2d5bf1d772f52836c07f64bfccc62ba6e664"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "file-per-thread-logger"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,6 +2148,16 @@ checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dabded2e32cd57ded879041205c60a4a4c4bab47bd0fd2fa8b01f30849f02b"
+dependencies = [
+ "rustix 0.38.31",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3464,8 +3464,8 @@ dependencies = [
  "crowd-funding",
  "current_platform",
  "dirs",
- "file-lock",
  "fs-err",
+ "fs4",
  "fs_extra",
  "fungible",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
 either = "1.10.0"
 frunk = "0.4.2"
 fs-err = { version = "2.11.0", features = ["tokio"] }
+fs4 = "0.8.2"
 fs_extra = "1.3.0"
 futures = "0.3.30"
 generic-array = { version = "0.14.7", features = ["serde"] }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -48,8 +48,8 @@ colored.workspace = true
 comfy-table.workspace = true
 current_platform = "0.2.0"
 dirs.workspace = true
-file-lock = "2.1.11"
 fs-err.workspace = true
+fs4.workspace = true
 fs_extra = { workspace = true, optional = true }
 futures.workspace = true
 hex.workspace = true


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The [`file-lock`](https://crates.io/file-lock) crate only supports POSIX operating systems, which prevents `linera-service` from compiling on Windows.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use the `fs4` crate instead, creating a custom `FileLock` wrapper to keep the same API.

I looked into other options, but they all seemed to require further changes to our code, because usually they have a guard with a lifetime linking it to the `&mut File`. While this makes sense in a lot of scenarios, it would better match our current code if there was something like `lock_owned()`, but I couldn't find a crate that supported that.

## Test Plan

<!-- How to test that the changes are correct. -->
One minimal integration test was added.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor, so in theory nothing needed, but it would be nice to release a patch version with this change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
