### PR TITLE
[amm] Send tokens back to owner's chains

### DIFF
--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -10,11 +10,10 @@ be adding/removing liquidity and also performing a swap.
 
 # How it works
 
-It supports the following operations.
+It supports the following operations. All operations need to be executed remotely.
 
 - Swap: For a given input token and an input amount, it swaps that token amount for an
-amount of the other token calculated based on the current AMM ratio. Note: The `Swap` operations
-need to be performed from a remote chain.
+amount of the other token calculated based on the current AMM ratio.
 
 - Add Liquidity: This operation allows adding liquidity to the AMM. Given a maximum
 `token0` and `token1` amount that you're willing to add, it adds liquidity such that you'll be
@@ -53,10 +52,12 @@ We use the test-only CLI option `--testing-prng-seed` to make keys deterministic
 explanation.
 
 ```bash
-OWNER_1=7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f
+OWNER_1=65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f
 OWNER_2=90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f
-CHAIN_1=e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65
+CHAIN_1=dad01517c7a3c428ea903253a9e59964e8db06d323a9bd3f4c74d6366832bdbf
 CHAIN_2=e54bdb17d41d5dbe16418f96b70e44546ccd63e6f3733ae3c192043548998ff3
+CHAIN_AMM=e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65
+OWNER_AMM=7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f
 ```
 
 Now we have to publish and create the fungible applications. The flag `--wait-for-outgoing-messages` waits until a quorum of validators has confirmed that all sent cross-chain messages have been delivered.
@@ -67,8 +68,7 @@ Now we have to publish and create the fungible applications. The flag `--wait-fo
 FUN1_APP_ID=$(linera --wait-for-outgoing-messages \
   publish-and-create examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm \
     --json-argument "{ \"accounts\": {
-        \"User:$OWNER_1\": \"100.\",
-        \"User:$OWNER_2\": \"150.\"
+        \"User:$OWNER_AMM\": \"100.\"
     } }" \
     --json-parameters "{ \"ticker_symbol\": \"FUN1\" }" \
 )
@@ -76,8 +76,7 @@ FUN1_APP_ID=$(linera --wait-for-outgoing-messages \
 FUN2_APP_ID=$(linera --wait-for-outgoing-messages \
   publish-and-create examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm \
     --json-argument "{ \"accounts\": {
-        \"User:$OWNER_1\": \"100.\",
-        \"User:$OWNER_2\": \"150.\"
+        \"User:$OWNER_AMM\": \"100.\"
     } }" \
     --json-parameters "{ \"ticker_symbol\": \"FUN2\" }" \
 )
@@ -100,6 +99,79 @@ linera service --port $PORT &
 
 ### Using GraphiQL
 
+To properly setup the tokens in the proper chains, we need to do some transfer operations:
+
+- Transfer 50 FUN1 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_1` in `$CHAIN_1`, so they're in the proper chain
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID
+    mutation {
+        transfer(
+            owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+            amount: "50.",
+            targetAccount: {
+                chainId: "dad01517c7a3c428ea903253a9e59964e8db06d323a9bd3f4c74d6366832bdbf",
+                owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
+            }
+        )
+    }
+```
+
+- Transfer 50 FUN1 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_2` in `$CHAIN_2`, so they're in the proper chain
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID
+    mutation {
+        transfer(
+            owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+            amount: "50.",
+            targetAccount: {
+                chainId: "e54bdb17d41d5dbe16418f96b70e44546ccd63e6f3733ae3c192043548998ff3",
+                owner: "User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
+            }
+        )
+    }
+```
+
+- Transfer 50 FUN2 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_1` in `$CHAIN_1`, so they're in the proper chain
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN2_APP_ID
+    mutation {
+        transfer(
+            owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+            amount: "50.",
+            targetAccount: {
+                chainId: "dad01517c7a3c428ea903253a9e59964e8db06d323a9bd3f4c74d6366832bdbf",
+                owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
+            }
+        )
+    }
+```
+
+- Transfer 50 FUN2 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_2` in `$CHAIN_2`, so they're in the proper chain
+```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN2_APP_ID
+    mutation {
+        transfer(
+            owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+            amount: "50.",
+            targetAccount: {
+                chainId: "e54bdb17d41d5dbe16418f96b70e44546ccd63e6f3733ae3c192043548998ff3",
+                owner: "User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
+            }
+        )
+    }
+```
+
+All operations can only be from a remote chain i.e. other than the chain on which `AMM` is deployed to.
+We can do it from GraphiQL by performing the `requestApplication` mutation so that we can perform the
+operation from the chain.
+
+```gql,uri=http://localhost:8080
+mutation {
+  requestApplication (
+    chainId:"dad01517c7a3c428ea903253a9e59964e8db06d323a9bd3f4c74d6366832bdbf",
+    applicationId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65060000000000000000000000e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65080000000000000000000000",
+    targetChainId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
+  )
+}
+```
+Note: The above mutation has to be performed from `http://localhost:8080`.
+
 Before performing any operation we need to provide liquidity to it, so we will use the `AddLiquidity` operation,
 navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID`.
 
@@ -110,18 +182,14 @@ mutation {
   operation(
     operation: {
       AddLiquidity: {
-        owner:"User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
         max_token0_amount: "50",
-        max_token1_amount: "40",
+        max_token1_amount: "50",
       }
     }
   )
 }
 ```
-
-We can only perform `Swap` from a remote chain i.e. other than the chain on which `AMM` is deployed to,
-we can do it from GraphiQL by performing the `requestApplication` mutation so that we can perform the
-`Swap` operation from the chain.
 
 ```gql,uri=http://localhost:8080
 mutation {
@@ -134,7 +202,7 @@ mutation {
 ```
 Note: The above mutation has to be performed from `http://localhost:8080`.
 
-Now to perform `Swap` operation, navigate to `http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID` and
+To perform `Swap` operation, navigate to `http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID` and
 perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID
@@ -142,7 +210,7 @@ mutation {
   operation(
     operation: {
       Swap: {
-        owner:"User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
+        owner: "User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
         input_token_idx: 1,
         input_amount: "1",
       }
@@ -151,17 +219,32 @@ mutation {
 }
 ```
 
-We can also perform the `RemoveLiquidity` operation, navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and
+To perform the `RemoveLiquidity` operation, navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and
 perform the following mutation:
 
-```gql
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
   operation(
     operation: {
       RemoveLiquidity: {
-        owner:"User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
         token_to_remove_idx: 1,
         token_to_remove_amount: "1",
+      }
+    }
+  )
+}
+```
+
+To perform the `RemoveAllAddedLiquidity` operation, navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID` and
+perform the following mutation:
+
+```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
+mutation {
+  operation(
+    operation: {
+      RemoveAllAddedLiquidity: {
+        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
       }
     }
   )
@@ -232,6 +315,11 @@ pub enum Operation {
         token_to_remove_idx: u32,
         token_to_remove_amount: Amount,
     },
+    /// Remove all added liquidity operation
+    /// Remove all the liquidity added by given user, that is remaining in the AMM.
+    /// Owner here is the user removing liquidity, which currently can only
+    /// be a chain owner
+    RemoveAllAddedLiquidity { owner: AccountOwner },
 }
 
 scalar!(Operation);
@@ -242,6 +330,19 @@ pub enum Message {
         owner: AccountOwner,
         input_token_idx: u32,
         input_amount: Amount,
+    },
+    AddLiquidity {
+        owner: AccountOwner,
+        max_token0_amount: Amount,
+        max_token1_amount: Amount,
+    },
+    RemoveLiquidity {
+        owner: AccountOwner,
+        token_to_remove_idx: u32,
+        token_to_remove_amount: Amount,
+    },
+    RemoveAllAddedLiquidity {
+        owner: AccountOwner,
     },
 }
 
@@ -270,14 +371,17 @@ pub enum AmmError {
     #[error("Invalid token index")]
     InvalidTokenIdx,
 
-    #[error("Can't remove liquidity from a remote chain")]
-    RemovingLiquidityFromRemoteChain,
+    #[error("Can't remove liquidity locally")]
+    RemovingLiquidityLocally,
 
-    #[error("Can't add liquidity from a remote chain")]
-    AddingLiquidityFromRemoteChain,
+    #[error("Can't add liquidity locally")]
+    AddingLiquidityLocally,
 
     #[error("Can't swap locally")]
     SwappingLocally,
+
+    #[error("Can't remove more liquidity than you added")]
+    RemovingMoreLiquidityThanAdded,
 
     /// Invalid query.
     #[error("Invalid query")]

--- a/examples/amm/src/state.rs
+++ b/examples/amm/src/state.rs
@@ -1,11 +1,27 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
+use fungible::Account;
+use linera_sdk::{
+    base::Amount,
+    views::{linera_views, MapView, RegisterView, RootView, ViewStorageContext},
+};
 
 #[derive(RootView, async_graphql::SimpleObject)]
 #[view(context = "ViewStorageContext")]
 pub struct Amm {
-    // TODO(#968): We should support stateless Applications/empty user views
-    pub _dummy: RegisterView<u8>,
+    pub shares: MapView<Account, Amount>,
+    pub total_shares_supply: RegisterView<Amount>,
+}
+
+#[allow(dead_code)]
+impl Amm {
+    /// Obtains the current shares for an `account`.
+    pub(crate) async fn current_shares_or_default(&self, account: &Account) -> Amount {
+        self.shares
+            .get(account)
+            .await
+            .expect("Failure in the retrieval")
+            .unwrap_or_default()
+    }
 }

--- a/linera-sdk/src/abis/fungible.rs
+++ b/linera-sdk/src/abis/fungible.rs
@@ -107,6 +107,7 @@ impl Parameters {
     SimpleObject,
     InputObject,
 )]
+#[graphql(input_name = "FungibleAccount")]
 pub struct Account {
     /// Chain ID of the account
     pub chain_id: ChainId,


### PR DESCRIPTION
## Motivation

Right now the tokens stay in the AMM chain, but they shouldn't. They should be sent back to the proper chains.

## Proposal

To do this, we had to do a few things:
- We had to redesign the AMM from Swaps executed remotely, Adding/Removing liquidity executed locally to Swaps and Adding liquidity executed remotely, removing liquidity executed locally
- Implemented a concept of shares based on the amount of liquidity that you add. You also can't remove more liquidity than you added now
- Improved the e2e tests to cover all these different cases

## Test Plan

e2e tests

