### PR TITLE
Receive `wasmer::Engine` by reference in `InstanceBuilder` constructor

### DIFF
--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -41,7 +41,7 @@ where
     UserData: Send + 'static,
 {
     /// Creates a new [`InstanceBuilder`].
-    pub fn new(engine: Engine, user_data: UserData) -> Self {
+    pub fn new(engine: &Engine, user_data: UserData) -> Self {
         InstanceBuilder {
             store: Store::new(engine),
             imports: Imports::default(),

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -110,7 +110,7 @@ where
         )
         .expect("Failed to load module");
 
-        let mut builder = wasmer::InstanceBuilder::new(engine, UserData::default());
+        let mut builder = wasmer::InstanceBuilder::new(&engine, UserData::default());
 
         ExportedFunctions::export_to(&mut builder)
             .expect("Failed to export functions to Wasmer instance builder");


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `InstanceBuilder` type in Witty allows creating a Wasm module instance for running with the Wasmer runtime. It had a parameter that took ownership of the Wasmer `Engine`, but there's no need for taking ownership. Not taking ownership also allows the `Engine` instance to be reused, which is something we do in `linera-execution`.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use a shared reference instead of taking ownership.

## Test Plan

<!-- How to test that the changes are correct. -->
No new functionality added, so no new coverage is needed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Changes are internal to Witty, so nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
