### PR TITLE
Make Wallet public and usable in tests with ClientContext.

### DIFF
--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -50,7 +50,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
     let (mut net, client) = config.instantiate().await.unwrap();
 
     let node_chains = {
-        let wallet = client.wallet().unwrap();
+        let wallet = client.load_wallet().unwrap();
         (wallet.default_chain(), wallet.chain_ids())
     };
     let chain_id = node_chains.0.unwrap();

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -50,7 +50,7 @@ async fn test_end_to_end_queries(config: impl LineraNetConfig) {
     let (mut net, client) = config.instantiate().await.unwrap();
 
     let node_chains = {
-        let wallet = client.get_wallet().unwrap();
+        let wallet = client.wallet().unwrap();
         (wallet.default_chain(), wallet.chain_ids())
     };
     let chain_id = node_chains.0.unwrap();

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -598,7 +598,7 @@ impl ClientWrapper {
         initial_balance: Amount,
     ) -> Result<ChainId> {
         let our_chain = self
-            .wallet()?
+            .load_wallet()?
             .default_chain()
             .context("no default chain found")?;
         let key = client.keygen().await?;
@@ -684,11 +684,7 @@ impl ClientWrapper {
         }
     }
 
-    pub fn get_wallet(&self) -> Result<WalletState> {
-        WalletState::from_file(self.wallet_path().as_path())
-    }
-
-    pub fn wallet(&self) -> Result<Wallet> {
+    pub fn load_wallet(&self) -> Result<Wallet> {
         Ok(WalletState::from_file(self.wallet_path().as_path())?.into_inner())
     }
 
@@ -701,14 +697,14 @@ impl ClientWrapper {
     }
 
     pub fn get_owner(&self) -> Option<Owner> {
-        let wallet = self.wallet().ok()?;
+        let wallet = self.load_wallet().ok()?;
         let chain_id = wallet.default_chain()?;
         let public_key = wallet.get(chain_id)?.key_pair.as_ref()?.public();
         Some(public_key.into())
     }
 
     pub async fn is_chain_present_in_wallet(&self, chain: ChainId) -> bool {
-        self.wallet()
+        self.load_wallet()
             .ok()
             .map_or(false, |wallet| wallet.get(chain).is_some())
     }
@@ -749,7 +745,7 @@ impl ClientWrapper {
 
     /// Returns the default chain.
     pub fn default_chain(&self) -> Option<ChainId> {
-        self.wallet().ok()?.default_chain()
+        self.load_wallet().ok()?.default_chain()
     }
 
     /// Runs `linera assign`.

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -3,25 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap},
     io::{BufRead, BufReader, BufWriter, Write},
     path::{Path, PathBuf},
 };
 
 use anyhow::{bail, Context as _};
-use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Color, ContentArrangement,
-    Table,
-};
 use fs4::FileExt as _;
 use fs_err::{self, File, OpenOptions};
 use linera_base::{
-    crypto::{BcsSignable, CryptoHash, CryptoRng, KeyPair, PublicKey},
-    data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{ChainDescription, ChainId, Owner},
+    crypto::{BcsSignable, KeyPair, PublicKey},
+    data_types::{Amount, Timestamp},
+    identifiers::{ChainDescription, ChainId},
 };
-use linera_chain::data_types::Block;
-use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
 use linera_execution::{
     committee::{Committee, ValidatorName, ValidatorState},
     ResourceControlPolicy,
@@ -29,8 +22,9 @@ use linera_execution::{
 use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use rand::Rng as _;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::wallet::Wallet;
 
 pub trait Import: DeserializeOwned {
     fn read(path: &Path) -> Result<Self, std::io::Error> {
@@ -98,48 +92,6 @@ impl CommitteeConfig {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct UserChain {
-    pub chain_id: ChainId,
-    pub key_pair: Option<KeyPair>,
-    pub block_hash: Option<CryptoHash>,
-    pub timestamp: Timestamp,
-    pub next_block_height: BlockHeight,
-    pub pending_block: Option<Block>,
-}
-
-impl UserChain {
-    /// Create a user chain that we own.
-    pub fn make_initial<R: CryptoRng>(
-        rng: &mut R,
-        description: ChainDescription,
-        timestamp: Timestamp,
-    ) -> Self {
-        let key_pair = KeyPair::generate_from(rng);
-        Self {
-            chain_id: description.into(),
-            key_pair: Some(key_pair),
-            block_hash: None,
-            timestamp,
-            next_block_height: BlockHeight::ZERO,
-            pending_block: None,
-        }
-    }
-
-    /// Creates an entry for a chain that we don't own. The timestamp must be the genesis
-    /// timestamp or earlier.
-    pub fn make_other(chain_id: ChainId, timestamp: Timestamp) -> Self {
-        Self {
-            chain_id,
-            key_pair: None,
-            block_hash: None,
-            timestamp,
-            next_block_height: BlockHeight::ZERO,
-            pending_block: None,
-        }
-    }
-}
-
 /// A guard that keeps an exclusive lock on a file.
 pub struct FileLock {
     file: File,
@@ -169,172 +121,25 @@ impl Drop for FileLock {
     }
 }
 
-/// A wrapper around `InnerWalletState` which owns a [`FileLock`] to prevent
+/// A wrapper around `Wallet` which owns a [`FileLock`] to prevent
 /// two processes accessing it at the same time.
 pub struct WalletState {
-    inner: InnerWallet,
+    inner: Wallet,
     wallet_path: PathBuf,
     _lock: FileLock,
 }
 
-#[derive(Serialize, Deserialize)]
-struct InnerWallet {
-    chains: BTreeMap<ChainId, UserChain>,
-    unassigned_key_pairs: HashMap<PublicKey, KeyPair>,
-    default: Option<ChainId>,
-    genesis_config: GenesisConfig,
-    testing_prng_seed: Option<u64>,
-}
-
 impl WalletState {
-    pub fn get(&self, chain_id: ChainId) -> Option<&UserChain> {
-        self.inner.chains.get(&chain_id)
+    pub fn inner(&self) -> &Wallet {
+        &self.inner
     }
 
-    pub fn insert(&mut self, chain: UserChain) {
-        if self.inner.chains.is_empty() {
-            self.inner.default = Some(chain.chain_id);
-        }
-        self.inner.chains.insert(chain.chain_id, chain);
+    pub fn inner_mut(&mut self) -> &mut Wallet {
+        &mut self.inner
     }
 
-    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<KeyPair, anyhow::Error> {
-        let chain = self
-            .inner
-            .chains
-            .get_mut(chain_id)
-            .context(format!("Failed to get chain for chain id: {}", chain_id))?;
-        chain.key_pair.take().context("Failed to take keypair")
-    }
-
-    pub fn forget_chain(&mut self, chain_id: &ChainId) -> Result<UserChain, anyhow::Error> {
+    pub fn into_inner(self) -> Wallet {
         self.inner
-            .chains
-            .remove(chain_id)
-            .context(format!("Failed to remove chain: {}", chain_id))
-    }
-
-    pub fn default_chain(&self) -> Option<ChainId> {
-        self.inner.default
-    }
-
-    pub fn chain_ids(&self) -> Vec<ChainId> {
-        self.inner.chains.keys().copied().collect()
-    }
-
-    /// Returns the list of all chain IDs for which we have a secret key.
-    pub fn own_chain_ids(&self) -> Vec<ChainId> {
-        self.inner
-            .chains
-            .iter()
-            .filter_map(|(chain_id, chain)| chain.key_pair.is_some().then_some(*chain_id))
-            .collect()
-    }
-
-    pub fn num_chains(&self) -> usize {
-        self.inner.chains.len()
-    }
-
-    pub fn last_chain(&mut self) -> Option<&UserChain> {
-        self.inner.chains.values().last()
-    }
-
-    pub fn chains_mut(&mut self) -> impl Iterator<Item = &mut UserChain> {
-        self.inner.chains.values_mut()
-    }
-
-    pub fn add_unassigned_key_pair(&mut self, keypair: KeyPair) {
-        self.inner
-            .unassigned_key_pairs
-            .insert(keypair.public(), keypair);
-    }
-
-    pub fn key_pair_for_pk(&self, key: &PublicKey) -> Option<KeyPair> {
-        if let Some(key_pair) = self
-            .inner
-            .unassigned_key_pairs
-            .get(key)
-            .map(|key_pair| key_pair.copy())
-        {
-            return Some(key_pair);
-        }
-        self.inner
-            .chains
-            .values()
-            .filter_map(|user_chain| user_chain.key_pair.as_ref())
-            .find(|key_pair| key_pair.public() == *key)
-            .map(|key_pair| key_pair.copy())
-    }
-
-    pub fn assign_new_chain_to_key(
-        &mut self,
-        key: PublicKey,
-        chain_id: ChainId,
-        timestamp: Timestamp,
-    ) -> Result<(), anyhow::Error> {
-        let key_pair = self
-            .inner
-            .unassigned_key_pairs
-            .remove(&key)
-            .context("could not assign chain to key as unassigned key was not found")?;
-        let user_chain = UserChain {
-            chain_id,
-            key_pair: Some(key_pair),
-            block_hash: None,
-            timestamp,
-            next_block_height: BlockHeight(0),
-            pending_block: None,
-        };
-        self.insert(user_chain);
-        Ok(())
-    }
-
-    pub fn set_default_chain(&mut self, chain_id: ChainId) -> Result<(), anyhow::Error> {
-        anyhow::ensure!(
-            self.inner.chains.contains_key(&chain_id),
-            "Chain {} cannot be assigned as the default chain since it does not exist in the \
-             wallet.",
-            &chain_id
-        );
-        self.inner.default = Some(chain_id);
-        Ok(())
-    }
-
-    pub async fn update_from_state<P, S>(&mut self, state: &mut ChainClient<P, S>)
-    where
-        P: ValidatorNodeProvider + Sync + 'static,
-        S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
-    {
-        self.inner.chains.insert(
-            state.chain_id(),
-            UserChain {
-                chain_id: state.chain_id(),
-                key_pair: state.key_pair().await.map(|k| k.copy()).ok(),
-                block_hash: state.block_hash(),
-                next_block_height: state.next_block_height(),
-                timestamp: state.timestamp(),
-                pending_block: state.pending_block().clone(),
-            },
-        );
-    }
-
-    pub fn genesis_admin_chain(&self) -> ChainId {
-        self.inner.genesis_config.admin_id
-    }
-
-    pub fn genesis_config(&self) -> &GenesisConfig {
-        &self.inner.genesis_config
-    }
-
-    pub fn make_prng(&self) -> Box<dyn CryptoRng> {
-        self.inner.testing_prng_seed.into()
-    }
-
-    pub fn refresh_prng_seed<R: CryptoRng>(&mut self, rng: &mut R) {
-        if self.inner.testing_prng_seed.is_some() {
-            self.inner.testing_prng_seed = Some(rng.gen());
-        }
     }
 
     pub fn from_file(path: &Path) -> Result<Self, anyhow::Error> {
@@ -361,15 +166,8 @@ impl WalletState {
         let file_lock = FileLock::new(file, path)?;
         let mut reader = BufReader::new(&file_lock.file);
         if reader.fill_buf()?.is_empty() {
-            let inner = InnerWallet {
-                chains: BTreeMap::new(),
-                unassigned_key_pairs: HashMap::new(),
-                default: None,
-                genesis_config,
-                testing_prng_seed,
-            };
             Ok(Self {
-                inner,
+                inner: Wallet::new(genesis_config, testing_prng_seed),
                 wallet_path: path.into(),
                 _lock: file_lock,
             })
@@ -407,80 +205,6 @@ impl WalletState {
         }
         fs_err::rename(&temp_file_path, &self.wallet_path)?;
         Ok(())
-    }
-
-    pub fn pretty_print(&self, chain_id: Option<ChainId>) {
-        let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .apply_modifier(UTF8_ROUND_CORNERS)
-            .set_content_arrangement(ContentArrangement::Dynamic)
-            .set_header(vec![
-                Cell::new("Chain Id").add_attribute(Attribute::Bold),
-                Cell::new("Latest Block").add_attribute(Attribute::Bold),
-            ]);
-        if let Some(chain_id) = chain_id {
-            if let Some(user_chain) = self.inner.chains.get(&chain_id) {
-                Self::update_table_with_chain(
-                    &mut table,
-                    chain_id,
-                    user_chain,
-                    Some(chain_id) == self.inner.default,
-                );
-            } else {
-                panic!("Chain {} not found.", chain_id);
-            }
-        } else {
-            for (chain_id, user_chain) in &self.inner.chains {
-                Self::update_table_with_chain(
-                    &mut table,
-                    *chain_id,
-                    user_chain,
-                    Some(chain_id) == self.inner.default.as_ref(),
-                );
-            }
-        }
-        println!("{}", table);
-    }
-
-    fn update_table_with_chain(
-        table: &mut Table,
-        chain_id: ChainId,
-        user_chain: &UserChain,
-        is_default_chain: bool,
-    ) {
-        let chain_id_cell = if is_default_chain {
-            Cell::new(format!("{}", chain_id)).fg(Color::Green)
-        } else {
-            Cell::new(format!("{}", chain_id))
-        };
-        table.add_row(vec![
-            chain_id_cell,
-            Cell::new(format!(
-                r#"Public Key:         {}
-Owner:              {}
-Block Hash:         {}
-Timestamp:          {}
-Next Block Height:  {}"#,
-                user_chain
-                    .key_pair
-                    .as_ref()
-                    .map(|kp| kp.public().to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-                user_chain
-                    .key_pair
-                    .as_ref()
-                    .map(|kp| Owner::from(kp.public()))
-                    .map(|o| o.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-                user_chain
-                    .block_hash
-                    .map(|bh| bh.to_string())
-                    .unwrap_or_else(|| "-".to_string()),
-                user_chain.timestamp,
-                user_chain.next_block_height
-            )),
-        ]);
     }
 }
 

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -15,3 +15,4 @@ pub mod project;
 pub mod prometheus_server;
 pub mod storage;
 pub mod util;
+pub mod wallet;

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -139,12 +139,12 @@ impl ClientContext {
         Ok(Self::configure(options, wallet_state))
     }
 
-    /// Returns the `Wallet` as an immutable reference.
+    /// Returns the [`Wallet`] as an immutable reference.
     fn wallet(&self) -> &Wallet {
         self.wallet_state.inner()
     }
 
-    /// Returns the `Wallet` as a mutable reference.
+    /// Returns the [`Wallet`] as a mutable reference.
     pub fn wallet_mut(&mut self) -> &mut Wallet {
         self.wallet_state.inner_mut()
     }

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -26,9 +26,10 @@ use linera_execution::Bytecode;
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_service::{
     chain_listener,
-    config::{GenesisConfig, UserChain, WalletState},
+    config::{GenesisConfig, WalletState},
     node_service::wait_for_next_round,
     storage::StorageConfigNamespace,
+    wallet::{UserChain, Wallet},
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -78,8 +79,8 @@ pub struct ClientContext {
 
 #[async_trait]
 impl chain_listener::ClientContext<NodeProvider> for ClientContext {
-    fn wallet_state(&self) -> &WalletState {
-        &self.wallet_state
+    fn wallet(&self) -> &Wallet {
+        self.wallet_state.inner()
     }
 
     fn make_chain_client<S>(&self, storage: S, chain_id: ChainId) -> ChainClient<NodeProvider, S> {
@@ -125,7 +126,7 @@ impl ClientContext {
                 .with_context(|| format!("Unable to create wallet at {:?}", &wallet_state_path))?;
         chains
             .into_iter()
-            .for_each(|chain| wallet_state.insert(chain));
+            .for_each(|chain| wallet_state.inner_mut().insert(chain));
         Ok(Self::configure(options, wallet_state))
     }
 
@@ -138,12 +139,18 @@ impl ClientContext {
         Ok(Self::configure(options, wallet_state))
     }
 
-    pub fn wallet_state_mut(&mut self) -> &mut WalletState {
-        &mut self.wallet_state
+    /// Returns the `Wallet` as an immutable reference.
+    fn wallet(&self) -> &Wallet {
+        self.wallet_state.inner()
+    }
+
+    /// Returns the `Wallet` as a mutable reference.
+    pub fn wallet_mut(&mut self) -> &mut Wallet {
+        self.wallet_state.inner_mut()
     }
 
     fn configure(options: &ClientOptions, wallet_state: WalletState) -> Self {
-        let prng = wallet_state.make_prng();
+        let prng = wallet_state.inner().make_prng();
 
         let node_options = NodeOptions {
             send_timeout: options.send_timeout,
@@ -211,14 +218,14 @@ impl ClientContext {
 
     /// Retrieve the default chain.
     pub fn default_chain(&self) -> ChainId {
-        self.wallet_state
+        self.wallet()
             .default_chain()
             .expect("No chain specified in wallet with no default chain")
     }
 
     fn make_chain_client<S>(&self, storage: S, chain_id: ChainId) -> ChainClient<NodeProvider, S> {
         let chain = self
-            .wallet_state
+            .wallet()
             .get(chain_id)
             .unwrap_or_else(|| panic!("Unknown chain: {}", chain_id));
         let known_key_pairs = chain
@@ -231,7 +238,7 @@ impl ClientContext {
             chain_id,
             known_key_pairs,
             storage,
-            self.wallet_state.genesis_admin_chain(),
+            self.wallet().genesis_admin_chain(),
             chain.block_hash,
             chain.timestamp,
             chain.next_block_height,
@@ -253,7 +260,9 @@ impl ClientContext {
     }
 
     pub fn save_wallet(&mut self) {
-        self.wallet_state.refresh_prng_seed(&mut self.prng);
+        self.wallet_state
+            .inner_mut()
+            .refresh_prng_seed(&mut self.prng);
         self.wallet_state
             .write()
             .expect("Unable to write user chains");
@@ -266,7 +275,7 @@ impl ClientContext {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        self.wallet_state.update_from_state(state).await
+        self.wallet_mut().update_from_state(state).await
     }
 
     pub async fn update_and_save_wallet<P, S>(&mut self, state: &mut ChainClient<P, S>)
@@ -286,8 +295,8 @@ impl ClientContext {
         key_pair: Option<KeyPair>,
         timestamp: Timestamp,
     ) {
-        if self.wallet_state.get(chain_id).is_none() {
-            self.wallet_state.insert(UserChain {
+        if self.wallet().get(chain_id).is_none() {
+            self.wallet_mut().insert(UserChain {
                 chain_id,
                 key_pair: key_pair.as_ref().map(|kp| kp.copy()),
                 block_hash: None,
@@ -474,7 +483,7 @@ impl ClientContext {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        for chain_id in self.wallet_state.own_chain_ids() {
+        for chain_id in self.wallet().own_chain_ids() {
             let chain_client = self.make_chain_client(storage.clone(), chain_id).into_arc();
             self.process_inbox(&chain_client).await.unwrap();
             chain_client.lock().await.update_validators().await.unwrap();
@@ -494,12 +503,12 @@ impl ClientContext {
         ViewError: From<S::ContextError>,
     {
         let mut key_pairs = HashMap::new();
-        for chain_id in self.wallet_state.own_chain_ids() {
+        for chain_id in self.wallet().own_chain_ids() {
             if key_pairs.len() == num_chains {
                 break;
             }
             let Some(key_pair) = self
-                .wallet_state
+                .wallet()
                 .get(chain_id)
                 .and_then(|chain| chain.key_pair.as_ref().map(|kp| kp.copy()))
             else {
@@ -514,7 +523,7 @@ impl ClientContext {
         }
 
         let default_chain_id = self
-            .wallet_state
+            .wallet()
             .default_chain()
             .context("should have default chain")?;
         let mut chain_client = self.make_chain_client(storage.clone(), default_chain_id);
@@ -528,7 +537,7 @@ impl ClientContext {
             let config = OpenChainConfig {
                 ownership: ChainOwnership::single(public_key),
                 committees,
-                admin_id: self.wallet_state.genesis_admin_chain(),
+                admin_id: self.wallet().genesis_admin_chain(),
                 epoch,
                 balance,
                 application_permissions: Default::default(),
@@ -558,9 +567,7 @@ impl ClientContext {
         for chain_id in key_pairs.keys() {
             let mut child_client = self.make_chain_client(storage.clone(), *chain_id);
             child_client.process_inbox().await?;
-            self.wallet_state_mut()
-                .update_from_state(&mut child_client)
-                .await;
+            self.wallet_mut().update_from_state(&mut child_client).await;
         }
         Ok(key_pairs)
     }
@@ -579,11 +586,11 @@ impl ClientContext {
         ViewError: From<S::ContextError>,
     {
         let default_chain_id = self
-            .wallet_state
+            .wallet()
             .default_chain()
             .context("should have default chain")?;
         let default_key = self
-            .wallet_state
+            .wallet()
             .get(default_chain_id)
             .unwrap()
             .key_pair
@@ -658,7 +665,7 @@ impl ClientContext {
         fungible_application_id: Option<ApplicationId>,
     ) -> Vec<RpcMessage> {
         let mut proposals = Vec::new();
-        let mut next_recipient = self.wallet_state.last_chain().unwrap().chain_id;
+        let mut next_recipient = self.wallet_mut().last_chain().unwrap().chain_id;
         let amount = Amount::from(1);
         for (&chain_id, key_pair) in key_pairs {
             let public_key = key_pair.public();
@@ -680,7 +687,7 @@ impl ClientContext {
             let operations = iter::repeat(operation)
                 .take(transactions_per_block)
                 .collect();
-            let chain = self.wallet_state.get(chain_id).expect("should have chain");
+            let chain = self.wallet().get(chain_id).expect("should have chain");
             let block = Block {
                 epoch: Epoch::ZERO,
                 chain_id,
@@ -709,7 +716,7 @@ impl ClientContext {
 
     /// Tries to aggregate votes into certificates.
     pub fn make_benchmark_certificates_from_votes(&self, votes: Vec<Vote>) -> Vec<Certificate> {
-        let committee = self.wallet_state.genesis_config().create_committee();
+        let committee = self.wallet().genesis_config().create_committee();
         let mut aggregators = HashMap::new();
         let mut certificates = Vec::new();
         let mut done_senders = HashSet::new();
@@ -792,7 +799,7 @@ impl ClientContext {
 
     fn make_validator_mass_clients(&self) -> Vec<Box<dyn MassClient + Send>> {
         let mut validator_clients = Vec::new();
-        for config in &self.wallet_state.genesis_config().committee.validators {
+        for config in &self.wallet().genesis_config().committee.validators {
             let client: Box<dyn MassClient + Send> = match config.network.protocol {
                 NetworkProtocol::Simple(protocol) => {
                     let network = config.network.clone_with_protocol(protocol);
@@ -831,7 +838,7 @@ impl ClientContext {
             node.handle_certificate(certificate, vec![]).await.unwrap();
         }
         // Last update the wallet.
-        for chain in self.wallet_state.chains_mut() {
+        for chain in self.wallet_mut().chains_mut() {
             let query = ChainInfoQuery::new(chain.chain_id);
             let info = node.handle_chain_info_query(query).await.unwrap().info;
             // We don't have private keys but that's ok.

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -123,7 +123,7 @@ impl ClientOptions {
 
     pub async fn run_command_with_storage(self) -> Result<(), Error> {
         let context = ClientContext::from_options(&self)?;
-        let genesis_config = context.wallet_state().genesis_config().clone();
+        let genesis_config = context.wallet().genesis_config().clone();
         let wasm_runtime = self.wasm_runtime.with_wasm_default();
         let max_concurrent_queries = self.max_concurrent_queries;
         let max_stream_queries = self.max_stream_queries;
@@ -147,7 +147,7 @@ impl ClientOptions {
 
     pub async fn initialize_storage(&self) -> Result<(), Error> {
         let context = ClientContext::from_options(self)?;
-        let genesis_config = context.wallet_state().genesis_config().clone();
+        let genesis_config = context.wallet().genesis_config().clone();
         let max_concurrent_queries = self.max_concurrent_queries;
         let max_stream_queries = self.max_stream_queries;
         let cache_size = self.cache_size;

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -15,8 +15,8 @@ use linera_core::{
 use linera_execution::committee::Committee;
 use linera_service::{
     chain_listener::{ChainListenerConfig, ClientContext},
-    config::WalletState,
     node_service::NodeService,
+    wallet::Wallet,
 };
 use linera_storage::{MemoryStorage, Storage};
 use linera_version::VersionInfo;
@@ -97,7 +97,7 @@ struct DummyContext;
 
 #[async_trait]
 impl ClientContext<DummyValidatorNodeProvider> for DummyContext {
-    fn wallet_state(&self) -> &WalletState {
+    fn wallet(&self) -> &Wallet {
         unimplemented!()
     }
 

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -18,7 +18,7 @@ use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{memory::MemoryStore, views::ViewError};
 
 use super::MutationRoot;
-use crate::{chain_listener, config::WalletState};
+use crate::{chain_listener, wallet::Wallet};
 
 #[derive(Default)]
 struct ClientContext {
@@ -29,7 +29,7 @@ struct ClientContext {
 impl chain_listener::ClientContext<NodeProvider<DbStorage<MemoryStore, TestClock>>>
     for ClientContext
 {
-    fn wallet_state(&self) -> &WalletState {
+    fn wallet(&self) -> &Wallet {
         unimplemented!()
     }
 

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -1,0 +1,302 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+
+use anyhow::Context as _;
+use comfy_table::{
+    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Attribute, Cell, Color, ContentArrangement,
+    Table,
+};
+use linera_base::{
+    crypto::{CryptoHash, CryptoRng, KeyPair, PublicKey},
+    data_types::{BlockHeight, Timestamp},
+    identifiers::{ChainDescription, ChainId, Owner},
+};
+use linera_chain::data_types::Block;
+use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
+use linera_storage::Storage;
+use linera_views::views::ViewError;
+use rand::Rng as _;
+use serde::{Deserialize, Serialize};
+
+use crate::config::GenesisConfig;
+
+#[derive(Serialize, Deserialize)]
+pub struct Wallet {
+    chains: BTreeMap<ChainId, UserChain>,
+    unassigned_key_pairs: HashMap<PublicKey, KeyPair>,
+    default: Option<ChainId>,
+    genesis_config: GenesisConfig,
+    testing_prng_seed: Option<u64>,
+}
+
+impl Wallet {
+    pub fn new(genesis_config: GenesisConfig, testing_prng_seed: Option<u64>) -> Self {
+        Wallet {
+            chains: BTreeMap::new(),
+            unassigned_key_pairs: HashMap::new(),
+            default: None,
+            genesis_config,
+            testing_prng_seed,
+        }
+    }
+
+    pub fn get(&self, chain_id: ChainId) -> Option<&UserChain> {
+        self.chains.get(&chain_id)
+    }
+
+    pub fn insert(&mut self, chain: UserChain) {
+        if self.chains.is_empty() {
+            self.default = Some(chain.chain_id);
+        }
+        self.chains.insert(chain.chain_id, chain);
+    }
+
+    pub fn forget_keys(&mut self, chain_id: &ChainId) -> Result<KeyPair, anyhow::Error> {
+        let chain = self
+            .chains
+            .get_mut(chain_id)
+            .context(format!("Failed to get chain for chain id: {}", chain_id))?;
+        chain.key_pair.take().context("Failed to take keypair")
+    }
+
+    pub fn forget_chain(&mut self, chain_id: &ChainId) -> Result<UserChain, anyhow::Error> {
+        self.chains
+            .remove(chain_id)
+            .context(format!("Failed to remove chain: {}", chain_id))
+    }
+
+    pub fn default_chain(&self) -> Option<ChainId> {
+        self.default
+    }
+
+    pub fn chain_ids(&self) -> Vec<ChainId> {
+        self.chains.keys().copied().collect()
+    }
+
+    /// Returns the list of all chain IDs for which we have a secret key.
+    pub fn own_chain_ids(&self) -> Vec<ChainId> {
+        self.chains
+            .iter()
+            .filter_map(|(chain_id, chain)| chain.key_pair.is_some().then_some(*chain_id))
+            .collect()
+    }
+
+    pub fn num_chains(&self) -> usize {
+        self.chains.len()
+    }
+
+    pub fn last_chain(&mut self) -> Option<&UserChain> {
+        self.chains.values().last()
+    }
+
+    pub fn chains_mut(&mut self) -> impl Iterator<Item = &mut UserChain> {
+        self.chains.values_mut()
+    }
+
+    pub fn add_unassigned_key_pair(&mut self, keypair: KeyPair) {
+        self.unassigned_key_pairs.insert(keypair.public(), keypair);
+    }
+
+    pub fn key_pair_for_pk(&self, key: &PublicKey) -> Option<KeyPair> {
+        if let Some(key_pair) = self
+            .unassigned_key_pairs
+            .get(key)
+            .map(|key_pair| key_pair.copy())
+        {
+            return Some(key_pair);
+        }
+        self.chains
+            .values()
+            .filter_map(|user_chain| user_chain.key_pair.as_ref())
+            .find(|key_pair| key_pair.public() == *key)
+            .map(|key_pair| key_pair.copy())
+    }
+
+    pub fn assign_new_chain_to_key(
+        &mut self,
+        key: PublicKey,
+        chain_id: ChainId,
+        timestamp: Timestamp,
+    ) -> Result<(), anyhow::Error> {
+        let key_pair = self
+            .unassigned_key_pairs
+            .remove(&key)
+            .context("could not assign chain to key as unassigned key was not found")?;
+        let user_chain = UserChain {
+            chain_id,
+            key_pair: Some(key_pair),
+            block_hash: None,
+            timestamp,
+            next_block_height: BlockHeight(0),
+            pending_block: None,
+        };
+        self.insert(user_chain);
+        Ok(())
+    }
+
+    pub fn set_default_chain(&mut self, chain_id: ChainId) -> Result<(), anyhow::Error> {
+        anyhow::ensure!(
+            self.chains.contains_key(&chain_id),
+            "Chain {} cannot be assigned as the default chain since it does not exist in the \
+             wallet.",
+            &chain_id
+        );
+        self.default = Some(chain_id);
+        Ok(())
+    }
+
+    pub async fn update_from_state<P, S>(&mut self, state: &mut ChainClient<P, S>)
+    where
+        P: ValidatorNodeProvider + Sync + 'static,
+        S: Storage + Clone + Send + Sync + 'static,
+        ViewError: From<S::ContextError>,
+    {
+        self.chains.insert(
+            state.chain_id(),
+            UserChain {
+                chain_id: state.chain_id(),
+                key_pair: state.key_pair().await.map(|k| k.copy()).ok(),
+                block_hash: state.block_hash(),
+                next_block_height: state.next_block_height(),
+                timestamp: state.timestamp(),
+                pending_block: state.pending_block().clone(),
+            },
+        );
+    }
+
+    pub fn genesis_admin_chain(&self) -> ChainId {
+        self.genesis_config.admin_id
+    }
+
+    pub fn genesis_config(&self) -> &GenesisConfig {
+        &self.genesis_config
+    }
+
+    pub fn make_prng(&self) -> Box<dyn CryptoRng> {
+        self.testing_prng_seed.into()
+    }
+
+    pub fn refresh_prng_seed<R: CryptoRng>(&mut self, rng: &mut R) {
+        if self.testing_prng_seed.is_some() {
+            self.testing_prng_seed = Some(rng.gen());
+        }
+    }
+
+    pub fn pretty_print(&self, chain_id: Option<ChainId>) {
+        let mut table = Table::new();
+        table
+            .load_preset(UTF8_FULL)
+            .apply_modifier(UTF8_ROUND_CORNERS)
+            .set_content_arrangement(ContentArrangement::Dynamic)
+            .set_header(vec![
+                Cell::new("Chain Id").add_attribute(Attribute::Bold),
+                Cell::new("Latest Block").add_attribute(Attribute::Bold),
+            ]);
+        if let Some(chain_id) = chain_id {
+            if let Some(user_chain) = self.chains.get(&chain_id) {
+                Self::update_table_with_chain(
+                    &mut table,
+                    chain_id,
+                    user_chain,
+                    Some(chain_id) == self.default,
+                );
+            } else {
+                panic!("Chain {} not found.", chain_id);
+            }
+        } else {
+            for (chain_id, user_chain) in &self.chains {
+                Self::update_table_with_chain(
+                    &mut table,
+                    *chain_id,
+                    user_chain,
+                    Some(chain_id) == self.default.as_ref(),
+                );
+            }
+        }
+        println!("{}", table);
+    }
+
+    fn update_table_with_chain(
+        table: &mut Table,
+        chain_id: ChainId,
+        user_chain: &UserChain,
+        is_default_chain: bool,
+    ) {
+        let chain_id_cell = if is_default_chain {
+            Cell::new(format!("{}", chain_id)).fg(Color::Green)
+        } else {
+            Cell::new(format!("{}", chain_id))
+        };
+        table.add_row(vec![
+            chain_id_cell,
+            Cell::new(format!(
+                r#"Public Key:         {}
+Owner:              {}
+Block Hash:         {}
+Timestamp:          {}
+Next Block Height:  {}"#,
+                user_chain
+                    .key_pair
+                    .as_ref()
+                    .map(|kp| kp.public().to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                user_chain
+                    .key_pair
+                    .as_ref()
+                    .map(|kp| Owner::from(kp.public()))
+                    .map(|o| o.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                user_chain
+                    .block_hash
+                    .map(|bh| bh.to_string())
+                    .unwrap_or_else(|| "-".to_string()),
+                user_chain.timestamp,
+                user_chain.next_block_height
+            )),
+        ]);
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UserChain {
+    pub chain_id: ChainId,
+    pub key_pair: Option<KeyPair>,
+    pub block_hash: Option<CryptoHash>,
+    pub timestamp: Timestamp,
+    pub next_block_height: BlockHeight,
+    pub pending_block: Option<Block>,
+}
+
+impl UserChain {
+    /// Create a user chain that we own.
+    pub fn make_initial<R: CryptoRng>(
+        rng: &mut R,
+        description: ChainDescription,
+        timestamp: Timestamp,
+    ) -> Self {
+        let key_pair = KeyPair::generate_from(rng);
+        Self {
+            chain_id: description.into(),
+            key_pair: Some(key_pair),
+            block_hash: None,
+            timestamp,
+            next_block_height: BlockHeight::ZERO,
+            pending_block: None,
+        }
+    }
+
+    /// Creates an entry for a chain that we don't own. The timestamp must be the genesis
+    /// timestamp or earlier.
+    pub fn make_other(chain_id: ChainId, timestamp: Timestamp) -> Self {
+        Self {
+            chain_id,
+            key_pair: None,
+            block_hash: None,
+            timestamp,
+            next_block_height: BlockHeight::ZERO,
+            pending_block: None,
+        }
+    }
+}

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -23,9 +23,12 @@ use linera_service::cli_wrappers::remote_net::RemoteNetTestingConfig;
 use linera_service::cli_wrappers::{
     docker::BuildArg, local_kubernetes_net::SharedLocalKubernetesNetTestingConfig,
 };
-use linera_service::cli_wrappers::{
-    local_net::{Database, LocalNet, LocalNetConfig, PathProvider},
-    ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
+use linera_service::{
+    cli_wrappers::{
+        local_net::{Database, LocalNet, LocalNetConfig, PathProvider},
+        ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
+    },
+    config::WalletState,
 };
 use serde_json::{json, Value};
 use test_case::test_case;
@@ -282,10 +285,10 @@ async fn test_wallet_lock() -> Result<()> {
 
     let (_net, client) = config.instantiate().await?;
 
-    let wallet = client.load_wallet()?;
-    let chain_id = wallet.default_chain().unwrap();
+    let wallet_state = WalletState::from_file(client.wallet_path().as_path())?;
+    let chain_id = wallet_state.inner().default_chain().unwrap();
 
-    let lock = wallet;
+    let lock = wallet_state;
     assert!(client.process_inbox(chain_id).await.is_err());
 
     mem::drop(lock);

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -282,7 +282,7 @@ async fn test_wallet_lock() -> Result<()> {
 
     let (_net, client) = config.instantiate().await?;
 
-    let wallet = client.get_wallet()?;
+    let wallet = client.wallet()?;
     let chain_id = wallet.default_chain().unwrap();
 
     let lock = wallet;
@@ -309,7 +309,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
     let original_counter_value = 35;
     let increment = 5;
 
-    let chain = client.get_wallet()?.default_chain().unwrap();
+    let chain = client.wallet()?.default_chain().unwrap();
     let (contract, service) = client.build_example("counter").await?;
 
     let application_id = client
@@ -361,7 +361,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
     let original_counter_value = 35;
     let increment = 5;
 
-    let chain = client.get_wallet()?.default_chain().unwrap();
+    let chain = client.wallet()?.default_chain().unwrap();
     let (contract, service) = client.build_example("counter").await?;
 
     let bytecode_id = client
@@ -408,7 +408,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.get_wallet()?.default_chain().unwrap();
+    let chain1 = client1.wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
     let (contract, service) = client1.build_example("social").await?;
     let bytecode_id = client1
@@ -503,7 +503,7 @@ async fn test_wasm_end_to_end_fungible(
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.get_wallet()?.default_chain().unwrap();
+    let chain1 = client1.wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
 
     // The players
@@ -652,10 +652,10 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client1) = config.instantiate().await?;
 
-    let chain1 = client1.get_wallet()?.default_chain().unwrap();
+    let chain1 = client1.wallet()?.default_chain().unwrap();
     // Get a chain different than the default
     let chain2 = client1
-        .get_wallet()?
+        .wallet()?
         .chain_ids()
         .into_iter()
         .find(|chain_id| chain_id != &chain1)
@@ -664,7 +664,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     // The players
     let account_owner1 = get_fungible_account_owner(&client1);
     let account_owner2 = {
-        let wallet = client1.get_wallet()?;
+        let wallet = client1.wallet()?;
         let user_chain = wallet.get(chain2).unwrap();
         let public_key = user_chain.key_pair.as_ref().unwrap().public();
         AccountOwner::User(public_key.into())
@@ -764,7 +764,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.get_wallet()?.default_chain().unwrap();
+    let chain1 = client1.wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
 
     // The players
@@ -1024,7 +1024,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.get_wallet()?.default_chain().unwrap();
+    let chain1 = client1.wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
 
     // The players
@@ -1159,7 +1159,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let (contract_matching, service_matching) =
         client_admin.build_example("matching-engine").await?;
 
-    let chain_admin = client_admin.get_wallet()?.default_chain().unwrap();
+    let chain_admin = client_admin.wallet()?.default_chain().unwrap();
     let chain_a = client_admin.open_and_assign(&client_a, Amount::ONE).await?;
     let chain_b = client_admin.open_and_assign(&client_b, Amount::ONE).await?;
 
@@ -1443,7 +1443,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     let (contract_amm, service_amm) = client_admin.build_example("amm").await?;
 
     // Admin chain
-    let chain_admin = client_admin.get_wallet()?.default_chain().unwrap();
+    let chain_admin = client_admin.wallet()?.default_chain().unwrap();
 
     // User chains
     let chain0 = client_admin.open_and_assign(&client0, Amount::ONE).await?;
@@ -1863,9 +1863,9 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client) = config.instantiate().await?;
 
-    let chain1 = client.get_wallet()?.default_chain().unwrap();
+    let chain1 = client.wallet()?.default_chain().unwrap();
     let public_key = client
-        .get_wallet()?
+        .wallet()?
         .get(chain1)
         .unwrap()
         .key_pair
@@ -2037,7 +2037,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     client2.wallet_init(&[], FaucetOption::None).await?;
 
     // Get some chain owned by Client 1.
-    let chain1 = *client1.get_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
 
     // Generate a key for Client 2.
     let client2_key = client2.keygen().await?;
@@ -2119,7 +2119,7 @@ async fn test_project_publish(database: Database, network: Network) -> Result<()
     client
         .project_publish(project_dir, vec![], None, &())
         .await?;
-    let chain = client.get_wallet()?.default_chain().unwrap();
+    let chain = client.wallet()?.default_chain().unwrap();
 
     let node_service = client.run_node_service(None).await?;
 
@@ -2197,7 +2197,7 @@ async fn test_example_publish(database: Database, network: Network) -> Result<()
     client
         .project_publish(example_dir, vec![], None, &0)
         .await?;
-    let chain = client.get_wallet()?.default_chain().unwrap();
+    let chain = client.wallet()?.default_chain().unwrap();
 
     let node_service = client.run_node_service(None).await?;
 
@@ -2227,7 +2227,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = *client1.get_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
 
     // Generate keys for both clients.
     let client1_key = client1.keygen().await?;
@@ -2292,9 +2292,9 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
     // Create runner and client.
     let (mut net, client) = config.instantiate().await?;
 
-    let chain = client.get_wallet()?.default_chain().unwrap();
+    let chain = client.wallet()?.default_chain().unwrap();
     let pub_key1 = {
-        let wallet = client.get_wallet()?;
+        let wallet = client.wallet()?;
         let user_chain = wallet.get(chain).unwrap();
         user_chain.key_pair.as_ref().unwrap().public()
     };
@@ -2335,7 +2335,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = *client1.get_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
 
     // Generate keys for client 2.
     let client2_key = client2.keygen().await?;
@@ -2380,7 +2380,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.get_wallet()?.default_chain().unwrap();
+    let chain1 = client1.wallet()?.default_chain().unwrap();
     let balance1 = client1.local_balance(Account::chain(chain1)).await?;
 
     // Generate keys for client 2.
@@ -2404,7 +2404,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
         .wallet_init(&[], FaucetOption::NewChain(&faucet))
         .await?;
     let chain3 = outcome.unwrap().chain_id;
-    assert_eq!(chain3, client3.get_wallet()?.default_chain().unwrap());
+    assert_eq!(chain3, client3.wallet()?.default_chain().unwrap());
 
     faucet_service.ensure_is_running()?;
     faucet_service.terminate().await?;
@@ -2456,7 +2456,7 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Res
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await?;
 
-    let chain1 = client1.get_wallet()?.default_chain().unwrap();
+    let chain1 = client1.wallet()?.default_chain().unwrap();
 
     let mut faucet_service = client1.run_faucet(None, chain1, Amount::ONE).await?;
     let faucet = faucet_service.instance();
@@ -2493,7 +2493,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     // Create runner and client.
     let (mut net, client) = config.instantiate().await?;
-    let chain_id = client.get_wallet()?.default_chain().unwrap();
+    let chain_id = client.wallet()?.default_chain().unwrap();
     let account = Account::chain(chain_id);
     let balance = client.local_balance(account).await?;
     // Stop validators.
@@ -2539,10 +2539,10 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client) = config.instantiate().await?;
 
-    assert_eq!(client.get_wallet()?.num_chains(), 2);
+    assert_eq!(client.wallet()?.num_chains(), 2);
     // Launch local benchmark using all user chains and creating additional ones.
     client.benchmark(2, 4, 10, None).await?;
-    assert_eq!(client.get_wallet()?.num_chains(), 4);
+    assert_eq!(client.wallet()?.num_chains(), 4);
 
     // Now we run the benchmark again, with the fungible token application instead of the
     // native token.
@@ -2605,7 +2605,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
     let (mut net, client1) = config.instantiate().await?;
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
-    let chain1 = *client1.get_wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
 
     // Open a chain owned by both clients, with only single-leader rounds.
     let client1_key = client1.keygen().await?;

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -282,7 +282,7 @@ async fn test_wallet_lock() -> Result<()> {
 
     let (_net, client) = config.instantiate().await?;
 
-    let wallet = client.wallet()?;
+    let wallet = client.load_wallet()?;
     let chain_id = wallet.default_chain().unwrap();
 
     let lock = wallet;
@@ -309,7 +309,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
     let original_counter_value = 35;
     let increment = 5;
 
-    let chain = client.wallet()?.default_chain().unwrap();
+    let chain = client.load_wallet()?.default_chain().unwrap();
     let (contract, service) = client.build_example("counter").await?;
 
     let application_id = client
@@ -361,7 +361,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
     let original_counter_value = 35;
     let increment = 5;
 
-    let chain = client.wallet()?.default_chain().unwrap();
+    let chain = client.load_wallet()?.default_chain().unwrap();
     let (contract, service) = client.build_example("counter").await?;
 
     let bytecode_id = client
@@ -408,7 +408,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.wallet()?.default_chain().unwrap();
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
     let (contract, service) = client1.build_example("social").await?;
     let bytecode_id = client1
@@ -503,7 +503,7 @@ async fn test_wasm_end_to_end_fungible(
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.wallet()?.default_chain().unwrap();
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
 
     // The players
@@ -652,10 +652,10 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client1) = config.instantiate().await?;
 
-    let chain1 = client1.wallet()?.default_chain().unwrap();
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
     // Get a chain different than the default
     let chain2 = client1
-        .wallet()?
+        .load_wallet()?
         .chain_ids()
         .into_iter()
         .find(|chain_id| chain_id != &chain1)
@@ -664,7 +664,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     // The players
     let account_owner1 = get_fungible_account_owner(&client1);
     let account_owner2 = {
-        let wallet = client1.wallet()?;
+        let wallet = client1.load_wallet()?;
         let user_chain = wallet.get(chain2).unwrap();
         let public_key = user_chain.key_pair.as_ref().unwrap().public();
         AccountOwner::User(public_key.into())
@@ -764,7 +764,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.wallet()?.default_chain().unwrap();
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
 
     // The players
@@ -1024,7 +1024,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.wallet()?.default_chain().unwrap();
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
 
     // The players
@@ -1159,7 +1159,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     let (contract_matching, service_matching) =
         client_admin.build_example("matching-engine").await?;
 
-    let chain_admin = client_admin.wallet()?.default_chain().unwrap();
+    let chain_admin = client_admin.load_wallet()?.default_chain().unwrap();
     let chain_a = client_admin.open_and_assign(&client_a, Amount::ONE).await?;
     let chain_b = client_admin.open_and_assign(&client_b, Amount::ONE).await?;
 
@@ -1443,7 +1443,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     let (contract_amm, service_amm) = client_admin.build_example("amm").await?;
 
     // Admin chain
-    let chain_admin = client_admin.wallet()?.default_chain().unwrap();
+    let chain_admin = client_admin.load_wallet()?.default_chain().unwrap();
 
     // User chains
     let chain0 = client_admin.open_and_assign(&client0, Amount::ONE).await?;
@@ -1863,9 +1863,9 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client) = config.instantiate().await?;
 
-    let chain1 = client.wallet()?.default_chain().unwrap();
+    let chain1 = client.load_wallet()?.default_chain().unwrap();
     let public_key = client
-        .wallet()?
+        .load_wallet()?
         .get(chain1)
         .unwrap()
         .key_pair
@@ -2037,7 +2037,7 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     client2.wallet_init(&[], FaucetOption::None).await?;
 
     // Get some chain owned by Client 1.
-    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Generate a key for Client 2.
     let client2_key = client2.keygen().await?;
@@ -2119,7 +2119,7 @@ async fn test_project_publish(database: Database, network: Network) -> Result<()
     client
         .project_publish(project_dir, vec![], None, &())
         .await?;
-    let chain = client.wallet()?.default_chain().unwrap();
+    let chain = client.load_wallet()?.default_chain().unwrap();
 
     let node_service = client.run_node_service(None).await?;
 
@@ -2197,7 +2197,7 @@ async fn test_example_publish(database: Database, network: Network) -> Result<()
     client
         .project_publish(example_dir, vec![], None, &0)
         .await?;
-    let chain = client.wallet()?.default_chain().unwrap();
+    let chain = client.load_wallet()?.default_chain().unwrap();
 
     let node_service = client.run_node_service(None).await?;
 
@@ -2227,7 +2227,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Generate keys for both clients.
     let client1_key = client1.keygen().await?;
@@ -2292,9 +2292,9 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
     // Create runner and client.
     let (mut net, client) = config.instantiate().await?;
 
-    let chain = client.wallet()?.default_chain().unwrap();
+    let chain = client.load_wallet()?.default_chain().unwrap();
     let pub_key1 = {
-        let wallet = client.wallet()?;
+        let wallet = client.load_wallet()?;
         let user_chain = wallet.get(chain).unwrap();
         user_chain.key_pair.as_ref().unwrap().public()
     };
@@ -2335,7 +2335,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Generate keys for client 2.
     let client2_key = client2.keygen().await?;
@@ -2380,7 +2380,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
 
-    let chain1 = client1.wallet()?.default_chain().unwrap();
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
     let balance1 = client1.local_balance(Account::chain(chain1)).await?;
 
     // Generate keys for client 2.
@@ -2404,7 +2404,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
         .wallet_init(&[], FaucetOption::NewChain(&faucet))
         .await?;
     let chain3 = outcome.unwrap().chain_id;
-    assert_eq!(chain3, client3.wallet()?.default_chain().unwrap());
+    assert_eq!(chain3, client3.load_wallet()?.default_chain().unwrap());
 
     faucet_service.ensure_is_running()?;
     faucet_service.terminate().await?;
@@ -2456,7 +2456,7 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Res
     // Create runner and two clients.
     let (mut net, client1) = config.instantiate().await?;
 
-    let chain1 = client1.wallet()?.default_chain().unwrap();
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
 
     let mut faucet_service = client1.run_faucet(None, chain1, Amount::ONE).await?;
     let faucet = faucet_service.instance();
@@ -2493,7 +2493,7 @@ async fn test_end_to_end_retry_pending_block(config: LocalNetConfig) -> Result<(
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     // Create runner and client.
     let (mut net, client) = config.instantiate().await?;
-    let chain_id = client.wallet()?.default_chain().unwrap();
+    let chain_id = client.load_wallet()?.default_chain().unwrap();
     let account = Account::chain(chain_id);
     let balance = client.local_balance(account).await?;
     // Stop validators.
@@ -2539,10 +2539,10 @@ async fn test_end_to_end_benchmark(mut config: LocalNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client) = config.instantiate().await?;
 
-    assert_eq!(client.wallet()?.num_chains(), 2);
+    assert_eq!(client.load_wallet()?.num_chains(), 2);
     // Launch local benchmark using all user chains and creating additional ones.
     client.benchmark(2, 4, 10, None).await?;
-    assert_eq!(client.wallet()?.num_chains(), 4);
+    assert_eq!(client.load_wallet()?.num_chains(), 4);
 
     // Now we run the benchmark again, with the fungible token application instead of the
     // native token.
@@ -2605,7 +2605,7 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
     let (mut net, client1) = config.instantiate().await?;
     let client2 = net.make_client().await;
     client2.wallet_init(&[], FaucetOption::None).await?;
-    let chain1 = *client1.wallet()?.chain_ids().first().unwrap();
+    let chain1 = *client1.load_wallet()?.chain_ids().first().unwrap();
 
     // Open a chain owned by both clients, with only single-leader rounds.
     let client1_key = client1.keygen().await?;


### PR DESCRIPTION
## Motivation

Writing tests (e.g. for https://github.com/linera-io/linera-protocol/issues/1906) would be easier if the `WalletState` didn't require being backed by a file.

## Proposal

Make `Wallet` (formerly `InnerWallet`) public, move most methods from `WalletState` to it, and make `ClientContext::wallet` return that.

## Test Plan

No logic was changed; this will simplify writing tests in the future.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
