### PR TITLE
Add some Wasmer specific getters to Witty

### DIFF
--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -125,6 +125,19 @@ impl<UserData> AsStoreMut for EntrypointInstance<UserData> {
     }
 }
 
+impl<UserData> EntrypointInstance<UserData> {
+    /// Returns mutable references to the [`Store`] and the [`wasmer::Instance`] stored inside this
+    /// [`EntrypointInstance`].
+    ///
+    /// The [`wasmer::Instance`] is wrapped inside an [`Option`] which might be [`None`] if this
+    /// [`EntrypointInstance`] was not initialized by [`InstanceBuilder::instantiate`].
+    pub fn as_store_and_instance_mut(
+        &mut self,
+    ) -> (&mut Store, MutexGuard<Option<wasmer::Instance>>) {
+        (&mut self.store, self.instance.instance())
+    }
+}
+
 impl<UserData> Instance for EntrypointInstance<UserData> {
     type Runtime = Wasmer;
     type UserData = UserData;

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -213,6 +213,17 @@ impl<UserData> InstanceSlot<UserData> {
             .cloned()
     }
 
+    /// Returns a reference to the [`wasmer::Instance`] stored in this [`InstanceSlot`].
+    ///
+    /// # Panics
+    ///
+    /// If the underlying instance is accessed concurrently.
+    fn instance(&mut self) -> MutexGuard<Option<wasmer::Instance>> {
+        self.instance
+            .try_lock()
+            .expect("Unexpected reentrant access to data")
+    }
+
     /// Returns a reference to the `UserData` stored in this [`InstanceSlot`].
     fn user_data(&self) -> MutexGuard<'_, UserData> {
         self.user_data


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When using Witty to prepare a Wasm module to run with the Wasmer runtime, it is sometimes useful to access the `Store` and the `wasmer::Instance` to do some Wasmer specific operations.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add some additional Wasmer-specific getter methods to access the `wasmer::Instance` and the `Store`.

## Test Plan

<!-- How to test that the changes are correct. -->
No additional functionality is being added, and existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
