### PR TITLE
Generate WIT files using a custom binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,9 @@ jobs:
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
+    - name: Check that the WIT files are up-to-date
+      run: |
+        cargo run --bin wit-generator -- -c
     - name: Run all tests using the default features
       run: |
         cargo test --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,6 +3439,7 @@ dependencies = [
  "linera-views",
  "linera-wit-bindgen-guest-rust",
  "linera-wit-bindgen-host-wasmtime-rust",
+ "linera-witty",
  "log",
  "serde",
  "serde_json",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2077,6 +2077,7 @@ dependencies = [
  "linera-views",
  "linera-wit-bindgen-guest-rust",
  "linera-wit-bindgen-host-wasmtime-rust",
+ "linera-witty",
  "log",
  "serde",
  "serde_json",

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -53,7 +53,10 @@ use thiserror::Error;
 #[cfg(all(with_testing, any(with_wasmer, with_wasmtime)))]
 pub use wasm::test as wasm_test;
 #[cfg(with_wasm_runtime)]
-pub use wasm::{WasmContractModule, WasmExecutionError, WasmServiceModule};
+pub use wasm::{
+    ContractEntrypoints, ContractSystemApi, ServiceEntrypoints, ServiceSystemApi, SystemApiData,
+    ViewSystemApi, WasmContractModule, WasmExecutionError, WasmServiceModule,
+};
 
 pub use crate::runtime::{ContractSyncRuntime, ServiceSyncRuntime};
 

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -35,9 +35,11 @@ use wasmer::{WasmerContractInstance, WasmerServiceInstance};
 #[cfg(with_wasmtime)]
 use wasmtime::{WasmtimeContractInstance, WasmtimeServiceInstance};
 
-#[allow(unused_imports)]
-pub use self::entrypoints::{ContractEntrypoints, ServiceEntrypoints};
 use self::sanitizer::sanitize;
+pub use self::{
+    entrypoints::{ContractEntrypoints, ServiceEntrypoints},
+    system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi},
+};
 use crate::{
     Bytecode, ContractSyncRuntime, ExecutionError, ServiceSyncRuntime, UserContractInstance,
     UserContractModule, UserServiceInstance, UserServiceModule, WasmRuntime,

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -51,6 +51,7 @@ linera-chain = { workspace = true, features = ["metrics"] }
 linera-core = { workspace = true, features = ["test", "metrics", "wasmer"] }
 linera-execution = { workspace = true, features = ["fs", "metrics", "wasmer"] }
 linera-storage = { workspace = true, features = ["metrics", "wasmer"] }
+linera-witty.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wasmtime.workspace = true

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -51,7 +51,7 @@ linera-chain = { workspace = true, features = ["metrics"] }
 linera-core = { workspace = true, features = ["test", "metrics", "wasmer"] }
 linera-execution = { workspace = true, features = ["fs", "metrics", "wasmer"] }
 linera-storage = { workspace = true, features = ["metrics", "wasmer"] }
-linera-witty.workspace = true
+linera-witty = { workspace = true, features = ["test"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wasmtime.workspace = true
@@ -62,3 +62,7 @@ cfg_aliases.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio-test.workspace = true
+
+[[bin]]
+name = "wit-generator"
+path = "src/bin/wit_generator.rs"

--- a/linera-sdk/src/bin/wit_generator.rs
+++ b/linera-sdk/src/bin/wit_generator.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generator of WIT files representing the interface between Linera applications and nodes.
+
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::Path,
+};
+
+use linera_execution::{
+    ContractEntrypoints, ContractSyncRuntime, ContractSystemApi, ServiceEntrypoints,
+    ServiceSyncRuntime, ServiceSystemApi, SystemApiData, ViewSystemApi,
+};
+use linera_sdk::MockSystemApi;
+use linera_witty::{
+    wit_generation::{WitInterfaceWriter, WitWorldWriter},
+    MockInstance,
+};
+
+/// WIT file generator entrypoint.
+fn main() -> Result<(), io::Error> {
+    let base_directory = Path::new("linera-sdk/wit");
+
+    let contract_entrypoints = WitInterfaceWriter::new::<ContractEntrypoints<MockInstance<()>>>();
+    let service_entrypoints = WitInterfaceWriter::new::<ServiceEntrypoints<MockInstance<()>>>();
+    let mock_system_api = WitInterfaceWriter::new::<MockSystemApi<MockInstance<()>>>();
+
+    let contract_system_api = WitInterfaceWriter::new::<
+        ContractSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>,
+    >();
+    let service_system_api = WitInterfaceWriter::new::<
+        ServiceSystemApi<MockInstance<SystemApiData<ServiceSyncRuntime>>>,
+    >();
+    let view_system_api = WitInterfaceWriter::new::<
+        ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>,
+    >();
+
+    let contract_world = WitWorldWriter::new("linera:app", "contract")
+        .export::<ContractEntrypoints<MockInstance<()>>>()
+        .import::<ContractSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>()
+        .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>();
+    let service_world = WitWorldWriter::new("linera:app", "service")
+        .export::<ServiceEntrypoints<MockInstance<()>>>()
+        .import::<ServiceSystemApi<MockInstance<SystemApiData<ServiceSyncRuntime>>>>()
+        .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>();
+    let unit_tests_world = WitWorldWriter::new("linera:app", "unit-tests")
+        .export::<MockSystemApi<MockInstance<()>>>()
+        .import::<ContractSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>()
+        .import::<ServiceSystemApi<MockInstance<SystemApiData<ServiceSyncRuntime>>>>()
+        .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>();
+
+    write_to_file(
+        &base_directory.join("contract-entrypoints.wit"),
+        contract_entrypoints.generate_file_contents(),
+    )?;
+    write_to_file(
+        &base_directory.join("service-entrypoints.wit"),
+        service_entrypoints.generate_file_contents(),
+    )?;
+    write_to_file(
+        &base_directory.join("mock-system-api.wit"),
+        mock_system_api.generate_file_contents(),
+    )?;
+
+    write_to_file(
+        &base_directory.join("contract-system-api.wit"),
+        contract_system_api.generate_file_contents(),
+    )?;
+    write_to_file(
+        &base_directory.join("service-system-api.wit"),
+        service_system_api.generate_file_contents(),
+    )?;
+    write_to_file(
+        &base_directory.join("view-system-api.wit"),
+        view_system_api.generate_file_contents(),
+    )?;
+
+    write_to_file(
+        &base_directory.join("contract.wit"),
+        contract_world.generate_file_contents(),
+    )?;
+    write_to_file(
+        &base_directory.join("service.wit"),
+        service_world.generate_file_contents(),
+    )?;
+    write_to_file(
+        &base_directory.join("unit-tests.wit"),
+        unit_tests_world.generate_file_contents(),
+    )?;
+
+    Ok(())
+}
+
+/// Writes the provided `contents` to a new file at the specified `path`.
+fn write_to_file<'c>(path: &Path, contents: impl Iterator<Item = &'c str>) -> io::Result<()> {
+    let mut file = BufWriter::new(File::create(path)?);
+    for part in contents {
+        file.write_all(part.as_bytes())?;
+    }
+    file.flush()
+}

--- a/linera-sdk/src/bin/wit_generator.rs
+++ b/linera-sdk/src/bin/wit_generator.rs
@@ -6,9 +6,10 @@
 use std::{
     fs::File,
     io::{self, BufWriter, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
+use clap::Parser as _;
 use linera_execution::{
     ContractEntrypoints, ContractSyncRuntime, ContractSystemApi, ServiceEntrypoints,
     ServiceSyncRuntime, ServiceSystemApi, SystemApiData, ViewSystemApi,
@@ -19,9 +20,17 @@ use linera_witty::{
     MockInstance,
 };
 
+/// Command line parameters for the WIT generator.
+#[derive(Debug, clap::Parser)]
+pub struct WitGeneratorOptions {
+    /// The base directory of where the WIT files should be placed.
+    #[arg(short, long, default_value = "linera-sdk/wit")]
+    base_directory: PathBuf,
+}
+
 /// WIT file generator entrypoint.
 fn main() -> Result<(), io::Error> {
-    let base_directory = Path::new("linera-sdk/wit");
+    let options = WitGeneratorOptions::parse();
 
     let contract_entrypoints = WitInterfaceWriter::new::<ContractEntrypoints<MockInstance<()>>>();
     let service_entrypoints = WitInterfaceWriter::new::<ServiceEntrypoints<MockInstance<()>>>();
@@ -52,41 +61,41 @@ fn main() -> Result<(), io::Error> {
         .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>();
 
     write_to_file(
-        &base_directory.join("contract-entrypoints.wit"),
+        &options.base_directory.join("contract-entrypoints.wit"),
         contract_entrypoints.generate_file_contents(),
     )?;
     write_to_file(
-        &base_directory.join("service-entrypoints.wit"),
+        &options.base_directory.join("service-entrypoints.wit"),
         service_entrypoints.generate_file_contents(),
     )?;
     write_to_file(
-        &base_directory.join("mock-system-api.wit"),
+        &options.base_directory.join("mock-system-api.wit"),
         mock_system_api.generate_file_contents(),
     )?;
 
     write_to_file(
-        &base_directory.join("contract-system-api.wit"),
+        &options.base_directory.join("contract-system-api.wit"),
         contract_system_api.generate_file_contents(),
     )?;
     write_to_file(
-        &base_directory.join("service-system-api.wit"),
+        &options.base_directory.join("service-system-api.wit"),
         service_system_api.generate_file_contents(),
     )?;
     write_to_file(
-        &base_directory.join("view-system-api.wit"),
+        &options.base_directory.join("view-system-api.wit"),
         view_system_api.generate_file_contents(),
     )?;
 
     write_to_file(
-        &base_directory.join("contract.wit"),
+        &options.base_directory.join("contract.wit"),
         contract_world.generate_file_contents(),
     )?;
     write_to_file(
-        &base_directory.join("service.wit"),
+        &options.base_directory.join("service.wit"),
         service_world.generate_file_contents(),
     )?;
     write_to_file(
-        &base_directory.join("unit-tests.wit"),
+        &options.base_directory.join("unit-tests.wit"),
         unit_tests_world.generate_file_contents(),
     )?;
 

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -43,6 +43,8 @@ pub mod contract;
 mod extensions;
 pub mod graphql;
 mod log;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod mock_system_api;
 pub mod service;
 #[cfg(feature = "test")]
 #[cfg_attr(not(target_arch = "wasm32"), path = "./test/integration/mod.rs")]
@@ -65,6 +67,8 @@ use serde::{de::DeserializeOwned, Serialize};
 pub use wit_bindgen_guest_rust;
 
 use self::contract::ContractStateStorage;
+#[cfg(not(target_arch = "wasm32"))]
+pub use self::mock_system_api::MockSystemApi;
 pub use self::{
     contract::ContractRuntime,
     extensions::{FromBcsBytes, ToBcsBytes},

--- a/linera-sdk/src/mock_system_api.rs
+++ b/linera-sdk/src/mock_system_api.rs
@@ -1,0 +1,216 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Hooks for mocking system APIs inside unit tests.
+
+#![allow(missing_docs)]
+#![allow(clippy::type_complexity)]
+
+use std::{any::Any, marker::PhantomData};
+
+use linera_base::{
+    data_types::{Amount, Timestamp},
+    identifiers::{ApplicationId, ChainId},
+};
+use linera_views::batch::WriteOperation;
+use linera_witty::{wit_export, wit_import, Instance, Runtime, RuntimeError, RuntimeMemory};
+
+/// A map of resources allocated on the host side.
+#[derive(Default)]
+pub struct Resources(Vec<Box<dyn Any + Send + 'static>>);
+
+impl Resources {
+    /// Adds a resource to the map, returning its handle.
+    pub fn insert(&mut self, value: impl Any + Send + 'static) -> i32 {
+        let handle = self.0.len().try_into().expect("Resources map overflow");
+
+        self.0.push(Box::new(value));
+
+        handle
+    }
+
+    /// Returns an immutable reference to a resource referenced by the provided `handle`.
+    pub fn get<T: 'static>(&self, handle: i32) -> &T {
+        self.0[usize::try_from(handle).expect("Invalid handle")]
+            .downcast_ref()
+            .expect("Incorrect handle type")
+    }
+}
+
+/// The interface application tests implement to intercept system API calls.
+#[wit_import(package = "linera:app")]
+pub trait MockSystemApi {
+    fn mocked_chain_id() -> ChainId;
+    fn mocked_application_id() -> ApplicationId;
+    fn mocked_application_parameters() -> Vec<u8>;
+    fn mocked_read_chain_balance() -> Amount;
+    fn mocked_read_system_timestamp() -> Timestamp;
+    fn mocked_log(message: String, level: log::Level);
+    fn mocked_read_multi_values_bytes(keys: Vec<Vec<u8>>) -> Vec<Option<Vec<u8>>>;
+    fn mocked_read_value_bytes(key: Vec<u8>) -> Option<Vec<u8>>;
+    fn mocked_find_keys(prefix: Vec<u8>) -> Vec<Vec<u8>>;
+    fn mocked_find_key_values(prefix: Vec<u8>) -> Vec<(Vec<u8>, Vec<u8>)>;
+    fn mocked_write_batch(operations: Vec<WriteOperation>);
+    fn mocked_try_query_application(application: ApplicationId, query: Vec<u8>) -> Vec<u8>;
+}
+
+/// Test runner's implementation of the contract system APIs.
+#[derive(Default)]
+pub struct ContractSystemApi<Caller>(PhantomData<Caller>);
+
+#[wit_export(package = "linera:app")]
+impl<Caller> ContractSystemApi<Caller>
+where
+    Caller: Instance<UserData = Resources> + InstanceForMockSystemApi,
+    <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+{
+    fn get_chain_id(caller: &mut Caller) -> Result<ChainId, RuntimeError> {
+        MockSystemApi::new(caller).mocked_chain_id()
+    }
+
+    fn get_application_id(caller: &mut Caller) -> Result<ApplicationId, RuntimeError> {
+        MockSystemApi::new(caller).mocked_application_id()
+    }
+
+    fn application_parameters(caller: &mut Caller) -> Result<Vec<u8>, RuntimeError> {
+        MockSystemApi::new(caller).mocked_application_parameters()
+    }
+
+    fn read_chain_balance(caller: &mut Caller) -> Result<Amount, RuntimeError> {
+        MockSystemApi::new(caller).mocked_read_chain_balance()
+    }
+
+    fn read_system_timestamp(caller: &mut Caller) -> Result<Timestamp, RuntimeError> {
+        MockSystemApi::new(caller).mocked_read_system_timestamp()
+    }
+
+    fn log(caller: &mut Caller, message: String, level: log::Level) -> Result<(), RuntimeError> {
+        MockSystemApi::new(caller).mocked_log(message, level)
+    }
+}
+
+/// Test runner's implementation of the service system APIs.
+#[derive(Default)]
+pub struct ServiceSystemApi<Caller>(PhantomData<Caller>);
+
+#[wit_export(package = "linera:app")]
+impl<Caller> ServiceSystemApi<Caller>
+where
+    Caller: Instance<UserData = Resources> + InstanceForMockSystemApi,
+    <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+{
+    fn get_chain_id(caller: &mut Caller) -> Result<ChainId, RuntimeError> {
+        MockSystemApi::new(caller).mocked_chain_id()
+    }
+
+    fn get_application_id(caller: &mut Caller) -> Result<ApplicationId, RuntimeError> {
+        MockSystemApi::new(caller).mocked_application_id()
+    }
+
+    fn get_application_parameters(caller: &mut Caller) -> Result<Vec<u8>, RuntimeError> {
+        MockSystemApi::new(caller).mocked_application_parameters()
+    }
+
+    fn read_chain_balance(caller: &mut Caller) -> Result<Amount, RuntimeError> {
+        MockSystemApi::new(caller).mocked_read_chain_balance()
+    }
+
+    fn read_system_timestamp(caller: &mut Caller) -> Result<Timestamp, RuntimeError> {
+        MockSystemApi::new(caller).mocked_read_system_timestamp()
+    }
+
+    fn try_query_application(
+        caller: &mut Caller,
+        application_id: ApplicationId,
+        query: Vec<u8>,
+    ) -> Result<Vec<u8>, RuntimeError> {
+        MockSystemApi::new(caller).mocked_try_query_application(application_id, query)
+    }
+
+    fn log(caller: &mut Caller, message: String, level: log::Level) -> Result<(), RuntimeError> {
+        MockSystemApi::new(caller).mocked_log(message, level)
+    }
+}
+
+/// Test runner's implementation of the view system APIs shared between contracts and services.
+#[derive(Default)]
+pub struct ViewSystemApi<Caller>(PhantomData<Caller>);
+
+#[wit_export(package = "linera:app")]
+impl<Caller> ViewSystemApi<Caller>
+where
+    Caller: Instance<UserData = Resources> + InstanceForMockSystemApi,
+    <Caller::Runtime as Runtime>::Memory: RuntimeMemory<Caller>,
+{
+    fn read_multi_values_bytes_new(
+        caller: &mut Caller,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<u32, RuntimeError> {
+        Ok(caller.user_data_mut().insert(keys) as u32)
+    }
+
+    fn read_multi_values_bytes_wait(
+        caller: &mut Caller,
+        promise_id: u32,
+    ) -> Result<Vec<Option<Vec<u8>>>, RuntimeError> {
+        let keys = caller
+            .user_data_mut()
+            .get::<Vec<Vec<u8>>>(promise_id as i32)
+            .clone();
+
+        MockSystemApi::new(caller).mocked_read_multi_values_bytes(keys)
+    }
+
+    fn read_value_bytes_new(caller: &mut Caller, key: Vec<u8>) -> Result<u32, RuntimeError> {
+        Ok(caller.user_data_mut().insert(key) as u32)
+    }
+
+    fn read_value_bytes_wait(
+        caller: &mut Caller,
+        promise_id: u32,
+    ) -> Result<Option<Vec<u8>>, RuntimeError> {
+        let key = caller
+            .user_data_mut()
+            .get::<Vec<u8>>(promise_id as i32)
+            .clone();
+
+        MockSystemApi::new(caller).mocked_read_value_bytes(key)
+    }
+
+    fn find_keys_new(caller: &mut Caller, prefix: Vec<u8>) -> Result<u32, RuntimeError> {
+        Ok(caller.user_data_mut().insert(prefix) as u32)
+    }
+
+    fn find_keys_wait(caller: &mut Caller, promise_id: u32) -> Result<Vec<Vec<u8>>, RuntimeError> {
+        let prefix = caller
+            .user_data_mut()
+            .get::<Vec<u8>>(promise_id as i32)
+            .clone();
+
+        MockSystemApi::new(caller).mocked_find_keys(prefix)
+    }
+
+    fn find_key_values_new(caller: &mut Caller, prefix: Vec<u8>) -> Result<u32, RuntimeError> {
+        Ok(caller.user_data_mut().insert(prefix) as u32)
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn find_key_values_wait(
+        caller: &mut Caller,
+        promise_id: u32,
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, RuntimeError> {
+        let prefix = caller
+            .user_data_mut()
+            .get::<Vec<u8>>(promise_id as i32)
+            .clone();
+
+        MockSystemApi::new(caller).mocked_find_key_values(prefix)
+    }
+
+    fn write_batch(
+        caller: &mut Caller,
+        operations: Vec<WriteOperation>,
+    ) -> Result<(), RuntimeError> {
+        MockSystemApi::new(caller).mocked_write_batch(operations)
+    }
+}

--- a/linera-sdk/wit/contract-entrypoints.wit
+++ b/linera-sdk/wit/contract-entrypoints.wit
@@ -1,0 +1,8 @@
+package linera:app;
+
+interface contract-entrypoints {
+    initialize: func(argument: list<u8>) -> result<tuple<>, string>;
+    execute-operation: func(operation: list<u8>) -> result<list<u8>, string>;
+    execute-message: func(message: list<u8>) -> result<tuple<>, string>;
+    finalize: func() -> result<tuple<>, string>;
+}

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -1,0 +1,139 @@
+package linera:app;
+
+interface contract-system-api {
+    get-chain-id: func() -> chain-id;
+    get-block-height: func() -> block-height;
+    get-application-id: func() -> application-id;
+    application-parameters: func() -> list<u8>;
+    authenticated-signer: func() -> option<owner>;
+    read-system-timestamp: func() -> timestamp;
+    get-message-id: func() -> option<message-id>;
+    message-is-bouncing: func() -> option<bool>;
+    authenticated-caller-id: func() -> option<application-id>;
+    read-chain-balance: func() -> amount;
+    read-owner-balance: func(owner: owner) -> amount;
+    send-message: func(message: send-message-request);
+    subscribe: func(chain: chain-id, channel: channel-name);
+    unsubscribe: func(chain: chain-id, channel: channel-name);
+    transfer: func(source: option<owner>, destination: account, amount: amount);
+    claim: func(source: account, destination: account, amount: amount);
+    get-chain-ownership: func() -> chain-ownership;
+    open-chain: func(chain-ownership: chain-ownership, balance: amount) -> chain-id;
+    close-chain: func() -> result<tuple<>, close-chain-error>;
+    try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
+    log: func(message: string, level: log-level);
+
+    record account {
+        chain-id: chain-id,
+        owner: option<owner>,
+    }
+
+    record amount {
+        inner0: u128,
+    }
+
+    record application-id {
+        bytecode-id: bytecode-id,
+        creation: message-id,
+    }
+
+    record block-height {
+        inner0: u64,
+    }
+
+    record bytecode-id {
+        message-id: message-id,
+    }
+
+    record chain-id {
+        inner0: crypto-hash,
+    }
+
+    record chain-ownership {
+        super-owners: list<tuple<owner, public-key>>,
+        owners: list<tuple<owner, tuple<public-key, u64>>>,
+        multi-leader-rounds: u32,
+        timeout-config: timeout-config,
+    }
+
+    record channel-name {
+        inner0: list<u8>,
+    }
+
+    enum close-chain-error {
+        not-permitted,
+    }
+
+    record crypto-hash {
+        part1: u64,
+        part2: u64,
+        part3: u64,
+        part4: u64,
+    }
+
+    variant destination {
+        recipient(chain-id),
+        subscribers(channel-name),
+    }
+
+    enum log-level {
+        error,
+        warn,
+        info,
+        debug,
+        trace,
+    }
+
+    record message-id {
+        chain-id: chain-id,
+        height: block-height,
+        index: u32,
+    }
+
+    record owner {
+        inner0: crypto-hash,
+    }
+
+    record public-key {
+        part1: u64,
+        part2: u64,
+        part3: u64,
+        part4: u64,
+    }
+
+    record resources {
+        fuel: u64,
+        read-operations: u32,
+        write-operations: u32,
+        bytes-to-read: u32,
+        bytes-to-write: u32,
+        messages: u32,
+        message-size: u32,
+        storage-size-delta: u32,
+    }
+
+    record send-message-request {
+        destination: destination,
+        authenticated: bool,
+        is-tracked: bool,
+        grant: resources,
+        message: list<u8>,
+    }
+
+    record time-delta {
+        inner0: u64,
+    }
+
+    record timeout-config {
+        fast-round-duration: option<time-delta>,
+        base-timeout: time-delta,
+        timeout-increment: time-delta,
+        fallback-duration: time-delta,
+    }
+
+    record timestamp {
+        inner0: u64,
+    }
+
+    type u128 = tuple<u64, u64>;
+}

--- a/linera-sdk/wit/contract.wit
+++ b/linera-sdk/wit/contract.wit
@@ -1,0 +1,8 @@
+package linera:app;
+
+world contract {
+    import contract-system-api;
+    import view-system-api;
+
+    export contract-entrypoints;
+}

--- a/linera-sdk/wit/mock-system-api.wit
+++ b/linera-sdk/wit/mock-system-api.wit
@@ -1,0 +1,70 @@
+package linera:app;
+
+interface mock-system-api {
+    mocked-chain-id: func() -> chain-id;
+    mocked-application-id: func() -> application-id;
+    mocked-application-parameters: func() -> list<u8>;
+    mocked-read-chain-balance: func() -> amount;
+    mocked-read-system-timestamp: func() -> timestamp;
+    mocked-log: func(message: string, level: log-level);
+    mocked-read-multi-values-bytes: func(keys: list<list<u8>>) -> list<option<list<u8>>>;
+    mocked-read-value-bytes: func(key: list<u8>) -> option<list<u8>>;
+    mocked-find-keys: func(prefix: list<u8>) -> list<list<u8>>;
+    mocked-find-key-values: func(prefix: list<u8>) -> list<tuple<list<u8>, list<u8>>>;
+    mocked-write-batch: func(operations: list<write-operation>);
+    mocked-try-query-application: func(application: application-id, query: list<u8>) -> list<u8>;
+
+    record amount {
+        inner0: u128,
+    }
+
+    record application-id {
+        bytecode-id: bytecode-id,
+        creation: message-id,
+    }
+
+    record block-height {
+        inner0: u64,
+    }
+
+    record bytecode-id {
+        message-id: message-id,
+    }
+
+    record chain-id {
+        inner0: crypto-hash,
+    }
+
+    record crypto-hash {
+        part1: u64,
+        part2: u64,
+        part3: u64,
+        part4: u64,
+    }
+
+    enum log-level {
+        error,
+        warn,
+        info,
+        debug,
+        trace,
+    }
+
+    record message-id {
+        chain-id: chain-id,
+        height: block-height,
+        index: u32,
+    }
+
+    record timestamp {
+        inner0: u64,
+    }
+
+    type u128 = tuple<u64, u64>;
+
+    variant write-operation {
+        delete(list<u8>),
+        delete-prefix(list<u8>),
+        put(tuple<list<u8>, list<u8>>),
+    }
+}

--- a/linera-sdk/wit/service-entrypoints.wit
+++ b/linera-sdk/wit/service-entrypoints.wit
@@ -1,0 +1,5 @@
+package linera:app;
+
+interface service-entrypoints {
+    handle-query: func(argument: list<u8>) -> result<list<u8>, string>;
+}

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -1,0 +1,67 @@
+package linera:app;
+
+interface service-system-api {
+    get-chain-id: func() -> chain-id;
+    get-next-block-height: func() -> block-height;
+    get-application-id: func() -> application-id;
+    get-application-parameters: func() -> list<u8>;
+    read-chain-balance: func() -> amount;
+    read-owner-balance: func(owner: owner) -> amount;
+    read-system-timestamp: func() -> timestamp;
+    read-owner-balances: func() -> list<tuple<owner, amount>>;
+    read-balance-owners: func() -> list<owner>;
+    try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
+    log: func(message: string, level: log-level);
+
+    record amount {
+        inner0: u128,
+    }
+
+    record application-id {
+        bytecode-id: bytecode-id,
+        creation: message-id,
+    }
+
+    record block-height {
+        inner0: u64,
+    }
+
+    record bytecode-id {
+        message-id: message-id,
+    }
+
+    record chain-id {
+        inner0: crypto-hash,
+    }
+
+    record crypto-hash {
+        part1: u64,
+        part2: u64,
+        part3: u64,
+        part4: u64,
+    }
+
+    enum log-level {
+        error,
+        warn,
+        info,
+        debug,
+        trace,
+    }
+
+    record message-id {
+        chain-id: chain-id,
+        height: block-height,
+        index: u32,
+    }
+
+    record owner {
+        inner0: crypto-hash,
+    }
+
+    record timestamp {
+        inner0: u64,
+    }
+
+    type u128 = tuple<u64, u64>;
+}

--- a/linera-sdk/wit/service.wit
+++ b/linera-sdk/wit/service.wit
@@ -1,0 +1,8 @@
+package linera:app;
+
+world service {
+    import service-system-api;
+    import view-system-api;
+
+    export service-entrypoints;
+}

--- a/linera-sdk/wit/unit-tests.wit
+++ b/linera-sdk/wit/unit-tests.wit
@@ -1,0 +1,9 @@
+package linera:app;
+
+world unit-tests {
+    import contract-system-api;
+    import service-system-api;
+    import view-system-api;
+
+    export mock-system-api;
+}

--- a/linera-sdk/wit/view-system-api.wit
+++ b/linera-sdk/wit/view-system-api.wit
@@ -1,0 +1,21 @@
+package linera:app;
+
+interface view-system-api {
+    contains-key-new: func(key: list<u8>) -> u32;
+    contains-key-wait: func(promise-id: u32) -> bool;
+    read-multi-values-bytes-new: func(keys: list<list<u8>>) -> u32;
+    read-multi-values-bytes-wait: func(promise-id: u32) -> list<option<list<u8>>>;
+    read-value-bytes-new: func(key: list<u8>) -> u32;
+    read-value-bytes-wait: func(promise-id: u32) -> option<list<u8>>;
+    find-keys-new: func(key-prefix: list<u8>) -> u32;
+    find-keys-wait: func(promise-id: u32) -> list<list<u8>>;
+    find-key-values-new: func(key-prefix: list<u8>) -> u32;
+    find-key-values-wait: func(promise-id: u32) -> list<tuple<list<u8>, list<u8>>>;
+    write-batch: func(operations: list<write-operation>);
+
+    variant write-operation {
+        delete(list<u8>),
+        delete-prefix(list<u8>),
+        put(tuple<list<u8>, list<u8>>),
+    }
+}


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
With Witty, the source of truth for the WIT interface is the Rust code. Witty can then be used to generate the WIT files that `wit-bindgen` can use inside the applications. But this requires a custom binary to actually generate the needed WIT files, and they must also be kept up-to-date with the Rust source of truth.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a new binary in `linera-sdk` that generates the WIT files for the SDK. The same binary can also check if the files are up-to-date with its expected contents.

A new CI step was added to run the binary to check if the WIT files are up-to-date.

The mock system API was also rewritten to use Witty, so that its WIT files can be generated.

## Test Plan

<!-- How to test that the changes are correct. -->
I manually tested if the binary returns a non-zero status code if the files differ from their expected contents.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
The WIT files aren't used yet, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
