### PR TITLE
Add TestClock::sleep to make sleeps respect simulated time.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -112,33 +112,33 @@ pub enum Round {
 pub struct TimeDelta(u64);
 
 impl TimeDelta {
-    /// Returns the given number of microseconds as a `TimeDelta`.
+    /// Returns the given number of microseconds as a [`TimeDelta`].
     pub fn from_micros(micros: u64) -> Self {
         TimeDelta(micros)
     }
 
-    /// Returns the given number of milliseconds as a `TimeDelta`.
+    /// Returns the given number of milliseconds as a [`TimeDelta`].
     pub fn from_millis(millis: u64) -> Self {
         TimeDelta(millis.saturating_mul(1_000))
     }
 
-    /// Returns the given number of seconds as a `TimeDelta`.
+    /// Returns the given number of seconds as a [`TimeDelta`].
     pub fn from_secs(secs: u64) -> Self {
         TimeDelta(secs.saturating_mul(1_000_000))
     }
 
     /// Returns the given duration, rounded to the nearest microsecond and capped to the maximum
-    /// `TimeDelta` value.
+    /// [`TimeDelta`] value.
     pub fn from_duration(duration: Duration) -> Self {
         TimeDelta::from_micros(u64::try_from(duration.as_micros()).unwrap_or(u64::MAX))
     }
 
-    /// Returns this `TimeDelta` as a number of microseconds.
+    /// Returns this [`TimeDelta`] as a number of microseconds.
     pub fn as_micros(&self) -> u64 {
         self.0
     }
 
-    /// Returns this `TimeDelta` as a `Duration`.
+    /// Returns this [`TimeDelta`] as a [`Duration`].
     pub fn as_duration(&self) -> Duration {
         Duration::from_micros(self.as_micros())
     }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -127,9 +127,20 @@ impl TimeDelta {
         TimeDelta(secs.saturating_mul(1_000_000))
     }
 
+    /// Returns the given duration, rounded to the nearest microsecond and capped to the maximum
+    /// `TimeDelta` value.
+    pub fn from_duration(duration: Duration) -> Self {
+        TimeDelta::from_micros(u64::try_from(duration.as_micros()).unwrap_or(u64::MAX))
+    }
+
     /// Returns this `TimeDelta` as a number of microseconds.
     pub fn as_micros(&self) -> u64 {
         self.0
+    }
+
+    /// Returns this `TimeDelta` as a `Duration`.
+    pub fn as_duration(&self) -> Duration {
+        Duration::from_micros(self.as_micros())
     }
 }
 

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1286,7 +1286,7 @@ where
     /// This will usually be the current time according to the local clock, but may be slightly
     /// ahead to make sure it's not earlier than the incoming messages or the previous block.
     async fn next_timestamp(&self, incoming_messages: &[IncomingMessage]) -> Timestamp {
-        let local_time = self.storage_client().await.current_time();
+        let local_time = self.storage_client().await.clock().current_time();
         incoming_messages
             .iter()
             .map(|msg| msg.event.timestamp)
@@ -1534,7 +1534,7 @@ where
         // If the current round has timed out, we request a timeout certificate and retry in
         // the next round.
         if let Some(round_timeout) = info.manager.round_timeout {
-            if round_timeout <= self.storage_client().await.current_time() {
+            if round_timeout <= self.storage_client().await.clock().current_time() {
                 self.request_leader_timeout().await?;
                 info = self.chain_info_with_manager_values().await?;
             }

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -137,7 +137,7 @@ where
         let mut client = self.client.lock().await;
 
         if self.start_timestamp < self.end_timestamp {
-            let local_time = client.storage_client().await.current_time();
+            let local_time = client.storage_client().await.clock().current_time();
             if local_time < self.end_timestamp {
                 let full_duration = self
                     .end_timestamp
@@ -237,7 +237,7 @@ where
         end_timestamp: Timestamp,
         genesis_config: Arc<GenesisConfig>,
     ) -> anyhow::Result<Self> {
-        let start_timestamp = client.storage_client().await.current_time();
+        let start_timestamp = client.storage_client().await.clock().current_time();
         client.process_inbox().await?;
         let start_balance = client.local_balance().await?;
         Ok(Self {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -253,14 +253,7 @@ impl TestClockInner {
     }
 
     fn add_sleep(&mut self, delta: TimeDelta) -> Receiver<()> {
-        let (sender, receiver) = oneshot::channel();
-        if delta == TimeDelta::ZERO {
-            let _ = sender.send(());
-        } else {
-            let until = self.time.saturating_add(delta);
-            self.sleeps.entry(Reverse(until)).or_default().push(sender);
-        }
-        receiver
+        self.add_sleep_until(self.time.saturating_add(delta))
     }
 
     fn add_sleep_until(&mut self, time: Timestamp) -> Receiver<()> {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -80,7 +80,7 @@ pub trait Storage: Sized {
     type ContextError: std::error::Error + Debug + Sync + Send;
 
     /// Returns the current wall clock time.
-    fn current_time(&self) -> Timestamp;
+    fn clock(&self) -> &dyn Clock;
 
     /// Loads the view of a chain state.
     async fn load_chain(&self, id: ChainId) -> Result<ChainStateView<Self::Context>, ViewError>
@@ -176,7 +176,7 @@ pub trait Storage: Sized {
         chain.manager.get_mut().reset(
             &ChainOwnership::single(public_key),
             BlockHeight(0),
-            self.current_time(),
+            self.clock().current_time(),
             committee.keys_and_weights(),
         )?;
         let system_state = &mut chain.execution_state.system;


### PR DESCRIPTION
## Motivation

For `ChainListener` unit tests we will need to use the `TestClock`, and `sleep` calls need to wake up whenever the simulated time is set high enough.

## Proposal

Add `sleep` to `TestClock`, which only waits until it receives a value from a channel. `TestClock::set` and `add` send to these channels accordingly.

Inside `TestClock` we use a standard mutex, not an asynchronous one, since the guard is never held across an `await` point. (And it would be ironic if `current_time` was `async`!)

## Test Plan

This will be used in tests in a later PR.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
