### PR TITLE
Add `fetch_url` to `ServiceSystemApi` type exported by Witty

### DIFF
--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -414,6 +414,15 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Fetches a blob of bytes from a given URL.
+    fn fetch_url(caller: &mut Caller, url: String) -> Result<Vec<u8>, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .fetch_url(&url)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Logs a `message` with the provided information `level`.
     fn log(_caller: &mut Caller, message: String, level: log::Level) -> Result<(), RuntimeError> {
         match level {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -11,6 +11,7 @@ interface service-system-api {
     read-owner-balances: func() -> list<tuple<owner, amount>>;
     read-balance-owners: func() -> list<owner>;
     try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
+    fetch-url: func(url: string) -> list<u8>;
     log: func(message: string, level: log-level);
 
     record amount {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `fetch_url` service system API is fairly new, and unfortunately was left out of the new `ServiceSystemApi` type that exports the APIs using Witty.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add the method to `ServiceSystemApi` and regenerate the WIT files (~but first check if CI catches the missing update to the WIT files~ Done).

## Test Plan

<!-- How to test that the changes are correct. -->
The API will be covered by an AI demo.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
The `ServiceSystemApi` and new WIT files aren't used yet, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
