### PR TITLE
Handle timeouts returned by process_inbox_if_owned in ChainListener.

### DIFF
--- a/linera-base/src/ownership.rs
+++ b/linera-base/src/ownership.rs
@@ -141,9 +141,16 @@ impl ChainOwnership {
         }
     }
 
-    /// Returns an iterator over all super owners' keys, followed by all owners'.
+    /// Returns an iterator over all super owners, followed by all owners.
     pub fn all_owners(&self) -> impl Iterator<Item = &Owner> {
         self.super_owners.keys().chain(self.owners.keys())
+    }
+
+    /// Returns an iterator over all super owners' keys, followed by all owners'.
+    pub fn all_public_keys(&self) -> impl Iterator<Item = &PublicKey> {
+        self.super_owners
+            .values()
+            .chain(self.owners.values().map(|(public_key, _)| public_key))
     }
 
     /// Returns the round following the specified one, if any.

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -94,6 +94,7 @@ impl chain_listener::ClientContext<NodeProvider> for ClientContext {
         timestamp: Timestamp,
     ) {
         self.update_wallet_for_new_chain(chain_id, key_pair, timestamp);
+        self.save_wallet();
     }
 
     async fn update_wallet<'a, S>(&'a mut self, client: &'a mut ChainClient<NodeProvider, S>)

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::lock::Mutex;
+use linera_base::{
+    crypto::{KeyPair, PublicKey},
+    data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
+    identifiers::{ChainDescription, ChainId},
+    ownership::{ChainOwnership, TimeoutConfig},
+};
+use linera_core::{
+    client::{ChainClient, ChainClientBuilder},
+    node::CrossChainMessageDelivery,
+    test_utils::{MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
+};
+use linera_execution::{
+    system::{Recipient, UserData},
+    ResourceControlPolicy,
+};
+use linera_rpc::{
+    config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
+    simple::TransportProtocol,
+};
+use linera_storage::{Clock, MemoryStorage, Storage, TestClock};
+use linera_views::views::ViewError;
+use rand::SeedableRng as _;
+
+use crate::{
+    chain_listener::{self, ChainListener, ChainListenerConfig, ClientContext as _},
+    config::{CommitteeConfig, GenesisConfig, ValidatorConfig},
+    wallet::{UserChain, Wallet},
+};
+
+struct ClientContext {
+    wallet: Wallet,
+    chain_client_builder: ChainClientBuilder<NodeProvider<MemoryStorage<TestClock>>>,
+}
+
+#[async_trait]
+impl chain_listener::ClientContext<NodeProvider<MemoryStorage<TestClock>>> for ClientContext {
+    fn wallet(&self) -> &Wallet {
+        &self.wallet
+    }
+
+    fn make_chain_client<S>(
+        &self,
+        storage: S,
+        chain_id: ChainId,
+    ) -> ChainClient<NodeProvider<MemoryStorage<TestClock>>, S> {
+        let chain = self
+            .wallet
+            .get(chain_id)
+            .unwrap_or_else(|| panic!("Unknown chain: {}", chain_id));
+        let known_key_pairs = chain
+            .key_pair
+            .as_ref()
+            .map(|kp| kp.copy())
+            .into_iter()
+            .collect();
+        self.chain_client_builder.build(
+            chain_id,
+            known_key_pairs,
+            storage,
+            self.wallet.genesis_admin_chain(),
+            chain.block_hash,
+            chain.timestamp,
+            chain.next_block_height,
+            chain.pending_block.clone(),
+        )
+    }
+
+    fn update_wallet_for_new_chain(
+        &mut self,
+        chain_id: ChainId,
+        key_pair: Option<KeyPair>,
+        timestamp: Timestamp,
+    ) {
+        if self.wallet.get(chain_id).is_none() {
+            self.wallet.insert(UserChain {
+                chain_id,
+                key_pair: key_pair.as_ref().map(|kp| kp.copy()),
+                block_hash: None,
+                timestamp,
+                next_block_height: BlockHeight::ZERO,
+                pending_block: None,
+            });
+        }
+    }
+
+    async fn update_wallet<'a, S>(
+        &'a mut self,
+        client: &'a mut ChainClient<NodeProvider<MemoryStorage<TestClock>>, S>,
+    ) where
+        S: Storage + Clone + Send + Sync + 'static,
+        ViewError: From<S::ContextError>,
+    {
+        self.wallet.update_from_state(client).await;
+    }
+}
+
+fn make_genesis_config(builder: &TestBuilder<MemoryStorageBuilder>) -> GenesisConfig {
+    let network = ValidatorPublicNetworkPreConfig {
+        protocol: NetworkProtocol::Simple(TransportProtocol::Tcp),
+        host: "localhost".to_string(),
+        port: 8080,
+    };
+    let validator_names = builder.initial_committee.validators().keys();
+    let validators = validator_names
+        .map(|name| ValidatorConfig {
+            name: *name,
+            network: network.clone(),
+        })
+        .collect();
+    let mut genesis_config = GenesisConfig::new(
+        CommitteeConfig { validators },
+        builder.admin_id(),
+        Timestamp::from(0),
+        ResourceControlPolicy::default(),
+        "test network".to_string(),
+    );
+    genesis_config.chains.extend(builder.genesis_chains());
+    genesis_config
+}
+
+/// Tests that the chain listener, if there is a message in the inbox, will continue requesting
+/// timeout certificates until it becomes the leader and can process the inbox.
+#[test_log::test(tokio::test)]
+async fn test_chain_listener() -> anyhow::Result<()> {
+    // Create two chains.
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+    let config = ChainListenerConfig::default();
+    let storage_builder = MemoryStorageBuilder::default();
+    let clock = storage_builder.clock().clone();
+    let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
+    let description0 = ChainDescription::Root(0);
+    let description1 = ChainDescription::Root(1);
+    let chain_id0 = ChainId::from(description0);
+    let mut client0 = builder.add_initial_chain(description0, Amount::ONE).await?;
+    let mut client1 = builder.add_initial_chain(description1, Amount::ONE).await?;
+
+    // Start a chain listener for chain 0 with a new key.
+    let genesis_config = make_genesis_config(&builder);
+    let storage = builder.make_storage().await?;
+    let delivery = CrossChainMessageDelivery::NonBlocking;
+    let mut context = ClientContext {
+        wallet: Wallet::new(genesis_config, Some(37)),
+        chain_client_builder: ChainClientBuilder::new(builder.make_node_provider(), 10, delivery),
+    };
+    let key_pair = KeyPair::generate_from(&mut rng);
+    let public_key = key_pair.public();
+    context.update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time());
+    let context = Arc::new(Mutex::new(context));
+    let listener = ChainListener::new(config, Default::default());
+    listener.run(context, storage).await;
+
+    // Transfer ownership of chain 0 to the chain listener and some other key. The listener will
+    // be leader in ~10% of the rounds.
+    let owners = [(public_key, 1), (PublicKey::test_key(1), 9)];
+    let timeout_config = TimeoutConfig {
+        base_timeout: TimeDelta::from_secs(1),
+        timeout_increment: TimeDelta::ZERO,
+        ..TimeoutConfig::default()
+    };
+    client0
+        .change_ownership(ChainOwnership::multiple(owners, 0, timeout_config))
+        .await?;
+
+    // Transfer one token to chain 0. The listener should eventually become leader and receive
+    // the message.
+    let recipient0 = Recipient::chain(chain_id0);
+    client1
+        .transfer(None, Amount::ONE, recipient0, UserData::default())
+        .await?;
+    for i in 0.. {
+        client0.synchronize_from_validators().await?;
+        let balance = client0.local_balance().await?;
+        if balance == Amount::from_tokens(2) {
+            break;
+        }
+        clock.add(TimeDelta::from_secs(1));
+        if i == 30 {
+            panic!("Unexpected local balance: {}", balance);
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

These are currently being ignored, so incoming messages sometimes won't get processed until the next notification in multi-owner chains.

## Proposal

Set a timeout if it is returned: In the chain listener loop, wait for either the timeout or a new notification.

## Test Plan

A unit test was added.

## Links

- #1906 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
