### PR TITLE
Run check-all-features also without --all-targets.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -197,6 +197,7 @@ jobs:
         cargo doc --locked --all-features
     - name: Run cargo check-all-features
       run: |
+        cargo check-all-features
         cargo check-all-features --all-targets
     - name: Restore `rust-toolchain.toml` file
       if: '!cancelled()'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ prettyplease = "0.2.16"
 prometheus = "0.13.3"
 proc-macro-error = "1.0.4"
 proc-macro2 = "1.0"
-proptest = { version = "1.4.0", default-features = false }
+proptest = { version = "1.4.0", default-features = false, features = ["alloc"] }
 prost = "0.12.3"
 quote = "1.0"
 rand = { version = "0.8.5", default-features = false }

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -22,7 +22,7 @@ mod kubectl;
 pub mod local_kubernetes_net;
 /// How to run Linera validators locally as native processes.
 pub mod local_net;
-#[cfg(feature = "remote_net")]
+#[cfg(all(with_testing, feature = "remote_net"))]
 /// How to connect to running GCP DevNet.
 pub mod remote_net;
 #[cfg(feature = "kubernetes")]

--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -17,12 +17,10 @@ use crate::{
     config::Export,
 };
 
-#[cfg(with_testing)]
 pub struct RemoteNetTestingConfig {
     faucet: Faucet,
 }
 
-#[cfg(with_testing)]
 impl RemoteNetTestingConfig {
     pub fn new(faucet_url: Option<String>) -> Self {
         Self {
@@ -36,7 +34,6 @@ impl RemoteNetTestingConfig {
     }
 }
 
-#[cfg(with_testing)]
 #[async_trait]
 impl LineraNetConfig for RemoteNetTestingConfig {
     type Net = RemoteNet;
@@ -76,7 +73,6 @@ impl LineraNetConfig for RemoteNetTestingConfig {
 }
 
 /// Remote net
-#[cfg(with_testing)]
 #[derive(Clone)]
 pub struct RemoteNet {
     network: Network,
@@ -85,7 +81,6 @@ pub struct RemoteNet {
     tmp_dir: Arc<TempDir>,
 }
 
-#[cfg(with_testing)]
 #[async_trait]
 impl LineraNet for RemoteNet {
     async fn ensure_is_running(&mut self) -> Result<()> {
@@ -118,7 +113,6 @@ impl LineraNet for RemoteNet {
     }
 }
 
-#[cfg(with_testing)]
 impl RemoteNet {
     async fn new(testing_prng_seed: Option<u64>, faucet: &Faucet) -> Result<Self> {
         let tmp_dir = Arc::new(tempdir()?);


### PR DESCRIPTION
## Motivation

`cargo check-all-features` currently fails due to `proptest` requiring either `std` or `alloc` (thanks @Twey for pointing that out), and prints a few warnings about `remote_net`. 

## Proposal

Use `proptest` with default features, and make the whole `remote_net` module test-only.

## Test Plan

`check-all-features` without `--all-targets` was added to CI.


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
