### PR TITLE
Split off `ChainWorker` type from `WorkerState`

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -29,6 +29,8 @@ use linera_views::{
     views::{CryptoHashView, RootView, View, ViewError},
 };
 use serde::{Deserialize, Serialize};
+#[cfg(with_testing)]
+use {linera_base::identifiers::BytecodeId, linera_execution::BytecodeLocation};
 
 use crate::{
     data_types::{
@@ -378,6 +380,23 @@ where
             .await
             .map_err(|error| ChainError::ExecutionError(error, ChainExecutionContext::Query))?;
         Ok(response)
+    }
+
+    /// Reads the [`BytecodeLocation`] for the requested [`BytecodeId`], if it is registered in
+    /// this chain's [`ApplicationRegistryView`][`linera_execution::ApplicationRegistryView`].
+    #[cfg(with_testing)]
+    pub async fn read_bytecode_location(
+        &mut self,
+        bytecode_id: BytecodeId,
+    ) -> Result<Option<BytecodeLocation>, ChainError> {
+        self.execution_state
+            .system
+            .registry
+            .bytecode_location_for(&bytecode_id)
+            .await
+            .map_err(|err| {
+                ChainError::ExecutionError(err.into(), ChainExecutionContext::ReadBytecodeLocation)
+            })
     }
 
     pub async fn describe_application(

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -396,10 +396,10 @@ where
 
     pub async fn mark_messages_as_received(
         &mut self,
-        target: Target,
+        target: &Target,
         height: BlockHeight,
     ) -> Result<bool, ChainError> {
-        let mut outbox = self.outboxes.try_load_entry_mut(&target).await?;
+        let mut outbox = self.outboxes.try_load_entry_mut(target).await?;
         let updates = outbox.mark_messages_as_received(height).await?;
         if updates.is_empty() {
             return Ok(false);
@@ -419,7 +419,7 @@ where
             }
         }
         if outbox.queue.count() == 0 {
-            self.outboxes.remove_entry(&target)?;
+            self.outboxes.remove_entry(target)?;
         }
         Ok(true)
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -145,6 +145,8 @@ pub enum ChainError {
 #[derive(Copy, Clone, Debug)]
 pub enum ChainExecutionContext {
     Query,
+    #[cfg(with_testing)]
+    ReadBytecodeLocation,
     DescribeApplication,
     IncomingMessage(u32),
     Operation(u32),

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -17,7 +17,10 @@ use {
 };
 
 use super::{config::ChainWorkerConfig, state::ChainWorkerState};
-use crate::{data_types::ChainInfoResponse, worker::WorkerError};
+use crate::{
+    data_types::{ChainInfoQuery, ChainInfoResponse},
+    worker::{NetworkActions, WorkerError},
+};
 
 /// A request for the [`ChainWorkerActor`].
 pub enum ChainWorkerRequest {
@@ -74,6 +77,12 @@ pub enum ChainWorkerRequest {
     ConfirmUpdatedRecipient {
         latest_heights: Vec<(Target, BlockHeight)>,
         callback: oneshot::Sender<Result<BlockHeight, WorkerError>>,
+    },
+
+    /// Handle a [`ChainInfoQuery`].
+    HandleChainInfoQuery {
+        query: ChainInfoQuery,
+        callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 }
 
@@ -173,6 +182,9 @@ where
                 } => {
                     let _ =
                         callback.send(self.worker.confirm_updated_recipient(latest_heights).await);
+                }
+                ChainWorkerRequest::HandleChainInfoQuery { query, callback } => {
+                    let _ = callback.send(self.worker.handle_chain_info_query(query).await);
                 }
             }
         }

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -5,7 +5,7 @@
 
 use linera_base::identifiers::ChainId;
 use linera_chain::data_types::{Block, ExecutedBlock};
-use linera_execution::{Query, Response};
+use linera_execution::{Query, Response, UserApplicationDescription, UserApplicationId};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use tokio::sync::{mpsc, oneshot};
@@ -20,6 +20,12 @@ pub enum ChainWorkerRequest {
     QueryApplication {
         query: Query,
         callback: oneshot::Sender<Result<Response, WorkerError>>,
+    },
+
+    /// Describe an application.
+    DescribeApplication {
+        application_id: UserApplicationId,
+        callback: oneshot::Sender<Result<UserApplicationDescription, WorkerError>>,
     },
 
     /// Execute a block but discard any changes to the chain state.
@@ -73,6 +79,12 @@ where
             match request {
                 ChainWorkerRequest::QueryApplication { query, callback } => {
                     let _ = callback.send(self.worker.query_application(query).await);
+                }
+                ChainWorkerRequest::DescribeApplication {
+                    application_id,
+                    callback,
+                } => {
+                    let _ = callback.send(self.worker.describe_application(application_id).await);
                 }
                 ChainWorkerRequest::StageBlockExecution { block, callback } => {
                     let _ = callback.send(self.worker.stage_block_execution(block).await);

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! An actor that runs a chain worker.
+
+use linera_base::identifiers::ChainId;
+use linera_storage::Storage;
+use linera_views::views::ViewError;
+use tokio::sync::mpsc;
+use tracing::{instrument, trace};
+
+use super::{config::ChainWorkerConfig, state::ChainWorkerState};
+use crate::worker::WorkerError;
+
+/// A request for the [`ChainWorkerActor`].
+pub enum ChainWorkerRequest {}
+
+/// The actor worker type.
+pub struct ChainWorkerActor<StorageClient>
+where
+    StorageClient: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    worker: ChainWorkerState<StorageClient>,
+    incoming_requests: mpsc::UnboundedReceiver<ChainWorkerRequest>,
+}
+
+impl<StorageClient> ChainWorkerActor<StorageClient>
+where
+    StorageClient: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    /// Spawns a new task to run the [`ChainWorkerActor`], returning an endpoint for sending
+    /// requests to the worker.
+    pub async fn spawn(
+        config: ChainWorkerConfig,
+        storage: StorageClient,
+        chain_id: ChainId,
+    ) -> Result<mpsc::UnboundedSender<ChainWorkerRequest>, WorkerError> {
+        let worker = ChainWorkerState::new(config, storage, chain_id).await?;
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        let actor = ChainWorkerActor {
+            worker,
+            incoming_requests: receiver,
+        };
+
+        tokio::spawn(actor.run());
+
+        Ok(sender)
+    }
+
+    /// Runs the worker until there are no more incoming requests.
+    #[instrument(skip_all, fields(chain_id = format!("{:.8}", self.worker.chain_id())))]
+    async fn run(mut self) {
+        trace!("Starting `ChainWorkerActor`");
+
+        while let Some(request) = self.incoming_requests.recv().await {
+            match request {}
+        }
+
+        trace!("`ChainWorkerActor` finished");
+    }
+}

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -66,6 +66,12 @@ pub enum ChainWorkerRequest {
         callback: oneshot::Sender<Result<(ExecutedBlock, ChainInfoResponse), WorkerError>>,
     },
 
+    /// Process a leader timeout issued for this multi-owner chain.
+    ProcessTimeout {
+        certificate: Certificate,
+        callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
+    },
+
     /// Process a cross-chain update.
     ProcessCrossChainUpdate {
         origin: Origin,
@@ -164,6 +170,12 @@ where
                 }
                 ChainWorkerRequest::StageBlockExecution { block, callback } => {
                     let _ = callback.send(self.worker.stage_block_execution(block).await);
+                }
+                ChainWorkerRequest::ProcessTimeout {
+                    certificate,
+                    callback,
+                } => {
+                    let _ = callback.send(self.worker.process_timeout(certificate).await);
                 }
                 ChainWorkerRequest::ProcessCrossChainUpdate {
                     origin,

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -3,9 +3,14 @@
 
 //! A worker to handle a single chain.
 
+mod actor;
 mod config;
 mod state;
 
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
-pub use self::{config::ChainWorkerConfig, state::ChainWorkerState};
+pub use self::{
+    actor::{ChainWorkerActor, ChainWorkerRequest},
+    config::ChainWorkerConfig,
+    state::ChainWorkerState,
+};

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A worker to handle a single chain.
+
+mod state;
+
+pub use self::state::ChainWorkerState;

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -3,6 +3,7 @@
 
 //! A worker to handle a single chain.
 
+mod config;
 mod state;
 
-pub use self::state::ChainWorkerState;
+pub use self::{config::ChainWorkerConfig, state::ChainWorkerState};

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -6,4 +6,6 @@
 mod config;
 mod state;
 
+#[cfg(test)]
+pub(crate) use self::state::CrossChainUpdateHelper;
 pub use self::{config::ChainWorkerConfig, state::ChainWorkerState};

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -8,7 +8,7 @@ use linera_chain::{
     data_types::{Block, ExecutedBlock},
     ChainStateView,
 };
-use linera_execution::{Query, Response};
+use linera_execution::{Query, Response, UserApplicationDescription, UserApplicationId};
 use linera_storage::Storage;
 use linera_views::views::{View, ViewError};
 
@@ -50,6 +50,16 @@ where
     pub async fn query_application(&mut self, query: Query) -> Result<Response, WorkerError> {
         self.ensure_is_active()?;
         let response = self.chain.query_application(query).await?;
+        Ok(response)
+    }
+
+    /// Returns an application's description.
+    pub async fn describe_application(
+        &mut self,
+        application_id: UserApplicationId,
+    ) -> Result<UserApplicationDescription, WorkerError> {
+        self.ensure_is_active()?;
+        let response = self.chain.describe_application(application_id).await?;
         Ok(response)
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -6,6 +6,8 @@
 use std::collections::BTreeMap;
 
 use linera_base::{data_types::BlockHeight, ensure, identifiers::ChainId};
+#[cfg(with_testing)]
+use linera_chain::data_types::Certificate;
 use linera_chain::{
     data_types::{Block, ExecutedBlock, MessageBundle, Origin, Target},
     ChainStateView,
@@ -60,6 +62,21 @@ where
     /// Returns the [`ChainId`] of the chain handled by this worker.
     pub fn chain_id(&self) -> ChainId {
         self.chain.chain_id()
+    }
+
+    /// Returns a stored [`Certificate`] for the chain's block at the requested [`BlockHeight`].
+    #[cfg(with_testing)]
+    pub async fn read_certificate(
+        &mut self,
+        height: BlockHeight,
+    ) -> Result<Option<Certificate>, WorkerError> {
+        self.ensure_is_active()?;
+        let certificate_hash = match self.chain.confirmed_log.get(height.try_into()?).await? {
+            Some(hash) => hash,
+            None => return Ok(None),
+        };
+        let certificate = self.storage.read_certificate(certificate_hash).await?;
+        Ok(Some(certificate))
     }
 
     /// Queries an application's state on the chain.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -8,6 +8,7 @@ use linera_chain::{
     data_types::{Block, ExecutedBlock},
     ChainStateView,
 };
+use linera_execution::{Query, Response};
 use linera_storage::Storage;
 use linera_views::views::{View, ViewError};
 
@@ -43,6 +44,13 @@ where
     /// Returns the [`ChainId`] of the chain handled by this worker.
     pub fn chain_id(&self) -> ChainId {
         self.chain.chain_id()
+    }
+
+    /// Queries an application's state on the chain.
+    pub async fn query_application(&mut self, query: Query) -> Result<Response, WorkerError> {
+        self.ensure_is_active()?;
+        let response = self.chain.query_application(query).await?;
+        Ok(response)
     }
 
     /// Executes a block without persisting any changes to the state.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -3,12 +3,18 @@
 
 //! The state and functionality of a chain worker.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
-use linera_base::{data_types::BlockHeight, ensure, identifiers::ChainId};
+use linera_base::{
+    data_types::{ArithmeticError, BlockHeight},
+    ensure,
+    identifiers::ChainId,
+};
 use linera_chain::{
-    data_types::{Block, ExecutedBlock, MessageBundle, Origin, Target},
-    ChainStateView,
+    data_types::{
+        Block, ExecutedBlock, IncomingMessage, Medium, MessageAction, MessageBundle, Origin, Target,
+    },
+    ChainError, ChainStateView,
 };
 use linera_execution::{
     committee::{Committee, Epoch},
@@ -28,12 +34,15 @@ use {
 };
 
 use super::ChainWorkerConfig;
-use crate::{data_types::ChainInfoResponse, worker::WorkerError};
+use crate::{
+    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    worker::{NetworkActions, WorkerError},
+};
 
 /// The state of the chain worker.
 pub struct ChainWorkerState<StorageClient>
 where
-    StorageClient: Storage + Send + Sync + 'static,
+    StorageClient: Storage + Clone + Send + Sync + 'static,
     ViewError: From<StorageClient::ContextError>,
 {
     config: ChainWorkerConfig,
@@ -44,7 +53,7 @@ where
 
 impl<StorageClient> ChainWorkerState<StorageClient>
 where
-    StorageClient: Storage + Send + Sync + 'static,
+    StorageClient: Storage + Clone + Send + Sync + 'static,
     ViewError: From<StorageClient::ContextError>,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
@@ -236,6 +245,113 @@ where
         Ok(height_with_fully_delivered_messages)
     }
 
+    /// Handles a [`ChainInfoQuery`], potentially voting on the next block.
+    pub async fn handle_chain_info_query(
+        &mut self,
+        query: ChainInfoQuery,
+    ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
+        let chain_id = self.chain.chain_id();
+        if query.request_leader_timeout {
+            if let Some(epoch) = self.chain.execution_state.system.epoch.get() {
+                let height = self.chain.tip_state.get().next_block_height;
+                let key_pair = self.config.key_pair();
+                let local_time = self.storage.clock().current_time();
+                let manager = self.chain.manager.get_mut();
+                if manager.vote_timeout(chain_id, height, *epoch, key_pair, local_time) {
+                    self.chain.save().await?;
+                }
+            }
+        }
+        if query.request_fallback {
+            if let (Some(epoch), Some(entry)) = (
+                self.chain.execution_state.system.epoch.get(),
+                self.chain.unskippable.front().await?,
+            ) {
+                let ownership = self.chain.execution_state.system.ownership.get();
+                let elapsed = self.storage.clock().current_time().delta_since(entry.seen);
+                if elapsed >= ownership.timeout_config.fallback_duration {
+                    let height = self.chain.tip_state.get().next_block_height;
+                    let key_pair = self.config.key_pair();
+                    let manager = self.chain.manager.get_mut();
+                    if manager.vote_fallback(chain_id, height, *epoch, key_pair) {
+                        self.chain.save().await?;
+                    }
+                }
+            }
+        }
+        let mut info = ChainInfo::from(&self.chain);
+        if query.request_committees {
+            info.requested_committees =
+                Some(self.chain.execution_state.system.committees.get().clone());
+        }
+        if let Some(owner) = query.request_owner_balance {
+            info.requested_owner_balance = self
+                .chain
+                .execution_state
+                .system
+                .balances
+                .get(&owner)
+                .await?;
+        }
+        if let Some(next_block_height) = query.test_next_block_height {
+            ensure!(
+                self.chain.tip_state.get().next_block_height == next_block_height,
+                WorkerError::UnexpectedBlockHeight {
+                    expected_block_height: next_block_height,
+                    found_block_height: self.chain.tip_state.get().next_block_height
+                }
+            );
+        }
+        if query.request_pending_messages {
+            let mut messages = Vec::new();
+            let origins = self.chain.inboxes.indices().await?;
+            let inboxes = self.chain.inboxes.try_load_entries(&origins).await?;
+            let action = if *self.chain.execution_state.system.closed.get() {
+                MessageAction::Reject
+            } else {
+                MessageAction::Accept
+            };
+            for (origin, inbox) in origins.into_iter().zip(inboxes) {
+                for event in inbox.added_events.elements().await? {
+                    messages.push(IncomingMessage {
+                        origin: origin.clone(),
+                        event: event.clone(),
+                        action,
+                    });
+                }
+            }
+
+            info.requested_pending_messages = messages;
+        }
+        if let Some(range) = query.request_sent_certificates_in_range {
+            let start: usize = range.start.try_into()?;
+            let end = match range.limit {
+                None => self.chain.confirmed_log.count(),
+                Some(limit) => start
+                    .checked_add(usize::try_from(limit).map_err(|_| ArithmeticError::Overflow)?)
+                    .ok_or(ArithmeticError::Overflow)?
+                    .min(self.chain.confirmed_log.count()),
+            };
+            let keys = self.chain.confirmed_log.read(start..end).await?;
+            let certs = self.storage.read_certificates(keys).await?;
+            info.requested_sent_certificates = certs;
+        }
+        if let Some(start) = query.request_received_log_excluding_first_nth {
+            let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
+            info.requested_received_log = self.chain.received_log.read(start..).await?;
+        }
+        if let Some(hash) = query.request_blob {
+            info.requested_blob = Some(self.storage.read_hashed_certificate_value(hash).await?);
+        }
+        if query.request_manager_values {
+            info.manager.add_values(self.chain.manager.get());
+        }
+        let response = ChainInfoResponse::new(info, self.config.key_pair());
+        // Trigger any outgoing cross-chain messages that haven't been confirmed yet.
+        let actions = self.create_network_actions().await?;
+        Ok((response, actions))
+    }
+
     /// Ensures that the current chain is active, returning an error otherwise.
     fn ensure_is_active(&mut self) -> Result<(), WorkerError> {
         if !self.knows_chain_is_active {
@@ -243,6 +359,82 @@ where
             self.knows_chain_is_active = true;
         }
         Ok(())
+    }
+
+    /// Loads pending cross-chain requests.
+    async fn create_network_actions(&self) -> Result<NetworkActions, WorkerError> {
+        let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
+        let targets = self.chain.outboxes.indices().await?;
+        let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
+        for (target, outbox) in targets.into_iter().zip(outboxes) {
+            let heights = outbox.queue.elements().await?;
+            heights_by_recipient
+                .entry(target.recipient)
+                .or_default()
+                .insert(target.medium, heights);
+        }
+        let mut actions = NetworkActions::default();
+        for (recipient, height_map) in heights_by_recipient {
+            let request = self
+                .create_cross_chain_request(height_map.into_iter().collect(), recipient)
+                .await?;
+            actions.cross_chain_requests.push(request);
+        }
+        Ok(actions)
+    }
+
+    /// Creates an `UpdateRecipient` request that informs the `recipient` about new
+    /// cross-chain messages from this chain.
+    async fn create_cross_chain_request(
+        &self,
+        height_map: Vec<(Medium, Vec<BlockHeight>)>,
+        recipient: ChainId,
+    ) -> Result<CrossChainRequest, WorkerError> {
+        // Load all the certificates we will need, regardless of the medium.
+        let heights =
+            BTreeSet::from_iter(height_map.iter().flat_map(|(_, heights)| heights).copied());
+        let heights_usize = heights
+            .iter()
+            .copied()
+            .map(usize::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        let hashes = self
+            .chain
+            .confirmed_log
+            .multi_get(heights_usize.clone())
+            .await?
+            .into_iter()
+            .zip(heights_usize)
+            .map(|(maybe_hash, height)| {
+                maybe_hash.ok_or_else(|| ViewError::not_found("confirmed log entry", height))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let certificates = self.storage.read_certificates(hashes).await?;
+        let certificates = heights
+            .into_iter()
+            .zip(certificates)
+            .collect::<HashMap<_, _>>();
+        // For each medium, select the relevant messages.
+        let bundle_vecs = height_map
+            .into_iter()
+            .map(|(medium, heights)| {
+                let bundles = heights
+                    .into_iter()
+                    .map(|height| {
+                        certificates
+                            .get(&height)?
+                            .message_bundle_for(&medium, recipient)
+                    })
+                    .collect::<Option<_>>()?;
+                Some((medium, bundles))
+            })
+            .collect::<Option<_>>()
+            .ok_or_else(|| ChainError::InternalError("missing certificates".to_string()))?;
+        Ok(CrossChainRequest::UpdateRecipient {
+            sender: self.chain.chain_id(),
+            recipient,
+            bundle_vecs,
+        })
     }
 }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The state and functionality of a chain worker.
+
+use linera_base::identifiers::ChainId;
+use linera_chain::ChainStateView;
+use linera_storage::Storage;
+use linera_views::views::ViewError;
+
+use crate::worker::WorkerError;
+
+/// The state of the chain worker.
+pub struct ChainWorkerState<StorageClient>
+where
+    StorageClient: Storage + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    storage: StorageClient,
+    chain: ChainStateView<StorageClient::Context>,
+    knows_chain_is_active: bool,
+}
+
+impl<StorageClient> ChainWorkerState<StorageClient>
+where
+    StorageClient: Storage + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
+    pub async fn new(storage: StorageClient, chain_id: ChainId) -> Result<Self, WorkerError> {
+        let chain = storage.load_chain(chain_id).await?;
+
+        Ok(ChainWorkerState {
+            storage,
+            chain,
+            knows_chain_is_active: false,
+        })
+    }
+
+    /// Returns the [`ChainId`] of the chain handled by this worker.
+    pub fn chain_id(&self) -> ChainId {
+        self.chain.chain_id()
+    }
+
+    /// Ensures that the current chain is active, returning an error otherwise.
+    fn ensure_is_active(&mut self) -> Result<(), WorkerError> {
+        if !self.knows_chain_is_active {
+            self.chain.ensure_is_active()?;
+            self.knows_chain_is_active = true;
+        }
+        Ok(())
+    }
+}

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -6,8 +6,6 @@
 use std::collections::BTreeMap;
 
 use linera_base::{data_types::BlockHeight, ensure, identifiers::ChainId};
-#[cfg(with_testing)]
-use linera_chain::data_types::Certificate;
 use linera_chain::{
     data_types::{Block, ExecutedBlock, MessageBundle, Origin, Target},
     ChainStateView,
@@ -22,6 +20,11 @@ use linera_views::{
     views::{RootView, View, ViewError},
 };
 use tracing::{debug, warn};
+#[cfg(with_testing)]
+use {
+    linera_base::identifiers::BytecodeId, linera_chain::data_types::Certificate,
+    linera_execution::BytecodeLocation,
+};
 
 use super::ChainWorkerConfig;
 use crate::{data_types::ChainInfoResponse, worker::WorkerError};
@@ -83,6 +86,18 @@ where
     pub async fn query_application(&mut self, query: Query) -> Result<Response, WorkerError> {
         self.ensure_is_active()?;
         let response = self.chain.query_application(query).await?;
+        Ok(response)
+    }
+
+    /// Returns the [`BytecodeLocation`] for the requested [`BytecodeId`], if it is known by the
+    /// chain.
+    #[cfg(with_testing)]
+    pub async fn read_bytecode_location(
+        &mut self,
+        bytecode_id: BytecodeId,
+    ) -> Result<Option<BytecodeLocation>, WorkerError> {
+        self.ensure_is_active()?;
+        let response = self.chain.read_bytecode_location(bytecode_id).await?;
         Ok(response)
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -12,6 +12,7 @@ use linera_execution::{Query, Response, UserApplicationDescription, UserApplicat
 use linera_storage::Storage;
 use linera_views::views::{RootView, View, ViewError};
 
+use super::ChainWorkerConfig;
 use crate::{data_types::ChainInfoResponse, worker::WorkerError};
 
 /// The state of the chain worker.
@@ -20,6 +21,7 @@ where
     StorageClient: Storage + Send + Sync + 'static,
     ViewError: From<StorageClient::ContextError>,
 {
+    config: ChainWorkerConfig,
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
     knows_chain_is_active: bool,
@@ -31,10 +33,15 @@ where
     ViewError: From<StorageClient::ContextError>,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
-    pub async fn new(storage: StorageClient, chain_id: ChainId) -> Result<Self, WorkerError> {
+    pub async fn new(
+        config: ChainWorkerConfig,
+        storage: StorageClient,
+        chain_id: ChainId,
+    ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
         Ok(ChainWorkerState {
+            config,
             storage,
             chain,
             knows_chain_is_active: false,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -265,6 +265,12 @@ impl ChainInfoResponse {
         Self { info, signature }
     }
 
+    /// Signs the [`ChainInfo`] stored inside this [`ChainInfoResponse`] with the provided
+    /// [`KeyPair`].
+    pub fn sign(&mut self, key_pair: &KeyPair) {
+        self.signature = Some(Signature::new(&*self.info, key_pair));
+    }
+
     pub fn check(&self, name: ValidatorName) -> Result<(), CryptoError> {
         Signature::check_optional_signature(self.signature.as_ref(), &*self.info, name.0)
     }

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! This module defines the core Linera protocol.
 
+pub mod chain_worker;
 pub mod client;
 pub mod data_types;
 pub mod local_node;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -134,7 +134,7 @@ fn make_certificate_with_round<S>(
     value: HashedCertificateValue,
     round: Round,
 ) -> Certificate {
-    let vote = LiteVote::new(value.lite(), round, worker.key_pair.as_ref().unwrap());
+    let vote = LiteVote::new(value.lite(), round, worker.key_pair().unwrap());
     let mut builder = SignatureAggregator::new(value, round, committee);
     builder
         .append(vote.validator, vote.signature)
@@ -1140,7 +1140,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (chain_info_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
-    chain_info_response.check(ValidatorName(worker.key_pair.unwrap().public()))?;
+    chain_info_response.check(ValidatorName(worker.key_pair().unwrap().public()))?;
     let pending_value = worker
         .storage
         .load_active_chain(ChainId::root(1))
@@ -1189,7 +1189,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (response, _actions) = worker.handle_block_proposal(block_proposal.clone()).await?;
-    response.check(ValidatorName(worker.key_pair.as_ref().unwrap().public()))?;
+    response.check(ValidatorName(worker.key_pair().unwrap().public()))?;
     let (replay_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
     // Workaround lack of equality.
     assert_eq!(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3093,7 +3093,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         .unwrap();
 
     let helper = CrossChainUpdateHelper {
-        nickname: "test",
         allow_messages_from_deprecated_epochs: true,
         current_epoch: Some(Epoch::from(1)),
         committees: &committees,
@@ -3143,7 +3142,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     );
 
     let helper = CrossChainUpdateHelper {
-        nickname: "test",
         allow_messages_from_deprecated_epochs: false,
         current_epoch: Some(Epoch::from(1)),
         committees: &committees,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -52,10 +52,11 @@ use crate::test_utils::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
 use crate::test_utils::ScyllaDbStorageBuilder;
 use crate::{
+    chain_worker::CrossChainUpdateHelper,
     data_types::*,
     test_utils::{MemoryStorageBuilder, StorageBuilder},
     worker::{
-        CrossChainUpdateHelper, Notification,
+        Notification,
         Reason::{self, NewBlock, NewIncomingMessage},
         ValidatorWorker, WorkerError, WorkerState,
     },

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -423,21 +423,10 @@ where
         &mut self,
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
-        let chain_actor = ChainWorkerActor::spawn(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            block.chain_id,
-        )
-        .await?;
-        let (callback, response) = oneshot::channel();
-
-        chain_actor
-            .send(ChainWorkerRequest::StageBlockExecution { block, callback })
-            .expect("`ChainWorkerActor` stopped executing unexpectedly");
-
-        response
-            .await
-            .expect("`ChainWorkerActor` stopped executing without responding")
+        self.query_chain_worker(block.chain_id, move |callback| {
+            ChainWorkerRequest::StageBlockExecution { block, callback }
+        })
+        .await
     }
 
     // Schedule a notification when cross-chain messages are delivered up to the given height.
@@ -478,21 +467,10 @@ where
         chain_id: ChainId,
         query: Query,
     ) -> Result<Response, WorkerError> {
-        let chain_actor = ChainWorkerActor::spawn(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            chain_id,
-        )
-        .await?;
-        let (callback, response) = oneshot::channel();
-
-        chain_actor
-            .send(ChainWorkerRequest::QueryApplication { query, callback })
-            .expect("`ChainWorkerActor` stopped executing unexpectedly");
-
-        response
-            .await
-            .expect("`ChainWorkerActor` stopped executing without responding")
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::QueryApplication { query, callback }
+        })
+        .await
     }
 
     #[cfg(with_testing)]
@@ -1026,6 +1004,31 @@ where
             }
         );
         Ok(())
+    }
+
+    /// Sends a request to the [`ChainWorker`] for a [`ChainId`] and waits for the `Response`.
+    async fn query_chain_worker<Response>(
+        &self,
+        chain_id: ChainId,
+        request_builder: impl FnOnce(
+            oneshot::Sender<Result<Response, WorkerError>>,
+        ) -> ChainWorkerRequest,
+    ) -> Result<Response, WorkerError> {
+        let chain_actor = ChainWorkerActor::spawn(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            chain_id,
+        )
+        .await?;
+        let (callback, response) = oneshot::channel();
+
+        chain_actor
+            .send(request_builder(callback))
+            .expect("`ChainWorkerActor` stopped executing unexpectedly");
+
+        response
+            .await
+            .expect("`ChainWorkerActor` stopped executing without responding")
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1243,17 +1243,11 @@ where
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);
-        let result = async move {
-            ChainWorkerState::new(
-                self.chain_worker_config.clone(),
-                self.storage.clone(),
-                query.chain_id,
-            )
-            .await?
-            .handle_chain_info_query(query)
-            .await
-        }
-        .await;
+        let result = self
+            .query_chain_worker(query.chain_id, move |callback| {
+                ChainWorkerRequest::HandleChainInfoQuery { query, callback }
+            })
+            .await;
         trace!("{} --> {:?}", self.nickname, result);
         result
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -961,19 +961,18 @@ where
         };
         let origin = Origin { sender, medium };
 
-        let Some(event) = ChainWorkerState::new(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            chain_id,
-        )
-        .await?
-        .find_event_in_inbox(
-            origin.clone(),
-            certificate.hash(),
-            message_id.height,
-            message_id.index,
-        )
-        .await?
+        let Some(event) = self
+            .query_chain_worker(chain_id, {
+                let origin = origin.clone();
+                move |callback| ChainWorkerRequest::FindEventInInbox {
+                    inbox_id: origin,
+                    certificate_hash: certificate.hash(),
+                    height: message_id.height,
+                    index: message_id.index,
+                    callback,
+                }
+            })
+            .await?
         else {
             return Ok(None);
         };

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -887,7 +887,6 @@ where
         let next_height_to_receive = chain.next_block_height_to_receive(origin).await?;
         let last_anticipated_block_height = chain.last_anticipated_block_height(origin).await?;
         let helper = CrossChainUpdateHelper {
-            nickname: &self.nickname,
             allow_messages_from_deprecated_epochs: self.allow_messages_from_deprecated_epochs,
             current_epoch: *chain.execution_state.system.epoch.get(),
             committees: chain.execution_state.system.committees.get(),
@@ -1447,7 +1446,6 @@ where
 }
 
 struct CrossChainUpdateHelper<'a> {
-    nickname: &'a str,
     allow_messages_from_deprecated_epochs: bool,
     current_epoch: Option<Epoch>,
     committees: &'a BTreeMap<Epoch, Committee>,
@@ -1497,16 +1495,16 @@ impl<'a> CrossChainUpdateHelper<'a> {
         if skipped_len > 0 {
             let sample_bundle = &bundles[skipped_len - 1];
             debug!(
-                "[{}] Ignoring repeated messages to {recipient:?} from {origin:?} at height {}",
-                self.nickname, sample_bundle.height,
+                "Ignoring repeated messages to {recipient:?} from {origin:?} at height {}",
+                sample_bundle.height,
             );
         }
         if skipped_len < bundles.len() && trusted_len < bundles.len() {
             let sample_bundle = &bundles[trusted_len];
             warn!(
-                "[{}] Refusing messages to {recipient:?} from {origin:?} at height {} \
+                "Refusing messages to {recipient:?} from {origin:?} at height {} \
                  because the epoch {:?} is not trusted any more",
-                self.nickname, sample_bundle.height, sample_bundle.epoch,
+                sample_bundle.height, sample_bundle.epoch,
             );
         }
         let certificates = if skipped_len < trusted_len {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1411,22 +1411,15 @@ where
                 recipient,
                 latest_heights,
             } => {
-                let mut chain = self.storage.load_chain(sender).await?;
-                let mut height_with_fully_delivered_messages = BlockHeight::ZERO;
-
-                for (medium, height) in latest_heights {
-                    let target = Target { recipient, medium };
-                    let fully_delivered = chain.mark_messages_as_received(&target, height).await?
-                        && chain.all_messages_delivered_up_to(height);
-
-                    if fully_delivered && height > height_with_fully_delivered_messages {
-                        height_with_fully_delivered_messages = height;
-                    }
-                }
-
-                // Save the chain state.
-                chain.save().await?;
-
+                let latest_heights = latest_heights
+                    .into_iter()
+                    .map(|(medium, height)| (Target { recipient, medium }, height))
+                    .collect();
+                let height_with_fully_delivered_messages =
+                    ChainWorkerState::new(self.storage.clone(), sender)
+                        .await?
+                        .confirm_updated_recipient(latest_heights)
+                        .await?;
                 // Handle delivery notifiers for this chain, if any.
                 if let hash_map::Entry::Occupied(mut map) =
                     self.delivery_notifiers.lock().await.entry(sender)

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -267,9 +267,6 @@ pub(crate) const DEFAULT_VALUE_CACHE_SIZE: usize = 1000;
 pub struct WorkerState<StorageClient> {
     /// A name used for logging
     nickname: String,
-    /// The signature key pair of the validator. The key may be missing for replicas
-    /// without voting rights (possibly with a partial view of chains).
-    key_pair: Option<Arc<KeyPair>>,
     /// Access to local persistent storage.
     storage: StorageClient,
     /// Configuration options for the [`ChainWorker`]s.
@@ -294,9 +291,8 @@ impl<StorageClient> WorkerState<StorageClient> {
         )));
         WorkerState {
             nickname,
-            key_pair: key_pair.map(Arc::new),
             storage,
-            chain_worker_config: ChainWorkerConfig::default(),
+            chain_worker_config: ChainWorkerConfig::default().with_key_pair(key_pair),
             grace_period: Duration::ZERO,
             recent_values,
             delivery_notifiers: Arc::default(),
@@ -311,7 +307,6 @@ impl<StorageClient> WorkerState<StorageClient> {
     ) -> Self {
         WorkerState {
             nickname,
-            key_pair: None,
             storage,
             chain_worker_config: ChainWorkerConfig::default(),
             grace_period: Duration::ZERO,
@@ -359,7 +354,7 @@ impl<StorageClient> WorkerState<StorageClient> {
 
     #[cfg(test)]
     pub(crate) fn with_key_pair(mut self, key_pair: Option<Arc<KeyPair>>) -> Self {
-        self.key_pair = key_pair;
+        self.chain_worker_config.key_pair = key_pair;
         self
     }
 
@@ -1023,7 +1018,7 @@ where
 impl<StorageClient> WorkerState<StorageClient> {
     /// Gets a reference to the [`KeyPair`], if available.
     fn key_pair(&self) -> Option<&KeyPair> {
-        self.key_pair.as_ref().map(Arc::as_ref)
+        self.chain_worker_config.key_pair()
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -494,13 +494,12 @@ where
         chain_id: ChainId,
         application_id: UserApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
-        ChainWorkerState::new(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            chain_id,
-        )
-        .await?
-        .describe_application(application_id)
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::DescribeApplication {
+                application_id,
+                callback,
+            }
+        })
         .await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -487,9 +487,10 @@ where
         chain_id: ChainId,
         application_id: UserApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let response = chain.describe_application(application_id).await?;
-        Ok(response)
+        ChainWorkerState::new(self.storage.clone(), chain_id)
+            .await?
+            .describe_application(application_id)
+            .await
     }
 
     /// Gets a reference to the [`KeyPair`], if available.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -52,7 +52,7 @@ use {
 };
 
 use crate::{
-    chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest, ChainWorkerState},
+    chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
 };
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -21,8 +21,8 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         Block, BlockAndRound, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue,
-        ExecutedBlock, HashedCertificateValue, IncomingMessage, LiteCertificate, Medium,
-        MessageAction, MessageBundle, Origin, OutgoingMessage, Target,
+        ExecutedBlock, HashedCertificateValue, LiteCertificate, Medium, MessageBundle, Origin,
+        OutgoingMessage, Target,
     },
     manager, ChainError, ChainStateView,
 };
@@ -43,7 +43,7 @@ use tracing::{error, instrument, trace, warn};
 #[cfg(with_testing)]
 use {
     linera_base::identifiers::{BytecodeId, Destination, MessageId},
-    linera_chain::data_types::ChannelFullName,
+    linera_chain::data_types::{ChannelFullName, IncomingMessage, MessageAction},
 };
 #[cfg(with_metrics)]
 use {
@@ -53,7 +53,7 @@ use {
 
 use crate::{
     chain_worker::{ChainWorkerConfig, ChainWorkerState},
-    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
 };
 
 #[cfg(test)]
@@ -1233,102 +1233,19 @@ where
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);
-        let chain_id = query.chain_id;
-        let mut chain = self.storage.load_chain(chain_id).await?;
-        if query.request_leader_timeout {
-            if let Some(epoch) = chain.execution_state.system.epoch.get() {
-                let height = chain.tip_state.get().next_block_height;
-                let key_pair = self.key_pair();
-                let local_time = self.storage.clock().current_time();
-                let manager = chain.manager.get_mut();
-                if manager.vote_timeout(chain_id, height, *epoch, key_pair, local_time) {
-                    chain.save().await?;
-                }
-            }
+        let result = async move {
+            ChainWorkerState::new(
+                self.chain_worker_config.clone(),
+                self.storage.clone(),
+                query.chain_id,
+            )
+            .await?
+            .handle_chain_info_query(query)
+            .await
         }
-        if query.request_fallback {
-            if let (Some(epoch), Some(entry)) = (
-                chain.execution_state.system.epoch.get(),
-                chain.unskippable.front().await?,
-            ) {
-                let ownership = chain.execution_state.system.ownership.get();
-                let elapsed = self.storage.clock().current_time().delta_since(entry.seen);
-                if elapsed >= ownership.timeout_config.fallback_duration {
-                    let height = chain.tip_state.get().next_block_height;
-                    let key_pair = self.key_pair();
-                    let manager = chain.manager.get_mut();
-                    if manager.vote_fallback(chain_id, height, *epoch, key_pair) {
-                        chain.save().await?;
-                    }
-                }
-            }
-        }
-        let mut info = ChainInfo::from(&chain);
-        if query.request_committees {
-            info.requested_committees = Some(chain.execution_state.system.committees.get().clone());
-        }
-        if let Some(owner) = query.request_owner_balance {
-            info.requested_owner_balance =
-                chain.execution_state.system.balances.get(&owner).await?;
-        }
-        if let Some(next_block_height) = query.test_next_block_height {
-            ensure!(
-                chain.tip_state.get().next_block_height == next_block_height,
-                WorkerError::UnexpectedBlockHeight {
-                    expected_block_height: next_block_height,
-                    found_block_height: chain.tip_state.get().next_block_height
-                }
-            );
-        }
-        if query.request_pending_messages {
-            let mut messages = Vec::new();
-            let origins = chain.inboxes.indices().await?;
-            let inboxes = chain.inboxes.try_load_entries(&origins).await?;
-            let action = if *chain.execution_state.system.closed.get() {
-                MessageAction::Reject
-            } else {
-                MessageAction::Accept
-            };
-            for (origin, inbox) in origins.into_iter().zip(inboxes) {
-                for event in inbox.added_events.elements().await? {
-                    messages.push(IncomingMessage {
-                        origin: origin.clone(),
-                        event: event.clone(),
-                        action,
-                    });
-                }
-            }
-
-            info.requested_pending_messages = messages;
-        }
-        if let Some(range) = query.request_sent_certificates_in_range {
-            let start: usize = range.start.try_into()?;
-            let end = match range.limit {
-                None => chain.confirmed_log.count(),
-                Some(limit) => start
-                    .checked_add(usize::try_from(limit).map_err(|_| ArithmeticError::Overflow)?)
-                    .ok_or(ArithmeticError::Overflow)?
-                    .min(chain.confirmed_log.count()),
-            };
-            let keys = chain.confirmed_log.read(start..end).await?;
-            let certs = self.storage.read_certificates(keys).await?;
-            info.requested_sent_certificates = certs;
-        }
-        if let Some(start) = query.request_received_log_excluding_first_nth {
-            let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
-            info.requested_received_log = chain.received_log.read(start..).await?;
-        }
-        if let Some(hash) = query.request_blob {
-            info.requested_blob = Some(self.storage.read_hashed_certificate_value(hash).await?);
-        }
-        if query.request_manager_values {
-            info.manager.add_values(chain.manager.get());
-        }
-        let response = ChainInfoResponse::new(info, self.key_pair());
-        trace!("{} --> {:?}", self.nickname, response);
-        // Trigger any outgoing cross-chain messages that haven't been confirmed yet.
-        let actions = self.create_network_actions(&chain).await?;
-        Ok((response, actions))
+        .await;
+        trace!("{} --> {:?}", self.nickname, result);
+        result
     }
 
     #[instrument(skip_all, fields(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -928,13 +928,14 @@ where
         chain_id: ChainId,
         height: BlockHeight,
     ) -> Result<Option<Certificate>, WorkerError> {
-        let chain = self.storage.load_active_chain(chain_id).await?;
-        let certificate_hash = match chain.confirmed_log.get(height.try_into()?).await? {
-            Some(hash) => hash,
-            None => return Ok(None),
-        };
-        let certificate = self.storage.read_certificate(certificate_hash).await?;
-        Ok(Some(certificate))
+        ChainWorkerState::new(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            chain_id,
+        )
+        .await?
+        .read_certificate(height)
+        .await
     }
 
     /// Returns the application registry for a specific chain.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -517,11 +517,6 @@ where
         .await
     }
 
-    /// Gets a reference to the [`KeyPair`], if available.
-    fn key_pair(&self) -> Option<&KeyPair> {
-        self.key_pair.as_ref().map(Arc::as_ref)
-    }
-
     /// Creates an `UpdateRecipient` request that informs the `recipient` about new
     /// cross-chain messages from `sender`.
     async fn create_cross_chain_request(
@@ -1022,6 +1017,13 @@ where
             }
         );
         Ok(())
+    }
+}
+
+impl<StorageClient> WorkerState<StorageClient> {
+    /// Gets a reference to the [`KeyPair`], if available.
+    fn key_pair(&self) -> Option<&KeyPair> {
+        self.key_pair.as_ref().map(Arc::as_ref)
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -479,13 +479,12 @@ where
         chain_id: ChainId,
         bytecode_id: BytecodeId,
     ) -> Result<Option<BytecodeLocation>, WorkerError> {
-        ChainWorkerState::new(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            chain_id,
-        )
-        .await?
-        .read_bytecode_location(bytecode_id)
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::ReadBytecodeLocation {
+                bytecode_id,
+                callback,
+            }
+        })
         .await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -487,7 +487,7 @@ where
         .await
     }
 
-    pub(crate) async fn describe_application(
+    pub async fn describe_application(
         &mut self,
         chain_id: ChainId,
         application_id: UserApplicationId,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1416,7 +1416,7 @@ where
 
                 for (medium, height) in latest_heights {
                     let target = Target { recipient, medium };
-                    let fully_delivered = chain.mark_messages_as_received(target, height).await?
+                    let fully_delivered = chain.mark_messages_as_received(&target, height).await?
                         && chain.all_messages_delivered_up_to(height);
 
                     if fully_delivered && height > height_with_fully_delivered_messages {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1320,14 +1320,14 @@ where
                     .into_iter()
                     .map(|(medium, height)| (Target { recipient, medium }, height))
                     .collect();
-                let height_with_fully_delivered_messages = ChainWorkerState::new(
-                    self.chain_worker_config.clone(),
-                    self.storage.clone(),
-                    sender,
-                )
-                .await?
-                .confirm_updated_recipient(latest_heights)
-                .await?;
+                let height_with_fully_delivered_messages = self
+                    .query_chain_worker(sender, move |callback| {
+                        ChainWorkerRequest::ConfirmUpdatedRecipient {
+                            latest_heights,
+                            callback,
+                        }
+                    })
+                    .await?;
                 // Handle delivery notifiers for this chain, if any.
                 if let hash_map::Entry::Occupied(mut map) =
                     self.delivery_notifiers.lock().await.entry(sender)

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -836,13 +836,12 @@ where
         let CertificateValue::Timeout { chain_id, .. } = certificate.value() else {
             panic!("Expecting a leader timeout certificate");
         };
-        ChainWorkerState::new(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            *chain_id,
-        )
-        .await?
-        .process_timeout(certificate)
+        self.query_chain_worker(*chain_id, move |callback| {
+            ChainWorkerRequest::ProcessTimeout {
+                certificate,
+                callback,
+            }
+        })
         .await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -887,13 +887,13 @@ where
         recipient: ChainId,
         bundles: Vec<MessageBundle>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
-        ChainWorkerState::new(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            recipient,
-        )
-        .await?
-        .process_cross_chain_update(origin, bundles)
+        self.query_chain_worker(recipient, move |callback| {
+            ChainWorkerRequest::ProcessCrossChainUpdate {
+                origin,
+                bundles,
+                callback,
+            }
+        })
         .await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -833,51 +833,17 @@ where
         &mut self,
         certificate: Certificate,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
-        let (chain_id, height, epoch) = match certificate.value() {
-            CertificateValue::Timeout {
-                chain_id,
-                height,
-                epoch,
-                ..
-            } => (*chain_id, *height, *epoch),
-            _ => panic!("Expecting a leader timeout certificate"),
+        let CertificateValue::Timeout { chain_id, .. } = certificate.value() else {
+            panic!("Expecting a leader timeout certificate");
         };
-        // Check that the chain is active and ready for this confirmation.
-        // Verify the certificate. Returns a catch-all error to make client code more robust.
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let (chain_epoch, committee) = chain
-            .execution_state
-            .system
-            .current_committee()
-            .expect("chain is active");
-        ensure!(
-            epoch == chain_epoch,
-            WorkerError::InvalidEpoch {
-                chain_id,
-                chain_epoch,
-                epoch
-            }
-        );
-        certificate.check(committee)?;
-        let mut actions = NetworkActions::default();
-        if chain.tip_state.get().already_validated_block(height)? {
-            return Ok((ChainInfoResponse::new(&chain, self.key_pair()), actions));
-        }
-        let old_round = chain.manager.get().current_round;
-        chain
-            .manager
-            .get_mut()
-            .handle_timeout_certificate(certificate.clone(), self.storage.clock().current_time());
-        let round = chain.manager.get().current_round;
-        if round > old_round {
-            actions.notifications.push(Notification {
-                chain_id,
-                reason: Reason::NewRound { height, round },
-            })
-        }
-        let info = ChainInfoResponse::new(&chain, self.key_pair());
-        chain.save().await?;
-        Ok((info, actions))
+        ChainWorkerState::new(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            *chain_id,
+        )
+        .await?
+        .process_timeout(certificate)
+        .await
     }
 
     async fn process_cross_chain_update(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -476,9 +476,10 @@ where
         chain_id: ChainId,
         query: Query,
     ) -> Result<Response, WorkerError> {
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let response = chain.query_application(query).await?;
-        Ok(response)
+        ChainWorkerState::new(self.storage.clone(), chain_id)
+            .await?
+            .query_application(query)
+            .await
     }
 
     pub(crate) async fn describe_application(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -52,7 +52,10 @@ use {
     prometheus::{HistogramVec, IntCounterVec},
 };
 
-use crate::data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest};
+use crate::{
+    chain_worker::ChainWorkerState,
+    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+};
 
 #[cfg(test)]
 #[path = "unit_tests/worker_tests.rs"]
@@ -429,20 +432,10 @@ where
         &mut self,
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
-        let mut chain = self.storage.load_active_chain(block.chain_id).await?;
-        let local_time = self.storage.clock().current_time();
-        let signer = block.authenticated_signer;
-        let executed_block = chain
-            .execute_block(&block, local_time, None)
+        ChainWorkerState::new(self.storage.clone(), block.chain_id)
             .await?
-            .with(block);
-        let mut response = ChainInfoResponse::new(&chain, None);
-        if let Some(signer) = signer {
-            response.info.requested_owner_balance =
-                chain.execution_state.system.balances.get(&signer).await?;
-        }
-        // Do not save the new state.
-        Ok((executed_block, response))
+            .stage_block_execution(block)
+            .await
     }
 
     // Schedule a notification when cross-chain messages are delivered up to the given height.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -44,7 +44,6 @@ use tracing::{error, instrument, trace, warn};
 use {
     linera_base::identifiers::{BytecodeId, Destination, MessageId},
     linera_chain::data_types::ChannelFullName,
-    linera_execution::ApplicationRegistryView,
 };
 #[cfg(with_metrics)]
 use {
@@ -952,21 +951,6 @@ where
         .await?
         .read_certificate(height)
         .await
-    }
-
-    /// Returns the application registry for a specific chain.
-    ///
-    /// # Notes
-    ///
-    /// The returned [`ApplicationRegistryView`] holds a lock of the chain it belongs to. Incorrect
-    /// usage of this method may cause deadlocks.
-    #[cfg(with_testing)]
-    pub async fn load_application_registry(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<ApplicationRegistryView<StorageClient::Context>, WorkerError> {
-        let chain = self.storage.load_active_chain(chain_id).await?;
-        Ok(chain.execution_state.system.registry)
     }
 
     /// Returns an [`IncomingMessage`] that's awaiting to be received by the chain specified by

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -42,7 +42,7 @@ use tokio::sync::{oneshot, Mutex};
 use tracing::{error, instrument, trace, warn};
 #[cfg(with_testing)]
 use {
-    linera_base::identifiers::{Destination, MessageId},
+    linera_base::identifiers::{BytecodeId, Destination, MessageId},
     linera_chain::data_types::ChannelFullName,
     linera_execution::ApplicationRegistryView,
 };
@@ -484,6 +484,22 @@ where
         )
         .await?
         .query_application(query)
+        .await
+    }
+
+    #[cfg(with_testing)]
+    pub async fn read_bytecode_location(
+        &mut self,
+        chain_id: ChainId,
+        bytecode_id: BytecodeId,
+    ) -> Result<Option<BytecodeLocation>, WorkerError> {
+        ChainWorkerState::new(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            chain_id,
+        )
+        .await?
+        .read_bytecode_location(bytecode_id)
         .await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -985,20 +985,19 @@ where
         };
         let origin = Origin { sender, medium };
 
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let mut inbox = chain.inboxes.try_load_entry_mut(&origin).await?;
-
-        let certificate_hash = certificate.hash();
-        let Some(event) = inbox
-            .added_events
-            .iter_mut()
-            .await?
-            .find(|event| {
-                event.certificate_hash == certificate_hash
-                    && event.height == message_id.height
-                    && event.index == message_id.index
-            })
-            .cloned()
+        let Some(event) = ChainWorkerState::new(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            chain_id,
+        )
+        .await?
+        .find_event_in_inbox(
+            origin.clone(),
+            certificate.hash(),
+            message_id.height,
+            message_id.index,
+        )
+        .await?
         else {
             return Ok(None);
         };

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -20,9 +20,9 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockAndRound, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue,
-        ExecutedBlock, HashedCertificateValue, LiteCertificate, Medium, MessageBundle, Origin,
-        OutgoingMessage, Target,
+        Block, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue, ExecutedBlock,
+        HashedCertificateValue, LiteCertificate, Medium, MessageBundle, Origin, OutgoingMessage,
+        Target,
     },
     manager, ChainError, ChainStateView,
 };
@@ -33,7 +33,7 @@ use linera_execution::{
 use linera_storage::Storage;
 use linera_views::{
     log_view::LogView,
-    views::{RootView, View, ViewError},
+    views::{RootView, ViewError},
 };
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
@@ -271,9 +271,6 @@ pub struct WorkerState<StorageClient> {
     storage: StorageClient,
     /// Configuration options for the [`ChainWorker`]s.
     chain_worker_config: ChainWorkerConfig,
-    /// Blocks with a timestamp this far in the future will still be accepted, but the validator
-    /// will wait until that timestamp before voting.
-    grace_period: Duration,
     /// Cached values by hash.
     recent_values: Arc<Mutex<LruCache<CryptoHash, HashedCertificateValue>>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
@@ -293,7 +290,6 @@ impl<StorageClient> WorkerState<StorageClient> {
             nickname,
             storage,
             chain_worker_config: ChainWorkerConfig::default().with_key_pair(key_pair),
-            grace_period: Duration::ZERO,
             recent_values,
             delivery_notifiers: Arc::default(),
         }
@@ -309,7 +305,6 @@ impl<StorageClient> WorkerState<StorageClient> {
             nickname,
             storage,
             chain_worker_config: ChainWorkerConfig::default(),
-            grace_period: Duration::ZERO,
             recent_values,
             delivery_notifiers,
         }
@@ -331,7 +326,7 @@ impl<StorageClient> WorkerState<StorageClient> {
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
     pub fn with_grace_period(mut self, grace_period: Duration) -> Self {
-        self.grace_period = grace_period;
+        self.chain_worker_config.grace_period = grace_period;
         self
     }
 
@@ -1013,101 +1008,21 @@ where
         proposal: BlockProposal,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, proposal);
-        let BlockProposal {
-            content: BlockAndRound { block, round },
-            owner,
-            blobs,
-            validated,
-            signature: _,
-        } = &proposal;
-        let chain_id = block.chain_id;
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        // Check the epoch.
-        let (epoch, committee) = chain
-            .execution_state
-            .system
-            .current_committee()
-            .expect("chain is active");
-        Self::check_block_epoch(epoch, block)?;
-        if let Some(validated) = validated {
-            validated.check(committee)?;
-        }
-        // Check the authentication of the block.
-        let public_key = chain
-            .manager
-            .get()
-            .verify_owner(&proposal)
-            .ok_or(WorkerError::InvalidOwner)?;
-        proposal.check_signature(public_key)?;
-        // Check the authentication of the operations in the block.
-        if let Some(signer) = block.authenticated_signer {
-            ensure!(signer == *owner, WorkerError::InvalidSigner(signer));
-        }
-        // Check if the chain is ready for this new block proposal.
-        // This should always pass for nodes without voting key.
-        chain.tip_state.get().verify_block_chaining(block)?;
-        if chain.manager.get().check_proposed_block(&proposal)? == manager::Outcome::Skip {
-            // If we just processed the same pending block, return the chain info unchanged.
-            return Ok((
-                ChainInfoResponse::new(&chain, self.key_pair()),
-                NetworkActions::default(),
-            ));
-        }
-        // Update the inboxes so that we can verify the provided blobs are legitimately required.
-        // Actual execution happens below, after other validity checks.
-        chain.remove_events_from_inboxes(block).await?;
-        // Verify that all required bytecode blobs are available, and no unrelated ones provided.
-        self.check_no_missing_bytecode(block, blobs).await?;
-        // Write the values so that the bytecode is available during execution.
-        self.storage.write_hashed_certificate_values(blobs).await?;
-        let local_time = self.storage.clock().current_time();
-        ensure!(
-            block.timestamp.duration_since(local_time) <= self.grace_period,
-            WorkerError::InvalidTimestamp
-        );
-        self.storage.clock().sleep_until(block.timestamp).await;
-        let local_time = self.storage.clock().current_time();
-        let outcome = if let Some(validated) = validated {
-            validated
-                .value()
-                .executed_block()
-                .ok_or_else(|| WorkerError::MissingExecutedBlockInProposal)?
-                .outcome
-                .clone()
-        } else {
-            chain.execute_block(block, local_time, None).await?
-        };
-        if round.is_fast() {
-            let mut records = outcome.oracle_records.iter();
-            ensure!(
-                records.all(|record| record.responses.is_empty()),
-                WorkerError::FastBlockUsingOracles
-            );
-        }
-        // Check if the counters of tip_state would be valid.
-        chain.tip_state.get().verify_counters(block, &outcome)?;
-        // Verify that the resulting chain would have no unconfirmed incoming messages.
-        chain.validate_incoming_messages().await?;
-        // Reset all the staged changes as we were only validating things.
-        chain.rollback();
-        // Create the vote and store it in the chain state.
-        let manager = chain.manager.get_mut();
         #[cfg(with_metrics)]
         let round = proposal.content.round;
-        manager.create_vote(proposal, outcome, self.key_pair(), local_time);
-        // Cache the value we voted on, so the client doesn't have to send it again.
-        if let Some(vote) = manager.pending() {
-            self.cache_validated(&vote.value).await;
-        }
-        let info = ChainInfoResponse::new(&chain, self.key_pair());
-        chain.save().await?;
-        // Trigger any outgoing cross-chain messages that haven't been confirmed yet.
-        let actions = self.create_network_actions(&chain).await?;
+        let response = ChainWorkerState::new(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            proposal.content.block.chain_id,
+        )
+        .await?
+        .handle_block_proposal(proposal)
+        .await?;
         #[cfg(with_metrics)]
         NUM_ROUNDS_IN_BLOCK_PROPOSAL
             .with_label_values(&[round.type_name()])
             .observe(round.number() as f64);
-        Ok((info, actions))
+        Ok(response)
     }
 
     // Other fields will be included in handle_certificate's span.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -924,13 +924,9 @@ where
         chain_id: ChainId,
         height: BlockHeight,
     ) -> Result<Option<Certificate>, WorkerError> {
-        ChainWorkerState::new(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            chain_id,
-        )
-        .await?
-        .read_certificate(height)
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::ReadCertificate { height, callback }
+        })
         .await
     }
 

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -361,16 +361,10 @@ impl ActiveChain {
         &self,
         bytecode_id: BytecodeId<Abi, Parameters, InstantiationArgument>,
     ) -> bool {
-        let applications = self
-            .validator
+        self.validator
             .worker()
             .await
-            .load_application_registry(self.id())
-            .await
-            .expect("Failed to load application registry");
-
-        applications
-            .bytecode_location_for(&bytecode_id.forget_abi())
+            .read_bytecode_location(self.id(), bytecode_id.forget_abi())
             .await
             .expect("Failed to check known bytecode locations")
             .is_none()

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -17,11 +17,14 @@ use linera_base::{
     data_types::BlockHeight,
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
 };
-use linera_chain::data_types::Certificate;
-use linera_core::{data_types::ChainInfoQuery, worker::ValidatorWorker};
+use linera_chain::{data_types::Certificate, ChainError, ChainExecutionContext};
+use linera_core::{
+    data_types::ChainInfoQuery,
+    worker::{ValidatorWorker, WorkerError},
+};
 use linera_execution::{
     system::{SystemChannel, SystemExecutionError, SystemMessage, SystemOperation},
-    Bytecode, Message, Query, Response,
+    Bytecode, ExecutionError, Message, Query, Response,
 };
 use serde::Serialize;
 use tokio::{fs, sync::Mutex};
@@ -448,20 +451,26 @@ impl ActiveChain {
 
     /// Checks if the `application_id` is missing from this microchain.
     async fn needs_application_description<Abi>(&self, application_id: ApplicationId<Abi>) -> bool {
-        let applications = self
+        let description_result = self
             .validator
             .worker()
             .await
-            .load_application_registry(self.id())
-            .await
-            .expect("Failed to load application registry");
+            .describe_application(self.id(), application_id.forget_abi())
+            .await;
 
-        match applications
-            .describe_application(application_id.forget_abi())
-            .await
-        {
+        match description_result {
             Ok(_) => false,
-            Err(SystemExecutionError::UnknownApplicationId(_)) => true,
+            Err(WorkerError::ChainError(boxed_chain_error))
+                if matches!(
+                    &*boxed_chain_error,
+                    ChainError::ExecutionError(
+                        ExecutionError::SystemError(SystemExecutionError::UnknownApplicationId(_)),
+                        ChainExecutionContext::DescribeApplication,
+                    )
+                ) =>
+            {
+                true
+            }
             Err(_) => panic!("Failed to check known bytecode locations"),
         }
     }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `WorkerState` constantly loads and stores the `ChainStateView` for the chains it is responsible for, which leads to repeated (and often times unnecessary) serialization and deserialization.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Keep the `ChainStateView` cached in memory for a longer period of time inside `ChainWorker` types. These are split-off from the `WorkerState`, and are responsible for a single chain. The `WorkerState` then passes requests to the active `ChainWorker`s which run as a separate actor.

## **WIP**

I'm still moving parts of the `WorkerState` into `ChainWorker`. After that, I will still need to figure out how to store all the `ChainWorker`s inside `WorkerState`, and change the `query_chain_worker` method (open to suggestions for a better name) to reuse the `ChainWorker` instead of creating a new one every time. The final step is figuring out how to access the `ChainWorker` from the client code that uses the `ChainStateView`.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, so existing tests should catch regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
