### PR TITLE
Remove redundant operation mutation from AMM

### DIFF
--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -177,14 +177,10 @@ To perform `AddLiquidity` operation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      AddLiquidity: {
-        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
-        max_token0_amount: "50",
-        max_token1_amount: "50",
-      }
-    }
+  addLiquidity(
+    owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
+    maxToken0Amount: "50",
+    maxToken1Amount: "50",
   )
 }
 ```
@@ -205,14 +201,10 @@ perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      Swap: {
-        owner: "User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
-        input_token_idx: 1,
-        input_amount: "1",
-      }
-    }
+  swap(
+    owner: "User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
+    inputTokenIdx: 1,
+    inputAmount: "1",
   )
 }
 ```
@@ -222,14 +214,10 @@ perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      RemoveLiquidity: {
-        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
-        token_to_remove_idx: 1,
-        token_to_remove_amount: "1",
-      }
-    }
+  removeLiquidity(
+    owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
+    tokenToRemoveIdx: 1,
+    tokenToRemoveAmount: "1",
   )
 }
 ```
@@ -239,12 +227,8 @@ perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      RemoveAllAddedLiquidity: {
-        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
-      }
-    }
+  removeAllAddedLiquidity(
+    owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
   )
 }
 ```

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -179,14 +179,10 @@ To perform `AddLiquidity` operation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      AddLiquidity: {
-        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
-        max_token0_amount: "50",
-        max_token1_amount: "50",
-      }
-    }
+  addLiquidity(
+    owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
+    maxToken0Amount: "50",
+    maxToken1Amount: "50",
   )
 }
 ```
@@ -207,14 +203,10 @@ perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_2/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      Swap: {
-        owner: "User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
-        input_token_idx: 1,
-        input_amount: "1",
-      }
-    }
+  swap(
+    owner: "User:90d81e6e76ac75497a10a40e689de7b912db61a91b3ae28ed4d908e52e44ef7f",
+    inputTokenIdx: 1,
+    inputAmount: "1",
   )
 }
 ```
@@ -224,14 +216,10 @@ perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      RemoveLiquidity: {
-        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
-        token_to_remove_idx: 1,
-        token_to_remove_amount: "1",
-      }
-    }
+  removeLiquidity(
+    owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
+    tokenToRemoveIdx: 1,
+    tokenToRemoveAmount: "1",
   )
 }
 ```
@@ -241,12 +229,8 @@ perform the following mutation:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$AMM_APPLICATION_ID
 mutation {
-  operation(
-    operation: {
-      RemoveAllAddedLiquidity: {
-        owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
-      }
-    }
+  removeAllAddedLiquidity(
+    owner: "User:65adbf65c9c1f48a0f1f2d06e0780994dcf8e428ffd5ee53948b3bb6c572c66f",
   )
 }
 ```
@@ -258,6 +242,7 @@ use async_graphql::{scalar, Request, Response};
 use fungible::FungibleResponse;
 use linera_sdk::{
     base::{AccountOwner, Amount, ArithmeticError, ContractAbi, ServiceAbi},
+    graphql::GraphQLMutationRoot,
     views::ViewError,
 };
 pub use matching_engine::Parameters;
@@ -277,7 +262,7 @@ impl ServiceAbi for AmmAbi {
 }
 
 /// Operations that can be sent to the application.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, GraphQLMutationRoot)]
 pub enum Operation {
     // TODO(#969): Need to also implement Swap Bids here
     /// Swap operation

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -239,13 +239,12 @@ impl AmmApp {
         input_token_idx: u32,
         input_amount: Amount,
     ) -> Result<Value> {
-        let operation = amm::Operation::Swap {
-            owner,
+        let mutation = format!(
+            "swap(owner: {}, inputTokenIdx: {}, inputAmount: \"{}\")",
+            owner.to_value(),
             input_token_idx,
-            input_amount,
-        };
-
-        let mutation = format!("operation(operation: {})", operation.to_value());
+            input_amount
+        );
         self.0.mutate(mutation).await
     }
 
@@ -255,13 +254,12 @@ impl AmmApp {
         max_token0_amount: Amount,
         max_token1_amount: Amount,
     ) -> Result<Value> {
-        let operation = amm::Operation::AddLiquidity {
-            owner,
+        let mutation = format!(
+            "addLiquidity(owner: {}, maxToken0Amount: \"{}\", maxToken1Amount: \"{}\")",
+            owner.to_value(),
             max_token0_amount,
-            max_token1_amount,
-        };
-
-        let mutation = format!("operation(operation: {})", operation.to_value());
+            max_token1_amount
+        );
         self.0.mutate(mutation).await
     }
 
@@ -271,20 +269,17 @@ impl AmmApp {
         token_to_remove_idx: u32,
         token_to_remove_amount: Amount,
     ) -> Result<Value> {
-        let operation = amm::Operation::RemoveLiquidity {
-            owner,
+        let mutation = format!(
+            "removeLiquidity(owner: {}, tokenToRemoveIdx: {}, tokenToRemoveAmount: \"{}\")",
+            owner.to_value(),
             token_to_remove_idx,
-            token_to_remove_amount,
-        };
-
-        let mutation = format!("operation(operation: {})", operation.to_value());
+            token_to_remove_amount
+        );
         self.0.mutate(mutation).await
     }
 
     async fn remove_all_added_liquidity(&self, owner: AccountOwner) -> Result<Value> {
-        let operation = amm::Operation::RemoveAllAddedLiquidity { owner };
-
-        let mutation = format!("operation(operation: {})", operation.to_value());
+        let mutation = format!("removeAllAddedLiquidity(owner: {})", owner.to_value(),);
         self.0.mutate(mutation).await
     }
 }


### PR DESCRIPTION
## Motivation

Right now we have this `operation` mutation for no reason. Not sure why I ever did it like that tbh

## Proposal

Use `GraphQLMutationRoot` instead. Much cleaner and simpler.

## Test Plan

CI

