### PR TITLE
Rename the `get_free_port` and introduce one for endpoint.

### DIFF
--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -46,7 +46,7 @@ use {
 use {
     linera_storage::ServiceStorage,
     linera_storage_service::{
-        child::{StorageService, StorageServiceGuard},
+        child::{get_free_endpoint, StorageService, StorageServiceGuard},
         client::service_config_from_endpoint,
         common::get_service_storage_binary,
     },
@@ -801,9 +801,7 @@ impl ServiceStorageBuilder {
     /// Creates a `ServiceStorage` with the given Wasm runtime.
     pub async fn with_wasm_runtime(wasm_runtime: impl Into<Option<WasmRuntime>>) -> Self {
         let _guard = None;
-        let endpoint = linera_storage_service::child::get_free_port()
-            .await
-            .unwrap();
+        let endpoint = get_free_endpoint().await.unwrap();
         let clock = TestClock::default();
         let namespace = generate_test_namespace();
         let use_child = true;

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -30,7 +30,7 @@ use tracing::{info, warn};
 use {
     async_lock::RwLock,
     linera_base::sync::Lazy,
-    linera_storage_service::child::{get_free_port, StorageService, StorageServiceGuard},
+    linera_storage_service::child::{get_free_endpoint, StorageService, StorageServiceGuard},
     linera_storage_service::common::get_service_storage_binary,
     std::ops::Deref,
 };
@@ -61,7 +61,7 @@ impl LocalServerInternal for LocalServerServiceInternal {
     type Config = String;
 
     async fn new_test() -> Result<Self> {
-        let service_endpoint = get_free_port().await.unwrap();
+        let service_endpoint = get_free_endpoint().await.unwrap();
         let binary = get_service_storage_binary().await?.display().to_string();
         let service = StorageService::new(&service_endpoint, binary);
         let _service_guard = service.run().await?;

--- a/linera-storage-service/src/child.rs
+++ b/linera-storage-service/src/child.rs
@@ -10,15 +10,20 @@ use tokio::process::{Child, Command};
 
 use crate::client::{storage_service_check_absence, storage_service_check_validity};
 
-pub async fn get_free_port() -> Result<String> {
+pub async fn get_free_port() -> Result<u16> {
     for i in 1..10 {
         let port = random_free_tcp_port();
         if let Some(port) = port {
-            return Ok(format!("127.0.0.1:{}", port));
+            return Ok(port);
         }
         tokio::time::sleep(Duration::from_secs(i)).await;
     }
     bail!("Failed to obtain a port");
+}
+
+pub async fn get_free_endpoint() -> Result<String> {
+    let port = get_free_port().await?;
+    Ok(format!("127.0.0.1:{}", port))
 }
 
 /// Configuration for a storage service running as a child process

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_storage_service::{
-    child::{get_free_port, StorageService},
+    child::{get_free_endpoint, StorageService},
     client::{create_service_test_store, service_config_from_endpoint, ServiceStoreClient},
 };
 use linera_views::{
@@ -23,7 +23,7 @@ fn get_storage_service_guard(endpoint: &str) -> StorageService {
 
 #[tokio::test]
 async fn test_reads_service_store() {
-    let endpoint = get_free_port().await.unwrap();
+    let endpoint = get_free_endpoint().await.unwrap();
     for scenario in get_random_test_scenarios() {
         let _guard = get_storage_service_guard(&endpoint).run().await;
         let key_value_store = create_service_test_store(&endpoint).await.unwrap();
@@ -33,7 +33,7 @@ async fn test_reads_service_store() {
 
 #[tokio::test]
 async fn test_service_store_writes_from_blank() {
-    let endpoint = get_free_port().await.unwrap();
+    let endpoint = get_free_endpoint().await.unwrap();
     let _guard = get_storage_service_guard(&endpoint).run().await;
     let key_value_store = create_service_test_store(&endpoint).await.unwrap();
     run_writes_from_blank(&key_value_store).await;
@@ -41,7 +41,7 @@ async fn test_service_store_writes_from_blank() {
 
 #[tokio::test]
 async fn test_service_store_writes_from_state() {
-    let endpoint = get_free_port().await.unwrap();
+    let endpoint = get_free_endpoint().await.unwrap();
     let _guard = get_storage_service_guard(&endpoint).run().await;
     let key_value_store = create_service_test_store(&endpoint).await.unwrap();
     run_writes_from_state(&key_value_store).await;
@@ -49,7 +49,7 @@ async fn test_service_store_writes_from_state() {
 
 #[tokio::test]
 async fn test_service_admin() {
-    let endpoint = get_free_port().await.unwrap();
+    let endpoint = get_free_endpoint().await.unwrap();
     let _guard = get_storage_service_guard(&endpoint).run().await;
     let config = service_config_from_endpoint(&endpoint).expect("config");
     admin_test::<ServiceStoreClient>(&config).await;
@@ -57,7 +57,7 @@ async fn test_service_admin() {
 
 #[tokio::test]
 async fn test_service_big_raw_write() {
-    let endpoint = get_free_port().await.unwrap();
+    let endpoint = get_free_endpoint().await.unwrap();
     let _guard = get_storage_service_guard(&endpoint).run().await;
     let key_value_store = create_service_test_store(&endpoint).await.unwrap();
     let n = 5000000;


### PR DESCRIPTION
## Motivation

The function `get_free_port` is returning a string which is not what one expects.

## Proposal

Introduce a `get_free_endpoint` function that returns the endpoint.
Change `get_free_port` so that it now returns the port.

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
