### PR TITLE
Fix incorrect delivery notifications for rejected blocks

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1379,26 +1379,19 @@ where
             } => {
                 let mut chain = self.storage.load_chain(sender).await?;
                 let mut height_with_fully_delivered_messages = BlockHeight::ZERO;
-                let mut chain_state_changed = false;
 
                 for (medium, height) in latest_heights {
                     let target = Target { recipient, medium };
-                    let marked_messages_as_received =
-                        chain.mark_messages_as_received(target, height).await?;
-                    let fully_delivered =
-                        marked_messages_as_received && chain.all_messages_delivered_up_to(height);
-
-                    chain_state_changed |= marked_messages_as_received;
+                    let fully_delivered = chain.mark_messages_as_received(target, height).await?
+                        && chain.all_messages_delivered_up_to(height);
 
                     if fully_delivered && height > height_with_fully_delivered_messages {
                         height_with_fully_delivered_messages = height;
                     }
                 }
 
-                if chain_state_changed {
-                    // Save the chain state.
-                    chain.save().await?;
-                }
+                // Save the chain state.
+                chain.save().await?;
 
                 // Handle delivery notifiers for this chain, if any.
                 if let hash_map::Entry::Occupied(mut map) =

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1378,39 +1378,47 @@ where
                 latest_heights,
             } => {
                 let mut chain = self.storage.load_chain(sender).await?;
+                let mut height_with_fully_delivered_messages = BlockHeight::ZERO;
                 let mut chain_state_changed = false;
+
                 for (medium, height) in latest_heights {
                     let target = Target { recipient, medium };
-                    if !chain.mark_messages_as_received(target, height).await? {
-                        continue;
-                    }
-                    chain_state_changed = true;
-                    if chain.all_messages_delivered_up_to(height) {
-                        // Handle delivery notifiers for this chain, if any.
-                        if let hash_map::Entry::Occupied(mut map) =
-                            self.delivery_notifiers.lock().await.entry(sender)
-                        {
-                            while let Some(entry) = map.get_mut().first_entry() {
-                                if entry.key() > &height {
-                                    break;
-                                }
-                                let notifiers = entry.remove();
-                                trace!("Notifying {} callers", notifiers.len());
-                                for notifier in notifiers {
-                                    if let Err(()) = notifier.send(()) {
-                                        warn!("Failed to notify message delivery to caller");
-                                    }
-                                }
-                            }
-                            if map.get().is_empty() {
-                                map.remove();
-                            }
-                        }
+                    let marked_messages_as_received =
+                        chain.mark_messages_as_received(target, height).await?;
+                    let fully_delivered =
+                        marked_messages_as_received && chain.all_messages_delivered_up_to(height);
+
+                    chain_state_changed |= marked_messages_as_received;
+
+                    if fully_delivered && height > height_with_fully_delivered_messages {
+                        height_with_fully_delivered_messages = height;
                     }
                 }
+
                 if chain_state_changed {
                     // Save the chain state.
                     chain.save().await?;
+                }
+
+                // Handle delivery notifiers for this chain, if any.
+                if let hash_map::Entry::Occupied(mut map) =
+                    self.delivery_notifiers.lock().await.entry(sender)
+                {
+                    while let Some(entry) = map.get_mut().first_entry() {
+                        if entry.key() > &height_with_fully_delivered_messages {
+                            break;
+                        }
+                        let notifiers = entry.remove();
+                        trace!("Notifying {} callers", notifiers.len());
+                        for notifier in notifiers {
+                            if let Err(()) = notifier.send(()) {
+                                warn!("Failed to notify message delivery to caller");
+                            }
+                        }
+                    }
+                    if map.get().is_empty() {
+                        map.remove();
+                    }
                 }
                 Ok(NetworkActions::default())
             }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
While handling a cross-chain request confirming that the recipients have been update, some fallible operations are performed. If one of them fail, the changes to the chain state are reverted, but the notification of some delivery notifiers is not. This means that the delivery notifiers might receive incorrect notifications in some edge cases.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Only notify the delivery notifiers after all fallible operations have succeeded.

## Test Plan

<!-- How to test that the changes are correct. -->
Tests should be written for this, but it not trivial to induce storage errors in order to reproduce the scenario. Therefore issue #1934 was opened to write the test later.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Bug fix, so nothing needed except maybe releasing a new patch version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
