### PR TITLE
Update Rust to version 1.77.0

### DIFF
--- a/toolchains/build/rust-toolchain.toml
+++ b/toolchains/build/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.77.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
While using `async fn` in a trait without `async_trait`, I ran into a compiler warning that was a bit annoying. There is a way around it, by requiring that `Self: Sized`, but it seems like [the lint has been removed](https://github.com/rust-lang/rust/pull/120360) on the latest stable.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Update Rust to the latest stable version.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should catch any issues with the new Rust version.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
If developers use the old version, they'll run into the same lint. It's not a blocker, but it is annoying and might be surprising. So I'd suggest

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
