### PR TITLE
Bounded the `exists` query for ScyllaDB

### DIFF
--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -516,7 +516,7 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
             .build()
             .await?;
         // We check the way the test can fail. It can fail in different ways.
-        let query = format!("SELECT dummy FROM kv.{} ALLOW FILTERING", namespace);
+        let query = format!("SELECT dummy FROM kv.{} LIMIT 1 ALLOW FILTERING", namespace);
 
         // Execute the query
         let result = session.query(query, &[]).await;


### PR DESCRIPTION
## Motivation

Running a naked select over the entire `table_linera` table could yield a very large number of rows which are unecessary.

## Proposal

Just use `LIMIT 1` to perform the same logical operation more efficiently.

## Test Plan

CI
