### PR TITLE
Increase memory limit for queries in ScyllaDB

### DIFF
--- a/kubernetes/linera-validator/templates/scylla-config.yaml
+++ b/kubernetes/linera-validator/templates/scylla-config.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
   scylla.yaml: |
     query_tombstone_page_limit: 200000
+    max_memory_for_unlimited_query_soft_limit: 104857600


### PR DESCRIPTION
## Motivation

Memory quotas for queries are set implicitly via pagination. Even so the default limit of 1 Mb might be quite small .

## Proposal

Increase the memory limit to 100 Mb.

## Test Plan

CI will check any regressions. Otherwise this has been tested manually.
