### PR TITLE
Use BlockExecutionOutcome in ExecutedBlock.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -261,14 +261,14 @@ impl OutgoingMessage {
     }
 }
 
-/// A block, together with the outcome from its execution.
+/// A [`Block`], together with the outcome from its execution.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct ExecutedBlock {
     pub block: Block,
     pub outcome: BlockExecutionOutcome,
 }
 
-/// The messages and the state hash resulting from a block's execution.
+/// The messages and the state hash resulting from a [`Block`]'s execution.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct BlockExecutionOutcome {
     pub messages: Vec<OutgoingMessage>,

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -15,12 +15,12 @@ fn test_signed_values() {
 
     let block =
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE);
-    let executed_block = ExecutedBlock {
-        block,
+    let executed_block = BlockExecutionOutcome {
         messages: Vec::new(),
         message_counts: vec![1],
         state_hash: CryptoHash::test_hash("state"),
-    };
+    }
+    .with(block);
     let value = HashedValue::new_confirmed(executed_block);
 
     let v = LiteVote::new(value.lite(), Round::Fast, &key1);
@@ -43,12 +43,12 @@ fn test_certificates() {
 
     let block =
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE);
-    let executed_block = ExecutedBlock {
-        block,
+    let executed_block = BlockExecutionOutcome {
         messages: Vec::new(),
         message_counts: vec![1],
         state_hash: CryptoHash::test_hash("state"),
-    };
+    }
+    .with(block);
     let value = HashedValue::new_confirmed(executed_block);
 
     let v1 = LiteVote::new(value.lite(), Round::Fast, &key1);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -20,9 +20,9 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockAndRound, BlockProposal, Certificate, CertificateValue, ExecutedBlock,
-        HashedValue, IncomingMessage, LiteCertificate, Medium, MessageAction, MessageBundle,
-        Origin, OutgoingMessage, Target,
+        Block, BlockAndRound, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue,
+        ExecutedBlock, HashedValue, IncomingMessage, LiteCertificate, Medium, MessageAction,
+        MessageBundle, Origin, OutgoingMessage, Target,
     },
     manager, ChainError, ChainStateView,
 };
@@ -582,12 +582,12 @@ where
         let CertificateValue::ConfirmedBlock { executed_block, .. } = certificate.value() else {
             panic!("Expecting a confirmation certificate");
         };
-        let ExecutedBlock {
-            block,
+        let block = &executed_block.block;
+        let BlockExecutionOutcome {
             messages,
             message_counts,
             state_hash,
-        } = executed_block;
+        } = &executed_block.outcome;
         let mut chain = self.storage.load_chain(block.chain_id).await?;
         // Check that the chain is active and ready for this confirmation.
         let tip = chain.tip_state.get().clone();

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -36,27 +36,29 @@ test('Block mounting', () => {
               }],
               operations: []
             },
-            messages: [{
-              destination: { Subscribers: [1] },
-              authenticatedSigner: null,
-              kind: "Protected",
-              grant: 0,
-              message: {
-                System: {
-                  BytecodeLocations: {
-                    locations: [
-                      [
-                        "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
-                        { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
-                      [
-                        "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
-                        { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
+            outcome: {
+              messages: [{
+                destination: { Subscribers: [1] },
+                authenticatedSigner: null,
+                kind: "Protected",
+                grant: 0,
+                message: {
+                  System: {
+                    BytecodeLocations: {
+                      locations: [
+                        [
+                          "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
+                          { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
+                        [
+                          "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
+                          { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
+                    }
                   }
                 }
-              }
-            }],
-            messageCounts: [1],
-            stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a"
+              }],
+              messageCounts: [1],
+              stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a"
+            }
           }
         }
       }

--- a/linera-explorer/src/components/Block.vue
+++ b/linera-explorer/src/components/Block.vue
@@ -56,7 +56,7 @@ defineProps<{block: HashedValue, title: string}>()
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>State Hash</strong></span>
-          <span>{{ block.value.executedBlock?.stateHash }}</span>
+          <span>{{ block.value.executedBlock?.outcome.stateHash }}</span>
         </li>
         <li class="list-group-item d-flex justify-content-between">
           <span><strong>Status</strong></span>
@@ -82,17 +82,17 @@ defineProps<{block: HashedValue, title: string}>()
             </li>
           </ul>
         </div>
-        <li v-if="block.value.executedBlock?.messages.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#out-messages-collapse-'+block.hash">
-          <span><strong>Outgoing Messages</strong> ({{ block.value.executedBlock?.messages.length }})</span>
+        <li v-if="block.value.executedBlock?.outcome.messages.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#out-messages-collapse-'+block.hash">
+          <span><strong>Outgoing Messages</strong> ({{ block.value.executedBlock?.outcome.messages.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Outgoing Messages</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.executedBlock?.messages.length!==0" class="collapse" :id="'out-messages-collapse-'+block.hash">
+        <div v-if="block.value.executedBlock?.outcome.messages.length!==0" class="collapse" :id="'out-messages-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.executedBlock?.messages" class="list-group-item p-0" key="block.hash+'-outmessage-'+i">
+            <li v-for="(m, i) in block.value.executedBlock?.outcome.messages" class="list-group-item p-0" key="block.hash+'-outmessage-'+i">
               <div class="card">
                 <div class="card-header">Message {{ i+1 }}</div>
                 <div class="card-body">

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -38,27 +38,29 @@ test('Blocks mounting', () => {
                   }],
                   operations: []
                 },
-                messages: [{
-                  destination: { Subscribers: [1] },
-                  authenticatedSigner: null,
-                  kind: "Protected",
-                  grant: 0,
-                  message: {
-                    System: {
-                      BytecodeLocations: {
-                        locations: [
-                          [
-                            "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
-                            { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
-                          [
-                            "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
-                            { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
+                outcome: {
+                  messages: [{
+                    destination: { Subscribers: [1] },
+                    authenticatedSigner: null,
+                    kind: "Protected",
+                    grant: 0,
+                    message: {
+                      System: {
+                        BytecodeLocations: {
+                          locations: [
+                            [
+                              "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65020000000000000000000000",
+                              { certificate_hash: "a4167c67ce9c94c301fd5cbbefeccf6c8e56d568a4c75ed85e93bfacee66bac5", operation_index: 0 }],
+                            [
+                              "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65050000000000000000000000",
+                              { certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a", operation_index: 0 }]]
+                        }
                       }
                     }
-                  }
-                }],
-                messageCounts: [1],
-                stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a"
+                  }],
+                  messageCounts: [1],
+                  stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a"
+                }
               }
             }
           }

--- a/linera-explorer/src/components/Blocks.vue
+++ b/linera-explorer/src/components/Blocks.vue
@@ -31,7 +31,7 @@ defineProps<{blocks: HashedValue[]}>()
           <td :title="b.value.executedBlock?.block.authenticatedSigner">{{ short_hash(b.value.executedBlock?.block.authenticatedSigner) }}</td>
           <td>{{ b.value.status }}</td>
           <td>{{ b.value.executedBlock?.block.incomingMessages.length }}</td>
-          <td>{{ b.value.executedBlock?.messages.length }}</td>
+          <td>{{ b.value.executedBlock?.outcome.messages.length }}</td>
           <td>{{ b.value.executedBlock?.block.operations.length }}</td>
           <td>
             <button class="btn btn-link btn-sm" data-bs-toggle="modal" :data-bs-target="'#'+b.hash+'-modal'" @click="json_load(b.hash+'-json', b)">

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -520,7 +520,7 @@ pub mod tests {
         data_types::{Amount, Round, Timestamp},
     };
     use linera_chain::{
-        data_types::{Block, BlockAndRound, ExecutedBlock, HashedValue},
+        data_types::{Block, BlockAndRound, BlockExecutionOutcome, HashedValue},
         test::make_first_block,
     };
     use linera_core::data_types::ChainInfo;
@@ -676,24 +676,28 @@ pub mod tests {
     pub fn test_certificate() {
         let key_pair = KeyPair::generate();
         let certificate = Certificate::new(
-            HashedValue::new_validated(ExecutedBlock {
-                block: get_block(),
-                messages: vec![],
-                message_counts: vec![],
-                state_hash: CryptoHash::new(&Foo("test".into())),
-            }),
+            HashedValue::new_validated(
+                BlockExecutionOutcome {
+                    messages: vec![],
+                    message_counts: vec![],
+                    state_hash: CryptoHash::new(&Foo("test".into())),
+                }
+                .with(get_block()),
+            ),
             Round::MultiLeader(3),
             vec![(
                 ValidatorName::from(key_pair.public()),
                 Signature::new(&Foo("test".into()), &key_pair),
             )],
         );
-        let blobs = vec![HashedValue::new_validated(ExecutedBlock {
-            block: get_block(),
-            messages: vec![],
-            message_counts: vec![],
-            state_hash: CryptoHash::new(&Foo("also test".into())),
-        })];
+        let blobs = vec![HashedValue::new_validated(
+            BlockExecutionOutcome {
+                messages: vec![],
+                message_counts: vec![],
+                state_hash: CryptoHash::new(&Foo("also test".into())),
+            }
+            .with(get_block()),
+        )];
         let request = HandleCertificateRequest {
             certificate,
             blobs,
@@ -736,19 +740,23 @@ pub mod tests {
             },
             owner: Owner::from(KeyPair::generate().public()),
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),
-            blobs: vec![HashedValue::new_confirmed(ExecutedBlock {
-                block: get_block(),
-                messages: vec![],
-                message_counts: vec![],
-                state_hash: CryptoHash::new(&Foo("execution state".into())),
-            })],
-            validated: Some(Certificate::new(
-                HashedValue::new_validated(ExecutedBlock {
-                    block: get_block(),
+            blobs: vec![HashedValue::new_confirmed(
+                BlockExecutionOutcome {
                     messages: vec![],
                     message_counts: vec![],
-                    state_hash: CryptoHash::new(&Foo("validated".into())),
-                }),
+                    state_hash: CryptoHash::new(&Foo("execution state".into())),
+                }
+                .with(get_block()),
+            )],
+            validated: Some(Certificate::new(
+                HashedValue::new_validated(
+                    BlockExecutionOutcome {
+                        messages: vec![],
+                        message_counts: vec![],
+                        state_hash: CryptoHash::new(&Foo("validated".into())),
+                    }
+                    .with(get_block()),
+                ),
                 Round::SingleLeader(2),
                 vec![(
                     ValidatorName::from(key_pair.public()),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -68,6 +68,15 @@ BlockAndRound:
         TYPENAME: Block
     - round:
         TYPENAME: Round
+BlockExecutionOutcome:
+  STRUCT:
+    - messages:
+        SEQ:
+          TYPENAME: OutgoingMessage
+    - message_counts:
+        SEQ: U32
+    - state_hash:
+        TYPENAME: CryptoHash
 BlockHeight:
   NEWTYPESTRUCT: U64
 BlockHeightRange:
@@ -379,13 +388,8 @@ ExecutedBlock:
   STRUCT:
     - block:
         TYPENAME: Block
-    - messages:
-        SEQ:
-          TYPENAME: OutgoingMessage
-    - message_counts:
-        SEQ: U32
-    - state_hash:
-        TYPENAME: CryptoHash
+    - outcome:
+        TYPENAME: BlockExecutionOutcome
 GenericApplicationId:
   ENUM:
     0:

--- a/linera-sdk/src/test/integration/block.rs
+++ b/linera-sdk/src/test/integration/block.rs
@@ -182,7 +182,7 @@ impl BlockBuilder {
             .await
             .expect("Failed to execute block");
 
-        let message_ids = (0..executed_block.messages.len() as u32)
+        let message_ids = (0..executed_block.messages().len() as u32)
             .map(|index| MessageId {
                 chain_id: executed_block.block.chain_id,
                 height: executed_block.block.height,

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -171,16 +171,18 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           }
           operations
         }
-        messages {
-          destination
-          authenticatedSigner
-          grant
-          refundGrantTo
-          kind
-          message
+        outcome {
+          messages {
+            destination
+            authenticatedSigner
+            grant
+            refundGrantTo
+            kind
+            message
+          }
+          messageCounts
+          stateHash
         }
-        messageCounts
-        stateHash
       }
     }
   }
@@ -206,15 +208,18 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
           }
           operations
         }
-        messages {
-          destination
-          authenticatedSigner
-          grant
-          refundGrantTo
-          kind
-          message
+        outcome {
+          messages {
+            destination
+            authenticatedSigner
+            grant
+            refundGrantTo
+            kind
+            message
+          }
+          messageCounts
+          stateHash
         }
-        stateHash
       }
     }
   }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -70,6 +70,20 @@ type Block {
 }
 
 """
+The messages and the state hash resulting from a block's execution.
+"""
+type BlockExecutionOutcome {
+	messages: [OutgoingMessage!]!
+	"""
+	For each transaction, the cumulative number of messages created by this and all previous
+	transactions, i.e. `message_counts[i]` is the index of the first message created by
+	transaction `i + 1` or later.
+	"""
+	messageCounts: [Int!]!
+	stateHash: CryptoHash!
+}
+
+"""
 A block height to identify blocks in a chain
 """
 scalar BlockHeight
@@ -330,18 +344,11 @@ A message together with non replayable information to ensure uniqueness in a par
 scalar Event
 
 """
-A block, together with the messages and the state hash resulting from its execution.
+A block, together with the outcome from its execution.
 """
 type ExecutedBlock {
 	block: Block!
-	messages: [OutgoingMessage!]!
-	"""
-	For each transaction, the cumulative number of messages created by this and all previous
-	transactions, i.e. `message_counts[i]` is the index of the first message created by
-	transaction `i + 1` or later.
-	"""
-	messageCounts: [Int!]!
-	stateHash: CryptoHash!
+	outcome: BlockExecutionOutcome!
 }
 
 type ExecutionStateView {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -70,7 +70,7 @@ type Block {
 }
 
 """
-The messages and the state hash resulting from a block's execution.
+The messages and the state hash resulting from a [`Block`]'s execution.
 """
 type BlockExecutionOutcome {
 	messages: [OutgoingMessage!]!
@@ -344,7 +344,7 @@ A message together with non replayable information to ensure uniqueness in a par
 scalar Event
 
 """
-A block, together with the outcome from its execution.
+A [`Block`], together with the outcome from its execution.
 """
 type ExecutedBlock {
 	block: Block!

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -129,7 +129,9 @@ pub struct Transfer;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
-    use linera_chain::data_types::{ExecutedBlock, HashedValue, IncomingMessage, OutgoingMessage};
+    use linera_chain::data_types::{
+        BlockExecutionOutcome, ExecutedBlock, HashedValue, IncomingMessage, OutgoingMessage,
+    };
 
     use super::*;
 
@@ -177,9 +179,9 @@ mod from {
         }
     }
 
-    impl From<block::BlockBlockValueExecutedBlockMessages> for OutgoingMessage {
-        fn from(val: block::BlockBlockValueExecutedBlockMessages) -> Self {
-            let block::BlockBlockValueExecutedBlockMessages {
+    impl From<block::BlockBlockValueExecutedBlockOutcomeMessages> for OutgoingMessage {
+        fn from(val: block::BlockBlockValueExecutedBlockOutcomeMessages) -> Self {
+            let block::BlockBlockValueExecutedBlockOutcomeMessages {
                 destination,
                 authenticated_signer,
                 grant,
@@ -202,9 +204,12 @@ mod from {
         fn from(val: block::BlockBlockValueExecutedBlock) -> Self {
             let block::BlockBlockValueExecutedBlock {
                 block,
-                messages,
-                message_counts,
-                state_hash,
+                outcome:
+                    block::BlockBlockValueExecutedBlockOutcome {
+                        messages,
+                        message_counts,
+                        state_hash,
+                    },
             } = val;
             let messages = messages
                 .into_iter()
@@ -212,9 +217,11 @@ mod from {
                 .collect::<Vec<_>>();
             ExecutedBlock {
                 block: block.into(),
-                messages,
-                message_counts: message_counts.into_iter().map(|c| c as u32).collect(),
-                state_hash,
+                outcome: BlockExecutionOutcome {
+                    messages,
+                    message_counts: message_counts.into_iter().map(|c| c as u32).collect(),
+                    state_hash,
+                },
             }
         }
     }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -183,7 +183,7 @@ where
                 continue;
             };
             let new_chains = executed_block
-                .messages
+                .messages()
                 .iter()
                 .filter_map(|outgoing_message| {
                     if let OutgoingMessage {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -459,7 +459,7 @@ impl Runnable for Job {
                     .await
                     .unwrap()
                     .into_iter()
-                    .filter_map(|c| c.value().executed_block().map(|e| e.messages.len()))
+                    .filter_map(|c| c.value().executed_block().map(|e| e.messages().len()))
                     .sum::<usize>();
                 info!("Subscribed {} chains to new committees", n);
                 let maybe_certificate = context


### PR DESCRIPTION
## Motivation

`ExecutedBlock` is a `Block` plus all the fields of a `BlockExecutionOutcome`. We will add more fields to that, so they would have to be added to both types.

## Proposal

Use `BlockExecutionOutcome` inside `ExecutedBlock` instead.

## Test Plan

No changed logic.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
