### PR TITLE
Update to Rust 1.77.2

### DIFF
--- a/toolchains/build/rust-toolchain.toml
+++ b/toolchains/build/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.77.2"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Earlier today I updated Rust to version 1.77.0 (#1937), but I didn't realize that there were [two](https://blog.rust-lang.org/2024/03/28/Rust-1.77.1.html) [patch](https://blog.rust-lang.org/2024/04/09/Rust-1.77.2.html) versions, both fixing issues on Windows. One of the issues is a security vulnerability, so even though Windows is not officially supported by Linera, it is a good practice to update to fix any vulnerability.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Update to the latest stable patch version.

## Test Plan

<!-- How to test that the changes are correct. -->
This is a patch version upgrade, so everything should be fine, but CI should fail if there are any new issues.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Updates the Rust version, so maybe:
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
