### PR TITLE
`linera-execution`: use instrumentation for Wasmer metering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4121,8 +4121,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-encoder 0.24.1",
+ "wasm-instrument",
  "wasmer",
- "wasmer-middlewares",
  "wasmparser 0.101.1",
  "wasmtime",
 ]
@@ -5180,6 +5180,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "parity-wasm"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
@@ -8191,6 +8197,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-instrument"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a47ecb37b9734d1085eaa5ae1a81e60801fd8c28d4cabdd8aedb982021918bc"
+dependencies = [
+ "parity-wasm",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8332,16 +8347,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "wasmer-middlewares"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
-dependencies = [
- "wasmer",
- "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
@@ -9390,3 +9395,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "wasmer-middlewares"
+version = "4.2.8"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ url = "2.4"
 wasm-bindgen = "0.2.92"
 wasm-bindgen-test = "0.3.42"
 wasm-encoder = "0.24.1"
+wasm-instrument = "0.4.0"
 wasmer = { version = "4.2.8", features = ["singlepass"] }
-wasmer-middlewares = "4.2.8"
 wasmparser = "0.101.1"
 wasmtime = "1.0"
 wasmtimer = "0.2.0"
@@ -197,9 +197,6 @@ max_combination_size = 1
 
 # Make sure to compile VMs with high optimization level
 [profile.dev.package.wasmer]
-opt-level = 3
-
-[profile.dev.package.wasmer-middlewares]
 opt-level = 3
 
 [profile.dev.package.wasmparser]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2405,8 +2405,8 @@ dependencies = [
  "tokio",
  "tracing",
  "wasm-encoder 0.24.1",
+ "wasm-instrument",
  "wasmer",
- "wasmer-middlewares",
  "wasmparser 0.101.1",
 ]
 
@@ -3036,6 +3036,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parity-wasm"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
@@ -4946,6 +4952,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-instrument"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a47ecb37b9734d1085eaa5ae1a81e60801fd8c28d4cabdd8aedb982021918bc"
+dependencies = [
+ "parity-wasm",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,16 +5076,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "wasmer-middlewares"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
-dependencies = [
- "wasmer",
- "wasmer-types",
- "wasmer-vm",
 ]
 
 [[package]]
@@ -5968,3 +5973,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "wasmer-middlewares"
+version = "4.2.8"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -19,7 +19,7 @@ wasmer = [
     "dep:wasmer",
     "linera-witty/wasmer",
     "wasm-encoder",
-    "wasmer-middlewares",
+    "wasm-instrument",
     "wasmparser",
 ]
 wasmtime = [
@@ -57,8 +57,8 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing = { workspace = true, features = ["log"] }
 wasm-encoder = { workspace = true, optional = true }
+wasm-instrument = { workspace = true, optional = true }
 wasmer = { workspace = true, optional = true }
-wasmer-middlewares = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
 

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -57,7 +57,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tracing = { workspace = true, features = ["log"] }
 wasm-encoder = { workspace = true, optional = true }
-wasm-instrument = { workspace = true, optional = true }
+wasm-instrument = { workspace = true, optional = true, features = ["sign_ext"] }
 wasmer = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -307,6 +307,18 @@ where
         }
         Ok(())
     }
+
+    /// Consume some fuel.
+    ///
+    /// This is intended for the metering instrumentation, but if the user wants to donate
+    /// some extra fuel, more power to them!
+    fn consume_fuel(caller: &mut Caller, fuel: u64) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime_mut()
+            .consume_fuel(fuel)
+            .map_err(|e| RuntimeError::Custom(e.into()))
+    }
 }
 
 /// An implementation of the system API made available to services.

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -22,6 +22,7 @@ interface contract-system-api {
     close-chain: func() -> result<tuple<>, close-chain-error>;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     log: func(message: string, level: log-level);
+    consume-fuel: func(fuel: u64);
 
     record account {
         chain-id: chain-id,


### PR DESCRIPTION
## Motivation

On the Web, we cannot use Wasmer's external metering support, as the browser Wasm implementation doesn't have support for it.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Instead, introduce:
- a function to the contract API that consumes fuel
- an instrumentation step implementation using the `wasm-instrument` crate that calls that function.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI should cover it.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

This seems to be compatible with existing Wasmer fuel calculation.  However, this behaviour is probably not to be relied upon.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
