### PR TITLE
Update `wit-bindgen` to 0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4308,7 +4308,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "wasmtime",
- "wit-bindgen 0.16.0",
+ "wit-bindgen 0.24.0",
 ]
 
 [[package]]
@@ -8182,18 +8182,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.1"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.41.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f97a5d8318f908dded23594188a90bcd09365986b1163e66d70170e5287ae"
+checksum = "bfd106365a7f5f7aa3c1916a98cbb3ad477f5ff96ddb130285a91c6e7429e67a"
 dependencies = [
  "leb128",
 ]
@@ -8213,9 +8204,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.20"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ebaa7bd0f9e7a5e5dd29b9a998acf21c4abed74265524dd7e85934597bfb10"
+checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
 dependencies = [
  "anyhow",
  "indexmap 2.2.5",
@@ -8223,8 +8214,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.41.2",
- "wasmparser 0.121.2",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
@@ -8433,19 +8424,20 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.118.2"
+version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f1154f1ab868e2a01d9834a805faca7bf8b50d041b4ca714d005d0dab1c50c"
+checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
+ "bitflags 2.4.2",
  "indexmap 2.2.5",
  "semver",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.121.2"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
+checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
 dependencies = [
  "bitflags 2.4.2",
  "indexmap 2.2.5",
@@ -9087,12 +9079,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.16.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b76f1d099678b4f69402a421e888bbe71bf20320c2f3f3565d0e7484dbe5bc20"
+checksum = "9fb4e7653763780be47e38f479e9aa83c768aa6a3b2ed086dc2826fdbbb7e7f5"
 dependencies = [
- "bitflags 2.4.2",
- "wit-bindgen-rust-macro 0.16.0",
+ "wit-bindgen-rt",
+ "wit-bindgen-rust-macro 0.24.0",
 ]
 
 [[package]]
@@ -9108,13 +9100,21 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.16.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d55e1a488af2981fb0edac80d8d20a51ac36897a1bdef4abde33c29c1b6d0d"
+checksum = "9b67e11c950041849a10828c7600ea62a4077c01e8af72e8593253575428f91b"
 dependencies = [
  "anyhow",
- "wit-component 0.18.2",
- "wit-parser 0.13.2",
+ "wit-parser 0.202.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0780cf7046630ed70f689a098cd8d56c5c3b22f2a7379bbdb088879963ff96"
+dependencies = [
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -9132,15 +9132,16 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.16.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01ff9cae7bf5736750d94d91eb8a49f5e3a04aff1d1a3218287d9b2964510f8"
+checksum = "30acbe8fb708c3a830a33c4cb705df82659bf831b492ec6ca1a17a369cfeeafb"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
- "wasm-metadata 0.10.20",
- "wit-bindgen-core 0.16.0",
- "wit-component 0.18.2",
+ "indexmap 2.2.5",
+ "wasm-metadata 0.202.0",
+ "wit-bindgen-core 0.24.0",
+ "wit-component 0.202.0",
 ]
 
 [[package]]
@@ -9169,17 +9170,16 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.16.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804a98e2538393d47aa7da65a7348116d6ff403b426665152b70a168c0146d49"
+checksum = "2b1b06eae85feaecdf9f2854f7cac124e00d5a6e5014bfb02eb1ecdeb5f265b9"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
- "wit-bindgen-core 0.16.0",
- "wit-bindgen-rust 0.16.0",
- "wit-component 0.18.2",
+ "wit-bindgen-core 0.24.0",
+ "wit-bindgen-rust 0.24.0",
 ]
 
 [[package]]
@@ -9200,9 +9200,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.18.2"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a35a2a9992898c9d27f1664001860595a4bc99d32dd3599d547412e17d7e2"
+checksum = "0c836b1fd9932de0431c1758d8be08212071b6bba0151f7bac826dbc4312a2a9"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -9211,10 +9211,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.38.1",
- "wasm-metadata 0.10.20",
- "wasmparser 0.118.2",
- "wit-parser 0.13.2",
+ "wasm-encoder 0.202.0",
+ "wasm-metadata 0.202.0",
+ "wasmparser 0.202.0",
+ "wit-parser 0.202.0",
 ]
 
 [[package]]
@@ -9235,9 +9235,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.13.2"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316b36a9f0005f5aa4b03c39bc3728d045df136f8c13a73b7db4510dec725e08"
+checksum = "744237b488352f4f27bca05a10acb79474415951c450e52ebd0da784c1df2bcc"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -9248,6 +9248,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ wasmtimer = "0.2.0"
 webassembly-test = "0.1.0"
 web-sys = "0.3.69"
 web-time = "1.1.0"
-wit-bindgen = "0.16.0"
+wit-bindgen = "0.24.0"
 
 linera-base = { version = "0.11.0", path = "./linera-base" }
 linera-chain = { version = "0.11.0", path = "./linera-chain" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4939,27 +4939,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.1"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad2b51884de9c7f4fe2fd1043fccb8dcad4b1e29558146ee57a144d15779f3f"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.41.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f97a5d8318f908dded23594188a90bcd09365986b1163e66d70170e5287ae"
+checksum = "bfd106365a7f5f7aa3c1916a98cbb3ad477f5ff96ddb130285a91c6e7429e67a"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.20"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ebaa7bd0f9e7a5e5dd29b9a998acf21c4abed74265524dd7e85934597bfb10"
+checksum = "094aea3cb90e09f16ee25a4c0e324b3e8c934e7fd838bfa039aef5352f44a917"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4967,8 +4958,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.41.2",
- "wasmparser 0.121.2",
+ "wasm-encoder 0.202.0",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]
@@ -5154,19 +5145,20 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.118.2"
+version = "0.121.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77f1154f1ab868e2a01d9834a805faca7bf8b50d041b4ca714d005d0dab1c50c"
+checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
 dependencies = [
+ "bitflags 2.5.0",
  "indexmap 2.2.6",
  "semver",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.121.2"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbe55c8f9d0dbd25d9447a5a889ff90c0cc3feaa7395310d3d826b2c703eaab"
+checksum = "d6998515d3cf3f8b980ef7c11b29a9b1017d4cf86b99ae93b546992df9931413"
 dependencies = [
  "bitflags 2.5.0",
  "indexmap 2.2.6",
@@ -5760,33 +5752,42 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.16.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b76f1d099678b4f69402a421e888bbe71bf20320c2f3f3565d0e7484dbe5bc20"
+checksum = "9fb4e7653763780be47e38f479e9aa83c768aa6a3b2ed086dc2826fdbbb7e7f5"
 dependencies = [
- "bitflags 2.5.0",
+ "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.16.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d55e1a488af2981fb0edac80d8d20a51ac36897a1bdef4abde33c29c1b6d0d"
+checksum = "9b67e11c950041849a10828c7600ea62a4077c01e8af72e8593253575428f91b"
 dependencies = [
  "anyhow",
- "wit-component",
  "wit-parser",
 ]
 
 [[package]]
-name = "wit-bindgen-rust"
-version = "0.16.0"
+name = "wit-bindgen-rt"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01ff9cae7bf5736750d94d91eb8a49f5e3a04aff1d1a3218287d9b2964510f8"
+checksum = "3b0780cf7046630ed70f689a098cd8d56c5c3b22f2a7379bbdb088879963ff96"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30acbe8fb708c3a830a33c4cb705df82659bf831b492ec6ca1a17a369cfeeafb"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
+ "indexmap 2.2.6",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -5794,9 +5795,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.16.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804a98e2538393d47aa7da65a7348116d6ff403b426665152b70a168c0146d49"
+checksum = "2b1b06eae85feaecdf9f2854f7cac124e00d5a6e5014bfb02eb1ecdeb5f265b9"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -5804,14 +5805,13 @@ dependencies = [
  "syn 2.0.60",
  "wit-bindgen-core",
  "wit-bindgen-rust",
- "wit-component",
 ]
 
 [[package]]
 name = "wit-component"
-version = "0.18.2"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a35a2a9992898c9d27f1664001860595a4bc99d32dd3599d547412e17d7e2"
+checksum = "0c836b1fd9932de0431c1758d8be08212071b6bba0151f7bac826dbc4312a2a9"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",
@@ -5820,17 +5820,17 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.38.1",
+ "wasm-encoder 0.202.0",
  "wasm-metadata",
- "wasmparser 0.118.2",
+ "wasmparser 0.202.0",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.13.2"
+version = "0.202.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316b36a9f0005f5aa4b03c39bc3728d045df136f8c13a73b7db4510dec725e08"
+checksum = "744237b488352f4f27bca05a10acb79474415951c450e52ebd0da784c1df2bcc"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -5841,6 +5841,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
+ "wasmparser 0.202.0",
 ]
 
 [[package]]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,7 +37,6 @@ thiserror = "1.0.38"
 tokenizers = { git = "https://github.com/christos-h/tokenizers", default-features = false, features = ["unstable_wasm"] }
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread"] }
 webassembly-test = "0.1.0"
-wit-bindgen = "0.16.0"
 
 counter = { path = "./counter" }
 crowd-funding = { path = "./crowd-funding" }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -118,11 +118,3 @@ where
 
     Ok(output.into())
 }
-
-// Import entrypoint proxy functions that applications implement with the `contract!` macro.
-extern "Rust" {
-    fn __contract_instantiate(argument: Vec<u8>) -> Result<(), String>;
-    fn __contract_execute_operation(argument: Vec<u8>) -> Result<Vec<u8>, String>;
-    fn __contract_execute_message(message: Vec<u8>) -> Result<(), String>;
-    fn __contract_finalize() -> Result<(), String>;
-}

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -6,9 +6,12 @@
 mod conversions_from_wit;
 mod conversions_to_wit;
 mod runtime;
-pub(crate) mod wit;
+#[doc(hidden)]
+pub mod wit;
 
 pub use self::runtime::ContractRuntime;
+#[doc(hidden)]
+pub use self::wit::export_contract;
 use crate::{log::ContractLogger, util::BlockingWait, Contract, State};
 
 /// Declares an implementation of the [`Contract`][`crate::Contract`] trait, exporting it from the
@@ -18,80 +21,74 @@ use crate::{log::ContractLogger, util::BlockingWait, Contract, State};
 /// necessary resource types and functions so that the host can call the contract application.
 #[macro_export]
 macro_rules! contract {
-    ($application:ty) => {
+    ($application:ident) => {
         #[doc(hidden)]
         static mut APPLICATION: Option<$application> = None;
 
-        #[doc(hidden)]
-        #[no_mangle]
-        fn __contract_instantiate(argument: Vec<u8>) -> Result<(), String> {
-            use $crate::util::BlockingWait;
-            $crate::contract::run_async_entrypoint::<$application, _, _, _>(
-                unsafe { &mut APPLICATION },
-                move |application| {
-                    let argument = serde_json::from_slice(&argument)?;
+        /// Export the contract interface.
+        $crate::export_contract!($application with_types_in $crate::contract::wit);
 
-                    application.instantiate(argument).blocking_wait()
-                },
-            )
-        }
+        /// Mark the contract type to be exported.
+        impl $crate::contract::wit::exports::linera::app::contract_entrypoints::Guest
+            for $application
+        {
+            fn instantiate(argument: Vec<u8>) -> Result<(), String> {
+                use $crate::util::BlockingWait;
+                $crate::contract::run_async_entrypoint::<$application, _, _, _>(
+                    unsafe { &mut APPLICATION },
+                    move |application| {
+                        let argument = serde_json::from_slice(&argument)?;
 
-        #[doc(hidden)]
-        #[no_mangle]
-        fn __contract_execute_operation(operation: Vec<u8>) -> Result<Vec<u8>, String> {
-            use $crate::util::BlockingWait;
-            $crate::contract::run_async_entrypoint::<$application, _, _, _>(
-                unsafe { &mut APPLICATION },
-                move |application| {
-                    let operation: <$application as $crate::abi::ContractAbi>::Operation =
-                        bcs::from_bytes(&operation)?;
+                        application.instantiate(argument).blocking_wait()
+                    },
+                )
+            }
 
-                    application
-                        .execute_operation(operation)
-                        .blocking_wait()
-                        .map(|response| {
-                            bcs::to_bytes(&response)
-                                .expect("Failed to serialize contract's `Response`")
-                        })
-                },
-            )
-        }
+            fn execute_operation(operation: Vec<u8>) -> Result<Vec<u8>, String> {
+                use $crate::util::BlockingWait;
+                $crate::contract::run_async_entrypoint::<$application, _, _, _>(
+                    unsafe { &mut APPLICATION },
+                    move |application| {
+                        let operation: <$application as $crate::abi::ContractAbi>::Operation =
+                            bcs::from_bytes(&operation)?;
 
-        #[doc(hidden)]
-        #[no_mangle]
-        fn __contract_execute_message(message: Vec<u8>) -> Result<(), String> {
-            use $crate::util::BlockingWait;
-            $crate::contract::run_async_entrypoint::<$application, _, _, _>(
-                unsafe { &mut APPLICATION },
-                move |application| {
-                    let message: <$application as $crate::Contract>::Message =
-                        bcs::from_bytes(&message)?;
+                        application
+                            .execute_operation(operation)
+                            .blocking_wait()
+                            .map(|response| {
+                                bcs::to_bytes(&response)
+                                    .expect("Failed to serialize contract's `Response`")
+                            })
+                    },
+                )
+            }
 
-                    application.execute_message(message).blocking_wait()
-                },
-            )
-        }
+            fn execute_message(message: Vec<u8>) -> Result<(), String> {
+                use $crate::util::BlockingWait;
+                $crate::contract::run_async_entrypoint::<$application, _, _, _>(
+                    unsafe { &mut APPLICATION },
+                    move |application| {
+                        let message: <$application as $crate::Contract>::Message =
+                            bcs::from_bytes(&message)?;
 
-        #[doc(hidden)]
-        #[no_mangle]
-        fn __contract_finalize() -> Result<(), String> {
-            use $crate::util::BlockingWait;
-            $crate::contract::run_async_entrypoint::<$application, _, _, _>(
-                unsafe { &mut APPLICATION },
-                move |application| application.finalize().blocking_wait(),
-            )
+                        application.execute_message(message).blocking_wait()
+                    },
+                )
+            }
+
+            fn finalize() -> Result<(), String> {
+                use $crate::util::BlockingWait;
+                $crate::contract::run_async_entrypoint::<$application, _, _, _>(
+                    unsafe { &mut APPLICATION },
+                    move |application| application.finalize().blocking_wait(),
+                )
+            }
         }
 
         /// Stub of a `main` entrypoint so that the binary doesn't fail to compile on targets other
         /// than WebAssembly.
         #[cfg(not(target_arch = "wasm32"))]
         fn main() {}
-
-        #[doc(hidden)]
-        #[no_mangle]
-        fn __service_handle_query(argument: Vec<u8>) -> Result<Vec<u8>, String> {
-            unreachable!("Service entrypoint should not be called in contract");
-        }
     };
 }
 

--- a/linera-sdk/src/contract/wit.rs
+++ b/linera-sdk/src/contract/wit.rs
@@ -8,9 +8,6 @@
 // Export the contract interface.
 wit_bindgen::generate!({
     world: "contract",
-    exports: {
-        "linera:app/contract-entrypoints": ContractEntrypoints,
-    },
 });
 
 pub use self::linera::app::contract_system_api;
@@ -39,3 +36,5 @@ impl self::exports::linera::app::contract_entrypoints::Guest for ContractEntrypo
         unsafe { __contract_finalize() }
     }
 }
+
+export!(ContractEntrypoints);

--- a/linera-sdk/src/contract/wit.rs
+++ b/linera-sdk/src/contract/wit.rs
@@ -13,28 +13,3 @@ wit_bindgen::generate!({
 });
 
 pub use self::linera::app::contract_system_api;
-use super::{
-    __contract_execute_message, __contract_execute_operation, __contract_finalize,
-    __contract_instantiate,
-};
-
-/// Implementation of the contract WIT entrypoints.
-pub struct ContractEntrypoints;
-
-impl self::exports::linera::app::contract_entrypoints::Guest for ContractEntrypoints {
-    fn instantiate(argument: Vec<u8>) -> Result<(), String> {
-        unsafe { __contract_instantiate(argument) }
-    }
-
-    fn execute_operation(operation: Vec<u8>) -> Result<Vec<u8>, String> {
-        unsafe { __contract_execute_operation(operation) }
-    }
-
-    fn execute_message(message: Vec<u8>) -> Result<(), String> {
-        unsafe { __contract_execute_message(message) }
-    }
-
-    fn finalize() -> Result<(), String> {
-        unsafe { __contract_finalize() }
-    }
-}

--- a/linera-sdk/src/contract/wit.rs
+++ b/linera-sdk/src/contract/wit.rs
@@ -8,6 +8,8 @@
 // Export the contract interface.
 wit_bindgen::generate!({
     world: "contract",
+    export_macro_name: "export_contract",
+    pub_export_macro: true,
 });
 
 pub use self::linera::app::contract_system_api;
@@ -36,5 +38,3 @@ impl self::exports::linera::app::contract_entrypoints::Guest for ContractEntrypo
         unsafe { __contract_finalize() }
     }
 }
-
-export!(ContractEntrypoints);

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -60,6 +60,8 @@ use serde::{de::DeserializeOwned, Serialize};
 #[cfg(not(target_arch = "wasm32"))]
 pub use self::mock_system_api::MockSystemApi;
 use self::views::{RootView, ViewStorageContext};
+#[doc(hidden)]
+pub use self::{contract::export_contract, service::export_service};
 pub use self::{
     contract::ContractRuntime,
     extensions::{FromBcsBytes, ToBcsBytes},

--- a/linera-sdk/src/service/mod.rs
+++ b/linera-sdk/src/service/mod.rs
@@ -20,24 +20,24 @@ use crate::{util::BlockingWait, ServiceLogger};
 /// Wasm module.
 ///
 /// Generates the necessary boilerplate for implementing the service WIT interface, exporting the
-/// necessary resource types and functions so that the host can call the service application.
+/// necessary resource types and functions so that the host can call the application service.
 #[macro_export]
 macro_rules! service {
-    ($application:ident) => {
+    ($service:ident) => {
         /// Export the service interface.
-        $crate::export_service!($application with_types_in $crate::service::wit);
+        $crate::export_service!($service with_types_in $crate::service::wit);
 
         /// Mark the service type to be exported.
-        impl $crate::service::wit::exports::linera::app::service_entrypoints::Guest for $application {
+        impl $crate::service::wit::exports::linera::app::service_entrypoints::Guest for $service {
             fn handle_query(argument: Vec<u8>) -> Result<Vec<u8>, String> {
                 let request = serde_json::from_slice(&argument).map_err(|error| error.to_string())?;
                 let response = $crate::service::run_async_entrypoint(move |runtime| async move {
                     let state =
-                        <<$application as $crate::Service>::State as $crate::State>::load().await;
-                    let application = <$application as $crate::Service>::new(state, runtime)
+                        <<$service as $crate::Service>::State as $crate::State>::load().await;
+                    let service = <$service as $crate::Service>::new(state, runtime)
                         .await
                         .map_err(|error| error.to_string())?;
-                    application
+                    service
                         .handle_query(request)
                         .await
                         .map_err(|error| error.to_string())

--- a/linera-sdk/src/service/mod.rs
+++ b/linera-sdk/src/service/mod.rs
@@ -69,8 +69,3 @@ where
         .blocking_wait()
         .map_err(|error| error.to_string())
 }
-
-// Import entrypoint proxy functions that applications implement with the `service!` macro.
-extern "Rust" {
-    fn __service_handle_query(argument: Vec<u8>) -> Result<Vec<u8>, String>;
-}

--- a/linera-sdk/src/service/wit.rs
+++ b/linera-sdk/src/service/wit.rs
@@ -8,9 +8,6 @@
 // Export the service interface.
 wit_bindgen::generate!({
     world: "service",
-    exports: {
-        "linera:app/service-entrypoints": ServiceEntrypoints,
-    },
 });
 
 pub use self::linera::app::{service_system_api, view_system_api};
@@ -24,3 +21,5 @@ impl self::exports::linera::app::service_entrypoints::Guest for ServiceEntrypoin
         unsafe { __service_handle_query(argument) }
     }
 }
+
+export!(ServiceEntrypoints);

--- a/linera-sdk/src/service/wit.rs
+++ b/linera-sdk/src/service/wit.rs
@@ -13,13 +13,3 @@ wit_bindgen::generate!({
 });
 
 pub use self::linera::app::{service_system_api, view_system_api};
-use super::__service_handle_query;
-
-/// Implementation of the service WIT entrypoints.
-pub struct ServiceEntrypoints;
-
-impl self::exports::linera::app::service_entrypoints::Guest for ServiceEntrypoints {
-    fn handle_query(argument: Vec<u8>) -> Result<Vec<u8>, String> {
-        unsafe { __service_handle_query(argument) }
-    }
-}

--- a/linera-sdk/src/service/wit.rs
+++ b/linera-sdk/src/service/wit.rs
@@ -8,6 +8,8 @@
 // Export the service interface.
 wit_bindgen::generate!({
     world: "service",
+    export_macro_name: "export_service",
+    pub_export_macro: true,
 });
 
 pub use self::linera::app::{service_system_api, view_system_api};
@@ -21,5 +23,3 @@ impl self::exports::linera::app::service_entrypoints::Guest for ServiceEntrypoin
         unsafe { __service_handle_query(argument) }
     }
 }
-
-export!(ServiceEntrypoints);

--- a/linera-sdk/src/test/unit/wit.rs
+++ b/linera-sdk/src/test/unit/wit.rs
@@ -5,14 +5,12 @@
 
 #![allow(missing_docs)]
 
-wit_bindgen::generate!({
-    world: "unit-tests",
-    exports: {
-        "linera:app/mock-system-api": super::MockSystemApi,
-    },
-});
+wit_bindgen::generate!("unit-tests");
 
 pub(super) use self::exports::linera::app::mock_system_api::{
     Amount, ApplicationId, BlockHeight, BytecodeId, ChainId, CryptoHash, Guest, LogLevel,
     MessageId, Timestamp, WriteOperation,
 };
+use super::MockSystemApi;
+
+export!(MockSystemApi);


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Newer versions of `wit-bindgen` [support generating a macro to export the WIT functions](https://docs.rs/wit-bindgen/latest/wit_bindgen/macro.generate.html#exports-the-export-macro) and [exporting that macro](https://docs.rs/wit-bindgen/latest/wit_bindgen/macro.generate.html#options-to-generate). This allows the removal of the proxy functions between the applications and the SDK.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Update `wit-bindgen` to the latest version, export the macros used to export the contract and service entrypoints and remove the proxy functions.

## Test Plan

<!-- How to test that the changes are correct. -->
This is a refactor, and existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This makes an invisible change to the SDK API, so
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
