### PR TITLE
Add an OracleQuery trait.

### DIFF
--- a/linera-base/src/abi.rs
+++ b/linera-base/src/abi.rs
@@ -4,9 +4,11 @@
 //! This module defines the notion of Application Binary Interface (ABI) for Linera
 //! applications across Wasm and native architectures.
 
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 
 use serde::{de::DeserializeOwned, Serialize};
+
+use crate::identifiers::OracleId;
 
 // ANCHOR: abi
 /// A trait that includes all the types exported by a Linera application (both contract
@@ -69,4 +71,25 @@ where
 {
     type Query = <<A as WithServiceAbi>::Abi as ServiceAbi>::Query;
     type QueryResponse = <<A as WithServiceAbi>::Abi as ServiceAbi>::QueryResponse;
+}
+
+/// The type of a query for an oracle.
+pub trait OracleQuery: Send + Sync + Debug + 'static {
+    /// The oracle's ID.
+    const ID: OracleId;
+
+    /// The response type of the oracle.
+    type Response: Send + Sync + Debug + 'static;
+
+    /// Error serializing the query.
+    type SerializationError: Debug + Display + 'static;
+
+    /// Error deserializing the response.
+    type DeserializationError: Debug + Display + 'static;
+
+    /// Serializes the query.
+    fn serialize(&self) -> Result<Vec<u8>, Self::SerializationError>;
+
+    /// Deserializes the response.
+    fn deserialize(response: Vec<u8>) -> Result<Self::Response, Self::DeserializationError>;
 }

--- a/linera-base/src/abi.rs
+++ b/linera-base/src/abi.rs
@@ -91,5 +91,5 @@ pub trait OracleQuery: Send + Sync + Debug + 'static {
     fn serialize(&self) -> Result<Vec<u8>, Self::SerializationError>;
 
     /// Deserializes the response.
-    fn deserialize(response: Vec<u8>) -> Result<Self::Response, Self::DeserializationError>;
+    fn deserialize(response: &[u8]) -> Result<Self::Response, Self::DeserializationError>;
 }

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -214,6 +214,12 @@ pub struct BytecodeId<Abi = (), Parameters = (), InstantiationArgument = ()> {
     _phantom: std::marker::PhantomData<(Abi, Parameters, InstantiationArgument)>,
 }
 
+/// A unique identifier for an oracle.
+#[derive(
+    Debug, Eq, PartialEq, Copy, Clone, Hash, Serialize, Deserialize, WitLoad, WitStore, WitType,
+)]
+pub struct OracleId(pub u32);
+
 /// The name of a subscription channel.
 #[derive(
     Clone,


### PR DESCRIPTION
## Motivation

We will add oracles to Linera that applications can query.

## Proposal

Add an `OracleQuery` trait that each oracle will implement for its query type(s). Contract code could then look something like this:

```rust
use linera-sdk-ethereum::EthereumBalanceRequest;

let query = EthereumBalanceRequest {
    address: "0x123abc",
    block_number: None, // Latest block.
};
assert_eq!(self.runtime.query_oracle(&query), Some(U256::from(5)));
```

The runtime method `query_oracle` would be generic in `O: OracleQuery`, so the response would be the appropriate type. Serialization and deserialization would happen inside `query_oracle`, but still in Wasm, by calling the `OracleQuery` implementation.

## Test Plan

This is not used yet.

## Links

- #1875 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
