### PR TITLE
Remove incorrect store of the contract state

### DIFF
--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -112,9 +112,7 @@ where
             .expect("Failed to create application contract hnadler instance")
     });
 
-    let output = entrypoint(contract).map_err(|error| error.to_string())?;
-
-    Contract::State::store(contract.state_mut()).blocking_wait();
-
-    Ok(output.into())
+    entrypoint(contract)
+        .map_err(|error| error.to_string())
+        .map(Output::into)
 }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -109,7 +109,7 @@ where
         let state = Contract::State::load().blocking_wait();
         Contract::new(state, ContractRuntime::new())
             .blocking_wait()
-            .expect("Failed to create application contract hnadler instance")
+            .expect("Failed to create application contract handler instance")
     });
 
     entrypoint(contract)


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The contract state should only be stored when the contract instance requests it to be stored, or at the end of the transaction if it did not override `finalize`. However, the state was being stored after every execution of the contract, whether it wanted it or not.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Don't store the contract state automatically after every execution.

## Test Plan

<!-- How to test that the changes are correct. -->
Issue #1956 was opened to track a test for this.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Fixes a bug without changing the API so:

- Need to bump the patch version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
