### PR TITLE
Replace `finalize` with `finish_transaction` in the lower-levels and the use of `Drop` in the SDK

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -9,7 +9,7 @@ use amm::{AmmAbi, AmmError, Message, Operation, Parameters};
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
     base::{AccountOwner, Amount, ApplicationId, ChainId, WithContractAbi},
-    ensure, Contract, ContractRuntime,
+    ensure, Contract, ContractRuntime, StoreOnDrop,
 };
 use num_bigint::BigUint;
 use num_traits::{cast::FromPrimitive, ToPrimitive};
@@ -17,7 +17,7 @@ use num_traits::{cast::FromPrimitive, ToPrimitive};
 use self::state::Amm;
 
 pub struct AmmContract {
-    state: Amm,
+    state: StoreOnDrop<Amm>,
     runtime: ContractRuntime<Self>,
 }
 
@@ -35,7 +35,10 @@ impl Contract for AmmContract {
     type Parameters = Parameters;
 
     async fn new(state: Amm, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(AmmContract { state, runtime })
+        Ok(AmmContract {
+            state: StoreOnDrop(state),
+            runtime,
+        })
     }
 
     fn state_mut(&mut self) -> &mut Self::State {

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -41,10 +41,6 @@ impl Contract for AmmContract {
         })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, _argument: ()) -> Result<(), AmmError> {
         // Validate that the application parameters were configured correctly.
         self.runtime.application_parameters();

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -34,11 +34,11 @@ impl Contract for AmmContract {
     type InstantiationArgument = ();
     type Parameters = Parameters;
 
-    async fn new(state: Amm, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(AmmContract {
-            state: StoreOnDrop(state),
-            runtime,
-        })
+    async fn new(
+        state: StoreOnDrop<Amm>,
+        runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(AmmContract { state, runtime })
     }
 
     async fn instantiate(&mut self, _argument: ()) -> Result<(), AmmError> {

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -36,10 +36,6 @@ impl Contract for CounterContract {
         })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, value: u64) -> Result<(), Self::Error> {
         // Validate that the application parameters were configured correctly.
         self.runtime.application_parameters();

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -29,11 +29,11 @@ impl Contract for CounterContract {
     type InstantiationArgument = u64;
     type Parameters = ();
 
-    async fn new(state: Counter, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(CounterContract {
-            state: StoreOnDrop(state),
-            runtime,
-        })
+    async fn new(
+        state: StoreOnDrop<Counter>,
+        runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(CounterContract { state, runtime })
     }
 
     async fn instantiate(&mut self, value: u64) -> Result<(), Self::Error> {

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -11,13 +11,13 @@ use linera_sdk::{
     base::{AccountOwner, Amount, ApplicationId, WithContractAbi},
     ensure,
     views::View,
-    Contract, ContractRuntime,
+    Contract, ContractRuntime, StoreOnDrop,
 };
 use state::{CrowdFunding, Status};
 use thiserror::Error;
 
 pub struct CrowdFundingContract {
-    state: CrowdFunding,
+    state: StoreOnDrop<CrowdFunding>,
     runtime: ContractRuntime<Self>,
 }
 
@@ -35,7 +35,10 @@ impl Contract for CrowdFundingContract {
     type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
 
     async fn new(state: CrowdFunding, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(CrowdFundingContract { state, runtime })
+        Ok(CrowdFundingContract {
+            state: StoreOnDrop(state),
+            runtime,
+        })
     }
 
     fn state_mut(&mut self) -> &mut Self::State {

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -41,10 +41,6 @@ impl Contract for CrowdFundingContract {
         })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, argument: InstantiationArgument) -> Result<(), Self::Error> {
         // Validate that the application parameters were configured correctly.
         let _ = self.runtime.application_parameters();

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -34,11 +34,11 @@ impl Contract for CrowdFundingContract {
     type InstantiationArgument = InstantiationArgument;
     type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
 
-    async fn new(state: CrowdFunding, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(CrowdFundingContract {
-            state: StoreOnDrop(state),
-            runtime,
-        })
+    async fn new(
+        state: StoreOnDrop<CrowdFunding>,
+        runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(CrowdFundingContract { state, runtime })
     }
 
     async fn instantiate(&mut self, argument: InstantiationArgument) -> Result<(), Self::Error> {

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -12,14 +12,14 @@ use fungible::{
 };
 use linera_sdk::{
     base::{AccountOwner, Amount, WithContractAbi},
-    ensure, Contract, ContractRuntime,
+    ensure, Contract, ContractRuntime, StoreOnDrop,
 };
 use thiserror::Error;
 
 use self::state::FungibleToken;
 
 pub struct FungibleTokenContract {
-    state: FungibleToken,
+    state: StoreOnDrop<FungibleToken>,
     runtime: ContractRuntime<Self>,
 }
 
@@ -40,7 +40,10 @@ impl Contract for FungibleTokenContract {
         state: FungibleToken,
         runtime: ContractRuntime<Self>,
     ) -> Result<Self, Self::Error> {
-        Ok(FungibleTokenContract { state, runtime })
+        Ok(FungibleTokenContract {
+            state: StoreOnDrop(state),
+            runtime,
+        })
     }
 
     fn state_mut(&mut self) -> &mut Self::State {

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -46,10 +46,6 @@ impl Contract for FungibleTokenContract {
         })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(
         &mut self,
         mut state: Self::InstantiationArgument,

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -37,13 +37,10 @@ impl Contract for FungibleTokenContract {
     type InstantiationArgument = InitialState;
 
     async fn new(
-        state: FungibleToken,
+        state: StoreOnDrop<FungibleToken>,
         runtime: ContractRuntime<Self>,
     ) -> Result<Self, Self::Error> {
-        Ok(FungibleTokenContract {
-            state: StoreOnDrop(state),
-            runtime,
-        })
+        Ok(FungibleTokenContract { state, runtime })
     }
 
     async fn instantiate(

--- a/examples/llm/src/contract.rs
+++ b/examples/llm/src/contract.rs
@@ -29,10 +29,6 @@ impl Contract for LlmContract {
         Ok(LlmContract { state })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, _value: ()) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/examples/llm/src/contract.rs
+++ b/examples/llm/src/contract.rs
@@ -8,9 +8,7 @@ mod state;
 use linera_sdk::{base::WithContractAbi, Contract, ContractRuntime, EmptyState};
 use thiserror::Error;
 
-pub struct LlmContract {
-    state: EmptyState,
-}
+pub struct LlmContract;
 
 linera_sdk::contract!(LlmContract);
 
@@ -25,8 +23,8 @@ impl Contract for LlmContract {
     type InstantiationArgument = ();
     type Parameters = ();
 
-    async fn new(state: Self::State, _runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(LlmContract { state })
+    async fn new(_: Self::State, _runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
+        Ok(LlmContract)
     }
 
     async fn instantiate(&mut self, _value: ()) -> Result<(), Self::Error> {

--- a/examples/llm/src/contract.rs
+++ b/examples/llm/src/contract.rs
@@ -5,7 +5,7 @@
 
 mod state;
 
-use linera_sdk::{base::WithContractAbi, Contract, ContractRuntime, EmptyState};
+use linera_sdk::{base::WithContractAbi, Contract, ContractRuntime, EmptyState, StoreOnDrop};
 use thiserror::Error;
 
 pub struct LlmContract;
@@ -23,7 +23,10 @@ impl Contract for LlmContract {
     type InstantiationArgument = ();
     type Parameters = ();
 
-    async fn new(_: Self::State, _runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
+    async fn new(
+        _: StoreOnDrop<Self::State>,
+        _runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error> {
         Ok(LlmContract)
     }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -9,7 +9,7 @@ use std::cmp::min;
 use fungible::{Account, FungibleTokenAbi};
 use linera_sdk::{
     base::{AccountOwner, Amount, ApplicationId, ChainId, WithContractAbi},
-    ensure, Contract, ContractRuntime,
+    ensure, Contract, ContractRuntime, StoreOnDrop,
 };
 use matching_engine::{
     product_price_amount, MatchingEngineAbi, Message, Operation, Order, OrderId, OrderNature,
@@ -20,7 +20,7 @@ use state::{LevelView, MatchingEngine, MatchingEngineError};
 use crate::state::{KeyBook, OrderEntry};
 
 pub struct MatchingEngineContract {
-    state: MatchingEngine,
+    state: StoreOnDrop<MatchingEngine>,
     runtime: ContractRuntime<Self>,
 }
 
@@ -61,7 +61,10 @@ impl Contract for MatchingEngineContract {
         state: MatchingEngine,
         runtime: ContractRuntime<Self>,
     ) -> Result<Self, Self::Error> {
-        Ok(MatchingEngineContract { state, runtime })
+        Ok(MatchingEngineContract {
+            state: StoreOnDrop(state),
+            runtime,
+        })
     }
 
     fn state_mut(&mut self) -> &mut Self::State {

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -67,10 +67,6 @@ impl Contract for MatchingEngineContract {
         })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, _argument: ()) -> Result<(), Self::Error> {
         // Validate that the application parameters were configured correctly.
         let _ = self.runtime.application_parameters();

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -58,13 +58,10 @@ impl Contract for MatchingEngineContract {
     type Parameters = Parameters;
 
     async fn new(
-        state: MatchingEngine,
+        state: StoreOnDrop<MatchingEngine>,
         runtime: ContractRuntime<Self>,
     ) -> Result<Self, Self::Error> {
-        Ok(MatchingEngineContract {
-            state: StoreOnDrop(state),
-            runtime,
-        })
+        Ok(MatchingEngineContract { state, runtime })
     }
 
     async fn instantiate(&mut self, _argument: ()) -> Result<(), Self::Error> {

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -11,7 +11,6 @@ use meta_counter::{Message, MetaCounterAbi, Operation};
 use thiserror::Error;
 
 pub struct MetaCounterContract {
-    state: EmptyState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -34,8 +33,8 @@ impl Contract for MetaCounterContract {
     type InstantiationArgument = ();
     type Parameters = ApplicationId<counter::CounterAbi>;
 
-    async fn new(state: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(MetaCounterContract { state, runtime })
+    async fn new(_: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
+        Ok(MetaCounterContract { runtime })
     }
 
     async fn instantiate(&mut self, _argument: ()) -> Result<(), Self::Error> {

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -38,10 +38,6 @@ impl Contract for MetaCounterContract {
         Ok(MetaCounterContract { state, runtime })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, _argument: ()) -> Result<(), Self::Error> {
         // Validate that the application parameters were configured correctly.
         self.counter_id();

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -5,7 +5,7 @@
 
 use linera_sdk::{
     base::{ApplicationId, WithContractAbi},
-    Contract, ContractRuntime, EmptyState, Resources,
+    Contract, ContractRuntime, EmptyState, Resources, StoreOnDrop,
 };
 use meta_counter::{Message, MetaCounterAbi, Operation};
 use thiserror::Error;
@@ -33,7 +33,10 @@ impl Contract for MetaCounterContract {
     type InstantiationArgument = ();
     type Parameters = ApplicationId<counter::CounterAbi>;
 
-    async fn new(_: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
+    async fn new(
+        _: StoreOnDrop<Self::State>,
+        runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error> {
         Ok(MetaCounterContract { runtime })
     }
 

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -33,10 +33,6 @@ impl Contract for NativeFungibleTokenContract {
         Ok(NativeFungibleTokenContract { state, runtime })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, state: Self::InstantiationArgument) -> Result<(), Self::Error> {
         // Validate that the application parameters were configured correctly.
         assert!(

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -12,7 +12,6 @@ use native_fungible::{Message, TICKER_SYMBOL};
 use thiserror::Error;
 
 pub struct NativeFungibleTokenContract {
-    state: EmptyState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -29,8 +28,8 @@ impl Contract for NativeFungibleTokenContract {
     type Parameters = Parameters;
     type InstantiationArgument = InitialState;
 
-    async fn new(state: EmptyState, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(NativeFungibleTokenContract { state, runtime })
+    async fn new(_: EmptyState, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
+        Ok(NativeFungibleTokenContract { runtime })
     }
 
     async fn instantiate(&mut self, state: Self::InstantiationArgument) -> Result<(), Self::Error> {

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -6,7 +6,7 @@
 use fungible::{FungibleResponse, FungibleTokenAbi, InitialState, Operation, Parameters};
 use linera_sdk::{
     base::{Account, AccountOwner, ChainId, Owner, WithContractAbi},
-    ensure, Contract, ContractRuntime, EmptyState,
+    ensure, Contract, ContractRuntime, EmptyState, StoreOnDrop,
 };
 use native_fungible::{Message, TICKER_SYMBOL};
 use thiserror::Error;
@@ -28,7 +28,10 @@ impl Contract for NativeFungibleTokenContract {
     type Parameters = Parameters;
     type InstantiationArgument = InitialState;
 
-    async fn new(_: EmptyState, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
+    async fn new(
+        _: StoreOnDrop<EmptyState>,
+        runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error> {
         Ok(NativeFungibleTokenContract { runtime })
     }
 

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use fungible::Account;
 use linera_sdk::{
     base::{AccountOwner, WithContractAbi},
-    ensure, Contract, ContractRuntime,
+    ensure, Contract, ContractRuntime, StoreOnDrop,
 };
 use non_fungible::{Message, Nft, NonFungibleTokenAbi, Operation, TokenId};
 use thiserror::Error;
@@ -18,7 +18,7 @@ use thiserror::Error;
 use self::state::NonFungibleToken;
 
 pub struct NonFungibleTokenContract {
-    state: NonFungibleToken,
+    state: StoreOnDrop<NonFungibleToken>,
     runtime: ContractRuntime<Self>,
 }
 
@@ -39,7 +39,10 @@ impl Contract for NonFungibleTokenContract {
         state: NonFungibleToken,
         runtime: ContractRuntime<Self>,
     ) -> Result<Self, Self::Error> {
-        Ok(NonFungibleTokenContract { state, runtime })
+        Ok(NonFungibleTokenContract {
+            state: StoreOnDrop(state),
+            runtime,
+        })
     }
 
     fn state_mut(&mut self) -> &mut Self::State {

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -45,10 +45,6 @@ impl Contract for NonFungibleTokenContract {
         })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(
         &mut self,
         _state: Self::InstantiationArgument,

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -36,13 +36,10 @@ impl Contract for NonFungibleTokenContract {
     type Parameters = ();
 
     async fn new(
-        state: NonFungibleToken,
+        state: StoreOnDrop<NonFungibleToken>,
         runtime: ContractRuntime<Self>,
     ) -> Result<Self, Self::Error> {
-        Ok(NonFungibleTokenContract {
-            state: StoreOnDrop(state),
-            runtime,
-        })
+        Ok(NonFungibleTokenContract { state, runtime })
     }
 
     async fn instantiate(

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -44,10 +44,6 @@ impl Contract for SocialContract {
         })
     }
 
-    fn state_mut(&mut self) -> &mut Self::State {
-        &mut self.state
-    }
-
     async fn instantiate(&mut self, _argument: ()) -> Result<(), Self::Error> {
         // Validate that the application parameters were configured correctly.
         self.runtime.application_parameters();

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -8,7 +8,7 @@ mod state;
 use linera_sdk::{
     base::{ChannelName, Destination, MessageId, WithContractAbi},
     views::ViewError,
-    Contract, ContractRuntime,
+    Contract, ContractRuntime, StoreOnDrop,
 };
 use social::{Key, Message, Operation, OwnPost, SocialAbi};
 use state::Social;
@@ -20,7 +20,7 @@ const POSTS_CHANNEL_NAME: &[u8] = b"posts";
 const RECENT_POSTS: usize = 10;
 
 pub struct SocialContract {
-    state: Social,
+    state: StoreOnDrop<Social>,
     runtime: ContractRuntime<Self>,
 }
 
@@ -38,7 +38,10 @@ impl Contract for SocialContract {
     type Parameters = ();
 
     async fn new(state: Social, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(SocialContract { state, runtime })
+        Ok(SocialContract {
+            state: StoreOnDrop(state),
+            runtime,
+        })
     }
 
     fn state_mut(&mut self) -> &mut Self::State {

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -37,11 +37,11 @@ impl Contract for SocialContract {
     type InstantiationArgument = ();
     type Parameters = ();
 
-    async fn new(state: Social, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
-        Ok(SocialContract {
-            state: StoreOnDrop(state),
-            runtime,
-        })
+    async fn new(
+        state: StoreOnDrop<Social>,
+        runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error> {
+        Ok(SocialContract { state, runtime })
     }
 
     async fn instantiate(&mut self, _argument: ()) -> Result<(), Self::Error> {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -128,7 +128,7 @@ async fn test_application_permissions() {
 
     // After registering, an app operation can already be used in the first block.
     application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
-    application.expect_call(ExpectedCall::default_finalize());
+    application.expect_call(ExpectedCall::default_finish_transaction());
     let app_operation = Operation::User {
         application_id,
         bytes: b"foo".to_vec(),
@@ -149,7 +149,7 @@ async fn test_application_permissions() {
 
     // But app operations continue to work.
     application.expect_call(ExpectedCall::execute_operation(|_, _, _| Ok(vec![])));
-    application.expect_call(ExpectedCall::default_finalize());
+    application.expect_call(ExpectedCall::default_finish_transaction());
     let valid_block = make_child_block(&value).with_operation(app_operation);
     chain.execute_block(&valid_block, time).await.unwrap();
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -113,9 +113,9 @@ pub enum ExecutionError {
     ReentrantCall(UserApplicationId),
     #[error(
         "Application {caller_id} attempted to perform a cross-application to {callee_id} call \
-        from `finalize`"
+        from `finish_transaction`"
     )]
-    CrossApplicationCallInFinalize {
+    CrossApplicationCallInFinishTransaction {
         caller_id: Box<UserApplicationId>,
         callee_id: Box<UserApplicationId>,
     },
@@ -164,7 +164,10 @@ pub trait UserContract {
     ) -> Result<(), ExecutionError>;
 
     /// Finishes execution of the current transaction.
-    fn finalize(&mut self, context: FinalizeContext) -> Result<(), ExecutionError>;
+    fn finish_transaction(
+        &mut self,
+        context: FinishTransactionContext,
+    ) -> Result<(), ExecutionError>;
 }
 
 /// The public entry points provided by the service part of an application.
@@ -263,7 +266,7 @@ pub struct MessageContext {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct FinalizeContext {
+pub struct FinishTransactionContext {
     /// The current chain ID.
     pub chain_id: ChainId,
     /// The authenticated signer of the operation, if any.

--- a/linera-execution/src/wasm/entrypoints.rs
+++ b/linera-execution/src/wasm/entrypoints.rs
@@ -11,7 +11,7 @@ pub trait ContractEntrypoints {
     fn instantiate(argument: Vec<u8>) -> Result<(), String>;
     fn execute_operation(operation: Vec<u8>) -> Result<Vec<u8>, String>;
     fn execute_message(message: Vec<u8>) -> Result<(), String>;
-    fn finalize() -> Result<(), String>;
+    fn finish_transaction() -> Result<(), String>;
 }
 
 /// WIT entrypoints for application services.

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -232,7 +232,7 @@ where
 
     fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
         self.configure_initial_fuel()?;
-        let result = ContractEntrypoints::new(&mut self.instance).finalize();
+        let result = ContractEntrypoints::new(&mut self.instance).finish_transaction();
         self.persist_remaining_fuel()?;
         result
             .map_err(WasmExecutionError::from)?

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -25,8 +25,8 @@ use super::{
 };
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
-    Bytecode, ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    Bytecode, ContractRuntime, ExecutionError, FinishTransactionContext, MessageContext,
+    OperationContext, QueryContext, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application services.
@@ -230,7 +230,10 @@ where
             .map_err(ExecutionError::UserError)
     }
 
-    fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
+    fn finish_transaction(
+        &mut self,
+        _context: FinishTransactionContext,
+    ) -> Result<(), ExecutionError> {
         self.configure_initial_fuel()?;
         let result = ContractEntrypoints::new(&mut self.instance).finish_transaction();
         self.persist_remaining_fuel()?;

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -227,7 +227,7 @@ where
 
     fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
         self.configure_initial_fuel()?;
-        let result = ContractEntrypoints::new(&mut self.instance).finalize();
+        let result = ContractEntrypoints::new(&mut self.instance).finish_transaction();
         self.persist_remaining_fuel()?;
         result
             .map_err(WasmExecutionError::from)?

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -17,8 +17,8 @@ use super::{
 };
 use crate::{
     wasm::{WasmContractModule, WasmServiceModule},
-    Bytecode, ContractRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceRuntime,
+    Bytecode, ContractRuntime, ExecutionError, FinishTransactionContext, MessageContext,
+    OperationContext, QueryContext, ServiceRuntime,
 };
 
 /// An [`Engine`] instance configured to run application contracts.
@@ -225,7 +225,10 @@ where
             .map_err(ExecutionError::UserError)
     }
 
-    fn finalize(&mut self, _context: FinalizeContext) -> Result<(), ExecutionError> {
+    fn finish_transaction(
+        &mut self,
+        _context: FinishTransactionContext,
+    ) -> Result<(), ExecutionError> {
         self.configure_initial_fuel()?;
         let result = ContractEntrypoints::new(&mut self.instance).finish_transaction();
         self.persist_remaining_fuel()?;

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -176,7 +176,7 @@ async fn test_fee_consumption(
             Ok(())
         },
     ));
-    application.expect_call(ExpectedCall::default_finalize());
+    application.expect_call(ExpectedCall::default_finish_transaction());
 
     let refund_grant_to = Some(Account {
         chain_id: ChainId::root(0),

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -77,12 +77,6 @@ macro_rules! contract {
             }
 
             fn finalize() -> Result<(), String> {
-                use $crate::util::BlockingWait;
-                $crate::contract::run_async_entrypoint::<$contract, _, _, _>(
-                    unsafe { &mut CONTRACT },
-                    move |contract| contract.finalize().blocking_wait(),
-                )?;
-
                 unsafe { CONTRACT.take(); }
                 Ok(())
             }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -81,7 +81,10 @@ macro_rules! contract {
                 $crate::contract::run_async_entrypoint::<$contract, _, _, _>(
                     unsafe { &mut CONTRACT },
                     move |contract| contract.finalize().blocking_wait(),
-                )
+                )?;
+
+                unsafe { CONTRACT.take(); }
+                Ok(())
             }
         }
 

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -76,7 +76,7 @@ macro_rules! contract {
                 )
             }
 
-            fn finalize() -> Result<(), String> {
+            fn finish_transaction() -> Result<(), String> {
                 unsafe { CONTRACT.take(); }
                 Ok(())
             }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -12,7 +12,7 @@ pub mod wit;
 pub use self::runtime::ContractRuntime;
 #[doc(hidden)]
 pub use self::wit::export_contract;
-use crate::{log::ContractLogger, util::BlockingWait, State};
+use crate::{log::ContractLogger, util::BlockingWait, State, StoreOnDrop};
 
 /// Declares an implementation of the [`Contract`][`crate::Contract`] trait, exporting it from the
 /// Wasm module.
@@ -104,7 +104,7 @@ where
 
     let contract = contract.get_or_insert_with(|| {
         let state = Contract::State::load().blocking_wait();
-        Contract::new(state, ContractRuntime::new())
+        Contract::new(StoreOnDrop(state), ContractRuntime::new())
             .blocking_wait()
             .expect("Failed to create application contract handler instance")
     });

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -108,9 +108,6 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// Creates a in-memory instance of the contract handler from the application's `state`.
     async fn new(state: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error>;
 
-    /// Returns the current state of the application so that it can be persisted.
-    fn state_mut(&mut self) -> &mut Self::State;
-
     /// Instantiates the application on the chain that created it.
     ///
     /// This is only called once when the application is created and only on the microchain that

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -141,19 +141,6 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// For a message to be executed, a user must mark it to be received in a block of the receiver
     /// chain.
     async fn execute_message(&mut self, message: Self::Message) -> Result<(), Self::Error>;
-
-    /// Finishes the execution of the current transaction.
-    ///
-    /// This is called once before a transaction ends, to allow all applications that participated
-    /// in the transaction to perform any final operations, and optionally it may also cancel the
-    /// transaction if there are any pendencies.
-    ///
-    /// The default implementation persists the state, so if this method is overriden, care must be
-    /// taken to persist the state manually.
-    async fn finalize(&mut self) -> Result<(), Self::Error> {
-        Self::State::store(self.state_mut()).await;
-        Ok(())
-    }
 }
 
 /// The service interface of a Linera application.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -67,7 +67,7 @@ pub use self::{
     extensions::{FromBcsBytes, ToBcsBytes},
     log::{ContractLogger, ServiceLogger},
     service::ServiceRuntime,
-    state::EmptyState,
+    state::{EmptyState, StoreOnDrop},
 };
 
 /// The contract interface of a Linera application.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -106,7 +106,10 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     type InstantiationArgument: Serialize + DeserializeOwned + Debug;
 
     /// Creates a in-memory instance of the contract handler from the application's `state`.
-    async fn new(state: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error>;
+    async fn new(
+        state: StoreOnDrop<Self::State>,
+        runtime: ContractRuntime<Self>,
+    ) -> Result<Self, Self::Error>;
 
     /// Instantiates the application on the chain that created it.
     ///

--- a/linera-sdk/src/state.rs
+++ b/linera-sdk/src/state.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Helper types for application states.
+
+use crate::views::{RootView, ViewStorageContext};
+
+/// Representation of an empty persistent state.
+///
+/// This can be used by applications that don't need to store anything in the database.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct EmptyState;
+
+impl crate::State for EmptyState {
+    async fn load() -> Self {
+        EmptyState
+    }
+
+    async fn store(&mut self) {}
+}
+
+impl<V> crate::State for V
+where
+    V: RootView<ViewStorageContext>,
+{
+    async fn load() -> Self {
+        V::load(ViewStorageContext::default())
+            .await
+            .expect("Failed to load application state")
+    }
+
+    async fn store(&mut self) {
+        self.save()
+            .await
+            .expect("Failed to store application state")
+    }
+}

--- a/linera-sdk/wit/contract-entrypoints.wit
+++ b/linera-sdk/wit/contract-entrypoints.wit
@@ -4,5 +4,5 @@ interface contract-entrypoints {
     instantiate: func(argument: list<u8>) -> result<tuple<>, string>;
     execute-operation: func(operation: list<u8>) -> result<list<u8>, string>;
     execute-message: func(message: list<u8>) -> result<tuple<>, string>;
-    finalize: func() -> result<tuple<>, string>;
+    finish-transaction: func() -> result<tuple<>, string>;
 }

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -8,7 +8,7 @@ use thiserror::Error;
 use self::state::Application;
 
 pub struct ApplicationContract {{
-    state: Application,
+    state: StoreOnDrop<Application>,
     runtime: ContractRuntime<Self>,
 }}
 
@@ -26,7 +26,10 @@ impl Contract for ApplicationContract {{
     type InstantiationArgument = ();
 
     async fn new(state: Self::State, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {{
-        Ok(ApplicationContract {{ state, runtime }})
+        Ok(ApplicationContract {{
+            state: StoreOnDrop(state),
+            StoreOnDrop(runtime),
+        }})
     }}
 
     fn state_mut(&mut self) -> &mut Self::State {{

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -32,10 +32,6 @@ impl Contract for ApplicationContract {{
         }})
     }}
 
-    fn state_mut(&mut self) -> &mut Self::State {{
-        &mut self.state
-    }}
-
     async fn instantiate(
         &mut self,
         _argument: Self::InstantiationArgument,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `finalize` entrypoint has two small issues:

- it's not obviously clear to new developers _when_ it is called in the lifecycle of the contract instance
- it's used as a destructor, which replaces the more idiomatic `Drop`

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Rename the entrypoint to `finish_transaction`, which makes when it is called more explicit. And in the SDK, drop the contract instance so that the `Drop` destructor is called at the correct moment (instead of never being called, like it is now).

To keep the developer experience of automatically persisting the state at the end of a transaction, a new `StoreOnDrop` helper type was created. When the `State` implementation is wrapped in a `StoreOnDrop`, the state is automatically persisted at the end of the transaction.

For applications that want to reject the transaction at the end, they can implement `Drop` on either the `State` or the `Contract` implementation, and panic if a condition isn't met.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, so existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Changes the WIT API and the SDK API, so:
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
