### PR TITLE
Use `EmptyState` in Native Fungible application

### DIFF
--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -8,15 +8,13 @@ mod state;
 use fungible::{FungibleResponse, FungibleTokenAbi, InitialState, Operation, Parameters};
 use linera_sdk::{
     base::{Account, AccountOwner, ChainId, Owner, WithContractAbi},
-    ensure, Contract, ContractRuntime,
+    ensure, Contract, ContractRuntime, EmptyState,
 };
 use native_fungible::{Message, TICKER_SYMBOL};
 use thiserror::Error;
 
-use self::state::NativeFungibleToken;
-
 pub struct NativeFungibleTokenContract {
-    state: NativeFungibleToken,
+    state: EmptyState,
     runtime: ContractRuntime<Self>,
 }
 
@@ -28,15 +26,12 @@ impl WithContractAbi for NativeFungibleTokenContract {
 
 impl Contract for NativeFungibleTokenContract {
     type Error = Error;
-    type State = NativeFungibleToken;
+    type State = EmptyState;
     type Message = Message;
     type Parameters = Parameters;
     type InstantiationArgument = InitialState;
 
-    async fn new(
-        state: NativeFungibleToken,
-        runtime: ContractRuntime<Self>,
-    ) -> Result<Self, Self::Error> {
+    async fn new(state: EmptyState, runtime: ContractRuntime<Self>) -> Result<Self, Self::Error> {
         Ok(NativeFungibleTokenContract { state, runtime })
     }
 
@@ -178,10 +173,6 @@ impl NativeFungibleTokenContract {
         }
     }
 }
-
-// Dummy ComplexObject implementation, required by the graphql(complex) attribute in state.rs.
-#[async_graphql::ComplexObject]
-impl NativeFungibleToken {}
 
 /// An error that can occur during the contract execution.
 #[derive(Debug, Error)]

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -3,8 +3,6 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
-mod state;
-
 use fungible::{FungibleResponse, FungibleTokenAbi, InitialState, Operation, Parameters};
 use linera_sdk::{
     base::{Account, AccountOwner, ChainId, Owner, WithContractAbi},
@@ -177,10 +175,6 @@ impl NativeFungibleTokenContract {
 /// An error that can occur during the contract execution.
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Insufficient balance in source account.
-    #[error("Source account does not have sufficient balance for transfer")]
-    InsufficientBalance(#[from] state::InsufficientBalanceError),
-
     /// Requested transfer does not have permission on this account.
     #[error("The requested transfer is not correctly authenticated.")]
     IncorrectAuthentication,

--- a/examples/native-fungible/src/service.rs
+++ b/examples/native-fungible/src/service.rs
@@ -3,8 +3,6 @@
 
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
-mod state;
-
 use std::sync::{Arc, Mutex};
 
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};

--- a/examples/native-fungible/src/service.rs
+++ b/examples/native-fungible/src/service.rs
@@ -12,12 +12,10 @@ use fungible::{Operation, Parameters};
 use linera_sdk::{
     base::{AccountOwner, WithServiceAbi},
     graphql::GraphQLMutationRoot,
-    Service, ServiceRuntime,
+    EmptyState, Service, ServiceRuntime,
 };
 use native_fungible::{AccountEntry, TICKER_SYMBOL};
 use thiserror::Error;
-
-use self::state::NativeFungibleToken;
 
 #[derive(Clone)]
 pub struct NativeFungibleTokenService {
@@ -32,7 +30,7 @@ impl WithServiceAbi for NativeFungibleTokenService {
 
 impl Service for NativeFungibleTokenService {
     type Error = Error;
-    type State = NativeFungibleToken;
+    type State = EmptyState;
     type Parameters = Parameters;
 
     async fn new(_state: Self::State, runtime: ServiceRuntime<Self>) -> Result<Self, Self::Error> {

--- a/examples/native-fungible/src/state.rs
+++ b/examples/native-fungible/src/state.rs
@@ -1,16 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_sdk::views::{linera_views, RegisterView, RootView, ViewStorageContext};
 use thiserror::Error;
-
-/// The application state.
-#[derive(RootView)]
-#[view(context = "ViewStorageContext")]
-pub struct NativeFungibleToken {
-    // TODO(#968): We should support stateless applications/empty user views
-    pub _dummy: RegisterView<u8>,
-}
 
 /// Attempts to debit from an account with insufficient funds.
 #[derive(Clone, Copy, Debug, Error)]

--- a/examples/native-fungible/src/state.rs
+++ b/examples/native-fungible/src/state.rs
@@ -1,9 +1,0 @@
-// Copyright (c) Zefchain Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use thiserror::Error;
-
-/// Attempts to debit from an account with insufficient funds.
-#[derive(Clone, Copy, Debug, Error)]
-#[error("Insufficient balance for transfer")]
-pub struct InsufficientBalanceError;


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
An `EmptyState` helper type was recently introduced (#1950), which allows replacing the custom empty state type in the Native Fungible application.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use the `EmptyState` type as the state for the Native Fungible application.

## Test Plan

<!-- How to test that the changes are correct. -->
This is a refactor of the application, and the existing end-to-end test should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Only changes the Native Fungible application, so nothing needed (assuming we are not deploying this application automatically on devnet).

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

Closes #968 
