### PR TITLE
`linera-witty`: use `wasmer` from `git` to avoid `wasmer-vm` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4575,7 +4575,6 @@ dependencies = [
  "thiserror",
  "tracing",
  "wasmer",
- "wasmer-vm",
  "wasmtime",
 ]
 
@@ -8236,8 +8235,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4014573f108a246858299eb230031e268316fd57207bd2e8afc79b20fc7ce983"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8266,8 +8264,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a77bfe259f08e8ec9e77f8f772ebfb4149f799d1f637231c5a5a6a90c447256"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8293,8 +8290,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9280c47ebc754f95357745a38a995dd766f149e16b26e1b7e35741eb23c03d12"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -8312,8 +8308,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-singlepass"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4fda4a263d8d9c3bd6cde59bc2f40dae6aaf355db75481c96a004aa8d8221"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -8331,8 +8326,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9352877c4f07fc59146d21b56ae6dc469caf342587f49c81b4fbeafead31972"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -8343,8 +8337,7 @@ dependencies = [
 [[package]]
 name = "wasmer-middlewares"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5c5d574dfd4674fefc3db98748ddb4193c6750f145736555e938c94c505207"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "wasmer",
  "wasmer-types",
@@ -8354,8 +8347,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749214b6170f2b2fbbfe5b7e7f8d381e64930ac4122f3abceb33cde0292d45d2"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -8370,8 +8362,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300215479de0deeb453e95aeb1b9c8ffd9bc7d9bd27c5f9e8a184e54db4d31a9"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "backtrace",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,6 @@ wasm-bindgen-test = "0.3.42"
 wasm-encoder = "0.24.1"
 wasmer = { version = "4.2.8", features = ["singlepass"] }
 wasmer-middlewares = "4.2.8"
-wasmer-vm = { version = "4.2.8" }
 wasmparser = "0.101.1"
 wasmtime = "1.0"
 wasmtimer = "0.2.0"
@@ -213,3 +212,15 @@ opt-level = 3
 version = "0.4.1"
 git = "https://github.com/Twey/rust-indexed-db"
 branch = "no-uuid-wasm-bindgen"
+
+# Needed to compile Witty on `wasm32-unknown-unknown`.  See
+# https://github.com/wasmerio/wasmer/pull/4546
+[patch.crates-io.wasmer]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
+
+[patch.crates-io.wasmer-middlewares]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2561,7 +2561,6 @@ dependencies = [
  "log",
  "thiserror",
  "wasmer",
- "wasmer-vm",
 ]
 
 [[package]]
@@ -4965,8 +4964,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4014573f108a246858299eb230031e268316fd57207bd2e8afc79b20fc7ce983"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -4995,8 +4993,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a77bfe259f08e8ec9e77f8f772ebfb4149f799d1f637231c5a5a6a90c447256"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5022,8 +5019,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9280c47ebc754f95357745a38a995dd766f149e16b26e1b7e35741eb23c03d12"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -5041,8 +5037,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-singlepass"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4fda4a263d8d9c3bd6cde59bc2f40dae6aaf355db75481c96a004aa8d8221"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -5060,8 +5055,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9352877c4f07fc59146d21b56ae6dc469caf342587f49c81b4fbeafead31972"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -5072,8 +5066,7 @@ dependencies = [
 [[package]]
 name = "wasmer-middlewares"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5c5d574dfd4674fefc3db98748ddb4193c6750f145736555e938c94c505207"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "wasmer",
  "wasmer-types",
@@ -5083,8 +5076,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749214b6170f2b2fbbfe5b7e7f8d381e64930ac4122f3abceb33cde0292d45d2"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -5099,8 +5091,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "4.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300215479de0deeb453e95aeb1b9c8ffd9bc7d9bd27c5f9e8a184e54db4d31a9"
+source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
 dependencies = [
  "backtrace",
  "cc",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -54,3 +54,15 @@ strip = 'debuginfo'
 
 [profile.bench]
 debug = true
+
+# Needed to compile Witty on `wasm32-unknown-unknown`.  See
+# https://github.com/wasmerio/wasmer/pull/4546
+[patch.crates-io.wasmer]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
+
+[patch.crates-io.wasmer-middlewares]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -29,3 +29,15 @@ debug = true
 lto = true
 opt-level = 'z'
 strip = 'debuginfo'
+
+# Needed to compile Witty on `wasm32-unknown-unknown`.  See
+# https://github.com/wasmerio/wasmer/pull/4546
+[patch.crates-io.wasmer]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
+
+[patch.crates-io.wasmer-middlewares]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -15,7 +15,7 @@ default = ["macros"]
 log = ["dep:log"]
 macros = ["linera-witty-macros"]
 test = ["linera-witty-macros?/test"]
-wasmer = ["dep:wasmer", "linera-witty-macros?/wasmer", "wasmer-vm"]
+wasmer = ["dep:wasmer", "linera-witty-macros?/wasmer"]
 wasmtime = ["dep:wasmtime", "linera-witty-macros?/wasmtime"]
 
 [dependencies]
@@ -27,7 +27,6 @@ linera-witty-macros = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 thiserror.workspace = true
 wasmer = { workspace = true, optional = true }
-wasmer-vm = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -39,3 +38,15 @@ tracing.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true
+
+# Needed to compile Witty on `wasm32-unknown-unknown`.  See
+# https://github.com/wasmerio/wasmer/pull/4546
+[patch.crates-io.wasmer]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
+
+[patch.crates-io.wasmer-middlewares]
+version = "4.2.8"
+git = "https://github.com/wasmerio/wasmer"
+rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -14,9 +14,8 @@ use std::sync::{Arc, Mutex, MutexGuard};
 pub use wasmer::FunctionEnvMut;
 use wasmer::{
     AsStoreMut, AsStoreRef, Engine, Extern, FunctionEnv, Imports, InstantiationError, Memory,
-    Module, Store, StoreMut, StoreRef,
+    Module, Store, StoreMut, StoreObjects, StoreRef,
 };
-use wasmer_vm::StoreObjects;
 
 pub use self::{parameters::WasmerParameters, results::WasmerResults};
 use super::traits::{Instance, Runtime};


### PR DESCRIPTION
## Motivation

`wasmer-vm` works only in a native interpreter environment (i.e. with `wasmer/sys`), and doesn't even compile for `wasm32-unknown-unknown`.  Thankfully, we only depend on `wasmer-vm` to get access to `StoreObjects`.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

I have patched `wasmer` in https://github.com/wasmerio/wasmer/pull/4546 to expose the required `StoreObjects` struct, meaning we can now access `StoreObjects` without depending on `wasmer-vm`.  This change will be released in Wasmer 4.2.9, but until then we can patch our `wasmer` dependency to use the version from GitHub that merges my patch.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Invisible to users.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
