### PR TITLE
Don't pass `wasmer::Instance` in a `wasmer::FunctionEnvMut`

### DIFF
--- a/linera-witty-macros/src/wit_export/mod.rs
+++ b/linera-witty-macros/src/wit_export/mod.rs
@@ -97,7 +97,7 @@ impl<'input> WitExportGenerator<'input> {
             let target_caller_type: Type = parse_quote! {
                 linera_witty::wasmer::FunctionEnvMut<
                     '_,
-                    linera_witty::wasmer::InstanceSlot<#user_data_type>,
+                    linera_witty::wasmer::Environment<#user_data_type>,
                 >
             };
             let exported_functions = self.functions.iter().map(|function| {

--- a/linera-witty/src/runtime/wasmer/export_function.rs
+++ b/linera-witty/src/runtime/wasmer/export_function.rs
@@ -9,7 +9,7 @@ use std::error::Error;
 
 use wasmer::{FromToNativeWasmType, Function, FunctionEnvMut, WasmTypeList};
 
-use super::{InstanceBuilder, InstanceSlot};
+use super::{Environment, InstanceBuilder};
 use crate::{primitive_types::MaybeFlatType, ExportFunction, RuntimeError};
 
 /// Implements [`ExportFunction`] for [`InstanceBuilder`] using the supported function signatures.
@@ -24,7 +24,7 @@ macro_rules! export_function {
             HandlerError: Error + Send + Sync + 'static,
             Handler:
                 Fn(
-                    FunctionEnvMut<'_, InstanceSlot<UserData>>,
+                    FunctionEnvMut<'_, Environment<UserData>>,
                     ($( $types, )*),
                 ) -> Result<FlatResult, HandlerError>
                 + Send
@@ -43,7 +43,7 @@ macro_rules! export_function {
                     self,
                     &environment,
                     move |
-                        environment: FunctionEnvMut<'_, InstanceSlot<UserData>>,
+                        environment: FunctionEnvMut<'_, Environment<UserData>>,
                         $( $names: $types ),*
                     | -> Result<FlatResult, wasmer::RuntimeError> {
                         handler(environment, ($( $names, )*))

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -97,7 +97,7 @@ where
 {
     type Builder = wasmer::InstanceBuilder<UserData>;
     type Instance = wasmer::EntrypointInstance<UserData>;
-    type Caller<'caller> = ::wasmer::FunctionEnvMut<'caller, wasmer::InstanceSlot<UserData>>;
+    type Caller<'caller> = ::wasmer::FunctionEnvMut<'caller, wasmer::Environment<UserData>>;
 
     fn load_test_module<ExportedFunctions>(&mut self, group: &str, module: &str) -> Self::Instance
     where


### PR DESCRIPTION
## Motivation

Since `wasmer::Instance` isn't `Send` on the Web, we need to avoid passing it in a `FunctionEnvMut`, which is required to be `Send`.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Thankfully, we didn't need to pass the `wasmer::Instance` in the first place.  `wasmer::Exports` is sufficient to access the exports — not their values, which requires an additional `Store`, but we're already passing in that store later.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Invisible to users.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
