### PR TITLE
Update README.md for "/examples/fungible"

### DIFF
--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -66,7 +66,7 @@ bytecode:
 (cd examples/fungible && cargo build --release)
 
 BYTECODE_ID=$(linera publish-bytecode \
-    examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm)
+    ~/linera-protocol/examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm)
 ```
 
 Here, we stored the new bytecode ID in a variable `BYTECODE_ID` to be reused it later.


### PR DESCRIPTION
Might cause errors like "No such file or directory (os error 2)" if not be added 

## Motivation

May be the cause of the error "No such file or directory (os error 2)" if not added to the command

## Proposal

A small change that can save time for newcommers

## Test Plan

Just try running this command with no changes
