### PR TITLE
Move `write_batch` into `ContractRuntime`

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -119,6 +119,8 @@ pub enum ExecutionError {
         caller_id: Box<UserApplicationId>,
         callee_id: Box<UserApplicationId>,
     },
+    #[error("Attempt to write to storage from a contract")]
+    ServiceWriteAttempt,
     #[error("Failed to load bytecode from storage {0:?}")]
     ApplicationBytecodeNotFound(Box<UserApplicationDescription>),
 
@@ -355,11 +357,6 @@ pub trait BaseRuntime {
         promise: &Self::ReadMultiValuesBytes,
     ) -> Result<Vec<Option<Vec<u8>>>, ExecutionError>;
 
-    /// Writes a batch of changes.
-    ///
-    /// Hack: This fails for services.
-    fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError>;
-
     /// Reads the key from the key-value store
     #[cfg(feature = "test")]
     fn read_value_bytes(&mut self, key: Vec<u8>) -> Result<Option<Vec<u8>>, ExecutionError> {
@@ -493,6 +490,9 @@ pub trait ContractRuntime: BaseRuntime {
 
     /// Closes the current chain.
     fn close_chain(&mut self) -> Result<(), ExecutionError>;
+
+    /// Writes a batch of changes.
+    fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError>;
 }
 
 /// An operation to be executed in a block.

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -17,7 +17,7 @@ use wasmer::{sys::EngineBuilder, Cranelift, Engine, Module, Singlepass, Store};
 
 use super::{
     module_cache::ModuleCache,
-    system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi},
+    system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi, WriteBatch},
     ContractEntrypoints, ServiceEntrypoints, WasmExecutionError,
 };
 use crate::{
@@ -65,7 +65,7 @@ impl WasmContractModule {
 
 impl<Runtime> WasmerContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + Clone + Send + Sync + Unpin + 'static,
+    Runtime: ContractRuntime + WriteBatch + Clone + Send + Sync + Unpin + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare(
@@ -100,7 +100,7 @@ impl WasmServiceModule {
 
 impl<Runtime> WasmerServiceInstance<Runtime>
 where
-    Runtime: ServiceRuntime + Clone + Send + Sync + Unpin + 'static,
+    Runtime: ServiceRuntime + WriteBatch + Clone + Send + Sync + Unpin + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare(service_module: &Module, runtime: Runtime) -> Result<Self, WasmExecutionError> {

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -12,7 +12,7 @@ use wasmtime::{AsContextMut, Config, Engine, Linker, Module, Store};
 
 use super::{
     module_cache::ModuleCache,
-    system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi},
+    system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi, WriteBatch},
     ContractEntrypoints, ServiceEntrypoints, WasmExecutionError,
 };
 use crate::{
@@ -124,7 +124,7 @@ impl WasmContractModule {
 
 impl<Runtime> WasmtimeContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + Send + Sync + 'static,
+    Runtime: ContractRuntime + WriteBatch + Send + Sync + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare(contract_module: &Module, runtime: Runtime) -> Result<Self, WasmExecutionError> {
@@ -161,7 +161,7 @@ impl WasmServiceModule {
 
 impl<Runtime> WasmtimeServiceInstance<Runtime>
 where
-    Runtime: ServiceRuntime + Send + Sync + 'static,
+    Runtime: ServiceRuntime + WriteBatch + Send + Sync + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare(service_module: &Module, runtime: Runtime) -> Result<Self, WasmExecutionError> {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Services should have a read-only view into the application state. However, it was previously possible to call `write_batch` from services and change the application state.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Remove access to `write_batch` from services, by making it only available in the `ContractRuntime` trait instead of the `BaseRuntime` trait which is shared by contracts and services.

In the `wasm` module the system API needs to be refactored to change the API and remove `write-batch` from the service WIT interface. However, the WIT system API interfaces need to be refactored in a larger way, so issue #1977 was opened to track it and a workaround was introduced in the meantime.

## Test Plan

<!-- How to test that the changes are correct. -->
The bug was discovered by writing a unit test, which failed before this PR. After this PR, the test no longer compiles, so it wasn't included in the PR. But for reference, the test code follows below:

```rust
/// Tests if attempting to persist data to storage from a service fails.
#[tokio::test]
async fn test_storing_from_service() -> anyhow::Result<()> {
    const KEY: &[u8] = b"entry key";
    const VALUE: &[u8] = b"entry value";

    let mut state = SystemExecutionState::default();
    state.description = Some(ChainDescription::Root(0));
    let mut view = state.into_view().await;

    let mut applications = register_mock_applications(&mut view, 1).await?;
    let (application_id, application) = applications.next().unwrap();

    application.expect_call(ExpectedCall::handle_query(|runtime, context, query| {
        assert!(query.is_empty());

        // Modify our state.
        let mut state = runtime
            .read_value_bytes(KEY.to_owned())?
            .unwrap_or_default();
        state.extend(VALUE.to_owned());
        let mut batch = Batch::new();
        batch.put_key_value_bytes(KEY.to_owned(), state);
        runtime.write_batch(batch)?;

        Ok(vec![])
    }));

    let context = make_query_context();
    let response = view
        .query_application(
            context,
            Query::User {
                application_id,
                bytes: vec![],
            },
        )
        .await?;

    assert_eq!(response, Response::User(vec![]));

    let application_storage = view
        .users
        .try_load_entry(&application_id)
        .await?
        .expect("Missing application storage");

    assert_eq!(application_storage.total_size(), SizeData::default());

    Ok(())
}
```

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Fixes a bug, but user applications are not affected, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
