### PR TITLE
Replace git `wasmer` dependency with prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8225,8 +8225,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063315805273d66057de5e7145919e745134374ee9a2acfeb354814a2240649e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8254,8 +8255,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f809637584d1ba52e43291703c255107f87858b7fc70d78b4bebc175f462f5d9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8280,8 +8282,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b092fd256db30f3ffe069173c7799bde50283a0969827e034004ae755d4fe8"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -8298,8 +8301,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6852aef78618c839d02874283cdc331beb91e01727789c29007920ff3803c915"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -8316,8 +8320,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f14f05a6665e0a4fcdfced554b1b9bc649b8a411414a2c99802c6daa3faed3"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -8327,8 +8332,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b718632586b3e2959435adabb1b449a8632ee50ff086058df2708878eb774b"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -8342,8 +8348,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3747c71e2dd938cdf90c735f37dc72cbb8538109b4a134d719a64826ae5c2"
 dependencies = [
  "backtrace",
  "cc",
@@ -9361,8 +9368,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "wasmer-middlewares"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,8 @@ wasm-bindgen = "0.2.92"
 wasm-bindgen-test = "0.3.42"
 wasm-encoder = "0.24.1"
 wasm-instrument = "0.4.0"
-wasmer = { version = "4.2.8", features = ["singlepass"] }
+wasmer = { version = "4.3.0-alpha.1", features = ["singlepass"] }
+wasmer-compiler-singlepass = "4.3.0-alpha.1"
 wasmparser = "0.101.1"
 wasmtime = "1.0"
 wasmtimer = "0.2.0"
@@ -208,15 +209,3 @@ opt-level = 3
 version = "0.4.1"
 git = "https://github.com/Twey/rust-indexed-db"
 branch = "no-uuid-wasm-bindgen"
-
-# Needed to compile Witty on `wasm32-unknown-unknown`.  See
-# https://github.com/wasmerio/wasmer/pull/4546
-[patch.crates-io.wasmer]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
-
-[patch.crates-io.wasmer-middlewares]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4963,8 +4963,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063315805273d66057de5e7145919e745134374ee9a2acfeb354814a2240649e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -4992,8 +4993,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f809637584d1ba52e43291703c255107f87858b7fc70d78b4bebc175f462f5d9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5018,8 +5020,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b092fd256db30f3ffe069173c7799bde50283a0969827e034004ae755d4fe8"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -5036,8 +5039,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6852aef78618c839d02874283cdc331beb91e01727789c29007920ff3803c915"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -5054,8 +5058,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7f14f05a6665e0a4fcdfced554b1b9bc649b8a411414a2c99802c6daa3faed3"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -5065,8 +5070,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b718632586b3e2959435adabb1b449a8632ee50ff086058df2708878eb774b"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -5080,8 +5086,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"
+version = "4.3.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3747c71e2dd938cdf90c735f37dc72cbb8538109b4a134d719a64826ae5c2"
 dependencies = [
  "backtrace",
  "cc",
@@ -5948,8 +5955,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "wasmer-middlewares"
-version = "4.2.8"
-source = "git+https://github.com/wasmerio/wasmer?rev=5800991767bc71a38dc4fc7e287cf451982a75a2#5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -52,15 +52,3 @@ strip = 'debuginfo'
 
 [profile.bench]
 debug = true
-
-# Needed to compile Witty on `wasm32-unknown-unknown`.  See
-# https://github.com/wasmerio/wasmer/pull/4546
-[patch.crates-io.wasmer]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
-
-[patch.crates-io.wasmer-middlewares]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -27,15 +27,3 @@ debug = true
 lto = true
 opt-level = 'z'
 strip = 'debuginfo'
-
-# Needed to compile Witty on `wasm32-unknown-unknown`.  See
-# https://github.com/wasmerio/wasmer/pull/4546
-[patch.crates-io.wasmer]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
-
-[patch.crates-io.wasmer-middlewares]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -38,15 +38,3 @@ tracing.workspace = true
 
 [build-dependencies]
 cfg_aliases.workspace = true
-
-# Needed to compile Witty on `wasm32-unknown-unknown`.  See
-# https://github.com/wasmerio/wasmer/pull/4546
-[patch.crates-io.wasmer]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"
-
-[patch.crates-io.wasmer-middlewares]
-version = "4.2.8"
-git = "https://github.com/wasmerio/wasmer"
-rev = "5800991767bc71a38dc4fc7e287cf451982a75a2"


### PR DESCRIPTION
## Motivation

Git dependencies are a pain to maintain, as we have to patch every `Cargo.toml` that might be a workspace root.  Now that Wasmer has released a prerelease, we can just use that version instead.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Replace our Wasmer git dependency patch with a prerelease version.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- Closes https://github.com/linera-io/linera-protocol/issues/1966
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)