### PR TITLE
Remove `bcs` and `serde-json` dependencies requirement for applications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,14 +102,12 @@ name = "amm"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "fungible",
  "linera-sdk",
  "matching-engine",
  "num-bigint",
  "num-traits",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1789,7 +1787,6 @@ name = "crowd-funding"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "fungible",
  "linera-sdk",
  "serde",
@@ -2840,11 +2837,9 @@ name = "fungible"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "futures",
  "linera-sdk",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4728,7 +4723,6 @@ dependencies = [
  "fungible",
  "linera-sdk",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4815,12 +4809,10 @@ name = "meta-counter"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "counter",
  "linera-sdk",
  "log",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4890,11 +4882,9 @@ name = "native-fungible"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "fungible",
  "linera-sdk",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4923,7 +4913,6 @@ dependencies = [
  "fungible",
  "linera-sdk",
  "serde",
- "serde_json",
  "sha3",
 ]
 
@@ -6820,7 +6809,6 @@ dependencies = [
  "bcs",
  "linera-sdk",
  "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -79,14 +79,12 @@ name = "amm"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "fungible",
  "linera-sdk",
  "matching-engine",
  "num-bigint",
  "num-traits",
  "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -1001,7 +999,6 @@ name = "crowd-funding"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "fungible",
  "linera-sdk",
  "serde",
@@ -1589,12 +1586,10 @@ name = "fungible"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "fungible",
  "futures",
  "linera-sdk",
  "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -2593,7 +2588,6 @@ name = "llm"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "candle-core",
  "candle-transformers",
  "getrandom",
@@ -2601,7 +2595,6 @@ dependencies = [
  "log",
  "rand",
  "serde",
- "serde_json",
  "tokenizers",
  "tokio",
 ]
@@ -2697,7 +2690,6 @@ dependencies = [
  "fungible",
  "linera-sdk",
  "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -2785,12 +2777,10 @@ name = "meta-counter"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "counter",
  "linera-sdk",
  "log",
  "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2881,12 +2871,10 @@ name = "native-fungible"
 version = "0.1.0"
 dependencies = [
  "async-graphql",
- "bcs",
  "fungible",
  "linera-sdk",
  "native-fungible",
  "serde",
- "serde_json",
  "tokio",
 ]
 
@@ -2911,7 +2899,6 @@ dependencies = [
  "linera-sdk",
  "non-fungible",
  "serde",
- "serde_json",
  "sha3",
  "tokio",
 ]
@@ -4067,7 +4054,6 @@ dependencies = [
  "bcs",
  "linera-sdk",
  "serde",
- "serde_json",
  "tokio",
 ]
 

--- a/examples/amm/Cargo.toml
+++ b/examples/amm/Cargo.toml
@@ -6,22 +6,16 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
-bcs.workspace = true
 fungible.workspace = true
 linera-sdk.workspace = true
 matching-engine.workspace = true
 num-bigint.workspace = true
 num-traits.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["bcs", "serde_json"]
 
 [[bin]]
 name = "amm_contract"

--- a/examples/crowd-funding/Cargo.toml
+++ b/examples/crowd-funding/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
-bcs.workspace = true
 fungible.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
@@ -16,10 +15,6 @@ serde_json.workspace = true
 fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio.workspace = true
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["bcs"]
 
 [[bin]]
 name = "crowd_funding_contract"

--- a/examples/fungible/Cargo.toml
+++ b/examples/fungible/Cargo.toml
@@ -9,20 +9,14 @@ test = []
 
 [dependencies]
 async-graphql.workspace = true
-bcs.workspace = true
 futures.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio.workspace = true
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["bcs", "serde_json"]
 
 [[bin]]
 name = "fungible_contract"

--- a/examples/llm/Cargo.toml
+++ b/examples/llm/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
-bcs.workspace = true
 candle-core.workspace = true
 candle-transformers.workspace = true
 getrandom.workspace = true
@@ -13,16 +12,11 @@ linera-sdk.workspace = true
 log.workspace = true
 rand.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 tokenizers.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["bcs", "serde_json"]
 
 [[bin]]
 name = "llm_contract"

--- a/examples/matching-engine/Cargo.toml
+++ b/examples/matching-engine/Cargo.toml
@@ -10,16 +10,11 @@ bcs.workspace = true
 fungible.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio.workspace = true
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["serde_json"]
 
 [[bin]]
 name = "matching_engine_contract"

--- a/examples/meta-counter/Cargo.toml
+++ b/examples/meta-counter/Cargo.toml
@@ -6,19 +6,13 @@ edition = "2021"
 
 [dependencies]
 async-graphql.workspace = true
-bcs.workspace = true
 counter.workspace = true
 linera-sdk.workspace = true
 log.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 
 [dev-dependencies]
 linera-sdk = { workspace = true, features = ["test"] }
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["bcs", "serde_json"]
 
 [[bin]]
 name = "meta_counter_contract"

--- a/examples/native-fungible/Cargo.toml
+++ b/examples/native-fungible/Cargo.toml
@@ -9,20 +9,14 @@ test = []
 
 [dependencies]
 async-graphql.workspace = true
-bcs.workspace = true
 fungible.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 native-fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true }
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["bcs", "serde_json"]
 
 [[bin]]
 name = "native_fungible_contract"

--- a/examples/non-fungible/Cargo.toml
+++ b/examples/non-fungible/Cargo.toml
@@ -14,7 +14,6 @@ bcs.workspace = true
 fungible.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 sha3.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
@@ -22,10 +21,6 @@ fungible = { workspace = true, features = ["test"] }
 non-fungible = { workspace = true, features = ["test"] }
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio.workspace = true
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["serde_json"]
 
 [[bin]]
 name = "non_fungible_contract"

--- a/examples/social/Cargo.toml
+++ b/examples/social/Cargo.toml
@@ -9,15 +9,10 @@ async-graphql.workspace = true
 bcs.workspace = true
 linera-sdk.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 linera-sdk = { workspace = true, features = ["test", "wasmer"] }
 tokio = { workspace = true, features = ["rt", "sync"] }
-
-# TODO(#1970): Remove once macros don't depend on them
-[package.metadata.cargo-machete]
-ignored = ["serde_json"]
 
 [[bin]]
 name = "social_contract"

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -47,7 +47,7 @@ macro_rules! contract {
                 $crate::contract::run_async_entrypoint::<$contract, _, _>(
                     unsafe { &mut CONTRACT },
                     move |contract| {
-                        let argument = serde_json::from_slice(&argument)
+                        let argument = $crate::serde_json::from_slice(&argument)
                             .expect("Failed to deserialize instantiation argument");
 
                         contract.instantiate(argument).blocking_wait()
@@ -61,11 +61,12 @@ macro_rules! contract {
                     unsafe { &mut CONTRACT },
                     move |contract| {
                         let operation: <$contract as $crate::abi::ContractAbi>::Operation =
-                            bcs::from_bytes(&operation).expect("Failed to deserialize operation");
+                            $crate::bcs::from_bytes(&operation)
+                                .expect("Failed to deserialize operation");
 
                         let response = contract.execute_operation(operation).blocking_wait();
 
-                        bcs::to_bytes(&response)
+                        $crate::bcs::to_bytes(&response)
                             .expect("Failed to serialize contract's `Response`")
                     },
                 )
@@ -77,7 +78,8 @@ macro_rules! contract {
                     unsafe { &mut CONTRACT },
                     move |contract| {
                         let message: <$contract as $crate::Contract>::Message =
-                            bcs::from_bytes(&message).expect("Failed to deserialize message");
+                            $crate::bcs::from_bytes(&message)
+                                .expect("Failed to deserialize message");
 
                         contract.execute_message(message).blocking_wait()
                     },

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -45,6 +45,7 @@ pub mod views;
 
 use std::fmt::Debug;
 
+pub use bcs;
 use linera_base::abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi};
 pub use linera_base::{
     abi,
@@ -52,6 +53,7 @@ pub use linera_base::{
     ensure,
 };
 use serde::{de::DeserializeOwned, Serialize};
+pub use serde_json;
 
 use self::views::{RootView, ViewStorageContext};
 #[doc(hidden)]

--- a/linera-sdk/src/service/mod.rs
+++ b/linera-sdk/src/service/mod.rs
@@ -40,7 +40,7 @@ macro_rules! service {
         /// Mark the service type to be exported.
         impl $crate::service::wit::exports::linera::app::service_entrypoints::Guest for $service {
             fn handle_query(argument: Vec<u8>) -> Vec<u8> {
-                let request = serde_json::from_slice(&argument)
+                let request = $crate::serde_json::from_slice(&argument)
                     .expect("Query is invalid and could not be deserialized");
                 let response = $crate::service::run_async_entrypoint(move |runtime| async move {
                     let state =
@@ -48,7 +48,7 @@ macro_rules! service {
                     let service = <$service as $crate::Service>::new(state, runtime).await;
                     service.handle_query(request).await
                 });
-                serde_json::to_vec(&response)
+                $crate::serde_json::to_vec(&response)
                     .expect("Failed to deserialize query response")
             }
         }

--- a/linera-service/template/Cargo.toml.template
+++ b/linera-service/template/Cargo.toml.template
@@ -5,11 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-graphql = {{ version = "7.0.2", default-features = false }}
-bcs = "0.1.3"
-futures = "0.3.24"
 {linera_sdk_dep}
-serde = {{ version = "1.0.130", features = ["derive"] }}
-serde_json = "1.0.93"
 
 [dev-dependencies]
 {linera_sdk_dev_dep}


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Linera applications always had to depend on the `bcs` and `serde-json` crates, because some macros assumed that they were always available. This can be confusing to users because they need to add dependencies to crates that they don't use directly. It also leads to some lint complaints (from `cargo machete` for example).

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Re-export the two crates from `linera-sdk` and update the macros to use those re-exports.

## Test Plan

<!-- How to test that the changes are correct. -->
This changes the dependencies and touches the macros. Existing tests should cover these changes and catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This changes the SDK, so:
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

Closes #1970
