### PR TITLE
`linera-execution`: enable `fetch_url` on Wasm environments

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,8 +72,7 @@ jobs:
         cargo test --locked --no-run
     - name: Compile `linera-core` for the browser
       run: |
-        cargo test -p linera-core \
-          --no-run \
+        cargo build -p linera-core \
           --locked \
           --target wasm32-unknown-unknown \
           --no-default-features \

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -69,7 +69,8 @@ where
     let sender = ArcChainClient::new(sender);
     // Listen to the notifications on the sender chain.
     let mut notifications = sender.lock().await.subscribe().await?;
-    let (_listen_handle, _) = sender.listen().await?;
+    let (listener, _listen_handle, _) = sender.listen().await?;
+    tokio::spawn(listener);
     {
         let mut sender = sender.lock().await;
         let certificate = sender

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -101,7 +101,8 @@ static NUM_BLOCKS: Lazy<IntCounterVec> = Lazy::new(|| {
 /// * Repeating commands produces no changes and returns no error.
 /// * Some handlers may return cross-chain requests, that is, messages
 ///   to be communicated to other workers of the same validator.
-#[async_trait]
+#[cfg_attr(not(web), async_trait)]
+#[cfg_attr(web, async_trait(?Send))]
 pub trait ValidatorWorker {
     /// Proposes a new block. In case of success, the chain info contains a vote on the new
     /// block.
@@ -1066,7 +1067,8 @@ where
     }
 }
 
-#[async_trait]
+#[cfg_attr(not(web), async_trait)]
+#[cfg_attr(web, async_trait(?Send))]
 impl<StorageClient> ValidatorWorker for WorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -262,13 +262,11 @@ where
                 }
             }
 
-            #[cfg(not(target_arch = "wasm32"))]
             FetchUrl { url, callback } => {
                 let bytes = reqwest::get(url).await?.bytes().await?.to_vec();
                 callback.respond(bytes);
             }
 
-            #[cfg(not(target_arch = "wasm32"))]
             FetchJson { url, callback } => {
                 let json: serde_json::Value = reqwest::get(url).await?.json().await?;
                 let string = serde_json::to_string_pretty(&json)?;
@@ -382,13 +380,11 @@ pub enum Request {
         callback: oneshot::Sender<Result<(), ExecutionError>>,
     },
 
-    #[cfg(not(target_arch = "wasm32"))]
     FetchUrl {
         url: String,
         callback: Sender<Vec<u8>>,
     },
 
-    #[cfg(not(target_arch = "wasm32"))]
     FetchJson {
         url: String,
         callback: oneshot::Sender<String>,
@@ -507,13 +503,11 @@ impl Debug for Request {
                 .field("application_id", application_id)
                 .finish_non_exhaustive(),
 
-            #[cfg(not(target_arch = "wasm32"))]
             Request::FetchUrl { url, .. } => formatter
                 .debug_struct("Request::FetchUrl")
                 .field("url", url)
                 .finish_non_exhaustive(),
 
-            #[cfg(not(target_arch = "wasm32"))]
             Request::FetchJson { url, .. } => formatter
                 .debug_struct("Request::FetchJson")
                 .field("url", url)

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -426,7 +426,6 @@ pub trait BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Makes a GET request to the given URL and returns the JSON part, if any.
-    #[cfg(not(target_arch = "wasm32"))]
     fn fetch_json(&mut self, url: &str) -> Result<String, ExecutionError>;
 }
 
@@ -439,7 +438,6 @@ pub trait ServiceRuntime: BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Fetches blob of bytes from an arbitrary URL.
-    #[cfg(not(target_arch = "wasm32"))]
     fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, ExecutionError>;
 }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -639,7 +639,6 @@ impl<UserInstance> BaseRuntime for SyncRuntime<UserInstance> {
         self.inner().query_service(application_id, query)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     fn fetch_json(&mut self, url: &str) -> Result<String, ExecutionError> {
         self.inner().fetch_json(url)
     }
@@ -868,7 +867,6 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(response)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     fn fetch_json(&mut self, url: &str) -> Result<String, ExecutionError> {
         if let OracleResponses::Replay(responses) = &mut self.oracle_responses {
             return match responses.next() {
@@ -1309,7 +1307,6 @@ impl ServiceRuntime for ServiceSyncRuntime {
         Ok(response)
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     /// Get a blob of bytes from an arbitrary URL.
     fn fetch_url(&mut self, url: &str) -> Result<Vec<u8>, ExecutionError> {
         let this = self.inner();

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -139,7 +139,8 @@ where
             entry.insert(client.clone());
             client
         };
-        let (_listen_handle, mut local_stream) = client.listen().await?;
+        let (listener, _listen_handle, mut local_stream) = client.listen().await?;
+        tokio::spawn(listener);
         let mut timeout = storage.clock().current_time();
         loop {
             let sleep = Box::pin(storage.clock().sleep_until(timeout));

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -737,7 +737,8 @@ impl Runnable for Job {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 let chain_client = context.make_chain_client(storage, chain_id).into_arc();
                 info!("Watching for notifications for chain {:?}", chain_id);
-                let (_listen_handle, mut notifications) = chain_client.listen().await?;
+                let (listener, _listen_handle, mut notifications) = chain_client.listen().await?;
+                tokio::spawn(listener);
                 while let Some(notification) = notifications.next().await {
                     if let Reason::NewBlock { .. } = notification.reason {
                         let mut guard = chain_client.lock().await;


### PR DESCRIPTION
## Motivation

The APIs when running on Wasm and non-Wasm should be the same.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal
Enable it!  In order to do so, we have to make some traits non-`Send` on the Web, since the Web fetch futures are not `Send`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

Nothing special required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
