### PR TITLE
Wasm on the Web

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,7 +80,7 @@ jobs:
           --locked \
           --target wasm32-unknown-unknown \
           --no-default-features \
-          --features web
+          --features web,wasmer
     - name: Compile the workspace with the default features (build)
       run: |
         cargo build --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8030,8 +8030,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063315805273d66057de5e7145919e745134374ee9a2acfeb354814a2240649e"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8061,8 +8060,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f809637584d1ba52e43291703c255107f87858b7fc70d78b4bebc175f462f5d9"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8088,8 +8086,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b092fd256db30f3ffe069173c7799bde50283a0969827e034004ae755d4fe8"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -8107,8 +8104,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-singlepass"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6852aef78618c839d02874283cdc331beb91e01727789c29007920ff3803c915"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -8126,8 +8122,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f14f05a6665e0a4fcdfced554b1b9bc649b8a411414a2c99802c6daa3faed3"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -8138,8 +8133,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b718632586b3e2959435adabb1b449a8632ee50ff086058df2708878eb774b"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -8154,8 +8148,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3747c71e2dd938cdf90c735f37dc72cbb8538109b4a134d719a64826ae5c2"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
 dependencies = [
  "backtrace",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8053,6 +8053,7 @@ dependencies = [
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
+ "wasmparser 0.121.2",
  "wat",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ wasm-bindgen = "0.2.92"
 wasm-bindgen-test = "0.3.42"
 wasm-encoder = "0.24.1"
 wasm-instrument = "0.4.0"
-wasmer = { version = "4.3.0-alpha.1", features = ["singlepass"] }
+wasmer = { version = "4.3.0-alpha.1", default-features = false }
 wasmer-compiler-singlepass = "4.3.0-alpha.1"
 wasmparser = "0.101.1"
 wasmtime = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,3 +217,8 @@ opt-level = 3
 version = "0.4.1"
 git = "https://github.com/Twey/rust-indexed-db"
 branch = "no-uuid-wasm-bindgen"
+
+[patch.crates-io.wasmer]
+version = "4.3.0-alpha.1"
+git = "https://github.com/Twey/wasmer"
+branch = "non-send-environments"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6205,8 +6205,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063315805273d66057de5e7145919e745134374ee9a2acfeb354814a2240649e"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6235,8 +6234,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f809637584d1ba52e43291703c255107f87858b7fc70d78b4bebc175f462f5d9"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6262,8 +6260,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b092fd256db30f3ffe069173c7799bde50283a0969827e034004ae755d4fe8"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -6281,8 +6278,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-singlepass"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6852aef78618c839d02874283cdc331beb91e01727789c29007920ff3803c915"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -6300,8 +6296,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f14f05a6665e0a4fcdfced554b1b9bc649b8a411414a2c99802c6daa3faed3"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -6312,8 +6307,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b718632586b3e2959435adabb1b449a8632ee50ff086058df2708878eb774b"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -6328,8 +6322,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "4.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3747c71e2dd938cdf90c735f37dc72cbb8538109b4a134d719a64826ae5c2"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
 dependencies = [
  "backtrace",
  "cc",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -57,3 +57,8 @@ strip = 'debuginfo'
 
 [profile.bench]
 debug = true
+
+[patch.crates-io.wasmer]
+version = "4.3.0-alpha.1"
+git = "https://github.com/Twey/wasmer"
+branch = "non-send-environments"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -88,3 +88,8 @@ cfg_aliases.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]
+
+[patch.crates-io.wasmer]
+version = "4.3.0-alpha.1"
+git = "https://github.com/Twey/wasmer"
+branch = "non-send-environments"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -29,7 +29,7 @@ wasmtime = [
     "wasm-encoder",
     "wasmparser",
 ]
-web = ["linera-base/web", "linera-views/web"]
+web = ["linera-base/web", "linera-views/web", "wasmer?/js-default"]
 
 [dependencies]
 anyhow.workspace = true
@@ -65,6 +65,7 @@ wasmtime = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
+wasmer = { workspace = true, features = ["sys-default", "singlepass"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true, features = ["rt"] }

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -29,7 +29,7 @@ wasmtime = [
     "wasm-encoder",
     "wasmparser",
 ]
-web = ["linera-base/web", "linera-views/web", "wasmer?/js-default"]
+web = ["linera-base/web", "linera-views/web"]
 
 [dependencies]
 anyhow.workspace = true
@@ -59,16 +59,16 @@ thiserror.workspace = true
 tracing = { workspace = true, features = ["log"] }
 wasm-encoder = { workspace = true, optional = true }
 wasm-instrument = { workspace = true, optional = true, features = ["sign_ext"] }
-wasmer = { workspace = true, optional = true }
 wasmparser = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-wasmer = { workspace = true, features = ["sys-default", "singlepass"] }
+wasmer = { workspace = true, optional = true, features = ["sys-default", "singlepass"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { workspace = true, features = ["rt"] }
+wasmer = { workspace = true, optional = true, features = ["js-default"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/linera-execution/build.rs
+++ b/linera-execution/build.rs
@@ -3,11 +3,13 @@
 
 fn main() {
     cfg_aliases::cfg_aliases! {
+        web: { all(target_arch = "wasm32", feature = "web") },
+
         with_fs: { all(not(target_arch = "wasm32"), feature = "fs") },
         with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
         with_testing: { any(test, feature = "test") },
         with_tokio_multi_thread: { not(target_arch = "wasm32") },
-        with_wasmer: { all(not(target_arch = "wasm32"), feature = "wasmer") },
+        with_wasmer: { feature = "wasmer" },
         with_wasmtime: { all(not(target_arch = "wasm32"), feature = "wasmtime") },
 
         // If you change this, don't forget to update `WasmRuntime` and

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -72,10 +72,10 @@ pub type UserContractCode = Arc<dyn UserContractModule + Send + Sync + 'static>;
 pub type UserServiceCode = Arc<dyn UserServiceModule + Send + Sync + 'static>;
 
 /// An implementation of [`UserContract`].
-pub type UserContractInstance = Box<dyn UserContract + Send + Sync + 'static>;
+pub type UserContractInstance = Box<dyn UserContract + 'static>;
 
 /// An implementation of [`UserService`].
-pub type UserServiceInstance = Box<dyn UserService + Send + Sync + 'static>;
+pub type UserServiceInstance = Box<dyn UserService + 'static>;
 
 /// A factory trait to obtain a [`UserContract`] from a [`UserContractModule`]
 pub trait UserContractModule {

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -195,7 +195,7 @@ impl UserContractModule for MockApplication {
     fn instantiate(
         &self,
         runtime: ContractSyncRuntime,
-    ) -> Result<Box<dyn UserContract + Send + Sync + 'static>, ExecutionError> {
+    ) -> Result<Box<dyn UserContract + 'static>, ExecutionError> {
         Ok(Box::new(self.create_mock_instance(runtime)))
     }
 }
@@ -204,7 +204,7 @@ impl UserServiceModule for MockApplication {
     fn instantiate(
         &self,
         runtime: ServiceSyncRuntime,
-    ) -> Result<Box<dyn UserService + Send + Sync + 'static>, ExecutionError> {
+    ) -> Result<Box<dyn UserService + 'static>, ExecutionError> {
         Ok(Box::new(self.create_mock_instance(runtime)))
     }
 }

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -79,7 +79,7 @@ pub struct ContractSystemApi<Caller>(PhantomData<Caller>);
 impl<Caller, Runtime> ContractSystemApi<Caller>
 where
     Caller: Instance<UserData = SystemApiData<Runtime>>,
-    Runtime: ContractRuntime + Send + 'static,
+    Runtime: ContractRuntime + 'static,
 {
     /// Returns the ID of the current chain.
     fn get_chain_id(caller: &mut Caller) -> Result<ChainId, RuntimeError> {
@@ -360,7 +360,7 @@ pub struct ServiceSystemApi<Caller>(PhantomData<Caller>);
 impl<Caller, Runtime> ServiceSystemApi<Caller>
 where
     Caller: Instance<UserData = SystemApiData<Runtime>>,
-    Runtime: ServiceRuntime + Send + 'static,
+    Runtime: ServiceRuntime + 'static,
 {
     /// Returns the ID of the current chain.
     fn get_chain_id(caller: &mut Caller) -> Result<ChainId, RuntimeError> {
@@ -514,7 +514,7 @@ pub struct ViewSystemApi<Caller>(PhantomData<Caller>);
 impl<Caller, Runtime> ViewSystemApi<Caller>
 where
     Caller: Instance<UserData = SystemApiData<Runtime>>,
-    Runtime: BaseRuntime + WriteBatch + Send + 'static,
+    Runtime: BaseRuntime + WriteBatch + 'static,
 {
     /// Creates a new promise to check if the `key` is in storage.
     fn contains_key_new(caller: &mut Caller, key: Vec<u8>) -> Result<u32, RuntimeError> {

--- a/linera-execution/src/wasm/wasmer.rs
+++ b/linera-execution/src/wasm/wasmer.rs
@@ -26,13 +26,6 @@ use crate::{
     QueryContext, ServiceRuntime,
 };
 
-#[cfg(not(web))]
-use {
-    wasmer::sys::EngineBuilder,
-    wasmer::Cranelift,
-    wasmer::Singlepass,
-};
-
 /// An [`Engine`] instance configured to run application services.
 static SERVICE_ENGINE: Lazy<Engine> = Lazy::new(|| {
     #[cfg(web)]
@@ -79,7 +72,7 @@ impl WasmContractModule {
 
 impl<Runtime> WasmerContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + WriteBatch + Clone + Send + Sync + Unpin + 'static,
+    Runtime: ContractRuntime + WriteBatch + Clone + Unpin + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare(
@@ -114,7 +107,7 @@ impl WasmServiceModule {
 
 impl<Runtime> WasmerServiceInstance<Runtime>
 where
-    Runtime: ServiceRuntime + WriteBatch + Clone + Send + Sync + Unpin + 'static,
+    Runtime: ServiceRuntime + WriteBatch + Clone + Unpin + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare(service_module: &Module, runtime: Runtime) -> Result<Self, WasmExecutionError> {
@@ -132,7 +125,7 @@ where
 
 impl<Runtime> crate::UserContract for WasmerContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + Send + Unpin + 'static,
+    Runtime: ContractRuntime + Unpin + 'static,
 {
     fn instantiate(
         &mut self,
@@ -174,10 +167,7 @@ where
     }
 }
 
-impl<Runtime> crate::UserService for WasmerServiceInstance<Runtime>
-where
-    Runtime: Send + 'static,
-{
+impl<Runtime: 'static> crate::UserService for WasmerServiceInstance<Runtime> {
     fn handle_query(
         &mut self,
         _context: QueryContext,

--- a/linera-execution/src/wasm/wasmtime.rs
+++ b/linera-execution/src/wasm/wasmtime.rs
@@ -46,7 +46,7 @@ static SERVICE_CACHE: Lazy<Mutex<ModuleCache<Module>>> = Lazy::new(Mutex::defaul
 /// system API.
 pub(crate) struct WasmtimeContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + Send + Sync + 'static,
+    Runtime: ContractRuntime + 'static,
 {
     /// The Wasm module instance.
     instance: EntrypointInstance<SystemApiData<Runtime>>,
@@ -59,7 +59,7 @@ where
 // dependency is updated
 impl<Runtime> WasmtimeContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + Send + Sync,
+    Runtime: ContractRuntime,
 {
     fn configure_initial_fuel(&mut self) -> Result<(), ExecutionError> {
         let runtime = &mut self.instance.user_data_mut().runtime_mut();
@@ -124,7 +124,7 @@ impl WasmContractModule {
 
 impl<Runtime> WasmtimeContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + WriteBatch + Send + Sync + 'static,
+    Runtime: ContractRuntime + WriteBatch + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm contract.
     pub fn prepare(contract_module: &Module, runtime: Runtime) -> Result<Self, WasmExecutionError> {
@@ -161,7 +161,7 @@ impl WasmServiceModule {
 
 impl<Runtime> WasmtimeServiceInstance<Runtime>
 where
-    Runtime: ServiceRuntime + WriteBatch + Send + Sync + 'static,
+    Runtime: ServiceRuntime + WriteBatch + 'static,
 {
     /// Prepares a runtime instance to call into the Wasm service.
     pub fn prepare(service_module: &Module, runtime: Runtime) -> Result<Self, WasmExecutionError> {
@@ -184,7 +184,7 @@ where
 
 impl<Runtime> crate::UserContract for WasmtimeContractInstance<Runtime>
 where
-    Runtime: ContractRuntime + Send + Sync + 'static,
+    Runtime: ContractRuntime + 'static,
 {
     fn instantiate(
         &mut self,
@@ -232,7 +232,7 @@ where
 
 impl<Runtime> crate::UserService for WasmtimeServiceInstance<Runtime>
 where
-    Runtime: ServiceRuntime + Send + Sync + 'static,
+    Runtime: ServiceRuntime + 'static,
 {
     fn handle_query(
         &mut self,

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -30,6 +30,16 @@ thiserror.workspace = true
 wasmer = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
 
+[target.wasm32-unknown-unknown.dependencies.wasmer]
+workspace = true
+optional = true
+features = ["js-default"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies.wasmer]
+workspace = true
+optional = true
+features = ["sys-default", "singlepass"]
+
 [dev-dependencies]
 assert_matches.workspace = true
 insta.workspace = true

--- a/linera-witty/src/runtime/wasmer/export_function.rs
+++ b/linera-witty/src/runtime/wasmer/export_function.rs
@@ -20,7 +20,7 @@ macro_rules! export_function {
         where
             $( $types: FromToNativeWasmType, )*
             FlatResult: MaybeFlatType + WasmTypeList,
-            UserData: Send + 'static,
+            UserData: 'static,
             HandlerError: Error + Send + Sync + 'static,
             Handler:
                 Fn(

--- a/linera-witty/src/runtime/wasmer/function.rs
+++ b/linera-witty/src/runtime/wasmer/function.rs
@@ -32,7 +32,7 @@ macro_rules! impl_instance_with_function_for {
         where
             $( $types: FlatType + FromToNativeWasmType + NativeWasmTypeInto, )*
             Results: FlatLayout + WasmerResults,
-            UserData: Send + 'static,
+            UserData: 'static,
         {
             type Function = TypedFunction<
                 <HList![$( $types ),*] as WasmerParameters>::ImportParameters,

--- a/linera-witty/src/runtime/wasmer/function.rs
+++ b/linera-witty/src/runtime/wasmer/function.rs
@@ -4,7 +4,7 @@
 //! Implementations of [`InstanceWithFunction`] for Wasmer instances.
 
 use frunk::{hlist_pat, HList};
-use wasmer::{AsStoreRef, Extern, FromToNativeWasmType, TypedFunction};
+use wasmer::{AsStoreRef, Extern, FromToNativeWasmType, NativeWasmTypeInto, TypedFunction};
 
 use super::{
     parameters::WasmerParameters, results::WasmerResults, EntrypointInstance, ReentrantInstance,
@@ -30,7 +30,7 @@ macro_rules! impl_instance_with_function_for {
         impl<$( $types, )* Results, UserData> InstanceWithFunction<HList![$( $types ),*], Results>
             for $instance
         where
-            $( $types: FlatType + FromToNativeWasmType, )*
+            $( $types: FlatType + FromToNativeWasmType + NativeWasmTypeInto, )*
             Results: FlatLayout + WasmerResults,
             UserData: Send + 'static,
         {

--- a/linera-witty/src/runtime/wasmer/memory.rs
+++ b/linera-witty/src/runtime/wasmer/memory.rs
@@ -12,10 +12,7 @@ use crate::{GuestPointer, RuntimeError, RuntimeMemory};
 
 macro_rules! impl_memory_traits {
     ($instance:ty) => {
-        impl<UserData> InstanceWithMemory for $instance
-        where
-            UserData: Send + 'static,
-        {
+        impl<UserData: 'static> InstanceWithMemory for $instance {
             fn memory_from_export(&self, export: Extern) -> Result<Option<Memory>, RuntimeError> {
                 Ok(match export {
                     Extern::Memory(memory) => Some(memory),
@@ -24,10 +21,7 @@ macro_rules! impl_memory_traits {
             }
         }
 
-        impl<UserData> RuntimeMemory<$instance> for Memory
-        where
-            UserData: Send + 'static,
-        {
+        impl<UserData: 'static> RuntimeMemory<$instance> for Memory {
             fn read<'instance>(
                 &self,
                 instance: &'instance $instance,

--- a/linera-witty/src/runtime/wasmer/mod.rs
+++ b/linera-witty/src/runtime/wasmer/mod.rs
@@ -35,10 +35,7 @@ pub struct InstanceBuilder<UserData> {
     environment: Environment<UserData>,
 }
 
-impl<UserData> InstanceBuilder<UserData>
-where
-    UserData: Send + 'static,
-{
+impl<UserData: 'static> InstanceBuilder<UserData> {
     /// Creates a new [`InstanceBuilder`].
     pub fn new(engine: Engine, user_data: UserData) -> Self {
         InstanceBuilder {
@@ -160,10 +157,7 @@ impl<UserData> Instance for EntrypointInstance<UserData> {
 /// guest.
 pub type ReentrantInstance<'a, UserData> = FunctionEnvMut<'a, Environment<UserData>>;
 
-impl<UserData> Instance for ReentrantInstance<'_, UserData>
-where
-    UserData: Send + 'static,
-{
+impl<UserData: 'static> Instance for ReentrantInstance<'_, UserData> {
     type Runtime = Wasmer;
     type UserData = UserData;
     type UserDataReference<'a> = MutexGuard<'a, UserData>


### PR DESCRIPTION
## Motivation

We would like to be able to execute application blocks in the browser wallet.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Make `linera-execution`'s `wasmer` feature work on the Web:
- [x] feature-gate things that need to be different between Linux and JS targets
- [x] loosen some `Send` requirements for things that aren't `Send` on the Web (e.g. `wasmer::Instance`)
- [ ] replace `tokio::task::spawn_blocking` with a Web worker (to be done in a future PR).

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI build of `linera-core`, and manual client worker build in `linera-web`.

Once the Web wallet is all working as intended, we should [add some tests](https://github.com/linera-io/linera-protocol/issues/1989) using `wasm-bindgen-test`.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
