### PR TITLE
Rename `new` and `finalize` to `load` and `store`

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -303,7 +303,7 @@ impl Contract for AmmContract {
         }
     }
 
-    async fn finalize(mut self) {
+    async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -33,7 +33,7 @@ impl Contract for AmmContract {
     type InstantiationArgument = ();
     type Parameters = Parameters;
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = Amm::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -303,7 +303,7 @@ impl Contract for AmmContract {
         }
     }
 
-    async fn finalize(&mut self) {
+    async fn finalize(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -54,7 +54,7 @@ impl Contract for CounterContract {
         panic!("Counter application doesn't support any cross-chain messages");
     }
 
-    async fn finalize(&mut self) {
+    async fn finalize(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -54,7 +54,7 @@ impl Contract for CounterContract {
         panic!("Counter application doesn't support any cross-chain messages");
     }
 
-    async fn finalize(mut self) {
+    async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/counter/src/contract.rs
+++ b/examples/counter/src/contract.rs
@@ -30,7 +30,7 @@ impl Contract for CounterContract {
     type InstantiationArgument = u64;
     type Parameters = ();
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = Counter::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -78,7 +78,7 @@ impl Contract for CrowdFundingContract {
         }
     }
 
-    async fn finalize(mut self) {
+    async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -78,7 +78,7 @@ impl Contract for CrowdFundingContract {
         }
     }
 
-    async fn finalize(&mut self) {
+    async fn finalize(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -30,7 +30,7 @@ impl Contract for CrowdFundingContract {
     type InstantiationArgument = InstantiationArgument;
     type Parameters = ApplicationId<fungible::FungibleTokenAbi>;
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = CrowdFunding::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -120,7 +120,7 @@ impl Contract for FungibleTokenContract {
         }
     }
 
-    async fn finalize(mut self) {
+    async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -120,7 +120,7 @@ impl Contract for FungibleTokenContract {
         }
     }
 
-    async fn finalize(&mut self) {
+    async fn finalize(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/fungible/src/contract.rs
+++ b/examples/fungible/src/contract.rs
@@ -34,7 +34,7 @@ impl Contract for FungibleTokenContract {
     type Parameters = Parameters;
     type InstantiationArgument = InitialState;
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = FungibleToken::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/examples/llm/src/contract.rs
+++ b/examples/llm/src/contract.rs
@@ -20,7 +20,7 @@ impl Contract for LlmContract {
     type InstantiationArgument = ();
     type Parameters = ();
 
-    async fn new(_runtime: ContractRuntime<Self>) -> Self {
+    async fn load(_runtime: ContractRuntime<Self>) -> Self {
         LlmContract
     }
 

--- a/examples/llm/src/contract.rs
+++ b/examples/llm/src/contract.rs
@@ -32,5 +32,5 @@ impl Contract for LlmContract {
         panic!("Llm application doesn't support any cross-chain messages");
     }
 
-    async fn finalize(self) {}
+    async fn store(self) {}
 }

--- a/examples/llm/src/contract.rs
+++ b/examples/llm/src/contract.rs
@@ -32,5 +32,5 @@ impl Contract for LlmContract {
         panic!("Llm application doesn't support any cross-chain messages");
     }
 
-    async fn finalize(&mut self) {}
+    async fn finalize(self) {}
 }

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -125,7 +125,7 @@ impl Contract for MatchingEngineContract {
         }
     }
 
-    async fn finalize(mut self) {
+    async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -56,7 +56,7 @@ impl Contract for MatchingEngineContract {
     type InstantiationArgument = ();
     type Parameters = Parameters;
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = MatchingEngine::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -125,7 +125,7 @@ impl Contract for MatchingEngineContract {
         }
     }
 
-    async fn finalize(&mut self) {
+    async fn finalize(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -30,7 +30,7 @@ impl Contract for MetaCounterContract {
     type InstantiationArgument = ();
     type Parameters = ApplicationId<counter::CounterAbi>;
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         MetaCounterContract { runtime }
     }
 

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -91,5 +91,5 @@ impl Contract for MetaCounterContract {
         }
     }
 
-    async fn finalize(self) {}
+    async fn store(self) {}
 }

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -91,5 +91,5 @@ impl Contract for MetaCounterContract {
         }
     }
 
-    async fn finalize(&mut self) {}
+    async fn finalize(self) {}
 }

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -103,7 +103,7 @@ impl Contract for NativeFungibleTokenContract {
         }
     }
 
-    async fn finalize(self) {}
+    async fn store(self) {}
 }
 
 impl NativeFungibleTokenContract {

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -103,7 +103,7 @@ impl Contract for NativeFungibleTokenContract {
         }
     }
 
-    async fn finalize(&mut self) {}
+    async fn finalize(self) {}
 }
 
 impl NativeFungibleTokenContract {

--- a/examples/native-fungible/src/contract.rs
+++ b/examples/native-fungible/src/contract.rs
@@ -25,7 +25,7 @@ impl Contract for NativeFungibleTokenContract {
     type Parameters = Parameters;
     type InstantiationArgument = InitialState;
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         NativeFungibleTokenContract { runtime }
     }
 

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -121,7 +121,7 @@ impl Contract for NonFungibleTokenContract {
         }
     }
 
-    async fn finalize(&mut self) {
+    async fn finalize(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -33,7 +33,7 @@ impl Contract for NonFungibleTokenContract {
     type InstantiationArgument = ();
     type Parameters = ();
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = NonFungibleToken::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -121,7 +121,7 @@ impl Contract for NonFungibleTokenContract {
         }
     }
 
-    async fn finalize(mut self) {
+    async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -74,7 +74,7 @@ impl Contract for SocialContract {
         }
     }
 
-    async fn finalize(&mut self) {
+    async fn finalize(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -34,7 +34,7 @@ impl Contract for SocialContract {
     type InstantiationArgument = ();
     type Parameters = ();
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
         let state = Social::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/examples/social/src/contract.rs
+++ b/examples/social/src/contract.rs
@@ -74,7 +74,7 @@ impl Contract for SocialContract {
         }
     }
 
-    async fn finalize(mut self) {
+    async fn store(mut self) {
         self.state.save().await.expect("Failed to save state");
     }
 }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -116,7 +116,7 @@ where
     ContractLogger::install();
 
     let contract =
-        contract.get_or_insert_with(|| Contract::new(ContractRuntime::new()).blocking_wait());
+        contract.get_or_insert_with(|| Contract::load(ContractRuntime::new()).blocking_wait());
 
     entrypoint(contract).into()
 }

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -90,9 +90,9 @@ macro_rules! contract {
                 use $crate::util::BlockingWait;
 
                 let contract = unsafe { CONTRACT.take() }
-                    .expect("Calling `finalize` on a `Contract` instance that wasn't initialized");
+                    .expect("Calling `store` on a `Contract` instance that wasn't loaded");
 
-                contract.finalize().blocking_wait();
+                contract.store().blocking_wait();
             }
         }
 

--- a/linera-sdk/src/contract/mod.rs
+++ b/linera-sdk/src/contract/mod.rs
@@ -88,10 +88,11 @@ macro_rules! contract {
 
             fn finalize() {
                 use $crate::util::BlockingWait;
-                $crate::contract::run_async_entrypoint::<$contract, _, _>(
-                    unsafe { &mut CONTRACT },
-                    move |contract| contract.finalize().blocking_wait(),
-                )
+
+                let contract = unsafe { CONTRACT.take() }
+                    .expect("Calling `finalize` on a `Contract` instance that wasn't initialized");
+
+                contract.finalize().blocking_wait();
             }
         }
 

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -125,7 +125,7 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// state.
     ///
     /// The application may also cancel the transaction by panicking if there are any pendencies.
-    async fn finalize(&mut self);
+    async fn finalize(self);
 }
 
 /// The service interface of a Linera application.

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -91,7 +91,7 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     type InstantiationArgument: Serialize + DeserializeOwned + Debug;
 
     /// Creates a in-memory instance of the contract handler.
-    async fn new(runtime: ContractRuntime<Self>) -> Self;
+    async fn load(runtime: ContractRuntime<Self>) -> Self;
 
     /// Instantiates the application on the chain that created it.
     ///

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -125,7 +125,7 @@ pub trait Contract: WithContractAbi + ContractAbi + Sized {
     /// state.
     ///
     /// The application may also cancel the transaction by panicking if there are any pendencies.
-    async fn finalize(self);
+    async fn store(self);
 }
 
 /// The service interface of a Linera application.

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -39,7 +39,7 @@ impl Contract for ApplicationContract {{
 
     async fn execute_message(&mut self, _message: Self::Message) {{}}
 
-    async fn finalize(&mut self) {{
+    async fn finalize(mut self) {{
         self.state.save().await.expect("Failed to save state");
     }}
 }}

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -26,7 +26,7 @@ impl Contract for ApplicationContract {{
     type Parameters = ();
     type InstantiationArgument = ();
 
-    async fn new(runtime: ContractRuntime<Self>) -> Self {{
+    async fn load(runtime: ContractRuntime<Self>) -> Self {{
         let state = Application::load(ViewStorageContext::from(runtime.key_value_store()))
             .await
             .expect("Failed to load state");

--- a/linera-service/template/contract.rs.template
+++ b/linera-service/template/contract.rs.template
@@ -39,7 +39,7 @@ impl Contract for ApplicationContract {{
 
     async fn execute_message(&mut self, _message: Self::Message) {{}}
 
-    async fn finalize(mut self) {{
+    async fn store(mut self) {{
         self.state.save().await.expect("Failed to save state");
     }}
 }}


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
It's not immediately obvious that `finalize` is called at the end of a transaction, and that applications should implement it to persist their state across transactions.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Make the `finalize` method take ownership of `self`, so that there's a stronger hint that this is the last call to the `Contract` implementation type. Also rename `finalize` into `store`, so that it is clearer what is the main thing applications should do when finishing up. In order to be consistent, the `new` constructor was also renamed into `load`, which also makes it clearer that it's the ideal place to load the application state.

## Test Plan

<!-- How to test that the changes are correct. -->
This is a refactor with the only change in behavior being the change in taking ownership of `self` when `store` (previously known as `finalize`) is called. This last change would lead to compiler errors in case of regressions, and existing tests should ensure that the rest of the functionalities stay the same.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Changes the SDK API, so:
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
