### PR TITLE
Don't create `.cargo/config.toml` in new projects

### DIFF
--- a/linera-service/src/project.rs
+++ b/linera-service/src/project.rs
@@ -60,9 +60,6 @@ impl Project {
         debug!("writing service.rs");
         Self::create_service_file(&source_directory, name)?;
 
-        debug!("creating cargo config");
-        Self::create_cargo_config(&root)?;
-
         Ok(Self { root })
     }
 
@@ -190,16 +187,6 @@ impl Project {
             project_name = project_name
         );
         Self::write_string_to_file(&service_path, &service_contents)
-    }
-
-    fn create_cargo_config(project_root: &Path) -> Result<()> {
-        let config_dir_path = project_root.join(".cargo");
-        let config_file_path = config_dir_path.join("config.toml");
-        fs_err::create_dir(&config_dir_path)?;
-        Self::write_string_to_file(
-            &config_file_path,
-            include_str!("../template/config.toml.template"),
-        )
     }
 
     fn write_string_to_file(path: &Path, content: &str) -> Result<()> {

--- a/linera-service/template/config.toml.template
+++ b/linera-service/template/config.toml.template
@@ -1,2 +1,0 @@
-[build]
-target = "wasm32-unknown-unknown"


### PR DESCRIPTION
Instead, the `wasm32-unknown-unknown` target should be specified manually.

## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Linera applications are built targeting `wasm32-unknown-unknown`, and previously unit tests also had to be executed targeting the same platform. This has since changed, and it doesn't make sense anymore to configure the default target for all `cargo` commands.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Don't generate the `.cargo/config.toml` file for new applications when running `linera project new`.

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This change is "backwards compatible"-ish, because applications still compile and test correctly with or without this change, but the commands to build and test change, so:

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Removed the convention of setting the standard platform in #1974 
