### PR TITLE
Clean-up example application READMEs and Cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,3 @@
-[target.wasm32-unknown-unknown]
-# Requires running `cargo build --release --bin linera-wasm-test-runner` once first.
-runner = "target/release/linera-wasm-test-runner"
-
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -61,7 +61,7 @@ OWNER_AMM=7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f
 Now we have to publish and create the fungible applications. The flag `--wait-for-outgoing-messages` waits until a quorum of validators has confirmed that all sent cross-chain messages have been delivered.
 
 ```bash
-(cd examples/fungible && cargo build --release)
+(cd examples/fungible && cargo build --release --target wasm32-unknown-unknown)
 
 FUN1_APP_ID=$(linera --wait-for-outgoing-messages \
   publish-and-create examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm \
@@ -79,7 +79,7 @@ FUN2_APP_ID=$(linera --wait-for-outgoing-messages \
     --json-parameters "{ \"ticker_symbol\": \"FUN2\" }" \
 )
 
-(cd examples/amm && cargo build --release)
+(cd examples/amm && cargo build --release --target wasm32-unknown-unknown)
 AMM_APPLICATION_ID=$(linera --wait-for-outgoing-messages \
   publish-and-create examples/target/wasm32-unknown-unknown/release/amm_{contract,service}.wasm \
   --json-parameters "{\"tokens\":["\"$FUN1_APP_ID\"","\"$FUN2_APP_ID\""]}" \

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -63,7 +63,7 @@ OWNER_AMM=7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f
 Now we have to publish and create the fungible applications. The flag `--wait-for-outgoing-messages` waits until a quorum of validators has confirmed that all sent cross-chain messages have been delivered.
 
 ```bash
-(cd examples/fungible && cargo build --release)
+(cd examples/fungible && cargo build --release --target wasm32-unknown-unknown)
 
 FUN1_APP_ID=$(linera --wait-for-outgoing-messages \
   publish-and-create examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm \
@@ -81,7 +81,7 @@ FUN2_APP_ID=$(linera --wait-for-outgoing-messages \
     --json-parameters "{ \"ticker_symbol\": \"FUN2\" }" \
 )
 
-(cd examples/amm && cargo build --release)
+(cd examples/amm && cargo build --release --target wasm32-unknown-unknown)
 AMM_APPLICATION_ID=$(linera --wait-for-outgoing-messages \
   publish-and-create examples/target/wasm32-unknown-unknown/release/amm_{contract,service}.wasm \
   --json-parameters "{\"tokens\":["\"$FUN1_APP_ID\"","\"$FUN2_APP_ID\""]}" \

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -46,7 +46,7 @@ OWNER_1=7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f
 Now, compile the `counter` application WebAssembly binaries, publish and create an application instance.
 
 ```bash
-(cd examples/counter && cargo build --release)
+(cd examples/counter && cargo build --release --target wasm32-unknown-unknown)
 
 APPLICATION_ID=$(linera publish-and-create \
   examples/target/wasm32-unknown-unknown/release/counter_{contract,service}.wasm \

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -48,7 +48,7 @@ OWNER_1=7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f
 Now, compile the `counter` application WebAssembly binaries, publish and create an application instance.
 
 ```bash
-(cd examples/counter && cargo build --release)
+(cd examples/counter && cargo build --release --target wasm32-unknown-unknown)
 
 APPLICATION_ID=$(linera publish-and-create \
   examples/target/wasm32-unknown-unknown/release/counter_{contract,service}.wasm \

--- a/examples/fungible/README.md
+++ b/examples/fungible/README.md
@@ -63,7 +63,7 @@ Now, compile the `fungible` application WebAssembly binaries, and publish them a
 bytecode:
 
 ```bash
-(cd examples/fungible && cargo build --release)
+(cd examples/fungible && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID=$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm)

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -65,7 +65,7 @@ Now, compile the `fungible` application WebAssembly binaries, and publish them a
 bytecode:
 
 ```bash
-(cd examples/fungible && cargo build --release)
+(cd examples/fungible && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID=$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/fungible_{contract,service}.wasm)

--- a/examples/native-fungible/README.md
+++ b/examples/native-fungible/README.md
@@ -26,7 +26,7 @@ Compile the `native-fungible` application WebAssembly binaries, and publish them
 bytecode:
 
 ```bash
-(cd examples/native-fungible && cargo build --release)
+(cd examples/native-fungible && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID="$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/native_fungible_{contract,service}.wasm)"

--- a/examples/native-fungible/src/lib.rs
+++ b/examples/native-fungible/src/lib.rs
@@ -28,7 +28,7 @@ Compile the `native-fungible` application WebAssembly binaries, and publish them
 bytecode:
 
 ```bash
-(cd examples/native-fungible && cargo build --release)
+(cd examples/native-fungible && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID="$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/native_fungible_{contract,service}.wasm)"

--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -40,7 +40,7 @@ linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
 Compile the `non-fungible` application WebAssembly binaries, and publish them as an application bytecode:
 
 ```bash
-(cd examples/non-fungible && cargo build --release)
+(cd examples/non-fungible && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID=$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/non_fungible_{contract,service}.wasm)

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -42,7 +42,7 @@ linera_spawn_and_read_wallet_variables linera net up --testing-prng-seed 37
 Compile the `non-fungible` application WebAssembly binaries, and publish them as an application bytecode:
 
 ```bash
-(cd examples/non-fungible && cargo build --release)
+(cd examples/non-fungible && cargo build --release --target wasm32-unknown-unknown)
 
 BYTECODE_ID=$(linera publish-bytecode \
     examples/target/wasm32-unknown-unknown/release/non_fungible_{contract,service}.wasm)


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The custom Wasm test runner was removed (#1974), and the custom Cargo configuration file to set the default target to Wasm for the examples was removed with it. However, some of the README files for the examples still assume that the default target is set to `wasm32-unknown-unknown`, and the custom test runner is still configured at the repository root.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Remove the custom test runner configuration and update the README files.

## Test Plan

<!-- How to test that the changes are correct. -->
No code was added or removed, so no testing needed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
