### PR TITLE
Feature gate the Ethereum tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,6 +105,9 @@ jobs:
       run: |
         cd examples
         cargo test --locked
+    - name: Run Ethereum tests
+      run: |
+        cargo test -p linera-ethereum --features ethereum
     - name: Run Witty integration tests
       run: |
         cargo test -p linera-witty --features wasmer,wasmtime

--- a/linera-ethereum/Cargo.toml
+++ b/linera-ethereum/Cargo.toml
@@ -10,6 +10,12 @@ documentation = "https://docs.rs/linera-ethereum/latest/linera_ethereum/"
 license = "Apache-2.0"
 edition = "2021"
 
+[package.metadata.docs.rs]
+features = ["features"]
+
+[features]
+ethereum = []
+
 [dependencies]
 anyhow.workspace = true
 ethers.workspace = true

--- a/linera-ethereum/README.md
+++ b/linera-ethereum/README.md
@@ -1,6 +1,11 @@
 <!-- cargo-rdme start -->
 
 This module provides functionalities for accessing an Ethereum blockchain node.
+Anabling the `ethereum` allows to make the test works. This requires installing
+the `anvil` from [FOUNDRY] and the [SOLC] compiler version 0.8.25
+
+[FOUNDRY]: https://book.getfoundry.sh/
+[SOLC]: https://soliditylang.org/
 
 <!-- cargo-rdme end -->
 

--- a/linera-ethereum/src/lib.rs
+++ b/linera-ethereum/src/lib.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module provides functionalities for accessing an Ethereum blockchain node.
+//! Anabling the `ethereum` allows to make the test works. This requires installing
+//! the `anvil` from [FOUNDRY] and the [SOLC] compiler version 0.8.25
+//!
+//! [FOUNDRY]: https://book.getfoundry.sh/
+//! [SOLC]: https://soliditylang.org/
 
 pub mod client;
 pub mod common;

--- a/linera-ethereum/tests/ethereum_test.rs
+++ b/linera-ethereum/tests/ethereum_test.rs
@@ -1,13 +1,17 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use ethers::types::U256;
-use ethers_core::types::Address;
-use linera_ethereum::{
-    common::{EthereumDataType, EthereumEvent},
-    test_utils::{get_anvil, EventNumericsContractFunction, SimpleTokenContractFunction},
+#[cfg(feature = "ethereum")]
+use {
+    ethers::types::U256,
+    ethers_core::types::Address,
+    linera_ethereum::{
+        common::{EthereumDataType, EthereumEvent},
+        test_utils::{get_anvil, EventNumericsContractFunction, SimpleTokenContractFunction},
+    },
 };
 
+#[cfg(feature = "ethereum")]
 #[tokio::test]
 async fn test_get_accounts_balance() {
     let anvil_test = get_anvil().await.unwrap();
@@ -24,6 +28,7 @@ async fn test_get_accounts_balance() {
     }
 }
 
+#[cfg(feature = "ethereum")]
 #[tokio::test]
 async fn test_event_numerics() -> anyhow::Result<()> {
     let anvil_test = get_anvil().await?;
@@ -61,6 +66,7 @@ async fn test_event_numerics() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "ethereum")]
 #[tokio::test]
 async fn test_simple_token_events() -> anyhow::Result<()> {
     let anvil_test = get_anvil().await?;
@@ -104,6 +110,7 @@ async fn test_simple_token_events() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "ethereum")]
 #[tokio::test]
 async fn test_simple_token_queries() -> anyhow::Result<()> {
     let anvil_test = get_anvil().await?;


### PR DESCRIPTION
## Motivation

The Ethereum tests require the foundry (for anvil) and solc (the solidity compiler) for effective running.
Users working on different aspects may not want to enable those.

## Proposal

The following was done:
* The Ethereum tests are feature-gated.
* There is additional documentation in `linera-ethereum` on how to install Foundry and solc.

## Test Plan

The CI has been changed but the same tests are being applied.

## Release Plan

No changes.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
