### PR TITLE
blob -> hashed_certificate_value

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -220,7 +220,7 @@ pub struct BlockProposal {
     pub content: BlockAndRound,
     pub owner: Owner,
     pub signature: Signature,
-    pub blobs: Vec<HashedCertificateValue>,
+    pub hashed_certificate_values: Vec<HashedCertificateValue>,
     pub validated: Option<Certificate>,
 }
 
@@ -799,7 +799,7 @@ impl BlockProposal {
     pub fn new(
         content: BlockAndRound,
         secret: &KeyPair,
-        blobs: Vec<HashedCertificateValue>,
+        hashed_certificate_values: Vec<HashedCertificateValue>,
         validated: Option<Certificate>,
     ) -> Self {
         let outcome = validated
@@ -817,7 +817,7 @@ impl BlockProposal {
             content,
             owner: secret.public().into(),
             signature,
-            blobs,
+            hashed_certificate_values,
             validated,
         }
     }

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -69,12 +69,12 @@ pub trait BlockTestExt: Sized {
     /// Returns the block with the specified epoch.
     fn with_epoch(self, epoch: impl Into<Epoch>) -> Self;
 
-    /// Returns a block proposal in `Round::Fast` without any blobs or validated block.
+    /// Returns a block proposal in `Round::Fast` without any hashed certificate values or validated block.
     fn into_fast_proposal(self, key_pair: &KeyPair) -> BlockProposal {
         self.into_proposal_with_round(key_pair, Round::Fast)
     }
 
-    /// Returns a block proposal without any blobs or validated block.
+    /// Returns a block proposal without any hashed certificate values or validated block.
     fn into_proposal_with_round(self, key_pair: &KeyPair, round: Round) -> BlockProposal;
 
     /// Returns a block proposal including a validated block as justification.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -68,8 +68,8 @@ pub struct ChainInfoQuery {
     pub request_leader_timeout: bool,
     /// Include a vote to switch to fallback mode, if appropriate.
     pub request_fallback: bool,
-    /// Query a value that contains a binary blob (e.g. bytecode) required by this chain.
-    pub request_blob: Option<CryptoHash>,
+    /// Query a value that contains a binary hashed certificate value (e.g. bytecode) required by this chain.
+    pub request_hashed_certificate_value: Option<CryptoHash>,
 }
 
 impl ChainInfoQuery {
@@ -85,7 +85,7 @@ impl ChainInfoQuery {
             request_manager_values: false,
             request_leader_timeout: false,
             request_fallback: false,
-            request_blob: None,
+            request_hashed_certificate_value: None,
         }
     }
 
@@ -134,8 +134,8 @@ impl ChainInfoQuery {
         self
     }
 
-    pub fn with_blob(mut self, hash: CryptoHash) -> Self {
-        self.request_blob = Some(hash);
+    pub fn with_hashed_certificate_value(mut self, hash: CryptoHash) -> Self {
+        self.request_hashed_certificate_value = Some(hash);
         self
     }
 }
@@ -173,8 +173,8 @@ pub struct ChainInfo {
     pub count_received_log: usize,
     /// The response to `request_received_certificates_excluding_first_nth`
     pub requested_received_log: Vec<ChainAndHeight>,
-    /// The requested blob, if any.
-    pub requested_blob: Option<HashedCertificateValue>,
+    /// The requested hashed certificate value, if any.
+    pub requested_hashed_certificate_value: Option<HashedCertificateValue>,
 }
 
 /// The response to an `ChainInfoQuery`
@@ -253,7 +253,7 @@ where
             requested_sent_certificates: Vec::new(),
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
-            requested_blob: None,
+            requested_hashed_certificate_value: None,
         }
     }
 }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -61,7 +61,7 @@ pub trait LocalValidatorNode {
     async fn handle_certificate(
         &mut self,
         certificate: Certificate,
-        blobs: Vec<HashedCertificateValue>,
+        hashed_certificate_values: Vec<HashedCertificateValue>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -125,11 +125,11 @@ where
     async fn handle_certificate(
         &mut self,
         certificate: Certificate,
-        blobs: Vec<HashedCertificateValue>,
+        hashed_certificate_values: Vec<HashedCertificateValue>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, blobs, sender)
+            validator.do_handle_certificate(certificate, hashed_certificate_values, sender)
         })
         .await
     }
@@ -256,7 +256,7 @@ where
     async fn do_handle_certificate(
         self,
         certificate: Certificate,
-        blobs: Vec<HashedCertificateValue>,
+        hashed_certificate_values: Vec<HashedCertificateValue>,
         sender: oneshot::Sender<Result<ChainInfoResponse, NodeError>>,
     ) -> Result<(), Result<ChainInfoResponse, NodeError>> {
         let mut validator = self.client.lock().await;
@@ -271,7 +271,7 @@ where
                 .state
                 .fully_handle_certificate_with_notifications(
                     certificate,
-                    blobs,
+                    hashed_certificate_values,
                     Some(&mut notifications),
                 )
                 .await

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -232,7 +232,7 @@ where
                 warn!("locations requested by validator contain duplicates");
                 return Err(NodeError::InvalidChainInfoResponse);
             }
-            let blobs = future::join_all(unique_locations.into_iter().map(|location| {
+            let values = future::join_all(unique_locations.into_iter().map(|location| {
                 self.storage
                     .read_hashed_certificate_value(location.certificate_hash)
             }))
@@ -241,7 +241,7 @@ where
             .collect::<Result<Vec<_>, _>>()?;
             result = self
                 .node
-                .handle_certificate(certificate.clone(), blobs, delivery)
+                .handle_certificate(certificate.clone(), values, delivery)
                 .await;
         }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -139,8 +139,8 @@ message ChainInfoQuery {
   // Request a signed vote for a leader timeout.
   bool request_leader_timeout = 8;
 
-  // Query a value that contains a binary blob (e.g. bytecode) required by this chain.
-  optional bytes request_blob = 9;
+  // Query a value that contains a binary hashed certificate value (e.g. bytecode) required by this chain.
+  optional bytes request_hashed_certificate_value = 9;
 
   // Query the balance of a given owner.
   optional Owner request_owner_balance = 10;
@@ -164,7 +164,7 @@ message BlockProposal {
   Signature signature = 4;
 
   // Required bytecode
-  bytes blobs = 5;
+  bytes hashed_certificate_values = 5;
 
   // A certificate for a validated block that justifies the proposal in this round.
   optional bytes validated = 6;
@@ -205,7 +205,7 @@ message Certificate {
   bytes signatures = 4;
 
   // Other certificates containing bytecode required by the first one
-  bytes blobs = 5;
+  bytes hashed_certificate_values = 5;
 
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -79,20 +79,20 @@ impl ValidatorNode for Client {
     async fn handle_certificate(
         &mut self,
         certificate: Certificate,
-        blobs: Vec<HashedCertificateValue>,
+        hashed_certificate_values: Vec<HashedCertificateValue>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
             Client::Grpc(grpc_client) => {
                 grpc_client
-                    .handle_certificate(certificate, blobs, delivery)
+                    .handle_certificate(certificate, hashed_certificate_values, delivery)
                     .await
             }
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => {
                 simple_client
-                    .handle_certificate(certificate, blobs, delivery)
+                    .handle_certificate(certificate, hashed_certificate_values, delivery)
                     .await
             }
         }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -161,13 +161,13 @@ impl ValidatorNode for GrpcClient {
     async fn handle_certificate(
         &mut self,
         certificate: data_types::Certificate,
-        blobs: Vec<data_types::HashedCertificateValue>,
+        hashed_certificate_values: Vec<data_types::HashedCertificateValue>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
-            blobs,
+            hashed_certificate_values,
             wait_for_outgoing_messages,
         };
         client_delegate!(self, handle_certificate, request)

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -515,7 +515,7 @@ where
         let start = Instant::now();
         let HandleCertificateRequest {
             certificate,
-            blobs,
+            hashed_certificate_values,
             wait_for_outgoing_messages,
         } = request.into_inner().try_into()?;
         debug!(?certificate, "Handling certificate");
@@ -523,7 +523,7 @@ where
         match self
             .state
             .clone()
-            .handle_certificate(certificate, blobs, sender)
+            .handle_certificate(certificate, hashed_certificate_values, sender)
             .await
         {
             Ok((info, actions)) => {

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -35,7 +35,7 @@ pub struct HandleLiteCertRequest<'a> {
 pub struct HandleCertificateRequest {
     pub certificate: linera_chain::data_types::Certificate,
     pub wait_for_outgoing_messages: bool,
-    pub blobs: Vec<linera_chain::data_types::HashedCertificateValue>,
+    pub hashed_certificate_values: Vec<linera_chain::data_types::HashedCertificateValue>,
 }
 
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("file_descriptor_set");

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -99,13 +99,13 @@ impl ValidatorNode for SimpleClient {
     async fn handle_certificate(
         &mut self,
         certificate: Certificate,
-        blobs: Vec<HashedCertificateValue>,
+        hashed_certificate_values: Vec<HashedCertificateValue>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
-            blobs,
+            hashed_certificate_values,
             wait_for_outgoing_messages,
         };
         self.query(request.into()).await

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -234,7 +234,11 @@ where
                 match self
                     .server
                     .state
-                    .handle_certificate(request.certificate, request.blobs, sender)
+                    .handle_certificate(
+                        request.certificate,
+                        request.hashed_certificate_values,
+                        sender,
+                    )
                     .await
                 {
                     Ok((info, actions)) => {

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -96,7 +96,7 @@ BlockProposal:
         TYPENAME: Owner
     - signature:
         TYPENAME: Signature
-    - blobs:
+    - hashed_certificate_values:
         SEQ:
           TYPENAME: CertificateValue
     - validated:
@@ -208,7 +208,7 @@ ChainInfo:
     - requested_received_log:
         SEQ:
           TYPENAME: ChainAndHeight
-    - requested_blob:
+    - requested_hashed_certificate_value:
         OPTION:
           TYPENAME: CertificateValue
 ChainInfoQuery:
@@ -231,7 +231,7 @@ ChainInfoQuery:
     - request_manager_values: BOOL
     - request_leader_timeout: BOOL
     - request_fallback: BOOL
-    - request_blob:
+    - request_hashed_certificate_value:
         OPTION:
           TYPENAME: CryptoHash
 ChainInfoResponse:
@@ -406,7 +406,7 @@ HandleCertificateRequest:
     - certificate:
         TYPENAME: Certificate
     - wait_for_outgoing_messages: BOOL
-    - blobs:
+    - hashed_certificate_values:
         SEQ:
           TYPENAME: CertificateValue
 HandleLiteCertRequest:

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -701,7 +701,7 @@ impl Runnable for Job {
                     .map(|certificate| {
                         HandleCertificateRequest {
                             certificate: certificate.clone(),
-                            blobs: vec![],
+                            hashed_certificate_values: vec![],
                             wait_for_outgoing_messages: true,
                         }
                         .into()


### PR DESCRIPTION
## Motivation

With user blobs on the way, the existing usage of `blob` in the code base can be confusing

## Proposal

Rename `blob` to what it actually is, a `hashed_certificate_value`

## Test Plan

CI

