### PR TITLE
Adding docker build to CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,43 @@
+name: Docker
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches:
+      - "**"
+    paths:
+      - '*'
+      - '*/'
+  workflow_dispatch:
+
+# This allows a subsequently queued workflow run to interrupt previous runs on pull-requests
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.run_id }}'
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+  RUST_LOG: warn
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          push: false
+          file: docker/Dockerfile

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,6 +49,7 @@ COPY linera-views linera-views
 COPY linera-views-derive linera-views-derive
 COPY linera-witty linera-witty
 COPY linera-witty-macros linera-witty-macros
+COPY linera-ethereum linera-ethereum
 COPY scripts scripts
 COPY rust-toolchain* Cargo.* ./
 


### PR DESCRIPTION
## Motivation

When new directories are added to the root of the repo, the Dockerfile needs to be updated

## Proposal

Adding CI to catch that, to prevent Docker builds from failing

## Test Plan

CI

