### PR TITLE
Create a `CertificateValueCache`

### DIFF
--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -15,3 +15,4 @@ pub mod test_utils;
 pub mod worker;
 
 pub(crate) mod updater;
+pub(crate) mod value_cache;

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -72,6 +72,28 @@ async fn test_insert_many_values_together() {
     );
 }
 
+/// Tests eviction of one entry.
+#[tokio::test]
+async fn test_one_eviction() {
+    let cache = CertificateValueCache::default();
+    let values = create_dummy_values(0..=(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
+
+    cache.insert_all(values.iter().map(Cow::Borrowed)).await;
+
+    assert!(!cache.contains(&values[0].hash()).await);
+    assert!(cache.get(&values[0].hash()).await.is_none());
+
+    for value in values.iter().skip(1) {
+        assert!(cache.contains(&value.hash()).await);
+        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+    }
+
+    assert_eq!(
+        cache.keys::<BTreeSet<_>>().await,
+        BTreeSet::from_iter(values.iter().skip(1).map(HashedCertificateValue::hash))
+    );
+}
+
 /// Creates multiple dummy [`HashedCertificateValue`]s to use in the tests.
 fn create_dummy_values<Heights>(heights: Heights) -> impl Iterator<Item = HashedCertificateValue>
 where

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -9,6 +9,16 @@ use linera_execution::committee::Epoch;
 
 use super::CertificateValueCache;
 
+/// Tests attempt to retrieve non-existent value.
+#[tokio::test]
+async fn test_retrieve_missing_value() {
+    let cache = CertificateValueCache::default();
+    let hash = CryptoHash::test_hash("Missing value");
+
+    assert!(cache.get(&hash).await.is_none());
+    assert!(cache.keys::<Vec<_>>().await.is_empty());
+}
+
 /// Tests inserting a value in the cache.
 #[tokio::test]
 async fn test_insert_single_value() {

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{borrow::Cow, collections::BTreeSet};
+
+use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
+use linera_chain::data_types::{CertificateValue, HashedCertificateValue};
+use linera_execution::committee::Epoch;
+
+use super::CertificateValueCache;
+
+/// Tests inserting a value in the cache.
+#[tokio::test]
+async fn test_insert_single_value() {
+    let cache = CertificateValueCache::default();
+    let value = create_dummy_value(0);
+    let hash = value.hash();
+
+    assert!(cache.insert(Cow::Borrowed(&value)).await);
+    assert!(cache.contains(&hash).await);
+    assert_eq!(cache.get(&hash).await, Some(value));
+    assert_eq!(cache.keys::<BTreeSet<_>>().await, BTreeSet::from([hash]));
+}
+
+/// Creates a new dummy [`HashedCertificateValue`] to use in the tests.
+fn create_dummy_value(height: impl Into<BlockHeight>) -> HashedCertificateValue {
+    CertificateValue::Timeout {
+        chain_id: ChainId(CryptoHash::test_hash("Fake chain ID")),
+        height: height.into(),
+        epoch: Epoch(0),
+    }
+    .into()
+}

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -7,7 +7,7 @@ use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::Chai
 use linera_chain::data_types::{CertificateValue, HashedCertificateValue};
 use linera_execution::committee::Epoch;
 
-use super::CertificateValueCache;
+use super::{CertificateValueCache, DEFAULT_VALUE_CACHE_SIZE};
 
 /// Tests attempt to retrieve non-existent value.
 #[tokio::test]
@@ -30,6 +30,36 @@ async fn test_insert_single_value() {
     assert!(cache.contains(&hash).await);
     assert_eq!(cache.get(&hash).await, Some(value));
     assert_eq!(cache.keys::<BTreeSet<_>>().await, BTreeSet::from([hash]));
+}
+
+/// Tests inserting many values in the cache, one-by-one.
+#[tokio::test]
+async fn test_insert_many_values_individually() {
+    let cache = CertificateValueCache::default();
+    let values = create_dummy_values(0..(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
+
+    for value in &values {
+        assert!(cache.insert(Cow::Borrowed(value)).await);
+    }
+
+    for value in &values {
+        assert!(cache.contains(&value.hash()).await);
+        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+    }
+
+    assert_eq!(
+        cache.keys::<BTreeSet<_>>().await,
+        BTreeSet::from_iter(values.iter().map(HashedCertificateValue::hash))
+    );
+}
+
+/// Creates multiple dummy [`HashedCertificateValue`]s to use in the tests.
+fn create_dummy_values<Heights>(heights: Heights) -> impl Iterator<Item = HashedCertificateValue>
+where
+    Heights: IntoIterator,
+    Heights::Item: Into<BlockHeight>,
+{
+    heights.into_iter().map(create_dummy_value)
 }
 
 /// Creates a new dummy [`HashedCertificateValue`] to use in the tests.

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -3,6 +3,10 @@
 
 //! A least-recently used cache of [`HashedCertificateValue`]s.
 
+#[cfg(test)]
+#[path = "unit_tests/value_cache_tests.rs"]
+mod unit_tests;
+
 use std::{borrow::Cow, num::NonZeroUsize};
 
 use linera_base::crypto::CryptoHash;

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -1,0 +1,122 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A least-recently used cache of [`HashedCertificateValue`]s.
+
+use std::{borrow::Cow, num::NonZeroUsize};
+
+use linera_base::crypto::CryptoHash;
+use linera_chain::data_types::{Certificate, HashedCertificateValue, LiteCertificate};
+use lru::LruCache;
+use tokio::sync::Mutex;
+
+use crate::worker::WorkerError;
+
+/// The default cache size.
+const DEFAULT_VALUE_CACHE_SIZE: usize = 1000;
+
+/// A least-recently used cache of [`HashedCertificateValue`]s.
+pub struct CertificateValueCache {
+    cache: Mutex<LruCache<CryptoHash, HashedCertificateValue>>,
+}
+
+impl Default for CertificateValueCache {
+    fn default() -> Self {
+        let size = NonZeroUsize::try_from(DEFAULT_VALUE_CACHE_SIZE)
+            .expect("Default cache size is larger than zero");
+
+        CertificateValueCache {
+            cache: Mutex::new(LruCache::new(size)),
+        }
+    }
+}
+
+impl CertificateValueCache {
+    /// Returns a `Collection` of the hashes in the cache.
+    pub async fn keys<Collection>(&self) -> Collection
+    where
+        Collection: FromIterator<CryptoHash>,
+    {
+        self.cache
+            .lock()
+            .await
+            .iter()
+            .map(|(key, _)| *key)
+            .collect()
+    }
+
+    /// Returns [`true`] if the cache contains the [`HashedCertificateValue`] with the
+    /// requested [`CryptoHash`].
+    pub async fn contains(&self, hash: &CryptoHash) -> bool {
+        self.cache.lock().await.contains(hash)
+    }
+
+    /// Returns a `Collection` created from a set of `items` minus the items that have an
+    /// equivalent entry in the cache.
+    ///
+    /// This is useful for selecting a sub-set of `items` which don't have an entry in the cache.
+    ///
+    /// An `Item` has an entry in the cache if `key_extractor` executed for the item returns a
+    /// [`CryptoHash`] key that has an entry in the cache.
+    pub async fn subtract_cached_items_from<Item, Collection>(
+        &self,
+        items: impl IntoIterator<Item = Item>,
+        key_extractor: impl Fn(&Item) -> &CryptoHash,
+    ) -> Collection
+    where
+        Collection: FromIterator<Item>,
+    {
+        let cache = self.cache.lock().await;
+
+        items
+            .into_iter()
+            .filter(|item| !cache.contains(key_extractor(item)))
+            .collect()
+    }
+
+    /// Returns a [`HashedCertificateValue`] from the cache, if present.
+    pub async fn get(&self, hash: &CryptoHash) -> Option<HashedCertificateValue> {
+        self.cache.lock().await.get(hash).cloned()
+    }
+
+    /// Populates a [`LiteCertificate`] with its [`CertificateValue`], if it's present in
+    /// the cache.
+    pub async fn full_certificate(
+        &self,
+        certificate: LiteCertificate<'_>,
+    ) -> Result<Certificate, WorkerError> {
+        let value = self
+            .get(&certificate.value.value_hash)
+            .await
+            .ok_or(WorkerError::MissingCertificateValue)?;
+        certificate
+            .with_value(value)
+            .ok_or(WorkerError::InvalidLiteCertificate)
+    }
+
+    /// Inserts a [`HashedCertificateValue`] into the cache, if it's not already present.
+    ///
+    /// The `value` is wrapped in a [`Cow`] so that it is only cloned if it needs to be
+    /// inserted in the cache.
+    ///
+    /// Returns [`true`] if the value was not already present in the cache.
+    pub async fn insert<'a>(&self, value: Cow<'a, HashedCertificateValue>) -> bool {
+        let hash = value.hash();
+        let mut cache = self.cache.lock().await;
+        if cache.contains(&hash) {
+            return false;
+        }
+        // Cache the certificate so that clients don't have to send the value again.
+        cache.push(hash, value.into_owned());
+        true
+    }
+
+    /// Inserts the validated block and the corresponding confirmed block.
+    pub async fn insert_validated_and_confirmed(&self, value: &HashedCertificateValue) {
+        if self.insert(Cow::Borrowed(value)).await {
+            if let Some(value) = value.validated_to_confirmed() {
+                self.insert(Cow::Owned(value)).await;
+            }
+        }
+    }
+}

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -5,7 +5,6 @@
 use std::{
     borrow::Cow,
     collections::{hash_map, BTreeMap, BTreeSet, HashMap, VecDeque},
-    num::NonZeroUsize,
     sync::Arc,
     time::Duration,
 };
@@ -35,7 +34,6 @@ use linera_views::{
     log_view::LogView,
     views::{RootView, View, ViewError},
 };
-use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{oneshot, Mutex};
@@ -52,7 +50,10 @@ use {
     prometheus::{HistogramVec, IntCounterVec},
 };
 
-use crate::data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest};
+use crate::{
+    data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    value_cache::CertificateValueCache,
+};
 
 #[cfg(test)]
 #[path = "unit_tests/worker_tests.rs"]
@@ -259,8 +260,6 @@ impl From<linera_chain::ChainError> for WorkerError {
     }
 }
 
-pub(crate) const DEFAULT_VALUE_CACHE_SIZE: usize = 1000;
-
 /// State of a worker in a validator or a local node.
 #[derive(Clone)]
 pub struct WorkerState<StorageClient> {
@@ -279,7 +278,7 @@ pub struct WorkerState<StorageClient> {
     /// will wait until that timestamp before voting.
     grace_period: Duration,
     /// Cached values by hash.
-    recent_values: Arc<Mutex<LruCache<CryptoHash, HashedCertificateValue>>>,
+    recent_values: Arc<CertificateValueCache>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
@@ -290,9 +289,6 @@ pub(crate) type DeliveryNotifiers =
 
 impl<StorageClient> WorkerState<StorageClient> {
     pub fn new(nickname: String, key_pair: Option<KeyPair>, storage: StorageClient) -> Self {
-        let recent_values = Arc::new(Mutex::new(LruCache::new(
-            NonZeroUsize::try_from(DEFAULT_VALUE_CACHE_SIZE).unwrap(),
-        )));
         WorkerState {
             nickname,
             key_pair: key_pair.map(Arc::new),
@@ -300,7 +296,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             allow_inactive_chains: false,
             allow_messages_from_deprecated_epochs: false,
             grace_period: Duration::ZERO,
-            recent_values,
+            recent_values: Arc::new(CertificateValueCache::default()),
             delivery_notifiers: Arc::default(),
         }
     }
@@ -308,7 +304,7 @@ impl<StorageClient> WorkerState<StorageClient> {
     pub fn new_for_client(
         nickname: String,
         storage: StorageClient,
-        recent_values: Arc<Mutex<LruCache<CryptoHash, HashedCertificateValue>>>,
+        recent_values: Arc<CertificateValueCache>,
         delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
     ) -> Self {
         WorkerState {
@@ -369,21 +365,14 @@ impl<StorageClient> WorkerState<StorageClient> {
         &mut self,
         certificate: LiteCertificate<'_>,
     ) -> Result<Certificate, WorkerError> {
-        let hash = certificate.value.value_hash;
-        let mut recent_values = self.recent_values.lock().await;
-        let value = recent_values
-            .get(&hash)
-            .ok_or(WorkerError::MissingCertificateValue)?;
-        certificate
-            .with_value(value.clone())
-            .ok_or(WorkerError::InvalidLiteCertificate)
+        self.recent_values.full_certificate(certificate).await
     }
 
     pub(crate) async fn recent_value(
         &mut self,
         hash: &CryptoHash,
     ) -> Option<HashedCertificateValue> {
-        self.recent_values.lock().await.get(hash).cloned()
+        self.recent_values.get(hash).await
     }
 }
 
@@ -726,7 +715,9 @@ where
             notify_when_messages_are_delivered,
         )
         .await;
-        self.cache_recent_value(Cow::Owned(certificate.value)).await;
+        self.recent_values
+            .insert(Cow::Owned(certificate.value))
+            .await;
 
         #[cfg(with_metrics)]
         NUM_BLOCKS.with_label_values(&[]).inc();
@@ -754,10 +745,14 @@ where
                 WorkerError::UnneededValue { value_hash }
             );
         }
-        let recent_values = self.recent_values.lock().await;
-        let tasks = required_locations_left
-            .into_values()
-            .filter(|location| !recent_values.contains(&location.certificate_hash))
+        let tasks = self
+            .recent_values
+            .subtract_cached_items_from::<_, Vec<_>>(
+                required_locations_left.into_values(),
+                |location| &location.certificate_hash,
+            )
+            .await
+            .into_iter()
             .map(|location| {
                 self.storage
                     .contains_hashed_certificate_value(location.certificate_hash)
@@ -815,7 +810,9 @@ where
                 true,
             ));
         }
-        self.cache_validated(&certificate.value).await;
+        self.recent_values
+            .insert_validated_and_confirmed(&certificate.value)
+            .await;
         let old_round = chain.manager.get().current_round;
         chain.manager.get_mut().create_final_vote(
             certificate,
@@ -937,23 +934,7 @@ where
     }
 
     pub async fn cache_recent_value<'a>(&mut self, value: Cow<'a, HashedCertificateValue>) -> bool {
-        let hash = value.hash();
-        let mut recent_values = self.recent_values.lock().await;
-        if recent_values.contains(&hash) {
-            return false;
-        }
-        // Cache the certificate so that clients don't have to send the value again.
-        recent_values.push(hash, value.into_owned());
-        true
-    }
-
-    /// Caches the validated block and the corresponding confirmed block.
-    async fn cache_validated(&mut self, value: &HashedCertificateValue) {
-        if self.cache_recent_value(Cow::Borrowed(value)).await {
-            if let Some(value) = value.validated_to_confirmed() {
-                self.cache_recent_value(Cow::Owned(value)).await;
-            }
-        }
+        self.recent_values.insert(value).await
     }
 
     /// Returns a stored [`Certificate`] for a chain's block.
@@ -1164,7 +1145,9 @@ where
         manager.create_vote(proposal, outcome, self.key_pair(), local_time);
         // Cache the value we voted on, so the client doesn't have to send it again.
         if let Some(vote) = manager.pending() {
-            self.cache_validated(&vote.value).await;
+            self.recent_values
+                .insert_validated_and_confirmed(&vote.value)
+                .await;
         }
         let info = ChainInfoResponse::new(&chain, self.key_pair());
         chain.save().await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -933,7 +933,11 @@ where
         Ok(Some(last_updated_height))
     }
 
-    pub async fn cache_recent_value<'a>(&mut self, value: Cow<'a, HashedCertificateValue>) -> bool {
+    /// Inserts a [`HashedCertificateValue`] into the worker's cache.
+    pub(crate) async fn cache_recent_value<'a>(
+        &mut self,
+        value: Cow<'a, HashedCertificateValue>,
+    ) -> bool {
         self.recent_values.insert(value).await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -811,7 +811,7 @@ where
             ));
         }
         self.recent_values
-            .insert_validated_and_confirmed(&certificate.value)
+            .insert(Cow::Borrowed(&certificate.value))
             .await;
         let old_round = chain.manager.get().current_round;
         chain.manager.get_mut().create_final_vote(
@@ -1149,9 +1149,7 @@ where
         manager.create_vote(proposal, outcome, self.key_pair(), local_time);
         // Cache the value we voted on, so the client doesn't have to send it again.
         if let Some(vote) = manager.pending() {
-            self.recent_values
-                .insert_validated_and_confirmed(&vote.value)
-                .await;
+            self.recent_values.insert(Cow::Borrowed(&vote.value)).await;
         }
         let info = ChainInfoResponse::new(&chain, self.key_pair());
         chain.save().await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -656,9 +656,9 @@ where
         self.check_no_missing_bytecode(block, hashed_certificate_values)
             .await?;
         // Persist certificate and hashed certificate values.
-        for value in hashed_certificate_values {
-            self.cache_recent_value(Cow::Borrowed(value)).await;
-        }
+        self.recent_values
+            .insert_all(hashed_certificate_values.iter().map(Cow::Borrowed))
+            .await;
         let (result_hashed_certificate_value, result_certificate) = tokio::join!(
             self.storage
                 .write_hashed_certificate_values(hashed_certificate_values),


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `WorkerState` has an internal LRU cache of certificate values. This helps with network usage, because it allows clients to only send the full `Certificate` once, and send `LiteCertificate`s (without the `CertificateValue`) afterwards.

The `WorkerState` also includes some helper methods to interface with the cache. These methods would have to be duplicated in the new `ChainWorkerState` type.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Move the cache functionality into a new `CertificateValueCache` type, so that the methods don't have to be duplicated in the new `ChainWorkerState`.

Also add metrics to the cache, so that the number of cache hits and misses is tracked.

## Test Plan

<!-- How to test that the changes are correct. -->
Some unit tests were added specifically for the new type.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor, nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
