### PR TITLE
PublishBlob

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -27,6 +27,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera service`↴](#linera-service)
 * [`linera faucet`↴](#linera-faucet)
 * [`linera publish-bytecode`↴](#linera-publish-bytecode)
+* [`linera publish-blob`↴](#linera-publish-blob)
 * [`linera create-application`↴](#linera-create-application)
 * [`linera publish-and-create`↴](#linera-publish-and-create)
 * [`linera request-application`↴](#linera-request-application)
@@ -77,6 +78,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `service` — Run a GraphQL service to explore and extend the chains of the wallet
 * `faucet` — Run a GraphQL service that exposes a faucet where users can claim tokens. This gives away the chain's tokens, and is mainly intended for testing
 * `publish-bytecode` — Publish bytecode
+* `publish-blob` — Publish a blob of binary data
 * `create-application` — Create an application
 * `publish-and-create` — Create an application, and publish the required bytecode
 * `request-application` — Request an application from another chain, so it can be used on this one
@@ -550,6 +552,19 @@ Publish bytecode
 * `<CONTRACT>` — Path to the Wasm file for the application "contract" bytecode
 * `<SERVICE>` — Path to the Wasm file for the application "service" bytecode
 * `<PUBLISHER>` — An optional chain ID to publish the bytecode. The default chain of the wallet is used otherwise
+
+
+
+## `linera publish-blob`
+
+Publish a blob of binary data
+
+**Usage:** `linera publish-blob <BLOB_PATH> [PUBLISHER]`
+
+###### **Arguments:**
+
+* `<BLOB_PATH>` — Path to blob file to be published
+* `<PUBLISHER>` — An optional chain ID to publish the blob. The default chain of the wallet is used otherwise
 
 
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2728,6 +2728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-game"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "linera-sdk",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "hex-literal"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,16 +2750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hex-game"
-version = "0.1.0"
-dependencies = [
- "async-graphql",
- "linera-sdk",
- "serde",
- "tokio",
 ]
 
 [[package]]

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -15,8 +15,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     bcs_scalar,
-    crypto::{BcsHashable, BcsSignable, CryptoError, CryptoHash, PublicKey},
-    data_types::BlockHeight,
+    crypto::{BcsHashable, CryptoError, CryptoHash, PublicKey},
+    data_types::{Blob, BlockHeight},
     doc_scalar,
 };
 
@@ -78,7 +78,7 @@ impl Account {
     }
 }
 
-impl std::fmt::Display for Account {
+impl Display for Account {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.owner {
             Some(owner) => write!(f, "{}:{}", self.chain_id, owner),
@@ -142,19 +142,23 @@ impl ChainDescription {
 #[cfg_attr(with_testing, derive(Default))]
 pub struct ChainId(pub CryptoHash);
 
-/// A blob ID.
+/// A content-addressed blob ID i.e. the hash of the Blob.
 #[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Serialize, Deserialize)]
-#[cfg_attr(with_testing, derive(Default))]
+#[cfg_attr(with_testing, derive(test_strategy::Arbitrary, Default))]
 pub struct BlobId(pub CryptoHash);
 
-/// A blob.
-#[derive(Serialize, Deserialize)]
-pub struct Blob {
-    #[serde(with = "serde_bytes")]
-    bytes: Vec<u8>,
+impl BlobId {
+    /// Creates a new `BlobId` from a `Blob`
+    pub fn new(blob: &Blob) -> Self {
+        BlobId(CryptoHash::new(blob))
+    }
 }
 
-impl BcsSignable for Blob {}
+impl Display for BlobId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
 
 /// The index of a message in a chain.
 #[derive(
@@ -802,7 +806,10 @@ doc_scalar!(
 );
 doc_scalar!(AccountOwner, "An owner of an account.");
 doc_scalar!(Account, "An account");
-doc_scalar!(BlobId, "A blob id");
+doc_scalar!(
+    BlobId,
+    "A content-addressed blob ID i.e. the hash of the Blob"
+);
 
 #[cfg(test)]
 mod tests {

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -122,7 +122,7 @@ impl BlockTestExt for Block {
 
     fn into_proposal_with_round(self, key_pair: &KeyPair, round: Round) -> BlockProposal {
         let content = BlockAndRound { block: self, round };
-        BlockProposal::new(content, key_pair, vec![], None)
+        BlockProposal::new(content, key_pair, vec![], vec![], None)
     }
 
     fn into_justified_proposal(
@@ -132,7 +132,7 @@ impl BlockTestExt for Block {
         validated: Certificate,
     ) -> BlockProposal {
         let content = BlockAndRound { block: self, round };
-        BlockProposal::new(content, key_pair, vec![], Some(validated))
+        BlockProposal::new(content, key_pair, vec![], vec![], Some(validated))
     }
 }
 

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 
 use linera_base::{
     crypto::{BcsSignable, CryptoError, CryptoHash, KeyPair, Signature},
-    data_types::{Amount, BlockHeight, Round, Timestamp},
-    identifiers::{ChainDescription, ChainId, Owner},
+    data_types::{Amount, BlockHeight, HashedBlob, Round, Timestamp},
+    identifiers::{BlobId, ChainDescription, ChainId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -68,8 +68,10 @@ pub struct ChainInfoQuery {
     pub request_leader_timeout: bool,
     /// Include a vote to switch to fallback mode, if appropriate.
     pub request_fallback: bool,
-    /// Query a value that contains a binary hashed certificate value (e.g. bytecode) required by this chain.
+    /// Query a certificate value that contains a binary blob (e.g. bytecode) required by this chain.
     pub request_hashed_certificate_value: Option<CryptoHash>,
+    /// Query a binary blob (e.g. bytecode) required by this chain.
+    pub request_blob: Option<BlobId>,
 }
 
 impl ChainInfoQuery {
@@ -86,6 +88,7 @@ impl ChainInfoQuery {
             request_leader_timeout: false,
             request_fallback: false,
             request_hashed_certificate_value: None,
+            request_blob: None,
         }
     }
 
@@ -138,6 +141,11 @@ impl ChainInfoQuery {
         self.request_hashed_certificate_value = Some(hash);
         self
     }
+
+    pub fn with_blob(mut self, blob_id: BlobId) -> Self {
+        self.request_blob = Some(blob_id);
+        self
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -175,6 +183,8 @@ pub struct ChainInfo {
     pub requested_received_log: Vec<ChainAndHeight>,
     /// The requested hashed certificate value, if any.
     pub requested_hashed_certificate_value: Option<HashedCertificateValue>,
+    /// The requested blob, if any.
+    pub requested_blob: Option<HashedBlob>,
 }
 
 /// The response to an `ChainInfoQuery`
@@ -254,6 +264,7 @@ where
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
             requested_hashed_certificate_value: None,
+            requested_blob: None,
         }
     }
 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -126,10 +126,16 @@ where
         &mut self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
+        hashed_blobs: Vec<HashedBlob>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.spawn_and_receive(move |validator, sender| {
-            validator.do_handle_certificate(certificate, hashed_certificate_values, sender)
+            validator.do_handle_certificate(
+                certificate,
+                hashed_certificate_values,
+                hashed_blobs,
+                sender,
+            )
         })
         .await
     }
@@ -238,6 +244,7 @@ where
                     .fully_handle_certificate_with_notifications(
                         cert,
                         vec![],
+                        vec![],
                         Some(&mut notifications),
                     )
                     .await
@@ -257,6 +264,7 @@ where
         self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
+        hashed_blobs: Vec<HashedBlob>,
         sender: oneshot::Sender<Result<ChainInfoResponse, NodeError>>,
     ) -> Result<(), Result<ChainInfoResponse, NodeError>> {
         let mut validator = self.client.lock().await;
@@ -272,6 +280,7 @@ where
                 .fully_handle_certificate_with_notifications(
                     certificate,
                     hashed_certificate_values,
+                    hashed_blobs,
                     Some(&mut notifications),
                 )
                 .await
@@ -616,6 +625,7 @@ where
             Timestamp::from(0),
             block_height,
             None,
+            BTreeMap::new(),
         ))
     }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -155,7 +155,7 @@ where
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(publish_certificate.clone(), vec![])
+        .fully_handle_certificate(publish_certificate.clone(), vec![], vec![])
         .await
         .unwrap()
         .info;
@@ -226,7 +226,7 @@ where
         make_certificate(&committee, &worker, failing_broadcast_block_proposal);
 
     worker
-        .fully_handle_certificate(failing_broadcast_certificate, vec![])
+        .fully_handle_certificate(failing_broadcast_certificate, vec![], vec![])
         .await
         .expect_err("Broadcast messages with grants should fail");
 
@@ -250,7 +250,7 @@ where
     let broadcast_certificate = make_certificate(&committee, &worker, broadcast_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(broadcast_certificate.clone(), vec![])
+        .fully_handle_certificate(broadcast_certificate.clone(), vec![], vec![])
         .await
         .unwrap()
         .info;
@@ -305,7 +305,7 @@ where
     let subscribe_certificate = make_certificate(&committee, &worker, subscribe_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(subscribe_certificate.clone(), vec![])
+        .fully_handle_certificate(subscribe_certificate.clone(), vec![], vec![])
         .await
         .unwrap()
         .info;
@@ -358,7 +358,7 @@ where
     let accept_certificate = make_certificate(&committee, &worker, accept_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(accept_certificate.clone(), vec![])
+        .fully_handle_certificate(accept_certificate.clone(), vec![], vec![])
         .await
         .unwrap()
         .info;
@@ -452,7 +452,7 @@ where
     let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(create_certificate.clone(), vec![])
+        .fully_handle_certificate(create_certificate.clone(), vec![], vec![])
         .await
         .unwrap()
         .info;
@@ -505,7 +505,7 @@ where
     let run_certificate = make_certificate(&committee, &worker, run_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(run_certificate.clone(), vec![])
+        .fully_handle_certificate(run_certificate.clone(), vec![], vec![])
         .await
         .unwrap()
         .info;

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -22,7 +22,7 @@ use {
 use crate::worker::WorkerError;
 
 /// The default cache size.
-const DEFAULT_VALUE_CACHE_SIZE: usize = 1000;
+pub const DEFAULT_VALUE_CACHE_SIZE: usize = 1000;
 
 /// A counter metric for the number of cache hits in the [`CertificateValueCache`].
 #[cfg(with_metrics)]

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -14,7 +14,7 @@ use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, ApplicationPermissions, ArithmeticError, Timestamp},
     ensure, hex_debug,
-    identifiers::{Account, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
+    identifiers::{Account, BlobId, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_views::{
@@ -158,6 +158,8 @@ pub enum SystemOperation {
         contract: Bytecode,
         service: Bytecode,
     },
+    /// Publishes a new blob
+    PublishBlob { blob_id: BlobId },
     /// Creates a new application.
     CreateApplication {
         bytecode_id: BytecodeId,
@@ -670,6 +672,7 @@ where
                 };
                 outcome.messages.push(message);
             }
+            PublishBlob { .. } => (),
         }
 
         Ok((outcome, new_application))

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -147,6 +147,9 @@ message ChainInfoQuery {
 
   // Request a signed vote for fallback mode.
   bool request_fallback = 11;
+  
+  // Query a value that contains a binary blob (e.g. bytecode) required by this chain.
+  optional bytes request_blob = 12;
 }
 
 // An authenticated proposal for a new block.
@@ -168,6 +171,9 @@ message BlockProposal {
 
   // A certificate for a validated block that justifies the proposal in this round.
   optional bytes validated = 6;
+  
+  // Required blob
+  bytes blobs = 7;
 }
 
 // A certified statement from the committee, without the value.
@@ -210,6 +216,9 @@ message Certificate {
   // Wait until all outgoing cross-chain messages from this certificate have
   // been received by the target chains.
   bool wait_for_outgoing_messages = 6;
+  
+  // Blobs required by this certificate
+  bytes blobs = 7;
 }
 
 message ChainId {

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use linera_base::identifiers::ChainId;
+use linera_base::{data_types::HashedBlob, identifiers::ChainId};
 use linera_chain::data_types::{
     BlockProposal, Certificate, HashedCertificateValue, LiteCertificate,
 };
@@ -80,19 +80,30 @@ impl ValidatorNode for Client {
         &mut self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
+        hashed_blobs: Vec<HashedBlob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
             Client::Grpc(grpc_client) => {
                 grpc_client
-                    .handle_certificate(certificate, hashed_certificate_values, delivery)
+                    .handle_certificate(
+                        certificate,
+                        hashed_certificate_values,
+                        hashed_blobs,
+                        delivery,
+                    )
                     .await
             }
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => {
                 simple_client
-                    .handle_certificate(certificate, hashed_certificate_values, delivery)
+                    .handle_certificate(
+                        certificate,
+                        hashed_certificate_values,
+                        hashed_blobs,
+                        delivery,
+                    )
                     .await
             }
         }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -4,7 +4,7 @@
 use std::{iter, time::Duration};
 
 use futures::{future, stream, StreamExt};
-use linera_base::identifiers::ChainId;
+use linera_base::{data_types::HashedBlob, identifiers::ChainId};
 use linera_chain::data_types;
 #[cfg(web)]
 use linera_core::node::{
@@ -162,12 +162,14 @@ impl ValidatorNode for GrpcClient {
         &mut self,
         certificate: data_types::Certificate,
         hashed_certificate_values: Vec<data_types::HashedCertificateValue>,
+        hashed_blobs: Vec<HashedBlob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
             hashed_certificate_values,
+            hashed_blobs,
             wait_for_outgoing_messages,
         };
         client_delegate!(self, handle_certificate, request)

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -516,6 +516,7 @@ where
         let HandleCertificateRequest {
             certificate,
             hashed_certificate_values,
+            hashed_blobs,
             wait_for_outgoing_messages,
         } = request.into_inner().try_into()?;
         debug!(?certificate, "Handling certificate");
@@ -523,7 +524,7 @@ where
         match self
             .state
             .clone()
-            .handle_certificate(certificate, hashed_certificate_values, sender)
+            .handle_certificate(certificate, hashed_certificate_values, hashed_blobs, sender)
             .await
         {
             Ok((info, actions)) => {

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -36,6 +36,7 @@ pub struct HandleCertificateRequest {
     pub certificate: linera_chain::data_types::Certificate,
     pub wait_for_outgoing_messages: bool,
     pub hashed_certificate_values: Vec<linera_chain::data_types::HashedCertificateValue>,
+    pub hashed_blobs: Vec<linera_base::data_types::HashedBlob>,
 }
 
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("file_descriptor_set");

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -6,7 +6,7 @@ use std::{future::Future, time::Duration};
 
 use async_trait::async_trait;
 use futures::{sink::SinkExt, stream::StreamExt};
-use linera_base::identifiers::ChainId;
+use linera_base::{data_types::HashedBlob, identifiers::ChainId};
 use linera_chain::data_types::{
     BlockProposal, Certificate, HashedCertificateValue, LiteCertificate,
 };
@@ -100,12 +100,14 @@ impl ValidatorNode for SimpleClient {
         &mut self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
+        hashed_blobs: Vec<HashedBlob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
             hashed_certificate_values,
+            hashed_blobs,
             wait_for_outgoing_messages,
         };
         self.query(request.into()).await

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -237,6 +237,7 @@ where
                     .handle_certificate(
                         request.certificate,
                         request.hashed_certificate_values,
+                        request.hashed_blobs,
                         sender,
                     )
                     .await

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -40,6 +40,12 @@ ApplicationPermissions:
     - close_chain:
         SEQ:
           TYPENAME: ApplicationId
+Blob:
+  STRUCT:
+    - bytes: BYTES
+BlobId:
+  NEWTYPESTRUCT:
+    TYPENAME: CryptoHash
 Block:
   STRUCT:
     - chain_id:
@@ -99,6 +105,9 @@ BlockProposal:
     - hashed_certificate_values:
         SEQ:
           TYPENAME: CertificateValue
+    - hashed_blobs:
+        SEQ:
+          TYPENAME: Blob
     - validated:
         OPTION:
           TYPENAME: Certificate
@@ -211,6 +220,9 @@ ChainInfo:
     - requested_hashed_certificate_value:
         OPTION:
           TYPENAME: CertificateValue
+    - requested_blob:
+        OPTION:
+          TYPENAME: Blob
 ChainInfoQuery:
   STRUCT:
     - chain_id:
@@ -234,6 +246,9 @@ ChainInfoQuery:
     - request_hashed_certificate_value:
         OPTION:
           TYPENAME: CryptoHash
+    - request_blob:
+        OPTION:
+          TYPENAME: BlobId
 ChainInfoResponse:
   STRUCT:
     - info:
@@ -274,6 +289,12 @@ ChainManagerInfo:
     - round_timeout:
         OPTION:
           TYPENAME: Timestamp
+    - pending_blobs:
+        MAP:
+          KEY:
+            TYPENAME: BlobId
+          VALUE:
+            TYPENAME: Blob
 ChainOwnership:
   STRUCT:
     - super_owners:
@@ -409,6 +430,9 @@ HandleCertificateRequest:
     - hashed_certificate_values:
         SEQ:
           TYPENAME: CertificateValue
+    - hashed_blobs:
+        SEQ:
+          TYPENAME: Blob
 HandleLiteCertRequest:
   STRUCT:
     - certificate:
@@ -548,40 +572,52 @@ NodeError:
           SEQ:
             TYPENAME: BytecodeLocation
     8:
-      MissingCertificateValue: UNIT
+      BlobsNotFound:
+        NEWTYPE:
+          SEQ:
+            TYPENAME: BlobId
     9:
-      MissingVoteInValidatorResponse: UNIT
+      ApplicationBytecodesAndBlobsNotFound:
+        TUPLE:
+          - SEQ:
+              TYPENAME: BytecodeLocation
+          - SEQ:
+              TYPENAME: BlobId
     10:
+      MissingCertificateValue: UNIT
+    11:
+      MissingVoteInValidatorResponse: UNIT
+    12:
       InactiveLocalChain:
         NEWTYPE:
           TYPENAME: ChainId
-    11:
-      InvalidChainInfoResponse: UNIT
-    12:
-      InvalidDecoding: UNIT
     13:
-      UnexpectedMessage: UNIT
+      InvalidChainInfoResponse: UNIT
     14:
+      InvalidDecoding: UNIT
+    15:
+      UnexpectedMessage: UNIT
+    16:
       GrpcError:
         STRUCT:
           - error: STR
-    15:
+    17:
       ClientIoError:
         STRUCT:
           - error: STR
-    16:
+    18:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    17:
+    19:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    18:
+    20:
       SubscriptionFailed:
         STRUCT:
           - status: STR
-    19:
+    21:
       LocalNodeQuery:
         STRUCT:
           - error: STR
@@ -913,6 +949,11 @@ SystemOperation:
           - service:
               TYPENAME: Bytecode
     9:
+      PublishBlob:
+        STRUCT:
+          - blob_id:
+              TYPENAME: BlobId
+    10:
       CreateApplication:
         STRUCT:
           - bytecode_id:
@@ -922,14 +963,14 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: ApplicationId
-    10:
+    11:
       RequestApplication:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
           - application_id:
               TYPENAME: ApplicationId
-    11:
+    12:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -103,7 +103,7 @@ impl ActiveChain {
         self.validator
             .worker()
             .await
-            .fully_handle_certificate(certificate.clone(), vec![])
+            .fully_handle_certificate(certificate.clone(), vec![], vec![])
             .await
             .expect("Rejected certificate");
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -20,6 +20,16 @@ type ApplicationOverview {
 }
 
 """
+A blob of binary data.
+"""
+scalar Blob
+
+"""
+A content-addressed blob ID i.e. the hash of the Blob
+"""
+scalar BlobId
+
+"""
 A block containing operations to apply on a given chain, as well as the
 acknowledgment of a number of incoming messages from other chains.
 * Incoming messages must be selected in the order they were
@@ -603,6 +613,10 @@ type MutationRoot {
 	Publishes a new application bytecode.
 	"""
 	publishBytecode(chainId: ChainId!, contract: Bytecode!, service: Bytecode!): BytecodeId!
+	"""
+	Publishes a new blob.
+	"""
+	publishBlob(chainId: ChainId!, blob: Blob!): BlobId!
 	"""
 	Creates a new application.
 	"""

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -585,6 +585,15 @@ pub enum ClientCommand {
         publisher: Option<ChainId>,
     },
 
+    /// Publish a blob of binary data.
+    PublishBlob {
+        /// Path to blob file to be published.
+        blob_path: PathBuf,
+        /// An optional chain ID to publish the blob. The default chain of the wallet
+        /// is used otherwise.
+        publisher: Option<ChainId>,
+    },
+
     /// Create an application.
     CreateApplication {
         /// The bytecode ID of the application to create.

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -702,6 +702,7 @@ impl Runnable for Job {
                         HandleCertificateRequest {
                             certificate: certificate.clone(),
                             hashed_certificate_values: vec![],
+                            hashed_blobs: vec![],
                             wait_for_outgoing_messages: true,
                         }
                         .into()
@@ -800,6 +801,20 @@ impl Runnable for Job {
                     .await?;
                 println!("{}", bytecode_id);
                 info!("{}", "Bytecode published successfully!".green().bold());
+                info!("Time elapsed: {} ms", start_time.elapsed().as_millis());
+            }
+
+            PublishBlob {
+                blob_path,
+                publisher,
+            } => {
+                let start_time = Instant::now();
+                let publisher = publisher.unwrap_or_else(|| context.default_chain());
+                info!("Publishing blob on chain {}", publisher);
+                let chain_client = context.make_chain_client(storage, publisher).into_arc();
+                let blob_id = context.publish_blob(&chain_client, blob_path).await?;
+                println!("{}", blob_id);
+                info!("{}", "Blob published successfully!".green().bold());
                 info!("Time elapsed: {} ms", start_time.elapsed().as_millis());
             }
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -18,8 +18,8 @@ use futures::{
 };
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
-    data_types::{Amount, ApplicationPermissions, TimeDelta, Timestamp},
-    identifiers::{ApplicationId, BytecodeId, ChainId, Owner},
+    data_types::{Amount, ApplicationPermissions, Blob, TimeDelta, Timestamp},
+    identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
     BcsHexParseError,
 };
@@ -616,6 +616,22 @@ where
                     .await
                     .map_err(Error::from)
                     .map(|outcome| outcome.map(|(bytecode_id, _)| bytecode_id));
+                (result, client)
+            }
+        })
+        .await
+    }
+
+    /// Publishes a new blob.
+    async fn publish_blob(&self, chain_id: ChainId, blob: Blob) -> Result<BlobId, Error> {
+        self.apply_client_command(&chain_id, move |mut client| {
+            let blob = blob.clone();
+            async move {
+                let result = client
+                    .publish_blob(blob.into_hashed())
+                    .await
+                    .map_err(Error::from)
+                    .map(|outcome| outcome.map(|(blob_id, _)| blob_id));
                 (result, client)
             }
         })

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use linera_base::{crypto::KeyPair, data_types::Timestamp, identifiers::ChainId};
+use linera_base::{
+    crypto::KeyPair,
+    data_types::{HashedBlob, Timestamp},
+    identifiers::ChainId,
+};
 use linera_chain::data_types::{
     BlockProposal, Certificate, HashedCertificateValue, LiteCertificate,
 };
@@ -52,6 +56,7 @@ impl ValidatorNode for DummyValidatorNode {
         &mut self,
         _: Certificate,
         _: Vec<HashedCertificateValue>,
+        _: Vec<HashedBlob>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 use futures::lock::Mutex;
@@ -69,6 +69,7 @@ impl chain_listener::ClientContext<NodeProvider<MemoryStorage<TestClock>>> for C
             chain.timestamp,
             chain.next_block_height,
             chain.pending_block.clone(),
+            chain.pending_blobs.clone(),
         )
     }
 
@@ -86,6 +87,7 @@ impl chain_listener::ClientContext<NodeProvider<MemoryStorage<TestClock>>> for C
                 timestamp,
                 next_block_height: BlockHeight::ZERO,
                 pending_block: None,
+                pending_blobs: BTreeMap::new(),
             });
         }
     }

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -10,8 +10,8 @@ use comfy_table::{
 };
 use linera_base::{
     crypto::{CryptoHash, CryptoRng, KeyPair, PublicKey},
-    data_types::{BlockHeight, Timestamp},
-    identifiers::{ChainDescription, ChainId, Owner},
+    data_types::{BlockHeight, HashedBlob, Timestamp},
+    identifiers::{BlobId, ChainDescription, ChainId, Owner},
 };
 use linera_chain::data_types::Block;
 use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
@@ -131,6 +131,7 @@ impl Wallet {
             timestamp,
             next_block_height: BlockHeight(0),
             pending_block: None,
+            pending_blobs: BTreeMap::new(),
         };
         self.insert(user_chain);
         Ok(())
@@ -162,6 +163,7 @@ impl Wallet {
                 next_block_height: state.next_block_height(),
                 timestamp: state.timestamp(),
                 pending_block: state.pending_block().clone(),
+                pending_blobs: state.pending_blobs().clone(),
             },
         );
     }
@@ -267,6 +269,7 @@ pub struct UserChain {
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
     pub pending_block: Option<Block>,
+    pub pending_blobs: BTreeMap<BlobId, HashedBlob>,
 }
 
 impl UserChain {
@@ -284,6 +287,7 @@ impl UserChain {
             timestamp,
             next_block_height: BlockHeight::ZERO,
             pending_block: None,
+            pending_blobs: BTreeMap::new(),
         }
     }
 
@@ -297,6 +301,7 @@ impl UserChain {
             timestamp,
             next_block_height: BlockHeight::ZERO,
             pending_block: None,
+            pending_blobs: BTreeMap::new(),
         }
     }
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -23,8 +23,8 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{Blob, BlobId, ChainDescription, ChainId, GenericApplicationId},
+    data_types::{Amount, BlockHeight, HashedBlob, Timestamp},
+    identifiers::{BlobId, ChainDescription, ChainId, GenericApplicationId},
     ownership::ChainOwnership,
 };
 use linera_chain::{
@@ -101,7 +101,7 @@ pub trait Storage: Sized {
     ) -> Result<HashedCertificateValue, ViewError>;
 
     /// Reads the blob with the given blob id.
-    async fn read_blob(&self, blob_id: BlobId) -> Result<Blob, ViewError>;
+    async fn read_hashed_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ViewError>;
 
     /// Reads the hashed certificate values in descending order from the given hash.
     async fn read_hashed_certificate_values_downward(
@@ -117,7 +117,7 @@ pub trait Storage: Sized {
     ) -> Result<(), ViewError>;
 
     /// Writes the given blob.
-    async fn write_blob(&self, blob: &Blob) -> Result<BlobId, ViewError>;
+    async fn write_hashed_blob(&self, blob: &HashedBlob) -> Result<(), ViewError>;
 
     /// Writes several hashed certificate values
     async fn write_hashed_certificate_values(
@@ -126,7 +126,7 @@ pub trait Storage: Sized {
     ) -> Result<(), ViewError>;
 
     /// Writes several blobs
-    async fn write_blobs(&self, blobs: &[Blob]) -> Result<(), ViewError>;
+    async fn write_hashed_blobs(&self, blobs: &[HashedBlob]) -> Result<(), ViewError>;
 
     /// Tests existence of the certificate with the given hash.
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError>;


### PR DESCRIPTION
## Motivation

Currently users are able to upload bytecode that can be used to create applications. Other chains have to subscribe to the publisher chain to be able to use the bytecode. We want to generalize this so that:
* Users can publish arbitrary data that can be used as bytecode or read by existing applications.
* One doesn’t have to subscribe to the publisher chain (and wait for it to handle the subscription request) to use the blob.
* Blobs are content-addressed, so that if two users upload identical blobs, they are stored only once.

## Proposal

This PR implements the `PublishBlob` operation

## Test Plan

Unit test

## Release Plan

Since we're adding a new `SystemOperation`, I'm guessing we have to do this:
- Need to update the developer manual.
