### PR TITLE
Workspace metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,14 @@ members = [
 exclude = ["examples", "scripts"]
 resolver = "2"
 
+[workspace.package]
+version = "0.11.0"
+authors = ["Linera <contact@linera.io>"]
+repository = "https://github.com/linera-io/linera-protocol"
+homepage = "https://linera.dev"
+license = "Apache-2.0"
+edition = "2021"
+
 [workspace.dependencies]
 heck = "0.4.1"
 anyhow = "1.0.80"

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-base"
-version = "0.11.0"
 description = "Base definitions, including cryptography, used by the Linera protocol."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-base/latest/linera_base/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 test = ["test-strategy", "proptest"]

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-chain"
-version = "0.11.0"
 description = "Persistent data and the corresponding logics used by the Linera protocol for chains of blocks, certificates, and cross-chain messaging."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-chain/latest/linera_chain/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 test = ["tokio/macros", "linera-base/test", "linera-execution/test"]

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-core"
-version = "0.11.0"
 description = "The core Linera protocol, including client and server logic, node synchronization, etc."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-core/latest/linera_core/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 wasmer = ["linera-execution/wasmer", "linera-storage/wasmer"]

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-execution"
-version = "0.11.0"
 description = "Persistent data and the corresponding logics used by the Linera protocol for runtime and execution of smart contracts / applications."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-execution/latest/linera_execution/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 test = ["tokio/macros"]

--- a/linera-explorer/Cargo.toml
+++ b/linera-explorer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linera-explorer"
-version = "0.11.0"
+version.workspace = true
 edition = "2021"
 description = "Block explorer for the Linera network"
 readme = "README.md"

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-rpc"
-version = "0.11.0"
 description = "RPC schemas and networking library for the Linera protocol."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-rpc/latest/linera_rpc/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 test = [

--- a/linera-sdk-derive/Cargo.toml
+++ b/linera-sdk-derive/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "linera-sdk-derive"
-version = "0.11.0"
 description = "The procedural macros for the crate `linera-sdk`"
-authors = ["Linera <contact@linera.io>"]
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.io"
-license = "Apache-2.0"
-edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [lib]
 proc-macro = true

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-sdk"
-version = "0.11.0"
 description = "Library to support developping Linera applications in Rust."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-sdk/latest/linera_sdk/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [package.metadata.cargo-udeps.ignore]
 development = ["linera-sdk"]

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "linera-service-graphql-client"
-version = "0.11.0"
-edition = "2021"
 description = "A GraphQL client for Linera node service"
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-service-graphql-client/latest/linera_service_graphql_client/"
-license = "Apache-2.0"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["rocksdb"]

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-service"
-version = "0.11.0"
 description = "Executable for clients (aka CLI wallets), proxy (aka validator frontend) and servers of the Linera protocol."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-service/latest/linera_service/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["wasmer", "rocksdb"]

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-storage-service"
-version = "0.11.0"
 description = "RPC shared key value store."
-authors = ["Linera <contact@linera.io>"]
-readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-storage-service/latest/linera_storage_service/"
-license = "Apache-2.0"
-edition = "2021"
+readme = "README.md"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["rocksdb"]

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-storage"
-version = "0.11.0"
 description = "Storage abstractions for the Linera protocol."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-storage/latest/linera_storage/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 test = [

--- a/linera-version/Cargo.toml
+++ b/linera-version/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-version"
-version = "0.11.0"
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-rpc/latest/linera_rpc/"
 description = "Crate version management for the Linera protocol"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 async-graphql.workspace = true

--- a/linera-views-derive/Cargo.toml
+++ b/linera-views-derive/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "linera-views-derive"
-version = "0.11.0"
 description = "The procedural macros for the crate `linera-views`"
-authors = ["Linera <contact@linera.io>"]
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 metrics = []

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-views"
-version = "0.11.0"
 description = "A library mapping complex data structures onto a key-value store, used by the Linera protocol"
-authors = ["Linera <contact@linera.io>"]
-readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-views/latest/linera_views/"
-license = "Apache-2.0"
-edition = "2021"
+readme = "README.md"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 # Not used, but here to provide the `js` feature to `rand`
 metadata.cargo-machete.ignored = ["getrandom"]

--- a/linera-witty-macros/Cargo.toml
+++ b/linera-witty-macros/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-witty-macros"
-version = "0.11.0"
 description = "Procedural macros for generation of WIT compatible host code from Rust code"
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-witty-macros/latest/linera_witty_macros/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [lib]
 proc-macro = true

--- a/linera-witty/Cargo.toml
+++ b/linera-witty/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-witty"
-version = "0.11.0"
 description = "Generation of WIT compatible host code from Rust code"
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-witty/latest/linera_witty/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["macros"]


### PR DESCRIPTION
## Motivation

Updating our package metadata across the workspace is a pain.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Move shared metadata into our `Cargo.toml`'s [`workspace.package`](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table) key, and refer to it from there.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

It would also be good to test publishing, but I failed to find a safe way to dry-run publishing.

<!-- How to test that the changes are correct. -->

## Release Plan

Bureaucracy — no user-visible changes.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
