### PR TITLE
`flake.nix`: use a Nix package to facilitate sharing

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,35 @@
+{ crane, pkgs }:
+let
+  rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile
+    ./toolchains/build/rust-toolchain.toml);
+in ((crane.mkLib pkgs).overrideToolchain rust-toolchain).buildPackage {
+  pname = "linera";
+  src = ./.;
+  cargoExtraArgs = "-p linera-service";
+  nativeBuildInputs = with pkgs; [
+    clang
+    pkg-config
+    rocksdb
+    protobufc
+  ];
+  buildInputs = with pkgs; [
+    clang.cc.lib
+    libiconv
+    nodejs
+    openssl
+    protobuf
+  ];
+  checkInputs = with pkgs; [
+    # for native testing
+    jq
+    kubernetes-helm
+    kind
+    kubectl
+
+    # for Wasm testing
+    chromium
+    chromedriver
+    wasm-pack
+  ];
+  passthru = { inherit rust-toolchain; };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,33 @@
 {
   "nodes": {
+    "crane": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1715274763,
+        "narHash": "sha256-3Iv1PGHJn9sV3HO4FlOVaaztOxa9uGLfOmUWrH7v7+A=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "27025ab71bdca30e7ed0a16c88fd74c5970fc7f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1712014858,
-        "narHash": "sha256-sB4SWl2lX95bExY2gMFG5HIzvva5AVMJd4Igm+GpZNw=",
+        "lastModified": 1714641030,
+        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9126214d0a59633752a136528f5f3b9aa8565b7d",
+        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
         "type": "github"
       },
       "original": {
@@ -38,39 +56,49 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1713714899,
-        "narHash": "sha256-+z/XjO3QJs5rLE5UOf015gdVauVRQd2vZtsFkaXBq2Y=",
-        "owner": "nixos",
+        "lastModified": 1714656196,
+        "narHash": "sha256-kjQkA98lMcsom6Gbhw8SYzmwrSo+2nruiTcTZp5jK7o=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6143fc5eeb9c4f00163267708e26191d1e918932",
+        "rev": "94035b482d181af0a0f8f77823a790b256b7c3cc",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
-        "owner": "NixOS",
+        "lastModified": 1714640452,
+        "narHash": "sha256-QBx10+k6JWz6u7VsohfSw8g8hjdBZEf8CFzXH1/1Z94=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/50eb7ecf4cd0a5756d7275c8ba36790e5bd53e33.tar.gz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1715447595,
+        "narHash": "sha256-VsVAUQOj/cS1LCOmMjAGeRksXIAdPnFIjCQ0XLkCsT0=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "062ca2a9370a27a35c524dc82d540e6e9824b652",
         "type": "github"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
+        "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1706487304,
         "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
@@ -86,7 +114,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1708475490,
         "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
@@ -104,8 +132,9 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "rust-overlay": "rust-overlay",
         "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
@@ -114,14 +143,14 @@
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1713924823,
-        "narHash": "sha256-kOeyS3GFwgnKvzuBMmFqEAX0xwZ7Nj4/5tXuvpZ0d4U=",
+        "lastModified": 1715480255,
+        "narHash": "sha256-gEZl8nYidQwqJhOigJ91JDjoBFoPEWVsd82AKnaE7Go=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8a2edac3ae926a2a6ce60f4595dcc4540fc8cad4",
+        "rev": "d690205a4f01ec0930303c4204e5063958e51255",
         "type": "github"
       },
       "original": {
@@ -162,14 +191,14 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1711963903,
-        "narHash": "sha256-N3QDhoaX+paWXHbEXZapqd1r95mdshxToGowtjtYkGI=",
+        "lastModified": 1714058656,
+        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "49dc4a92b02b8e68798abd99184f228243b6e3ac",
+        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,10 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
+
+    # Rust
     rust-overlay.url = "github:oxalica/rust-overlay";
+    crane.url = "github:ipetkov/crane";
 
     # Dev tools
     treefmt-nix.url = "github:numtide/treefmt-nix";
@@ -14,62 +17,43 @@
     imports = [
       inputs.treefmt-nix.flakeModule
     ];
-    perSystem = { config, self', pkgs, lib, system, rust-overlay, ... }:
+    perSystem = { config, self', inputs', pkgs, lib, system, ... }:
       let
         cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         nonRustDeps = with pkgs; [
-          # for building
-          clang
-          libclang.lib
-          libiconv
-          nodejs
-          openssl
-          protobuf
-          pkg-config
-          rocksdb
-
-          # for testing
-          jq
-          kubernetes-helm
-          kind
-          kubectl
-
-          # for Wasm testing
-          chromium
-          chromedriver
-          wasm-pack
         ];
-        rustBuildToolchain = (pkgs.rust-bin.fromRustupToolchainFile
-          ./toolchains/build/rust-toolchain.toml);
-        rustLintToolchain = (pkgs.rust-bin.fromRustupToolchainFile
-          ./toolchains/lint/rust-toolchain.toml);
+        linera = pkgs.callPackage ./. { inherit (inputs) crane; };
       in {
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
           overlays = [ (import inputs.rust-overlay) ];
         };
 
+        packages.default = linera;
+
         # Rust dev environment
         devShells.default = pkgs.mkShell {
           inputsFrom = [
             config.treefmt.build.devShell
+            linera
           ];
           shellHook = ''
             # For rust-analyzer 'hover' tooltips to work.
-            export RUST_SRC_PATH=${rustBuildToolchain.availableComponents.rust-src}
+            export RUST_SRC_PATH=${linera.rust-toolchain.availableComponents.rust-src}
             export LIBCLANG_PATH=${pkgs.libclang.lib}/lib
             export PATH=$PWD/target/debug:~/.cargo/bin:$PATH
             export ROCKSDB_LIB_DIR=${pkgs.rocksdb}/lib
           '';
-          buildInputs = nonRustDeps;
           nativeBuildInputs = with pkgs; [
-            rustBuildToolchain
             rust-analyzer
           ];
         };
 
         devShells.lint = pkgs.mkShell {
-          nativeBuildInputs = [ rustLintToolchain ];
+          nativeBuildInputs = [
+            (pkgs.rust-bin.fromRustupToolchainFile
+              ./toolchains/lint/rust-toolchain.toml)
+          ];
         };
 
         # Add your auto-formatters here.


### PR DESCRIPTION
## Motivation

The `linera-web` repository wants to compile `linera-protocol` as well, plus some other tools, but with the current setup must duplicate its build environment.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Instead of just a dev shell, make a real package for `linera-service` using [Crane](https://crane.dev/).  Then, we can re-use that package's `buildInputs` in `linera-web`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Tested locally.

<!-- How to test that the changes are correct. -->

## Release Plan

Since Nix is not currently a supported install path, no documentation is required.  Nix-based environments (e.g. on [Gitpod](https://gitpod.io/)) should also continue to work the same.

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
