### PR TITLE
fix async-graphql-derive for linera-version as well

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5106,6 +5106,7 @@ name = "linera-version"
 version = "0.11.0"
 dependencies = [
  "async-graphql",
+ "async-graphql-derive",
  "base64 0.22.0",
  "cargo_metadata",
  "glob",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2486,6 +2486,7 @@ name = "linera-version"
 version = "0.11.0"
 dependencies = [
  "async-graphql",
+ "async-graphql-derive",
  "base64 0.22.0",
  "cargo_metadata",
  "glob",

--- a/linera-version/Cargo.toml
+++ b/linera-version/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 
 [dependencies]
 async-graphql.workspace = true
+async-graphql-derive.workspace = true
 base64.workspace = true
 cargo_metadata.workspace = true
 glob.workspace = true
@@ -31,3 +32,6 @@ quote.workspace = true
 semver.workspace = true
 sha3.workspace = true
 thiserror.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["async-graphql-derive"]


### PR DESCRIPTION
## Motivation

Fix cargo publish for `linera-version`

## Proposal

Apply the same fix as for `linera-base`

## Test Plan

Used in `devnet_2024_03_26`

## Release Plan

To be cherry-picked in `devnet_2024_05_07` as well