### PR TITLE
Use workspace metadata in linera-ethereum as well

### DIFF
--- a/linera-ethereum/Cargo.toml
+++ b/linera-ethereum/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-ethereum"
-version = "0.11.0"
 description = "Oracle functionality for Ethereum"
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-ethereum/latest/linera_ethereum/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["ethereum"]


### PR DESCRIPTION
## Motivation

`linera-ethereum` was not included in #2015 (possibly a rebase issue)

## Proposal

Use workspace metadata in linera-ethereum as well

## Test Plan

CI
