### PR TITLE
Do not run docker workflow on examples and scripts directories

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,8 @@ on:
       - '**/*.md'
       - 'configuration/**'
       - 'kubernetes/**'
+      - 'examples/**'
+      - 'scripts/**'
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests


### PR DESCRIPTION
## Motivation

We do not want Docker workflows to run when the image cannot be affected.

## Proposal

Add `examples` and `scripts`  to `paths-ignore`.