### PR TITLE
Limit network actions to tracked chains

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1992,6 +1992,14 @@ where
         .await
     }
 
+    /// Handles any cross-chain requests for any pending outgoing messages.
+    pub async fn retry_pending_outgoing_messages(&mut self) -> Result<(), ChainClientError> {
+        self.node_client
+            .retry_pending_cross_chain_requests(self.chain_id)
+            .await?;
+        Ok(())
+    }
+
     pub async fn read_value(&self, hash: CryptoHash) -> Result<HashedValue, ViewError> {
         self.storage_client().await.read_value(hash).await
     }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -111,6 +111,13 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
         }
     }
 
+    /// Adds a chain to the set of chains tracked by the local node.
+    ///
+    /// This only affects the [`ChainClient`]s created after this call.
+    pub fn track_chain(&mut self, chain_id: ChainId) {
+        self.tracked_chains.insert(chain_id);
+    }
+
     /// Creates a new `ChainClient`.
     #[allow(clippy::too_many_arguments)]
     pub fn build<Storage>(

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1730,6 +1730,13 @@ where
                     executed_block.message_id_for_operation(0, OPEN_CHAIN_MESSAGE_INDEX)
                 })
                 .ok_or_else(|| ChainClientError::InternalError("Failed to create new chain"))?;
+            // Add the new chain to the list of tracked chains
+            self.node_client
+                .track_chain(ChainId::child(message_id))
+                .await;
+            self.node_client
+                .retry_pending_cross_chain_requests(self.chain_id)
+                .await?;
             return Ok(ClientOutcome::Committed((message_id, certificate)));
         }
     }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -540,6 +540,11 @@ where
         None
     }
 
+    /// Adds a chain to the set of chains tracked by this node.
+    pub async fn track_chain(&mut self, chain_id: ChainId) {
+        self.node.lock().await.state.track_chain(chain_id)
+    }
+
     /// Handles any pending local cross-chain requests.
     pub async fn retry_pending_cross_chain_requests(
         &mut self,

--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -564,7 +564,12 @@ where
             .await;
         self.chain_client_storages.push(storage.clone());
         let provider = self.validator_clients.iter().cloned().collect();
-        let builder = ChainClientBuilder::new(provider, 10, CrossChainMessageDelivery::NonBlocking);
+        let builder = ChainClientBuilder::new(
+            provider,
+            10,
+            CrossChainMessageDelivery::NonBlocking,
+            [chain_id],
+        );
         Ok(builder.build(
             chain_id,
             vec![key_pair],

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -552,7 +552,10 @@ where
         chain: &ChainStateView<StorageClient::Context>,
     ) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
-        let targets = chain.outboxes.indices().await?;
+        let mut targets = chain.outboxes.indices().await?;
+        if let Some(tracked_chains) = self.tracked_chains.as_ref() {
+            targets.retain(|target| tracked_chains.contains(&target.recipient));
+        }
         let outboxes = chain.outboxes.try_load_entries(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {
             let heights = outbox.queue.elements().await?;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -345,6 +345,13 @@ impl<StorageClient> WorkerState<StorageClient> {
         self
     }
 
+    /// Adds a chain to the set of tracked chains.
+    pub fn track_chain(&mut self, chain_id: ChainId) {
+        if let Some(tracked_chains) = self.tracked_chains.as_mut() {
+            tracked_chains.insert(chain_id);
+        }
+    }
+
     pub fn nickname(&self) -> &str {
         &self.nickname
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -269,6 +269,8 @@ pub struct WorkerState<StorageClient> {
     grace_period: Duration,
     /// Cached values by hash.
     recent_values: Arc<Mutex<LruCache<CryptoHash, HashedValue>>>,
+    /// Chain IDs that should be tracked by a worker.
+    tracked_chains: Option<HashSet<ChainId>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
@@ -290,6 +292,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             allow_messages_from_deprecated_epochs: false,
             grace_period: Duration::ZERO,
             recent_values,
+            tracked_chains: None,
             delivery_notifiers: Arc::default(),
         }
     }
@@ -298,6 +301,7 @@ impl<StorageClient> WorkerState<StorageClient> {
         nickname: String,
         storage: StorageClient,
         recent_values: Arc<Mutex<LruCache<CryptoHash, HashedValue>>>,
+        tracked_chains: HashSet<ChainId>,
         delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
     ) -> Self {
         WorkerState {
@@ -308,6 +312,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             allow_messages_from_deprecated_epochs: false,
             grace_period: Duration::ZERO,
             recent_values,
+            tracked_chains: Some(tracked_chains),
             delivery_notifiers,
         }
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -327,6 +327,15 @@ impl<StorageClient> WorkerState<StorageClient> {
         self
     }
 
+    /// Configures the subset of chains that this worker is tracking.
+    pub fn with_tracked_chains(
+        mut self,
+        tracked_chains: impl IntoIterator<Item = ChainId>,
+    ) -> Self {
+        self.tracked_chains = Some(tracked_chains.into_iter().collect());
+        self
+    }
+
     /// Returns an instance with the specified grace period, in microseconds.
     ///
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -572,9 +572,15 @@ impl ClientContext {
                     .context("failed to create new chain")?;
                 let chain_id = ChainId::child(message_id);
                 key_pairs.insert(chain_id, key_pair.copy());
+                self.chain_client_builder.track_chain(chain_id);
                 self.update_wallet_for_new_chain(chain_id, Some(key_pair.copy()), timestamp);
             }
         }
+        let mut updated_chain_client = self.make_chain_client(storage.clone(), default_chain_id);
+        updated_chain_client
+            .retry_pending_outgoing_messages()
+            .await
+            .context("outgoing messages to create the new chains should be delivered")?;
 
         for chain_id in key_pairs.keys() {
             let mut child_client = self.make_chain_client(storage.clone(), *chain_id);

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -152,8 +152,12 @@ impl ClientContext {
         };
         let node_provider = NodeProvider::new(node_options);
         let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
-        let chain_client_builder =
-            ChainClientBuilder::new(node_provider, options.max_pending_messages, delivery);
+        let chain_client_builder = ChainClientBuilder::new(
+            node_provider,
+            options.max_pending_messages,
+            delivery,
+            wallet_state.chain_ids(),
+        );
         ClientContext {
             chain_client_builder,
             wallet_state,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1076,6 +1076,7 @@ impl Job {
         ViewError: From<S::ContextError>,
     {
         let state = WorkerState::new("Local node".to_string(), None, storage)
+            .with_tracked_chains([message_id.chain_id, chain_id])
             .with_allow_inactive_chains(true)
             .with_allow_messages_from_deprecated_epochs(true);
         let mut node_client = LocalNodeClient::new(state, Arc::new(Notifier::default()));


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Currently, processing a chain on the client creates network actions for all other chains it sends messages to. This leads to cross-chain requests that create chain states on storage for those other chains. These other chains might not be relevant to the client, which means it wastes storage and hinders performance.

As a real world example, the faucet chain is used to create new chains. Every block creates a new chain. That means that when a user uses the wallet to create a chain using the faucet, it will keep in storage the initial chain states for all chains created by the faucet before it.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add an optional `tracked_chains` field to `WorkerState`, and only create `NetworkActions` for those tracked chains.

## Test Plan

<!-- How to test that the changes are correct. -->
Did a quick manual test and saw that the time to create a chain using the faucet was reduced by a bit more than 50%. Further tests should be written later.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is a quick fix for the devnet, and only changes internal client behavior, so:
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #2024 