### PR TITLE
Add hex-game example.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -176,7 +176,7 @@ jobs:
       run: |
         (set -e; for I in linera-*; do if [ -d "$I" ]; then echo $I; cargo rdme --check --no-fail-on-warnings -w $I; fi; done)
         cd examples
-        (set -e; for I in fungible native-fungible non-fungible social crowd-funding amm counter meta-counter matching-engine; do echo $I; cargo rdme --check --no-fail-on-warnings -w $I; done)
+        (set -e; for I in fungible native-fungible non-fungible social crowd-funding amm hex-game counter meta-counter matching-engine; do echo $I; cargo rdme --check --no-fail-on-warnings -w $I; done)
     - name: Run Wasm application lints
       run: |
         cd examples

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1997,6 +1997,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-game"
+version = "0.1.0"
+dependencies = [
+ "async-graphql",
+ "linera-sdk",
+ "serde",
+ "tokio",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "counter",
     "crowd-funding",
     "fungible",
+    "hex-game",
     "llm",
     "matching-engine",
     "meta-counter",

--- a/examples/hex-game/Cargo.toml
+++ b/examples/hex-game/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "hex-game"
+version = "0.1.0"
+authors = ["Linera <contact@linera.io>"]
+edition = "2021"
+
+[dependencies]
+async-graphql.workspace = true
+linera-sdk.workspace = true
+serde.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { workspace = true, features = ["test", "wasmer"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+linera-sdk = { workspace = true, features = ["test"] }
+
+[[bin]]
+name = "hex_game_contract"
+path = "src/contract.rs"
+
+[[bin]]
+name = "hex_game_service"
+path = "src/service.rs"

--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -1,0 +1,23 @@
+<!-- cargo-rdme start -->
+
+# Hex
+
+Hex is a game where player `One` tries to connect the left and right sides of the board and player
+`Two` tries to connect top to bottom. The board is rhombic and has a configurable side length `s`.
+It consists of `s * s` hexagonal cells, indexed like this:
+
+```rust
+(0, 0)      (1, 0)      (2, 0)
+
+      (0, 1)      (1, 1)      (2, 1)
+
+            (0, 2)      (1, 2)      (2, 2)
+```
+
+The players alternate placing a stone in their color on an empty cell until one of them wins.
+
+This implementation shows how to write a game that is meant to be played on a shared chain:
+Users make turns by submitting operations to the chain, not by sending messages, so a player
+does not have to wait for any other chain owner to accept any message.
+
+<!-- cargo-rdme end -->

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use hex_game::{Board, HexAbi, MoveOutcome, Operation};
+use linera_sdk::{
+    base::{Owner, WithContractAbi},
+    views::{RootView, View, ViewStorageContext},
+    Contract, ContractRuntime,
+};
+use state::HexState;
+
+pub struct HexContract {
+    state: HexState,
+    runtime: ContractRuntime<Self>,
+}
+
+linera_sdk::contract!(HexContract);
+
+impl WithContractAbi for HexContract {
+    type Abi = HexAbi;
+}
+
+impl Contract for HexContract {
+    type Message = ();
+    type InstantiationArgument = ([Owner; 2], u16);
+    type Parameters = ();
+
+    async fn load(runtime: ContractRuntime<Self>) -> Self {
+        let state = HexState::load(ViewStorageContext::from(runtime.key_value_store()))
+            .await
+            .expect("Failed to load state");
+        HexContract { state, runtime }
+    }
+
+    async fn instantiate(&mut self, (owners, size): Self::InstantiationArgument) {
+        self.runtime.application_parameters(); // Verifies that these are empty.
+        self.state.owners.set(Some(owners));
+        self.state.board.set(Board::new(size));
+    }
+
+    async fn execute_operation(&mut self, operation: Operation) -> MoveOutcome {
+        let Operation::MakeMove { x, y } = operation;
+        let active = self.state.board.get().active_player();
+        assert_eq!(
+            self.runtime.authenticated_signer(),
+            Some(self.state.owners.get().unwrap()[active.index()]),
+            "Move must be signed by the player whose turn it is."
+        );
+        self.state.board.get_mut().make_move(x, y)
+    }
+
+    async fn execute_message(&mut self, _message: ()) {
+        panic!("The Hex application doesn't support any cross-chain messages");
+    }
+
+    async fn store(mut self) {
+        self.state.save().await.expect("Failed to save state");
+    }
+}

--- a/examples/hex-game/src/service.rs
+++ b/examples/hex-game/src/service.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg_attr(target_arch = "wasm32", no_main)]
+
+mod state;
+
+use std::sync::Arc;
+
+use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
+use hex_game::{Board, Operation, Player};
+use linera_sdk::{
+    base::{Owner, WithServiceAbi},
+    graphql::GraphQLMutationRoot,
+    views::{View, ViewStorageContext},
+    Service, ServiceRuntime,
+};
+
+use self::state::HexState;
+
+#[derive(Clone)]
+pub struct HexService {
+    state: Arc<HexState>,
+}
+
+linera_sdk::service!(HexService);
+
+impl WithServiceAbi for HexService {
+    type Abi = hex_game::HexAbi;
+}
+
+impl Service for HexService {
+    type Parameters = ();
+
+    async fn new(runtime: ServiceRuntime<Self>) -> Self {
+        let state = HexState::load(ViewStorageContext::from(runtime.key_value_store()))
+            .await
+            .expect("Failed to load state");
+        HexService {
+            state: Arc::new(state),
+        }
+    }
+
+    async fn handle_query(&self, request: Request) -> Response {
+        let schema =
+            Schema::build(self.clone(), Operation::mutation_root(), EmptySubscription).finish();
+        schema.execute(request).await
+    }
+}
+
+#[Object]
+impl HexService {
+    async fn winner(&self) -> Option<Player> {
+        self.state.board.get().winner()
+    }
+
+    async fn owners(&self) -> [Owner; 2] {
+        self.state.owners.get().unwrap()
+    }
+
+    async fn board(&self) -> &Board {
+        self.state.board.get()
+    }
+}

--- a/examples/hex-game/src/state.rs
+++ b/examples/hex-game/src/state.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use async_graphql::SimpleObject;
+use hex_game::Board;
+use linera_sdk::{
+    base::Owner,
+    views::{linera_views, RegisterView, RootView, ViewStorageContext},
+};
+
+/// The application state.
+#[derive(RootView, SimpleObject)]
+#[view(context = "ViewStorageContext")]
+pub struct HexState {
+    /// The `Owner`s controlling players `One` and `Two`.
+    pub owners: RegisterView<Option<[Owner; 2]>>,
+    /// The current game state.
+    pub board: RegisterView<Board>,
+}

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the Hex application.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use hex_game::{HexAbi, Operation};
+use linera_sdk::{
+    base::{KeyPair, Owner},
+    test::TestValidator,
+};
+
+#[tokio::test]
+async fn hex_game() {
+    let key_pair1 = KeyPair::generate();
+    let key_pair2 = KeyPair::generate();
+    let owner1 = Owner::from(key_pair1.public());
+    let owner2 = Owner::from(key_pair2.public());
+    let (_, app_id, mut chain) =
+        TestValidator::with_current_application::<HexAbi, _, _>((), ([owner1, owner2], 2u16)).await;
+
+    chain
+        .add_block(|block| {
+            block.with_owner_change(
+                Vec::new(),
+                vec![(key_pair1.public(), 1), (key_pair2.public(), 1)],
+                100,
+                Default::default(),
+            );
+        })
+        .await;
+
+    chain.set_key_pair(key_pair1.copy());
+    chain
+        .add_block(|block| {
+            block.with_operation(app_id, Operation::MakeMove { x: 0, y: 0 });
+        })
+        .await;
+
+    chain.set_key_pair(key_pair2.copy());
+    chain
+        .add_block(|block| {
+            block.with_operation(app_id, Operation::MakeMove { x: 0, y: 1 });
+        })
+        .await;
+
+    chain.set_key_pair(key_pair1.copy());
+    chain
+        .add_block(|block| {
+            block.with_operation(app_id, Operation::MakeMove { x: 1, y: 1 });
+        })
+        .await;
+
+    let response = chain.graphql_query(app_id, "query { winner }").await;
+    assert!(response["winner"].is_null());
+
+    chain.set_key_pair(key_pair2.copy());
+    chain
+        .add_block(|block| {
+            block.with_operation(app_id, Operation::MakeMove { x: 1, y: 0 });
+        })
+        .await;
+
+    let response = chain.graphql_query(app_id, "query { winner }").await;
+    assert_eq!(Some("TWO"), response["winner"].as_str());
+}

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -8,8 +8,10 @@
 use std::mem;
 
 use linera_base::{
+    crypto::PublicKey,
     data_types::{ApplicationPermissions, Round, Timestamp},
     identifiers::{ApplicationId, ChainId, MessageId, Owner},
+    ownership::TimeoutConfig,
 };
 use linera_chain::data_types::{
     Block, Certificate, HashedCertificateValue, IncomingMessage, LiteVote, MessageAction,
@@ -93,6 +95,22 @@ impl BlockBuilder {
         self.with_system_operation(SystemOperation::RequestApplication {
             chain_id: application.creation.chain_id,
             application_id: application.forget_abi(),
+        })
+    }
+
+    /// Adds an operation to change this chain's ownership.
+    pub fn with_owner_change(
+        &mut self,
+        super_owners: Vec<PublicKey>,
+        owners: Vec<(PublicKey, u64)>,
+        multi_leader_rounds: u32,
+        timeout_config: TimeoutConfig,
+    ) -> &mut Self {
+        self.with_system_operation(SystemOperation::ChangeOwnership {
+            super_owners,
+            owners,
+            multi_leader_rounds,
+            timeout_config,
         })
     }
 

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -68,9 +68,19 @@ impl ActiveChain {
         self.description.into()
     }
 
-    /// Returns the [`PublicKey`] of the owner of this microchain.
+    /// Returns the [`PublicKey`] of the active owner of this microchain.
     pub fn public_key(&self) -> PublicKey {
         self.key_pair.public()
+    }
+
+    /// Returns the [`KeyPair`] of the active owner of this microchain.
+    pub fn key_pair(&self) -> &KeyPair {
+        &self.key_pair
+    }
+
+    /// Sets the [`KeyPair`] to use for signing new blocks.
+    pub fn set_key_pair(&mut self, key_pair: KeyPair) {
+        self.key_pair = key_pair
     }
 
     /// Adds a block to this microchain.

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -112,11 +112,12 @@ impl TestValidator {
     /// The bytecode is first published on one microchain, then the application is created on
     /// another microchain.
     ///
-    /// Returns the new [`TestValidator`] and the [`ApplicationId`] of the created application.
+    /// Returns the new [`TestValidator`], the [`ApplicationId`] of the created application, and
+    /// the chain on which it was created.
     pub async fn with_current_application<Abi, Parameters, InstantiationArgument>(
         parameters: Parameters,
         instantiation_argument: InstantiationArgument,
-    ) -> (TestValidator, ApplicationId<Abi>)
+    ) -> (TestValidator, ApplicationId<Abi>, ActiveChain)
     where
         Abi: ContractAbi,
         Parameters: Serialize,
@@ -131,7 +132,7 @@ impl TestValidator {
             .create_application(bytecode_id, parameters, instantiation_argument, vec![])
             .await;
 
-        (validator, application_id)
+        (validator, application_id, creator)
     }
 
     /// Returns the locked [`WorkerState`] of this validator.


### PR DESCRIPTION
## Motivation

Multi-owner chains can be useful for playing games where owners make moves without having to wait for anyone to receive a message.

## Proposal

Implement [Hex](https://en.wikipedia.org/wiki/Hex_(board_game)) as a game that is played using operations, not messages.

## Test Plan

A unit and an integration test was added.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
