### PR TITLE
Batch handling of certificates

### DIFF
--- a/linera-core/src/unit_tests/client_test_utils.rs
+++ b/linera-core/src/unit_tests/client_test_utils.rs
@@ -234,7 +234,7 @@ where
                     .state
                     .fully_handle_certificate_with_notifications(
                         cert,
-                        vec![],
+                        &[],
                         Some(&mut notifications),
                     )
                     .await
@@ -268,7 +268,7 @@ where
                 .state
                 .fully_handle_certificate_with_notifications(
                     certificate,
-                    blobs,
+                    &blobs,
                     Some(&mut notifications),
                 )
                 .await

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -152,7 +152,7 @@ where
     let publish_certificate = make_certificate(&committee, &worker, publish_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(publish_certificate.clone(), vec![])
+        .fully_handle_certificate(publish_certificate.clone(), &[])
         .await
         .unwrap()
         .info;
@@ -217,7 +217,7 @@ where
     let broadcast_certificate = make_certificate(&committee, &worker, broadcast_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(broadcast_certificate.clone(), vec![])
+        .fully_handle_certificate(broadcast_certificate.clone(), &[])
         .await
         .unwrap()
         .info;
@@ -269,7 +269,7 @@ where
     let subscribe_certificate = make_certificate(&committee, &worker, subscribe_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(subscribe_certificate.clone(), vec![])
+        .fully_handle_certificate(subscribe_certificate.clone(), &[])
         .await
         .unwrap()
         .info;
@@ -319,7 +319,7 @@ where
     let accept_certificate = make_certificate(&committee, &worker, accept_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(accept_certificate.clone(), vec![])
+        .fully_handle_certificate(accept_certificate.clone(), &[])
         .await
         .unwrap()
         .info;
@@ -410,7 +410,7 @@ where
     let create_certificate = make_certificate(&committee, &worker, create_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(create_certificate.clone(), vec![])
+        .fully_handle_certificate(create_certificate.clone(), &[])
         .await
         .unwrap()
         .info;
@@ -459,7 +459,7 @@ where
     let run_certificate = make_certificate(&committee, &worker, run_block_proposal);
 
     let info = worker
-        .fully_handle_certificate(run_certificate.clone(), vec![])
+        .fully_handle_certificate(run_certificate.clone(), &[])
         .await
         .unwrap()
         .info;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -583,7 +583,7 @@ where
         });
         make_certificate(&committee, &worker, value)
     };
-    let future = worker.fully_handle_certificate(certificate.clone(), vec![]);
+    let future = worker.fully_handle_certificate(certificate.clone(), &[]);
     clock.set(block_0_time);
     future.await.expect("handle certificate with valid tick");
 
@@ -763,7 +763,7 @@ where
         .pending()
         .is_some());
     worker
-        .handle_certificate(certificate0, vec![], None)
+        .handle_certificate(certificate0, &[], None)
         .await
         .unwrap();
     worker.handle_block_proposal(block_proposal1).await.unwrap();
@@ -882,7 +882,7 @@ where
     // Missing earlier blocks
     assert_matches!(
         worker
-            .handle_certificate(certificate1.clone(), vec![], None)
+            .handle_certificate(certificate1.clone(), &[], None)
             .await,
         Err(WorkerError::MissingEarlierBlocks { .. })
     );
@@ -892,7 +892,7 @@ where
     worker
         .fully_handle_certificate_with_notifications(
             certificate0.clone(),
-            vec![],
+            &[],
             Some(&mut notifications),
         )
         .await
@@ -900,7 +900,7 @@ where
     worker
         .fully_handle_certificate_with_notifications(
             certificate1.clone(),
-            vec![],
+            &[],
             Some(&mut notifications),
         )
         .await
@@ -1137,7 +1137,7 @@ where
             }),
         );
         worker
-            .handle_certificate(certificate.clone(), vec![], None)
+            .handle_certificate(certificate.clone(), &[], None)
             .await
             .unwrap();
 
@@ -1453,7 +1453,7 @@ where
     .await;
     assert_matches!(
         worker
-            .fully_handle_certificate(certificate, vec![])
+            .fully_handle_certificate(certificate, &[])
             .await,
         Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::InactiveChain {..})
     );
@@ -1554,7 +1554,7 @@ where
     });
     let certificate = make_certificate(&committee, &worker, value);
     let info = worker
-        .fully_handle_certificate(certificate, vec![])
+        .fully_handle_certificate(certificate, &[])
         .await
         .unwrap()
         .info;
@@ -1619,7 +1619,7 @@ where
     // This fails because `make_simple_transfer_certificate` uses `sender_key_pair.public()` to
     // compute the hash of the execution state.
     assert_matches!(
-        worker.fully_handle_certificate(certificate, vec![]).await,
+        worker.fully_handle_certificate(certificate, &[]).await,
         Err(WorkerError::IncorrectStateHash)
     );
 }
@@ -1688,11 +1688,11 @@ where
     .await;
     // Replays are ignored.
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap();
     worker
-        .fully_handle_certificate(certificate, vec![])
+        .fully_handle_certificate(certificate, &[])
         .await
         .unwrap();
 }
@@ -1775,7 +1775,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap();
     let mut chain = worker
@@ -1894,7 +1894,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap();
     let new_sender_chain = worker
@@ -1977,7 +1977,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap();
     let mut chain = worker
@@ -2343,7 +2343,7 @@ where
     .await;
 
     let info = worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap()
         .info;
@@ -2391,7 +2391,7 @@ where
     )
     .await;
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap();
 
@@ -2500,7 +2500,7 @@ where
     .await;
 
     let info = worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap()
         .info;
@@ -2593,7 +2593,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate00.clone(), vec![])
+        .fully_handle_certificate(certificate00.clone(), &[])
         .await
         .unwrap();
 
@@ -2631,7 +2631,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate01.clone(), vec![])
+        .fully_handle_certificate(certificate01.clone(), &[])
         .await
         .unwrap();
 
@@ -2661,7 +2661,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate(certificate1.clone(), &[])
         .await
         .unwrap();
 
@@ -2681,7 +2681,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate2.clone(), vec![])
+        .fully_handle_certificate(certificate2.clone(), &[])
         .await
         .unwrap();
 
@@ -2741,7 +2741,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate.clone(), vec![])
+        .fully_handle_certificate(certificate.clone(), &[])
         .await
         .unwrap();
 
@@ -2789,7 +2789,7 @@ where
     .await;
 
     worker
-        .fully_handle_certificate(certificate3.clone(), vec![])
+        .fully_handle_certificate(certificate3.clone(), &[])
         .await
         .unwrap();
 
@@ -2917,7 +2917,7 @@ where
         }),
     );
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate(certificate0.clone(), &[])
         .await
         .unwrap();
     {
@@ -2975,7 +2975,7 @@ where
         }),
     );
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate(certificate1.clone(), &[])
         .await
         .unwrap();
 
@@ -3021,7 +3021,7 @@ where
         }),
     );
     worker
-        .fully_handle_certificate(certificate2.clone(), vec![])
+        .fully_handle_certificate(certificate2.clone(), &[])
         .await
         .unwrap();
     {
@@ -3201,7 +3201,7 @@ where
         }),
     );
     worker
-        .fully_handle_certificate(certificate3, vec![])
+        .fully_handle_certificate(certificate3, &[])
         .await
         .unwrap();
     {
@@ -3356,13 +3356,13 @@ where
         }),
     );
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate(certificate1.clone(), &[])
         .await
         .unwrap();
 
     // Try to execute the transfer.
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate(certificate0.clone(), &[])
         .await
         .unwrap();
 
@@ -3510,13 +3510,13 @@ where
         }),
     );
     worker
-        .fully_handle_certificate(certificate1.clone(), vec![])
+        .fully_handle_certificate(certificate1.clone(), &[])
         .await
         .unwrap();
 
     // Try to execute the transfer from the user chain to the admin chain.
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate(certificate0.clone(), &[])
         .await
         .unwrap();
 
@@ -3576,7 +3576,7 @@ where
         }),
     );
     worker
-        .fully_handle_certificate(certificate2.clone(), vec![])
+        .fully_handle_certificate(certificate2.clone(), &[])
         .await
         .unwrap();
 
@@ -3592,7 +3592,7 @@ where
     // Try again to execute the transfer from the user chain to the admin chain.
     // This time, the epoch verification should be overruled.
     worker
-        .fully_handle_certificate(certificate0.clone(), vec![])
+        .fully_handle_certificate(certificate0.clone(), &[])
         .await
         .unwrap();
 
@@ -3872,7 +3872,7 @@ where
     let value0 = HashedValue::new_confirmed(executed_block0);
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate(certificate0, vec![])
+        .fully_handle_certificate(certificate0, &[])
         .await
         .unwrap();
 
@@ -3913,7 +3913,7 @@ where
         .unwrap()
         .into_certificate();
     let (response, _) = worker
-        .handle_certificate(certificate_timeout, vec![], None)
+        .handle_certificate(certificate_timeout, &[], None)
         .await
         .unwrap();
     assert_eq!(response.info.manager.leader, Some(Owner::from(pub_key0)));
@@ -3936,7 +3936,7 @@ where
     let vote = response.info.manager.pending.clone().unwrap();
     let certificate1 = vote.with_value(value1.clone()).unwrap().into_certificate();
     let (response, _) = worker
-        .handle_certificate(certificate1.clone(), vec![], None)
+        .handle_certificate(certificate1.clone(), &[], None)
         .await
         .unwrap();
     let vote = response.info.manager.pending.as_ref().unwrap();
@@ -3951,7 +3951,7 @@ where
         Round::SingleLeader(4),
     );
     let (response, _) = worker
-        .handle_certificate(certificate_timeout, vec![], None)
+        .handle_certificate(certificate_timeout, &[], None)
         .await
         .unwrap();
     assert_eq!(response.info.manager.leader, Some(Owner::from(pub_key1)));
@@ -3968,7 +3968,7 @@ where
     let certificate =
         make_certificate_with_round(&committee, &worker, value2.clone(), Round::SingleLeader(2));
     worker
-        .handle_certificate(certificate, vec![], None)
+        .handle_certificate(certificate, &[], None)
         .await
         .unwrap();
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();
@@ -4017,7 +4017,7 @@ where
         Round::SingleLeader(5),
     );
     let (response, _) = worker
-        .handle_certificate(certificate_timeout, vec![], None)
+        .handle_certificate(certificate_timeout, &[], None)
         .await
         .unwrap();
     assert_eq!(response.info.manager.leader, Some(Owner::from(pub_key0)));
@@ -4034,7 +4034,7 @@ where
     let certificate_timeout =
         make_certificate_with_round(&committee, &worker, value_timeout, Round::SingleLeader(7));
     let (response, _) = worker
-        .handle_certificate(certificate_timeout, vec![], None)
+        .handle_certificate(certificate_timeout, &[], None)
         .await
         .unwrap();
     assert_eq!(response.info.manager.current_round, Round::SingleLeader(8));
@@ -4045,7 +4045,7 @@ where
         make_certificate_with_round(&committee, &worker, value1, Round::SingleLeader(7));
     let mut worker = worker.with_key_pair(None); // Forget validator keys.
     worker
-        .handle_certificate(certificate.clone(), vec![], None)
+        .handle_certificate(certificate.clone(), &[], None)
         .await
         .unwrap();
     let (response, _) = worker.handle_chain_info_query(query_values).await.unwrap();
@@ -4111,7 +4111,7 @@ where
     let value0 = HashedValue::new_confirmed(executed_block0);
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate(certificate0, vec![])
+        .fully_handle_certificate(certificate0, &[])
         .await
         .unwrap();
 
@@ -4151,7 +4151,7 @@ where
         .unwrap()
         .into_certificate();
     let (response, _) = worker
-        .handle_certificate(certificate_timeout, vec![], None)
+        .handle_certificate(certificate_timeout, &[], None)
         .await
         .unwrap();
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
@@ -4224,7 +4224,7 @@ where
     let value0 = HashedValue::new_confirmed(executed_block0);
     let certificate0 = make_certificate(&committee, &worker, value0.clone());
     let response = worker
-        .fully_handle_certificate(certificate0, vec![])
+        .fully_handle_certificate(certificate0, &[])
         .await
         .unwrap();
 
@@ -4252,7 +4252,7 @@ where
     let certificate_timeout =
         make_certificate_with_round(&committee, &worker, value_timeout.clone(), Round::Fast);
     let (response, _) = worker
-        .handle_certificate(certificate_timeout, vec![], None)
+        .handle_certificate(certificate_timeout, &[], None)
         .await
         .unwrap();
     assert_eq!(response.info.manager.current_round, Round::MultiLeader(0));
@@ -4299,7 +4299,7 @@ where
     let certificate3 =
         make_certificate_with_round(&committee, &worker, value2.clone(), Round::MultiLeader(2));
     worker
-        .handle_certificate(certificate3.clone(), vec![], None)
+        .handle_certificate(certificate3.clone(), &[], None)
         .await
         .unwrap();
     let query_values = ChainInfoQuery::new(chain_id).with_manager_values();

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -523,7 +523,7 @@ where
         match self
             .state
             .clone()
-            .handle_certificate(certificate, blobs, sender)
+            .handle_certificate(certificate, &blobs, sender)
             .await
         {
             Ok((info, actions)) => {

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -234,7 +234,7 @@ where
                 match self
                     .server
                     .state
-                    .handle_certificate(request.certificate, request.blobs, sender)
+                    .handle_certificate(request.certificate, &request.blobs, sender)
                     .await
                 {
                     Ok((info, actions)) => {

--- a/linera-sdk/src/test/integration/chain.rs
+++ b/linera-sdk/src/test/integration/chain.rs
@@ -92,7 +92,7 @@ impl ActiveChain {
         self.validator
             .worker()
             .await
-            .fully_handle_certificate(certificate.clone(), vec![])
+            .fully_handle_certificate(certificate.clone(), &[])
             .await
             .expect("Rejected certificate");
 

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -855,7 +855,7 @@ impl ClientContext {
         // Second replay the certificates locally.
         for certificate in certificates {
             // No required certificates from other chains: This is only used with benchmark.
-            node.handle_certificate(certificate, vec![]).await.unwrap();
+            node.handle_certificate(certificate, &[]).await.unwrap();
         }
         // Last update the wallet.
         for chain in self.wallet_state.chains_mut() {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When synchronizing a chain, each certificate with a block is processed individually. This means that after each certificate is processed, the cross-chain requests handled, notifications are sent and the chain information is summarized. This is not optimal because these operations can be done once after all certificates have been processed.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add a `ValidatorWorker::handle_certificates` that handles a batch of certificates. This allows performing once the execution all the cross-chain requests, sending notifications and summarizing the chain information.

## Test Plan

<!-- How to test that the changes are correct. -->
Tested manually, and it seems to h have improved the wallet initialization time from about 7 seconds to 6 seconds.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This only changes the internal behavior of the client, so
- Need to bump the patch version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
