### PR TITLE
Docker CI workflow is more strict

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,12 +6,10 @@ on:
   pull_request:
     branches:
       - "**"
-    paths-ignore:
-      - '**/*.md'
-      - 'configuration/**'
-      - 'kubernetes/**'
-      - 'examples/**'
-      - 'scripts/**'
+    paths:
+      - 'docker/Dockerfile'
+      - 'Cargo.toml'
+      - '.github/workflows/docker.yml'
   workflow_dispatch:
 
 # This allows a subsequently queued workflow run to interrupt previous runs on pull-requests


### PR DESCRIPTION
## Motivation

Reduce the scope for running the Docker CI workflow.

## Proposal

If `Cargo.toml` changes we can pick up most workspace changes.