### PR TITLE
Limit network actions to tracked chains (in `devnet_2024_05_07`)

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1778,6 +1778,13 @@ where
                     executed_block.message_id_for_operation(0, OPEN_CHAIN_MESSAGE_INDEX)
                 })
                 .ok_or_else(|| ChainClientError::InternalError("Failed to create new chain"))?;
+            // Add the new chain to the list of tracked chains
+            self.node_client
+                .track_chain(ChainId::child(message_id))
+                .await;
+            self.node_client
+                .retry_pending_cross_chain_requests(self.chain_id)
+                .await?;
             return Ok(ClientOutcome::Committed((message_id, certificate)));
         }
     }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2065,6 +2065,14 @@ where
             .await
     }
 
+    /// Handles any cross-chain requests for any pending outgoing messages.
+    pub async fn retry_pending_outgoing_messages(&mut self) -> Result<(), ChainClientError> {
+        self.node_client
+            .retry_pending_cross_chain_requests(self.chain_id)
+            .await?;
+        Ok(())
+    }
+
     /// Wraps this chain client into an `Arc<Mutex<_>>`.
     pub fn into_arc(self) -> ArcChainClient<P, S> {
         ArcChainClient::new(self)

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{hash_map, BTreeMap, HashMap},
+    collections::{hash_map, BTreeMap, HashMap, HashSet},
     convert::Infallible,
     iter,
     num::NonZeroUsize,
@@ -79,6 +79,8 @@ pub struct ChainClientBuilder<ValidatorNodeProvider> {
     cross_chain_message_delivery: CrossChainMessageDelivery,
     /// Cached values by hash.
     recent_values: Arc<tokio::sync::Mutex<LruCache<CryptoHash, HashedCertificateValue>>>,
+    /// Chains that should be tracked by the client.
+    tracked_chains: HashSet<ChainId>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<tokio::sync::Mutex<DeliveryNotifiers>>,
@@ -92,6 +94,7 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
         validator_node_provider: ValidatorNodeProvider,
         max_pending_messages: usize,
         cross_chain_message_delivery: CrossChainMessageDelivery,
+        tracked_chains: impl IntoIterator<Item = ChainId>,
     ) -> Self {
         let recent_values = Arc::new(tokio::sync::Mutex::new(LruCache::new(
             NonZeroUsize::try_from(DEFAULT_VALUE_CACHE_SIZE).unwrap(),
@@ -102,6 +105,7 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
             message_policy: MessagePolicy::Accept,
             cross_chain_message_delivery,
             recent_values,
+            tracked_chains: tracked_chains.into_iter().collect(),
             delivery_notifiers: Arc::new(tokio::sync::Mutex::new(DeliveryNotifiers::default())),
             notifier: Arc::new(Notifier::default()),
         }
@@ -134,6 +138,7 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
             format!("Client node {:?}", chain_id),
             storage,
             self.recent_values.clone(),
+            self.tracked_chains.clone(),
             self.delivery_notifiers.clone(),
         )
         .with_allow_inactive_chains(true)

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -117,6 +117,13 @@ impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
         self
     }
 
+    /// Adds a chain to the set of chains tracked by the local node.
+    ///
+    /// This only affects the [`ChainClient`]s created after this call.
+    pub fn track_chain(&mut self, chain_id: ChainId) {
+        self.tracked_chains.insert(chain_id);
+    }
+
     /// Creates a new `ChainClient`.
     #[allow(clippy::too_many_arguments)]
     pub fn build<Storage>(

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -543,6 +543,11 @@ where
         None
     }
 
+    /// Adds a chain to the set of chains tracked by this node.
+    pub async fn track_chain(&mut self, chain_id: ChainId) {
+        self.node.lock().await.state.track_chain(chain_id)
+    }
+
     /// Handles any pending local cross-chain requests.
     pub async fn retry_pending_cross_chain_requests(
         &mut self,

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, collections::VecDeque, sync::Arc};
 
 use futures::{future, lock::Mutex};
 use linera_base::{
@@ -541,5 +541,23 @@ where
             }
         }
         None
+    }
+
+    /// Handles any pending local cross-chain requests.
+    pub async fn retry_pending_cross_chain_requests(
+        &mut self,
+        sender_chain: ChainId,
+    ) -> Result<(), LocalNodeError> {
+        let mut node = self.node.lock().await;
+        let (_response, actions) = node
+            .state
+            .handle_chain_info_query(ChainInfoQuery::new(sender_chain))
+            .await?;
+        let mut requests = VecDeque::from_iter(actions.cross_chain_requests);
+        while let Some(request) = requests.pop_front() {
+            let new_actions = node.state.handle_cross_chain_request(request).await?;
+            requests.extend(new_actions.cross_chain_requests);
+        }
+        Ok(())
     }
 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -606,7 +606,12 @@ where
         let storage = self.make_storage().await?;
         self.chain_client_storages.push(storage.clone());
         let provider = self.make_node_provider();
-        let builder = ChainClientBuilder::new(provider, 10, CrossChainMessageDelivery::NonBlocking);
+        let builder = ChainClientBuilder::new(
+            provider,
+            10,
+            CrossChainMessageDelivery::NonBlocking,
+            [chain_id],
+        );
         Ok(builder.build(
             chain_id,
             vec![key_pair],

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -279,6 +279,8 @@ pub struct WorkerState<StorageClient> {
     grace_period: Duration,
     /// Cached values by hash.
     recent_values: Arc<Mutex<LruCache<CryptoHash, HashedCertificateValue>>>,
+    /// Chain IDs that should be tracked by a worker.
+    tracked_chains: Option<HashSet<ChainId>>,
     /// One-shot channels to notify callers when messages of a particular chain have been
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
@@ -300,6 +302,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             allow_messages_from_deprecated_epochs: false,
             grace_period: Duration::ZERO,
             recent_values,
+            tracked_chains: None,
             delivery_notifiers: Arc::default(),
         }
     }
@@ -308,6 +311,7 @@ impl<StorageClient> WorkerState<StorageClient> {
         nickname: String,
         storage: StorageClient,
         recent_values: Arc<Mutex<LruCache<CryptoHash, HashedCertificateValue>>>,
+        tracked_chains: HashSet<ChainId>,
         delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
     ) -> Self {
         WorkerState {
@@ -318,6 +322,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             allow_messages_from_deprecated_epochs: false,
             grace_period: Duration::ZERO,
             recent_values,
+            tracked_chains: Some(tracked_chains),
             delivery_notifiers,
         }
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -337,6 +337,15 @@ impl<StorageClient> WorkerState<StorageClient> {
         self
     }
 
+    /// Configures the subset of chains that this worker is tracking.
+    pub fn with_tracked_chains(
+        mut self,
+        tracked_chains: impl IntoIterator<Item = ChainId>,
+    ) -> Self {
+        self.tracked_chains = Some(tracked_chains.into_iter().collect());
+        self
+    }
+
     /// Returns an instance with the specified grace period, in microseconds.
     ///
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -355,6 +355,13 @@ impl<StorageClient> WorkerState<StorageClient> {
         self
     }
 
+    /// Adds a chain to the set of tracked chains.
+    pub fn track_chain(&mut self, chain_id: ChainId) {
+        if let Some(tracked_chains) = self.tracked_chains.as_mut() {
+            tracked_chains.insert(chain_id);
+        }
+    }
+
     pub fn nickname(&self) -> &str {
         &self.nickname
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -568,7 +568,10 @@ where
         chain: &ChainStateView<StorageClient::Context>,
     ) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
-        let targets = chain.outboxes.indices().await?;
+        let mut targets = chain.outboxes.indices().await?;
+        if let Some(tracked_chains) = self.tracked_chains.as_ref() {
+            targets.retain(|target| tracked_chains.contains(&target.recipient));
+        }
         let outboxes = chain.outboxes.try_load_entries(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {
             let heights = outbox.queue.elements().await?;

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -565,9 +565,15 @@ impl ClientContext {
                     .context("failed to create new chain")?;
                 let chain_id = ChainId::child(message_id);
                 key_pairs.insert(chain_id, key_pair.copy());
+                self.chain_client_builder.track_chain(chain_id);
                 self.update_wallet_for_new_chain(chain_id, Some(key_pair.copy()), timestamp);
             }
         }
+        let mut updated_chain_client = self.make_chain_client(storage.clone(), default_chain_id);
+        updated_chain_client
+            .retry_pending_outgoing_messages()
+            .await
+            .context("outgoing messages to create the new chains should be delivered")?;
 
         for chain_id in key_pairs.keys() {
             let mut child_client = self.make_chain_client(storage.clone(), *chain_id);

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -161,8 +161,12 @@ impl ClientContext {
         };
         let node_provider = NodeProvider::new(node_options);
         let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
-        let chain_client_builder =
-            ChainClientBuilder::new(node_provider, options.max_pending_messages, delivery);
+        let chain_client_builder = ChainClientBuilder::new(
+            node_provider,
+            options.max_pending_messages,
+            delivery,
+            wallet_state.inner().chain_ids(),
+        );
         ClientContext {
             chain_client_builder,
             wallet_state,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1061,6 +1061,7 @@ impl Job {
         ViewError: From<S::ContextError>,
     {
         let state = WorkerState::new("Local node".to_string(), None, storage)
+            .with_tracked_chains([message_id.chain_id, chain_id])
             .with_allow_inactive_chains(true)
             .with_allow_messages_from_deprecated_epochs(true);
         let mut node_client = LocalNodeClient::new(state, Arc::new(Notifier::default()));

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -147,7 +147,12 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let delivery = CrossChainMessageDelivery::NonBlocking;
     let mut context = ClientContext {
         wallet: Wallet::new(genesis_config, Some(37)),
-        chain_client_builder: ChainClientBuilder::new(builder.make_node_provider(), 10, delivery),
+        chain_client_builder: ChainClientBuilder::new(
+            builder.make_node_provider(),
+            10,
+            delivery,
+            [ChainId::from(description0), ChainId::from(description1)],
+        ),
     };
     let key_pair = KeyPair::generate_from(&mut rng);
     let public_key = key_pair.public();


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
This PR is a port of #2035 to the `devnet_2024_05_07` branch.

Currently, processing a chain on the client creates network actions for all other chains it sends messages to. This leads to cross-chain requests that create chain states on storage for those other chains. These other chains might not be relevant to the client, which means it wastes storage and hinders performance.

As a real world example, the faucet chain is used to create new chains. Every block creates a new chain. That means that when a user uses the wallet to create a chain using the faucet, it will keep in storage the initial chain states for all chains created by the faucet before it.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add an optional `tracked_chains` field to `WorkerState`, and only create `NetworkActions` for those tracked chains.

## Test Plan

<!-- How to test that the changes are correct. -->
Did a quick manual test and saw that the time to create a chain using the faucet was reduced by a bit more than 50%. Further tests should be written later.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is a quick fix for the devnet, and only changes internal client behavior, so:
- Need to bump the major/minor version number in the next release of the crates.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)