### PR TITLE
Split the end-to-end tests from the other tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,9 +35,26 @@ permissions:
   contents: read
 
 jobs:
+  end-to-end:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Clear up some space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    - name: Run the end-to-end tests using the default features
+      run: |
+        cargo test --locked -p linera-service
+
   test:
-    runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 95
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@v3
@@ -86,9 +103,9 @@ jobs:
     - name: Check that the WIT files are up-to-date
       run: |
         cargo run --bin wit-generator -- -c
-    - name: Run all tests using the default features
+    - name: Run tests except end to end tests using the default features
       run: |
-        cargo test --locked
+        cargo test --locked --exclude linera-service
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,10 @@ jobs:
         sudo rm -rf /opt/ghc
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Run the end-to-end tests using the default features
       run: |
         cargo test --locked -p linera-service

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,9 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Compile the linera-storage-service needed for the tests
+      run: |
+        cargo build -p linera-storage-service
     - name: Run the end-to-end tests using the default features
       run: |
         cargo test --locked -p linera-service
@@ -109,7 +112,7 @@ jobs:
         cargo run --bin wit-generator -- -c
     - name: Run tests except end to end tests using the default features
       run: |
-        cargo test --locked --exclude linera-service
+        cargo test --locked --workspace --exclude linera-service
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime


### PR DESCRIPTION
## Motivation

A disproportionate proportion of the runtime of the CI is by the end-to-end tests which hampers
normal work. Improvement in this respect can have a lot of positive impact on the runtime.

## Proposal

The GitHub actions allow to have jobs and this can be used to exploit parallelism and speed
up the CI. This is especially significant as the end-to-end tests are serial in nature and so the
spit reflects that.

## Test Plan

The CI is the point.

## Release Plan

No impact.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
