### PR TITLE
Promote reinserted values in cache

### DIFF
--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -196,7 +196,7 @@ async fn test_insertion_of_validated_also_inserts_confirmed() {
     );
 }
 
-/// Tests if reinstertion of the first entry promotes so that it's not evicted so soon.
+/// Tests if reinstertion of the first entry promotes it so that it's not evicted so soon.
 #[tokio::test]
 async fn test_promotion_of_reinsertion() {
     let cache = CertificateValueCache::default();
@@ -240,6 +240,58 @@ async fn test_promotion_of_reinsertion() {
                 .map(HashedCertificateValue::hash)
                 .chain(Some(values[0].hash()))
         )
+    );
+}
+
+/// Tests if reinstertion of a validated block certificate value promotes it and its respective
+/// confirmed block certificate value so that it's not evicted so soon.
+#[tokio::test]
+async fn test_promotion_of_reinsertion_of_validated_block() {
+    let cache = CertificateValueCache::default();
+    let dummy_values =
+        create_dummy_values(0..(DEFAULT_VALUE_CACHE_SIZE as u64)).collect::<Vec<_>>();
+    let validated_value = create_dummy_validated_block_value();
+    let confirmed_value = validated_value
+        .validated_to_confirmed()
+        .expect("Dummy validated value should be able to create a confirmed value");
+
+    assert!(cache.insert(Cow::Borrowed(&validated_value)).await);
+    cache
+        .insert_all(
+            dummy_values
+                .iter()
+                .take(DEFAULT_VALUE_CACHE_SIZE - 2)
+                .map(Cow::Borrowed),
+        )
+        .await;
+    assert!(!cache.insert(Cow::Borrowed(&validated_value)).await);
+    cache
+        .insert_all(
+            dummy_values
+                .iter()
+                .skip(DEFAULT_VALUE_CACHE_SIZE - 2)
+                .map(Cow::Borrowed),
+        )
+        .await;
+
+    for value in dummy_values.iter().take(2) {
+        assert!(!cache.contains(&value.hash()).await);
+        assert_eq!(cache.get(&value.hash()).await.as_ref(), None);
+    }
+
+    let expected_values_in_cache = dummy_values
+        .iter()
+        .skip(2)
+        .chain([&validated_value, &confirmed_value]);
+
+    for value in expected_values_in_cache.clone() {
+        assert!(cache.contains(&value.hash()).await);
+        assert_eq!(cache.get(&value.hash()).await.as_ref(), Some(value));
+    }
+
+    assert_eq!(
+        cache.keys::<BTreeSet<_>>().await,
+        BTreeSet::from_iter(expected_values_in_cache.map(HashedCertificateValue::hash))
     );
 }
 

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -196,7 +196,7 @@ async fn test_insertion_of_validated_also_inserts_confirmed() {
     );
 }
 
-/// Tests if reinstertion of the first entry promotes it so that it's not evicted so soon.
+/// Tests if reinsertion of the first entry promotes it so that it's not evicted so soon.
 #[tokio::test]
 async fn test_promotion_of_reinsertion() {
     let cache = CertificateValueCache::default();
@@ -243,7 +243,7 @@ async fn test_promotion_of_reinsertion() {
     );
 }
 
-/// Tests if reinstertion of a validated block certificate value promotes it and its respective
+/// Tests if reinsertion of a validated block certificate value promotes it and its respective
 /// confirmed block certificate value so that it's not evicted so soon.
 #[tokio::test]
 async fn test_promotion_of_reinsertion_of_validated_block() {
@@ -295,7 +295,7 @@ async fn test_promotion_of_reinsertion_of_validated_block() {
     );
 }
 
-/// Tests if reinstertion of a confirmed block certificate value promotes it but not its respective
+/// Tests if reinsertion of a confirmed block certificate value promotes it but not its respective
 /// validated block certificate value.
 #[tokio::test]
 async fn test_promotion_of_reinsertion_of_confirmed_block() {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
If a certificate value is inserted in the `CertificateValueCache`, there's a high chance it will be used again soon. This is also true if the value is already in the cache, so it should be promoted as if it was just recently inserted.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Promote values that were attempted to be inserted in the cache but were already present.

## Test Plan

<!-- How to test that the changes are correct. -->
Unit tests were added for the new behavior.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal changes, so nothing needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
