### PR TITLE
Disable 3 tests that frequently fail.

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -164,10 +164,20 @@ impl FungibleApp {
     }
 }
 
-#[cfg(any(feature = "scylladb", feature = "dynamodb", feature = "kubernetes", feature = "remote_net"))]
+#[cfg(any(
+    feature = "scylladb",
+    feature = "dynamodb",
+    feature = "kubernetes",
+    feature = "remote_net"
+))]
 struct NonFungibleApp(ApplicationWrapper<non_fungible::NonFungibleTokenAbi>);
 
-#[cfg(any(feature = "scylladb", feature = "dynamodb", feature = "kubernetes", feature = "remote_net"))]
+#[cfg(any(
+    feature = "scylladb",
+    feature = "dynamodb",
+    feature = "kubernetes",
+    feature = "remote_net"
+))]
 impl NonFungibleApp {
     pub fn create_token_id(
         chain_id: &ChainId,
@@ -888,7 +898,12 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 // TODO(#2051): The test `test_wasm_end_to_end_non_fungible::service_grpc` is frequently failing
 // with the error `Error: Could not find application URI: .... after 15 tries`.
 //#[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
-#[cfg(any(feature = "scylladb", feature = "dynamodb", feature = "kubernetes", feature = "remote_net"))]
+#[cfg(any(
+    feature = "scylladb",
+    feature = "dynamodb",
+    feature = "kubernetes",
+    feature = "remote_net"
+))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2285,10 +2285,9 @@ async fn test_resolve_binary() -> Result<()> {
 
 // TODO(#1655): Make the scylladb_udp / rocksdb_udp test work.
 //#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Udp) ; "scylladb_udp"))]
-#[ignore]
+//#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Tcp) ; "service_tcp")]
-#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Tcp) ; "scylladb_tcp"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Tcp) ; "aws_tcp"))]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -612,11 +612,11 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     Ok(())
 }
 
-// TODO(#2051): Enable this test that is often failing for failure to publish the bytecode
-#[ignore]
+// TODO(#2051): Enable the test `test_wasm_end_to_end_fungible::scylladb_grpc` that is frequently failing.
+// The failure is `Error: Could not find application URI: .... after 15 tries`.
+//#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "fungible" ; "scylladb_grpc"))]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "service_grpc")]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_service_grpc")]
-#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "fungible" ; "scylladb_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "native-fungible" ; "native_scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "fungible" ; "aws_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "native-fungible" ; "native_aws_grpc"))]
@@ -883,7 +883,9 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     Ok(())
 }
 
-// TODO(#2051): Enable this test that is often failing for failure to publish the bytecode
+// TODO(#2051): The test `test_wasm_end_to_end_non_fungible::service_grpc` is frequently failing
+// with the error `Error: Could not find application URI: .... after 15 tries`.
+// The whole test is marked as ignored since `tokio::test` needs at least one test.
 #[ignore]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
@@ -2286,7 +2288,7 @@ async fn test_resolve_binary() -> Result<()> {
 }
 
 // TODO(#1655): Make the scylladb_udp / rocksdb_udp test work.
-// TODO(#2051): Enable the scylladb test that is failing due to runtime exhaustion
+// TODO(#2051): Enable the `test_end_to_end_reconfiguration::scylladb_grpc` that is sometimes failing due to runtime exhaustion.
 //#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Udp) ; "scylladb_udp"))]
 //#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -885,9 +885,8 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 
 // TODO(#2051): The test `test_wasm_end_to_end_non_fungible::service_grpc` is frequently failing
 // with the error `Error: Could not find application URI: .... after 15 tries`.
-// The whole test is marked as ignored since `tokio::test` needs at least one test.
-#[ignore]
-#[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
+//#[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
+#[cfg(any(feature = "scylladb", feature = "dynamodb", feature = "kubernetes", feature = "remote_net"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -164,8 +164,10 @@ impl FungibleApp {
     }
 }
 
+#[cfg(any(feature = "scylladb", feature = "dynamodb", feature = "kubernetes", feature = "remote_net"))]
 struct NonFungibleApp(ApplicationWrapper<non_fungible::NonFungibleTokenAbi>);
 
+#[cfg(any(feature = "scylladb", feature = "dynamodb", feature = "kubernetes", feature = "remote_net"))]
 impl NonFungibleApp {
     pub fn create_token_id(
         chain_id: &ChainId,

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -612,6 +612,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     Ok(())
 }
 
+// TODO(#2051): Enable this test that is often failing for failure to publish the bytecode
 #[ignore]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "service_grpc")]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_service_grpc")]
@@ -882,6 +883,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     Ok(())
 }
 
+// TODO(#2051): Enable this test that is often failing for failure to publish the bytecode
 #[ignore]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
@@ -2284,6 +2286,7 @@ async fn test_resolve_binary() -> Result<()> {
 }
 
 // TODO(#1655): Make the scylladb_udp / rocksdb_udp test work.
+// TODO(#2051): Enable the scylladb test that is failing due to runtime exhaustion
 //#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Udp) ; "scylladb_udp"))]
 //#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -612,6 +612,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     Ok(())
 }
 
+#[ignore]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "service_grpc")]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_service_grpc")]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "fungible" ; "scylladb_grpc"))]
@@ -881,6 +882,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     Ok(())
 }
 
+#[ignore]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
@@ -2283,6 +2285,7 @@ async fn test_resolve_binary() -> Result<()> {
 
 // TODO(#1655): Make the scylladb_udp / rocksdb_udp test work.
 //#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Udp) ; "scylladb_udp"))]
+#[ignore]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc")]
 #[test_case(LocalNetConfig::new_test(Database::Service, Network::Tcp) ; "service_tcp")]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]


### PR DESCRIPTION
## Motivation

Some tests in the CI are frequently failing for largely unknown reasons. It makes sense to disable some of them for the ease of the developer and to isolate what goes wrong.

## Proposal

The following is done:
* The test `test_wasm_end_to_end_non_fungible` is disabled as it is affected by the error `Error: Could not find application URI: .... after 15 tries`.
* The test `test_wasm_end_to_end_fungible` is disabled as it is affected by the error `Error: Could not find application URI: .... after 15 tries`.
* The test `test_end_to_end_reconfiguration::scylladb_grpc` is disabled as it is affected by timeouts.

## Test Plan

We are testing less things.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
