### PR TITLE
Split off `ChainWorkerState` from `WorkerState`

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -29,6 +29,8 @@ use linera_views::{
     views::{CryptoHashView, RootView, View, ViewError},
 };
 use serde::{Deserialize, Serialize};
+#[cfg(with_testing)]
+use {linera_base::identifiers::BytecodeId, linera_execution::BytecodeLocation};
 
 use crate::{
     data_types::{
@@ -378,6 +380,23 @@ where
             .await
             .map_err(|error| ChainError::ExecutionError(error, ChainExecutionContext::Query))?;
         Ok(response)
+    }
+
+    /// Reads the [`BytecodeLocation`] for the requested [`BytecodeId`], if it is registered in
+    /// this chain's [`ApplicationRegistryView`][`linera_execution::ApplicationRegistryView`].
+    #[cfg(with_testing)]
+    pub async fn read_bytecode_location(
+        &mut self,
+        bytecode_id: BytecodeId,
+    ) -> Result<Option<BytecodeLocation>, ChainError> {
+        self.execution_state
+            .system
+            .registry
+            .bytecode_location_for(&bytecode_id)
+            .await
+            .map_err(|err| {
+                ChainError::ExecutionError(err.into(), ChainExecutionContext::ReadBytecodeLocation)
+            })
     }
 
     pub async fn describe_application(

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -396,10 +396,10 @@ where
 
     pub async fn mark_messages_as_received(
         &mut self,
-        target: Target,
+        target: &Target,
         height: BlockHeight,
     ) -> Result<bool, ChainError> {
-        let mut outbox = self.outboxes.try_load_entry_mut(&target).await?;
+        let mut outbox = self.outboxes.try_load_entry_mut(target).await?;
         let updates = outbox.mark_messages_as_received(height).await?;
         if updates.is_empty() {
             return Ok(false);
@@ -419,7 +419,7 @@ where
             }
         }
         if outbox.queue.count() == 0 {
-            self.outboxes.remove_entry(&target)?;
+            self.outboxes.remove_entry(target)?;
         }
         Ok(true)
     }

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -149,4 +149,6 @@ pub enum ChainExecutionContext {
     IncomingMessage(u32),
     Operation(u32),
     Block,
+    #[cfg(with_testing)]
+    ReadBytecodeLocation,
 }

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -3,11 +3,31 @@
 
 //! Configuration parameters for the chain worker.
 
+use std::sync::Arc;
+
+use linera_base::crypto::KeyPair;
+
 /// Configuration parameters for the [`ChainWorkerState`][`super::state::ChainWorkerState`].
 #[derive(Clone, Default)]
 pub struct ChainWorkerConfig {
+    /// The signature key pair of the validator. The key may be missing for replicas
+    /// without voting rights (possibly with a partial view of chains).
+    pub key_pair: Option<Arc<KeyPair>>,
     /// Whether inactive chains are allowed in storage.
     pub allow_inactive_chains: bool,
     /// Whether new messages from deprecated epochs are allowed.
     pub allow_messages_from_deprecated_epochs: bool,
+}
+
+impl ChainWorkerConfig {
+    /// Configures the `key_pair` in this [`ChainWorkerConfig`].
+    pub fn with_key_pair(mut self, key_pair: impl Into<Option<KeyPair>>) -> Self {
+        self.key_pair = key_pair.into().map(Arc::new);
+        self
+    }
+
+    /// Gets a reference to the [`KeyPair`], if available.
+    pub fn key_pair(&self) -> Option<&KeyPair> {
+        self.key_pair.as_ref().map(Arc::as_ref)
+    }
 }

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -1,0 +1,13 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Configuration parameters for the chain worker.
+
+/// Configuration parameters for the [`ChainWorkerState`][`super::state::ChainWorkerState`].
+#[derive(Clone, Default)]
+pub struct ChainWorkerConfig {
+    /// Whether inactive chains are allowed in storage.
+    pub allow_inactive_chains: bool,
+    /// Whether new messages from deprecated epochs are allowed.
+    pub allow_messages_from_deprecated_epochs: bool,
+}

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -3,7 +3,7 @@
 
 //! Configuration parameters for the chain worker.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use linera_base::crypto::KeyPair;
 
@@ -17,6 +17,9 @@ pub struct ChainWorkerConfig {
     pub allow_inactive_chains: bool,
     /// Whether new messages from deprecated epochs are allowed.
     pub allow_messages_from_deprecated_epochs: bool,
+    /// Blocks with a timestamp this far in the future will still be accepted, but the validator
+    /// will wait until that timestamp before voting.
+    pub grace_period: Duration,
 }
 
 impl ChainWorkerConfig {

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! A worker to handle a single chain.
+
+mod state;
+
+pub use self::state::ChainWorkerState;

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -3,6 +3,7 @@
 
 //! A worker to handle a single chain.
 
+mod config;
 mod state;
 
-pub use self::state::ChainWorkerState;
+pub use self::{config::ChainWorkerConfig, state::ChainWorkerState};

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -6,4 +6,6 @@
 mod config;
 mod state;
 
+#[cfg(test)]
+pub(crate) use self::state::CrossChainUpdateHelper;
 pub use self::{config::ChainWorkerConfig, state::ChainWorkerState};

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -201,7 +201,7 @@ where
             } => (*chain_id, *height, *epoch),
             _ => panic!("Expecting a leader timeout certificate"),
         };
-        // Check that the chain is active and ready for this confirmation.
+        // Check that the chain is active and ready for this timeout.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
         self.ensure_is_active()?;
         let (chain_epoch, committee) = self
@@ -363,7 +363,7 @@ where
             _ => panic!("Expecting a validation certificate"),
         };
         let height = block.height;
-        // Check that the chain is active and ready for this confirmation.
+        // Check that the chain is active and ready for this validated block.
         // Verify the certificate. Returns a catch-all error to make client code more robust.
         self.ensure_is_active()?;
         let (epoch, committee) = self

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -10,9 +10,9 @@ use std::{
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{ArithmeticError, BlockHeight},
+    data_types::{ArithmeticError, BlockHeight, HashedBlob},
     ensure,
-    identifiers::ChainId,
+    identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
     data_types::{
@@ -54,6 +54,7 @@ where
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
     recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
+    recent_hashed_blobs: Arc<ValueCache<BlobId, HashedBlob>>,
     knows_chain_is_active: bool,
 }
 
@@ -67,6 +68,7 @@ where
         config: ChainWorkerConfig,
         storage: StorageClient,
         certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
+        blob_cache: Arc<ValueCache<BlobId, HashedBlob>>,
         chain_id: ChainId,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
@@ -76,6 +78,7 @@ where
             storage,
             chain,
             recent_hashed_certificate_values: certificate_value_cache,
+            recent_hashed_blobs: blob_cache,
             knows_chain_is_active: false,
         })
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -862,7 +862,7 @@ where
             }
         }
 
-        Ok(missing_locations.into_iter().collect())
+        Ok(missing_locations)
     }
 
     /// Inserts a [`HashedBlob`] into the worker's cache.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -8,7 +8,7 @@ use linera_chain::{
     data_types::{Block, ExecutedBlock},
     ChainStateView,
 };
-use linera_execution::{Query, Response};
+use linera_execution::{Query, Response, UserApplicationDescription, UserApplicationId};
 use linera_storage::Storage;
 use linera_views::views::{View, ViewError};
 
@@ -50,6 +50,16 @@ where
     pub async fn query_application(&mut self, query: Query) -> Result<Response, WorkerError> {
         self.ensure_is_active()?;
         let response = self.chain.query_application(query).await?;
+        Ok(response)
+    }
+
+    /// Returns an application's description.
+    pub async fn describe_application(
+        &mut self,
+        application_id: UserApplicationId,
+    ) -> Result<UserApplicationDescription, WorkerError> {
+        self.ensure_is_active()?;
+        let response = self.chain.describe_application(application_id).await?;
         Ok(response)
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -6,6 +6,8 @@
 use std::collections::BTreeMap;
 
 use linera_base::{data_types::BlockHeight, ensure, identifiers::ChainId};
+#[cfg(with_testing)]
+use linera_chain::data_types::Certificate;
 use linera_chain::{
     data_types::{Block, ExecutedBlock, MessageBundle, Origin, Target},
     ChainStateView,
@@ -60,6 +62,21 @@ where
     /// Returns the [`ChainId`] of the chain handled by this worker.
     pub fn chain_id(&self) -> ChainId {
         self.chain.chain_id()
+    }
+
+    /// Returns a stored [`Certificate`] for the chain's block at the requested [`BlockHeight`].
+    #[cfg(with_testing)]
+    pub async fn read_certificate(
+        &mut self,
+        height: BlockHeight,
+    ) -> Result<Option<Certificate>, WorkerError> {
+        self.ensure_is_active()?;
+        let certificate_hash = match self.chain.confirmed_log.get(height.try_into()?).await? {
+            Some(hash) => hash,
+            None => return Ok(None),
+        };
+        let certificate = self.storage.read_certificate(certificate_hash).await?;
+        Ok(Some(certificate))
     }
 
     /// Queries an application's state on the chain.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -8,6 +8,7 @@ use linera_chain::{
     data_types::{Block, ExecutedBlock},
     ChainStateView,
 };
+use linera_execution::{Query, Response};
 use linera_storage::Storage;
 use linera_views::views::{View, ViewError};
 
@@ -43,6 +44,13 @@ where
     /// Returns the [`ChainId`] of the chain handled by this worker.
     pub fn chain_id(&self) -> ChainId {
         self.chain.chain_id()
+    }
+
+    /// Queries an application's state on the chain.
+    pub async fn query_application(&mut self, query: Query) -> Result<Response, WorkerError> {
+        self.ensure_is_active()?;
+        let response = self.chain.query_application(query).await?;
+        Ok(response)
     }
 
     /// Executes a block without persisting any changes to the state.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -799,7 +799,7 @@ where
             .await
             .into_iter()
             .filter(|blob_id| !pending_blobs.contains_key(blob_id))
-            .collect::<Vec<_>>())
+            .collect())
     }
 
     /// Returns the blobs requested by their `blob_ids` that are either in pending in the

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -6,8 +6,6 @@
 use std::collections::BTreeMap;
 
 use linera_base::{data_types::BlockHeight, ensure, identifiers::ChainId};
-#[cfg(with_testing)]
-use linera_chain::data_types::Certificate;
 use linera_chain::{
     data_types::{Block, ExecutedBlock, MessageBundle, Origin, Target},
     ChainStateView,
@@ -22,6 +20,11 @@ use linera_views::{
     views::{RootView, View, ViewError},
 };
 use tracing::{debug, warn};
+#[cfg(with_testing)]
+use {
+    linera_base::identifiers::BytecodeId, linera_chain::data_types::Certificate,
+    linera_execution::BytecodeLocation,
+};
 
 use super::ChainWorkerConfig;
 use crate::{data_types::ChainInfoResponse, worker::WorkerError};
@@ -83,6 +86,18 @@ where
     pub async fn query_application(&mut self, query: Query) -> Result<Response, WorkerError> {
         self.ensure_is_active()?;
         let response = self.chain.query_application(query).await?;
+        Ok(response)
+    }
+
+    /// Returns the [`BytecodeLocation`] for the requested [`BytecodeId`], if it is known by the
+    /// chain.
+    #[cfg(with_testing)]
+    pub async fn read_bytecode_location(
+        &mut self,
+        bytecode_id: BytecodeId,
+    ) -> Result<Option<BytecodeLocation>, WorkerError> {
+        self.ensure_is_active()?;
+        let response = self.chain.read_bytecode_location(bytecode_id).await?;
         Ok(response)
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -12,6 +12,7 @@ use linera_execution::{Query, Response, UserApplicationDescription, UserApplicat
 use linera_storage::Storage;
 use linera_views::views::{RootView, View, ViewError};
 
+use super::ChainWorkerConfig;
 use crate::{data_types::ChainInfoResponse, worker::WorkerError};
 
 /// The state of the chain worker.
@@ -20,6 +21,7 @@ where
     StorageClient: Storage + Send + Sync + 'static,
     ViewError: From<StorageClient::ContextError>,
 {
+    config: ChainWorkerConfig,
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
     knows_chain_is_active: bool,
@@ -31,10 +33,15 @@ where
     ViewError: From<StorageClient::ContextError>,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
-    pub async fn load(storage: StorageClient, chain_id: ChainId) -> Result<Self, WorkerError> {
+    pub async fn load(
+        config: ChainWorkerConfig,
+        storage: StorageClient,
+        chain_id: ChainId,
+    ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
         Ok(ChainWorkerState {
+            config,
             storage,
             chain,
             knows_chain_is_active: false,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The state and functionality of a chain worker.
+
+use linera_base::identifiers::ChainId;
+use linera_chain::ChainStateView;
+use linera_storage::Storage;
+use linera_views::views::ViewError;
+
+use crate::worker::WorkerError;
+
+/// The state of the chain worker.
+pub struct ChainWorkerState<StorageClient>
+where
+    StorageClient: Storage + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    storage: StorageClient,
+    chain: ChainStateView<StorageClient::Context>,
+    knows_chain_is_active: bool,
+}
+
+impl<StorageClient> ChainWorkerState<StorageClient>
+where
+    StorageClient: Storage + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
+    pub async fn load(storage: StorageClient, chain_id: ChainId) -> Result<Self, WorkerError> {
+        let chain = storage.load_chain(chain_id).await?;
+
+        Ok(ChainWorkerState {
+            storage,
+            chain,
+            knows_chain_is_active: false,
+        })
+    }
+
+    /// Returns the [`ChainId`] of the chain handled by this worker.
+    pub fn chain_id(&self) -> ChainId {
+        self.chain.chain_id()
+    }
+
+    /// Ensures that the current chain is active, returning an error otherwise.
+    fn ensure_is_active(&mut self) -> Result<(), WorkerError> {
+        if !self.knows_chain_is_active {
+            self.chain.ensure_is_active()?;
+            self.knows_chain_is_active = true;
+        }
+        Ok(())
+    }
+}

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -3,17 +3,21 @@
 
 //! The state and functionality of a chain worker.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use linera_base::{
+    crypto::CryptoHash,
     data_types::{ArithmeticError, BlockHeight},
     ensure,
     identifiers::ChainId,
 };
 use linera_chain::{
     data_types::{
-        Block, Certificate, CertificateValue, ExecutedBlock, IncomingMessage, Medium,
-        MessageAction, MessageBundle, Origin, Target,
+        Block, Certificate, CertificateValue, ExecutedBlock, HashedCertificateValue,
+        IncomingMessage, Medium, MessageAction, MessageBundle, Origin, Target,
     },
     ChainError, ChainStateView,
 };
@@ -29,14 +33,14 @@ use linera_views::{
 use tracing::{debug, warn};
 #[cfg(with_testing)]
 use {
-    linera_base::{crypto::CryptoHash, identifiers::BytecodeId},
-    linera_chain::data_types::Event,
+    linera_base::identifiers::BytecodeId, linera_chain::data_types::Event,
     linera_execution::BytecodeLocation,
 };
 
 use super::ChainWorkerConfig;
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    value_cache::ValueCache,
     worker::{NetworkActions, Notification, Reason, WorkerError},
 };
 
@@ -49,6 +53,7 @@ where
     config: ChainWorkerConfig,
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
+    recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
     knows_chain_is_active: bool,
 }
 
@@ -61,6 +66,7 @@ where
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,
+        certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
         chain_id: ChainId,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
@@ -69,6 +75,7 @@ where
             config,
             storage,
             chain,
+            recent_hashed_certificate_values: certificate_value_cache,
             knows_chain_is_active: false,
         })
     }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1312,7 +1312,8 @@ where
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         loop {
             let messages = self.pending_messages().await?;
-            match self.execute_block(messages, operations.clone()).await? {
+            // TODO(#2066): Remove boxing once the call-stack is shallower
+            match Box::pin(self.execute_block(messages, operations.clone())).await? {
                 ExecuteBlockOutcome::Executed(certificate) => {
                     return Ok(ClientOutcome::Committed(certificate));
                 }

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -276,6 +276,12 @@ impl ChainInfoResponse {
         Self { info, signature }
     }
 
+    /// Signs the [`ChainInfo`] stored inside this [`ChainInfoResponse`] with the provided
+    /// [`KeyPair`].
+    pub fn sign(&mut self, key_pair: &KeyPair) {
+        self.signature = Some(Signature::new(&*self.info, key_pair));
+    }
+
     pub fn check(&self, name: ValidatorName) -> Result<(), CryptoError> {
         Signature::check_optional_signature(self.signature.as_ref(), &*self.info, name.0)
     }

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! This module defines the core Linera protocol.
 
+pub mod chain_worker;
 pub mod client;
 pub mod data_types;
 pub mod local_node;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -134,7 +134,7 @@ fn make_certificate_with_round<S>(
     value: HashedCertificateValue,
     round: Round,
 ) -> Certificate {
-    let vote = LiteVote::new(value.lite(), round, worker.key_pair.as_ref().unwrap());
+    let vote = LiteVote::new(value.lite(), round, worker.key_pair().unwrap());
     let mut builder = SignatureAggregator::new(value, round, committee);
     builder
         .append(vote.validator, vote.signature)
@@ -1142,7 +1142,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (chain_info_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
-    chain_info_response.check(ValidatorName(worker.key_pair.unwrap().public()))?;
+    chain_info_response.check(ValidatorName(worker.key_pair().unwrap().public()))?;
     let pending_value = worker
         .storage
         .load_active_chain(ChainId::root(1))
@@ -1191,7 +1191,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (response, _actions) = worker.handle_block_proposal(block_proposal.clone()).await?;
-    response.check(ValidatorName(worker.key_pair.as_ref().unwrap().public()))?;
+    response.check(ValidatorName(worker.key_pair().unwrap().public()))?;
     let (replay_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
     // Workaround lack of equality.
     assert_eq!(

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3099,7 +3099,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
         .unwrap();
 
     let helper = CrossChainUpdateHelper {
-        nickname: "test",
         allow_messages_from_deprecated_epochs: true,
         current_epoch: Some(Epoch::from(1)),
         committees: &committees,
@@ -3149,7 +3148,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     );
 
     let helper = CrossChainUpdateHelper {
-        nickname: "test",
         allow_messages_from_deprecated_epochs: false,
         current_epoch: Some(Epoch::from(1)),
         committees: &committees,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -52,10 +52,11 @@ use crate::test_utils::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
 use crate::test_utils::ScyllaDbStorageBuilder;
 use crate::{
+    chain_worker::CrossChainUpdateHelper,
     data_types::*,
     test_utils::{MemoryStorageBuilder, StorageBuilder},
     worker::{
-        CrossChainUpdateHelper, Notification,
+        Notification,
         Reason::{self, NewBlock, NewIncomingMessage},
         ValidatorWorker, WorkerError, WorkerState,
     },

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -43,7 +43,6 @@ use tracing::{error, instrument, trace, warn};
 use {
     linera_base::identifiers::{BytecodeId, Destination, MessageId},
     linera_chain::data_types::ChannelFullName,
-    linera_execution::ApplicationRegistryView,
 };
 #[cfg(with_metrics)]
 use {
@@ -1032,21 +1031,6 @@ where
             .await?
             .read_certificate(height)
             .await
-    }
-
-    /// Returns the application registry for a specific chain.
-    ///
-    /// # Notes
-    ///
-    /// The returned [`ApplicationRegistryView`] holds a lock of the chain it belongs to. Incorrect
-    /// usage of this method may cause deadlocks.
-    #[cfg(with_testing)]
-    pub async fn load_application_registry(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<ApplicationRegistryView<StorageClient::Context>, WorkerError> {
-        let chain = self.storage.load_active_chain(chain_id).await?;
-        Ok(chain.execution_state.system.registry)
     }
 
     /// Returns an [`IncomingMessage`] that's awaiting to be received by the chain specified by

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -32,7 +32,10 @@ use tokio::sync::{oneshot, Mutex};
 use tracing::{error, instrument, trace, warn};
 #[cfg(with_testing)]
 use {
-    linera_base::identifiers::{BytecodeId, Destination, MessageId},
+    linera_base::{
+        crypto::PublicKey,
+        identifiers::{BytecodeId, Destination, MessageId},
+    },
     linera_chain::data_types::{ChannelFullName, IncomingMessage, Medium, MessageAction},
 };
 #[cfg(with_metrics)]
@@ -676,10 +679,21 @@ where
     }
 }
 
+#[cfg(with_testing)]
 impl<StorageClient> WorkerState<StorageClient> {
-    /// Gets a reference to the [`KeyPair`], if available.
-    fn key_pair(&self) -> Option<&KeyPair> {
-        self.chain_worker_config.key_pair()
+    /// Gets a reference to the validator's [`PublicKey`].
+    ///
+    /// # Panics
+    ///
+    /// If the validator doesn't have a key pair assigned to it.
+    pub fn public_key(&self) -> PublicKey {
+        self.chain_worker_config
+            .key_pair()
+            .expect(
+                "Test validator should have a key pair assigned to it \
+                in order to obtain it's public key",
+            )
+            .public()
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -507,9 +507,10 @@ where
         chain_id: ChainId,
         application_id: UserApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let response = chain.describe_application(application_id).await?;
-        Ok(response)
+        self.create_chain_worker(chain_id)
+            .await?
+            .describe_application(application_id)
+            .await
     }
 
     /// Gets a reference to the [`KeyPair`], if available.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -499,7 +499,7 @@ where
             .await
     }
 
-    pub(crate) async fn describe_application(
+    pub async fn describe_application(
         &mut self,
         chain_id: ChainId,
         application_id: UserApplicationId,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -998,7 +998,6 @@ where
         let next_height_to_receive = chain.next_block_height_to_receive(origin).await?;
         let last_anticipated_block_height = chain.last_anticipated_block_height(origin).await?;
         let helper = CrossChainUpdateHelper {
-            nickname: &self.nickname,
             allow_messages_from_deprecated_epochs: self.allow_messages_from_deprecated_epochs,
             current_epoch: *chain.execution_state.system.epoch.get(),
             committees: chain.execution_state.system.committees.get(),
@@ -1582,7 +1581,6 @@ where
 }
 
 struct CrossChainUpdateHelper<'a> {
-    nickname: &'a str,
     allow_messages_from_deprecated_epochs: bool,
     current_epoch: Option<Epoch>,
     committees: &'a BTreeMap<Epoch, Committee>,
@@ -1632,16 +1630,16 @@ impl<'a> CrossChainUpdateHelper<'a> {
         if skipped_len > 0 {
             let sample_bundle = &bundles[skipped_len - 1];
             debug!(
-                "[{}] Ignoring repeated messages to {recipient:?} from {origin:?} at height {}",
-                self.nickname, sample_bundle.height,
+                "Ignoring repeated messages to {recipient:?} from {origin:?} at height {}",
+                sample_bundle.height,
             );
         }
         if skipped_len < bundles.len() && trusted_len < bundles.len() {
             let sample_bundle = &bundles[trusted_len];
             warn!(
-                "[{}] Refusing messages to {recipient:?} from {origin:?} at height {} \
+                "Refusing messages to {recipient:?} from {origin:?} at height {} \
                  because the epoch {:?} is not trusted any more",
-                self.nickname, sample_bundle.height, sample_bundle.epoch,
+                sample_bundle.height, sample_bundle.epoch,
             );
         }
         let certificates = if skipped_len < trusted_len {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1065,20 +1065,16 @@ where
         };
         let origin = Origin { sender, medium };
 
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let mut inbox = chain.inboxes.try_load_entry_mut(&origin).await?;
-
-        let certificate_hash = certificate.hash();
-        let Some(event) = inbox
-            .added_events
-            .iter_mut()
+        let Some(event) = self
+            .create_chain_worker(chain_id)
             .await?
-            .find(|event| {
-                event.certificate_hash == certificate_hash
-                    && event.height == message_id.height
-                    && event.index == message_id.index
-            })
-            .cloned()
+            .find_event_in_inbox(
+                origin.clone(),
+                certificate.hash(),
+                message_id.height,
+                message_id.index,
+            )
+            .await?
         else {
             return Ok(None);
         };

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -27,8 +27,8 @@ use linera_chain::{
     ChainError, ChainStateView,
 };
 use linera_execution::{
-    committee::{Committee, Epoch},
-    BytecodeLocation, Query, Response, UserApplicationDescription, UserApplicationId,
+    committee::Epoch, BytecodeLocation, Query, Response, UserApplicationDescription,
+    UserApplicationId,
 };
 use linera_storage::Storage;
 use linera_views::{
@@ -38,7 +38,7 @@ use linera_views::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{oneshot, Mutex};
-use tracing::{debug, error, instrument, trace, warn};
+use tracing::{error, instrument, trace, warn};
 #[cfg(with_testing)]
 use {
     linera_base::identifiers::{Destination, MessageId},
@@ -990,49 +990,10 @@ where
         recipient: ChainId,
         bundles: Vec<MessageBundle>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
-        let mut chain = self.storage.load_chain(recipient).await?;
-        // Only process certificates with relevant heights and epochs.
-        let next_height_to_receive = chain.next_block_height_to_receive(&origin).await?;
-        let last_anticipated_block_height = chain.last_anticipated_block_height(&origin).await?;
-        let helper = CrossChainUpdateHelper {
-            allow_messages_from_deprecated_epochs: self
-                .chain_worker_config
-                .allow_messages_from_deprecated_epochs,
-            current_epoch: *chain.execution_state.system.epoch.get(),
-            committees: chain.execution_state.system.committees.get(),
-        };
-        let bundles = helper.select_message_bundles(
-            &origin,
-            recipient,
-            next_height_to_receive,
-            last_anticipated_block_height,
-            bundles,
-        )?;
-        let Some(last_updated_height) = bundles.last().map(|bundle| bundle.height) else {
-            return Ok(None);
-        };
-        // Process the received messages in certificates.
-        let local_time = self.storage.clock().current_time();
-        for bundle in bundles {
-            // Update the staged chain state with the received block.
-            chain
-                .receive_message_bundle(&origin, bundle, local_time)
-                .await?
-        }
-        if !self.chain_worker_config.allow_inactive_chains && !chain.is_active() {
-            // Refuse to create a chain state if the chain is still inactive by
-            // now. Accordingly, do not send a confirmation, so that the
-            // cross-chain update is retried later.
-            warn!(
-                "[{}] Refusing to deliver messages to {recipient:?} from {origin:?} \
-                at height {last_updated_height} because the recipient is still inactive",
-                self.nickname
-            );
-            return Ok(None);
-        }
-        // Save the chain.
-        chain.save().await?;
-        Ok(Some(last_updated_height))
+        self.create_chain_worker(recipient)
+            .await?
+            .process_cross_chain_update(origin, bundles)
+            .await
     }
 
     /// Inserts a [`HashedCertificateValue`] into the worker's cache.
@@ -1581,76 +1542,5 @@ where
                 Ok(NetworkActions::default())
             }
         }
-    }
-}
-
-struct CrossChainUpdateHelper<'a> {
-    allow_messages_from_deprecated_epochs: bool,
-    current_epoch: Option<Epoch>,
-    committees: &'a BTreeMap<Epoch, Committee>,
-}
-
-impl<'a> CrossChainUpdateHelper<'a> {
-    /// Checks basic invariants and deals with repeated heights and deprecated epochs.
-    /// * Returns a range of message bundles that are both new to us and not relying on
-    /// an untrusted set of validators.
-    /// * In the case of validators, if the epoch(s) of the highest bundles are not
-    /// trusted, we only accept bundles that contain messages that were already
-    /// executed by anticipation (i.e. received in certified blocks).
-    /// * Basic invariants are checked for good measure. We still crucially trust
-    /// the worker of the sending chain to have verified and executed the blocks
-    /// correctly.
-    fn select_message_bundles(
-        &self,
-        origin: &'a Origin,
-        recipient: ChainId,
-        next_height_to_receive: BlockHeight,
-        last_anticipated_block_height: Option<BlockHeight>,
-        mut bundles: Vec<MessageBundle>,
-    ) -> Result<Vec<MessageBundle>, WorkerError> {
-        let mut latest_height = None;
-        let mut skipped_len = 0;
-        let mut trusted_len = 0;
-        for (i, bundle) in bundles.iter().enumerate() {
-            // Make sure that heights are increasing.
-            ensure!(
-                latest_height < Some(bundle.height),
-                WorkerError::InvalidCrossChainRequest
-            );
-            latest_height = Some(bundle.height);
-            // Check if the block has been received already.
-            if bundle.height < next_height_to_receive {
-                skipped_len = i + 1;
-            }
-            // Check if the height is trusted or the epoch is trusted.
-            if self.allow_messages_from_deprecated_epochs
-                || Some(bundle.height) <= last_anticipated_block_height
-                || Some(bundle.epoch) >= self.current_epoch
-                || self.committees.contains_key(&bundle.epoch)
-            {
-                trusted_len = i + 1;
-            }
-        }
-        if skipped_len > 0 {
-            let sample_bundle = &bundles[skipped_len - 1];
-            debug!(
-                "Ignoring repeated messages to {recipient:?} from {origin:?} at height {}",
-                sample_bundle.height,
-            );
-        }
-        if skipped_len < bundles.len() && trusted_len < bundles.len() {
-            let sample_bundle = &bundles[trusted_len];
-            warn!(
-                "Refusing messages to {recipient:?} from {origin:?} at height {} \
-                 because the epoch {:?} is not trusted any more",
-                sample_bundle.height, sample_bundle.epoch,
-            );
-        }
-        let certificates = if skipped_len < trusted_len {
-            bundles.drain(skipped_len..trusted_len).collect()
-        } else {
-            vec![]
-        };
-        Ok(certificates)
     }
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -986,14 +986,14 @@ where
 
     async fn process_cross_chain_update(
         &mut self,
-        origin: &Origin,
+        origin: Origin,
         recipient: ChainId,
         bundles: Vec<MessageBundle>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
         let mut chain = self.storage.load_chain(recipient).await?;
         // Only process certificates with relevant heights and epochs.
-        let next_height_to_receive = chain.next_block_height_to_receive(origin).await?;
-        let last_anticipated_block_height = chain.last_anticipated_block_height(origin).await?;
+        let next_height_to_receive = chain.next_block_height_to_receive(&origin).await?;
+        let last_anticipated_block_height = chain.last_anticipated_block_height(&origin).await?;
         let helper = CrossChainUpdateHelper {
             allow_messages_from_deprecated_epochs: self
                 .chain_worker_config
@@ -1002,7 +1002,7 @@ where
             committees: chain.execution_state.system.committees.get(),
         };
         let bundles = helper.select_message_bundles(
-            origin,
+            &origin,
             recipient,
             next_height_to_receive,
             last_anticipated_block_height,
@@ -1016,7 +1016,7 @@ where
         for bundle in bundles {
             // Update the staged chain state with the received block.
             chain
-                .receive_message_bundle(origin, bundle, local_time)
+                .receive_message_bundle(&origin, bundle, local_time)
                 .await?
         }
         if !self.chain_worker_config.allow_inactive_chains && !chain.is_active() {
@@ -1516,7 +1516,7 @@ where
                 for (medium, bundles) in bundle_vecs {
                     let origin = Origin { sender, medium };
                     if let Some(height) = self
-                        .process_cross_chain_update(&origin, recipient, bundles)
+                        .process_cross_chain_update(origin.clone(), recipient, bundles)
                         .await?
                     {
                         height_by_origin.push((origin, height));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -496,9 +496,10 @@ where
         chain_id: ChainId,
         query: Query,
     ) -> Result<Response, WorkerError> {
-        let mut chain = self.storage.load_active_chain(chain_id).await?;
-        let response = chain.query_application(query).await?;
-        Ok(response)
+        self.create_chain_worker(chain_id)
+            .await?
+            .query_application(query)
+            .await
     }
 
     pub(crate) async fn describe_application(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1551,7 +1551,7 @@ where
 
                 for (medium, height) in latest_heights {
                     let target = Target { recipient, medium };
-                    let fully_delivered = chain.mark_messages_as_received(target, height).await?
+                    let fully_delivered = chain.mark_messages_as_received(&target, height).await?
                         && chain.all_messages_delivered_up_to(height);
 
                     if fully_delivered && height > height_with_fully_delivered_messages {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -521,11 +521,6 @@ where
             .await
     }
 
-    /// Gets a reference to the [`KeyPair`], if available.
-    fn key_pair(&self) -> Option<&KeyPair> {
-        self.key_pair.as_ref().map(Arc::as_ref)
-    }
-
     /// Creates an `UpdateRecipient` request that informs the `recipient` about new
     /// cross-chain messages from `sender`.
     async fn create_cross_chain_request(
@@ -1112,6 +1107,13 @@ where
             chain_id,
         )
         .await
+    }
+}
+
+impl<StorageClient> WorkerState<StorageClient> {
+    /// Gets a reference to the [`KeyPair`], if available.
+    fn key_pair(&self) -> Option<&KeyPair> {
+        self.key_pair.as_ref().map(Arc::as_ref)
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -41,7 +41,7 @@ use tokio::sync::{oneshot, Mutex};
 use tracing::{error, instrument, trace, warn};
 #[cfg(with_testing)]
 use {
-    linera_base::identifiers::{Destination, MessageId},
+    linera_base::identifiers::{BytecodeId, Destination, MessageId},
     linera_chain::data_types::ChannelFullName,
     linera_execution::ApplicationRegistryView,
 };
@@ -496,6 +496,18 @@ where
         self.create_chain_worker(chain_id)
             .await?
             .query_application(query)
+            .await
+    }
+
+    #[cfg(with_testing)]
+    pub async fn read_bytecode_location(
+        &mut self,
+        chain_id: ChainId,
+        bytecode_id: BytecodeId,
+    ) -> Result<Option<BytecodeLocation>, WorkerError> {
+        self.create_chain_worker(chain_id)
+            .await?
+            .read_bytecode_location(bytecode_id)
             .await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1062,6 +1062,7 @@ where
             self.chain_worker_config.clone(),
             self.storage.clone(),
             self.recent_hashed_certificate_values.clone(),
+            self.recent_hashed_blobs.clone(),
             chain_id,
         )
         .await

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1016,13 +1016,10 @@ where
         chain_id: ChainId,
         height: BlockHeight,
     ) -> Result<Option<Certificate>, WorkerError> {
-        let chain = self.storage.load_active_chain(chain_id).await?;
-        let certificate_hash = match chain.confirmed_log.get(height.try_into()?).await? {
-            Some(hash) => hash,
-            None => return Ok(None),
-        };
-        let certificate = self.storage.read_certificate(certificate_hash).await?;
-        Ok(Some(certificate))
+        self.create_chain_worker(chain_id)
+            .await?
+            .read_certificate(height)
+            .await
     }
 
     /// Returns the application registry for a specific chain.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -1061,6 +1061,7 @@ where
         ChainWorkerState::load(
             self.chain_worker_config.clone(),
             self.storage.clone(),
+            self.recent_hashed_certificate_values.clone(),
             chain_id,
         )
         .await

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -52,7 +52,7 @@ use {
 };
 
 use crate::{
-    chain_worker::ChainWorkerState,
+    chain_worker::{ChainWorkerConfig, ChainWorkerState},
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     value_cache::ValueCache,
 };
@@ -279,10 +279,8 @@ pub struct WorkerState<StorageClient> {
     key_pair: Option<Arc<KeyPair>>,
     /// Access to local persistent storage.
     storage: StorageClient,
-    /// Whether inactive chains are allowed in storage.
-    allow_inactive_chains: bool,
-    /// Whether new messages from deprecated epochs are allowed.
-    allow_messages_from_deprecated_epochs: bool,
+    /// Configuration options for the [`ChainWorker`]s.
+    chain_worker_config: ChainWorkerConfig,
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
     grace_period: Duration,
@@ -304,8 +302,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             nickname,
             key_pair: key_pair.map(Arc::new),
             storage,
-            allow_inactive_chains: false,
-            allow_messages_from_deprecated_epochs: false,
+            chain_worker_config: ChainWorkerConfig::default(),
             grace_period: Duration::ZERO,
             recent_hashed_certificate_values: Arc::new(ValueCache::default()),
             recent_hashed_blobs: Arc::new(ValueCache::default()),
@@ -324,8 +321,7 @@ impl<StorageClient> WorkerState<StorageClient> {
             nickname,
             key_pair: None,
             storage,
-            allow_inactive_chains: false,
-            allow_messages_from_deprecated_epochs: false,
+            chain_worker_config: ChainWorkerConfig::default(),
             grace_period: Duration::ZERO,
             recent_hashed_certificate_values,
             recent_hashed_blobs,
@@ -334,12 +330,13 @@ impl<StorageClient> WorkerState<StorageClient> {
     }
 
     pub fn with_allow_inactive_chains(mut self, value: bool) -> Self {
-        self.allow_inactive_chains = value;
+        self.chain_worker_config.allow_inactive_chains = value;
         self
     }
 
     pub fn with_allow_messages_from_deprecated_epochs(mut self, value: bool) -> Self {
-        self.allow_messages_from_deprecated_epochs = value;
+        self.chain_worker_config
+            .allow_messages_from_deprecated_epochs = value;
         self
     }
 
@@ -998,7 +995,9 @@ where
         let next_height_to_receive = chain.next_block_height_to_receive(origin).await?;
         let last_anticipated_block_height = chain.last_anticipated_block_height(origin).await?;
         let helper = CrossChainUpdateHelper {
-            allow_messages_from_deprecated_epochs: self.allow_messages_from_deprecated_epochs,
+            allow_messages_from_deprecated_epochs: self
+                .chain_worker_config
+                .allow_messages_from_deprecated_epochs,
             current_epoch: *chain.execution_state.system.epoch.get(),
             committees: chain.execution_state.system.committees.get(),
         };
@@ -1020,7 +1019,7 @@ where
                 .receive_message_bundle(origin, bundle, local_time)
                 .await?
         }
-        if !self.allow_inactive_chains && !chain.is_active() {
+        if !self.chain_worker_config.allow_inactive_chains && !chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by
             // now. Accordingly, do not send a confirmation, so that the
             // cross-chain update is retried later.
@@ -1157,7 +1156,12 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<ChainWorkerState<StorageClient>, WorkerError> {
-        ChainWorkerState::load(self.storage.clone(), chain_id).await
+        ChainWorkerState::load(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            chain_id,
+        )
+        .await
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -52,6 +52,7 @@ use {
 };
 
 use crate::{
+    chain_worker::ChainWorkerState,
     data_types::{ChainInfo, ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     value_cache::ValueCache,
 };
@@ -1158,6 +1159,14 @@ where
             }
         );
         Ok(())
+    }
+
+    /// Creates a [`ChainWorkerState`] instance for a specific chain.
+    async fn create_chain_worker(
+        &self,
+        chain_id: ChainId,
+    ) -> Result<ChainWorkerState<StorageClient>, WorkerError> {
+        ChainWorkerState::load(self.storage.clone(), chain_id).await
     }
 }
 

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -101,7 +101,8 @@ impl ActiveChain {
 
         block_builder(&mut block);
 
-        let (certificate, message_ids) = block.sign().await;
+        // TODO(#2066): Remove boxing once call-stack is shallower
+        let (certificate, message_ids) = Box::pin(block.sign()).await;
 
         self.validator
             .worker()

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -17,11 +17,14 @@ use linera_base::{
     data_types::BlockHeight,
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
 };
-use linera_chain::data_types::Certificate;
-use linera_core::{data_types::ChainInfoQuery, worker::ValidatorWorker};
+use linera_chain::{data_types::Certificate, ChainError, ChainExecutionContext};
+use linera_core::{
+    data_types::ChainInfoQuery,
+    worker::{ValidatorWorker, WorkerError},
+};
 use linera_execution::{
     system::{SystemChannel, SystemExecutionError, SystemMessage, SystemOperation},
-    Bytecode, Message, Query, Response,
+    Bytecode, ExecutionError, Message, Query, Response,
 };
 use serde::Serialize;
 use tokio::{fs, sync::Mutex};
@@ -458,20 +461,26 @@ impl ActiveChain {
 
     /// Checks if the `application_id` is missing from this microchain.
     async fn needs_application_description<Abi>(&self, application_id: ApplicationId<Abi>) -> bool {
-        let applications = self
+        let description_result = self
             .validator
             .worker()
             .await
-            .load_application_registry(self.id())
-            .await
-            .expect("Failed to load application registry");
+            .describe_application(self.id(), application_id.forget_abi())
+            .await;
 
-        match applications
-            .describe_application(application_id.forget_abi())
-            .await
-        {
+        match description_result {
             Ok(_) => false,
-            Err(SystemExecutionError::UnknownApplicationId(_)) => true,
+            Err(WorkerError::ChainError(boxed_chain_error))
+                if matches!(
+                    &*boxed_chain_error,
+                    ChainError::ExecutionError(
+                        ExecutionError::SystemError(SystemExecutionError::UnknownApplicationId(_)),
+                        ChainExecutionContext::DescribeApplication,
+                    )
+                ) =>
+            {
+                true
+            }
             Err(_) => panic!("Failed to check known bytecode locations"),
         }
     }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -371,16 +371,10 @@ impl ActiveChain {
         &self,
         bytecode_id: BytecodeId<Abi, Parameters, InstantiationArgument>,
     ) -> bool {
-        let applications = self
-            .validator
+        self.validator
             .worker()
             .await
-            .load_application_registry(self.id())
-            .await
-            .expect("Failed to load application registry");
-
-        applications
-            .bytecode_location_for(&bytecode_id.forget_abi())
+            .read_bytecode_location(self.id(), bytecode_id.forget_abi())
             .await
             .expect("Failed to check known bytecode locations")
             .is_none()


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `WorkerState` constantly loads and stores the `ChainStateView` for the chains it is responsible for, which leads to repeated (and often times unnecessary) serialization and deserialization.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Keep the `ChainStateView` cached in memory for a longer period of time inside longer lived `ChainWorkerState` types. These are split-off from the `WorkerState`, and are responsible for a single chain. For now the `WorkerState` creates and destroys the `ChainWorkerState` on every request, which makes the functionality practically the same as before. But this paves the way to have a `ChainWorkerActor` type that is longer lived and wraps the `ChainWorkerState`.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, so existing tests should catch regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
