### PR TITLE
Group outgoing messages by transaction.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -918,7 +918,7 @@ where
                 }
             }
             next_message_index +=
-                u32::try_from(messages.len()).map_err(|_| ArithmeticError::Overflow)?;
+                u32::try_from(messages_out.len()).map_err(|_| ArithmeticError::Overflow)?;
             messages.push(messages_out);
         }
         // Second, execute the operations in the block and remember the recipients to notify.
@@ -970,7 +970,7 @@ where
                     .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
             }
             next_message_index +=
-                u32::try_from(messages.len()).map_err(|_| ArithmeticError::Overflow)?;
+                u32::try_from(messages_out.len()).map_err(|_| ArithmeticError::Overflow)?;
             messages.push(messages_out);
         }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -689,6 +689,11 @@ impl ExecutedBlock {
     ) -> Option<MessageId> {
         let block = &self.block;
         let transaction_index = block.incoming_messages.len().checked_add(operation_index)?;
+        if message_index
+            >= u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()?
+        {
+            return None;
+        }
         let first_message_index = u32::try_from(
             self.outcome
                 .messages
@@ -699,13 +704,7 @@ impl ExecutedBlock {
         )
         .ok()?;
         let index = first_message_index.checked_add(message_index)?;
-        if message_index
-            < u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()?
-        {
-            Some(self.message_id(index))
-        } else {
-            None
-        }
+        Some(self.message_id(index))
     }
 
     pub fn message_by_id(&self, message_id: &MessageId) -> Option<&OutgoingMessage> {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -699,7 +699,9 @@ impl ExecutedBlock {
         )
         .ok()?;
         let index = first_message_index.checked_add(message_index)?;
-        if index < u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()? {
+        if message_index
+            < u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()?
+        {
             Some(self.message_id(index))
         } else {
             None

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -278,11 +278,8 @@ pub struct ExecutedBlock {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 #[cfg_attr(with_testing, derive(Default))]
 pub struct BlockExecutionOutcome {
-    pub messages: Vec<OutgoingMessage>,
-    /// For each transaction, the cumulative number of messages created by this and all previous
-    /// transactions, i.e. `message_counts[i]` is the index of the first message created by
-    /// transaction `i + 1` or later.
-    pub message_counts: Vec<u32>,
+    /// The list of outgoing messages for each transaction.
+    pub messages: Vec<Vec<OutgoingMessage>>,
     pub state_hash: CryptoHash,
     /// The record of oracle responses for each transaction.
     pub oracle_records: Vec<OracleRecord>,
@@ -630,7 +627,7 @@ impl CertificateValue {
     }
 
     #[cfg(with_testing)]
-    pub fn messages(&self) -> Option<&Vec<OutgoingMessage>> {
+    pub fn messages(&self) -> Option<&Vec<Vec<OutgoingMessage>>> {
         Some(self.executed_block()?.messages())
     }
 
@@ -679,7 +676,7 @@ impl Event {
 }
 
 impl ExecutedBlock {
-    pub fn messages(&self) -> &Vec<OutgoingMessage> {
+    pub fn messages(&self) -> &Vec<Vec<OutgoingMessage>> {
         &self.outcome.messages
     }
 
@@ -692,13 +689,17 @@ impl ExecutedBlock {
     ) -> Option<MessageId> {
         let block = &self.block;
         let transaction_index = block.incoming_messages.len().checked_add(operation_index)?;
-        let first_message_index = match transaction_index.checked_sub(1) {
-            None => 0,
-            Some(index) => *self.outcome.message_counts.get(index)?,
-        };
+        let first_message_index = u32::try_from(
+            self.outcome
+                .messages
+                .iter()
+                .take(transaction_index)
+                .map(Vec::len)
+                .sum::<usize>(),
+        )
+        .ok()?;
         let index = first_message_index.checked_add(message_index)?;
-        let next_transaction_index = *self.outcome.message_counts.get(transaction_index)?;
-        if index < next_transaction_index {
+        if index < u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()? {
             Some(self.message_id(index))
         } else {
             None
@@ -714,7 +715,14 @@ impl ExecutedBlock {
         if self.block.chain_id != *chain_id || self.block.height != *height {
             return None;
         }
-        self.messages().get(usize::try_from(*index).ok()?)
+        let mut index = usize::try_from(*index).ok()?;
+        for messages in self.messages() {
+            if let Some(message) = messages.get(index) {
+                return Some(message);
+            }
+            index -= messages.len();
+        }
+        None
     }
 
     /// Returns the message ID belonging to the `index`th outgoing message in this block.
@@ -1056,7 +1064,7 @@ impl Certificate {
     pub fn message_bundle_for(&self, medium: &Medium, recipient: ChainId) -> Option<MessageBundle> {
         let executed_block = self.value().executed_block()?;
         let messages = (0u32..)
-            .zip(executed_block.messages())
+            .zip(executed_block.messages().iter().flatten())
             .filter(|(_, message)| message.has_destination(medium, recipient))
             .map(|(idx, message)| (idx, message.clone()))
             .collect();

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -728,7 +728,7 @@ impl ExecutedBlock {
     }
 
     /// Returns the message ID belonging to the `index`th outgoing message in this block.
-    fn message_id(&self, index: u32) -> MessageId {
+    pub fn message_id(&self, index: u32) -> MessageId {
         MessageId {
             chain_id: self.block.chain_id,
             height: self.block.height,

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -16,8 +16,7 @@ fn test_signed_values() {
     let block =
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(2), Amount::ONE);
     let executed_block = BlockExecutionOutcome {
-        messages: Vec::new(),
-        message_counts: vec![1],
+        messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
         oracle_records: vec![OracleRecord::default()],
     }
@@ -45,8 +44,7 @@ fn test_certificates() {
     let block =
         make_first_block(ChainId::root(1)).with_simple_transfer(ChainId::root(1), Amount::ONE);
     let executed_block = BlockExecutionOutcome {
-        messages: Vec::new(),
-        message_counts: vec![1],
+        messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
         oracle_records: vec![OracleRecord::default()],
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -438,7 +438,6 @@ where
         let block = &executed_block.block;
         let BlockExecutionOutcome {
             messages,
-            message_counts,
             state_hash,
             oracle_records,
         } = &executed_block.outcome;
@@ -523,10 +522,6 @@ where
                 computed: verified_outcome.messages,
                 submitted: messages.clone(),
             }
-        );
-        ensure!(
-            *message_counts == verified_outcome.message_counts,
-            WorkerError::IncorrectMessageCounts
         );
         ensure!(
             *state_hash == verified_outcome.state_hash,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -402,7 +402,8 @@ where
     assert_eq!(incoming_messages[0].action, MessageAction::Reject);
     assert_eq!(incoming_messages[0].event.kind, MessageKind::Simple);
     let messages = cert.value().messages().unwrap();
-    assert_eq!(messages.len(), 0);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].len(), 0);
 
     // Try again with a value that will make the (tracked) message fail.
     let mut operation = meta_counter::Operation::fail(receiver_id);
@@ -557,7 +558,7 @@ where
             destination,
             message,
             ..
-        } = &messages[0][0];
+        } = &messages[1][0];
         assert_matches!(
             message, Message::System(SystemMessage::RegisterApplications { applications })
             if applications.len() == 1 && matches!(

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -557,7 +557,7 @@ where
             destination,
             message,
             ..
-        } = &messages[0];
+        } = &messages[0][0];
         assert_matches!(
             message, Message::System(SystemMessage::RegisterApplications { applications })
             if applications.len() == 1 && matches!(

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -138,15 +138,14 @@ where
     let publisher_state_hash = publisher_system_state.clone().into_hash().await;
     let publish_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![OutgoingMessage {
+            messages: vec![vec![OutgoingMessage {
                 destination: Destination::Recipient(publisher_chain.into()),
                 authenticated_signer: None,
                 grant: Amount::ZERO,
                 refund_grant_to: None,
                 kind: MessageKind::Protected,
                 message: Message::System(publish_message.clone()),
-            }],
-            message_counts: vec![1],
+            }]],
             state_hash: publisher_state_hash,
             oracle_records: vec![OracleRecord::default()],
         }
@@ -215,8 +214,7 @@ where
     };
     let failing_broadcast_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![failing_broadcast_outgoing_message],
-            message_counts: vec![1],
+            messages: vec![vec![failing_broadcast_outgoing_message]],
             state_hash: publisher_state_hash,
             oracle_records: vec![OracleRecord::default()],
         }
@@ -240,8 +238,7 @@ where
     };
     let broadcast_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![broadcast_outgoing_message],
-            message_counts: vec![1],
+            messages: vec![vec![broadcast_outgoing_message]],
             state_hash: publisher_state_hash,
             oracle_records: vec![OracleRecord::default()],
         }
@@ -288,15 +285,14 @@ where
     let creator_state = creator_system_state.clone().into_view().await;
     let subscribe_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![OutgoingMessage {
+            messages: vec![vec![OutgoingMessage {
                 destination: Destination::Recipient(publisher_chain.into()),
                 authenticated_signer: None,
                 grant: Amount::ZERO,
                 refund_grant_to: None,
                 kind: MessageKind::Protected,
                 message: Message::System(subscribe_message.clone()),
-            }],
-            message_counts: vec![1],
+            }]],
             state_hash: creator_state.crypto_hash().await?,
             oracle_records: vec![OracleRecord::default()],
         }
@@ -339,7 +335,7 @@ where
     let publisher_state_hash = publisher_system_state.into_hash().await;
     let accept_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![OutgoingMessage {
+            messages: vec![vec![OutgoingMessage {
                 destination: Destination::Recipient(creator_chain.into()),
                 authenticated_signer: None,
                 grant: Amount::ZERO,
@@ -348,8 +344,7 @@ where
                 message: Message::System(SystemMessage::Notify {
                     id: creator_chain.into(),
                 }),
-            }],
-            message_counts: vec![1],
+            }]],
             state_hash: publisher_state_hash,
             oracle_records: vec![OracleRecord::default()],
         }
@@ -436,15 +431,17 @@ where
         .await?;
     let create_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![OutgoingMessage {
-                destination: Destination::Recipient(creator_chain.into()),
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Protected,
-                message: Message::System(SystemMessage::ApplicationCreated),
-            }],
-            message_counts: vec![0, 1],
+            messages: vec![
+                Vec::new(),
+                vec![OutgoingMessage {
+                    destination: Destination::Recipient(creator_chain.into()),
+                    authenticated_signer: None,
+                    grant: Amount::ZERO,
+                    refund_grant_to: None,
+                    kind: MessageKind::Protected,
+                    message: Message::System(SystemMessage::ApplicationCreated),
+                }],
+            ],
             state_hash: creator_state.crypto_hash().await?,
             oracle_records: vec![OracleRecord::default(); 2],
         }
@@ -498,7 +495,6 @@ where
     let run_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages: Vec::new(),
-            message_counts: vec![0],
             state_hash: creator_state.crypto_hash().await?,
             oracle_records: vec![OracleRecord::default()],
         }

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -494,7 +494,7 @@ where
     creator_state.system.timestamp.set(Timestamp::from(5));
     let run_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: Vec::new(),
+            messages: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
             oracle_records: vec![OracleRecord::default()],
         }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2309,8 +2309,8 @@ where
         &worker,
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
-                messages: vec![
-                    vec![direct_outgoing_message(
+                messages: vec![vec![
+                    direct_outgoing_message(
                         user_id,
                         MessageKind::Protected,
                         SystemMessage::OpenChain(OpenChainConfig {
@@ -2321,16 +2321,16 @@ where
                             balance: Amount::ZERO,
                             application_permissions: Default::default(),
                         }),
-                    )],
-                    vec![direct_outgoing_message(
+                    ),
+                    direct_outgoing_message(
                         admin_id,
                         MessageKind::Protected,
                         SystemMessage::Subscribe {
                             id: user_id,
                             subscription: admin_channel_subscription.clone(),
                         },
-                    )],
-                ],
+                    ),
+                ]],
                 state_hash: SystemExecutionState {
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair.public()),

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -37,7 +37,7 @@ test('Block mounting', () => {
               operations: []
             },
             outcome: {
-              messages: [{
+              messages: [[{
                 destination: { Subscribers: [1] },
                 authenticatedSigner: null,
                 kind: "Protected",
@@ -55,8 +55,7 @@ test('Block mounting', () => {
                     }
                   }
                 }
-              }],
-              messageCounts: [1],
+              }]],
               stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
               oracleRecords: []
             }

--- a/linera-explorer/src/components/Block.vue
+++ b/linera-explorer/src/components/Block.vue
@@ -94,7 +94,7 @@ defineProps<{block: HashedCertificateValue, title: string}>()
           <ul class="list-group">
             <li v-for="(m, i) in block.value.executedBlock?.outcome.messages" class="list-group-item p-0" key="block.hash+'-outmessage-'+i">
               <div class="card">
-                <div class="card-header">Message {{ i+1 }}</div>
+                <div class="card-header">Messages for transaction {{ i+1 }}</div>
                 <div class="card-body">
                   <Json :data="m"/>
                 </div>

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -39,7 +39,7 @@ test('Blocks mounting', () => {
                   operations: []
                 },
                 outcome: {
-                  messages: [{
+                  messages: [[{
                     destination: { Subscribers: [1] },
                     authenticatedSigner: null,
                     kind: "Protected",
@@ -57,8 +57,7 @@ test('Blocks mounting', () => {
                         }
                       }
                     }
-                  }],
-                  messageCounts: [1],
+                  }]],
                   stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
                   oracleRecords: []
                 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -75,9 +75,8 @@ BlockExecutionOutcome:
   STRUCT:
     - messages:
         SEQ:
-          TYPENAME: OutgoingMessage
-    - message_counts:
-        SEQ: U32
+          SEQ:
+            TYPENAME: OutgoingMessage
     - state_hash:
         TYPENAME: CryptoHash
     - oracle_records:

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -200,12 +200,12 @@ impl BlockBuilder {
             .stage_block_execution(self.block)
             .await?;
 
-        let message_ids = (0..executed_block.messages().len() as u32)
-            .map(|index| MessageId {
-                chain_id: executed_block.block.chain_id,
-                height: executed_block.block.height,
-                index,
-            })
+        let message_ids = (0..executed_block
+            .messages()
+            .iter()
+            .map(Vec::len)
+            .sum::<usize>() as u32)
+            .map(|index| executed_block.message_id(index))
             .collect();
 
         let value = HashedCertificateValue::new_confirmed(executed_block);

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -413,7 +413,7 @@ impl ActiveChain {
                 .value()
                 .messages()
                 .expect("Unexpected certificate value");
-            let message_index = messages.iter().position(|message| {
+            let message_index = messages.iter().flatten().position(|message| {
                 matches!(
                     &message.message,
                     Message::System(SystemMessage::BytecodeLocations { locations })

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -180,7 +180,6 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
             kind
             message
           }
-          messageCounts
           stateHash
           oracleRecords {
             responses
@@ -220,7 +219,6 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
             kind
             message
           }
-          messageCounts
           stateHash
           oracleRecords {
             responses

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -104,13 +104,10 @@ type Block {
 The messages and the state hash resulting from a [`Block`]'s execution.
 """
 type BlockExecutionOutcome {
-	messages: [OutgoingMessage!]!
 	"""
-	For each transaction, the cumulative number of messages created by this and all previous
-	transactions, i.e. `message_counts[i]` is the index of the first message created by
-	transaction `i + 1` or later.
+	The list of outgoing messages for each transaction.
 	"""
-	messageCounts: [Int!]!
+	messages: [[OutgoingMessage!]!]!
 	stateHash: CryptoHash!
 	"""
 	The record of oracle responses for each transaction.

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -209,20 +209,18 @@ mod from {
                 outcome:
                     block::BlockBlockValueExecutedBlockOutcome {
                         messages,
-                        message_counts,
                         state_hash,
                         oracle_records,
                     },
             } = val;
             let messages = messages
                 .into_iter()
-                .map(OutgoingMessage::from)
-                .collect::<Vec<_>>();
+                .map(|messages| messages.into_iter().map(OutgoingMessage::from).collect())
+                .collect::<Vec<Vec<_>>>();
             ExecutedBlock {
                 block: block.into(),
                 outcome: BlockExecutionOutcome {
                     messages,
-                    message_counts: message_counts.into_iter().map(|c| c as u32).collect(),
                     state_hash,
                     oracle_records: oracle_records.into_iter().map(Into::into).collect(),
                 },

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -149,7 +149,10 @@ where
                 Either::Left((None, _)) => break,
                 Either::Right(((), _)) => {
                     match client.lock().await.process_inbox_if_owned().await {
-                        Err(error) => warn!(%error, "Failed to process inbox."),
+                        Err(error) => {
+                            warn!(%error, "Failed to process inbox.");
+                            timeout = Timestamp::from(u64::MAX);
+                        }
                         Ok((_, None)) => timeout = Timestamp::from(u64::MAX),
                         Ok((_, Some(new_timeout))) => timeout = new_timeout.timestamp,
                     }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -186,6 +186,7 @@ where
             let new_chains = executed_block
                 .messages()
                 .iter()
+                .flatten()
                 .filter_map(|outgoing_message| {
                     if let OutgoingMessage {
                         destination: Destination::Recipient(new_id),


### PR DESCRIPTION
## Motivation

In the execution outcome, oracle records are grouped by transaction, but outgoing messages are in a single flat vector.

## Proposal

For consistency, group outgoing messages by transaction, too.

As a follow-up and/or alternative, we might consider:
* Changing `MessageId`, so that there is a _transaction_ index, and another index for the message _within_ that transaction's outcome.
* We could merge the two vectors and have something like:

```rust
struct TransactionExecutionOutcome {
    messages: Vec<OutgoingMessage>,
    oracle_responses: Vec<OracleResponse>,
}
```

## Test Plan

Only refactoring.

## Release Plan

- Need to bump the minor version number in the next release of the crates.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
