### PR TITLE
Reintroduce Ethereum in the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions-rust-lang/setup-rust-toolchain@v1
-    - uses: foundry-rs/foundry-toolchain@v1
+    - uses: foundry-rs/foundry-toolchain@v1.2.0
     - uses: pontem-network/get-solc@master
       with:
         version: v0.8.25
@@ -63,6 +63,10 @@ jobs:
       with:
         version: 'latest'
 
+    - name: Run Ethereum tests
+      run: |
+        cargo test -p linera-ethereum --features ethereum
+        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum
     - name: Build example applications
       run: |
         cd examples

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 [[package]]
 name = "alloy"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-contract",
  "alloy-core",
@@ -97,7 +97,7 @@ dependencies = [
  "alloy-network",
  "alloy-node-bindings",
  "alloy-provider",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-signer",
  "alloy-signer-wallet",
  "alloy-transport",
@@ -105,14 +105,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+dependencies = [
+ "alloy-core",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fd095a9d70f4b1c5c102c84a4c782867a5c6416dbf6dcd42a63e7c7a89d3c8"
+dependencies = [
+ "num_enum 0.7.2",
+ "strum 0.26.2",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "c-kzg",
+ "serde",
+]
+
+[[package]]
 name = "alloy-consensus"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "c-kzg",
  "serde",
 ]
@@ -120,14 +152,14 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-sol-types",
  "alloy-transport",
  "futures",
@@ -167,11 +199,25 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "c-kzg",
+ "once_cell",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "c-kzg",
  "once_cell",
  "serde",
@@ -181,10 +227,21 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
 dependencies = [
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "serde",
  "serde_json",
 ]
@@ -204,7 +261,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -216,16 +273,17 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
+ "auto_impl",
  "futures-utils-wasm",
  "thiserror",
 ]
@@ -233,9 +291,9 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-genesis",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -270,15 +328,17 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-eips",
+ "alloy-chains",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-rpc-types-trace",
  "alloy-signer-wallet",
  "alloy-transport",
@@ -290,7 +350,9 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
+ "pin-project",
  "reqwest 0.12.4",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",
@@ -322,7 +384,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -342,14 +404,32 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "alloy-sol-types",
  "itertools 0.12.1",
  "serde",
@@ -360,11 +440,21 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
- "alloy-serde",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-primitives",
  "serde",
  "serde_json",
 ]
@@ -382,7 +472,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -395,9 +485,9 @@ dependencies = [
 [[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -468,7 +558,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.0",
@@ -486,7 +576,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -2696,7 +2786,7 @@ dependencies = [
 name = "ethereum-tracker"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "async-graphql",
  "linera-ethereum",
  "linera-sdk",
@@ -4040,7 +4130,7 @@ dependencies = [
 name = "linera-ethereum"
 version = "0.11.0"
 dependencies = [
- "alloy",
+ "alloy 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-primitives",
  "anyhow",
  "async-lock",
@@ -4301,7 +4391,7 @@ dependencies = [
 name = "linera-service"
 version = "0.11.0"
 dependencies = [
- "alloy",
+ "alloy 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "amm",
  "anyhow",
  "assert_matches",
@@ -4961,7 +5051,16 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
- "num_enum_derive",
+ "num_enum_derive 0.6.1",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive 0.7.2",
 ]
 
 [[package]]
@@ -4971,6 +5070,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -6209,7 +6319,7 @@ dependencies = [
  "histogram",
  "itertools 0.11.0",
  "lz4_flex",
- "num_enum",
+ "num_enum 0.6.1",
  "rand",
  "rand_pcg",
  "scylla-cql",
@@ -6235,7 +6345,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "lz4_flex",
- "num_enum",
+ "num_enum 0.6.1",
  "scylla-macros",
  "snap",
  "thiserror",
@@ -6756,6 +6866,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6773,6 +6892,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ edition = "2021"
 
 [workspace.dependencies]
 heck = "0.4.1"
-alloy = { git = "https://github.com/alloy-rs/alloy", rev = "b79db21734cffddc11753fe62ba571565c896f42", default-features = false }
+alloy = { git = "https://github.com/alloy-rs/alloy", rev = "aed6de2c4a0e901c4aa71e4b67c2ed628285d270", default-features = false }
 alloy-primitives = "0.7.2"
 anyhow = "1.0.80"
 assert_matches = "1.5.0"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "alloy"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-contract",
  "alloy-core",
@@ -85,7 +85,7 @@ dependencies = [
  "alloy-network",
  "alloy-node-bindings",
  "alloy-provider",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-signer",
  "alloy-signer-wallet",
  "alloy-transport",
@@ -93,14 +93,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+dependencies = [
+ "alloy-core",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fd095a9d70f4b1c5c102c84a4c782867a5c6416dbf6dcd42a63e7c7a89d3c8"
+dependencies = [
+ "num_enum",
+ "strum 0.26.2",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "c-kzg",
+ "serde",
+]
+
+[[package]]
 name = "alloy-consensus"
 version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "c-kzg",
  "serde",
 ]
@@ -108,14 +140,14 @@ dependencies = [
 [[package]]
 name = "alloy-contract"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-sol-types",
  "alloy-transport",
  "futures",
@@ -155,11 +187,25 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "c-kzg",
+ "once_cell",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "c-kzg",
  "once_cell",
  "serde",
@@ -169,10 +215,21 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
 source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
 dependencies = [
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "serde",
  "serde_json",
 ]
@@ -192,7 +249,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-rpc"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -204,16 +261,17 @@ dependencies = [
 [[package]]
 name = "alloy-network"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-json-rpc",
  "alloy-primitives",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
+ "auto_impl",
  "futures-utils-wasm",
  "thiserror",
 ]
@@ -221,9 +279,9 @@ dependencies = [
 [[package]]
 name = "alloy-node-bindings"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-genesis",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-primitives",
  "k256",
  "serde_json",
@@ -258,15 +316,17 @@ dependencies = [
 [[package]]
 name = "alloy-provider"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-eips",
+ "alloy-chains",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
  "alloy-primitives",
  "alloy-rpc-client",
- "alloy-rpc-types",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-rpc-types-trace",
  "alloy-signer-wallet",
  "alloy-transport",
@@ -278,7 +338,9 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
+ "pin-project",
  "reqwest 0.12.4",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",
@@ -310,7 +372,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-client"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -330,14 +392,32 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-genesis",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+dependencies = [
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+ "alloy-eips 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+ "alloy-genesis 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "alloy-sol-types",
  "itertools 0.12.1",
  "serde",
@@ -348,11 +428,21 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types",
- "alloy-serde",
+ "alloy-rpc-types 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "alloy-serde 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
+dependencies = [
+ "alloy-primitives",
  "serde",
  "serde_json",
 ]
@@ -370,7 +460,7 @@ dependencies = [
 [[package]]
 name = "alloy-signer"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -383,9 +473,9 @@ dependencies = [
 [[package]]
 name = "alloy-signer-wallet"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-network",
  "alloy-primitives",
  "alloy-signer",
@@ -470,7 +560,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.0",
@@ -488,7 +578,7 @@ dependencies = [
 [[package]]
 name = "alloy-transport-http"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42#b79db21734cffddc11753fe62ba571565c896f42"
+source = "git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270#aed6de2c4a0e901c4aa71e4b67c2ed628285d270"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -754,7 +844,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "strum",
+ "strum 0.25.0",
  "syn 2.0.60",
  "thiserror",
 ]
@@ -2107,7 +2197,7 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 name = "ethereum-tracker"
 version = "0.1.0"
 dependencies = [
- "alloy",
+ "alloy 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=b79db21734cffddc11753fe62ba571565c896f42)",
  "assert_matches",
  "async-graphql",
  "linera-ethereum",
@@ -3230,7 +3320,7 @@ dependencies = [
 name = "linera-ethereum"
 version = "0.11.0"
 dependencies = [
- "alloy",
+ "alloy 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=aed6de2c4a0e901c4aa71e4b67c2ed628285d270)",
  "alloy-primitives",
  "anyhow",
  "async-lock",
@@ -3847,6 +3937,26 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -5262,7 +5372,16 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -5270,6 +5389,19 @@ name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/linera-ethereum/src/provider.rs
+++ b/linera-ethereum/src/provider.rs
@@ -90,8 +90,7 @@ impl EthereumQueries for EthereumClient<HttpProvider> {
     ) -> Result<U256, EthereumServiceError> {
         let address = address.parse::<Address>()?;
         let block_id = get_block_id(block_number);
-        let request = self.provider.get_balance(address)
-            .block_id(block_id);
+        let request = self.provider.get_balance(address).block_id(block_id);
         Ok(request.await?)
     }
 

--- a/linera-ethereum/src/provider.rs
+++ b/linera-ethereum/src/provider.rs
@@ -90,7 +90,9 @@ impl EthereumQueries for EthereumClient<HttpProvider> {
     ) -> Result<U256, EthereumServiceError> {
         let address = address.parse::<Address>()?;
         let block_id = get_block_id(block_number);
-        Ok(self.provider.get_balance(address, block_id).await?)
+        let request = self.provider.get_balance(address)
+            .block_id(block_id);
+        Ok(request.await?)
     }
 
     async fn read_events(


### PR DESCRIPTION
## Motivation

Ethereum has just been removed from the CI. But in order to progress, we need to have it running.

## Proposal

The following is done:
* Put the Ethereum at first to fail first.
* Upgrade alloy to the latest.
* Specify the version of foundry used.

## Test Plan

That is the point. Looking that it worked.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
