### PR TITLE
Update the crates of the main workspace to v0.12.0 with workspace config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "linera-base"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3969,7 +3969,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "assert_matches",
  "async-graphql",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4038,7 +4038,7 @@ dependencies = [
 
 [[package]]
 name = "linera-ethereum"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "linera-explorer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-graphql",
  "async-graphql-axum",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-example"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-graphql-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "graphql_client",
  "linera-base",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "linera-indexer-plugins"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "linera-rpc"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "alloy",
  "amm",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "linera-service-graphql-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "fungible",
  "graphql_client",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage-service"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "linera-version"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-graphql",
  "async-graphql-derive",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cfg_aliases",
  "insta",
@@ -4523,7 +4523,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cfg_aliases",
  "heck 0.4.1",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-test-modules"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "wit-bindgen 0.7.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = ["examples", "scripts"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Linera <contact@linera.io>"]
 repository = "https://github.com/linera-io/linera-protocol"
 homepage = "https://linera.dev"
@@ -159,26 +159,27 @@ web-sys = "0.3.69"
 web-time = "1.1.0"
 wit-bindgen = "0.24.0"
 
-linera-base = { version = "0.11.0", path = "./linera-base" }
-linera-chain = { version = "0.11.0", path = "./linera-chain" }
-linera-core = { version = "0.11.0", path = "./linera-core", default-features = false }
-linera-ethereum = { version = "0.11.0", path = "./linera-ethereum", default-features = false }
-linera-execution = { version = "0.11.0", path = "./linera-execution", default-features = false }
-linera-indexer = { path = "./linera-indexer/lib" }
-linera-indexer-graphql-client = { path = "./linera-indexer/graphql-client" }
-linera-indexer-plugins = { path = "./linera-indexer/plugins" }
-linera-rpc = { version = "0.11.0", path = "./linera-rpc" }
-linera-sdk = { version = "0.11.0", path = "./linera-sdk" }
-linera-storage = { version = "0.11.0", path = "./linera-storage", default-features = false }
-linera-storage-service = { version = "0.11.0", path = "./linera-storage-service", default-features = false }
-linera-version = { version = "0.11.0", path = "./linera-version" }
-linera-views = { version = "0.11.0", path = "./linera-views", default-features = false }
-linera-views-derive = { version = "0.11.0", path = "./linera-views-derive" }
-linera-witty = { version = "0.11.0", path = "./linera-witty" }
-linera-witty-macros = { version = "0.11.0", path = "./linera-witty-macros" }
-linera-sdk-derive = { version = "0.11.0", path = "./linera-sdk-derive" }
-linera-service = { version = "0.11.0", path = "./linera-service" }
-linera-service-graphql-client = { version = "0.11.0", path = "./linera-service-graphql-client" }
+linera-base = { version = "0.12.0", path = "./linera-base" }
+linera-chain = { version = "0.12.0", path = "./linera-chain" }
+linera-core = { version = "0.12.0", path = "./linera-core", default-features = false }
+linera-ethereum = { version = "0.12.0", path = "./linera-ethereum", default-features = false }
+linera-execution = { version = "0.12.0", path = "./linera-execution", default-features = false }
+linera-indexer = { version = "0.12.0", path = "./linera-indexer/lib" }
+linera-indexer-graphql-client = { version = "0.12.0", path = "./linera-indexer/graphql-client" }
+linera-indexer-plugins = { version = "0.12.0", path = "./linera-indexer/plugins" }
+linera-rpc = { version = "0.12.0", path = "./linera-rpc" }
+linera-sdk = { version = "0.12.0", path = "./linera-sdk" }
+linera-storage = { version = "0.12.0", path = "./linera-storage", default-features = false }
+linera-storage-service = { version = "0.12.0", path = "./linera-storage-service", default-features = false }
+linera-version = { version = "0.12.0", path = "./linera-version" }
+linera-views = { version = "0.12.0", path = "./linera-views", default-features = false }
+linera-views-derive = { version = "0.12.0", path = "./linera-views-derive" }
+linera-witty = { version = "0.12.0", path = "./linera-witty" }
+linera-witty-macros = { version = "0.12.0", path = "./linera-witty-macros" }
+linera-witty-test-modules  = { version = "0.12.0", path = "./linera-witty/test-modules" }
+linera-sdk-derive = { version = "0.12.0", path = "./linera-sdk-derive" }
+linera-service = { version = "0.12.0", path = "./linera-service" }
+linera-service-graphql-client = { version = "0.12.0", path = "./linera-service-graphql-client" }
 
 counter = { path = "./examples/counter" }
 meta-counter = { path = "./examples/meta-counter" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3141,7 +3141,7 @@ dependencies = [
 
 [[package]]
 name = "linera-base"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "linera-chain"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -3191,7 +3191,7 @@ dependencies = [
 
 [[package]]
 name = "linera-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3228,7 +3228,7 @@ dependencies = [
 
 [[package]]
 name = "linera-ethereum"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "linera-execution"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3286,7 +3286,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "linera-sdk-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -3325,7 +3325,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "linera-storage-service"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -3367,7 +3367,7 @@ dependencies = [
 
 [[package]]
 name = "linera-version"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-graphql",
  "async-graphql-derive",
@@ -3385,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-graphql",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "linera-views-derive"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cfg_aliases",
  "proc-macro2",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "cfg_aliases",
@@ -3441,7 +3441,7 @@ dependencies = [
 
 [[package]]
 name = "linera-witty-macros"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "cfg_aliases",
  "heck 0.4.1",

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-indexer-example"
-version = "0.11.0"
 description = "Indexer example."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.io"
 documentation = "https://docs.rs/linera-indexer/latest/linera_indexer/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["rocksdb"]

--- a/linera-indexer/graphql-client/Cargo.toml
+++ b/linera-indexer/graphql-client/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "linera-indexer-graphql-client"
-version = "0.11.0"
-edition = "2021"
 description = "GraphQL client for the indexer"
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
 documentation = "https://docs.rs/linera-indexer-graphql-client/latest/linera_indexer_graphql_client/"
-license = "Apache-2.0"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 graphql_client = { version = "0.13", features = [ "reqwest-rustls" ] }

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-indexer"
-version = "0.11.0"
 description = "Indexer for Linera protocol."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.io"
 documentation = "https://docs.rs/linera-indexer/latest/linera_indexer/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["rocksdb"]

--- a/linera-indexer/plugins/Cargo.toml
+++ b/linera-indexer/plugins/Cargo.toml
@@ -1,14 +1,15 @@
 [package]
 name = "linera-indexer-plugins"
-version = "0.11.0"
 description = "Indexer plugins."
-authors = ["Linera <contact@linera.io>"]
 readme = "README.md"
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.io"
 documentation = "https://docs.rs/linera-indexer/latest/linera_indexer/"
-license = "Apache-2.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [features]
 default = ["rocksdb"]

--- a/linera-witty/test-modules/Cargo.toml
+++ b/linera-witty/test-modules/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "linera-witty-test-modules"
 description = "Generation of WIT compatible host code from Rust code"
-authors = ["Linera <contact@linera.io>"]
-repository = "https://github.com/linera-io/linera-protocol"
-homepage = "https://linera.dev"
-license = "Apache-2.0"
-version = "0.11.0"
-edition = "2021"
+
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
 
 [[bin]]
 name = "export-simple-function"


### PR DESCRIPTION
## Motivation

Need to prepare future releases

## Proposal

* Update all the crates of the main workspace to v0.12.0
* Use workspace versioning for all crates in the main workspace
* Examples have their own workspace and are not concerned.

## Test Plan

* `git grep contact@linera.io`
* CI

## Release Plan

This prepares future breaking changes
