### PR TITLE
Fix `linera-sdk` docs.rs build

### DIFF
--- a/linera-sdk/build.rs
+++ b/linera-sdk/build.rs
@@ -5,5 +5,8 @@ fn main() {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
         with_wasm_runtime: { any(feature = "wasmer", feature = "wasmtime") },
+        with_integration_testing: {
+            all(not(target_arch = "wasm32"), with_testing, with_wasm_runtime)
+        },
     };
 }

--- a/linera-sdk/build.rs
+++ b/linera-sdk/build.rs
@@ -4,5 +4,6 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
+        with_wasm_runtime: { any(feature = "wasmer", feature = "wasmtime") },
     };
 }

--- a/linera-sdk/src/bin/wit_generator.rs
+++ b/linera-sdk/src/bin/wit_generator.rs
@@ -3,6 +3,9 @@
 
 //! Generator of WIT files representing the interface between Linera applications and nodes.
 
+#![cfg_attr(target_arch = "wasm32", no_main)]
+#![cfg(not(target_arch = "wasm32"))]
+
 use std::{
     fs::File,
     io::{BufReader, BufWriter, Read, Write},

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -8,19 +8,19 @@
 //! executed targeting the host architecture, instead of targeting `wasm32-unknown-unknown` like
 //! done for unit tests.
 
-#![cfg(any(with_testing, feature = "wasmer", feature = "wasmtime"))]
+#![cfg(any(with_testing, with_wasm_runtime))]
 
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_wasm_runtime)]
 mod block;
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_wasm_runtime)]
 mod chain;
 mod mock_stubs;
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_wasm_runtime)]
 mod validator;
 
 #[cfg(with_testing)]
 pub use self::mock_stubs::*;
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_wasm_runtime)]
 pub use self::{block::BlockBuilder, chain::ActiveChain, validator::TestValidator};
 use crate::{Contract, ContractRuntime, Service, ServiceRuntime};
 

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -10,17 +10,17 @@
 
 #![cfg(any(with_testing, with_wasm_runtime))]
 
-#[cfg(with_wasm_runtime)]
+#[cfg(with_integration_testing)]
 mod block;
-#[cfg(with_wasm_runtime)]
+#[cfg(with_integration_testing)]
 mod chain;
 mod mock_stubs;
-#[cfg(with_wasm_runtime)]
+#[cfg(with_integration_testing)]
 mod validator;
 
 #[cfg(with_testing)]
 pub use self::mock_stubs::*;
-#[cfg(with_wasm_runtime)]
+#[cfg(with_integration_testing)]
 pub use self::{block::BlockBuilder, chain::ActiveChain, validator::TestValidator};
 use crate::{Contract, ContractRuntime, Service, ServiceRuntime};
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The documentation in docs.rs is failing to build. It's happening because it attempts to build the crate for the `wasm32-unknown-unknown` target with all features enabled, which does not work. Right now only the library part of the crate can compile to Wasm, and with the `test` feature disabled.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Ensure that the `wit-generator` binary does not lead to compiler errors when compiling `linera-sdk` for `wasm32-unknown-unknown`, and ensure that the integration test parts of the `test` module is only compiled for non-Wasm target architectures.

## Test Plan

<!-- How to test that the changes are correct. -->
This now makes `cargo build -p linera-sdk --target wasm32-unknown-unknown` and `cargo build -p linera-sdk --all-features --target wasm32-unknown-unknown` work.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, but the changes to the documentation should only appear with the next release.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
