### PR TITLE
Endpoint to download a certificate value

### DIFF
--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -16,7 +16,7 @@ pub mod test;
 pub use chain::ChainStateView;
 use data_types::{Event, Origin};
 use linera_base::{
-    crypto::CryptoError,
+    crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
     identifiers::{ApplicationId, ChainId},
 };
@@ -142,6 +142,11 @@ pub enum ChainError {
     GrantUseOnBroadcast,
     #[error("ExecutedBlock contains fewer oracle responses than requests")]
     MissingOracleRecord,
+    #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
+    CertificateValueHashMismatch {
+        expected: CryptoHash,
+        actual: CryptoHash,
+    },
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -4,7 +4,7 @@
 
 use futures::stream::{BoxStream, LocalBoxStream, Stream};
 use linera_base::{
-    crypto::CryptoError,
+    crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, Blob, BlockHeight, HashedBlob},
     identifiers::{BlobId, ChainId},
 };
@@ -82,6 +82,11 @@ pub trait LocalValidatorNode {
     ) -> Result<Self::NotificationStream, NodeError>;
 
     async fn download_blob(&mut self, blob_id: BlobId) -> Result<Blob, NodeError>;
+
+    async fn download_certificate_value(
+        &mut self,
+        hash: CryptoHash,
+    ) -> Result<HashedCertificateValue, NodeError>;
 }
 
 /// Turn an address into a validator node.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -54,6 +54,9 @@ service ValidatorNode {
 
   // Downloads a blob.
   rpc DownloadBlob(BlobId) returns (Blob);
+
+  // Downloads a certificate value.
+  rpc DownloadCertificateValue(CryptoHash) returns (CertificateValue);
 }
 
 // Information about the Linera crate version the validator is running
@@ -221,11 +224,19 @@ message Certificate {
   bytes blobs = 7;
 }
 
+message CertificateValue {
+  bytes bytes = 1;
+}
+
 message ChainId {
   bytes bytes = 1;
 }
 
 message PublicKey {
+  bytes bytes = 1;
+}
+
+message CryptoHash {
   bytes bytes = 1;
 }
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
+    crypto::CryptoHash,
     data_types::{Blob, HashedBlob},
     identifiers::{BlobId, ChainId},
 };
@@ -151,6 +152,18 @@ impl ValidatorNode for Client {
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => simple_client.download_blob(blob_id).await?,
+        })
+    }
+
+    async fn download_certificate_value(
+        &mut self,
+        hash: CryptoHash,
+    ) -> Result<HashedCertificateValue, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.download_certificate_value(hash).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.download_certificate_value(hash).await?,
         })
     }
 }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -7,11 +7,12 @@ use std::{future::Future, time::Duration};
 use async_trait::async_trait;
 use futures::{sink::SinkExt, stream::StreamExt};
 use linera_base::{
+    crypto::CryptoHash,
     data_types::{Blob, HashedBlob},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{
-    BlockProposal, Certificate, HashedCertificateValue, LiteCertificate,
+    BlockProposal, Certificate, CertificateValue, HashedCertificateValue, LiteCertificate,
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
@@ -139,6 +140,16 @@ impl ValidatorNode for SimpleClient {
     async fn download_blob(&mut self, blob_id: BlobId) -> Result<Blob, NodeError> {
         self.query(RpcMessage::DownloadBlob(Box::new(blob_id)))
             .await
+    }
+
+    async fn download_certificate_value(
+        &mut self,
+        hash: CryptoHash,
+    ) -> Result<HashedCertificateValue, NodeError> {
+        let certificate_value: CertificateValue = self
+            .query(RpcMessage::DownloadCertificateValue(Box::new(hash)))
+            .await?;
+        Ok(certificate_value.with_hash_checked(hash)?)
     }
 }
 

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -299,7 +299,9 @@ where
             | RpcMessage::ChainInfoResponse(_)
             | RpcMessage::VersionInfoResponse(_)
             | RpcMessage::DownloadBlob(_)
-            | RpcMessage::DownloadBlobResponse(_) => Err(NodeError::UnexpectedMessage),
+            | RpcMessage::DownloadBlobResponse(_)
+            | RpcMessage::DownloadCertificateValue(_)
+            | RpcMessage::DownloadCertificateValueResponse(_) => Err(NodeError::UnexpectedMessage),
         };
 
         self.server.packets_processed += 1;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -768,28 +768,36 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: BlobId
     5:
-      VersionInfoQuery: UNIT
+      DownloadCertificateValue:
+        NEWTYPE:
+          TYPENAME: CryptoHash
     6:
+      VersionInfoQuery: UNIT
+    7:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    7:
+    8:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    8:
+    9:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    9:
+    10:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    10:
+    11:
       DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: Blob
-    11:
+    12:
+      DownloadCertificateValueResponse:
+        NEWTYPE:
+          TYPENAME: CertificateValue
+    13:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -27,8 +27,9 @@ use linera_rpc::{
             notifier_service_server::{NotifierService, NotifierServiceServer},
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
-            Blob, BlobId, BlockProposal, Certificate, ChainInfoQuery, ChainInfoResult,
-            LiteCertificate, Notification, SubscriptionRequest, VersionInfo,
+            Blob, BlobId, BlockProposal, Certificate, CertificateValue, ChainInfoQuery,
+            ChainInfoResult, CryptoHash, LiteCertificate, Notification, SubscriptionRequest,
+            VersionInfo,
         },
         pool::GrpcConnectionPool,
         GrpcProxyable, GRPC_MAX_MESSAGE_SIZE,
@@ -409,6 +410,21 @@ where
             .await
             .map_err(|err| Status::from_error(Box::new(err)))?;
         Ok(Response::new(hashed_blob.into_inner().into()))
+    }
+
+    #[instrument(skip_all, err(Display))]
+    async fn download_certificate_value(
+        &self,
+        request: Request<CryptoHash>,
+    ) -> Result<Response<CertificateValue>, Status> {
+        let hash = request.into_inner().try_into()?;
+        let certificate = self
+            .0
+            .storage
+            .read_hashed_certificate_value(hash)
+            .await
+            .map_err(|err| Status::from_error(Box::new(err)))?;
+        Ok(Response::new(certificate.try_into()?))
     }
 }
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use linera_base::{
-    crypto::KeyPair,
+    crypto::{CryptoHash, KeyPair},
     data_types::{Blob, HashedBlob, Timestamp},
     identifiers::{BlobId, ChainId},
 };
@@ -75,6 +75,13 @@ impl ValidatorNode for DummyValidatorNode {
     }
 
     async fn download_blob(&mut self, _: BlobId) -> Result<Blob, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
+    async fn download_certificate_value(
+        &mut self,
+        _: CryptoHash,
+    ) -> Result<HashedCertificateValue, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 }


### PR DESCRIPTION
## Motivation

We need to be able to download certificate values directly from the Proxy. Fixes #2029

## Proposal

Adds an entrypoint for downloading a certificate value given a hash

## Test Plan

CI for now, will replace chain info queries in following PR

