### PR TITLE
Add the block to the non_executive_call.

### DIFF
--- a/linera-ethereum/src/client.rs
+++ b/linera-ethereum/src/client.rs
@@ -126,6 +126,7 @@ pub trait EthereumQueries {
         contract_address: &str,
         data: Bytes,
         from: &str,
+        block: u64,
     ) -> Result<Bytes, Self::Error>;
 }
 
@@ -192,6 +193,7 @@ where
         contract_address: &str,
         data: Bytes,
         from: &str,
+        block: u64
     ) -> Result<Bytes, Self::Error> {
         let contract_address = contract_address.parse::<Address>()?;
         let from = from.parse::<Address>()?;
@@ -200,6 +202,7 @@ where
             .from(from)
             .to(contract_address)
             .input(input);
-        Ok(self.request::<_, Bytes>("eth_call", (tx,)).await?)
+        let tag = get_block_id(Some(block));
+        Ok(self.request::<_, Bytes>("eth_call", (tx,tag)).await?)
     }
 }

--- a/linera-ethereum/src/client.rs
+++ b/linera-ethereum/src/client.rs
@@ -193,7 +193,7 @@ where
         contract_address: &str,
         data: Bytes,
         from: &str,
-        block: u64
+        block: u64,
     ) -> Result<Bytes, Self::Error> {
         let contract_address = contract_address.parse::<Address>()?;
         let from = from.parse::<Address>()?;
@@ -203,6 +203,6 @@ where
             .to(contract_address)
             .input(input);
         let tag = get_block_id(Some(block));
-        Ok(self.request::<_, Bytes>("eth_call", (tx,tag)).await?)
+        Ok(self.request::<_, Bytes>("eth_call", (tx, tag)).await?)
     }
 }

--- a/linera-ethereum/src/provider.rs
+++ b/linera-ethereum/src/provider.rs
@@ -131,8 +131,7 @@ impl EthereumQueries for EthereumClient<HttpProvider> {
             .to(contract_address)
             .input(input);
         let block_id = get_block_id(Some(block));
-        let eth_call = self.provider.call(&tx)
-            .block(block_id);
+        let eth_call = self.provider.call(&tx).block(block_id);
         Ok(eth_call.await?)
     }
 }

--- a/linera-ethereum/src/provider.rs
+++ b/linera-ethereum/src/provider.rs
@@ -121,6 +121,7 @@ impl EthereumQueries for EthereumClient<HttpProvider> {
         contract_address: &str,
         data: Bytes,
         from: &str,
+        block: u64,
     ) -> Result<Bytes, EthereumServiceError> {
         let contract_address = contract_address.parse::<Address>()?;
         let from = from.parse::<Address>()?;
@@ -129,7 +130,10 @@ impl EthereumQueries for EthereumClient<HttpProvider> {
             .from(from)
             .to(contract_address)
             .input(input);
-        Ok(self.provider.call(&tx).await?)
+        let block_id = get_block_id(Some(block));
+        let eth_call = self.provider.call(&tx)
+            .block(block_id);
+        Ok(eth_call.await?)
     }
 }
 

--- a/linera-ethereum/src/test_utils/mod.rs
+++ b/linera-ethereum/src/test_utils/mod.rs
@@ -116,7 +116,7 @@ impl SimpleTokenContractFunction {
     }
 
     // Only the balanceOf operation is of interest for this contract
-    pub async fn balance_of(&self, to: &str) -> anyhow::Result<U256> {
+    pub async fn balance_of(&self, to: &str, block: u64) -> anyhow::Result<U256> {
         // Getting the simple_token
         let contract_address = self.contract_address.parse::<Address>()?;
         let simple_token =
@@ -128,12 +128,12 @@ impl SimpleTokenContractFunction {
         let answer = self
             .anvil_test
             .ethereum_client
-            .non_executive_call(&self.contract_address, data.clone(), to)
+            .non_executive_call(&self.contract_address, data.clone(), to, block)
             .await?;
         // Using the Ethereum client simplified.
         let ethereum_client_simp = EthereumClientSimplified::new(self.anvil_test.endpoint.clone());
         let answer_simp = ethereum_client_simp
-            .non_executive_call(&self.contract_address, data, to)
+            .non_executive_call(&self.contract_address, data, to, block)
             .await?;
         assert_eq!(answer_simp, answer);
         // Converting the output

--- a/linera-ethereum/tests/ethereum_test.rs
+++ b/linera-ethereum/tests/ethereum_test.rs
@@ -155,11 +155,19 @@ async fn test_simple_token_queries() -> anyhow::Result<()> {
     simple_token.transfer(&addr0, &addr1, value).await?;
 
     // Checking the balances
-    let balance0 = simple_token.balance_of(&addr0).await?;
+    let block1 = 1;
+    let balance0 = simple_token.balance_of(&addr0, block1).await?;
+    assert_eq!(balance0, U256::from(1000));
+    let balance1 = simple_token.balance_of(&addr1, block1).await?;
+    assert_eq!(balance1, U256::from(0));
+
+    // Checking the balances
+    let block2 = 2;
+    let balance0 = simple_token.balance_of(&addr0, block2).await?;
     assert_eq!(balance0, U256::from(990));
-    let balance1 = simple_token.balance_of(&addr1).await?;
+    let balance1 = simple_token.balance_of(&addr1, block2).await?;
     assert_eq!(balance1, U256::from(10));
-    let balance_contract = simple_token.balance_of(&contract_address).await?;
+    let balance_contract = simple_token.balance_of(&contract_address, block2).await?;
     assert_eq!(balance_contract, U256::from(0));
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The function `non_executive_call` was not taking a block. This is a problem for validator coherency.

## Proposal

The non-executive call is now taking a block number.

## Test Plan

The test is added to the `ethereum_test.rs`.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
