### PR TITLE
Extend open chain functions in CLI, node service and system API.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -232,6 +232,9 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 * `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds
 
   Default value: `86400000`
+* `--execute-operations <EXECUTE_OPERATIONS>` — If this is `None`, all system operations and application operations are allowed. If it is `Some`, only operations from the specified applications are allowed, and no system operations
+* `--mandatory-applications <MANDATORY_APPLICATIONS>` — At least one operation or incoming message from each of these applications must occur in every block
+* `--close-chain <CLOSE_CHAIN>` — These applications are allowed to close the current chain using the system API
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
 
   Default value: `0`
@@ -275,7 +278,7 @@ Changes the application permissions configuration
 ###### **Options:**
 
 * `--chain-id <CHAIN_ID>` — The ID of the chain to which the new permissions will be applied
-* `--execute-operations <EXECUTE_OPERATIONS>` — If this is not set, all system operations and application operations are allowed. If it is set, only operations from the specified applications are allowed, and no system operations
+* `--execute-operations <EXECUTE_OPERATIONS>` — If this is `None`, all system operations and application operations are allowed. If it is `Some`, only operations from the specified applications are allowed, and no system operations
 * `--mandatory-applications <MANDATORY_APPLICATIONS>` — At least one operation or incoming message from each of these applications must occur in every block
 * `--close-chain <CLOSE_CHAIN>` — These applications are allowed to close the current chain using the system API
 

--- a/CLI.md
+++ b/CLI.md
@@ -232,7 +232,7 @@ Open (i.e. activate) a new multi-owner chain deriving the UID from an existing o
 * `--fallback-duration-ms <FALLBACK_DURATION>` — The age of an incoming tracked or protected message after which the validators start transitioning the chain to fallback mode, in milliseconds
 
   Default value: `86400000`
-* `--execute-operations <EXECUTE_OPERATIONS>` — If this is `None`, all system operations and application operations are allowed. If it is `Some`, only operations from the specified applications are allowed, and no system operations
+* `--execute-operations <EXECUTE_OPERATIONS>` — If present, only operations from the specified applications are allowed, and no system operations. Otherwise all operations are allowed
 * `--mandatory-applications <MANDATORY_APPLICATIONS>` — At least one operation or incoming message from each of these applications must occur in every block
 * `--close-chain <CLOSE_CHAIN>` — These applications are allowed to close the current chain using the system API
 * `--initial-balance <BALANCE>` — The initial balance of the new chain. This is subtracted from the parent chain's balance
@@ -278,7 +278,7 @@ Changes the application permissions configuration
 ###### **Options:**
 
 * `--chain-id <CHAIN_ID>` — The ID of the chain to which the new permissions will be applied
-* `--execute-operations <EXECUTE_OPERATIONS>` — If this is `None`, all system operations and application operations are allowed. If it is `Some`, only operations from the specified applications are allowed, and no system operations
+* `--execute-operations <EXECUTE_OPERATIONS>` — If present, only operations from the specified applications are allowed, and no system operations. Otherwise all operations are allowed
 * `--mandatory-applications <MANDATORY_APPLICATIONS>` — At least one operation or incoming message from each of these applications must occur in every block
 * `--close-chain <CLOSE_CHAIN>` — These applications are allowed to close the current chain using the system API
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 use anyhow::Context as _;
-use async_graphql::SimpleObject;
+use async_graphql::{InputObject, SimpleObject};
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -653,7 +653,18 @@ impl Amount {
 
 /// Permissions for applications on a chain.
 #[derive(
-    Default, Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, WitType, WitLoad, WitStore,
+    Default,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Serialize,
+    Deserialize,
+    WitType,
+    WitLoad,
+    WitStore,
+    InputObject,
 )]
 pub struct ApplicationPermissions {
     /// If this is `None`, all system operations and application operations are allowed.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -673,8 +673,10 @@ pub struct ApplicationPermissions {
     pub execute_operations: Option<Vec<ApplicationId>>,
     /// At least one operation or incoming message from each of these applications must occur in
     /// every block.
+    #[graphql(default)]
     pub mandatory_applications: Vec<ApplicationId>,
     /// These applications are allowed to close the current chain using the system API.
+    #[graphql(default)]
     pub close_chain: Vec<ApplicationId>,
 }
 

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -652,7 +652,9 @@ impl Amount {
 }
 
 /// Permissions for applications on a chain.
-#[derive(Default, Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[derive(
+    Default, Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, WitType, WitLoad, WitStore,
+)]
 pub struct ApplicationPermissions {
     /// If this is `None`, all system operations and application operations are allowed.
     /// If it is `Some`, only operations from the specified applications are allowed, and

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1864,6 +1864,7 @@ where
     pub async fn open_chain(
         &mut self,
         ownership: ChainOwnership,
+        application_permissions: ApplicationPermissions,
         balance: Amount,
     ) -> Result<ClientOutcome<(MessageId, Certificate)>, ChainClientError> {
         self.prepare_chain().await?;
@@ -1877,7 +1878,7 @@ where
                 admin_id: self.admin_id,
                 epoch,
                 balance,
-                application_permissions: Default::default(),
+                application_permissions: application_permissions.clone(),
             };
             let operation = Operation::System(SystemOperation::OpenChain(config));
             let certificate = match self.execute_block(messages, vec![operation]).await? {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -509,7 +509,11 @@ where
     let new_key_pair = KeyPair::generate();
     // Open the new chain.
     let (message_id, certificate) = sender
-        .open_chain(ChainOwnership::single(new_key_pair.public()), Amount::ZERO)
+        .open_chain(
+            ChainOwnership::single(new_key_pair.public()),
+            ApplicationPermissions::default(),
+            Amount::ZERO,
+        )
         .await
         .unwrap()
         .unwrap();
@@ -567,7 +571,11 @@ where
         .unwrap();
     // Open the new chain.
     let (open_chain_message_id, certificate) = parent
-        .open_chain(ChainOwnership::single(new_key_pair.public()), Amount::ZERO)
+        .open_chain(
+            ChainOwnership::single(new_key_pair.public()),
+            ApplicationPermissions::default(),
+            Amount::ZERO,
+        )
         .await
         .unwrap()
         .unwrap();
@@ -664,7 +672,11 @@ where
         .unwrap();
     // Open the new chain.
     let (open_chain_message_id, certificate) = sender
-        .open_chain(ChainOwnership::single(new_key_pair.public()), Amount::ZERO)
+        .open_chain(
+            ChainOwnership::single(new_key_pair.public()),
+            ApplicationPermissions::default(),
+            Amount::ZERO,
+        )
         .await
         .unwrap()
         .unwrap();
@@ -737,7 +749,7 @@ where
     let ownership = ChainOwnership::single(new_key_pair.public())
         .with_regular_owner(new_key_pair.public(), 100);
     let (message_id, creation_certificate) = sender
-        .open_chain(ownership, Amount::ZERO)
+        .open_chain(ownership, ApplicationPermissions::default(), Amount::ZERO)
         .await
         .unwrap()
         .unwrap();

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -27,7 +27,10 @@ use derive_more::Display;
 use linera_base::{
     abi::Abi,
     crypto::CryptoHash,
-    data_types::{Amount, ArithmeticError, BlockHeight, Resources, SendMessageRequest, Timestamp},
+    data_types::{
+        Amount, ApplicationPermissions, ArithmeticError, BlockHeight, Resources,
+        SendMessageRequest, Timestamp,
+    },
     doc_scalar, hex_debug,
     identifiers::{
         Account, ApplicationId, BytecodeId, ChainId, ChannelName, Destination,
@@ -505,6 +508,7 @@ pub trait ContractRuntime: BaseRuntime {
     fn open_chain(
         &mut self,
         ownership: ChainOwnership,
+        application_permissions: ApplicationPermissions,
         balance: Amount,
     ) -> Result<ChainId, ExecutionError>;
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1194,17 +1194,16 @@ impl ContractRuntime for ContractSyncRuntime {
     fn open_chain(
         &mut self,
         ownership: ChainOwnership,
+        application_permissions: ApplicationPermissions,
         balance: Amount,
     ) -> Result<ChainId, ExecutionError> {
         let mut this = self.inner();
-        let id = this.current_application().id;
         let next_message_id = MessageId {
             chain_id: this.chain_id,
             height: this.height,
             index: this.next_message_index()?,
         };
         let chain_id = ChainId::child(next_message_id);
-        let application_permissions = ApplicationPermissions::new_single(id);
         let [open_chain_message, subscribe_message] = this
             .execution_state_sender
             .send_request(|callback| Request::OpenChain {

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -4,7 +4,7 @@
 use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
-    data_types::{Amount, BlockHeight, SendMessageRequest, Timestamp},
+    data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
     identifiers::{Account, ApplicationId, ChainId, ChannelName, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError},
 };
@@ -259,17 +259,18 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Opens a new chain, configuring it with the provided `chain_ownership` and initial `balance`
-    /// (debited from the current chain).
+    /// Opens a new chain, configuring it with the provided `chain_ownership`,
+    /// `application_permissions` and initial `balance` (debited from the current chain).
     fn open_chain(
         caller: &mut Caller,
         chain_ownership: ChainOwnership,
+        application_permissions: ApplicationPermissions,
         balance: Amount,
     ) -> Result<ChainId, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .open_chain(chain_ownership, balance)
+            .open_chain(chain_ownership, application_permissions, balance)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1459,7 +1459,11 @@ async fn test_open_chain() {
             assert_eq!(runtime.chain_ownership().unwrap(), ownership);
             let destination = Account::chain(ChainId::root(2));
             runtime.transfer(None, destination, Amount::ONE).unwrap();
-            let chain_id = runtime.open_chain(child_ownership, Amount::ONE).unwrap();
+            let id = runtime.application_id().unwrap();
+            let application_permissions = ApplicationPermissions::new_single(id);
+            let chain_id = runtime
+                .open_chain(child_ownership, application_permissions, Amount::ONE)
+                .unwrap();
             assert_eq!(chain_id, ChainId::child(message_id));
             Ok(vec![])
         }

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -18,7 +18,7 @@ interface contract-system-api {
     transfer: func(source: option<owner>, destination: account, amount: amount);
     claim: func(source: account, destination: account, amount: amount);
     get-chain-ownership: func() -> chain-ownership;
-    open-chain: func(chain-ownership: chain-ownership, balance: amount) -> chain-id;
+    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
     close-chain: func() -> result<tuple<>, close-chain-error>;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
@@ -38,6 +38,12 @@ interface contract-system-api {
     record application-id {
         bytecode-id: bytecode-id,
         creation: message-id,
+    }
+
+    record application-permissions {
+        execute-operations: option<list<application-id>>,
+        mandatory-applications: list<application-id>,
+        close-chain: list<application-id>,
     }
 
     record block-height {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -559,7 +559,7 @@ type MutationRoot {
 	Creates (or activates) a new chain by installing the given authentication keys.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openMultiOwnerChain(		chainId: ChainId!,		applicationPermissions: ApplicationPermissions!,		publicKeys: [PublicKey!]!,		weights: [Int!],		multiLeaderRounds: Int,		balance: Amount,
+	openMultiOwnerChain(		chainId: ChainId!,		applicationPermissions: ApplicationPermissions,		publicKeys: [PublicKey!]!,		weights: [Int!],		multiLeaderRounds: Int,		balance: Amount,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -33,11 +33,11 @@ input ApplicationPermissions {
 	At least one operation or incoming message from each of these applications must occur in
 	every block.
 	"""
-	mandatoryApplications: [ApplicationId!]!
+	mandatoryApplications: [ApplicationId!]! = []
 	"""
 	These applications are allowed to close the current chain using the system API.
 	"""
-	closeChain: [ApplicationId!]!
+	closeChain: [ApplicationId!]! = []
 }
 
 """

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -20,6 +20,27 @@ type ApplicationOverview {
 }
 
 """
+Permissions for applications on a chain.
+"""
+input ApplicationPermissions {
+	"""
+	If this is `None`, all system operations and application operations are allowed.
+	If it is `Some`, only operations from the specified applications are allowed, and
+	no system operations.
+	"""
+	executeOperations: [ApplicationId!]
+	"""
+	At least one operation or incoming message from each of these applications must occur in
+	every block.
+	"""
+	mandatoryApplications: [ApplicationId!]!
+	"""
+	These applications are allowed to close the current chain using the system API.
+	"""
+	closeChain: [ApplicationId!]!
+}
+
+"""
 A blob of binary data.
 """
 scalar Blob
@@ -538,7 +559,7 @@ type MutationRoot {
 	Creates (or activates) a new chain by installing the given authentication keys.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""
-	openMultiOwnerChain(		chainId: ChainId!,		publicKeys: [PublicKey!]!,		weights: [Int!],		multiLeaderRounds: Int,		balance: Amount,
+	openMultiOwnerChain(		chainId: ChainId!,		applicationPermissions: ApplicationPermissions!,		publicKeys: [PublicKey!]!,		weights: [Int!],		multiLeaderRounds: Int,		balance: Amount,
 		"""
 		The duration of the fast round, in milliseconds; default: no timeout
 		"""

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -9,7 +9,7 @@ use axum::{http::StatusCode, response, response::IntoResponse, Extension, Router
 use futures::lock::Mutex;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ChainId, MessageId},
     ownership::ChainOwnership,
 };
@@ -161,7 +161,9 @@ where
         }
 
         let ownership = ChainOwnership::single(public_key);
-        let result = client.open_chain(ownership, self.amount).await;
+        let result = client
+            .open_chain(ownership, ApplicationPermissions::default(), self.amount)
+            .await;
         self.context.lock().await.update_wallet(&mut *client).await;
         let (message_id, certificate) = match result? {
             ClientOutcome::Committed(result) => result,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -958,9 +958,8 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
 
 #[derive(Debug, Clone, clap::Args)]
 pub struct ApplicationPermissionsConfig {
-    /// If this is `None`, all system operations and application operations are allowed.
-    /// If it is `Some`, only operations from the specified applications are allowed, and
-    /// no system operations.
+    /// If present, only operations from the specified applications are allowed, and
+    /// no system operations. Otherwise all operations are allowed.
     #[arg(long)]
     pub execute_operations: Option<Vec<ApplicationId>>,
     /// At least one operation or incoming message from each of these applications must occur in

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -7,7 +7,7 @@ use anyhow::Error;
 use chrono::{DateTime, Utc};
 use linera_base::{
     crypto::PublicKey,
-    data_types::{Amount, TimeDelta},
+    data_types::{Amount, ApplicationPermissions, TimeDelta},
     identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -238,6 +238,9 @@ pub enum ClientCommand {
         #[clap(flatten)]
         ownership_config: ChainOwnershipConfig,
 
+        #[clap(flatten)]
+        application_permissions_config: ApplicationPermissionsConfig,
+
         /// The initial balance of the new chain. This is subtracted from the parent chain's
         /// balance.
         #[arg(long = "initial-balance", default_value = "0")]
@@ -262,18 +265,9 @@ pub enum ClientCommand {
         /// The ID of the chain to which the new permissions will be applied.
         #[arg(long)]
         chain_id: Option<ChainId>,
-        /// If this is not set, all system operations and application operations are allowed.
-        /// If it is set, only operations from the specified applications are allowed, and
-        /// no system operations.
-        #[arg(long)]
-        execute_operations: Option<Vec<ApplicationId>>,
-        /// At least one operation or incoming message from each of these applications must
-        /// occur in every block.
-        #[arg(long)]
-        mandatory_applications: Vec<ApplicationId>,
-        /// These applications are allowed to close the current chain using the system API.
-        #[arg(long)]
-        close_chain: Vec<ApplicationId>,
+
+        #[clap(flatten)]
+        application_permissions_config: ApplicationPermissionsConfig,
     },
 
     /// Close an existing chain.
@@ -959,5 +953,31 @@ impl TryFrom<ChainOwnershipConfig> for ChainOwnership {
             multi_leader_rounds,
             timeout_config,
         })
+    }
+}
+
+#[derive(Debug, Clone, clap::Args)]
+pub struct ApplicationPermissionsConfig {
+    /// If this is `None`, all system operations and application operations are allowed.
+    /// If it is `Some`, only operations from the specified applications are allowed, and
+    /// no system operations.
+    #[arg(long)]
+    pub execute_operations: Option<Vec<ApplicationId>>,
+    /// At least one operation or incoming message from each of these applications must occur in
+    /// every block.
+    #[arg(long)]
+    pub mandatory_applications: Option<Vec<ApplicationId>>,
+    /// These applications are allowed to close the current chain using the system API.
+    #[arg(long)]
+    pub close_chain: Option<Vec<ApplicationId>>,
+}
+
+impl From<ApplicationPermissionsConfig> for ApplicationPermissions {
+    fn from(config: ApplicationPermissionsConfig) -> ApplicationPermissions {
+        ApplicationPermissions {
+            execute_operations: config.execute_operations,
+            mandatory_applications: config.mandatory_applications.unwrap_or_default(),
+            close_chain: config.close_chain.unwrap_or_default(),
+        }
     }
 }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -150,7 +150,11 @@ impl Runnable for Job {
                 let (message_id, certificate) = context
                     .apply_client_command(&chain_client, |mut chain_client| {
                         let ownership = ChainOwnership::single(new_public_key);
-                        async move { chain_client.open_chain(ownership, balance).await }
+                        async move {
+                            chain_client
+                                .open_chain(ownership, ApplicationPermissions::default(), balance)
+                                .await
+                        }
                     })
                     .await
                     .context("Failed to open chain")?;
@@ -188,7 +192,11 @@ impl Runnable for Job {
                 let (message_id, certificate) = context
                     .apply_client_command(&chain_client, |mut chain_client| {
                         let ownership = ownership.clone();
-                        async move { chain_client.open_chain(ownership, balance).await }
+                        async move {
+                            chain_client
+                                .open_chain(ownership, ApplicationPermissions::default(), balance)
+                                .await
+                        }
                     })
                     .await
                     .context("Failed to open chain")?;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -385,7 +385,7 @@ where
                 let ownership = ownership.clone();
                 async move {
                     let result = client
-                        .open_chain(ownership, balance)
+                        .open_chain(ownership, ApplicationPermissions::default(), balance)
                         .await
                         .map_err(Error::from)
                         .map(|outcome| outcome.map(|(message_id, _)| message_id));
@@ -402,6 +402,7 @@ where
     async fn open_multi_owner_chain(
         &self,
         chain_id: ChainId,
+        application_permissions: Option<ApplicationPermissions>,
         public_keys: Vec<PublicKey>,
         weights: Option<Vec<u64>>,
         multi_leader_rounds: Option<u32>,
@@ -453,9 +454,10 @@ where
         let message_id = self
             .apply_client_command(&chain_id, move |mut client| {
                 let ownership = ownership.clone();
+                let application_permissions = application_permissions.clone().unwrap_or_default();
                 async move {
                     let result = client
-                        .open_chain(ownership, balance)
+                        .open_chain(ownership, application_permissions, balance)
                         .await
                         .map_err(Error::from)
                         .map(|outcome| outcome.map(|(message_id, _)| message_id));

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2495,15 +2495,18 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     // Open another new chain.
     // This is a regression test; a PR had to be reverted because this was hanging:
     // https://github.com/linera-io/linera-protocol/pull/899
+    // We use openMultiOwnerChain to test that mutation, too, and allow only the fungible app.
+    let raw_app_id = application_id.forget_abi();
     let query = format!(
-        "mutation {{ openChain(\
-            chainId:\"{chain1}\", \
-            publicKey:\"{public_key}\", \
-            balance:\"1\"
+        "mutation {{ openMultiOwnerChain(\
+            chainId: \"{chain1}\", \
+            publicKeys: [\"{public_key}\"], \
+            applicationPermissions: {{ executeOperations: [\"{raw_app_id}\"] }}, \
+            balance: \"1\"
         ) }}"
     );
     let data = node_service.query_node(query).await?;
-    let chain2: ChainId = serde_json::from_value(data["openChain"].clone())?;
+    let chain2: ChainId = serde_json::from_value(data["openMultiOwnerChain"].clone())?;
 
     // Send 8 tokens to the new chain.
     let app1 = FungibleApp(


### PR DESCRIPTION
## Motivation

When opening a new chain, in addition to the chain ownership, users and contracts should be able to configure application permissions: which application's operations and messages are allowed or even mandatory on the new chain, and which applications can close the chain.

## Proposal

Extend the `open-multi-owner-chain` CLI command, the `openMultiOwnerChain` node service mutation, and the `open_chain` system API function.

## Test Plan

Existing tests were extended.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2071.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
