### PR TITLE
Add an assert_before oracle.

### DIFF
--- a/examples/hex-game/src/lib.rs
+++ b/examples/hex-game/src/lib.rs
@@ -129,7 +129,7 @@ pub enum Player {
 
 impl Player {
     /// Returns the opponent of `self`.
-    pub fn other(&self) -> Self {
+    pub fn other(self) -> Self {
         match self {
             Player::One => Player::Two,
             Player::Two => Player::One,

--- a/examples/hex-game/src/lib.rs
+++ b/examples/hex-game/src/lib.rs
@@ -38,6 +38,8 @@ pub struct HexAbi;
 pub enum Operation {
     /// Make a move, and place a stone onto cell `(x, y)`.
     MakeMove { x: u16, y: u16 },
+    /// Claim victory if the opponent has timed out.
+    ClaimVictory,
 }
 
 impl ContractAbi for HexAbi {
@@ -127,7 +129,7 @@ pub enum Player {
 
 impl Player {
     /// Returns the opponent of `self`.
-    fn other(&self) -> Self {
+    pub fn other(&self) -> Self {
         match self {
             Player::One => Player::Two,
             Player::Two => Player::One,

--- a/examples/hex-game/src/state.rs
+++ b/examples/hex-game/src/state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_graphql::SimpleObject;
-use hex_game::Board;
+use hex_game::{Board, Clock};
 use linera_sdk::{
     base::Owner,
     views::{linera_views, RegisterView, RootView, ViewStorageContext},
@@ -16,4 +16,6 @@ pub struct HexState {
     pub owners: RegisterView<Option<[Owner; 2]>>,
     /// The current game state.
     pub board: RegisterView<Board>,
+    /// The game clock.
+    pub clock: RegisterView<Clock>,
 }

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -5,9 +5,9 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use hex_game::{HexAbi, Operation};
+use hex_game::{HexAbi, InstantiationArgument, Operation};
 use linera_sdk::{
-    base::{KeyPair, Owner},
+    base::{KeyPair, Owner, TimeDelta},
     test::TestValidator,
 };
 
@@ -17,8 +17,15 @@ async fn hex_game() {
     let key_pair2 = KeyPair::generate();
     let owner1 = Owner::from(key_pair1.public());
     let owner2 = Owner::from(key_pair2.public());
+    let arg = InstantiationArgument {
+        players: [owner1, owner2],
+        board_size: 2u16,
+        start_time: TimeDelta::from_secs(60),
+        increment: TimeDelta::from_secs(30),
+        block_delay: TimeDelta::from_secs(5),
+    };
     let (_, app_id, mut chain) =
-        TestValidator::with_current_application::<HexAbi, _, _>((), ([owner1, owner2], 2u16)).await;
+        TestValidator::with_current_application::<HexAbi, _, _>((), arg).await;
 
     chain
         .add_block(|block| {

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -139,4 +139,16 @@ async fn hex_game_clock() {
         })
         .await
         .is_err());
+
+    chain.set_key_pair(key_pair1.copy());
+    chain
+        .add_block(|block| {
+            block
+                .with_operation(app_id, Operation::ClaimVictory)
+                .with_timestamp(time);
+        })
+        .await;
+
+    let response = chain.graphql_query(app_id, "query { winner }").await;
+    assert_eq!(Some("ONE"), response["winner"].as_str());
 }

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -72,3 +72,71 @@ async fn hex_game() {
     let response = chain.graphql_query(app_id, "query { winner }").await;
     assert_eq!(Some("TWO"), response["winner"].as_str());
 }
+
+#[tokio::test]
+async fn hex_game_clock() {
+    let key_pair1 = KeyPair::generate();
+    let key_pair2 = KeyPair::generate();
+    let owner1 = Owner::from(key_pair1.public());
+    let owner2 = Owner::from(key_pair2.public());
+    let arg = InstantiationArgument {
+        players: [owner1, owner2],
+        board_size: 2u16,
+        start_time: TimeDelta::from_secs(60),
+        increment: TimeDelta::from_secs(30),
+        block_delay: TimeDelta::from_secs(5),
+    };
+    let (validator, app_id, mut chain) =
+        TestValidator::with_current_application::<HexAbi, _, _>((), arg.clone()).await;
+
+    chain
+        .add_block(|block| {
+            block.with_owner_change(
+                Vec::new(),
+                vec![(key_pair1.public(), 1), (key_pair2.public(), 1)],
+                100,
+                Default::default(),
+            );
+        })
+        .await;
+
+    let time = validator.clock().current_time();
+    validator
+        .clock()
+        .add(arg.block_delay.saturating_sub(TimeDelta::from_millis(1)));
+
+    chain.set_key_pair(key_pair1.copy());
+    chain
+        .add_block(|block| {
+            block
+                .with_operation(app_id, Operation::MakeMove { x: 0, y: 0 })
+                .with_timestamp(time);
+        })
+        .await;
+
+    validator.clock().add(TimeDelta::from_millis(1));
+
+    // Block timestamp is too far behind.
+    chain.set_key_pair(key_pair2.copy());
+    assert!(chain
+        .try_add_block(|block| {
+            block
+                .with_operation(app_id, Operation::MakeMove { x: 0, y: 1 })
+                .with_timestamp(time);
+        })
+        .await
+        .is_err());
+
+    validator.clock().add(arg.start_time);
+    let time = validator.clock().current_time();
+
+    // Player 2 has timed out.
+    assert!(chain
+        .try_add_block(|block| {
+            block
+                .with_operation(app_id, Operation::MakeMove { x: 0, y: 1 })
+                .with_timestamp(time);
+        })
+        .await
+        .is_err());
+}

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -200,6 +200,11 @@ impl Timestamp {
         Timestamp(self.0.saturating_add(duration.0))
     }
 
+    /// Returns the timestamp that is `duration` earlier than `self`.
+    pub fn saturating_sub(&self, duration: TimeDelta) -> Timestamp {
+        Timestamp(self.0.saturating_sub(duration.0))
+    }
+
     /// Returns a timestamp `micros` microseconds later than `self`, or the highest possible value
     /// if it would overflow.
     pub fn saturating_add_micros(&self, micros: u64) -> Timestamp {
@@ -853,6 +858,7 @@ doc_scalar!(
     Timestamp,
     "A timestamp, in microseconds since the Unix epoch"
 );
+doc_scalar!(TimeDelta, "A duration in microseconds");
 doc_scalar!(
     Round,
     "A number to identify successive attempts to decide a value in a consensus protocol."

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -720,6 +720,8 @@ pub enum OracleResponse {
     Service(Vec<u8>),
     /// The response from an HTTP POST request.
     Post(Vec<u8>),
+    /// An assertion oracle that passed.
+    Assert,
 }
 
 impl fmt::Display for OracleResponse {
@@ -729,6 +731,7 @@ impl fmt::Display for OracleResponse {
                 write!(f, "Service:{}", STANDARD_NO_PAD.encode(bytes))?
             }
             OracleResponse::Post(bytes) => write!(f, "Post:{}", STANDARD_NO_PAD.encode(bytes))?,
+            OracleResponse::Assert => write!(f, "Assert")?,
         };
 
         Ok(())

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -378,10 +378,11 @@ where
         let context = QueryContext {
             chain_id: self.chain_id(),
             next_block_height: self.tip_state.get().next_block_height,
+            local_time,
         };
         let response = self
             .execution_state
-            .query_application(context, local_time, query)
+            .query_application(context, query)
             .await
             .map_err(|error| ChainError::ExecutionError(error, ChainExecutionContext::Query))?;
         Ok(response)

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -370,14 +370,18 @@ where
         self.context().extra().chain_id()
     }
 
-    pub async fn query_application(&mut self, query: Query) -> Result<Response, ChainError> {
+    pub async fn query_application(
+        &mut self,
+        local_time: Timestamp,
+        query: Query,
+    ) -> Result<Response, ChainError> {
         let context = QueryContext {
             chain_id: self.chain_id(),
             next_block_height: self.tip_state.get().next_block_height,
         };
         let response = self
             .execution_state
-            .query_application(context, query)
+            .query_application(context, local_time, query)
             .await
             .map_err(|error| ChainError::ExecutionError(error, ChainExecutionContext::Query))?;
         Ok(response)
@@ -823,6 +827,7 @@ where
                         .execution_state
                         .execute_message(
                             context,
+                            local_time,
                             message.event.message.clone(),
                             (grant > Amount::ZERO).then_some(&mut grant),
                             match &mut oracle_records {
@@ -937,6 +942,7 @@ where
                 .execution_state
                 .execute_operation(
                     context,
+                    local_time,
                     operation.clone(),
                     match &mut oracle_records {
                         Some(records) => Some(

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -129,7 +129,8 @@ where
     /// Queries an application's state on the chain.
     pub async fn query_application(&mut self, query: Query) -> Result<Response, WorkerError> {
         self.ensure_is_active()?;
-        let response = self.chain.query_application(query).await?;
+        let local_time = self.storage.clock().current_time();
+        let response = self.chain.query_application(local_time, query).await?;
         Ok(response)
     }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -429,6 +429,7 @@ where
     creator_state
         .simulate_instantiation(
             contract,
+            Timestamp::from(4),
             application_description,
             initial_value_bytes.clone(),
         )
@@ -484,6 +485,7 @@ where
     creator_state
         .execute_operation(
             operation_context,
+            Timestamp::from(5),
             Operation::User {
                 application_id,
                 bytes: user_operation,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
 use linera_base::{
-    data_types::{Amount, BlockHeight, OracleRecord},
+    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
     identifiers::{Account, ChainId, Destination, Owner},
 };
 use linera_views::{
@@ -52,6 +52,7 @@ where
     pub async fn simulate_instantiation(
         &mut self,
         contract: UserContractCode,
+        local_time: Timestamp,
         application_description: UserApplicationDescription,
         instantiation_argument: Vec<u8>,
     ) -> Result<(), ExecutionError> {
@@ -88,6 +89,7 @@ where
         self.run_user_action(
             application_id,
             chain_id,
+            local_time,
             action,
             context.refund_grant_to(),
             None,
@@ -144,6 +146,7 @@ where
         &mut self,
         application_id: UserApplicationId,
         chain_id: ChainId,
+        local_time: Timestamp,
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
@@ -156,6 +159,7 @@ where
                     self.run_user_action_with_synchronous_runtime(
                         application_id,
                         chain_id,
+                        local_time,
                         action,
                         refund_grant_to,
                         grant,
@@ -176,6 +180,7 @@ where
         &mut self,
         application_id: UserApplicationId,
         chain_id: ChainId,
+        local_time: Timestamp,
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
@@ -199,6 +204,7 @@ where
                 execution_state_sender,
                 application_id,
                 chain_id,
+                local_time,
                 refund_grant_to,
                 controller,
                 action,
@@ -282,6 +288,7 @@ where
     pub async fn execute_operation(
         &mut self,
         context: OperationContext,
+        local_time: Timestamp,
         operation: Operation,
         oracle_record: Option<OracleRecord>,
         resource_controller: &mut ResourceController<Option<Owner>>,
@@ -300,6 +307,7 @@ where
                         .run_user_action(
                             application_id,
                             context.chain_id,
+                            local_time,
                             user_action,
                             context.refund_grant_to(),
                             None,
@@ -319,6 +327,7 @@ where
                 self.run_user_action(
                     application_id,
                     context.chain_id,
+                    local_time,
                     UserAction::Operation(context, bytes),
                     context.refund_grant_to(),
                     None,
@@ -333,6 +342,7 @@ where
     pub async fn execute_message(
         &mut self,
         context: MessageContext,
+        local_time: Timestamp,
         message: Message,
         grant: Option<&mut Amount>,
         oracle_record: Option<OracleRecord>,
@@ -354,6 +364,7 @@ where
                 self.run_user_action(
                     application_id,
                     context.chain_id,
+                    local_time,
                     UserAction::Message(context, bytes),
                     context.refund_grant_to,
                     grant,
@@ -436,6 +447,7 @@ where
     pub async fn query_application(
         &mut self,
         context: QueryContext,
+        local_time: Timestamp,
         query: Query,
     ) -> Result<Response, ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
@@ -450,8 +462,13 @@ where
             } => {
                 let response = match self.context().extra().execution_runtime_config() {
                     ExecutionRuntimeConfig::Synchronous => {
-                        self.query_application_with_sync_runtime(application_id, context, bytes)
-                            .await?
+                        self.query_application_with_sync_runtime(
+                            application_id,
+                            context,
+                            local_time,
+                            bytes,
+                        )
+                        .await?
                     }
                 };
                 Ok(Response::User(response))
@@ -463,12 +480,19 @@ where
         &mut self,
         application_id: UserApplicationId,
         context: QueryContext,
+        local_time: Timestamp,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
         let query_result_future = tokio::task::spawn_blocking(move || {
-            ServiceSyncRuntime::run_query(execution_state_sender, application_id, context, query)
+            ServiceSyncRuntime::run_query(
+                execution_state_sender,
+                application_id,
+                context,
+                local_time,
+                query,
+            )
         });
         while let Some(request) = execution_state_receiver.next().await {
             self.handle_request(request).await?;

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -296,6 +296,8 @@ pub struct QueryContext {
     pub chain_id: ChainId,
     /// The height of the next block on this chain.
     pub next_block_height: BlockHeight,
+    /// The local time in the node executing the query.
+    pub local_time: Timestamp,
 }
 
 pub trait BaseRuntime {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -443,7 +443,7 @@ pub trait BaseRuntime {
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
 
-    /// Panics if the current time at block validation is `>= timestamp`. Note that block
+    /// Ensures that the current time at block validation is `< timestamp`. Note that block
     /// validation happens at or after the block timestamp, but isn't necessarily the same.
     ///
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -149,6 +149,11 @@ pub enum ExecutionError {
     Json(#[from] serde_json::Error),
     #[error("Recorded response for oracle query has the wrong type")]
     OracleResponseMismatch,
+    #[error("Assertion failed: local time {local_time} is not earlier than {timestamp}")]
+    AssertBefore {
+        timestamp: Timestamp,
+        local_time: Timestamp,
+    },
 }
 
 /// The public entry points provided by the contract part of an application.
@@ -435,6 +440,13 @@ pub trait BaseRuntime {
         content_type: String,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError>;
+
+    /// Panics if the current time at block validation is `>= timestamp`. Note that block
+    /// validation happens at or after the block timestamp, but isn't necessarily the same.
+    ///
+    /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
+    /// owner, not a super owner.
+    fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError>;
 }
 
 pub trait ServiceRuntime: BaseRuntime {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -871,10 +871,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         let context = crate::QueryContext {
             chain_id: self.chain_id,
             next_block_height: self.height,
+            local_time: self.local_time,
         };
         let sender = self.execution_state_sender.clone();
-        let response =
-            ServiceSyncRuntime::run_query(sender, application_id, context, self.local_time, query)?;
+        let response = ServiceSyncRuntime::run_query(sender, application_id, context, query)?;
         if let OracleResponses::Record(responses) = &mut self.oracle_responses {
             responses.push(OracleResponse::Service(response.clone()));
         }
@@ -1294,13 +1294,12 @@ impl ServiceSyncRuntime {
         execution_state_sender: ExecutionStateSender,
         application_id: UserApplicationId,
         context: crate::QueryContext,
-        local_time: Timestamp,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let runtime_internal = SyncRuntimeInternal::new(
             context.chain_id,
             context.next_block_height,
-            local_time,
+            context.local_time,
             None,
             0,
             None,
@@ -1337,6 +1336,7 @@ impl ServiceRuntime for ServiceSyncRuntime {
             let query_context = crate::QueryContext {
                 chain_id: this.chain_id,
                 next_block_height: this.height,
+                local_time: this.local_time,
             };
             this.push_application(ApplicationStatus {
                 caller_id: None,

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -7,7 +7,7 @@
 
 use futures::{channel::mpsc, StreamExt};
 use linera_base::{
-    data_types::BlockHeight,
+    data_types::{BlockHeight, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, MessageId},
 };
 use linera_views::batch::Batch;
@@ -93,6 +93,7 @@ fn create_contract_runtime() -> (
     let mut runtime = SyncRuntimeInternal::new(
         chain_id,
         BlockHeight(0),
+        Timestamp::from(0),
         None,
         0,
         None,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -327,8 +327,9 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Panics if the current time at block validation is `>= timestamp`. Note that block
-    /// validation happens at or after the block timestamp, but isn't necessarily the same.
+    /// Rejects the transaction if the current time at block validation is `>= timestamp`. Note
+    /// that block validation happens at or after the block timestamp, but isn't necessarily the
+    /// same.
     fn assert_before(caller: &mut Caller, timestamp: Timestamp) -> Result<(), RuntimeError> {
         caller
             .user_data_mut()

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -327,6 +327,16 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Panics if the current time at block validation is `>= timestamp`. Note that block
+    /// validation happens at or after the block timestamp, but isn't necessarily the same.
+    fn assert_before(caller: &mut Caller, timestamp: Timestamp) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .assert_before(timestamp)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Logs a `message` with the provided information `level`.
     fn log(_caller: &mut Caller, message: String, level: log::Level) -> Result<(), RuntimeError> {
         match level {
@@ -489,6 +499,16 @@ where
             .user_data_mut()
             .runtime
             .http_post(&query, content_type, payload)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Panics if the current time at block validation is `>= timestamp`. Note that block
+    /// validation happens at or after the block timestamp, but isn't necessarily the same.
+    fn assert_before(caller: &mut Caller, timestamp: Timestamp) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .assert_before(timestamp)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -503,7 +503,7 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Panics if the current time at block validation is `>= timestamp`. Note that block
+    /// Aborts the query if the current time at block validation is `>= timestamp`. Note that block
     /// validation happens at or after the block timestamp, but isn't necessarily the same.
     fn assert_before(caller: &mut Caller, timestamp: Timestamp) -> Result<(), RuntimeError> {
         caller

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, vec};
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, OracleRecord},
+    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
@@ -196,6 +196,7 @@ async fn test_fee_consumption(
     let (outcomes, _) = view
         .execute_message(
             context,
+            Timestamp::from(0),
             Message::User {
                 application_id,
                 bytes: vec![],

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -206,11 +206,11 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     let context = QueryContext {
         chain_id: ChainId::root(0),
         next_block_height: BlockHeight(0),
+        local_time: Timestamp::from(0),
     };
     assert_eq!(
         view.query_application(
             context,
-            Timestamp::from(0),
             Query::User {
                 application_id: caller_id,
                 bytes: vec![]

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -54,6 +54,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: *app_id,
                 bytes: vec![],
@@ -149,6 +150,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: dummy_operation.clone(),
@@ -208,6 +210,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
     assert_eq!(
         view.query_application(
             context,
+            Timestamp::from(0),
             Query::User {
                 application_id: caller_id,
                 bytes: vec![]
@@ -301,6 +304,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -401,6 +405,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -441,6 +446,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: id,
                 bytes: vec![],
@@ -511,6 +517,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
     let result = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: first_id,
                 bytes: vec![],
@@ -627,6 +634,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: first_id,
                 bytes: vec![],
@@ -733,6 +741,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -792,6 +801,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
     let result = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -850,6 +860,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
     let result = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -906,6 +917,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
     assert_matches!(
         view.execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -959,6 +971,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id,
                 bytes: vec![],
@@ -1060,6 +1073,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -1175,6 +1189,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -1335,6 +1350,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::User {
                 application_id: caller_id,
                 bytes: vec![],
@@ -1478,6 +1494,7 @@ async fn test_open_chain() {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             operation,
             Some(OracleRecord::default()),
             &mut controller,
@@ -1559,6 +1576,7 @@ async fn test_close_chain() {
     };
     view.execute_operation(
         context,
+        Timestamp::from(0),
         operation,
         Some(OracleRecord::default()),
         &mut controller,
@@ -1572,6 +1590,7 @@ async fn test_close_chain() {
     let operation = SystemOperation::ChangeApplicationPermissions(permissions);
     view.execute_operation(
         context,
+        Timestamp::from(0),
         operation.into(),
         Some(OracleRecord::default()),
         &mut controller,
@@ -1593,6 +1612,7 @@ async fn test_close_chain() {
     };
     view.execute_operation(
         context,
+        Timestamp::from(0),
         operation,
         Some(OracleRecord::default()),
         &mut controller,

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, OracleRecord},
+    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
@@ -40,6 +40,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_operation(
             context,
+            Timestamp::from(0),
             Operation::System(operation),
             Some(OracleRecord::default()),
             &mut controller,
@@ -88,6 +89,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     let (outcomes, _) = view
         .execute_message(
             context,
+            Timestamp::from(0),
             Message::System(message),
             None,
             Some(OracleRecord::default()),
@@ -114,7 +116,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         next_block_height: BlockHeight(0),
     };
     let response = view
-        .query_application(context, Query::System(SystemQuery))
+        .query_application(context, Timestamp::from(0), Query::System(SystemQuery))
         .await
         .unwrap();
     assert_eq!(

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -114,9 +114,10 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
     let context = QueryContext {
         chain_id: ChainId::root(0),
         next_block_height: BlockHeight(0),
+        local_time: Timestamp::from(0),
     };
     let response = view
-        .query_application(context, Timestamp::from(0), Query::System(SystemQuery))
+        .query_application(context, Query::System(SystemQuery))
         .await
         .unwrap();
     assert_eq!(

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, BlockHeight, OracleRecord},
+    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -92,6 +92,7 @@ async fn test_fuel_for_counter_wasm_application(
         let (outcomes, _) = view
             .execute_operation(
                 context,
+                Timestamp::from(0),
                 Operation::user(app_id, increment).unwrap(),
                 Some(OracleRecord::default()),
                 &mut controller,
@@ -129,7 +130,11 @@ async fn test_fuel_for_counter_wasm_application(
     );
     let request = async_graphql::Request::new("query { value }");
     let Response::User(serialized_value) = view
-        .query_application(context, Query::user(app_id, &request).unwrap())
+        .query_application(
+            context,
+            Timestamp::from(0),
+            Query::user(app_id, &request).unwrap(),
+        )
         .await?
     else {
         panic!("unexpected response")

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -123,6 +123,7 @@ async fn test_fuel_for_counter_wasm_application(
     let context = QueryContext {
         chain_id: ChainId::root(0),
         next_block_height: BlockHeight(0),
+        local_time: Timestamp::from(0),
     };
     let expected_value = async_graphql::Response::new(
         async_graphql::Value::from_json(json!({"value" : increments.into_iter().sum::<u64>()}))
@@ -130,11 +131,7 @@ async fn test_fuel_for_counter_wasm_application(
     );
     let request = async_graphql::Request::new("query { value }");
     let Response::User(serialized_value) = view
-        .query_application(
-            context,
-            Timestamp::from(0),
-            Query::user(app_id, &request).unwrap(),
-        )
+        .query_application(context, Query::user(app_id, &request).unwrap())
         .await?
     else {
         panic!("unexpected response")

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -663,6 +663,8 @@ OracleResponse:
       Post:
         NEWTYPE:
           SEQ: U8
+    2:
+      Assert: UNIT
 Origin:
   STRUCT:
     - sender:

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, Resources, SendMessageRequest},
+    data_types::{Amount, BlockHeight, Resources, SendMessageRequest, Timestamp},
     identifiers::{
         Account, ApplicationId, BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner,
     },
@@ -96,6 +96,14 @@ impl From<MessageId> for wit_system_api::MessageId {
             chain_id: message_id.chain_id.into(),
             height: message_id.height.into(),
             index: message_id.index,
+        }
+    }
+}
+
+impl From<Timestamp> for wit_system_api::Timestamp {
+    fn from(timestamp: Timestamp) -> Self {
+        Self {
+            inner0: timestamp.micros(),
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -234,6 +234,15 @@ where
     pub fn http_post(&mut self, url: &str, content_type: &str, payload: Vec<u8>) -> Vec<u8> {
         wit::http_post(url, content_type, &payload)
     }
+
+    /// Panics if the current time at block validation is `>= timestamp`. Note that block
+    /// validation happens at or after the block timestamp, but isn't necessarily the same.
+    ///
+    /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
+    /// owner, not a super owner.
+    pub fn assert_before(&mut self, timestamp: Timestamp) {
+        wit::assert_before(timestamp.into());
+    }
 }
 
 /// A helper type that uses the builder pattern to configure how a message is sent, and then

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -637,6 +637,15 @@ where
         assert_eq!(payload, expected_payload);
         response
     }
+
+    /// Panics if the current time at block validation is `>= timestamp`. Note that block
+    /// validation happens at or after the block timestamp, but isn't necessarily the same.
+    ///
+    /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
+    /// owner, not a super owner.
+    pub fn assert_before(&mut self, timestamp: Timestamp) {
+        assert!(self.timestamp.is_some_and(|t| t < timestamp.into()))
+    }
 }
 
 /// A type alias for the handler for cross-application calls.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -644,7 +644,7 @@ where
     /// Cannot be used in fast blocks: A block using this call should be proposed by a regular
     /// owner, not a super owner.
     pub fn assert_before(&mut self, timestamp: Timestamp) {
-        assert!(self.timestamp.is_some_and(|t| t < timestamp.into()))
+        assert!(self.timestamp.is_some_and(|t| t < timestamp))
     }
 }
 

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -23,6 +23,7 @@ interface contract-system-api {
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
     consume-fuel: func(fuel: u64);
 

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,6 +14,7 @@ interface service-system-api {
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
 
     record amount {

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -24,7 +24,7 @@ use linera_rpc::{
     config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
     simple::TransportProtocol,
 };
-use linera_storage::{Clock, MemoryStorage, Storage, TestClock};
+use linera_storage::{MemoryStorage, Storage, TestClock};
 use linera_views::views::ViewError;
 use rand::SeedableRng as _;
 

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -349,6 +349,11 @@ impl TestClock {
         guard.set(time);
     }
 
+    /// Returns the current time according to the test clock.
+    pub fn current_time(&self) -> Timestamp {
+        self.lock().time
+    }
+
     fn lock(&self) -> std::sync::MutexGuard<TestClockInner> {
         self.0.lock().expect("poisoned TestClock mutex")
     }


### PR DESCRIPTION
## Motivation

The block timestamp itself can be used by contracts to verify that the current block is validated _after_ a certain point.

We should add an oracle (for regular blocks only!), so contracts can call `runtime.assert_before(some_time)`, which will panic if at validation, the current time is not _before_ `some_time`.

## Proposal

Add an `assert_before_ oracle to the service and contract runtime.

## Test Plan

A clock using the oracle was added to the Hex game, and two tests were added.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- Closes #2077.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
