### PR TITLE
Replace certificate chain info query usage with certificate download

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -2,10 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use std::{borrow::Cow, collections::HashSet};
 
 use async_graphql::{Object, SimpleObject};
 use linera_base::{
@@ -62,17 +59,12 @@ pub struct Block {
 }
 
 impl Block {
-    /// Returns all bytecode locations referred to in this block's incoming messages, with the
-    /// sender chain ID.
-    pub fn bytecode_locations(&self) -> HashMap<BytecodeLocation, ChainId> {
-        let mut locations = HashMap::new();
+    /// Returns all bytecode locations referred to in this block's incoming messages.
+    pub fn bytecode_locations(&self) -> HashSet<BytecodeLocation> {
+        let mut locations = HashSet::new();
         for message in &self.incoming_messages {
             if let Message::System(sys_message) = &message.event.message {
-                locations.extend(
-                    sys_message
-                        .bytecode_locations(message.event.certificate_hash)
-                        .map(|location| (location, message.origin.sender)),
-                );
+                locations.extend(sys_message.bytecode_locations(message.event.certificate_hash));
             }
         }
         locations

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -741,10 +741,6 @@ where
             let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;
             info.requested_received_log = self.chain.received_log.read(start..).await?;
         }
-        if let Some(hash) = query.request_hashed_certificate_value {
-            info.requested_hashed_certificate_value =
-                Some(self.storage.read_hashed_certificate_value(hash).await?);
-        }
         if query.request_manager_values {
             info.manager.add_values(self.chain.manager.get());
         }
@@ -858,7 +854,7 @@ where
         // Find all certificates containing bytecode used when executing this block.
         let mut required_locations_left: HashMap<_, _> = block
             .bytecode_locations()
-            .into_keys()
+            .into_iter()
             .map(|bytecode_location| (bytecode_location.certificate_hash, bytecode_location))
             .collect();
         for value in hashed_certificate_values {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -10,9 +10,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_chain::{
-    data_types::{
-        Certificate, ChainAndHeight, HashedCertificateValue, IncomingMessage, Medium, MessageBundle,
-    },
+    data_types::{Certificate, ChainAndHeight, IncomingMessage, Medium, MessageBundle},
     manager::ChainManagerInfo,
     ChainStateView,
 };
@@ -68,8 +66,6 @@ pub struct ChainInfoQuery {
     pub request_leader_timeout: bool,
     /// Include a vote to switch to fallback mode, if appropriate.
     pub request_fallback: bool,
-    /// Query a certificate value that contains a binary blob (e.g. bytecode) required by this chain.
-    pub request_hashed_certificate_value: Option<CryptoHash>,
 }
 
 impl ChainInfoQuery {
@@ -85,7 +81,6 @@ impl ChainInfoQuery {
             request_manager_values: false,
             request_leader_timeout: false,
             request_fallback: false,
-            request_hashed_certificate_value: None,
         }
     }
 
@@ -133,11 +128,6 @@ impl ChainInfoQuery {
         self.request_fallback = true;
         self
     }
-
-    pub fn with_hashed_certificate_value(mut self, hash: CryptoHash) -> Self {
-        self.request_hashed_certificate_value = Some(hash);
-        self
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -173,8 +163,6 @@ pub struct ChainInfo {
     pub count_received_log: usize,
     /// The response to `request_received_certificates_excluding_first_nth`
     pub requested_received_log: Vec<ChainAndHeight>,
-    /// The requested hashed certificate value, if any.
-    pub requested_hashed_certificate_value: Option<HashedCertificateValue>,
 }
 
 /// The response to an `ChainInfoQuery`
@@ -253,7 +241,6 @@ where
             requested_sent_certificates: Vec::new(),
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
-            requested_hashed_certificate_value: None,
         }
     }
 }

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -361,7 +361,6 @@ where
             .storage_client()
             .read_hashed_certificate_value(hash)
             .await
-            .map(Into::into)
             .map_err(Into::into);
         sender.send(certificate_value)
     }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -220,10 +220,10 @@ where
             | CertificateValue::ValidatedBlock { executed_block, .. } => {
                 executed_block.block.bytecode_locations()
             }
-            CertificateValue::Timeout { .. } => HashMap::new(),
+            CertificateValue::Timeout { .. } => HashSet::new(),
         };
         for location in locations {
-            if !required.contains_key(location) {
+            if !required.contains(location) {
                 let hash = location.certificate_hash;
                 warn!("validator requested {:?} but it is not required", hash);
                 return Err(NodeError::InvalidChainInfoResponse);

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -145,9 +145,6 @@ message ChainInfoQuery {
   // Request a signed vote for a leader timeout.
   bool request_leader_timeout = 8;
 
-  // Query a value that contains a binary hashed certificate value (e.g. bytecode) required by this chain.
-  optional bytes request_hashed_certificate_value = 9;
-
   // Query the balance of a given owner.
   optional Owner request_owner_balance = 10;
 

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -356,10 +356,6 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             .request_sent_certificates_in_range
             .map(|range| bincode::deserialize(&range))
             .transpose()?;
-        let request_hashed_certificate_value = chain_info_query
-            .request_hashed_certificate_value
-            .map(|bytes| bincode::deserialize(&bytes))
-            .transpose()?;
 
         Ok(Self {
             request_committees: chain_info_query.request_committees,
@@ -376,7 +372,6 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout: chain_info_query.request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
-            request_hashed_certificate_value,
         })
     }
 }
@@ -388,10 +383,6 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
         let request_sent_certificates_in_range = chain_info_query
             .request_sent_certificates_in_range
             .map(|range| bincode::serialize(&range))
-            .transpose()?;
-        let request_hashed_certificate_value = chain_info_query
-            .request_hashed_certificate_value
-            .map(|hash| bincode::serialize(&hash))
             .transpose()?;
 
         Ok(Self {
@@ -406,7 +397,6 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_manager_values: chain_info_query.request_manager_values,
             request_leader_timeout: chain_info_query.request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
-            request_hashed_certificate_value,
         })
     }
 }
@@ -696,7 +686,6 @@ pub mod tests {
             requested_sent_certificates: vec![],
             count_received_log: 0,
             requested_received_log: vec![],
-            requested_hashed_certificate_value: None,
         });
 
         let chain_info_response_none = ChainInfoResponse {
@@ -733,7 +722,6 @@ pub mod tests {
             request_manager_values: false,
             request_leader_timeout: false,
             request_fallback: true,
-            request_hashed_certificate_value: None,
         };
         round_trip_check::<_, api::ChainInfoQuery>(chain_info_query_some);
     }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -213,9 +213,6 @@ ChainInfo:
     - requested_received_log:
         SEQ:
           TYPENAME: ChainAndHeight
-    - requested_hashed_certificate_value:
-        OPTION:
-          TYPENAME: CertificateValue
 ChainInfoQuery:
   STRUCT:
     - chain_id:
@@ -236,9 +233,6 @@ ChainInfoQuery:
     - request_manager_values: BOOL
     - request_leader_timeout: BOOL
     - request_fallback: BOOL
-    - request_hashed_certificate_value:
-        OPTION:
-          TYPENAME: CryptoHash
 ChainInfoResponse:
   STRUCT:
     - info:


### PR DESCRIPTION
## Motivation

Now that we can download certificates, using the chain info query isn't needed anymore

## Proposal

Use the download certificate entrypoint instead

## Test Plan

CI

