### PR TITLE
Certificate -> CertificateRequest on rpc.proto

### DIFF
--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -23,7 +23,7 @@ service ValidatorWorker {
   rpc HandleLiteCertificate(LiteCertificate) returns (ChainInfoResult);
 
   // Process a certificate.
-  rpc HandleCertificate(Certificate) returns (ChainInfoResult);
+  rpc HandleCertificate(HandleCertificateRequest) returns (ChainInfoResult);
 
   // Handle information queries for this chain.
   rpc HandleChainInfoQuery(ChainInfoQuery) returns (ChainInfoResult);
@@ -41,7 +41,7 @@ service ValidatorNode {
   rpc HandleLiteCertificate(LiteCertificate) returns (ChainInfoResult);
 
   // Process a certificate.
-  rpc HandleCertificate(Certificate) returns (ChainInfoResult);
+  rpc HandleCertificate(HandleCertificateRequest) returns (ChainInfoResult);
 
   // Handle information queries for this chain.
   rpc HandleChainInfoQuery(ChainInfoQuery) returns (ChainInfoResult);
@@ -197,18 +197,9 @@ message LiteCertificate {
 
 // A certified statement from the committee, together with other certificates
 // required for execution.
-message Certificate {
+message HandleCertificateRequest {
   // The ID of the chain (used for routing).
   ChainId chain_id = 1;
-
-  // The certified value
-  bytes value = 2;
-
-  // The round in which the value was certified.
-  bytes round = 3;
-
-  // Signatures on the value hash and round
-  bytes signatures = 4;
 
   // Other certificates containing bytecode required by the first one
   bytes hashed_certificate_values = 5;
@@ -219,6 +210,21 @@ message Certificate {
 
   // Blobs required by this certificate
   bytes blobs = 7;
+
+  // A certified statement from the committee.
+  Certificate certificate = 8;
+}
+
+// A certified statement from the committee.
+message Certificate {
+  // The certified value
+  bytes value = 1;
+
+  // The round in which the value was certified.
+  bytes round = 2;
+
+  // Signatures on the value hash and round
+  bytes signatures = 3;
 }
 
 message CertificateValue {

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -310,21 +310,22 @@ impl<'a> TryFrom<HandleLiteCertRequest<'a>> for api::LiteCertificate {
     }
 }
 
-impl TryFrom<api::Certificate> for HandleCertificateRequest {
+impl TryFrom<api::HandleCertificateRequest> for HandleCertificateRequest {
     type Error = GrpcProtoConversionError;
 
-    fn try_from(cert_request: api::Certificate) -> Result<Self, Self::Error> {
-        let value: HashedCertificateValue = bincode::deserialize(&cert_request.value)?;
+    fn try_from(cert_request: api::HandleCertificateRequest) -> Result<Self, Self::Error> {
+        let certificate = cert_request
+            .certificate
+            .ok_or(GrpcProtoConversionError::MissingField)?;
+        let value: HashedCertificateValue = bincode::deserialize(&certificate.value)?;
         ensure!(
             Some(value.inner().chain_id().into()) == cert_request.chain_id,
             GrpcProtoConversionError::InconsistentChainId
         );
-        let signatures = bincode::deserialize(&cert_request.signatures)?;
         let values = bincode::deserialize(&cert_request.hashed_certificate_values)?;
         let blobs = bincode::deserialize(&cert_request.blobs)?;
-        let round = bincode::deserialize(&cert_request.round)?;
         Ok(HandleCertificateRequest {
-            certificate: Certificate::new(value, round, signatures),
+            certificate: certificate.try_into()?,
             wait_for_outgoing_messages: cert_request.wait_for_outgoing_messages,
             hashed_certificate_values: values,
             hashed_blobs: blobs,
@@ -332,18 +333,40 @@ impl TryFrom<api::Certificate> for HandleCertificateRequest {
     }
 }
 
-impl TryFrom<HandleCertificateRequest> for api::Certificate {
+impl TryFrom<HandleCertificateRequest> for api::HandleCertificateRequest {
     type Error = GrpcProtoConversionError;
 
     fn try_from(request: HandleCertificateRequest) -> Result<Self, Self::Error> {
         Ok(Self {
             chain_id: Some(request.certificate.value().chain_id().into()),
-            value: bincode::serialize(&request.certificate.value)?,
-            round: bincode::serialize(&request.certificate.round)?,
-            signatures: bincode::serialize(request.certificate.signatures())?,
+            certificate: Some(request.certificate.try_into()?),
             hashed_certificate_values: bincode::serialize(&request.hashed_certificate_values)?,
             blobs: bincode::serialize(&request.hashed_blobs)?,
             wait_for_outgoing_messages: request.wait_for_outgoing_messages,
+        })
+    }
+}
+
+impl TryFrom<api::Certificate> for Certificate {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from(certificate: api::Certificate) -> Result<Self, Self::Error> {
+        Ok(Certificate::new(
+            bincode::deserialize(&certificate.value)?,
+            bincode::deserialize(&certificate.round)?,
+            bincode::deserialize(&certificate.signatures)?,
+        ))
+    }
+}
+
+impl TryFrom<Certificate> for api::Certificate {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from(certificate: Certificate) -> Result<Self, Self::Error> {
+        Ok(Self {
+            value: bincode::serialize(&certificate.value)?,
+            round: bincode::serialize(&certificate.round)?,
+            signatures: bincode::serialize(certificate.signatures())?,
         })
     }
 }
@@ -779,7 +802,7 @@ pub mod tests {
             wait_for_outgoing_messages: false,
         };
 
-        round_trip_check::<_, api::Certificate>(request);
+        round_trip_check::<_, api::HandleCertificateRequest>(request);
     }
 
     #[test]

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -39,8 +39,7 @@ use super::{
         notifier_service_client::NotifierServiceClient,
         validator_worker_client::ValidatorWorkerClient,
         validator_worker_server::{ValidatorWorker as ValidatorWorkerRpc, ValidatorWorkerServer},
-        BlockProposal, Certificate, ChainInfoQuery, ChainInfoResult, CrossChainRequest,
-        LiteCertificate,
+        BlockProposal, ChainInfoQuery, ChainInfoResult, CrossChainRequest, LiteCertificate,
     },
     pool::GrpcConnectionPool,
     GrpcError, GRPC_MAX_MESSAGE_SIZE,
@@ -512,7 +511,7 @@ where
     #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
     async fn handle_certificate(
         &self,
-        request: Request<Certificate>,
+        request: Request<api::HandleCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
         let start = Instant::now();
         let HandleCertificateRequest {
@@ -624,7 +623,7 @@ impl GrpcProxyable for LiteCertificate {
     }
 }
 
-impl GrpcProxyable for Certificate {
+impl GrpcProxyable for api::HandleCertificateRequest {
     fn chain_id(&self) -> Option<ChainId> {
         self.chain_id.clone()?.try_into().ok()
     }

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -27,9 +27,9 @@ use linera_rpc::{
             notifier_service_server::{NotifierService, NotifierServiceServer},
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
-            Blob, BlobId, BlockProposal, Certificate, CertificateValue, ChainInfoQuery,
-            ChainInfoResult, CryptoHash, LiteCertificate, Notification, SubscriptionRequest,
-            VersionInfo,
+            Blob, BlobId, BlockProposal, CertificateValue, ChainInfoQuery, ChainInfoResult,
+            CryptoHash, HandleCertificateRequest, LiteCertificate, Notification,
+            SubscriptionRequest, VersionInfo,
         },
         pool::GrpcConnectionPool,
         GrpcProxyable, GRPC_MAX_MESSAGE_SIZE,
@@ -355,7 +355,7 @@ where
     #[instrument(skip_all, err(Display))]
     async fn handle_certificate(
         &self,
-        request: Request<Certificate>,
+        request: Request<HandleCertificateRequest>,
     ) -> Result<Response<ChainInfoResult>, Status> {
         let (mut client, inner) = self.client_for_proxy_worker(request).await?;
         Self::log_and_return_proxy_request_outcome(


### PR DESCRIPTION
## Motivation

The current proto struct is called `Certificate`, but it isn't really representing that

## Proposal

Rename it to what it actually represents

## Test Plan

CI

