### PR TITLE
Clean-up simple server shutdown

### DIFF
--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -75,21 +75,14 @@ pub trait MessageHandler: Clone {
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage>;
 }
 
-/// The result of spawning a server is oneshot channel to kill it and a handle to track completion.
+/// The result of spawning a server is a handle to track completion.
 pub struct ServerHandle {
-    pub abort: AbortHandle,
     pub handle: tokio::task::JoinHandle<Result<(), std::io::Error>>,
 }
 
 impl ServerHandle {
     pub async fn join(self) -> Result<(), std::io::Error> {
         // Note that dropping `self.complete` would terminate the server.
-        self.handle.await??;
-        Ok(())
-    }
-
-    pub async fn kill(self) -> Result<(), std::io::Error> {
-        self.abort.abort();
         self.handle.await??;
         Ok(())
     }
@@ -172,7 +165,7 @@ impl TransportProtocol {
                 tokio::spawn(Self::run_tcp_server(listener, state, registration))
             }
         };
-        Ok(ServerHandle { abort, handle })
+        Ok(ServerHandle { handle })
     }
 }
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The simple server implementation had a `ServerHandle::kill` method that was never used. It also used a redundant `AbortHandle` for the server task, because `JoinHandle::abort` could be used instead.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Remove the unused `kill` method and the redundant `AbortHandle` channel.

## Test Plan

<!-- How to test that the changes are correct. -->
Removed code that wasn't used, so no extra test coverage is needed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
