### PR TITLE
Refactor usage of `SocketAddr`

### DIFF
--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -139,7 +139,7 @@ where
             "Listening to {:?} traffic on {}:{}",
             self.network.protocol, self.host, self.port
         );
-        let address = format!("{}:{}", self.host, self.port);
+        let address = (self.host.clone(), self.port);
 
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(self.cross_chain_config.queue_size);
@@ -161,7 +161,7 @@ where
             cross_chain_sender,
         };
         // Launch server for the appropriate protocol.
-        protocol.spawn_server(&address, state).await
+        protocol.spawn_server(address, state).await
     }
 }
 

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, io, net::ToSocketAddrs, sync::Arc};
+use std::{collections::HashMap, io, sync::Arc};
 
 use async_trait::async_trait;
 use futures::{
@@ -12,7 +12,7 @@ use futures::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::{
-    net::{TcpListener, TcpStream, UdpSocket},
+    net::{lookup_host, TcpListener, TcpStream, ToSocketAddrs, UdpSocket},
     sync::Mutex,
 };
 use tokio_util::{codec::Framed, udp::UdpFramed};
@@ -111,9 +111,12 @@ impl<T> Transport for T where
 
 impl TransportProtocol {
     /// Creates a transport for this protocol.
-    pub async fn connect(self, address: String) -> Result<impl Transport, std::io::Error> {
-        let mut addresses = address
-            .to_socket_addrs()
+    pub async fn connect(
+        self,
+        address: impl ToSocketAddrs,
+    ) -> Result<impl Transport, std::io::Error> {
+        let mut addresses = lookup_host(address)
+            .await
             .expect("Invalid address to connect to");
         let address = addresses
             .next()

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -155,7 +155,7 @@ impl TransportProtocol {
     /// Runs a server for this protocol and the given message handler.
     pub async fn spawn_server<S>(
         self,
-        address: &str,
+        address: impl ToSocketAddrs,
         state: S,
     ) -> Result<ServerHandle, std::io::Error>
     where
@@ -164,7 +164,7 @@ impl TransportProtocol {
         let (abort, registration) = AbortHandle::new_pair();
         let handle = match self {
             Self::Udp => {
-                let socket = UdpSocket::bind(&address).await?;
+                let socket = UdpSocket::bind(address).await?;
                 tokio::spawn(Self::run_udp_server(socket, state, registration))
             }
             Self::Tcp => {

--- a/linera-service/src/prometheus_server.rs
+++ b/linera-service/src/prometheus_server.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::SocketAddr;
+use std::fmt::Debug;
 
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
+use tokio::net::ToSocketAddrs;
 use tracing::info;
 
-pub fn start_metrics(address: SocketAddr) {
+pub fn start_metrics(address: impl ToSocketAddrs + Debug + Send + 'static) {
     info!("Starting to serve metrics on {:?}", address);
     let prometheus_router = Router::new().route("/metrics", get(serve_metrics));
 

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{path::PathBuf, time::Duration};
+use std::{net::SocketAddr, path::PathBuf, time::Duration};
 
 use anyhow::{bail, Result};
 use async_trait::async_trait;
@@ -15,6 +15,8 @@ use linera_rpc::{
     simple::{MessageHandler, TransportProtocol},
     RpcMessage,
 };
+#[cfg(with_metrics)]
+use linera_service::prometheus_server;
 use linera_service::{
     config::{GenesisConfig, Import, ValidatorServerConfig},
     grpc_proxy::GrpcProxy,
@@ -24,8 +26,6 @@ use linera_service::{
 use linera_storage::Storage;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
 use tracing::{error, info, instrument};
-#[cfg(with_metrics)]
-use {linera_service::prometheus_server, std::net::SocketAddr};
 
 /// Options for running the proxy.
 #[derive(clap::Parser, Debug, Clone)]
@@ -232,7 +232,7 @@ where
         let address = self.get_listen_address(self.public_config.port);
 
         #[cfg(with_metrics)]
-        Self::start_metrics(&self.get_listen_address(self.internal_config.metrics_port));
+        Self::start_metrics(self.get_listen_address(self.internal_config.metrics_port));
 
         self.public_config
             .protocol
@@ -244,15 +244,12 @@ where
     }
 
     #[cfg(with_metrics)]
-    pub fn start_metrics(address: &String) {
-        match address.parse::<SocketAddr>() {
-            Err(err) => panic!("Invalid metrics address for {address}: {err}"),
-            Ok(address) => prometheus_server::start_metrics(address),
-        }
+    pub fn start_metrics(address: SocketAddr) {
+        prometheus_server::start_metrics(address)
     }
 
-    fn get_listen_address(&self, port: u16) -> String {
-        format!("0.0.0.0:{}", port)
+    fn get_listen_address(&self, port: u16) -> SocketAddr {
+        SocketAddr::from(([0, 0, 0, 0], port))
     }
 
     async fn try_proxy_message(

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -17,6 +17,8 @@ use linera_rpc::{
     },
     grpc, simple,
 };
+#[cfg(with_metrics)]
+use linera_service::prometheus_server;
 use linera_service::{
     config::{
         CommitteeConfig, Export, GenesisConfig, Import, ValidatorConfig, ValidatorServerConfig,
@@ -28,8 +30,6 @@ use linera_storage::Storage;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
 use serde::Deserialize;
 use tracing::{error, info};
-#[cfg(with_metrics)]
-use {linera_service::prometheus_server, std::net::SocketAddr};
 
 struct ServerContext {
     server_config: ValidatorServerConfig,
@@ -160,10 +160,7 @@ impl ServerContext {
 
     #[cfg(with_metrics)]
     fn start_metrics(host: &str, port: u16) {
-        match format!("{}:{}", host, port).parse::<SocketAddr>() {
-            Err(err) => panic!("Invalid metrics address for {host}:{port}: {err}"),
-            Ok(address) => prometheus_server::start_metrics(address),
-        }
+        prometheus_server::start_metrics((host.to_owned(), port));
     }
 
     fn get_listen_address(&self) -> String {

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -84,7 +84,7 @@ impl ServerContext {
             handles.push(async move {
                 #[cfg(with_metrics)]
                 if let Some(port) = shard.metrics_port {
-                    Self::start_metrics(listen_address, &port);
+                    Self::start_metrics(listen_address, port);
                 }
                 let server = simple::Server::new(
                     internal_network,
@@ -128,7 +128,7 @@ impl ServerContext {
             handles.push(async move {
                 #[cfg(with_metrics)]
                 if let Some(port) = shard.metrics_port {
-                    Self::start_metrics(listen_address, &port);
+                    Self::start_metrics(listen_address, port);
                 }
                 let spawned_server = match grpc::GrpcServer::spawn(
                     listen_address.to_string(),
@@ -159,7 +159,7 @@ impl ServerContext {
     }
 
     #[cfg(with_metrics)]
-    fn start_metrics(host: &str, port: &u16) {
+    fn start_metrics(host: &str, port: u16) {
         match format!("{}:{}", host, port).parse::<SocketAddr>() {
             Err(err) => panic!("Invalid metrics address for {host}:{port}: {err}"),
             Ok(address) => prometheus_server::start_metrics(address),


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The `ToSocketAddrs::to_socket_addrs` function performs a blocking DNS lookup, so it should be avoided inside asynchronous contexts.

Also, there were a few cases where a string was built just to have its parts parsed out again, which is a bit inefficient.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use `tokio::net::lookup_host` instead of `.to_socket_addrs`, because it performs a non-blocking DNS lookup better suited for asynchronous contexts.

Refactor how `SocketAddr`s are built and passed around, to minimize the amount of parsing.

As a consequence of this refactoring, there's a little new feature. The listening address for the metrics server can now be a host name instead of an IP address. This allows using `localhost`, for example.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, and CI should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
