### PR TITLE
Endpoint to download a Certificate

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -87,6 +87,8 @@ pub trait LocalValidatorNode {
         &mut self,
         hash: CryptoHash,
     ) -> Result<HashedCertificateValue, NodeError>;
+
+    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError>;
 }
 
 /// Turn an address into a validator node.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -168,6 +168,13 @@ where
         })
         .await
     }
+
+    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError> {
+        self.spawn_and_receive(move |validator, sender| {
+            validator.do_download_certificate(hash, sender)
+        })
+        .await
+    }
 }
 
 impl<S> LocalValidatorClient<S>
@@ -363,6 +370,23 @@ where
             .await
             .map_err(Into::into);
         sender.send(certificate_value)
+    }
+
+    async fn do_download_certificate(
+        self,
+        hash: CryptoHash,
+        sender: oneshot::Sender<Result<Certificate, NodeError>>,
+    ) -> Result<(), Result<Certificate, NodeError>> {
+        let validator = self.client.lock().await;
+        let certificate = validator
+            .state
+            .storage_client()
+            .read_certificate(hash)
+            .await
+            .map(Into::into)
+            .map_err(Into::into);
+
+        sender.send(certificate)
     }
 }
 

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -57,6 +57,9 @@ service ValidatorNode {
 
   // Downloads a certificate value.
   rpc DownloadCertificateValue(CryptoHash) returns (CertificateValue);
+
+  // Downloads a certificate.
+  rpc DownloadCertificate(CryptoHash) returns (Certificate);
 }
 
 // Information about the Linera crate version the validator is running

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -166,4 +166,13 @@ impl ValidatorNode for Client {
             Client::Simple(simple_client) => simple_client.download_certificate_value(hash).await?,
         })
     }
+
+    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.download_certificate(hash).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.download_certificate(hash).await?,
+        })
+    }
 }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -9,7 +9,7 @@ use linera_base::{
     data_types::{Blob, HashedBlob},
     identifiers::{BlobId, ChainId},
 };
-use linera_chain::data_types::{self, CertificateValue, HashedCertificateValue};
+use linera_chain::data_types::{self, Certificate, CertificateValue, HashedCertificateValue};
 #[cfg(web)]
 use linera_core::node::{
     LocalNotificationStream as NotificationStream, LocalValidatorNode as ValidatorNode,
@@ -165,7 +165,7 @@ impl ValidatorNode for GrpcClient {
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
     async fn handle_certificate(
         &mut self,
-        certificate: data_types::Certificate,
+        certificate: Certificate,
         hashed_certificate_values: Vec<data_types::HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
         delivery: CrossChainMessageDelivery,
@@ -288,6 +288,16 @@ impl ValidatorNode for GrpcClient {
             .into_inner()
             .try_into()?;
         Ok(certificate_value.with_hash_checked(hash)?)
+    }
+
+    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
+    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError> {
+        Ok(self
+            .client
+            .download_certificate(<CryptoHash as Into<api::CryptoHash>>::into(hash))
+            .await?
+            .into_inner()
+            .try_into()?)
     }
 }
 

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -151,6 +151,11 @@ impl ValidatorNode for SimpleClient {
             .await?;
         Ok(certificate_value.with_hash_checked(hash)?)
     }
+
+    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError> {
+        self.query(RpcMessage::DownloadCertificate(Box::new(hash)))
+            .await
+    }
 }
 
 #[derive(Clone)]

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -301,7 +301,9 @@ where
             | RpcMessage::DownloadBlob(_)
             | RpcMessage::DownloadBlobResponse(_)
             | RpcMessage::DownloadCertificateValue(_)
-            | RpcMessage::DownloadCertificateValueResponse(_) => Err(NodeError::UnexpectedMessage),
+            | RpcMessage::DownloadCertificateValueResponse(_)
+            | RpcMessage::DownloadCertificate(_)
+            | RpcMessage::DownloadCertificateResponse(_) => Err(NodeError::UnexpectedMessage),
         };
 
         self.server.packets_processed += 1;

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -766,32 +766,40 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: CryptoHash
     6:
-      VersionInfoQuery: UNIT
+      DownloadCertificate:
+        NEWTYPE:
+          TYPENAME: CryptoHash
     7:
+      VersionInfoQuery: UNIT
+    8:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    8:
+    9:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    9:
+    10:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    10:
+    11:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    11:
+    12:
       DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: Blob
-    12:
+    13:
       DownloadCertificateValueResponse:
         NEWTYPE:
           TYPENAME: CertificateValue
-    13:
+    14:
+      DownloadCertificateResponse:
+        NEWTYPE:
+          TYPENAME: Certificate
+    15:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -27,8 +27,8 @@ use linera_rpc::{
             notifier_service_server::{NotifierService, NotifierServiceServer},
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
-            Blob, BlobId, BlockProposal, CertificateValue, ChainInfoQuery, ChainInfoResult,
-            CryptoHash, HandleCertificateRequest, LiteCertificate, Notification,
+            Blob, BlobId, BlockProposal, Certificate, CertificateValue, ChainInfoQuery,
+            ChainInfoResult, CryptoHash, HandleCertificateRequest, LiteCertificate, Notification,
             SubscriptionRequest, VersionInfo,
         },
         pool::GrpcConnectionPool,
@@ -422,6 +422,21 @@ where
             .0
             .storage
             .read_hashed_certificate_value(hash)
+            .await
+            .map_err(|err| Status::from_error(Box::new(err)))?;
+        Ok(Response::new(certificate.try_into()?))
+    }
+
+    #[instrument(skip_all, err(Display))]
+    async fn download_certificate(
+        &self,
+        request: Request<CryptoHash>,
+    ) -> Result<Response<Certificate>, Status> {
+        let hash = request.into_inner().try_into()?;
+        let certificate = self
+            .0
+            .storage
+            .read_certificate(hash)
             .await
             .map_err(|err| Status::from_error(Box::new(err)))?;
         Ok(Response::new(certificate.try_into()?))

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -301,6 +301,9 @@ where
                     .into_inner()
                     .into(),
             )),
+            DownloadCertificate(hash) => {
+                Ok(Some(self.storage.read_certificate(*hash).await?.into()))
+            }
             BlockProposal(_)
             | LiteCertificate(_)
             | Certificate(_)
@@ -311,7 +314,8 @@ where
             | ChainInfoResponse(_)
             | VersionInfoResponse(_)
             | DownloadBlobResponse(_)
-            | DownloadCertificateValueResponse(_) => {
+            | DownloadCertificateValueResponse(_)
+            | DownloadCertificateResponse(_) => {
                 Err(anyhow::Error::from(NodeError::UnexpectedMessage))
             }
         }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -84,6 +84,10 @@ impl ValidatorNode for DummyValidatorNode {
     ) -> Result<HashedCertificateValue, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
+
+    async fn download_certificate(&mut self, _: CryptoHash) -> Result<Certificate, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
 }
 
 struct DummyValidatorNodeProvider;


### PR DESCRIPTION
## Motivation

There are also cases where we need to be able to download one certificate directly from the Proxy.

## Proposal

Adds an endpoint for downloading a certificate given it's hash

## Test Plan

CI for now, will replace chain info queries in following PR

