### PR TITLE
Replace request_sent_certificates_in_range and use the download of certificates

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -724,7 +724,7 @@ where
 
             info.requested_pending_messages = messages;
         }
-        if let Some(range) = query.request_sent_certificates_in_range {
+        if let Some(range) = query.request_sent_certificate_hashes_in_range {
             let start: usize = range.start.try_into()?;
             let end = match range.limit {
                 None => self.chain.confirmed_log.count(),
@@ -734,8 +734,7 @@ where
                     .min(self.chain.confirmed_log.count()),
             };
             let keys = self.chain.confirmed_log.read(start..end).await?;
-            let certs = self.storage.read_certificates(keys).await?;
-            info.requested_sent_certificates = certs;
+            info.requested_sent_certificate_hashes = keys;
         }
         if let Some(start) = query.request_received_log_excluding_first_nth {
             let start = usize::try_from(start).map_err(|_| ArithmeticError::Overflow)?;

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -10,7 +10,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_chain::{
-    data_types::{Certificate, ChainAndHeight, IncomingMessage, Medium, MessageBundle},
+    data_types::{ChainAndHeight, IncomingMessage, Medium, MessageBundle},
     manager::ChainManagerInfo,
     ChainStateView,
 };
@@ -56,8 +56,8 @@ pub struct ChainInfoQuery {
     pub request_committees: bool,
     /// Query the received messages that are waiting be picked in the next block.
     pub request_pending_messages: bool,
-    /// Query a range of certificates sent from the chain.
-    pub request_sent_certificates_in_range: Option<BlockHeightRange>,
+    /// Query a range of certificate hashes sent from the chain.
+    pub request_sent_certificate_hashes_in_range: Option<BlockHeightRange>,
     /// Query new certificate sender chain IDs and block heights received from the chain.
     pub request_received_log_excluding_first_nth: Option<u64>,
     /// Query values from the chain manager, not just votes.
@@ -76,7 +76,7 @@ impl ChainInfoQuery {
             request_committees: false,
             request_owner_balance: None,
             request_pending_messages: false,
-            request_sent_certificates_in_range: None,
+            request_sent_certificate_hashes_in_range: None,
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
             request_leader_timeout: false,
@@ -104,8 +104,8 @@ impl ChainInfoQuery {
         self
     }
 
-    pub fn with_sent_certificates_in_range(mut self, range: BlockHeightRange) -> Self {
-        self.request_sent_certificates_in_range = Some(range);
+    pub fn with_sent_certificate_hashes_in_range(mut self, range: BlockHeightRange) -> Self {
+        self.request_sent_certificate_hashes_in_range = Some(range);
         self
     }
 
@@ -157,8 +157,8 @@ pub struct ChainInfo {
     pub requested_committees: Option<BTreeMap<Epoch, Committee>>,
     /// The received messages that are waiting be picked in the next block (if requested).
     pub requested_pending_messages: Vec<IncomingMessage>,
-    /// The response to `request_sent_certificates_in_range`
-    pub requested_sent_certificates: Vec<Certificate>,
+    /// The response to `request_sent_certificate_hashes_in_range`
+    pub requested_sent_certificate_hashes: Vec<CryptoHash>,
     /// The current number of received certificates (useful for `request_received_log_excluding_first_nth`)
     pub count_received_log: usize,
     /// The response to `request_received_certificates_excluding_first_nth`
@@ -238,7 +238,7 @@ where
             requested_committees: None,
             requested_owner_balance: None,
             requested_pending_messages: Vec::new(),
-            requested_sent_certificates: Vec::new(),
+            requested_sent_certificate_hashes: Vec::new(),
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
         }

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -136,8 +136,8 @@ message ChainInfoQuery {
   // Query the received messages that are waiting be picked in the next block.
   bool request_pending_messages = 4;
 
-  // Query a range of certificates sent from the chain.
-  optional bytes request_sent_certificates_in_range = 5;
+  // Query a range of certificates hashes sent from the chain.
+  optional bytes request_sent_certificate_hashes_in_range = 5;
 
   // Query new certificate removed from the chain.
   optional uint64 request_received_log_excluding_first_nth = 6;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -375,8 +375,8 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
     type Error = GrpcProtoConversionError;
 
     fn try_from(chain_info_query: api::ChainInfoQuery) -> Result<Self, Self::Error> {
-        let request_sent_certificates_in_range = chain_info_query
-            .request_sent_certificates_in_range
+        let request_sent_certificate_hashes_in_range = chain_info_query
+            .request_sent_certificate_hashes_in_range
             .map(|range| bincode::deserialize(&range))
             .transpose()?;
 
@@ -388,7 +388,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
                 .transpose()?,
             request_pending_messages: chain_info_query.request_pending_messages,
             chain_id: try_proto_convert(chain_info_query.chain_id)?,
-            request_sent_certificates_in_range,
+            request_sent_certificate_hashes_in_range,
             request_received_log_excluding_first_nth: chain_info_query
                 .request_received_log_excluding_first_nth,
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
@@ -403,8 +403,8 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
     type Error = GrpcProtoConversionError;
 
     fn try_from(chain_info_query: ChainInfoQuery) -> Result<Self, Self::Error> {
-        let request_sent_certificates_in_range = chain_info_query
-            .request_sent_certificates_in_range
+        let request_sent_certificate_hashes_in_range = chain_info_query
+            .request_sent_certificate_hashes_in_range
             .map(|range| bincode::serialize(&range))
             .transpose()?;
 
@@ -414,7 +414,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_owner_balance: chain_info_query.request_owner_balance.map(Into::into),
             request_pending_messages: chain_info_query.request_pending_messages,
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
-            request_sent_certificates_in_range,
+            request_sent_certificate_hashes_in_range,
             request_received_log_excluding_first_nth: chain_info_query
                 .request_received_log_excluding_first_nth,
             request_manager_values: chain_info_query.request_manager_values,
@@ -706,7 +706,7 @@ pub mod tests {
             requested_committees: None,
             requested_owner_balance: None,
             requested_pending_messages: vec![],
-            requested_sent_certificates: vec![],
+            requested_sent_certificate_hashes: vec![],
             count_received_log: 0,
             requested_received_log: vec![],
         });
@@ -737,10 +737,12 @@ pub mod tests {
             request_committees: false,
             request_owner_balance: None,
             request_pending_messages: false,
-            request_sent_certificates_in_range: Some(linera_core::data_types::BlockHeightRange {
-                start: BlockHeight::from(3),
-                limit: Some(5),
-            }),
+            request_sent_certificate_hashes_in_range: Some(
+                linera_core::data_types::BlockHeightRange {
+                    start: BlockHeight::from(3),
+                    limit: Some(5),
+                },
+            ),
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
             request_leader_timeout: false,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -206,9 +206,9 @@ ChainInfo:
     - requested_pending_messages:
         SEQ:
           TYPENAME: IncomingMessage
-    - requested_sent_certificates:
+    - requested_sent_certificate_hashes:
         SEQ:
-          TYPENAME: Certificate
+          TYPENAME: CryptoHash
     - count_received_log: U64
     - requested_received_log:
         SEQ:
@@ -225,7 +225,7 @@ ChainInfoQuery:
           TYPENAME: Owner
     - request_committees: BOOL
     - request_pending_messages: BOOL
-    - request_sent_certificates_in_range:
+    - request_sent_certificate_hashes_in_range:
         OPTION:
           TYPENAME: BlockHeightRange
     - request_received_log_excluding_first_nth:


### PR DESCRIPTION
## Motivation

Right now we have `request_sent_certificates_in_range` in the chain info query. We don't need to go all the way to the server to get these certificates.

## Proposal

With the new endpoints, as discussed on Slack, we could modify this to return just the certificate hashes, and then download the certificates from the proxy directly using the new endpoints.

## Test Plan

CI

