### PR TITLE
Parse only `IpAddr` instead of parsing a new string for `SocketAddr`

### DIFF
--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    net::SocketAddr,
+    net::{IpAddr, SocketAddr},
     str::FromStr,
     task::{Context, Poll},
     time::{Duration, Instant},
@@ -191,7 +191,7 @@ where
             host, port, shard_id
         );
 
-        let server_address = SocketAddr::from_str(&format!("{}:{}", host, port))?;
+        let server_address = SocketAddr::from((IpAddr::from_str(&host)?, port));
 
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(cross_chain_config.queue_size);


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The creation of `SocketAddr`s was recently optimized (#2088), but one expression was missed. In the expression, a `String` is built just so that it could be parsed again, instead of parsing just the `IpAddr` and passing the port value directly.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Refactor to only parse the `IpAddr`.

## Test Plan

<!-- How to test that the changes are correct. -->
Internal refactor, so no extra coverage is needed. CI should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
