### PR TITLE
Refactor server spawning to be synchronous and infallible

### DIFF
--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io, time::Duration};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::{channel::mpsc, stream::StreamExt};
@@ -134,7 +134,7 @@ where
         }
     }
 
-    pub async fn spawn(self) -> Result<ServerHandle, io::Error> {
+    pub fn spawn(self) -> ServerHandle {
         info!(
             "Listening to {:?} traffic on {}:{}",
             self.network.protocol, self.host, self.port
@@ -161,7 +161,7 @@ where
             cross_chain_sender,
         };
         // Launch server for the appropriate protocol.
-        protocol.spawn_server(address, state).await
+        protocol.spawn_server(address, state)
     }
 }
 

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -236,8 +236,7 @@ where
 
         self.public_config
             .protocol
-            .spawn_server(&address, self)
-            .await?
+            .spawn_server(address, self)
             .join()
             .await?;
         Ok(())

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -81,11 +81,13 @@ impl ServerContext {
         for (state, shard_id, shard) in states {
             let internal_network = internal_network.clone();
             let cross_chain_config = self.cross_chain_config.clone();
+
+            #[cfg(with_metrics)]
+            if let Some(port) = shard.metrics_port {
+                Self::start_metrics(listen_address, port);
+            }
+
             handles.push(async move {
-                #[cfg(with_metrics)]
-                if let Some(port) = shard.metrics_port {
-                    Self::start_metrics(listen_address, port);
-                }
                 let server = simple::Server::new(
                     internal_network,
                     listen_address.to_string(),
@@ -118,11 +120,13 @@ impl ServerContext {
         for (state, shard_id, shard) in states {
             let cross_chain_config = self.cross_chain_config.clone();
             let notification_config = self.notification_config.clone();
+
+            #[cfg(with_metrics)]
+            if let Some(port) = shard.metrics_port {
+                Self::start_metrics(listen_address, port);
+            }
+
             handles.push(async move {
-                #[cfg(with_metrics)]
-                if let Some(port) = shard.metrics_port {
-                    Self::start_metrics(listen_address, port);
-                }
                 let spawned_server = grpc::GrpcServer::spawn(
                     listen_address.to_string(),
                     shard.port,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -123,7 +123,7 @@ impl ServerContext {
                 if let Some(port) = shard.metrics_port {
                     Self::start_metrics(listen_address, port);
                 }
-                let spawned_server = match grpc::GrpcServer::spawn(
+                let spawned_server = grpc::GrpcServer::spawn(
                     listen_address.to_string(),
                     shard.port,
                     state,
@@ -131,13 +131,7 @@ impl ServerContext {
                     self.server_config.internal_network.clone(),
                     cross_chain_config,
                     notification_config,
-                ) {
-                    Ok(spawned_server) => spawned_server,
-                    Err(err) => {
-                        error!("Failed to start server: {:?}", err);
-                        return;
-                    }
-                };
+                );
                 if let Err(err) = spawned_server.join().await {
                     error!("Server ended with an error: {}", err);
                 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -94,15 +94,8 @@ impl ServerContext {
                     shard_id,
                     cross_chain_config,
                 );
-                let spawned_server = match server.spawn().await {
-                    Ok(server) => server,
-                    Err(err) => {
-                        error!("Failed to start server: {}", err);
-                        return;
-                    }
-                };
-                if let Err(err) = spawned_server.join().await {
-                    error!("Server ended with an error: {}", err);
+                if let Err(err) = server.spawn().join().await {
+                    error!("Error while running server: {}", err);
                 }
             });
         }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -114,9 +114,6 @@ impl ServerContext {
     {
         let mut handles = Vec::new();
         for (state, shard_id, shard) in states {
-            let cross_chain_config = self.cross_chain_config.clone();
-            let notification_config = self.notification_config.clone();
-
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
                 Self::start_metrics(listen_address, port);
@@ -129,8 +126,8 @@ impl ServerContext {
                     state,
                     shard_id,
                     self.server_config.internal_network.clone(),
-                    cross_chain_config,
-                    notification_config,
+                    self.cross_chain_config.clone(),
+                    self.notification_config.clone(),
                 );
                 if let Err(err) = spawned_server.join().await {
                     error!("Server ended with an error: {}", err);

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, time::Duration};
 
 use anyhow::bail;
 use async_trait::async_trait;
-use futures::future::join_all;
+use futures::{future::join_all, FutureExt, TryFutureExt};
 use linera_base::crypto::{CryptoRng, KeyPair};
 use linera_core::worker::WorkerState;
 use linera_execution::{committee::ValidatorName, WasmRuntime, WithWasmDefault};
@@ -80,25 +80,31 @@ impl ServerContext {
         for (state, shard_id, shard) in states {
             let internal_network = internal_network.clone();
             let cross_chain_config = self.cross_chain_config.clone();
+            let listen_address = listen_address.to_owned();
 
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
-                Self::start_metrics(listen_address, port);
+                Self::start_metrics(&listen_address, port);
             }
 
-            handles.push(async move {
-                let server = simple::Server::new(
-                    internal_network,
-                    listen_address.to_string(),
-                    shard.port,
-                    state,
-                    shard_id,
-                    cross_chain_config,
-                );
-                if let Err(err) = server.spawn().join().await {
-                    error!("Error while running server: {}", err);
-                }
-            });
+            let server_handle = simple::Server::new(
+                internal_network,
+                listen_address,
+                shard.port,
+                state,
+                shard_id,
+                cross_chain_config,
+            )
+            .spawn();
+
+            handles.push(
+                server_handle
+                    .join()
+                    .inspect_err(move |error| {
+                        error!("Error running server for shard {shard_id}: {error:?}")
+                    })
+                    .map(|_| ()),
+            );
         }
 
         join_all(handles).await;
@@ -119,20 +125,24 @@ impl ServerContext {
                 Self::start_metrics(listen_address, port);
             }
 
-            handles.push(async move {
-                let spawned_server = grpc::GrpcServer::spawn(
-                    listen_address.to_string(),
-                    shard.port,
-                    state,
-                    shard_id,
-                    self.server_config.internal_network.clone(),
-                    self.cross_chain_config.clone(),
-                    self.notification_config.clone(),
-                );
-                if let Err(err) = spawned_server.join().await {
-                    error!("Server ended with an error: {}", err);
-                }
-            });
+            let server_handle = grpc::GrpcServer::spawn(
+                listen_address.to_string(),
+                shard.port,
+                state,
+                shard_id,
+                self.server_config.internal_network.clone(),
+                self.cross_chain_config.clone(),
+                self.notification_config.clone(),
+            );
+
+            handles.push(
+                server_handle
+                    .join()
+                    .inspect_err(move |error| {
+                        error!("Error running server for shard {shard_id}: {error:?}")
+                    })
+                    .map(|_| ()),
+            );
         }
 
         join_all(handles).await;

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -67,8 +67,7 @@ impl ServerContext {
         listen_address: &str,
         states: Vec<(WorkerState<S>, ShardId, ShardConfig)>,
         protocol: simple::TransportProtocol,
-    ) -> Result<(), anyhow::Error>
-    where
+    ) where
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
@@ -103,16 +102,13 @@ impl ServerContext {
         }
 
         join_all(handles).await;
-
-        Ok(())
     }
 
     async fn spawn_grpc<S>(
         &self,
         listen_address: &str,
         states: Vec<(WorkerState<S>, ShardId, ShardConfig)>,
-    ) -> Result<(), anyhow::Error>
-    where
+    ) where
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
@@ -143,8 +139,6 @@ impl ServerContext {
         }
 
         join_all(handles).await;
-
-        Ok(())
     }
 
     #[cfg(with_metrics)]
@@ -186,10 +180,10 @@ impl Runnable for ServerContext {
 
         match self.server_config.internal_network.protocol {
             NetworkProtocol::Simple(protocol) => {
-                self.spawn_simple(&listen_address, states, protocol).await?
+                self.spawn_simple(&listen_address, states, protocol).await
             }
             NetworkProtocol::Grpc(tls_config) => match tls_config {
-                TlsConfig::ClearText => self.spawn_grpc(&listen_address, states).await?,
+                TlsConfig::ClearText => self.spawn_grpc(&listen_address, states).await,
                 TlsConfig::Tls => bail!("TLS not supported between proxy and shards."),
             },
         };

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -131,9 +131,7 @@ impl ServerContext {
                     self.server_config.internal_network.clone(),
                     cross_chain_config,
                     notification_config,
-                )
-                .await
-                {
+                ) {
                     Ok(spawned_server) => spawned_server,
                     Err(err) => {
                         error!("Failed to start server: {:?}", err);


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
While refactoring to replace `tokio::spawn`s with spawning on `JoinSet`s, I realized it would help if the spawning of servers was synchronous and infallible. That means that the `spawn*` methods only spawn tasks, and do no other work.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Refactor server `spawn*` methods to be infallible and (mostly) synchronous. The `spawn_{grpc,simple}` methods in `linera-service` are still asynchronous but they only `await` the collection of the handles, which can be done in a spawned task as well. However, that requires some further refactoring so that the caller awaits all the tasks, which I left for the next PR.

In terms of functionality, the visible part of the changes is error reporting. Before it would log a separate error message if an error occurred while a task was starting (for example when parsing an IP address or binding to a socket). With this PR, all errors are logged by the same expression which handles any error during the spawn and during the execution.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor. No new coverage is needed and CI should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is an internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
