### PR TITLE
Replace blob chain info query usage with blob download

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -713,9 +713,6 @@ where
             info.requested_hashed_certificate_value =
                 Some(self.storage.read_hashed_certificate_value(hash).await?);
         }
-        if let Some(blob_id) = query.request_blob {
-            info.requested_blob = Some(self.storage.read_hashed_blob(blob_id).await?);
-        }
         if query.request_manager_values {
             info.manager.add_values(self.chain.manager.get());
         }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -748,16 +748,15 @@ where
     async fn find_missing_blobs(
         &self,
         blob_ids: &[BlobId],
-        nodes: &[<P as LocalValidatorNodeProvider>::Node],
+        nodes: &[(ValidatorName, <P as LocalValidatorNodeProvider>::Node)],
     ) -> Vec<HashedBlob> {
         future::join_all(
             blob_ids
                 .iter()
-                .map(|blob_id| LocalNodeClient::<S>::try_download_blob(nodes.to_owned(), *blob_id)),
+                .map(|blob_id| LocalNodeClient::<S>::download_blob(nodes.to_owned(), *blob_id)),
         )
         .await
         .into_iter()
-        .flatten()
         .flatten()
         .collect::<Vec<_>>()
     }
@@ -809,15 +808,7 @@ where
                         .await?;
                 }
                 LocalNodeError::WorkerError(WorkerError::BlobsNotFound(blob_ids)) => {
-                    let blobs = self
-                        .find_missing_blobs(
-                            blob_ids,
-                            &nodes
-                                .into_iter()
-                                .map(|(_name, node)| node)
-                                .collect::<Vec<_>>(),
-                        )
-                        .await;
+                    let blobs = self.find_missing_blobs(blob_ids, &nodes).await;
 
                     ensure!(blobs.len() == blob_ids.len(), err);
                     self.process_certificate(certificate.clone(), vec![], blobs)
@@ -830,15 +821,7 @@ where
                     let values = self
                         .find_missing_application_bytecodes(locations, &nodes, block.chain_id)
                         .await;
-                    let blobs = self
-                        .find_missing_blobs(
-                            blob_ids,
-                            &nodes
-                                .into_iter()
-                                .map(|(_name, node)| node)
-                                .collect::<Vec<_>>(),
-                        )
-                        .await;
+                    let blobs = self.find_missing_blobs(blob_ids, &nodes).await;
 
                     ensure!(
                         blobs.len() == blob_ids.len() && values.len() == locations.len(),

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 
 use linera_base::{
     crypto::{BcsSignable, CryptoError, CryptoHash, KeyPair, Signature},
-    data_types::{Amount, BlockHeight, HashedBlob, Round, Timestamp},
-    identifiers::{BlobId, ChainDescription, ChainId, Owner},
+    data_types::{Amount, BlockHeight, Round, Timestamp},
+    identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_chain::{
     data_types::{
@@ -70,8 +70,6 @@ pub struct ChainInfoQuery {
     pub request_fallback: bool,
     /// Query a certificate value that contains a binary blob (e.g. bytecode) required by this chain.
     pub request_hashed_certificate_value: Option<CryptoHash>,
-    /// Query a binary blob (e.g. bytecode) required by this chain.
-    pub request_blob: Option<BlobId>,
 }
 
 impl ChainInfoQuery {
@@ -88,7 +86,6 @@ impl ChainInfoQuery {
             request_leader_timeout: false,
             request_fallback: false,
             request_hashed_certificate_value: None,
-            request_blob: None,
         }
     }
 
@@ -141,11 +138,6 @@ impl ChainInfoQuery {
         self.request_hashed_certificate_value = Some(hash);
         self
     }
-
-    pub fn with_blob(mut self, blob_id: BlobId) -> Self {
-        self.request_blob = Some(blob_id);
-        self
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -183,8 +175,6 @@ pub struct ChainInfo {
     pub requested_received_log: Vec<ChainAndHeight>,
     /// The requested hashed certificate value, if any.
     pub requested_hashed_certificate_value: Option<HashedCertificateValue>,
-    /// The requested blob, if any.
-    pub requested_blob: Option<HashedBlob>,
 }
 
 /// The response to an `ChainInfoQuery`
@@ -264,7 +254,6 @@ where
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),
             requested_hashed_certificate_value: None,
-            requested_blob: None,
         }
     }
 }

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -687,7 +687,7 @@ where
                 None
             }
             Err(error) => {
-                tracing::debug!("Validator {name} failed to send blob {blob_id}: {error}");
+                tracing::debug!("Failed to fetch blob {blob_id} from validator {name}: {error}");
                 None
             }
         }

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -150,9 +150,6 @@ message ChainInfoQuery {
 
   // Request a signed vote for fallback mode.
   bool request_fallback = 11;
-
-  // Query a value that contains a binary blob (e.g. bytecode) required by this chain.
-  optional bytes request_blob = 12;
 }
 
 // An authenticated proposal for a new block.

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -351,10 +351,6 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             .request_hashed_certificate_value
             .map(|bytes| bincode::deserialize(&bytes))
             .transpose()?;
-        let request_blob = chain_info_query
-            .request_blob
-            .map(|bytes| bincode::deserialize(&bytes))
-            .transpose()?;
 
         Ok(Self {
             request_committees: chain_info_query.request_committees,
@@ -372,7 +368,6 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
             request_leader_timeout: chain_info_query.request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
             request_hashed_certificate_value,
-            request_blob,
         })
     }
 }
@@ -389,10 +384,6 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             .request_hashed_certificate_value
             .map(|hash| bincode::serialize(&hash))
             .transpose()?;
-        let request_blob = chain_info_query
-            .request_blob
-            .map(|blob_id| bincode::serialize(&blob_id))
-            .transpose()?;
 
         Ok(Self {
             chain_id: Some(chain_info_query.chain_id.into()),
@@ -407,7 +398,6 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             request_leader_timeout: chain_info_query.request_leader_timeout,
             request_fallback: chain_info_query.request_fallback,
             request_hashed_certificate_value,
-            request_blob,
         })
     }
 }
@@ -656,7 +646,6 @@ pub mod tests {
             count_received_log: 0,
             requested_received_log: vec![],
             requested_hashed_certificate_value: None,
-            requested_blob: None,
         });
 
         let chain_info_response_none = ChainInfoResponse {
@@ -694,7 +683,6 @@ pub mod tests {
             request_leader_timeout: false,
             request_fallback: true,
             request_hashed_certificate_value: None,
-            request_blob: None,
         };
         round_trip_check::<_, api::ChainInfoQuery>(chain_info_query_some);
     }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -223,9 +223,6 @@ ChainInfo:
     - requested_hashed_certificate_value:
         OPTION:
           TYPENAME: CertificateValue
-    - requested_blob:
-        OPTION:
-          TYPENAME: Blob
 ChainInfoQuery:
   STRUCT:
     - chain_id:
@@ -249,9 +246,6 @@ ChainInfoQuery:
     - request_hashed_certificate_value:
         OPTION:
           TYPENAME: CryptoHash
-    - request_blob:
-        OPTION:
-          TYPENAME: BlobId
 ChainInfoResponse:
   STRUCT:
     - info:

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -100,7 +100,7 @@ pub trait Storage: Sized {
         hash: CryptoHash,
     ) -> Result<HashedCertificateValue, ViewError>;
 
-    /// Reads the blob with the given blob id.
+    /// Reads the blob with the given blob ID.
     async fn read_hashed_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ViewError>;
 
     /// Reads the hashed certificate values in descending order from the given hash.


### PR DESCRIPTION
## Motivation

Now that we can download blobs, using the chain info query isn't needed anymore.

## Proposal

Use the `download_blob` entry point instead, to download the blob directly from the validator proxy.

## Test Plan

Existing tests should catch regressions.

## Links

- Based on @andresilva91's #2079.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
