### PR TITLE
Fix `linera-sdk` docs.rs build (#2064)

### DIFF
--- a/linera-sdk/build.rs
+++ b/linera-sdk/build.rs
@@ -4,5 +4,9 @@
 fn main() {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
+        with_wasm_runtime: { any(feature = "wasmer", feature = "wasmtime") },
+        with_integration_testing: {
+            all(not(target_arch = "wasm32"), with_testing, with_wasm_runtime)
+        },
     };
 }

--- a/linera-sdk/src/bin/wit_generator.rs
+++ b/linera-sdk/src/bin/wit_generator.rs
@@ -3,6 +3,9 @@
 
 //! Generator of WIT files representing the interface between Linera applications and nodes.
 
+#![cfg_attr(target_arch = "wasm32", no_main)]
+#![cfg(not(target_arch = "wasm32"))]
+
 use std::{
     fs::File,
     io::{BufReader, BufWriter, Read, Write},

--- a/linera-sdk/src/ethereum.rs
+++ b/linera-sdk/src/ethereum.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Ethereum support is disabled on SDK v0.11
+#![cfg(not(target_arch = "wasm32"))]
+
 //! Support for Linera applications that interact with Ethereum or other EVM contracts.
 
 use std::fmt::Debug;
@@ -17,8 +20,7 @@ pub struct EthereumClient {
     pub url: String,
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl JsonRpcClient for EthereumClient {
     type Error = ProviderError;
 

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -8,19 +8,19 @@
 //! executed targeting the host architecture, instead of targeting `wasm32-unknown-unknown` like
 //! done for unit tests.
 
-#![cfg(any(with_testing, feature = "wasmer", feature = "wasmtime"))]
+#![cfg(any(with_testing, with_wasm_runtime))]
 
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_integration_testing)]
 mod block;
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_integration_testing)]
 mod chain;
 mod mock_stubs;
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_integration_testing)]
 mod validator;
 
 #[cfg(with_testing)]
 pub use self::mock_stubs::*;
-#[cfg(any(feature = "wasmer", feature = "wasmtime"))]
+#[cfg(with_integration_testing)]
 pub use self::{block::BlockBuilder, chain::ActiveChain, validator::TestValidator};
 use crate::{Contract, ContractRuntime, Service, ServiceRuntime};
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The build on `docs.rs` is [failing](https://docs.rs/crate/linera-sdk/0.11.3/builds/1227306). This was fixed on `main` by #2064, but it should also be fixed in the next patch release of the SDK.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Cherry-pick the fix from `main`, and disable initial support for Ethereum when compiling for `wasm32-unknown-unknown`.

## Test Plan

<!-- How to test that the changes are correct. -->
This now makes `cargo build -p linera-sdk --target wasm32-unknown-unknown` and `cargo build -p linera-sdk --all-features --target wasm32-unknown-unknown` work.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
No functionality has changed except for disabling Ethereum support (which is currently not documented). Nothing is needed except releasing a new patch version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
