### PR TITLE
Enable Kubernetes CI to work in parallel

### DIFF
--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -15,7 +15,7 @@ version.workspace = true
 ethereum = []
 default = ["wasmer", "rocksdb"]
 test = ["linera-views/test", "linera-execution/test"]
-benchmark = ["linera-base/test", "dep:linera-sdk", "dep:port-selector"]
+benchmark = ["linera-base/test", "dep:linera-sdk"]
 wasmer = ["linera-execution/wasmer", "linera-storage/wasmer"]
 wasmtime = ["linera-execution/wasmtime", "linera-storage/wasmtime"]
 rocksdb = [
@@ -71,7 +71,7 @@ linera-storage-service.workspace = true
 linera-version.workspace = true
 linera-views = { workspace = true, features = ["metrics"] }
 pathdiff = { workspace = true, optional = true }
-port-selector = { workspace = true, optional = true }
+port-selector.workspace = true
 prometheus = { workspace = true, optional = true }
 rand.workspace = true
 rcgen.workspace = true

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -26,11 +26,10 @@ use tonic_health::pb::{
     health_check_response::ServingStatus, health_client::HealthClient, HealthCheckRequest,
 };
 use tracing::{info, warn};
+#[cfg(with_testing)]
+use {async_lock::RwLock, linera_base::sync::Lazy};
 #[cfg(all(feature = "rocksdb", with_testing))]
-use {
-    async_lock::RwLock, linera_base::sync::Lazy, linera_views::rocks_db::create_rocks_db_test_path,
-    std::ops::Deref,
-};
+use {linera_views::rocks_db::create_rocks_db_test_path, std::ops::Deref};
 
 use crate::{
     cli_wrappers::{ClientWrapper, LineraNet, LineraNetConfig, Network},

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -121,7 +121,7 @@ pub async fn get_node_port() -> u16 {
     let mut port = PORT_PROVIDER.write().await;
     let port_ret = *port;
     *port += 1;
-    println!("get_node_port returning port_ret={}", port_ret);
+    info!("get_node_port returning port_ret={}", port_ret);
     assert!(port_selector::is_free(port_ret));
     port_ret
 }

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -114,6 +114,20 @@ static LOCAL_SERVER_ROCKS_DB: Lazy<LocalServer<LocalServerRocksDbInternal>> =
     Lazy::new(LocalServer::new);
 
 #[cfg(with_testing)]
+static PORT_PROVIDER: Lazy<RwLock<u16>> = Lazy::new(|| RwLock::new(7080));
+
+/// Provides a port for the node_service. Increment the port numbers.
+#[cfg(with_testing)]
+pub async fn get_node_port() -> u16 {
+    let mut port = PORT_PROVIDER.write().await;
+    let port_ret = *port;
+    *port += 1;
+    println!("get_node_port returning port_ret={}", port_ret);
+    assert!(port_selector::is_free(port_ret));
+    port_ret
+}
+
+#[cfg(with_testing)]
 async fn make_testing_config(database: Database) -> StorageConfig {
     match database {
         Database::Service => {
@@ -432,23 +446,23 @@ impl LocalNet {
     }
 
     pub fn proxy_port(validator: usize) -> usize {
-        9000 + validator * 100
-    }
-
-    fn shard_port(validator: usize, shard: usize) -> usize {
-        9000 + validator * 100 + shard + 1
-    }
-
-    fn internal_port(validator: usize) -> usize {
         10000 + validator * 100
     }
 
-    fn proxy_metrics_port(validator: usize) -> usize {
+    fn shard_port(validator: usize, shard: usize) -> usize {
+        10000 + validator * 100 + shard + 1
+    }
+
+    fn internal_port(validator: usize) -> usize {
         11000 + validator * 100
     }
 
+    fn proxy_metrics_port(validator: usize) -> usize {
+        12000 + validator * 100
+    }
+
     fn shard_metrics_port(validator: usize, shard: usize) -> usize {
-        11000 + validator * 100 + shard + 1
+        12000 + validator * 100 + shard + 1
     }
 
     fn configuration_string(&self, server_number: usize) -> Result<String> {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -369,6 +369,7 @@ impl ClientWrapper {
     /// Runs `linera service`.
     pub async fn run_node_service(&self, port: impl Into<Option<u16>>) -> Result<NodeService> {
         let port = port.into().unwrap_or(8080);
+        tracing::info!("Creating a node service on port={}", port);
         let mut command = self.command().await?;
         command.arg("service");
         if let Ok(var) = env::var(CLIENT_SERVICE_ENV) {

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -13,12 +13,24 @@
 // TODO(#2112): The end-to-end tests are taking a pair `(Database,Network)` which is
 // a relatively rigid structure. We should be able to have tests for mixes of validators.
 
+#[cfg(any(
+    feature = "dynamodb",
+    feature = "scylladb",
+    feature = "storage_service",
+    feature = "remote_net"
+))]
 mod common;
 
 use std::{env, path::PathBuf, time::Duration};
 
 use anyhow::Result;
 use async_graphql::InputType;
+#[cfg(any(
+    feature = "dynamodb",
+    feature = "scylladb",
+    feature = "storage_service",
+    feature = "remote_net"
+))]
 use common::INTEGRATION_TEST_GUARD;
 use futures::{channel::mpsc, SinkExt, StreamExt};
 use linera_base::{

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -10,6 +10,9 @@
     feature = "remote_net"
 ))]
 
+// TODO(#2112): The end-to-end tests are taking a pair `(Database,Network)` which is
+// a relatively rigid structure. We should be able to have tests for mixes of validators.
+
 mod common;
 
 use std::{env, path::PathBuf, time::Duration};
@@ -36,8 +39,8 @@ use linera_service::cli_wrappers::{
     docker::BuildArg, local_kubernetes_net::SharedLocalKubernetesNetTestingConfig,
 };
 use linera_service::cli_wrappers::{
-    local_net::PathProvider, ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet,
-    LineraNetConfig, Network,
+    local_net::{get_node_port, PathProvider},
+    ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
 };
 use serde_json::{json, Value};
 use test_case::test_case;
@@ -450,7 +453,8 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
             None,
         )
         .await?;
-    let node_service = client.run_node_service(None).await?;
+    let port = get_node_port().await;
+    let node_service = client.run_node_service(port).await?;
 
     let app = EthereumTrackerApp(
         node_service
@@ -493,6 +497,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client) = config.instantiate().await?;
@@ -513,7 +518,8 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
             None,
         )
         .await?;
-    let mut node_service = client.run_node_service(None).await?;
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port).await?;
 
     let application = node_service
         .make_application(&chain, &application_id)
@@ -544,7 +550,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
-
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client) = config.instantiate().await?;
@@ -561,7 +567,8 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
     let application_id = client
         .create_application(&bytecode_id, &(), &original_counter_value, &[], None)
         .await?;
-    let mut node_service = client.run_node_service(None).await?;
+    let port = get_node_port().await;
+    let mut node_service = client.run_node_service(port).await?;
 
     let application = node_service
         .make_application(&chain, &application_id)
@@ -594,6 +601,7 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     use std::time::Instant;
 
     use social::SocialAbi;
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client1) = config.instantiate().await?;
@@ -611,8 +619,10 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
         .create_application(&bytecode_id, &(), &(), &[], None)
         .await?;
 
-    let mut node_service1 = client1.run_node_service(8080).await?;
-    let mut node_service2 = client2.run_node_service(8081).await?;
+    let port1 = get_node_port().await;
+    let port2 = get_node_port().await;
+    let mut node_service1 = client1.run_node_service(port1).await?;
+    let mut node_service2 = client2.run_node_service(port2).await?;
 
     node_service1.process_inbox(&chain1).await?;
 
@@ -689,7 +699,7 @@ async fn test_wasm_end_to_end_fungible(
     use std::collections::BTreeMap;
 
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
-
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client1) = config.instantiate().await?;
@@ -728,8 +738,10 @@ async fn test_wasm_end_to_end_fungible(
         )
         .await?;
 
-    let mut node_service1 = client1.run_node_service(8080).await?;
-    let mut node_service2 = client2.run_node_service(8081).await?;
+    let port1 = get_node_port().await;
+    let port2 = get_node_port().await;
+    let mut node_service1 = client1.run_node_service(port1).await?;
+    let mut node_service2 = client2.run_node_service(port2).await?;
 
     let app1 = FungibleApp(
         node_service1
@@ -848,7 +860,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     use std::collections::BTreeMap;
 
     use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
-
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let (mut net, client1) = config.instantiate().await?;
 
@@ -894,7 +906,8 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
         )
         .await?;
 
-    let mut node_service = client1.run_node_service(8080).await?;
+    let port = get_node_port().await;
+    let mut node_service = client1.run_node_service(port).await?;
 
     let app1 = FungibleApp(
         node_service
@@ -968,7 +981,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Result<()> {
     use non_fungible::{NftOutput, NonFungibleTokenAbi};
-
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client1) = config.instantiate().await?;
@@ -989,8 +1002,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
         .publish_and_create::<NonFungibleTokenAbi, (), ()>(contract, service, &(), &(), &[], None)
         .await?;
 
-    let mut node_service1 = client1.run_node_service(8080).await?;
-    let mut node_service2 = client2.run_node_service(8081).await?;
+    let port1 = get_node_port().await;
+    let port2 = get_node_port().await;
+    let mut node_service1 = client1.run_node_service(port1).await?;
+    let mut node_service2 = client2.run_node_service(port2).await?;
 
     let app1 = NonFungibleApp(
         node_service1
@@ -1232,6 +1247,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
     use linera_base::data_types::Timestamp;
 
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client1) = config.instantiate().await?;
@@ -1285,8 +1301,10 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
         )
         .await?;
 
-    let mut node_service1 = client1.run_node_service(8080).await?;
-    let mut node_service2 = client2.run_node_service(8081).await?;
+    let port1 = get_node_port().await;
+    let port2 = get_node_port().await;
+    let mut node_service1 = client1.run_node_service(port1).await?;
+    let mut node_service2 = client2.run_node_service(port2).await?;
 
     let app_fungible1 = FungibleApp(
         node_service1
@@ -1360,7 +1378,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     use std::collections::BTreeMap;
 
     use matching_engine::{MatchingEngineAbi, OrderNature, Parameters, Price};
-
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client_admin) = config.instantiate().await?;
@@ -1420,9 +1438,12 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
         .await?;
 
     // Now creating the service and exporting the applications
-    let mut node_service_admin = client_admin.run_node_service(8080).await?;
-    let mut node_service_a = client_a.run_node_service(8081).await?;
-    let mut node_service_b = client_b.run_node_service(8082).await?;
+    let port1 = get_node_port().await;
+    let port2 = get_node_port().await;
+    let port3 = get_node_port().await;
+    let mut node_service_admin = client_admin.run_node_service(port1).await?;
+    let mut node_service_a = client_a.run_node_service(port2).await?;
+    let mut node_service_b = client_b.run_node_service(port3).await?;
 
     node_service_a
         .request_application(&chain_a, &token1)
@@ -1650,6 +1671,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
 
     use amm::{AmmAbi, Parameters};
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     let (mut net, client_amm) = config.instantiate().await?;
@@ -1676,9 +1698,12 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     let owner0 = get_fungible_account_owner(&client0);
     let owner1 = get_fungible_account_owner(&client1);
 
-    let mut node_service_amm = client_amm.run_node_service(8080).await?;
-    let mut node_service0 = client0.run_node_service(8081).await?;
-    let mut node_service1 = client1.run_node_service(8082).await?;
+    let port1 = get_node_port().await;
+    let port2 = get_node_port().await;
+    let port3 = get_node_port().await;
+    let mut node_service_amm = client_amm.run_node_service(port1).await?;
+    let mut node_service0 = client0.run_node_service(port2).await?;
+    let mut node_service1 = client1.run_node_service(port3).await?;
 
     // Amounts of token0 that will be owned by each user
     let state_fungible0 = fungible::InitialState {
@@ -2398,8 +2423,9 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     let chain_2 = client
         .open_and_assign(&client_2, Amount::from_tokens(3))
         .await?;
+    let port = get_node_port().await;
     let node_service_2 = match network {
-        Network::Grpc => Some(client_2.run_node_service(8081).await?),
+        Network::Grpc => Some(client_2.run_node_service(port).await?),
         Network::Tcp | Network::Udp => None,
     };
 
@@ -2500,7 +2526,10 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
 #[test_log::test(tokio::test)]
 async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
+
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
+
     let (mut net, client) = config.instantiate().await?;
 
     let chain1 = client.load_wallet()?.default_chain().unwrap();
@@ -2531,7 +2560,8 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
         .await
         ?;
 
-    let node_service = client.run_node_service(8080).await?;
+    let port = get_node_port().await;
+    let node_service = client.run_node_service(port).await?;
 
     // Open a new chain with the same public key.
     // The node service should automatically create a client for it internally.
@@ -2625,7 +2655,8 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
     client2.wallet_init(&[chain], FaucetOption::None).await?;
 
     // Listen for updates on root chain 0. There are no blocks on that chain yet.
-    let mut node_service2 = client2.run_node_service(8081).await?;
+    let port = get_node_port().await;
+    let mut node_service2 = client2.run_node_service(port).await?;
     let response = node_service2
         .query_node(format!(
             "query {{ chain(chainId:\"{chain}\") {{ tipState {{ nextBlockHeight }} }} }}"
@@ -2676,6 +2707,7 @@ async fn test_end_to_end_retry_notification_stream(config: LocalNetConfig) -> Re
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create net and two clients.
@@ -2774,7 +2806,8 @@ async fn test_project_publish(database: Database, network: Network) -> Result<()
         .await?;
     let chain = client.load_wallet()?.default_chain().unwrap();
 
-    let node_service = client.run_node_service(None).await?;
+    let port = get_node_port().await;
+    let node_service = client.run_node_service(port).await?;
 
     assert_eq!(
         node_service.try_get_applications_uri(&chain).await?.len(),
@@ -2858,7 +2891,8 @@ async fn test_example_publish(database: Database, network: Network) -> Result<()
         .await?;
     let chain = client.load_wallet()?.default_chain().unwrap();
 
-    let node_service = client.run_node_service(None).await?;
+    let port = get_node_port().await;
+    let node_service = client.run_node_service(port).await?;
 
     assert_eq!(
         node_service.try_get_applications_uri(&chain).await?.len(),
@@ -2878,6 +2912,7 @@ async fn test_example_publish(database: Database, network: Network) -> Result<()
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -2947,6 +2982,8 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::crypto::PublicKey;
+
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and client.
@@ -2987,6 +3024,7 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -3032,6 +3070,7 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -3110,7 +3149,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::command::CommandExt;
     use tokio::process::Command;
-
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
 
     // Create runner and two clients.
@@ -3271,6 +3310,7 @@ impl Drop for RestoreVarOnDrop {
 #[cfg_attr(feature = "remote_net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(not(feature = "kubernetes"))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     use tokio::task::JoinHandle;
 


### PR DESCRIPTION
## Motivation

We want to enable the `LocalNet` in parallel with a shared set of validators. However, PR #2096 has indicated that some protocol issues may have to be resolved. Since PR #2096 was using the same schema for `make_client` it makes sense to enable it for the Kubernetes.

## Proposal

This PR enables the Kubernetes tests to work in parallel by disabling the Mutex `INTEGRATION_TEST_GUARD` for the Kubernetes runs.

This is not sufficient to have the end-to-end tests working in Kubernetes. The node services have to run on disjoint ports. The chosen solution is to remove the `run_node_service(None)` from the end-to-end tests and instead use a `run_node_service(port)` with `port` obtained from a `get_node_port`. That function `get_node_port` returns increasing port numbers starting from `8080`. It is not reasonable to write down the port number explicitly in the code since some tests have several matching `test_case` instances. A random port number exposes us to a potential birthday problem though the probability of collision is very low.

## Test Plan

Only the CI for Kubernetes should be affected by the change.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
