### PR TITLE
Run single validator with Docker Compose

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,25 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build client binary
+        run: |
+          cargo install --path linera-service --bin linera --bin linera-server --debug
       - name: Build Docker image
-        run: docker build . -f docker/Dockerfile
+        run: docker build . -f docker/Dockerfile -t linera-test
+      - name: Run Compose
+        run: cd docker && ./compose.sh &
+      - name: Sync
+        uses: nick-fields/retry@v2
+        with:
+          # Docker compose can take some time to start
+          max_attempts: 5
+          timeout_minutes: 2
+          command: sleep 60 && linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance

--- a/configuration/compose/validator.toml
+++ b/configuration/compose/validator.toml
@@ -1,0 +1,22 @@
+# This is the configuration file for running
+# a single validator in Docker Compose.
+# In Docker Compose, the hostname of a service
+# is the name of the service.
+
+server_config_path = "server.json"
+host = "127.0.0.1"
+port = 19100
+metrics_host = "proxy"
+metrics_port = 21100
+internal_host = "proxy"
+internal_port = 20100
+[external_protocol]
+Grpc = "ClearText"
+[internal_protocol]
+Grpc = "ClearText"
+
+[[shards]]
+host = "shard"
+port = 19100
+metrics_host = "shard"
+metrics_port = 21100

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -111,4 +111,7 @@ COPY --chmod=755 \
     docker/server-entrypoint.sh \
     docker/server-init.sh \
     docker/proxy-init.sh \
+    docker/compose-server-entrypoint.sh \
+    docker/compose-proxy-entrypoint.sh \
+    docker/compose-server-init.sh \
     ./

--- a/docker/compose-proxy-entrypoint.sh
+++ b/docker/compose-proxy-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+while [ ! -f /shared/init_done ]; do
+  echo "waiting for db init"
+  sleep 5
+done
+
+exec ./linera-proxy \
+  --storage scylladb:tcp:scylla:9042 \
+  --genesis /config/genesis.json \
+  /config/server.json

--- a/docker/compose-server-entrypoint.sh
+++ b/docker/compose-server-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while [ ! -f /shared/init_done ]; do
+  echo "waiting for db init"
+  sleep 5
+done
+
+exec ./linera-server run \
+  --storage scylladb:tcp:scylla:9042 \
+  --server /config/server.json \
+  --shard 0 \
+  --genesis /config/genesis.json

--- a/docker/compose-server-init.sh
+++ b/docker/compose-server-init.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+while true; do
+  ./linera-db check_existence --storage "scylladb:tcp:scylla:9042"
+  status=$?
+
+  if [ $status -eq 0 ]; then
+    echo "Database already exists, no need to initialize."
+    exit 0
+  elif [ $status -eq 1 ]; then
+    echo "Database does not exist, attempting to initialize..."
+    if ./linera-server initialize \
+      --storage scylladb:tcp:scylla:9042 \
+      --genesis /config/genesis.json; then
+      echo "Initialization successful."
+      touch /shared/init_done
+      exit 0
+    else
+      echo "Initialization failed, retrying in 5 seconds..."
+      sleep 5
+    fi
+  else
+    echo "An unexpected error occurred (status: $status), retrying in 5 seconds..."
+    sleep 5
+  fi
+done

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+rm -r wallet.json linera.db
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+CONF_DIR=../configuration/compose
+set -xe
+
+# Create configuration files.
+# * Private server states are stored in `server.json`.
+# * `committee.json` is the public description of the Linera committee.
+linera-server generate --validators "$CONF_DIR/validator.toml" --committee committee.json --testing-prng-seed 1
+
+# Create configuration files for 10 user chains.
+# * Private chain states are stored in one local wallet `wallet.json`.
+# * `genesis.json` will contain the initial balances of chains as well as the initial committee.
+
+linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
+
+mv server_1.json server.json
+
+docker compose up

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -1,9 +1,37 @@
 #!/bin/sh
 
-rm -r wallet.json linera.db
-
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-CONF_DIR=../configuration/compose
+ROOT_DIR=$SCRIPT_DIR/..
+CONF_DIR=$ROOT_DIR/configuration/compose
+
+cleanup_started=false
+
+# Clean up hanging volumes when the script is terminated.
+cleanup() {
+  if [ "$cleanup_started" = true ]; then
+      exit 0
+    fi
+  cleanup_started=true
+  rm committee.json
+  rm genesis.json
+  rm -r linera.db
+  rm server.json
+  rm wallet.json
+  SCYLLA_VOLUME=docker_linera-scylla-data
+  SHARED_VOLUME=docker_linera-shared
+  docker rm -f $(docker ps -a -q --filter volume=$SCYLLA_VOLUME)
+  docker volume rm $SCYLLA_VOLUME
+  docker rm -f $(docker ps -a -q --filter volume=$SHARED_VOLUME)
+  docker volume rm $SHARED_VOLUME
+}
+
+trap cleanup EXIT INT
+
+cd "$ROOT_DIR"
+docker build -f docker/Dockerfile . -t linera-test
+
+cd "$SCRIPT_DIR"
+
 set -xe
 
 # Create configuration files.
@@ -16,7 +44,5 @@ linera-server generate --validators "$CONF_DIR/validator.toml" --committee commi
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
 
 linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
-
-mv server_1.json server.json
 
 docker compose up

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR=$SCRIPT_DIR/..

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+services:
+  scylla:
+    image: scylladb/scylla:latest
+    container_name: scylla
+    volumes:
+      - scylla-data:/var/lib/scylla
+    environment:
+      SCYLLA_AUTO_CONF: 1
+      SCYLLA_ENABLE_EXPERIMENTAL: 1
+  proxy:
+    image: linera-test
+    container_name: proxy
+    ports:
+      - "19100:19100"
+    command: [ "./compose-proxy-entrypoint.sh" ]
+    volumes:
+      - .:/config
+      - shared:/shared
+  shard:
+    image: linera-test
+    container_name: shard
+    command: [ "./compose-server-entrypoint.sh" ]
+    volumes:
+      - .:/config
+      - shared:/shared
+    depends_on:
+      - shard-init
+  shard-init:
+    image: linera-test
+    container_name: shard-init
+    command: [ "./compose-server-init.sh" ]
+    volumes:
+      - .:/config
+      - shared:/shared
+    depends_on:
+      - scylla
+
+volumes:
+  scylla-data:
+    driver: local
+  shared: # used for cross-container comms.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: scylladb/scylla:latest
     container_name: scylla
     volumes:
-      - scylla-data:/var/lib/scylla
+      - linera-scylla-data:/var/lib/scylla
     environment:
       SCYLLA_AUTO_CONF: 1
       SCYLLA_ENABLE_EXPERIMENTAL: 1
@@ -16,14 +16,14 @@ services:
     command: [ "./compose-proxy-entrypoint.sh" ]
     volumes:
       - .:/config
-      - shared:/shared
+      - linera-shared:/shared
   shard:
     image: linera-test
     container_name: shard
     command: [ "./compose-server-entrypoint.sh" ]
     volumes:
       - .:/config
-      - shared:/shared
+      - linera-shared:/shared
     depends_on:
       - shard-init
   shard-init:
@@ -32,11 +32,11 @@ services:
     command: [ "./compose-server-init.sh" ]
     volumes:
       - .:/config
-      - shared:/shared
+      - linera-shared:/shared
     depends_on:
       - scylla
 
 volumes:
-  scylla-data:
+  linera-scylla-data:
     driver: local
-  shared: # used for cross-container comms.
+  linera-shared: # used for cross-container comms.


### PR DESCRIPTION
## Motivation

Our reference validator implementation runs with Kubernetes. This may be overkill for certain situtations / usecases.

## Proposal

We now support a lighter validator running on Docker Compose. This doesn't come with all the bells and whistles of the Kubernetes deployment such as observability and monitoring.

There is lot's of room for improvement here:
1. Add faucet for single-validator network
2. Add multiple shards (if it is deemed performant)
3. Add capabilities to join existing network

## Test Plan

Manually tested for now, see above.


