### PR TITLE
Use notification subscriptions in the pub-sub end-to-end test.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2779,7 +2779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cdf7b487d864c2939b23902291a5041bc4a84418268f25fda1c8d4e15ad8fa"
 dependencies = [
  "graphql_query_derive",
- "reqwest 0.11.24",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
 ]
@@ -4140,7 +4140,7 @@ dependencies = [
  "once_cell",
  "oneshot",
  "prometheus",
- "reqwest 0.11.24",
+ "reqwest 0.11.27",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -4171,7 +4171,7 @@ dependencies = [
  "linera-indexer-graphql-client",
  "linera-service-graphql-client",
  "once_cell",
- "reqwest 0.11.24",
+ "reqwest 0.11.27",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
@@ -4204,7 +4204,7 @@ dependencies = [
  "linera-service-graphql-client",
  "linera-version",
  "linera-views",
- "reqwest 0.11.24",
+ "reqwest 0.11.27",
  "thiserror",
  "tokio",
  "tower-http 0.5.2",
@@ -4223,7 +4223,7 @@ dependencies = [
  "linera-indexer-plugins",
  "linera-service",
  "linera-service-graphql-client",
- "reqwest 0.11.24",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tempfile",
@@ -4364,6 +4364,7 @@ dependencies = [
  "async-graphql-axum",
  "async-lock",
  "async-trait",
+ "async-tungstenite",
  "axum 0.7.4",
  "base64 0.22.0",
  "bcs",
@@ -4410,7 +4411,7 @@ dependencies = [
  "proptest",
  "rand",
  "rcgen",
- "reqwest 0.11.24",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "social",
@@ -4443,7 +4444,7 @@ dependencies = [
  "linera-core",
  "linera-execution",
  "linera-service",
- "reqwest 0.11.24",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "tempfile",
@@ -5867,9 +5868,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ async-graphql-axum = "=7.0.2"
 async-graphql-derive = "=7.0.2"
 async-lock = "3.3.0"
 async-trait = "0.1.77"
+async-tungstenite = { version = "0.22", features = ["tokio-runtime"] }
 aws-config = "1.1.7"
 aws-sdk-dynamodb = "1.16.0"
 aws-sdk-s3 = "1.17.0"

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -22,7 +22,7 @@ scylladb = ["linera-views/scylladb", "linera-core/scylladb"]
 async-graphql.workspace = true
 async-graphql-axum.workspace = true
 async-trait.workspace = true
-async-tungstenite = { version = "0.22", features = ["tokio-runtime"] }
+async-tungstenite.workspace = true
 axum = { workspace = true, features = ["ws"] }
 bcs.workspace = true
 clap.workspace = true

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -40,6 +40,7 @@ async-graphql.workspace = true
 async-graphql-axum.workspace = true
 async-lock.workspace = true
 async-trait.workspace = true
+async-tungstenite.workspace = true
 axum = { workspace = true, features = ["ws"] }
 bcs.workspace = true
 cargo_toml.workspace = true


### PR DESCRIPTION
## Motivation

In the end-to-end tests we have several loops that wait for a condition to become true, and use increasing `sleep`s in each iteration. In some cases this is about a node service, where some checks are unnecessary and some `sleep`s are too long: We should check for the condition exactly whenever we receive a notification.

## Proposal

Implement a `notifications` method on the node service wrapper, and use it in the pub-sub test.

## Test Plan

The added code is used in the test.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
