### PR TITLE
Update examples Cargo.lock.

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6227,6 +6227,7 @@ dependencies = [
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
+ "wasmparser 0.121.2",
  "wat",
  "winapi",
 ]


### PR DESCRIPTION
## Motivation

CI on main fails because the examples `Cargo.lock` needs to be updated.

## Proposal

Update it.

## Test Plan

I'm not sure if this was only caught after merging, while the tests on the PR itself were green. `cargo build --locked --release --target wasm32-unknown-unknown` should have caught this. Maybe a dependency was updated?

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
