### PR TITLE
Eliminate the spawning of the storage service in the `cargo test`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,11 +62,10 @@ jobs:
       uses: jetli/wasm-pack-action@v0.4.0
       with:
         version: 'latest'
-
-    - name: Run Ethereum tests
+    - name: Set environment variables
       run: |
-        cargo test -p linera-ethereum --features ethereum
-        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum
+        echo "LINERA_STORAGE_SERVICE=127.0.0.1:1235" >> "$GITHUB_ENV"
+
     - name: Build example applications
       run: |
         cd examples
@@ -84,6 +83,14 @@ jobs:
     - name: Compile the workspace with the default features (build)
       run: |
         cargo build --locked
+    - name: Run Storage Service
+      run: |
+        ./target/debug/storage_service_server memory --endpoint $LINERA_STORAGE_SERVICE &
+        cargo test --features storage_service -- storage_service
+    - name: Run Ethereum tests
+      run: |
+        cargo test -p linera-ethereum --features ethereum
+        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage_service
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -33,7 +33,7 @@ use crate::test_utils::DynamoDbStorageBuilder;
 use crate::test_utils::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
 use crate::test_utils::ScyllaDbStorageBuilder;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "storage_service")]
 use crate::test_utils::ServiceStorageBuilder;
 use crate::{
     client::{ArcChainClient, ChainClientError, ClientOutcome, MessageAction, MessagePolicy},
@@ -48,7 +48,7 @@ use crate::{
 };
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -109,7 +109,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -236,7 +236,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -285,7 +285,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -343,7 +343,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -488,7 +488,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -532,7 +532,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -636,7 +636,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -726,7 +726,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -800,7 +800,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -916,7 +916,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -955,7 +955,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1058,7 +1058,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1107,7 +1107,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1211,7 +1211,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1343,7 +1343,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[test_log::test(tokio::test)]
 async fn test_insufficient_balance<B>(storage_builder: B) -> anyhow::Result<()>
 where
@@ -1396,7 +1396,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1478,7 +1478,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1604,7 +1604,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1715,7 +1715,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
@@ -1760,7 +1760,7 @@ where
 }
 
 #[test_case(MemoryStorageBuilder::default(); "memory")]
-#[cfg_attr(not(target_arch = "wasm32"), test_case(ServiceStorageBuilder::new().await; "service"))]
+#[cfg_attr(feature = "storage_service", test_case(ServiceStorageBuilder::new().await; "storage_service"))]
 #[test_log::test(tokio::test)]
 async fn test_message_policy<B>(storage_builder: B) -> anyhow::Result<()>
 where

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -38,9 +38,9 @@ use crate::client::client_tests::DynamoDbStorageBuilder;
 use crate::client::client_tests::RocksDbStorageBuilder;
 #[cfg(feature = "scylladb")]
 use crate::client::client_tests::ScyllaDbStorageBuilder;
-use crate::client::client_tests::{
-    MemoryStorageBuilder, ServiceStorageBuilder, StorageBuilder, TestBuilder,
-};
+#[cfg(feature = "storage_service")]
+use crate::client::client_tests::ServiceStorageBuilder;
+use crate::client::client_tests::{MemoryStorageBuilder, StorageBuilder, TestBuilder};
 
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
@@ -50,6 +50,7 @@ async fn test_memory_create_application(wasm_runtime: WasmRuntime) -> anyhow::Re
 }
 
 #[ignore]
+#[cfg(feature = "storage_service")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -194,6 +195,7 @@ async fn test_memory_run_application_with_dependency(
 }
 
 #[ignore]
+#[cfg(feature = "storage_service")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -452,6 +454,7 @@ async fn test_memory_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow::R
 }
 
 #[ignore]
+#[cfg(feature = "storage_service")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer ; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime ; "wasmtime"))]
 #[test_log::test(tokio::test)]
@@ -659,6 +662,7 @@ async fn test_memory_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyhow:
 }
 
 #[ignore]
+#[cfg(feature = "storage_service")]
 #[cfg_attr(feature = "wasmer", test_case(WasmRuntime::Wasmer; "wasmer"))]
 #[cfg_attr(feature = "wasmtime", test_case(WasmRuntime::Wasmtime; "wasmtime"))]
 #[test_log::test(tokio::test)]

--- a/linera-indexer/example/tests/test.rs
+++ b/linera-indexer/example/tests/test.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(any(feature = "rocksdb", feature = "dynamodb", feature = "scylladb"))]
+#![cfg(any(
+    feature = "storage_service",
+    feature = "dynamodb",
+    feature = "scylladb"
+))]
 
 use std::{str::FromStr, time::Duration};
 
@@ -82,7 +86,7 @@ const TRANSFER_DELAY_MILLIS: u64 = 1000;
 #[cfg(not(debug_assertions))]
 const TRANSFER_DELAY_MILLIS: u64 = 100;
 
-#[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc); "service_grpc")]
+#[cfg_attr(feature = "storage_service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc); "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[test_log::test(tokio::test)]

--- a/linera-service-graphql-client/tests/test.rs
+++ b/linera-service-graphql-client/tests/test.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(any(feature = "rocksdb", feature = "dynamodb", feature = "scylladb"))]
+#![cfg(any(
+    feature = "storage_service",
+    feature = "dynamodb",
+    feature = "scylladb"
+))]
 
 use std::{collections::BTreeMap, io::Read, str::FromStr, time::Duration};
 
@@ -40,7 +44,7 @@ async fn transfer(client: &reqwest::Client, url: &str, from: ChainId, to: ChainI
         .unwrap();
 }
 
-#[test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc); "service_grpc")]
+#[cfg_attr(feature = "storage_service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc); "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[test_log::test(tokio::test)]

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -32,6 +32,7 @@ scylladb = [
 kubernetes = ["dep:k8s-openapi", "dep:kube", "dep:pathdiff", "dep:fs_extra"]
 remote_net = ["dep:k8s-openapi", "dep:kube"]
 metrics = ["prometheus", "linera-base/metrics"]
+storage_service = []
 
 [dependencies]
 anyhow.workspace = true

--- a/linera-service/src/database_tool.rs
+++ b/linera-service/src/database_tool.rs
@@ -24,9 +24,7 @@ struct DatabaseToolOptions {
 
 #[derive(clap::Parser)]
 enum DatabaseToolCommand {
-    /// Subcommands. Acceptable values are delete_all, delete_single, initialize
-
-    /// Delete all the entries of the database
+    /// Delete all the namespaces of the database
     #[command(name = "delete_all")]
     DeleteAll {
         /// Storage configuration for the blockchain history.
@@ -34,7 +32,7 @@ enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// Delete a single table from the database
+    /// Delete a single namespace from the database
     #[command(name = "delete_namespace")]
     DeleteNamespace {
         /// Storage configuration for the blockchain history.
@@ -42,7 +40,7 @@ enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// Check existence of a database
+    /// Check existence of a namespace in the database
     #[command(name = "check_existence")]
     CheckExistence {
         /// Storage configuration for the blockchain history.
@@ -50,7 +48,7 @@ enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// Check absence of a database
+    /// Check absence of a namespace in the database
     #[command(name = "check_absence")]
     CheckAbsence {
         /// Storage configuration for the blockchain history.
@@ -58,7 +56,7 @@ enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// Initialize a table in the database
+    /// Initialize a namespace in the database
     #[command(name = "initialize")]
     Initialize {
         /// Storage configuration for the blockchain history.
@@ -66,7 +64,7 @@ enum DatabaseToolCommand {
         storage_config: String,
     },
 
-    /// List the tables of the database
+    /// List the namespaces of the database
     #[command(name = "list_namespaces")]
     ListNamespaces {
         /// Storage configuration for the blockchain history.

--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -2,7 +2,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "rocksdb")]
+#![cfg(feature = "storage_service")]
 
 mod common;
 
@@ -22,7 +22,7 @@ use tokio::{process::Command, time::Duration};
 #[test_case::test_case("../examples/meta-counter" ; "meta counter")]
 #[test_case::test_case("../examples/social" ; "social")]
 #[test_log::test(tokio::test)]
-async fn test_script_in_readme(path: &str) -> std::io::Result<()> {
+async fn test_script_in_readme_with_storage_service(path: &str) -> std::io::Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     let script = QuotedBashAndGraphQlScript::from_markdown(
         format!("{path}/README.md"),

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -17,6 +17,7 @@ rocksdb = ["linera-views/rocksdb"]
 dynamodb = ["linera-views/dynamodb"]
 scylladb = ["linera-views/scylladb"]
 test = ["linera-views/test"]
+storage_service = []
 
 [[bin]]
 name = "storage_service_server"

--- a/linera-storage-service/src/lib.rs
+++ b/linera-storage-service/src/lib.rs
@@ -10,6 +10,10 @@ pub mod key_value_store {
     tonic::include_proto!("key_value_store.v1");
 }
 
+pub fn storage_service_test_endpoint() -> anyhow::Result<String> {
+    Ok(std::env::var("LINERA_STORAGE_SERVICE")?)
+}
+
 pub mod child;
 pub mod client;
 pub mod common;

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(feature = "storage_service")]
+
+use anyhow::Result;
 use linera_storage_service::{
     client::{create_service_test_store, service_config_from_endpoint, ServiceStoreClient},
+    storage_service_test_endpoint,
 };
 use linera_views::{
     batch::Batch,
@@ -14,34 +18,43 @@ use linera_views::{
 };
 
 #[tokio::test]
-async fn test_reads_service_store() {
+async fn test_storage_service_reads() -> Result<()> {
+    let endpoint = storage_service_test_endpoint()?;
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
+        let key_value_store = create_service_test_store(&endpoint).await?;
         run_reads(key_value_store, scenario).await;
     }
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_service_store_writes_from_blank() {
-    let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
+async fn test_storage_service_writes_from_blank() -> Result<()> {
+    let endpoint = storage_service_test_endpoint()?;
+    let key_value_store = create_service_test_store(&endpoint).await?;
     run_writes_from_blank(&key_value_store).await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_service_store_writes_from_state() {
-    let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
+async fn test_storage_service_writes_from_state() -> Result<()> {
+    let endpoint = storage_service_test_endpoint()?;
+    let key_value_store = create_service_test_store(&endpoint).await?;
     run_writes_from_state(&key_value_store).await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_service_admin() {
-    let config = service_config_from_endpoint("127.0.0.1:1235").expect("config");
+async fn test_storage_service_admin() -> Result<()> {
+    let endpoint = storage_service_test_endpoint()?;
+    let config = service_config_from_endpoint(&endpoint)?;
     admin_test::<ServiceStoreClient>(&config).await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_service_big_raw_write() {
-    let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
+async fn test_storage_service_big_raw_write() -> Result<()> {
+    let endpoint = storage_service_test_endpoint()?;
+    let key_value_store = create_service_test_store(&endpoint).await?;
     let n = 5000000;
     let mut rng = test_utils::make_deterministic_rng();
     let vector = get_random_byte_vector(&mut rng, &[], n);
@@ -49,4 +62,5 @@ async fn test_service_big_raw_write() {
     let key_prefix = vec![43];
     batch.put_key_value_bytes(vec![43, 57], vector);
     run_test_batch_from_blank(&key_value_store, key_prefix, batch).await;
+    Ok(())
 }

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_storage_service::{
-    child::{get_free_endpoint, StorageService},
     client::{create_service_test_store, service_config_from_endpoint, ServiceStoreClient},
 };
 use linera_views::{
@@ -14,52 +13,35 @@ use linera_views::{
     },
 };
 
-/// The endpoint used for the storage service tests.
-#[cfg(test)]
-fn get_storage_service_guard(endpoint: &str) -> StorageService {
-    let binary = env!("CARGO_BIN_EXE_storage_service_server").to_string();
-    StorageService::new(endpoint, binary)
-}
-
 #[tokio::test]
 async fn test_reads_service_store() {
-    let endpoint = get_free_endpoint().await.unwrap();
     for scenario in get_random_test_scenarios() {
-        let _guard = get_storage_service_guard(&endpoint).run().await;
-        let key_value_store = create_service_test_store(&endpoint).await.unwrap();
+        let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
         run_reads(key_value_store, scenario).await;
     }
 }
 
 #[tokio::test]
 async fn test_service_store_writes_from_blank() {
-    let endpoint = get_free_endpoint().await.unwrap();
-    let _guard = get_storage_service_guard(&endpoint).run().await;
-    let key_value_store = create_service_test_store(&endpoint).await.unwrap();
+    let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
     run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
 async fn test_service_store_writes_from_state() {
-    let endpoint = get_free_endpoint().await.unwrap();
-    let _guard = get_storage_service_guard(&endpoint).run().await;
-    let key_value_store = create_service_test_store(&endpoint).await.unwrap();
+    let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
     run_writes_from_state(&key_value_store).await;
 }
 
 #[tokio::test]
 async fn test_service_admin() {
-    let endpoint = get_free_endpoint().await.unwrap();
-    let _guard = get_storage_service_guard(&endpoint).run().await;
-    let config = service_config_from_endpoint(&endpoint).expect("config");
+    let config = service_config_from_endpoint("127.0.0.1:1235").expect("config");
     admin_test::<ServiceStoreClient>(&config).await;
 }
 
 #[tokio::test]
 async fn test_service_big_raw_write() {
-    let endpoint = get_free_endpoint().await.unwrap();
-    let _guard = get_storage_service_guard(&endpoint).run().await;
-    let key_value_store = create_service_test_store(&endpoint).await.unwrap();
+    let key_value_store = create_service_test_store("127.0.0.1:1235").await.unwrap();
     let n = 5000000;
     let mut rng = test_utils::make_deterministic_rng();
     let vector = get_random_byte_vector(&mut rng, &[], n);


### PR DESCRIPTION
## Motivation

We have worked with the storage service, but it is quite different from other storage systems.

## Proposal

The following is done:
* A feature `storage_service`is introduced. It is used for enabling tests based on storage service.
* The functionality of the storage service is not feature gated, only the tests.
* The practice of spawning a storage service is kept as it is still needed for the `linera net up`.
* The `end_to_end_tests.rs` is restructured. Since RocksDb tests are not enabled, by default, no tests are enabled if no feature is selected.
* The `cargo test` runs locally if only the corresponding witty has been precompiled.
* A storage service is spawned in the CI before running the tests similarly to what is done for `ScyllaDb` and `DynamoDb`.
* The names like `service_grpc` are renamed as `storage_service_grpc` so that it pattern matches the call in the CI.

## Test Plan

The order, the names, and the way tests are called changed, but their nature remains identical.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
