### PR TITLE
`Cargo.lock`: update patched version of `wasmer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8251,7 +8251,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8278,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -8296,7 +8296,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-singlepass"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -8336,7 +8336,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -8347,7 +8347,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -8367,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ checksum = "9547f7f22688f022ea8001bdd57a1fce8996045dcb959b1730a79bafd366a9d9"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
- "darling",
+ "darling 0.20.3",
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
@@ -1193,6 +1193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bzip2-sys"
 version = "0.1.11+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,7 +1938,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f731440b39c73910e253cb465ec1fac97732b3c7af215639881ec0c2a38f4f69"
 dependencies = [
- "darling",
+ "darling 0.20.3",
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
@@ -1939,12 +1948,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1963,11 +1996,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.3",
  "quote",
  "syn 2.0.52",
 ]
@@ -2030,6 +2074,37 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
  "syn 1.0.109",
 ]
 
@@ -2110,10 +2185,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "dynasm"
@@ -2257,7 +2347,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling",
+ "darling 0.20.3",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -2415,6 +2505,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2431,6 +2533,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2702,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3449,7 +3561,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml 0.9.32",
+ "serde_yaml 0.9.34+deprecated",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -3494,9 +3606,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -4635,6 +4747,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -6249,6 +6367,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6326,7 +6469,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb6085ff9c3fd7e5163826901d39164ab86f11bdca16b2f766a00c528ff9cef9"
 dependencies = [
- "darling",
+ "darling 0.20.3",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -6496,10 +6639,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6562,9 +6726,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
  "indexmap 2.2.5",
  "itoa",
@@ -6964,6 +7128,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7283,6 +7458,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
@@ -7309,6 +7496,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.5",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.5.26",
 ]
@@ -7736,9 +7925,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -7755,6 +7944,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -8030,8 +8220,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -8060,8 +8250,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8082,12 +8272,13 @@ dependencies = [
  "wasmer-vm",
  "wasmparser 0.121.2",
  "winapi",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -8104,8 +8295,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -8121,9 +8312,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-config"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a0f70c177b1c5062cfe0f5308c3317751796fef9403c22a0cd7b4cacd4ccd8"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "derive_builder",
+ "hex",
+ "indexmap 2.2.5",
+ "schemars",
+ "semver 1.0.22",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "serde_yaml 0.9.34+deprecated",
+ "thiserror",
+ "toml 0.8.10",
+ "url",
+]
+
+[[package]]
 name = "wasmer-derive"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -8133,23 +8346,28 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
+ "getrandom",
+ "hex",
  "indexmap 1.9.3",
  "more-asserts",
  "rkyv",
+ "sha2 0.10.8",
  "target-lexicon",
  "thiserror",
+ "webc",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#2e48e6bc7b220558d854f3b512d62292e3e0c263"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "cc",
@@ -8465,6 +8683,35 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webc"
+version = "6.0.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fc686c7b43c9bc630a499f6ae1f0a4c4bd656576a53ae8a147b0cc9bc983ad"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bytes",
+ "cfg-if",
+ "document-features",
+ "flate2",
+ "indexmap 1.9.3",
+ "libc",
+ "once_cell",
+ "semver 1.0.22",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "shared-buffer",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "toml 0.7.8",
+ "url",
+ "wasmer-config",
 ]
 
 [[package]]
@@ -9060,10 +9307,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.31",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ wasm-bindgen = "0.2.92"
 wasm-bindgen-test = "0.3.42"
 wasm-encoder = "0.24.1"
 wasm-instrument = "0.4.0"
-wasmer = { version = "4.3.0-alpha.1", default-features = false }
+wasmer = { version = "4.3.1", default-features = false }
 wasmer-compiler-singlepass = "4.3.0-alpha.1"
 wasmparser = "0.101.1"
 wasmtime = "1.0"
@@ -220,6 +220,5 @@ git = "https://github.com/Twey/rust-indexed-db"
 branch = "no-uuid-wasm-bindgen"
 
 [patch.crates-io.wasmer]
-version = "4.3.0-alpha.1"
 git = "https://github.com/Twey/wasmer"
 branch = "non-send-environments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ version = "0.4.1"
 git = "https://github.com/Twey/rust-indexed-db"
 branch = "no-uuid-wasm-bindgen"
 
+
 [patch.crates-io.wasmer]
 git = "https://github.com/Twey/wasmer"
-branch = "non-send-environments"
+tag = "4.3.1-linera"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6387,7 +6387,7 @@ dependencies = [
 [[package]]
 name = "wasmer"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6417,7 +6417,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6444,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-cranelift"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -6462,7 +6462,7 @@ dependencies = [
 [[package]]
 name = "wasmer-compiler-singlepass"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -6502,7 +6502,7 @@ dependencies = [
 [[package]]
 name = "wasmer-derive"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -6513,7 +6513,7 @@ dependencies = [
 [[package]]
 name = "wasmer-types"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytecheck",
  "enum-iterator",
@@ -6533,7 +6533,7 @@ dependencies = [
 [[package]]
 name = "wasmer-vm"
 version = "4.3.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
+source = "git+https://github.com/Twey/wasmer?tag=4.3.1-linera#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "cc",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -699,6 +699,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "c-kzg"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,7 +738,7 @@ checksum = "6f1b20174c1707e20f4cb364a355b449803c03e9b0c9193324623cf9787a4e00"
 dependencies = [
  "byteorder",
  "gemm",
- "half",
+ "half 2.4.1",
  "memmap2 0.9.4",
  "num-traits",
  "num_cpus",
@@ -749,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66a27533c8edfc915a6459f9850641ef523a829fa1a181c670766c1f752d873a"
 dependencies = [
  "candle-core",
- "half",
+ "half 2.4.1",
  "num-traits",
  "rayon",
  "safetensors",
@@ -1400,11 +1409,32 @@ dependencies = [
 
 [[package]]
 name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro 0.12.0",
+]
+
+[[package]]
+name = "derive_builder"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f59169f400d8087f238c5c0c7db6a28af18681717f3b623227d92f397e938c7"
 dependencies = [
- "derive_builder_macro",
+ "derive_builder_macro 0.13.1",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1421,11 +1451,21 @@ dependencies = [
 
 [[package]]
 name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core 0.12.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "870368c3fb35b8031abb378861d4460f573b92238ec2152c927a21f77e3e0127"
 dependencies = [
- "derive_builder_core",
+ "derive_builder_core 0.13.1",
  "syn 1.0.109",
 ]
 
@@ -1485,10 +1525,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "dyn-stack"
@@ -1813,6 +1868,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1829,6 +1896,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2077,7 +2154,7 @@ checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
 dependencies = [
  "bytemuck",
  "dyn-stack",
- "half",
+ "half 2.4.1",
  "num-complex",
  "num-traits",
  "once_cell",
@@ -2098,7 +2175,7 @@ dependencies = [
  "dyn-stack",
  "gemm-common",
  "gemm-f32",
- "half",
+ "half 2.4.1",
  "num-complex",
  "num-traits",
  "paste",
@@ -2220,8 +2297,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2276,6 +2355,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -3531,6 +3616,12 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "llm"
@@ -4948,6 +5039,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.60",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5068,10 +5184,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5117,6 +5254,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5481,6 +5631,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5609,7 +5770,7 @@ version = "0.15.3-dev.0"
 source = "git+https://github.com/christos-h/tokenizers#bd09c18c95ce9191e3a7ca8f5306794d918e166b"
 dependencies = [
  "aho-corasick",
- "derive_builder",
+ "derive_builder 0.13.1",
  "esaxx-rs",
  "fancy-regex",
  "getrandom",
@@ -5720,6 +5881,18 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
@@ -5746,6 +5919,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -6010,6 +6185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6024,6 +6205,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -6204,8 +6386,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -6227,14 +6409,15 @@ dependencies = [
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
+ "wasmparser 0.121.2",
  "wat",
  "winapi",
 ]
 
 [[package]]
 name = "wasmer-compiler"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6255,12 +6438,13 @@ dependencies = [
  "wasmer-vm",
  "wasmparser 0.121.2",
  "winapi",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "cranelift-codegen 0.91.1",
  "cranelift-entity 0.91.1",
@@ -6277,8 +6461,8 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler-singlepass"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "byteorder",
  "dynasm",
@@ -6294,9 +6478,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmer-config"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a0f70c177b1c5062cfe0f5308c3317751796fef9403c22a0cd7b4cacd4ccd8"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "derive_builder 0.12.0",
+ "hex",
+ "indexmap 2.2.6",
+ "schemars",
+ "semver 1.0.22",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "toml 0.8.12",
+ "url",
+]
+
+[[package]]
 name = "wasmer-derive"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "proc-macro-error 1.0.4",
  "proc-macro2",
@@ -6306,23 +6512,28 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "bytecheck",
  "enum-iterator",
  "enumset",
+ "getrandom",
+ "hex",
  "indexmap 1.9.3",
  "more-asserts",
  "rkyv",
+ "sha2 0.10.8",
  "target-lexicon",
  "thiserror",
+ "webc",
+ "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "4.3.0-alpha.1"
-source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#22d085d25f1b1141d22b22938163541efe34cbe7"
+version = "4.3.1"
+source = "git+https://github.com/Twey/wasmer?branch=non-send-environments#1906b166f73b1318ddfc2de1deeab5f55617ee4e"
 dependencies = [
  "backtrace",
  "cc",
@@ -6604,6 +6815,35 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webc"
+version = "6.0.0-rc1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fc686c7b43c9bc630a499f6ae1f0a4c4bd656576a53ae8a147b0cc9bc983ad"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bytes",
+ "cfg-if",
+ "document-features",
+ "flate2",
+ "indexmap 1.9.3",
+ "libc",
+ "once_cell",
+ "semver 1.0.22",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "shared-buffer",
+ "tar",
+ "tempfile",
+ "thiserror",
+ "toml 0.7.8",
+ "url",
+ "wasmer-config",
 ]
 
 [[package]]
@@ -7074,6 +7314,23 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.32",
+]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927da81e25be1e1a2901d59b81b37dd2efd1fc9c9345a55007f09bf5a2d3ee03"
 
 [[package]]
 name = "yoke"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -59,6 +59,5 @@ strip = 'debuginfo'
 debug = true
 
 [patch.crates-io.wasmer]
-version = "4.3.0-alpha.1"
 git = "https://github.com/Twey/wasmer"
 branch = "non-send-environments"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -60,4 +60,4 @@ debug = true
 
 [patch.crates-io.wasmer]
 git = "https://github.com/Twey/wasmer"
-branch = "non-send-environments"
+tag = "4.3.1-linera"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -90,6 +90,5 @@ cfg_aliases.workspace = true
 ignored = ["serde_bytes"]
 
 [patch.crates-io.wasmer]
-version = "4.3.0-alpha.1"
 git = "https://github.com/Twey/wasmer"
 branch = "non-send-environments"

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -91,4 +91,4 @@ ignored = ["serde_bytes"]
 
 [patch.crates-io.wasmer]
 git = "https://github.com/Twey/wasmer"
-branch = "non-send-environments"
+tag = "4.3.1-linera"


### PR DESCRIPTION
## Motivation

Wasmer released 4.3.0 to `crates.io`, breaking our patch.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Update our patched Wasmer to version 4.3.1.  Also, patch without a version constraint to help ensure this doesn't happen again.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
