### PR TITLE
Implement graceful shutdown of server and proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4534,6 +4534,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "toml 0.8.10",
  "tonic",
  "tonic-health",

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -30,7 +30,7 @@ metrics = [
     "linera-views/metrics",
 ]
 
-server = ["tonic-health", "tonic-reflection"]
+server = ["tokio-util", "tonic-health", "tonic-reflection"]
 simple-network = ["tokio-util/net"]
 
 web = [

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -13,6 +13,7 @@ use linera_storage::Storage;
 use linera_views::views::ViewError;
 use rand::Rng;
 use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, warn};
 
 use super::transport::{MessageHandler, ServerHandle, TransportProtocol};
@@ -134,7 +135,7 @@ where
         }
     }
 
-    pub fn spawn(self) -> ServerHandle {
+    pub fn spawn(self, shutdown_signal: CancellationToken) -> ServerHandle {
         info!(
             "Listening to {:?} traffic on {}:{}",
             self.network.protocol, self.host, self.port
@@ -161,7 +162,7 @@ where
             cross_chain_sender,
         };
         // Launch server for the appropriate protocol.
-        protocol.spawn_server(address, state)
+        protocol.spawn_server(address, state, shutdown_signal)
     }
 }
 

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -214,11 +214,9 @@ where
             match server.udp_stream.next().await {
                 Some(Ok((message, peer))) => server.handle_message(message, peer),
                 Some(Err(error)) => server.handle_error(error).await?,
-                None => break,
+                None => unreachable!("`UdpFramed` should never return `None`"),
             }
         }
-
-        Ok(())
     }
 
     /// Creates a [`UpdServer`] bound to the provided `address`, handling messages using the

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -245,7 +245,7 @@ where
             if let Some(reply) = state.handle_message(message).await {
                 if let Some(task) = previous_task {
                     if let Err(error) = task.await {
-                        warn!("Previous task cannot be joined: {}", error);
+                        warn!("Message handler task panicked: {}", error);
                     }
                 }
                 let status = udp_sink.lock().await.send((reply, peer)).await;

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -265,6 +265,7 @@ where
     async fn handle_error(&mut self, error: codec::Error) -> Result<(), std::io::Error> {
         match error {
             codec::Error::Io(io_error) => {
+                error!("IO error in UDP server: {io_error}");
                 self.shutdown().await;
                 Err(io_error)
             }

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -378,7 +378,9 @@ where
                     tokio::spawn(server.serve());
                 }
                 Some(Err(error)) => return Err(error),
-                None => return Ok(()),
+                None => {
+                    unreachable!("The `accept_stream` should never finish unless there's an error")
+                }
             }
         }
     }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -81,6 +81,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tokio-stream.workspace = true
+tokio-util.workspace = true
 toml.workspace = true
 tonic = { workspace = true, features = ["transport", "tls", "tls-roots"] }
 tonic-health.workspace = true

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -229,7 +229,7 @@ where
         info!("Starting gRPC server");
 
         #[cfg(with_metrics)]
-        prometheus_server::start_metrics(self.metrics_address());
+        prometheus_server::start_metrics(self.metrics_address(), shutdown_signal.clone());
 
         let (mut health_reporter, health_service) = tonic_health::server::health_reporter();
         health_reporter

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -56,7 +56,7 @@ pub async fn handle_net_up_kubernetes(
     };
     let (mut net, client1) = config.instantiate().await?;
     net_up(extra_wallets, &mut net, client1).await?;
-    listen_for_signals(shutdown_receiver, &mut net).await
+    wait_for_shutdown(shutdown_receiver, &mut net).await
 }
 
 pub async fn handle_net_up_service(
@@ -105,7 +105,7 @@ pub async fn handle_net_up_service(
     };
     let (mut net, client1) = config.instantiate().await?;
     net_up(extra_wallets, &mut net, client1).await?;
-    listen_for_signals(shutdown_receiver, &mut net).await
+    wait_for_shutdown(shutdown_receiver, &mut net).await
 }
 
 fn handle_signals() -> impl Future<Output = ()> {
@@ -128,7 +128,7 @@ fn handle_signals() -> impl Future<Output = ()> {
     }
 }
 
-async fn listen_for_signals(
+async fn wait_for_shutdown(
     shutdown_receiver: impl Future<Output = ()>,
     net: &mut impl LineraNet,
 ) -> anyhow::Result<()> {

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -235,7 +235,10 @@ where
         let address = self.get_listen_address(self.public_config.port);
 
         #[cfg(with_metrics)]
-        Self::start_metrics(self.get_listen_address(self.internal_config.metrics_port));
+        Self::start_metrics(
+            self.get_listen_address(self.internal_config.metrics_port),
+            shutdown_signal.clone(),
+        );
 
         self.public_config
             .protocol
@@ -246,8 +249,8 @@ where
     }
 
     #[cfg(with_metrics)]
-    pub fn start_metrics(address: SocketAddr) {
-        prometheus_server::start_metrics(address)
+    pub fn start_metrics(address: SocketAddr, shutdown_signal: CancellationToken) {
+        prometheus_server::start_metrics(address, shutdown_signal)
     }
 
     fn get_listen_address(&self, port: u16) -> SocketAddr {

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -25,6 +25,7 @@ use linera_service::{
 };
 use linera_storage::Storage;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
 /// Options for running the proxy.
@@ -236,7 +237,7 @@ where
 
         self.public_config
             .protocol
-            .spawn_server(address, self)
+            .spawn_server(address, self, CancellationToken::new())
             .join()
             .await?;
         Ok(())

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -121,6 +121,7 @@ impl ServerContext {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
+        let shutdown_signal = CancellationToken::new();
         let handles = FuturesUnordered::new();
         for (state, shard_id, shard) in states {
             #[cfg(with_metrics)]
@@ -136,6 +137,7 @@ impl ServerContext {
                 self.server_config.internal_network.clone(),
                 self.cross_chain_config.clone(),
                 self.notification_config.clone(),
+                shutdown_signal.clone(),
             );
 
             handles.push(

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -87,7 +87,7 @@ impl ServerContext {
 
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
-                Self::start_metrics(&listen_address, port);
+                Self::start_metrics(&listen_address, port, shutdown_signal.clone());
             }
 
             let server_handle = simple::Server::new(
@@ -126,7 +126,7 @@ impl ServerContext {
         for (state, shard_id, shard) in states {
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
-                Self::start_metrics(listen_address, port);
+                Self::start_metrics(listen_address, port, shutdown_signal.clone());
             }
 
             let server_handle = grpc::GrpcServer::spawn(
@@ -154,8 +154,8 @@ impl ServerContext {
     }
 
     #[cfg(with_metrics)]
-    fn start_metrics(host: &str, port: u16) {
-        prometheus_server::start_metrics((host.to_owned(), port));
+    fn start_metrics(host: &str, port: u16, shutdown_signal: CancellationToken) {
+        prometheus_server::start_metrics((host.to_owned(), port), shutdown_signal);
     }
 
     fn get_listen_address(&self) -> String {

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -29,6 +29,7 @@ use linera_service::{
 use linera_storage::Storage;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
 use serde::Deserialize;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 struct ServerContext {
@@ -72,6 +73,7 @@ impl ServerContext {
         ViewError: From<S::ContextError>,
     {
         let handles = FuturesUnordered::new();
+        let shutdown_signal = CancellationToken::new();
 
         let internal_network = self
             .server_config
@@ -96,7 +98,7 @@ impl ServerContext {
                 shard_id,
                 cross_chain_config,
             )
-            .spawn();
+            .spawn(shutdown_signal.clone());
 
             handles.push(
                 server_handle

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -12,6 +12,8 @@ use http::Uri;
 #[cfg(test)]
 use linera_base::command::parse_version_message;
 use linera_base::data_types::TimeDelta;
+use tokio::signal::unix;
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
 /// Extension trait for [`tokio::process::Child`].
@@ -31,6 +33,28 @@ impl ChildExt for tokio::process::Child {
         debug!("Child process {:?} is running as expected.", self);
         Ok(())
     }
+}
+
+/// Listens for shutdown signals, and notifies the [`CancellationToken`] if one is
+/// received.
+pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
+    let mut sigint =
+        unix::signal(unix::SignalKind::interrupt()).expect("Failed to set up SIGINT handler");
+    let mut sigterm =
+        unix::signal(unix::SignalKind::terminate()).expect("Failed to set up SIGTERM handler");
+    let mut sigpipe =
+        unix::signal(unix::SignalKind::pipe()).expect("Failed to set up SIGPIPE handler");
+    let mut sighup =
+        unix::signal(unix::SignalKind::hangup()).expect("Failed to set up SIGHUP handler");
+
+    tokio::select! {
+        _ = sigint.recv() => (),
+        _ = sigterm.recv() => (),
+        _ = sigpipe.recv() => (),
+        _ = sighup.recv() => (),
+    }
+
+    shutdown_sender.cancel();
 }
 
 #[cfg(with_testing)]

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -38,6 +38,8 @@ impl ChildExt for tokio::process::Child {
 /// Listens for shutdown signals, and notifies the [`CancellationToken`] if one is
 /// received.
 pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
+    let _shutdown_guard = shutdown_sender.drop_guard();
+
     let mut sigint =
         unix::signal(unix::SignalKind::interrupt()).expect("Failed to set up SIGINT handler");
     let mut sigterm =
@@ -50,8 +52,6 @@ pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
         _ = sigterm.recv() => debug!("Received SIGTERM"),
         _ = sighup.recv() => debug!("Received SIGHUP"),
     }
-
-    shutdown_sender.cancel();
 }
 
 #[cfg(with_testing)]

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -42,15 +42,12 @@ pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
         unix::signal(unix::SignalKind::interrupt()).expect("Failed to set up SIGINT handler");
     let mut sigterm =
         unix::signal(unix::SignalKind::terminate()).expect("Failed to set up SIGTERM handler");
-    let mut sigpipe =
-        unix::signal(unix::SignalKind::pipe()).expect("Failed to set up SIGPIPE handler");
     let mut sighup =
         unix::signal(unix::SignalKind::hangup()).expect("Failed to set up SIGHUP handler");
 
     tokio::select! {
         _ = sigint.recv() => (),
         _ = sigterm.recv() => (),
-        _ = sigpipe.recv() => (),
         _ = sighup.recv() => (),
     }
 

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -46,9 +46,9 @@ pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
         unix::signal(unix::SignalKind::hangup()).expect("Failed to set up SIGHUP handler");
 
     tokio::select! {
-        _ = sigint.recv() => (),
-        _ = sigterm.recv() => (),
-        _ = sighup.recv() => (),
+        _ = sigint.recv() => debug!("Received SIGINT"),
+        _ = sigterm.recv() => debug!("Received SIGTERM"),
+        _ = sighup.recv() => debug!("Received SIGHUP"),
     }
 
     shutdown_sender.cancel();


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When shutting down the server and the proxy, any active connections should be closed gracefully.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Move the code to listen for UNIX signals that indicate the user requested the process to stop from the `linera` binary to the `linera-service` library. Tweak it so that it uses a [`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html) to notify tasks that they should shutdown.

Refactor the simple TCP and UDP servers so that they can gracefully shutdown when requested.

## Test Plan

<!-- How to test that the changes are correct. -->
Issue #2111 tracks implementation of tests for this functionality. I drafted some initial tests in a separate [branch](https://github.com/jvff/linera-protocol/compare/graceful-shutdown..graceful-shutdown-tests#diff-dfc6c0645ad6ae581de82afaec88c92e55b565a53d3437fcf5467f807000e571) and they pass with the current PR.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
The new feature is barely user visible and backwards compatible, so just releasing a new patch version should suffice.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #2095 
