### PR TITLE
Avoid allocating a `String` to parse `SocketAddr`

### DIFF
--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -258,8 +258,7 @@ where
         send_timeout: Duration,
         recv_timeout: Duration,
     ) -> Result<Option<RpcMessage>> {
-        let shard_address = format!("{}:{}", shard.host, shard.port);
-        let mut connection = protocol.connect(shard_address).await?;
+        let mut connection = protocol.connect((shard.host, shard.port)).await?;
         tokio::time::timeout(send_timeout, connection.send(message)).await??;
         let message = tokio::time::timeout(recv_timeout, connection.next())
             .await?


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
I ran into another instance of a `String` allocation just to parse a `SocketAddr`. Some of these cases were removed in previous PRs (#2088, #2093). 

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Parse only the `IpAddr` instead, reusing the port value. This avoids an allocation and parsing of the port value.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor. Existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is an internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
