### PR TITLE
Add metrics to the `storage_service`

### DIFF
--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -13,11 +13,10 @@ version.workspace = true
 
 [features]
 default = ["rocksdb"]
+metrics = ["linera-views/metrics"]
 rocksdb = ["linera-views/rocksdb"]
-dynamodb = ["linera-views/dynamodb"]
-scylladb = ["linera-views/scylladb"]
-test = ["linera-views/test"]
 storage_service = []
+test = ["linera-views/test"]
 
 [[bin]]
 name = "storage_service_server"

--- a/linera-storage-service/build.rs
+++ b/linera-storage-service/build.rs
@@ -4,6 +4,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     cfg_aliases::cfg_aliases! {
         with_testing: { any(test, feature = "test") },
+        with_metrics: { all(not(target_arch = "wasm32"), feature = "metrics") },
     };
     let no_includes: &[&str] = &[];
     tonic_build::configure()

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -550,7 +550,7 @@ impl AdminKeyValueStore for ServiceStoreClient {
         let store = ServiceStoreClientInternal::connect(config, namespace).await?;
         let store = LruCachingStore::new(store, cache_size);
         #[cfg(with_metrics)]
-        let store = MeteredStore::new(&LRU_CACHING_METRICS, store);
+        let store = MeteredStore::new(&STORAGE_SERVICE_METRICS, store);
         Ok(Self { store })
     }
 

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -4,6 +4,8 @@
 use std::path::PathBuf;
 
 use linera_base::command::resolve_binary;
+#[cfg(with_metrics)]
+use linera_views::metering::KeyValueStoreMetrics;
 use linera_views::{
     common::{CommonStoreConfig, MIN_VIEW_TAG},
     value_splitting::DatabaseConsistencyError,
@@ -87,6 +89,10 @@ pub fn create_shared_store_common_config() -> CommonStoreConfig {
         cache_size: usize::MAX,
     }
 }
+
+#[cfg(with_metrics)]
+pub(crate) static STORAGE_SERVICE_METRICS: Lazy<KeyValueStoreMetrics> =
+    Lazy::new(|| KeyValueStoreMetrics::new("storage service".to_string()));
 
 #[derive(Debug, Clone)]
 pub struct ServiceStoreConfig {

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 
 use linera_base::command::resolve_binary;
 #[cfg(with_metrics)]
+use linera_base::sync::Lazy;
+#[cfg(with_metrics)]
 use linera_views::metering::KeyValueStoreMetrics;
 use linera_views::{
     common::{CommonStoreConfig, MIN_VIEW_TAG},


### PR DESCRIPTION
## Motivation

Metrics are available for `ScyllaDb`, `DynamoDb`, `RocksDb` but not for storage service.

## Proposal

Two changes are made:
* Add the LRU caching for the client. We expect gains from that because it saves at least one gRPC call.
* Add the Metering for the `ServiceStoreClient`. 

## Test Plan

The CI should do the job.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
