### PR TITLE
Spawn tasks in `JoinSet`s

### DIFF
--- a/linera-core/src/join_set_ext.rs
+++ b/linera-core/src/join_set_ext.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! An extension trait to allow determining at compile time how tasks are spawned on the Tokio
+//! runtime.
+//!
+//! In most cases the [`Future`] task to be spawned should implement [`Send`], but that's
+//! not possible when compiling for `wasm32-unknown-unknown`. In that case, the task is
+//! spawned in a [`LocalSet`][`tokio::tast::LocalSet`].
+
+use std::future::Future;
+
+use tokio::{
+    sync::oneshot,
+    task::{AbortHandle, JoinSet},
+};
+
+/// An extension trait for the [`JoinSet`] type.
+#[cfg(not(web))]
+pub trait JoinSetExt: Sized {
+    /// Spawns a `future` task on this [`JoinSet`] using [`JoinSet::spawn`].
+    ///
+    /// Returns a [`oneshot::Receiver`] to receive the `future`'s output, and an
+    /// [`AbortHandle`] to cancel execution of the task.
+    fn spawn_task<F>(&mut self, future: F) -> (oneshot::Receiver<F::Output>, AbortHandle)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send;
+
+    /// Awaits all tasks spawned in this [`JoinSet`].
+    fn await_all_tasks(&mut self) -> impl Future<Output = ()> + Send;
+
+    /// Reaps tasks that have finished.
+    fn reap_finished_tasks(&mut self);
+}
+
+/// An extension trait for the [`JoinSet`] type.
+#[cfg(web)]
+pub trait JoinSetExt: Sized {
+    /// Spawns a `future` task on this [`JoinSet`] using [`JoinSet::spawn_local`].
+    ///
+    /// Returns a [`oneshot::Receiver`] to receive the `future`'s output, and an
+    /// [`AbortHandle`] to cancel execution of the task.
+    fn spawn_task<F>(&mut self, future: F) -> (oneshot::Receiver<F::Output>, AbortHandle)
+    where
+        F: Future + 'static;
+
+    /// Awaits all tasks spawned in this [`JoinSet`].
+    fn await_all_tasks(&mut self) -> impl Future<Output = ()>;
+
+    /// Reaps tasks that have finished.
+    fn reap_finished_tasks(&mut self);
+}
+
+#[cfg(not(web))]
+impl JoinSetExt for JoinSet<()> {
+    fn spawn_task<F>(&mut self, future: F) -> (oneshot::Receiver<F::Output>, AbortHandle)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send,
+    {
+        let (output_sender, output_receiver) = oneshot::channel();
+
+        let abort_handle = self.spawn(async move {
+            let _ = output_sender.send(future.await);
+        });
+
+        (output_receiver, abort_handle)
+    }
+
+    async fn await_all_tasks(&mut self) {
+        while self.join_next().await.is_some() {}
+    }
+
+    fn reap_finished_tasks(&mut self) {
+        while self.try_join_next().is_some() {}
+    }
+}
+
+#[cfg(web)]
+impl JoinSetExt for JoinSet<()> {
+    fn spawn_task<F>(&mut self, future: F) -> (oneshot::Receiver<F::Output>, AbortHandle)
+    where
+        F: Future + 'static,
+    {
+        let (output_sender, output_receiver) = oneshot::channel();
+
+        let abort_handle = self.spawn_local(async move {
+            let _ = output_sender.send(future.await);
+        });
+
+        (output_receiver, abort_handle)
+    }
+
+    async fn await_all_tasks(&mut self) {
+        while self.join_next().await.is_some() {}
+    }
+
+    fn reap_finished_tasks(&mut self) {
+        while self.try_join_next().is_some() {}
+    }
+}

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -19,4 +19,4 @@ pub mod worker;
 pub(crate) mod updater;
 pub(crate) mod value_cache;
 
-pub use crate::join_set_ext::JoinSetExt;
+pub use crate::join_set_ext::{JoinSetExt, TaskHandle};

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod chain_worker;
 pub mod client;
 pub mod data_types;
+mod join_set_ext;
 pub mod local_node;
 pub mod node;
 pub mod notifier;
@@ -17,3 +18,5 @@ pub mod worker;
 
 pub(crate) mod updater;
 pub(crate) mod value_cache;
+
+pub use crate::join_set_ext::JoinSetExt;

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -30,7 +30,7 @@ pub enum GrpcError {
     CrossChain(#[from] tonic::Status),
 
     #[error("failed to execute task to completion: {0}")]
-    Join(#[from] tokio::task::JoinError),
+    Join(#[from] tokio::sync::oneshot::error::RecvError),
 
     #[error("failed to parse socket address: {0}")]
     SocketAddr(#[from] std::net::AddrParseError),

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -112,7 +112,6 @@ pub struct GrpcServer<S> {
 
 pub struct GrpcServerHandle {
     handle: TaskHandle<Result<(), GrpcError>>,
-    _join_set: JoinSet<()>,
 }
 
 impl GrpcServerHandle {
@@ -188,6 +187,7 @@ where
         cross_chain_config: CrossChainConfig,
         notification_config: NotificationConfig,
         shutdown_signal: CancellationToken,
+        join_set: &mut JoinSet<()>,
     ) -> GrpcServerHandle {
         info!(
             "spawning gRPC server on {}:{} for shard {}",
@@ -199,8 +199,6 @@ where
 
         let (notification_sender, notification_receiver) =
             mpsc::channel(notification_config.notification_queue_size);
-
-        let mut join_set = JoinSet::new();
 
         join_set.spawn_task({
             info!(
@@ -272,10 +270,7 @@ where
             Ok(())
         });
 
-        GrpcServerHandle {
-            handle,
-            _join_set: join_set,
-        }
+        GrpcServerHandle { handle }
     }
 
     /// Continuously waits for receiver to receive a notification which is then sent to

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -136,7 +136,11 @@ where
         }
     }
 
-    pub fn spawn(self, shutdown_signal: CancellationToken) -> ServerHandle {
+    pub fn spawn(
+        self,
+        shutdown_signal: CancellationToken,
+        join_set: &mut JoinSet<()>,
+    ) -> ServerHandle {
         info!(
             "Listening to {:?} traffic on {}:{}",
             self.network.protocol, self.host, self.port
@@ -146,7 +150,6 @@ where
         let (cross_chain_sender, cross_chain_receiver) =
             mpsc::channel(self.cross_chain_config.queue_size);
 
-        let mut join_set = JoinSet::new();
         join_set.spawn_task(Self::forward_cross_chain_queries(
             self.state.nickname().to_string(),
             self.network.clone(),

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -159,11 +159,11 @@ impl TransportProtocol {
         address: impl ToSocketAddrs + Send + 'static,
         state: S,
         shutdown_signal: CancellationToken,
+        mut join_set: JoinSet<()>,
     ) -> ServerHandle
     where
         S: MessageHandler + Send + 'static,
     {
-        let mut join_set = JoinSet::new();
         let handle = match self {
             Self::Udp => join_set.spawn_task(UdpServer::run(address, state, shutdown_signal)),
             Self::Tcp => join_set.spawn_task(TcpServer::run(address, state, shutdown_signal)),

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -29,6 +29,9 @@ use crate::{
 /// Suggested buffer size
 pub const DEFAULT_MAX_DATAGRAM_SIZE: &str = "65507";
 
+/// Number of tasks to spawn before attempting to reap some finished tasks to prevent memory leaks.
+const REAP_TASKS_THRESHOLD: usize = 100;
+
 // Supported transport protocols.
 #[derive(clap::ValueEnum, Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TransportProtocol {
@@ -280,7 +283,7 @@ where
 
         self.active_handlers.insert(peer, new_task);
 
-        if self.active_handlers.len() >= 100 {
+        if self.active_handlers.len() >= REAP_TASKS_THRESHOLD {
             // Collect finished tasks to avoid leaking memory.
             self.active_handlers.retain(|_, task| task.is_running());
             self.join_set.reap_finished_tasks();

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -85,7 +85,6 @@ pub trait MessageHandler: Clone {
 /// executing tasks.
 pub struct ServerHandle {
     pub handle: TaskHandle<Result<(), std::io::Error>>,
-    _join_set: JoinSet<()>,
 }
 
 impl ServerHandle {
@@ -162,7 +161,7 @@ impl TransportProtocol {
         address: impl ToSocketAddrs + Send + 'static,
         state: S,
         shutdown_signal: CancellationToken,
-        mut join_set: JoinSet<()>,
+        join_set: &mut JoinSet<()>,
     ) -> ServerHandle
     where
         S: MessageHandler + Send + 'static,
@@ -171,11 +170,7 @@ impl TransportProtocol {
             Self::Udp => join_set.spawn_task(UdpServer::run(address, state, shutdown_signal)),
             Self::Tcp => join_set.spawn_task(TcpServer::run(address, state, shutdown_signal)),
         };
-
-        ServerHandle {
-            handle,
-            _join_set: join_set,
-        }
+        ServerHandle { handle }
     }
 }
 

--- a/linera-rpc/src/simple/transport.rs
+++ b/linera-rpc/src/simple/transport.rs
@@ -16,7 +16,7 @@ use tokio::{
     io::AsyncWriteExt,
     net::{lookup_host, TcpListener, TcpStream, ToSocketAddrs, UdpSocket},
     sync::Mutex,
-    task::{JoinHandle, JoinSet},
+    task::JoinSet,
 };
 use tokio_util::{codec::Framed, sync::CancellationToken, udp::UdpFramed};
 use tracing::{error, warn};
@@ -209,7 +209,8 @@ pub struct UdpServer<State> {
     handler: State,
     udp_sink: SharedUdpSink,
     udp_stream: SplitStream<UdpFramed<Codec>>,
-    active_handlers: HashMap<SocketAddr, JoinHandle<()>>,
+    active_handlers: HashMap<SocketAddr, TaskHandle<()>>,
+    join_set: JoinSet<()>,
 }
 
 /// Type alias for the outgoing endpoint of UDP messages.
@@ -253,6 +254,7 @@ where
             udp_sink: Arc::new(Mutex::new(udp_sink)),
             udp_stream,
             active_handlers: HashMap::new(),
+            join_set: JoinSet::new(),
         })
     }
 
@@ -262,7 +264,7 @@ where
         let mut state = self.handler.clone();
         let udp_sink = self.udp_sink.clone();
 
-        let new_task = tokio::spawn(async move {
+        let new_task = self.join_set.spawn_task(async move {
             if let Some(reply) = state.handle_message(message).await {
                 if let Some(task) = previous_task {
                     if let Err(error) = task.await {
@@ -280,7 +282,8 @@ where
 
         if self.active_handlers.len() >= 100 {
             // Collect finished tasks to avoid leaking memory.
-            self.active_handlers.retain(|_, task| !task.is_finished());
+            self.active_handlers.retain(|_, task| task.is_running());
+            self.join_set.reap_finished_tasks();
         }
     }
 
@@ -309,6 +312,8 @@ where
                 warn!("Message handler panicked: {}", error);
             }
         }
+
+        self.join_set.await_all_tasks().await;
     }
 }
 

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -22,6 +22,7 @@ use linera_core::{
     client::{ArcChainClient, ChainClient, Client},
     data_types::ClientOutcome,
     node::{CrossChainMessageDelivery, ValidatorNodeProvider},
+    JoinSetExt as _,
 };
 use linera_execution::Bytecode;
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
@@ -33,6 +34,7 @@ use linera_service::{
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
+use tokio::task::JoinSet;
 use tracing::{debug, info};
 #[cfg(feature = "benchmark")]
 use {
@@ -70,6 +72,7 @@ pub struct ClientContext {
     pub(crate) recv_timeout: Duration,
     pub(crate) notification_retry_delay: Duration,
     pub(crate) notification_retries: u32,
+    chain_listeners: JoinSet<()>,
 }
 
 #[async_trait]
@@ -130,6 +133,7 @@ impl ClientContext {
             recv_timeout: options.recv_timeout,
             notification_retry_delay: options.notification_retry_delay,
             notification_retries: options.notification_retries,
+            chain_listeners: JoinSet::new(),
         }
     }
 
@@ -258,7 +262,7 @@ impl ClientContext {
 
         // Start listening for notifications, so we learn about new rounds and blocks.
         let (listener, _listen_handle, mut notification_stream) = chain_client.listen().await?;
-        tokio::spawn(listener);
+        self.chain_listeners.spawn_task(listener);
 
         loop {
             let (new_certificates, maybe_timeout) = {
@@ -383,7 +387,7 @@ impl ClientContext {
 
         // Start listening for notifications, so we learn about new rounds and blocks.
         let (listener, _listen_handle, mut notification_stream) = client.listen().await?;
-        tokio::spawn(listener);
+        self.chain_listeners.spawn_task(listener);
 
         loop {
             // Try applying f. Return if committed.
@@ -721,10 +725,11 @@ impl ClientContext {
     ) -> Vec<RpcMessage> {
         let time_start = Instant::now();
         info!("Broadcasting {} {}", proposals.len(), phase);
+        let mut join_set = JoinSet::new();
         let mut handles = Vec::new();
         for mut client in self.make_validator_mass_clients() {
             let proposals = proposals.clone();
-            handles.push(tokio::spawn(async move {
+            let handle = join_set.spawn_task(async move {
                 debug!("Sending {} requests", proposals.len());
                 let responses = client
                     .send(proposals, max_in_flight)
@@ -732,7 +737,8 @@ impl ClientContext {
                     .unwrap_or_default();
                 debug!("Done sending requests");
                 responses
-            }));
+            });
+            handles.push(handle);
         }
         let responses = futures::future::join_all(handles)
             .await

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -25,6 +25,7 @@ use linera_service::{
 };
 use linera_storage::Storage;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
 
@@ -242,7 +243,7 @@ where
 
         self.public_config
             .protocol
-            .spawn_server(address, self, shutdown_signal)
+            .spawn_server(address, self, shutdown_signal, JoinSet::new())
             .join()
             .await?;
         Ok(())

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -8,7 +8,7 @@ use anyhow::bail;
 use async_trait::async_trait;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryFutureExt};
 use linera_base::crypto::{CryptoRng, KeyPair};
-use linera_core::worker::WorkerState;
+use linera_core::{worker::WorkerState, JoinSetExt as _};
 use linera_execution::{committee::ValidatorName, WasmRuntime, WithWasmDefault};
 use linera_rpc::{
     config::{
@@ -29,6 +29,7 @@ use linera_service::{
 use linera_storage::Storage;
 use linera_views::{common::CommonStoreConfig, views::ViewError};
 use serde::Deserialize;
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
@@ -73,6 +74,7 @@ impl ServerContext {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
+        let mut join_set = JoinSet::new();
         let handles = FuturesUnordered::new();
 
         let internal_network = self
@@ -98,7 +100,7 @@ impl ServerContext {
                 shard_id,
                 cross_chain_config,
             )
-            .spawn(shutdown_signal.clone());
+            .spawn(shutdown_signal.clone(), &mut join_set);
 
             handles.push(
                 server_handle
@@ -111,6 +113,7 @@ impl ServerContext {
         }
 
         handles.collect::<()>().await;
+        join_set.await_all_tasks().await;
     }
 
     async fn spawn_grpc<S>(
@@ -122,7 +125,9 @@ impl ServerContext {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
+        let mut join_set = JoinSet::new();
         let handles = FuturesUnordered::new();
+
         for (state, shard_id, shard) in states {
             #[cfg(with_metrics)]
             if let Some(port) = shard.metrics_port {
@@ -138,6 +143,7 @@ impl ServerContext {
                 self.cross_chain_config.clone(),
                 self.notification_config.clone(),
                 shutdown_signal.clone(),
+                &mut join_set,
             );
 
             handles.push(
@@ -151,6 +157,7 @@ impl ServerContext {
         }
 
         handles.collect::<()>().await;
+        join_set.await_all_tasks().await;
     }
 
     #[cfg(with_metrics)]


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
There are quite a few calls to `tokio::spawn` in the code. However, in order to run the code on the browser (for the web wallet), `tokio::spawn` does not work because execution is single-threaded. The solution is to spawn tasks in a `LocalSet`, so that it runs inside the same worker thread.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a `JoinSetExt` trait with a few extension methods for [`tokio::task::JoinSet`](https://docs.rs/tokio/latest/tokio/task/struct.JoinSet.html). One of the extension methods allows spawning a new task in the `JoinSet`, and its behavior is determined during compilation by the `web` feature. If the `web` feature is enabled, `JoinSet::spawn_local` is used. Otherwise, `JoinSet::spawn` is used, which is the same as `tokio::spawn`.

The code is then refactored to use `JoinSet`s to keep track of the spawned tasks.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, so CI should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, since this is an internal refactor.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- This is part of #2115, but does not close it because there are still other places with direct `tokio::spawn` calls.
