### PR TITLE
Remove the Optionality to the `get_balance`.

### DIFF
--- a/linera-ethereum/src/client.rs
+++ b/linera-ethereum/src/client.rs
@@ -97,7 +97,7 @@ pub trait EthereumQueries {
     async fn get_balance(
         &self,
         address: &str,
-        block_number: Option<u64>,
+        block_number: u64,
     ) -> Result<U256, Self::Error>;
 
     /// Reads the events of the smart contract.
@@ -129,11 +129,8 @@ pub trait EthereumQueries {
     ) -> Result<Bytes, Self::Error>;
 }
 
-pub(crate) fn get_block_id(block_number: Option<u64>) -> BlockId {
-    let number = match block_number {
-        None => BlockNumberOrTag::Latest,
-        Some(val) => BlockNumberOrTag::Number(val),
-    };
+pub(crate) fn get_block_id(block_number: u64) -> BlockId {
+    let number = BlockNumberOrTag::Number(block_number);
     BlockId::Number(number)
 }
 
@@ -157,7 +154,7 @@ where
     async fn get_balance(
         &self,
         address: &str,
-        block_number: Option<u64>,
+        block_number: u64,
     ) -> Result<U256, Self::Error> {
         let address = address.parse::<Address>()?;
         let tag = get_block_id(block_number);
@@ -201,7 +198,7 @@ where
             .from(from)
             .to(contract_address)
             .input(input);
-        let tag = get_block_id(Some(block));
+        let tag = get_block_id(block);
         Ok(self.request::<_, Bytes>("eth_call", (tx, tag)).await?)
     }
 }

--- a/linera-ethereum/src/client.rs
+++ b/linera-ethereum/src/client.rs
@@ -94,11 +94,7 @@ pub trait EthereumQueries {
     /// Gets the balance of the specified address at the specified block number.
     /// if no block number is specified then the balance of the latest block is
     /// returned.
-    async fn get_balance(
-        &self,
-        address: &str,
-        block_number: u64,
-    ) -> Result<U256, Self::Error>;
+    async fn get_balance(&self, address: &str, block_number: u64) -> Result<U256, Self::Error>;
 
     /// Reads the events of the smart contract.
     ///
@@ -151,11 +147,7 @@ where
         Ok(result.to::<u64>())
     }
 
-    async fn get_balance(
-        &self,
-        address: &str,
-        block_number: u64,
-    ) -> Result<U256, Self::Error> {
+    async fn get_balance(&self, address: &str, block_number: u64) -> Result<U256, Self::Error> {
         let address = address.parse::<Address>()?;
         let tag = get_block_id(block_number);
         Ok(self.request("eth_getBalance", (address, tag)).await?)

--- a/linera-ethereum/src/provider.rs
+++ b/linera-ethereum/src/provider.rs
@@ -86,7 +86,7 @@ impl EthereumQueries for EthereumClient<HttpProvider> {
     async fn get_balance(
         &self,
         address: &str,
-        block_number: Option<u64>,
+        block_number: u64,
     ) -> Result<U256, EthereumServiceError> {
         let address = address.parse::<Address>()?;
         let block_id = get_block_id(block_number);
@@ -129,7 +129,7 @@ impl EthereumQueries for EthereumClient<HttpProvider> {
             .from(from)
             .to(contract_address)
             .input(input);
-        let block_id = get_block_id(Some(block));
+        let block_id = get_block_id(block);
         let eth_call = self.provider.call(&tx).block(block_id);
         Ok(eth_call.await?)
     }

--- a/linera-ethereum/tests/ethereum_test.rs
+++ b/linera-ethereum/tests/ethereum_test.rs
@@ -35,9 +35,7 @@ async fn test_get_accounts_balance() -> anyhow::Result<()> {
     assert_eq!(block_number, block_number_simp);
     let target_balance = U256::from_str("10000000000000000000000")?;
     for address in addresses {
-        let balance = ethereum_client
-            .get_balance(&address, block_number)
-            .await?;
+        let balance = ethereum_client.get_balance(&address, block_number).await?;
         let balance_simp = ethereum_client_simp
             .get_balance(&address, block_number)
             .await?;

--- a/linera-ethereum/tests/ethereum_test.rs
+++ b/linera-ethereum/tests/ethereum_test.rs
@@ -36,10 +36,10 @@ async fn test_get_accounts_balance() -> anyhow::Result<()> {
     let target_balance = U256::from_str("10000000000000000000000")?;
     for address in addresses {
         let balance = ethereum_client
-            .get_balance(&address, Some(block_number))
+            .get_balance(&address, block_number)
             .await?;
         let balance_simp = ethereum_client_simp
-            .get_balance(&address, Some(block_number))
+            .get_balance(&address, block_number)
             .await?;
         assert_eq!(balance, balance_simp);
         assert_eq!(balance, target_balance);


### PR DESCRIPTION
## Motivation

The `get_balance` takes an `Option<u64>` with `None` corresponding to latest which is not congruent with an Oracle.

## Proposal

We simply replace `Option<u64>` by `u64` in a straightforward way.

## Test Plan

The tests are actually simplified by the 

## Release Plan

This actually makes the API coherent with the manual of the release plan.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
