### PR TITLE
Fix re-proposing another owner's proposal from an earlier round.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -234,7 +234,7 @@ pub struct BlockProposal {
     pub signature: Signature,
     pub hashed_certificate_values: Vec<HashedCertificateValue>,
     pub hashed_blobs: Vec<HashedBlob>,
-    pub validated: Option<Certificate>,
+    pub validated_block_certificate: Option<Certificate>,
 }
 
 /// A message together with routing information.
@@ -814,9 +814,9 @@ impl BlockProposal {
         secret: &KeyPair,
         hashed_certificate_values: Vec<HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
-        validated: Option<Certificate>,
+        validated_block_certificate: Option<Certificate>,
     ) -> Self {
-        let outcome = validated
+        let outcome = validated_block_certificate
             .as_ref()
             .and_then(|certificate| certificate.value().executed_block())
             .map(|executed_block| Cow::Borrowed(&executed_block.outcome));
@@ -833,13 +833,13 @@ impl BlockProposal {
             signature,
             hashed_certificate_values,
             hashed_blobs,
-            validated,
+            validated_block_certificate,
         }
     }
 
     pub fn check_signature(&self, public_key: PublicKey) -> Result<(), CryptoError> {
         let outcome = self
-            .validated
+            .validated_block_certificate
             .as_ref()
             .and_then(|certificate| certificate.value().executed_block())
             .map(|executed_block| Cow::Borrowed(&executed_block.outcome));

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -254,7 +254,7 @@ where
             owner,
             hashed_certificate_values,
             hashed_blobs,
-            validated,
+            validated_block_certificate,
             signature: _,
         } = &proposal;
         self.ensure_is_active()?;
@@ -274,9 +274,9 @@ where
             .verify_owner(&proposal)
             .ok_or(WorkerError::InvalidOwner)?;
         proposal.check_signature(public_key)?;
-        if let Some(validated) = validated {
+        if let Some(validated_block_certificate) = validated_block_certificate {
             // Verify that this block has been validated by a quorum before.
-            validated.check(committee)?;
+            validated_block_certificate.check(committee)?;
         } else if let Some(signer) = block.authenticated_signer {
             // Check the authentication of the operations in the new block.
             ensure!(signer == *owner, WorkerError::InvalidSigner(signer));
@@ -310,8 +310,8 @@ where
         );
         self.storage.clock().sleep_until(block.timestamp).await;
         let local_time = self.storage.clock().current_time();
-        let outcome = if let Some(validated) = validated {
-            validated
+        let outcome = if let Some(validated_block_certificate) = validated_block_certificate {
+            validated_block_certificate
                 .value()
                 .executed_block()
                 .ok_or_else(|| WorkerError::MissingExecutedBlockInProposal)?

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1237,10 +1237,10 @@ where
             }
         }
         // Make sure that we follow the steps in the multi-round protocol.
-        let validated = manager.highest_validated().cloned();
-        if let Some(validated) = &validated {
+        let validated_block_certificate = manager.highest_validated().cloned();
+        if let Some(validated_block_certificate) = &validated_block_certificate {
             ensure!(
-                validated.value().block() == Some(&block),
+                validated_block_certificate.value().block() == Some(&block),
                 ChainClientError::BlockProposalError(
                     "A different block has already been validated at this height"
                 )
@@ -1285,7 +1285,7 @@ where
             key_pair,
             values,
             hashed_blobs,
-            validated,
+            validated_block_certificate,
         );
         // Check the final block proposal. This will be cheaper after #1401.
         self.node_client

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -412,7 +412,7 @@ where
     );
 
     // We need at least three validators for making a transfer.
-    builder.set_fault_type(..2, FaultType::Offline).await;
+    builder.set_fault_type([0, 1], FaultType::Offline).await;
     let result = client
         .transfer_to_account(
             None,
@@ -427,8 +427,8 @@ where
             CommunicationError::Trusted(ClientIoError { .. }),
         ))
     );
-    builder.set_fault_type(..2, FaultType::Honest).await;
-    builder.set_fault_type(2.., FaultType::Offline).await;
+    builder.set_fault_type([0, 1], FaultType::Honest).await;
+    builder.set_fault_type([2, 3], FaultType::Offline).await;
     assert_matches!(
         sender
             .transfer_to_account(
@@ -445,7 +445,9 @@ where
 
     // Half the validators voted for one block, half for the other. We need to make a proposal in
     // the next round to succeed.
-    builder.set_fault_type(.., FaultType::Honest).await;
+    builder
+        .set_fault_type([0, 1, 2, 3], FaultType::Honest)
+        .await;
     client.synchronize_from_validators().await.unwrap();
     client.process_inbox().await.unwrap();
     assert_eq!(
@@ -1437,7 +1439,7 @@ where
         .await?;
 
     // Take one validator down
-    builder.set_fault_type(..1, FaultType::Offline).await;
+    builder.set_fault_type([0], FaultType::Offline).await;
     let blob = HashedBlob::test_blob("blob1");
     let expected_blob_id = blob.id();
     let (blob_id, certificate) = client_a.publish_blob(blob).await.unwrap().unwrap();
@@ -1447,9 +1449,9 @@ where
     let previous_block_hash = client_a.block_hash.unwrap();
 
     // Validators goes back up
-    builder.set_fault_type(..1, FaultType::Honest).await;
+    builder.set_fault_type([0], FaultType::Honest).await;
     // But another one goes down
-    builder.set_fault_type(1..2, FaultType::Offline).await;
+    builder.set_fault_type([1], FaultType::Offline).await;
 
     let certificate = client_b
         .burn(None, Amount::from_tokens(1), UserData::default())
@@ -1647,7 +1649,7 @@ where
     // Client 0 tries to burn 3 tokens. Two validators are offline, so nothing will get
     // validated or confirmed. However, client 0 now has a pending block.
     builder
-        .set_fault_type(2..3, FaultType::OfflineWithInfo)
+        .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client0
         .burn(None, Amount::from_tokens(3), UserData::default())
@@ -1656,7 +1658,7 @@ where
 
     // Client 1 thinks it is madness to burn 3 tokens! They want to publish a blob instead.
     // The validators are still faulty: They validate blocks but don't confirm them.
-    builder.set_fault_type(2..3, FaultType::NoConfirm).await;
+    builder.set_fault_type([2], FaultType::NoConfirm).await;
     client1.synchronize_from_validators().await.unwrap();
     let manager = client1
         .chain_info_with_manager_values()
@@ -1671,7 +1673,7 @@ where
     assert!(!client1.pending_blobs.is_empty());
 
     // Finally, the validators are online and honest again.
-    builder.set_fault_type(1..3, FaultType::Honest).await;
+    builder.set_fault_type([1, 2], FaultType::Honest).await;
     client0.synchronize_from_validators().await.unwrap();
     let manager = client0
         .chain_info_with_manager_values()
@@ -1734,7 +1736,7 @@ where
     // The client tries to burn 3 tokens. Two validators are offline, so nothing will get
     // validated or confirmed. However, the client now has a pending block.
     builder
-        .set_fault_type(2..3, FaultType::OfflineWithInfo)
+        .set_fault_type([2], FaultType::OfflineWithInfo)
         .await;
     let result = client
         .burn(None, Amount::from_tokens(3), UserData::default())
@@ -1742,7 +1744,7 @@ where
     assert!(result.is_err());
 
     // Now three validators are online again.
-    builder.set_fault_type(2..3, FaultType::Honest).await;
+    builder.set_fault_type([2], FaultType::Honest).await;
 
     // The client tries to burn another token. Before that, they automatically finalize the
     // pending block, which burns 3 tokens, leaving 10 - 3 - 1 = 6.
@@ -1802,8 +1804,8 @@ where
 
     // Client 0 tries to burn 3 tokens. Three validators are faulty: 1 and 2 will validate the
     // block but not receive it for confirmation. Validator 3 is offline.
-    builder.set_fault_type(1..3, FaultType::NoConfirm).await;
-    builder.set_fault_type(3..4, FaultType::Offline).await;
+    builder.set_fault_type([1, 2], FaultType::NoConfirm).await;
+    builder.set_fault_type([3], FaultType::Offline).await;
     let result = client0
         .burn(None, Amount::from_tokens(3), UserData::default())
         .await;
@@ -1812,9 +1814,9 @@ where
     // Client 1 wants to burn 2 tokens. They learn about the proposal in round 0, but now the
     // validator 0 is offline, so they don't learn about the validated block and make their own
     // proposal in round 1.
-    builder.set_fault_type(0..1, FaultType::Offline).await;
+    builder.set_fault_type([0], FaultType::Offline).await;
     builder
-        .set_fault_type(3..4, FaultType::OfflineWithInfo)
+        .set_fault_type([3], FaultType::OfflineWithInfo)
         .await;
     client1.synchronize_from_validators().await.unwrap();
     let manager = client1
@@ -1832,8 +1834,8 @@ where
 
     // Finally, three validators are online and honest again. Client 1 realizes there has been a
     // validated block in round 0, and re-proposes it when it tries to burn 4 tokens.
-    builder.set_fault_type(0..3, FaultType::Honest).await;
-    builder.set_fault_type(3..4, FaultType::Offline).await;
+    builder.set_fault_type([0, 1, 2], FaultType::Honest).await;
+    builder.set_fault_type([3], FaultType::Offline).await;
     client1.synchronize_from_validators().await.unwrap();
     let manager = client1
         .chain_info_with_manager_values()

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -3,7 +3,6 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    slice::SliceIndex,
     sync::Arc,
 };
 
@@ -514,15 +513,10 @@ where
         self
     }
 
-    pub async fn set_fault_type<I>(&mut self, range: I, fault_type: FaultType)
-    where
-        I: SliceIndex<
-            [LocalValidatorClient<B::Storage>],
-            Output = [LocalValidatorClient<B::Storage>],
-        >,
-    {
+    pub async fn set_fault_type(&mut self, indexes: impl AsRef<[usize]>, fault_type: FaultType) {
         let mut faulty_validators = vec![];
-        for validator in &mut self.validator_clients[range] {
+        for index in indexes.as_ref() {
+            let validator = &mut self.validator_clients[*index];
             validator.set_fault_type(fault_type).await;
             faulty_validators.push(validator.name);
         }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -414,12 +414,6 @@ where
                 self.send_certificate(cert, delivery).await?;
             }
         }
-        if let Some(cert) = manager.locked {
-            if cert.value().is_validated() && cert.value().chain_id() == chain_id {
-                self.send_certificate(cert, CrossChainMessageDelivery::NonBlocking)
-                    .await?;
-            }
-        }
         if let Some(cert) = manager.timeout {
             if cert.value().is_timeout() && cert.value().chain_id() == chain_id {
                 self.send_certificate(cert, CrossChainMessageDelivery::NonBlocking)

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -175,7 +175,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
             )?,
             blobs: bincode::serialize(&block_proposal.hashed_blobs)?,
             validated: block_proposal
-                .validated
+                .validated_block_certificate
                 .map(|cert| bincode::serialize(&cert))
                 .transpose()?,
         })
@@ -199,7 +199,7 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
                 &block_proposal.hashed_certificate_values,
             )?,
             hashed_blobs: bincode::deserialize(&block_proposal.blobs)?,
-            validated: block_proposal
+            validated_block_certificate: block_proposal
                 .validated
                 .map(|bytes| bincode::deserialize(&bytes))
                 .transpose()?,
@@ -784,7 +784,7 @@ pub mod tests {
                 .with(get_block()),
             )],
             hashed_blobs: vec![],
-            validated: Some(Certificate::new(
+            validated_block_certificate: Some(Certificate::new(
                 HashedCertificateValue::new_validated(
                     BlockExecutionOutcome {
                         state_hash: CryptoHash::new(&Foo("validated".into())),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -111,7 +111,7 @@ BlockProposal:
     - hashed_blobs:
         SEQ:
           TYPENAME: Blob
-    - validated:
+    - validated_block_certificate:
         OPTION:
           TYPENAME: Certificate
 Bytecode:

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -89,7 +89,7 @@ async fn test_faucet_rate_limiting() {
     assert!(root.do_claim(KeyPair::generate().public()).await.is_err());
     // If a validator is offline, it will create a pending block and then fail.
     clock.set(Timestamp::from(6000));
-    builder.set_fault_type(0..2, FaultType::Offline).await;
+    builder.set_fault_type([0, 1], FaultType::Offline).await;
     assert!(root.do_claim(KeyPair::generate().public()).await.is_err());
     assert_eq!(context.lock().await.update_calls, 4); // Also called in the last error case.
 }


### PR DESCRIPTION
## Motivation

When there is any validated block certificate in an earlier round, an honest round leader (both in multi- and single-leader rounds) should re-propose that block in the current round.

This is currently only working if the earlier block was proposed by the current round leader itself, or doesn't have an authenticated signer.

Also, the client is currently failing in some cases where it tries to update the validators and inform them about the highest locked block: They will return an error if that block is older than their own most recent vote. But actually, informing them about the highest locked block should be unnecessary anyway, because the block will be included in the proposal.

## Proposal

Check the authenticated signer only if there is no validated block included in the proposal. If there is, that means a quorum of validators already verified that the earlier proposal was signed by the authenticated signer.

Don't update validators about the highest locked block.

Also, simplify `set_fault_type`: For these types of tests, `[1, 2]` makes it clearer that validators numbers 1 and 2 are affected, compared to `1..3`.

## Test Plan

A client test was added that failed without the fixes.

## Links

- Fixes https://github.com/linera-io/linera-protocol/issues/2113.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
