### PR TITLE
`linera-core`: rename `ChainClientBuilder` to `Client`

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -68,7 +68,7 @@ use crate::{
 mod client_tests;
 
 /// A builder that creates `ChainClients` which share the cache and notifiers.
-pub struct ChainClientBuilder<ValidatorNodeProvider> {
+pub struct Client<ValidatorNodeProvider> {
     /// How to talk to the validators.
     validator_node_provider: ValidatorNodeProvider,
     /// Maximum number of pending messages processed at a time in a block.
@@ -88,8 +88,8 @@ pub struct ChainClientBuilder<ValidatorNodeProvider> {
     notifier: Arc<Notifier<Notification>>,
 }
 
-impl<ValidatorNodeProvider: Clone> ChainClientBuilder<ValidatorNodeProvider> {
-    /// Creates a new `ChainClientBuilder` with a new cache and notifiers.
+impl<ValidatorNodeProvider: Clone> Client<ValidatorNodeProvider> {
+    /// Creates a new `Client` with a new cache and notifiers.
     pub fn new(
         validator_node_provider: ValidatorNodeProvider,
         max_pending_messages: usize,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -51,7 +51,7 @@ use {
 };
 
 use crate::{
-    client::{ChainClient, ChainClientBuilder},
+    client::{ChainClient, Client},
     data_types::*,
     node::{
         CrossChainMessageDelivery, LocalValidatorNodeProvider, NodeError, NotificationStream,
@@ -625,7 +625,7 @@ where
         let storage = self.make_storage().await?;
         self.chain_client_storages.push(storage.clone());
         let provider = self.make_node_provider();
-        let builder = ChainClientBuilder::new(provider, 10, CrossChainMessageDelivery::NonBlocking);
+        let builder = Client::new(provider, 10, CrossChainMessageDelivery::NonBlocking);
         Ok(builder.build(
             chain_id,
             vec![key_pair],

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -19,7 +19,7 @@ use linera_base::{
 };
 use linera_chain::data_types::Certificate;
 use linera_core::{
-    client::{ArcChainClient, ChainClient, ChainClientBuilder},
+    client::{ArcChainClient, ChainClient, Client},
     data_types::ClientOutcome,
     node::{CrossChainMessageDelivery, ValidatorNodeProvider},
 };
@@ -66,7 +66,7 @@ use crate::{client_options::ChainOwnershipConfig, ClientOptions};
 
 pub struct ClientContext {
     wallet_state: WalletState,
-    chain_client_builder: ChainClientBuilder<NodeProvider>,
+    chain_client_builder: Client<NodeProvider>,
     send_timeout: Duration,
     recv_timeout: Duration,
     notification_retry_delay: Duration,
@@ -159,7 +159,7 @@ impl ClientContext {
         let node_provider = NodeProvider::new(node_options);
         let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
         let chain_client_builder =
-            ChainClientBuilder::new(node_provider, options.max_pending_messages, delivery);
+            Client::new(node_provider, options.max_pending_messages, delivery);
         ClientContext {
             chain_client_builder,
             wallet_state,

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -12,7 +12,7 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_core::{
-    client::{ChainClient, ChainClientBuilder},
+    client::{ChainClient, Client},
     node::CrossChainMessageDelivery,
     test_utils::{MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
 };
@@ -36,7 +36,7 @@ use crate::{
 
 struct ClientContext {
     wallet: Wallet,
-    chain_client_builder: ChainClientBuilder<NodeProvider<MemoryStorage<TestClock>>>,
+    chain_client_builder: Client<NodeProvider<MemoryStorage<TestClock>>>,
 }
 
 #[async_trait]
@@ -149,7 +149,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let delivery = CrossChainMessageDelivery::NonBlocking;
     let mut context = ClientContext {
         wallet: Wallet::new(genesis_config, Some(37)),
-        chain_client_builder: ChainClientBuilder::new(builder.make_node_provider(), 10, delivery),
+        chain_client_builder: Client::new(builder.make_node_provider(), 10, delivery),
     };
     let key_pair = KeyPair::generate_from(&mut rng);
     let public_key = key_pair.public();


### PR DESCRIPTION
## Motivation

In the future, the `ChainClientBuilder` will, rather than just being a factory for chain clients, also take on functionality related to being a client for the protocol as a whole.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Rename `ChainClientBuilder` to simply `Client`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- This is a minor version bump.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
