### PR TITLE
Fix the flaky test_re_propose_validated.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -633,9 +633,9 @@ where
         let certificate = self
             .communicate_chain_action(committee, submit_action, value)
             .await?;
+        self.process_certificate(certificate.clone(), vec![], vec![])
+            .await?;
         if certificate.value().is_confirmed() {
-            self.process_certificate(certificate.clone(), vec![], vec![])
-                .await?;
             Ok(certificate)
         } else {
             self.finalize_block(committee, certificate).await

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -602,6 +602,10 @@ where
         self.validator_clients.iter().cloned().collect()
     }
 
+    pub fn node(&mut self, index: usize) -> &mut LocalValidatorClient<B::Storage> {
+        &mut self.validator_clients[index]
+    }
+
     pub async fn make_storage(&mut self) -> anyhow::Result<B::Storage> {
         Ok(self
             .genesis_storage_builder


### PR DESCRIPTION
## Motivation

`test_re_propose_validated` is currently flaky: Client 1 can only re-propose the validated block if it can download it from validator 0, but depending on timing, validator 0 may not have stored it as its locked block before the updater was canceled due to the faulty validators' errors.

## Proposal

In the client, process all certificates for validated blocks as soon as we have them, so that client 0 in the test is guaranteed to have it in its local chain manager.

In the test, get the certificate from client 0 and directly send it to validator 0 to make sure it has processed it, too.

## Test Plan

I reproduced the flakiness locally with ScyllaDB, and this fixed it. CI will show if there are any remaining issues.


## Links

- The test was added in https://github.com/linera-io/linera-protocol/pull/2118.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
