### PR TITLE
Allow client node to read `ChainStateView` outside the `ChainWorkerState`

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -232,6 +232,7 @@ impl InboxEntry {
 
 /// A view accessing the state of a chain.
 #[derive(Debug, RootView, ClonableView, SimpleObject)]
+#[graphql(cache_control(no_cache))]
 pub struct ChainStateView<C>
 where
     C: Clone + Context + Send + Sync + 'static,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -27,7 +27,7 @@ use linera_views::{
     reentrant_collection_view::ReentrantCollectionView,
     register_view::RegisterView,
     set_view::SetView,
-    views::{CryptoHashView, RootView, View, ViewError},
+    views::{ClonableView, CryptoHashView, RootView, View, ViewError},
 };
 use serde::{Deserialize, Serialize};
 #[cfg(with_testing)]
@@ -231,7 +231,7 @@ impl InboxEntry {
 }
 
 /// A view accessing the state of a chain.
-#[derive(Debug, RootView, SimpleObject)]
+#[derive(Debug, RootView, ClonableView, SimpleObject)]
 pub struct ChainStateView<C>
 where
     C: Clone + Context + Send + Sync + 'static,
@@ -348,7 +348,7 @@ impl ChainTipState {
 }
 
 /// The state of a channel followed by subscribers.
-#[derive(Debug, View, SimpleObject)]
+#[derive(Debug, ClonableView, View, SimpleObject)]
 pub struct ChannelStateView<C>
 where
     C: Context + Send + Sync,

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -13,7 +13,7 @@ use linera_views::{
     common::Context,
     queue_view::QueueView,
     register_view::RegisterView,
-    views::{View, ViewError},
+    views::{ClonableView, View, ViewError},
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -35,7 +35,7 @@ mod inbox_tests;
 /// * The cursors of added events (resp. removed events) must be increasing over time.
 /// * Reconciliation of added and removed events is allowed to skip some added events.
 /// However, the opposite is not true: every removed event must be eventually added.
-#[derive(Debug, View, async_graphql::SimpleObject)]
+#[derive(Debug, ClonableView, View, async_graphql::SimpleObject)]
 pub struct InboxStateView<C>
 where
     C: Clone + Context + Send + Sync,

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -8,7 +8,7 @@ use linera_views::{
     common::Context,
     queue_view::QueueView,
     register_view::RegisterView,
-    views::{View, ViewError},
+    views::{ClonableView, View, ViewError},
 };
 
 #[cfg(test)]
@@ -22,7 +22,7 @@ mod outbox_tests;
 /// we just send the certified blocks over and let the receivers figure out what were the
 /// messages for them.
 /// * When marking block heights as received, messages at lower heights are also marked (ie. dequeued).
-#[derive(Debug, View, async_graphql::SimpleObject)]
+#[derive(Debug, ClonableView, View, async_graphql::SimpleObject)]
 pub struct OutboxStateView<C>
 where
     C: Context + Send + Sync + 'static,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -240,7 +240,7 @@ where
             })
         }
         let info = ChainInfoResponse::new(&self.chain, self.config.key_pair());
-        self.chain.save().await?;
+        self.save().await?;
         Ok((info, actions))
     }
 
@@ -358,7 +358,7 @@ where
                 .await;
         }
         let info = ChainInfoResponse::new(&self.chain, self.config.key_pair());
-        self.chain.save().await?;
+        self.save().await?;
         // Trigger any outgoing cross-chain messages that haven't been confirmed yet.
         let actions = self.create_network_actions().await?;
         Ok((info, actions))
@@ -414,7 +414,7 @@ where
             self.storage.clock().current_time(),
         );
         let info = ChainInfoResponse::new(&self.chain, self.config.key_pair());
-        self.chain.save().await?;
+        self.save().await?;
         let round = self.chain.manager.get().current_round;
         if round > old_round {
             actions.notifications.push(Notification {
@@ -545,7 +545,7 @@ where
             },
         });
         // Persist chain.
-        self.chain.save().await?;
+        self.save().await?;
         self.recent_hashed_certificate_values
             .insert(Cow::Owned(certificate.value))
             .await;
@@ -594,7 +594,7 @@ where
             return Ok(None);
         }
         // Save the chain.
-        self.chain.save().await?;
+        self.save().await?;
         Ok(Some(last_updated_height))
     }
 
@@ -617,7 +617,7 @@ where
             }
         }
 
-        self.chain.save().await?;
+        self.save().await?;
 
         Ok(height_with_fully_delivered_messages)
     }
@@ -635,7 +635,7 @@ where
                 let local_time = self.storage.clock().current_time();
                 let manager = self.chain.manager.get_mut();
                 if manager.vote_timeout(chain_id, height, *epoch, key_pair, local_time) {
-                    self.chain.save().await?;
+                    self.save().await?;
                 }
             }
         }
@@ -651,7 +651,7 @@ where
                     let key_pair = self.config.key_pair();
                     let manager = self.chain.manager.get_mut();
                     if manager.vote_fallback(chain_id, height, *epoch, key_pair) {
-                        self.chain.save().await?;
+                        self.save().await?;
                     }
                 }
             }
@@ -949,6 +949,11 @@ where
             recipient,
             bundle_vecs,
         })
+    }
+
+    /// Stores the chain state in persistent storage.
+    async fn save(&mut self) -> Result<(), WorkerError> {
+        Ok(self.chain.save().await?)
     }
 }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -33,6 +33,7 @@ use linera_views::{
     common::Context,
     views::{RootView, View, ViewError},
 };
+use tokio::sync::RwLock;
 use tracing::{debug, warn};
 #[cfg(with_testing)]
 use {linera_base::identifiers::BytecodeId, linera_chain::data_types::Event};
@@ -53,6 +54,7 @@ where
     config: ChainWorkerConfig,
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
+    shared_chain_view: Option<Arc<RwLock<ChainStateView<StorageClient::Context>>>>,
     recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
     recent_hashed_blobs: Arc<ValueCache<BlobId, HashedBlob>>,
     knows_chain_is_active: bool,
@@ -77,6 +79,7 @@ where
             config,
             storage,
             chain,
+            shared_chain_view: None,
             recent_hashed_certificate_values: certificate_value_cache,
             recent_hashed_blobs: blob_cache,
             knows_chain_is_active: false,
@@ -952,7 +955,20 @@ where
     }
 
     /// Stores the chain state in persistent storage.
+    ///
+    /// Waits until the [`ChainStateView`] is no longer shared before persisting the changes.
     async fn save(&mut self) -> Result<(), WorkerError> {
+        // SAFETY: this is the only place a write-lock is acquired, and read-locks are acquired in
+        // the `chain_state_view` method, which has a `&mut self` receiver like this `save` method.
+        // That means that when the write-lock is acquired, no readers will be waiting to acquire
+        // the lock. This is important because otherwise readers could have a stale view of the
+        // chain state.
+        let maybe_shared_chain_view = self.shared_chain_view.take();
+        let _maybe_write_guard = match &maybe_shared_chain_view {
+            Some(shared_chain_view) => Some(shared_chain_view.write().await),
+            None => None,
+        };
+
         Ok(self.chain.save().await?)
     }
 }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -653,8 +653,7 @@ where
         height: BlockHeight,
         delivery: CrossChainMessageDelivery,
     ) -> Result<(), ChainClientError> {
-        let storage_client = self.storage_client().await;
-        let recent_hashed_blobs = self.node_client.recent_hashed_blobs().await;
+        let local_node = self.node_client.clone();
         let chain_manager_pending_blobs = self.chain_managers_pending_blobs().await?;
         let nodes: Vec<_> = self.validator_node_provider.make_nodes(committee)?;
         communicate_with_quorum(
@@ -665,8 +664,7 @@ where
                 let mut updater = ValidatorUpdater {
                     name,
                     node,
-                    storage: storage_client.clone(),
-                    local_node_recent_hashed_blobs: recent_hashed_blobs.clone(),
+                    local_node: local_node.clone(),
                     local_node_chain_managers_pending_blobs: chain_manager_pending_blobs.clone(),
                 };
                 Box::pin(async move {
@@ -691,8 +689,7 @@ where
         action: CommunicateAction,
         value: HashedCertificateValue,
     ) -> Result<Certificate, ChainClientError> {
-        let storage_client = self.storage_client().await;
-        let recent_hashed_blobs = self.node_client.recent_hashed_blobs().await;
+        let local_node = self.node_client.clone();
         let chain_manager_pending_blobs = self.chain_managers_pending_blobs().await?;
         let nodes: Vec<_> = self.validator_node_provider.make_nodes(committee)?;
         let ((votes_hash, votes_round), votes) = communicate_with_quorum(
@@ -703,8 +700,7 @@ where
                 let mut updater = ValidatorUpdater {
                     name,
                     node,
-                    storage: storage_client.clone(),
-                    local_node_recent_hashed_blobs: recent_hashed_blobs.clone(),
+                    local_node: local_node.clone(),
                     local_node_chain_managers_pending_blobs: chain_manager_pending_blobs.clone(),
                 };
                 let action = action.clone();

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -45,6 +45,7 @@ use linera_storage::Storage;
 use linera_views::views::ViewError;
 use serde::Serialize;
 use thiserror::Error;
+use tokio::sync::OwnedRwLockReadGuard;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info};
 
@@ -332,13 +333,8 @@ where
     /// Obtains a `ChainStateView` for a given `ChainId`.
     pub async fn chain_state_view(
         &self,
-    ) -> Result<Arc<ChainStateView<S::Context>>, LocalNodeError> {
-        let chain_state_view = self
-            .storage_client()
-            .await
-            .load_chain(self.chain_id)
-            .await?;
-        Ok(Arc::new(chain_state_view))
+    ) -> Result<OwnedRwLockReadGuard<ChainStateView<S::Context>>, LocalNodeError> {
+        Ok(self.node_client.chain_state_view(self.chain_id).await?)
     }
 
     /// Subscribes to notifications from this client's chain.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -674,10 +674,8 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<OwnedRwLockReadGuard<ChainStateView<StorageClient::Context>>, WorkerError> {
-        self.create_chain_worker(chain_id)
-            .await?
-            .chain_state_view()
-            .await
+        let mut worker = self.create_chain_worker(chain_id).await?;
+        worker.chain_state_view().await
     }
 
     /// Creates a [`ChainWorkerState`] instance for a specific chain.

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -12,7 +12,7 @@ use linera_base::{
 use linera_views::{
     common::Context,
     map_view::HashedMapView,
-    views::{HashableView, ViewError},
+    views::{ClonableView, HashableView, ViewError},
 };
 use serde::{Deserialize, Serialize};
 #[cfg(with_testing)]
@@ -68,7 +68,7 @@ pub struct BytecodeLocation {
     pub operation_index: u32,
 }
 
-#[derive(Debug, HashableView)]
+#[derive(Debug, ClonableView, HashableView)]
 pub struct ApplicationRegistryView<C> {
     /// The application bytecodes that have been published.
     pub published_bytecodes: HashedMapView<C, BytecodeId, BytecodeLocation>,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -12,7 +12,7 @@ use linera_views::{
     common::Context,
     key_value_store_view::KeyValueStoreView,
     reentrant_collection_view::HashedReentrantCollectionView,
-    views::{View, ViewError},
+    views::{ClonableView, View, ViewError},
 };
 use linera_views_derive::CryptoHashView;
 #[cfg(with_testing)]
@@ -33,7 +33,7 @@ use crate::{
 };
 
 /// A view accessing the execution state of a chain.
-#[derive(Debug, CryptoHashView)]
+#[derive(Debug, ClonableView, CryptoHashView)]
 pub struct ExecutionStateView<C> {
     /// System application.
     pub system: SystemExecutionStateView<C>,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -22,7 +22,7 @@ use linera_views::{
     map_view::HashedMapView,
     register_view::HashedRegisterView,
     set_view::HashedSetView,
-    views::{HashableView, View, ViewError},
+    views::{ClonableView, HashableView, View, ViewError},
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -62,7 +62,7 @@ static OPEN_CHAIN_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 });
 
 /// A view accessing the execution state of the system of a chain.
-#[derive(Debug, HashableView)]
+#[derive(Debug, ClonableView, HashableView)]
 pub struct SystemExecutionStateView<C> {
     /// How the chain was created. May be unknown for inactive chains.
     pub description: HashedRegisterView<C, Option<ChainDescription>>,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -801,7 +801,7 @@ impl ChainStateViewExtension {
 }
 
 #[derive(MergedObject)]
-struct ChainStateExtendedView<C>(ChainStateViewExtension, Arc<ChainStateView<C>>)
+struct ChainStateExtendedView<C>(ChainStateViewExtension, ReadOnlyChainStateView<C>)
 where
     C: linera_views::common::Context + Clone + Send + Sync + 'static,
     ViewError: From<C::Error>,
@@ -855,8 +855,11 @@ where
     ViewError: From<C::Error>,
     C::Extra: linera_execution::ExecutionRuntimeContext,
 {
-    fn new(view: Arc<ChainStateView<C>>) -> Self {
-        Self(ChainStateViewExtension(view.chain_id()), view)
+    fn new(view: OwnedRwLockReadGuard<ChainStateView<C>>) -> Self {
+        Self(
+            ChainStateViewExtension(view.chain_id()),
+            ReadOnlyChainStateView(view),
+        )
     }
 }
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The client node currently loads `ChainStateView` directly from storage when it needs to read some information from it. This is inefficient because it requires reloading the `ChainStateView` (which means deserializing its data) every time. It also holds a lock while doing so, preventing others to access the same chain state.

The goal is to keep the `ChainStateView` in memory for a longer amount of time. In order to do so, each `ChainWorkerState` (introduced in #2055) becomes the owner of its respective `ChainStateView`. That means that it will hold a lock on the `ChainStateView` and the client node won't be able to access it as it is currently accessed.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Access the `ChainStateView` through the `WorkerState` in the `LocalNode`. The `ChainStateView` is wrapped inside an `Arc<RwLock<ChainStateView>>`, which allows the `ChainWorkerState` to share a read-only view of the chain state with the client when needed.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, so existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is an internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
