### PR TITLE
`linera-service`: give `ClientContext` access to storage

### DIFF
--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -33,7 +33,7 @@ use linera_execution::{
 use linera_service::{
     chain_listener::ClientContext as _,
     cli_wrappers,
-    config::{CommitteeConfig, Export, GenesisConfig, Import},
+    config::{CommitteeConfig, Export, GenesisConfig, Import, WalletState},
     faucet::FaucetService,
     node_service::NodeService,
     project::{self, Project},
@@ -75,7 +75,7 @@ fn deserialize_response(response: RpcMessage) -> Option<ChainInfoResponse> {
     }
 }
 
-struct Job(ClientContext, ClientCommand);
+struct Job(ClientOptions, WalletState);
 
 fn read_json(string: Option<String>, path: Option<PathBuf>) -> anyhow::Result<Vec<u8>> {
     let value = match (string, path) {
@@ -99,7 +99,10 @@ impl Runnable for Job {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
-        let Job(mut context, command) = self;
+        let Job(options, wallet) = self;
+        let mut context = ClientContext::new(&options, wallet);
+        let command = options.command;
+
         use ClientCommand::*;
         match command {
             Transfer {


### PR DESCRIPTION
## Motivation

In the future, the `ClientContext` will contain a `Client`, which needs to be constructed with access to a `Storage` instance.  However, currently the `ClientContext` is constructed outside the `Job`, which is the only place the `Storage` is available.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Move the construction of the `ClientContext` into the `Job`, so it has access to storage.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
