### PR TITLE
Refactor BlockProposal.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -794,17 +794,20 @@ impl HashedCertificateValue {
     }
 }
 
-/// The data a block proposer signs: the round, the block, and, if it is a retry from an earlier
-/// consensus round, the oracle records.
+/// The data a block proposer signs.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ProposalContent {
+    /// The proposed block.
     pub block: Block,
+    /// The consensus round in which this proposal is made.
     pub round: Round,
-    pub oracle_records: Option<Vec<OracleRecord>>,
+    /// If this is a retry from an earlier round, the oracle records from when the block was
+    /// first validated. These are reused so the execution outcome remains the same.
+    pub forced_oracle_records: Option<Vec<OracleRecord>>,
 }
 
 impl BlockProposal {
-    pub fn new(
+    pub fn new_initial(
         round: Round,
         block: Block,
         secret: &KeyPair,
@@ -814,7 +817,7 @@ impl BlockProposal {
         let content = ProposalContent {
             round,
             block,
-            oracle_records: None,
+            forced_oracle_records: None,
         };
         let signature = Signature::new(&content, secret);
         Self {
@@ -843,7 +846,7 @@ impl BlockProposal {
         let content = ProposalContent {
             block: executed_block.block,
             round,
-            oracle_records: Some(executed_block.outcome.oracle_records),
+            forced_oracle_records: Some(executed_block.outcome.oracle_records),
         };
         let signature = Signature::new(&content, secret);
         Self {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -841,7 +841,7 @@ impl BlockProposal {
         let CertificateValue::ValidatedBlock { executed_block } =
             validated_block_certificate.value.into_inner()
         else {
-            panic!("called new_retry with a certificate without a block");
+            panic!("called new_retry with a certificate without a validated block");
         };
         let content = ProposalContent {
             block: executed_block.block,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -108,8 +108,6 @@ pub enum ChainError {
     InvalidBlockTimestamp,
     #[error("Cannot initiate a new block while the previous one is still pending confirmation")]
     PreviousBlockMustBeConfirmedFirst,
-    #[error("Invalid block proposal")]
-    InvalidBlockProposal,
     #[error("Round number should be at least {0:?}")]
     InsufficientRound(Round),
     #[error("Round number should greater than {0:?}")]

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -113,7 +113,7 @@ impl BlockTestExt for Block {
     }
 
     fn into_proposal_with_round(self, key_pair: &KeyPair, round: Round) -> BlockProposal {
-        BlockProposal::new(round, self, key_pair, vec![], vec![])
+        BlockProposal::new_initial(round, self, key_pair, vec![], vec![])
     }
 }
 

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -15,8 +15,8 @@ use linera_execution::{
 };
 
 use crate::data_types::{
-    Block, BlockAndRound, BlockProposal, Certificate, Event, HashedCertificateValue,
-    IncomingMessage, MessageAction, Origin, SignatureAggregator, Vote,
+    Block, BlockProposal, Certificate, Event, HashedCertificateValue, IncomingMessage,
+    MessageAction, Origin, SignatureAggregator, Vote,
 };
 
 /// Creates a new child of the given block, with the same timestamp.
@@ -76,14 +76,6 @@ pub trait BlockTestExt: Sized {
 
     /// Returns a block proposal without any hashed certificate values or validated block.
     fn into_proposal_with_round(self, key_pair: &KeyPair, round: Round) -> BlockProposal;
-
-    /// Returns a block proposal including a validated block as justification.
-    fn into_justified_proposal(
-        self,
-        key_pair: &KeyPair,
-        round: Round,
-        validated: Certificate,
-    ) -> BlockProposal;
 }
 
 impl BlockTestExt for Block {
@@ -121,18 +113,7 @@ impl BlockTestExt for Block {
     }
 
     fn into_proposal_with_round(self, key_pair: &KeyPair, round: Round) -> BlockProposal {
-        let content = BlockAndRound { block: self, round };
-        BlockProposal::new(content, key_pair, vec![], vec![], None)
-    }
-
-    fn into_justified_proposal(
-        self,
-        key_pair: &KeyPair,
-        round: Round,
-        validated: Certificate,
-    ) -> BlockProposal {
-        let content = BlockAndRound { block: self, round };
-        BlockProposal::new(content, key_pair, vec![], vec![], Some(validated))
+        BlockProposal::new(round, self, key_pair, vec![], vec![])
     }
 }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -327,7 +327,7 @@ where
             .await?;
         if let Some(lite_certificate) = &validated_block_certificate {
             let value = HashedCertificateValue::new_validated(outcome.clone().with(block.clone()));
-            let _ = lite_certificate
+            lite_certificate
                 .clone()
                 .with_value(value)
                 .ok_or_else(|| WorkerError::InvalidLiteCertificate)?;

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -18,9 +18,9 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockAndRound, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue,
-        ExecutedBlock, HashedCertificateValue, IncomingMessage, Medium, MessageAction,
-        MessageBundle, Origin, Target,
+        Block, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue, ExecutedBlock,
+        HashedCertificateValue, IncomingMessage, Medium, MessageAction, MessageBundle, Origin,
+        ProposalContent, Target,
     },
     manager, ChainError, ChainStateView,
 };
@@ -250,13 +250,24 @@ where
         proposal: BlockProposal,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let BlockProposal {
-            content: BlockAndRound { block, round },
+            content:
+                ProposalContent {
+                    block,
+                    round,
+                    oracle_records,
+                },
             owner,
             hashed_certificate_values,
             hashed_blobs,
             validated_block_certificate,
             signature: _,
         } = &proposal;
+        ensure!(
+            validated_block_certificate.is_some() == oracle_records.is_some(),
+            WorkerError::InvalidBlockProposal(
+                "Must contain a certificate if and only if it contains oracle records".to_string()
+            )
+        );
         self.ensure_is_active()?;
         // Check the epoch.
         let (epoch, committee) = self
@@ -274,9 +285,9 @@ where
             .verify_owner(&proposal)
             .ok_or(WorkerError::InvalidOwner)?;
         proposal.check_signature(public_key)?;
-        if let Some(validated_block_certificate) = validated_block_certificate {
+        if let Some(lite_certificate) = validated_block_certificate {
             // Verify that this block has been validated by a quorum before.
-            validated_block_certificate.check(committee)?;
+            lite_certificate.check(committee)?;
         } else if let Some(signer) = block.authenticated_signer {
             // Check the authentication of the operations in the new block.
             ensure!(signer == *owner, WorkerError::InvalidSigner(signer));
@@ -310,16 +321,17 @@ where
         );
         self.storage.clock().sleep_until(block.timestamp).await;
         let local_time = self.storage.clock().current_time();
-        let outcome = if let Some(validated_block_certificate) = validated_block_certificate {
-            validated_block_certificate
-                .value()
-                .executed_block()
-                .ok_or_else(|| WorkerError::MissingExecutedBlockInProposal)?
-                .outcome
+        let outcome = self
+            .chain
+            .execute_block(block, local_time, oracle_records.clone())
+            .await?;
+        if let Some(lite_certificate) = &validated_block_certificate {
+            let value = HashedCertificateValue::new_validated(outcome.clone().with(block.clone()));
+            let _ = lite_certificate
                 .clone()
-        } else {
-            self.chain.execute_block(block, local_time, None).await?
-        };
+                .with_value(value)
+                .ok_or_else(|| WorkerError::InvalidLiteCertificate)?;
+        }
         if round.is_fast() {
             let mut records = outcome.oracle_records.iter();
             ensure!(

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -254,7 +254,7 @@ where
                 ProposalContent {
                     block,
                     round,
-                    oracle_records,
+                    forced_oracle_records: oracle_records,
                 },
             owner,
             hashed_certificate_values,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1284,7 +1284,7 @@ where
         let proposal = if let Some(cert) = manager.requested_locked {
             BlockProposal::new_retry(round, *cert, key_pair, values, hashed_blobs)
         } else {
-            BlockProposal::new(round, block.clone(), key_pair, values, hashed_blobs)
+            BlockProposal::new_initial(round, block.clone(), key_pair, values, hashed_blobs)
         };
         // Check the final block proposal. This will be cheaper after #1401.
         self.node_client

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1682,7 +1682,7 @@ where
         .unwrap()
         .manager;
     assert_eq!(
-        manager.highest_validated().unwrap().round,
+        manager.requested_locked.unwrap().round,
         Round::MultiLeader(1)
     );
     assert!(client0.pending_block.is_some());
@@ -1819,7 +1819,7 @@ where
     // Validator 0 may or may not have processed the validated block before the update was
     // canceled due to the errors from the faulty validators. Submit it again to make sure
     // it's there, so that client 1 can download and re-propose it later.
-    let validated_block_certificate = manager.highest_validated().unwrap().clone();
+    let validated_block_certificate = *manager.requested_locked.unwrap();
     builder
         .node(0)
         .handle_certificate(
@@ -1845,7 +1845,7 @@ where
         .unwrap()
         .manager;
     assert!(manager.requested_proposed.is_some());
-    assert!(manager.highest_validated().is_none());
+    assert!(manager.requested_locked.is_none());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
     let result = client1
         .burn(None, Amount::from_tokens(2), UserData::default())
@@ -1863,7 +1863,7 @@ where
         .unwrap()
         .manager;
     assert_eq!(
-        manager.highest_validated().unwrap().round,
+        manager.requested_locked.unwrap().round,
         Round::MultiLeader(0)
     );
     assert_eq!(manager.current_round, Round::MultiLeader(1));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -254,6 +254,8 @@ pub enum WorkerError {
     BlobsNotFound(Vec<BlobId>),
     #[error("The following values containing application bytecode are missing: {0:?} and the following blobs are missing: {1:?}.")]
     ApplicationBytecodesAndBlobsNotFound(Vec<BytecodeLocation>, Vec<BlobId>),
+    #[error("The block proposal is invalid: {0}")]
+    InvalidBlockProposal(String),
 }
 
 impl From<linera_chain::ChainError> for WorkerError {

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -169,8 +169,8 @@ message BlockProposal {
   // Required bytecode
   bytes hashed_certificate_values = 5;
 
-  // A certificate for a validated block that justifies the proposal in this round.
-  optional bytes validated = 6;
+  // A lite certificate for a validated block that justifies the proposal in this round.
+  optional bytes validated_block_certificate = 6;
 
   // Required blob
   bytes blobs = 7;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -8,7 +8,7 @@ use linera_base::{
     identifiers::{BlobId, ChainId, Owner},
 };
 use linera_chain::data_types::{
-    BlockAndRound, BlockProposal, Certificate, HashedCertificateValue, LiteCertificate, LiteValue,
+    BlockProposal, Certificate, HashedCertificateValue, LiteCertificate, LiteValue, ProposalContent,
 };
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
@@ -174,7 +174,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
                 &block_proposal.hashed_certificate_values,
             )?,
             blobs: bincode::serialize(&block_proposal.hashed_blobs)?,
-            validated: block_proposal
+            validated_block_certificate: block_proposal
                 .validated_block_certificate
                 .map(|cert| bincode::serialize(&cert))
                 .transpose()?,
@@ -186,7 +186,7 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
     type Error = GrpcProtoConversionError;
 
     fn try_from(block_proposal: api::BlockProposal) -> Result<Self, Self::Error> {
-        let content: BlockAndRound = bincode::deserialize(&block_proposal.content)?;
+        let content: ProposalContent = bincode::deserialize(&block_proposal.content)?;
         ensure!(
             Some(content.block.chain_id.into()) == block_proposal.chain_id,
             GrpcProtoConversionError::InconsistentChainId
@@ -200,7 +200,7 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
             )?,
             hashed_blobs: bincode::deserialize(&block_proposal.blobs)?,
             validated_block_certificate: block_proposal
-                .validated
+                .validated_block_certificate
                 .map(|bytes| bincode::deserialize(&bytes))
                 .transpose()?,
         })
@@ -557,7 +557,7 @@ pub mod tests {
         data_types::{Amount, Round, Timestamp},
     };
     use linera_chain::{
-        data_types::{Block, BlockAndRound, BlockExecutionOutcome, HashedCertificateValue},
+        data_types::{Block, BlockExecutionOutcome, HashedCertificateValue},
         test::make_first_block,
     };
     use linera_core::data_types::ChainInfo;
@@ -769,10 +769,27 @@ pub mod tests {
     #[test]
     pub fn test_block_proposal() {
         let key_pair = KeyPair::generate();
+        let cert = Certificate::new(
+            HashedCertificateValue::new_validated(
+                BlockExecutionOutcome {
+                    state_hash: CryptoHash::new(&Foo("validated".into())),
+                    ..BlockExecutionOutcome::default()
+                }
+                .with(get_block()),
+            ),
+            Round::SingleLeader(2),
+            vec![(
+                ValidatorName::from(key_pair.public()),
+                Signature::new(&Foo("signed".into()), &key_pair),
+            )],
+        )
+        .lite_certificate()
+        .cloned();
         let block_proposal = BlockProposal {
-            content: BlockAndRound {
+            content: ProposalContent {
                 block: get_block(),
                 round: Round::SingleLeader(4),
+                oracle_records: Some(Vec::new()),
             },
             owner: Owner::from(KeyPair::generate().public()),
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),
@@ -784,20 +801,7 @@ pub mod tests {
                 .with(get_block()),
             )],
             hashed_blobs: vec![],
-            validated_block_certificate: Some(Certificate::new(
-                HashedCertificateValue::new_validated(
-                    BlockExecutionOutcome {
-                        state_hash: CryptoHash::new(&Foo("validated".into())),
-                        ..BlockExecutionOutcome::default()
-                    }
-                    .with(get_block()),
-                ),
-                Round::SingleLeader(2),
-                vec![(
-                    ValidatorName::from(key_pair.public()),
-                    Signature::new(&Foo("signed".into()), &key_pair),
-                )],
-            )),
+            validated_block_certificate: Some(cert),
         };
 
         round_trip_check::<_, api::BlockProposal>(block_proposal);

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -789,7 +789,7 @@ pub mod tests {
             content: ProposalContent {
                 block: get_block(),
                 round: Round::SingleLeader(4),
-                oracle_records: Some(Vec::new()),
+                forced_oracle_records: Some(Vec::new()),
             },
             owner: Owner::from(KeyPair::generate().public()),
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -71,12 +71,6 @@ Block:
     - previous_block_hash:
         OPTION:
           TYPENAME: CryptoHash
-BlockAndRound:
-  STRUCT:
-    - block:
-        TYPENAME: Block
-    - round:
-        TYPENAME: Round
 BlockExecutionOutcome:
   STRUCT:
     - messages:
@@ -100,7 +94,7 @@ BlockHeightRange:
 BlockProposal:
   STRUCT:
     - content:
-        TYPENAME: BlockAndRound
+        TYPENAME: ProposalContent
     - owner:
         TYPENAME: Owner
     - signature:
@@ -113,7 +107,7 @@ BlockProposal:
           TYPENAME: Blob
     - validated_block_certificate:
         OPTION:
-          TYPENAME: Certificate
+          TYPENAME: LiteCertificate
 Bytecode:
   STRUCT:
     - bytes: BYTES
@@ -690,6 +684,16 @@ OutgoingMessage:
 Owner:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
+ProposalContent:
+  STRUCT:
+    - block:
+        TYPENAME: Block
+    - round:
+        TYPENAME: Round
+    - oracle_records:
+        OPTION:
+          SEQ:
+            TYPENAME: OracleRecord
 PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -690,7 +690,7 @@ ProposalContent:
         TYPENAME: Block
     - round:
         TYPENAME: Round
-    - oracle_records:
+    - forced_oracle_records:
         OPTION:
           SEQ:
             TYPENAME: OracleRecord

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -42,7 +42,7 @@ use {
         data_types::Amount,
         identifiers::{AccountOwner, ApplicationId, Owner},
     },
-    linera_chain::data_types::{Block, BlockAndRound, BlockProposal, SignatureAggregator, Vote},
+    linera_chain::data_types::{Block, BlockProposal, SignatureAggregator, Vote},
     linera_core::{data_types::ChainInfoQuery, local_node::LocalNodeClient, worker::WorkerState},
     linera_execution::{
         committee::Epoch,
@@ -656,14 +656,11 @@ impl ClientContext {
             };
             trace!("Preparing block proposal: {:?}", block);
             let proposal = BlockProposal::new(
-                BlockAndRound {
-                    block: block.clone(),
-                    round: linera_base::data_types::Round::Fast,
-                },
+                linera_base::data_types::Round::Fast,
+                block.clone(),
                 key_pair,
                 vec![],
                 vec![],
-                None,
             );
             proposals.push(proposal.into());
             next_recipient = chain.chain_id;

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -655,7 +655,7 @@ impl ClientContext {
                 timestamp: chain.timestamp.max(Timestamp::now()),
             };
             trace!("Preparing block proposal: {:?}", block);
-            let proposal = BlockProposal::new(
+            let proposal = BlockProposal::new_initial(
                 linera_base::data_types::Round::Fast,
                 block.clone(),
                 key_pair,


### PR DESCRIPTION
## Motivation

Originally `BlockAndRound` was exactly the part of the block proposal that was signed. But now, if you re-propose a validated block from an earlier round, you also have to sign at least the oracle records from that block. This is currently solved with a temporary `ProposalPayload` structure. Also, the block is duplicated in `BlockProposal`, since it is contained in the earlier round's certificate and in `BlockAndRound`.

## Proposal

Replace `BlockAndRound` with `ProposalContent`, which also contains an optional list of oracle records. Use a lite certificate instead of a certificate if it is a retry from an earlier round.

To simplify the code a bit, remove the option to re-propose a validated block without including the certificate. (Currently, the manager would accept that.)

## Test Plan

The tests have been updated. No new features have been added.

## Links

- Closes #1987.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
