### PR TITLE
Global local client

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -117,7 +117,7 @@ impl<ValidatorNodeProvider: Clone> Client<ValidatorNodeProvider> {
     /// Creates a new `ChainClient`.
     #[allow(clippy::too_many_arguments)]
     pub fn build<Storage>(
-        &self,
+        self: &Arc<Self>,
         chain_id: ChainId,
         known_key_pairs: Vec<KeyPair>,
         storage: Storage,
@@ -143,6 +143,7 @@ impl<ValidatorNodeProvider: Clone> Client<ValidatorNodeProvider> {
         .with_allow_messages_from_deprecated_epochs(true);
         let node_client = LocalNodeClient::new(state);
         ChainClient {
+            client: self.clone(),
             chain_id,
             known_key_pairs,
             validator_node_provider: self.validator_node_provider.clone(),
@@ -193,6 +194,8 @@ impl MessagePolicy {
 /// * As a rule, operations are considered successful (and communication may stop) when
 /// they succeeded in gathering a quorum of responses.
 pub struct ChainClient<ValidatorNodeProvider, Storage> {
+    /// The Linera [`Client`] that manages operations on this chain.
+    client: Arc<Client<ValidatorNodeProvider>>,
     /// The off-chain chain ID.
     chain_id: ChainId,
     /// How to talk to the validators.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -629,11 +629,15 @@ where
         let storage = self.make_storage().await?;
         self.chain_client_storages.push(storage.clone());
         let provider = self.make_node_provider();
-        let builder = Arc::new(Client::new(provider, 10, CrossChainMessageDelivery::NonBlocking));
+        let builder = Arc::new(Client::new(
+            provider,
+            storage,
+            10,
+            CrossChainMessageDelivery::NonBlocking,
+        ));
         Ok(builder.build(
             chain_id,
             vec![key_pair],
-            storage,
             self.admin_id,
             block_hash,
             Timestamp::from(0),

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -629,7 +629,7 @@ where
         let storage = self.make_storage().await?;
         self.chain_client_storages.push(storage.clone());
         let provider = self.make_node_provider();
-        let builder = Client::new(provider, 10, CrossChainMessageDelivery::NonBlocking);
+        let builder = Arc::new(Client::new(provider, 10, CrossChainMessageDelivery::NonBlocking));
         Ok(builder.build(
             chain_id,
             vec![key_pair],

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -116,7 +116,7 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
-    C: ClientContext<P> + Send + 'static,
+    C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     ViewError: From<S::ContextError>,
 {
     /// Creates a new chain with the given authentication key, and transfers tokens to it.
@@ -130,7 +130,7 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
-    C: ClientContext<P> + Send + 'static,
+    C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     ViewError: From<S::ContextError>,
 {
     async fn do_claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
@@ -227,7 +227,7 @@ impl<P, S, C> FaucetService<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    C: ClientContext<P> + Send + 'static,
+    C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     ViewError: From<S::ContextError>,
 {
     /// Creates a new instance of the faucet service.

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -137,7 +137,7 @@ where
         let mut client = self.client.lock().await;
 
         if self.start_timestamp < self.end_timestamp {
-            let local_time = client.storage_client().await.clock().current_time();
+            let local_time = client.storage_client().clock().current_time();
             if local_time < self.end_timestamp {
                 let full_duration = self
                     .end_timestamp
@@ -239,7 +239,7 @@ where
         end_timestamp: Timestamp,
         genesis_config: Arc<GenesisConfig>,
     ) -> anyhow::Result<Self> {
-        let start_timestamp = client.storage_client().await.clock().current_time();
+        let start_timestamp = client.storage_client().clock().current_time();
         client.process_inbox().await?;
         let start_balance = client.local_balance().await?;
         Ok(Self {

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::BTreeMap,
     path::PathBuf,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -67,7 +68,7 @@ use crate::{client_options::ChainOwnershipConfig, ClientOptions};
 
 pub struct ClientContext {
     pub(crate) wallet_state: WalletState,
-    pub(crate) chain_client_builder: Client<NodeProvider>,
+    pub(crate) chain_client_builder: Arc<Client<NodeProvider>>,
     pub(crate) send_timeout: Duration,
     pub(crate) recv_timeout: Duration,
     pub(crate) notification_retry_delay: Duration,
@@ -125,7 +126,7 @@ impl ClientContext {
         let node_provider = NodeProvider::new(node_options);
         let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
         let chain_client_builder =
-            Client::new(node_provider, options.max_pending_messages, delivery);
+            Arc::new(Client::new(node_provider, options.max_pending_messages, delivery));
         ClientContext {
             chain_client_builder,
             wallet_state,

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -419,7 +419,11 @@ where
 }
 
 #[cfg(feature = "benchmark")]
-impl<S> ClientContext<S> {
+impl<S> ClientContext<S>
+where
+    S: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
+{
     pub async fn process_inboxes_and_force_validator_updates(&mut self) {
         for chain_id in self.wallet().own_chain_ids() {
             let chain_client = self.make_chain_client(chain_id).into_arc();
@@ -430,7 +434,7 @@ impl<S> ClientContext<S> {
 
     /// Creates chains if necessary, and returns a map of exactly `num_chains` chain IDs
     /// with key pairs.
-    pub async fn make_benchmark_chains<S>(
+    pub async fn make_benchmark_chains(
         &mut self,
         num_chains: usize,
         balance: Amount,

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -756,7 +756,7 @@ where
         let worker = WorkerState::new(
             "Temporary client node".to_string(),
             None,
-            self.client.storage_client().await,
+            self.client.storage_client().clone(),
         )
         .with_allow_inactive_chains(true)
         .with_allow_messages_from_deprecated_epochs(true);

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -102,7 +102,7 @@ impl Runnable for Job {
         ViewError: From<S::ContextError>,
     {
         let Job(options, wallet) = self;
-        let mut context = ClientContext::new(&options, wallet);
+        let mut context = ClientContext::new(storage.clone(), &options, wallet);
         let command = options.command;
 
         use ClientCommand::*;
@@ -112,9 +112,7 @@ impl Runnable for Job {
                 recipient,
                 amount,
             } => {
-                let chain_client = context
-                    .make_chain_client(storage, sender.chain_id)
-                    .into_arc();
+                let chain_client = context.make_chain_client(sender.chain_id).into_arc();
                 info!(
                     "Starting transfer of {} native tokens from {} to {}",
                     amount, sender, recipient
@@ -140,7 +138,7 @@ impl Runnable for Job {
                 balance,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
+                let chain_client = context.make_chain_client(chain_id).into_arc();
                 let (new_public_key, key_pair) = match public_key {
                     Some(key) => (key, None),
                     None => {
@@ -186,7 +184,7 @@ impl Runnable for Job {
                 application_permissions_config,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
+                let chain_client = context.make_chain_client(chain_id).into_arc();
                 info!(
                     "Opening a new multi-owner chain from existing chain {}",
                     chain_id
@@ -230,18 +228,14 @@ impl Runnable for Job {
             ChangeOwnership {
                 chain_id,
                 ownership_config,
-            } => {
-                context
-                    .change_ownership(chain_id, ownership_config, storage)
-                    .await?
-            }
+            } => context.change_ownership(chain_id, ownership_config).await?,
 
             ChangeApplicationPermissions {
                 chain_id,
                 application_permissions_config,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
+                let chain_client = context.make_chain_client(chain_id).into_arc();
                 info!("Changing application permissions for chain {}", chain_id);
                 let time_start = Instant::now();
                 let application_permissions =
@@ -263,7 +257,7 @@ impl Runnable for Job {
             }
 
             CloseChain { chain_id } => {
-                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
+                let chain_client = context.make_chain_client(chain_id).into_arc();
                 info!("Closing chain {}", chain_id);
                 let time_start = Instant::now();
                 let certificate = context
@@ -283,7 +277,7 @@ impl Runnable for Job {
                 channel,
             } => {
                 let subscriber = subscriber.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(storage, subscriber).into_arc();
+                let chain_client = context.make_chain_client(subscriber).into_arc();
                 let time_start = Instant::now();
                 info!("Subscribing");
                 let certificate = context
@@ -315,7 +309,7 @@ impl Runnable for Job {
                 channel,
             } => {
                 let subscriber = subscriber.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(storage, subscriber).into_arc();
+                let chain_client = context.make_chain_client(subscriber).into_arc();
                 let time_start = Instant::now();
                 let certificate = context
                     .apply_client_command(&chain_client, |mut chain_client| async move {
@@ -344,7 +338,7 @@ impl Runnable for Job {
 
             LocalBalance { account } => {
                 let account = account.unwrap_or_else(|| context.default_account());
-                let mut chain_client = context.make_chain_client(storage, account.chain_id);
+                let mut chain_client = context.make_chain_client(account.chain_id);
                 info!("Reading the balance of {} from the local state", account);
                 let time_start = Instant::now();
                 let balance = match account.owner {
@@ -358,7 +352,7 @@ impl Runnable for Job {
 
             QueryBalance { account } => {
                 let account = account.unwrap_or_else(|| context.default_account());
-                let mut chain_client = context.make_chain_client(storage, account.chain_id);
+                let mut chain_client = context.make_chain_client(account.chain_id);
                 info!(
                     "Evaluating the local balance of {} by staging execution of known incoming messages", account
                 );
@@ -374,7 +368,7 @@ impl Runnable for Job {
 
             SyncBalance { account } => {
                 let account = account.unwrap_or_else(|| context.default_account());
-                let mut chain_client = context.make_chain_client(storage, account.chain_id);
+                let mut chain_client = context.make_chain_client(account.chain_id);
                 info!("Synchronizing chain information and querying the local balance");
                 warn!("This command is deprecated. Use `linera sync && linera query-balance` instead.");
                 let time_start = Instant::now();
@@ -392,7 +386,7 @@ impl Runnable for Job {
 
             Sync { chain_id } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let mut chain_client = context.make_chain_client(storage, chain_id);
+                let mut chain_client = context.make_chain_client(chain_id);
                 info!("Synchronizing chain information");
                 let time_start = Instant::now();
                 chain_client.synchronize_from_validators().await?;
@@ -406,7 +400,7 @@ impl Runnable for Job {
 
             ProcessInbox { chain_id } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
+                let chain_client = context.make_chain_client(chain_id).into_arc();
                 info!("Processing the inbox of chain {}", chain_id);
                 let time_start = Instant::now();
                 let certificates = context.process_inbox(&chain_client).await?;
@@ -422,7 +416,7 @@ impl Runnable for Job {
                 use linera_core::node::ValidatorNode as _;
 
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let mut chain_client = context.make_chain_client(storage, chain_id);
+                let mut chain_client = context.make_chain_client(chain_id);
                 info!(
                     "Querying the validators of the current epoch of chain {}",
                     chain_id
@@ -464,7 +458,7 @@ impl Runnable for Job {
                 let context = Arc::new(Mutex::new(context));
                 let mut context = context.lock().await;
                 let chain_client = context
-                    .make_chain_client(storage.clone(), context.wallet().genesis_admin_chain())
+                    .make_chain_client(context.wallet().genesis_admin_chain())
                     .into_arc();
                 let n = context
                     .process_inbox(&chain_client)
@@ -749,7 +743,7 @@ impl Runnable for Job {
             Watch { chain_id, raw } => {
                 let mut join_set = JoinSet::new();
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
-                let chain_client = context.make_chain_client(storage, chain_id).into_arc();
+                let chain_client = context.make_chain_client(chain_id).into_arc();
                 info!("Watching for notifications for chain {:?}", chain_id);
                 let (listener, _listen_handle, mut notifications) = chain_client.listen().await?;
                 join_set.spawn_task(listener);
@@ -779,7 +773,7 @@ impl Runnable for Job {
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Starting faucet service using chain {}", chain_id);
-                let chain_client = context.make_chain_client(storage, chain_id);
+                let chain_client = context.make_chain_client(chain_id);
                 let end_timestamp = limit_rate_until
                     .map(|et| {
                         let micros = u64::try_from(et.timestamp_micros())
@@ -808,7 +802,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing bytecode on chain {}", publisher);
-                let chain_client = context.make_chain_client(storage, publisher).into_arc();
+                let chain_client = context.make_chain_client(publisher).into_arc();
                 let bytecode_id = context
                     .publish_bytecode(&chain_client, contract, service)
                     .await?;
@@ -824,7 +818,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing blob on chain {}", publisher);
-                let chain_client = context.make_chain_client(storage, publisher).into_arc();
+                let chain_client = context.make_chain_client(publisher).into_arc();
                 let blob_id = context.publish_blob(&chain_client, blob_path).await?;
                 println!("{}", blob_id);
                 info!("{}", "Blob published successfully!".green().bold());
@@ -843,7 +837,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let creator = creator.unwrap_or_else(|| context.default_chain());
                 info!("Creating application on chain {}", creator);
-                let mut chain_client = context.make_chain_client(storage, creator);
+                let mut chain_client = context.make_chain_client(creator);
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
 
@@ -888,7 +882,7 @@ impl Runnable for Job {
                 let start_time = Instant::now();
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing and creating application on chain {}", publisher);
-                let chain_client = context.make_chain_client(storage, publisher).into_arc();
+                let chain_client = context.make_chain_client(publisher).into_arc();
                 let parameters = read_json(json_parameters, json_parameters_path)?;
                 let argument = read_json(json_argument, json_argument_path)?;
 
@@ -927,9 +921,7 @@ impl Runnable for Job {
                 let requester_chain_id =
                     requester_chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Requesting application for chain {}", requester_chain_id);
-                let chain_client = context
-                    .make_chain_client(storage, requester_chain_id)
-                    .into_arc();
+                let chain_client = context.make_chain_client(requester_chain_id).into_arc();
                 let certificate = context
                     .apply_client_command(&chain_client, |mut chain_client| async move {
                         chain_client
@@ -975,7 +967,7 @@ impl Runnable for Job {
                     let start_time = Instant::now();
                     let publisher = publisher.unwrap_or_else(|| context.default_chain());
                     info!("Creating application on chain {}", publisher);
-                    let chain_client = context.make_chain_client(storage, publisher).into_arc();
+                    let chain_client = context.make_chain_client(publisher).into_arc();
 
                     let parameters = read_json(json_parameters, json_parameters_path)?;
                     let argument = read_json(json_argument, json_argument_path)?;
@@ -1016,7 +1008,7 @@ impl Runnable for Job {
             RetryPendingBlock { chain_id } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Committing pending block for chain {}", chain_id);
-                let mut chain_client = context.make_chain_client(storage, chain_id);
+                let mut chain_client = context.make_chain_client(chain_id);
                 match chain_client.process_pending_block().await? {
                     ClientOutcome::Committed(Some(certificate)) => {
                         info!("Pending block committed successfully.");
@@ -1083,7 +1075,7 @@ impl Job {
         storage: S,
         public_key: PublicKey,
         validators: Option<Vec<(ValidatorName, String)>>,
-        context: &mut ClientContext,
+        context: &mut ClientContext<S>,
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
@@ -1154,7 +1146,7 @@ impl Job {
     async fn print_peg_certificate_hash<S>(
         storage: S,
         chain_ids: impl IntoIterator<Item = ChainId>,
-        context: &ClientContext,
+        context: &ClientContext<S>,
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -642,17 +642,15 @@ impl Runnable for Job {
                 // Below all block proposals are supposed to succeed without retries, we
                 // must make sure that all incoming payments have been accepted on-chain
                 // and that no validator is missing user certificates.
-                context
-                    .process_inboxes_and_force_validator_updates(&storage)
-                    .await;
+                context.process_inboxes_and_force_validator_updates().await;
 
                 let key_pairs = context
-                    .make_benchmark_chains(num_chains, tokens_per_chain, &storage)
+                    .make_benchmark_chains(num_chains, tokens_per_chain)
                     .await?;
 
                 if let Some(id) = fungible_application_id {
                     context
-                        .supply_fungible_tokens(&key_pairs, id, max_in_flight, &storage)
+                        .supply_fungible_tokens(&key_pairs, id, max_in_flight)
                         .await?;
                 }
 
@@ -734,9 +732,7 @@ impl Runnable for Job {
                 );
 
                 info!("Updating local state of user chains");
-                context
-                    .update_wallet_from_certificates(storage, certificates)
-                    .await;
+                context.update_wallet_from_certificates(certificates).await;
                 context.save_wallet();
             }
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -216,7 +216,7 @@ impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    C: ClientContext<P> + Send + 'static,
+    C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     ViewError: From<S::ContextError>,
 {
     async fn execute_system_operation(
@@ -276,7 +276,7 @@ impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    C: ClientContext<P> + Send + 'static,
+    C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     ViewError: From<S::ContextError>,
 {
     /// Processes the inbox and returns the lists of certificate hashes that were created, if any.
@@ -969,7 +969,7 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
-    C: ClientContext<P> + Send + 'static,
+    C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     ViewError: From<S::ContextError>,
 {
     /// Creates a new instance of the node service given a client chain and a port.

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -36,7 +36,7 @@ use crate::{
 
 struct ClientContext {
     wallet: Wallet,
-    chain_client_builder: Client<NodeProvider<MemoryStorage<TestClock>>>,
+    chain_client_builder: Arc<Client<NodeProvider<MemoryStorage<TestClock>>>>,
 }
 
 #[async_trait]
@@ -149,7 +149,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let delivery = CrossChainMessageDelivery::NonBlocking;
     let mut context = ClientContext {
         wallet: Wallet::new(genesis_config, Some(37)),
-        chain_client_builder: Client::new(builder.make_node_provider(), 10, delivery),
+        chain_client_builder: Arc::new(Client::new(builder.make_node_provider(), 10, delivery)),
     };
     let key_pair = KeyPair::generate_from(&mut rng);
     let public_key = key_pair.public();

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -24,8 +24,7 @@ use linera_rpc::{
     config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
     simple::TransportProtocol,
 };
-use linera_storage::{MemoryStorage, Storage, TestClock};
-use linera_views::views::ViewError;
+use linera_storage::{MemoryStorage, TestClock};
 use rand::SeedableRng as _;
 
 use crate::{
@@ -34,22 +33,24 @@ use crate::{
     wallet::{UserChain, Wallet},
 };
 
+type TestStorage = MemoryStorage<TestClock>;
+type TestProvider = NodeProvider<TestStorage>;
+
 struct ClientContext {
     wallet: Wallet,
-    chain_client_builder: Arc<Client<NodeProvider<MemoryStorage<TestClock>>>>,
+    client: Arc<Client<TestProvider, TestStorage>>,
 }
 
 #[async_trait]
-impl chain_listener::ClientContext<NodeProvider<MemoryStorage<TestClock>>> for ClientContext {
+impl chain_listener::ClientContext for ClientContext {
+    type ValidatorNodeProvider = TestProvider;
+    type Storage = TestStorage;
+
     fn wallet(&self) -> &Wallet {
         &self.wallet
     }
 
-    fn make_chain_client<S>(
-        &self,
-        storage: S,
-        chain_id: ChainId,
-    ) -> ChainClient<NodeProvider<MemoryStorage<TestClock>>, S> {
+    fn make_chain_client(&self, chain_id: ChainId) -> ChainClient<TestProvider, TestStorage> {
         let chain = self
             .wallet
             .get(chain_id)
@@ -60,10 +61,9 @@ impl chain_listener::ClientContext<NodeProvider<MemoryStorage<TestClock>>> for C
             .map(|kp| kp.copy())
             .into_iter()
             .collect();
-        self.chain_client_builder.build(
+        self.client.build(
             chain_id,
             known_key_pairs,
-            storage,
             self.wallet.genesis_admin_chain(),
             chain.block_hash,
             chain.timestamp,
@@ -92,13 +92,10 @@ impl chain_listener::ClientContext<NodeProvider<MemoryStorage<TestClock>>> for C
         }
     }
 
-    async fn update_wallet<'a, S>(
+    async fn update_wallet<'a>(
         &'a mut self,
-        client: &'a mut ChainClient<NodeProvider<MemoryStorage<TestClock>>, S>,
-    ) where
-        S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
-    {
+        client: &'a mut ChainClient<TestProvider, TestStorage>,
+    ) {
         self.wallet.update_from_state(client).await;
     }
 }
@@ -149,7 +146,12 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let delivery = CrossChainMessageDelivery::NonBlocking;
     let mut context = ClientContext {
         wallet: Wallet::new(genesis_config, Some(37)),
-        chain_client_builder: Arc::new(Client::new(builder.make_node_provider(), 10, delivery)),
+        client: Arc::new(Client::new(
+            builder.make_node_provider(),
+            storage.clone(),
+            10,
+            delivery,
+        )),
     };
     let key_pair = KeyPair::generate_from(&mut rng);
     let public_key = key_pair.public();

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -14,8 +14,7 @@ use linera_core::{
     client::ChainClient,
     test_utils::{FaultType, MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
 };
-use linera_storage::{DbStorage, Storage, TestClock};
-use linera_views::{memory::MemoryStore, views::ViewError};
+use linera_storage::{MemoryStorage, TestClock};
 
 use super::MutationRoot;
 use crate::{chain_listener, wallet::Wallet};
@@ -25,19 +24,19 @@ struct ClientContext {
     update_calls: usize,
 }
 
+type TestStorage = MemoryStorage<TestClock>;
+type TestProvider = NodeProvider<TestStorage>;
+
 #[async_trait]
-impl chain_listener::ClientContext<NodeProvider<DbStorage<MemoryStore, TestClock>>>
-    for ClientContext
-{
+impl chain_listener::ClientContext for ClientContext {
+    type ValidatorNodeProvider = TestProvider;
+    type Storage = TestStorage;
+
     fn wallet(&self) -> &Wallet {
         unimplemented!()
     }
 
-    fn make_chain_client<S>(
-        &self,
-        _: S,
-        _: ChainId,
-    ) -> ChainClient<NodeProvider<DbStorage<MemoryStore, TestClock>>, S> {
+    fn make_chain_client(&self, _: ChainId) -> ChainClient<TestProvider, TestStorage> {
         unimplemented!()
     }
 
@@ -45,13 +44,7 @@ impl chain_listener::ClientContext<NodeProvider<DbStorage<MemoryStore, TestClock
         self.update_calls += 1;
     }
 
-    async fn update_wallet<'a, S>(
-        &'a mut self,
-        _: &'a mut ChainClient<NodeProvider<DbStorage<MemoryStore, TestClock>>, S>,
-    ) where
-        S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
-    {
+    async fn update_wallet<'a>(&'a mut self, _: &'a mut ChainClient<TestProvider, TestStorage>) {
         self.update_calls += 1;
     }
 }


### PR DESCRIPTION
## Motivation

In order to have a multi-chain protocol client we can wrap at higher levels in ways that allow us to create wrapped chain clients, that client needs to have access to a local node.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Move the `LocalNodeClient` out of `ChainClient` and into `Client`, where it can be accessed through a reference (currently in an `Arc`, as we need to `tokio::spawn` it).

Then, remove the `Storage` parameter from functions on `linera_service::linera::client_context::ClientContext`, as we can now retrieve it directly from the `Client` (so long as we're in an async context). 

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
