### PR TITLE
Add some process_inbox calls for the `matching_engine` end to end test

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1436,6 +1436,9 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     node_service_admin
         .request_application(&chain_admin, &token1)
         .await?;
+    node_service_admin.process_inbox(&chain_admin).await?;
+    node_service_a.process_inbox(&chain_a).await?;
+    node_service_b.process_inbox(&chain_b).await?;
 
     let app_fungible0_a = FungibleApp(node_service_a.make_application(&chain_a, &token0).await?);
     let app_fungible1_a = FungibleApp(node_service_a.make_application(&chain_a, &token1).await?);
@@ -1500,6 +1503,9 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             &[token0.forget_abi(), token1.forget_abi()],
         )
         .await?;
+    node_service_admin.process_inbox(&chain_admin).await?;
+    node_service_a.process_inbox(&chain_a).await?;
+    node_service_b.process_inbox(&chain_b).await?;
     let app_matching_admin = MatchingEngineApp(
         node_service_admin
             .make_application(&chain_admin, &application_id_matching)

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1503,9 +1503,6 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             &[token0.forget_abi(), token1.forget_abi()],
         )
         .await?;
-    node_service_admin.process_inbox(&chain_admin).await?;
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_b.process_inbox(&chain_b).await?;
     let app_matching_admin = MatchingEngineApp(
         node_service_admin
             .make_application(&chain_admin, &application_id_matching)
@@ -1527,6 +1524,9 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             .make_application(&chain_b, &application_id_matching)
             .await?,
     );
+    node_service_admin.process_inbox(&chain_admin).await?;
+    node_service_a.process_inbox(&chain_a).await?;
+    node_service_b.process_inbox(&chain_b).await?;
 
     // Now creating orders
     for price in [1, 2] {

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1511,6 +1511,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     node_service_a
         .request_application(&chain_a, &application_id_matching)
         .await?;
+    node_service_a.process_inbox(&chain_a).await?;
     let app_matching_a = MatchingEngineApp(
         node_service_a
             .make_application(&chain_a, &application_id_matching)
@@ -1519,14 +1520,12 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     node_service_b
         .request_application(&chain_b, &application_id_matching)
         .await?;
+    node_service_b.process_inbox(&chain_b).await?;
     let app_matching_b = MatchingEngineApp(
         node_service_b
             .make_application(&chain_b, &application_id_matching)
             .await?,
     );
-    node_service_admin.process_inbox(&chain_admin).await?;
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_b.process_inbox(&chain_b).await?;
 
     // Now creating orders
     for price in [1, 2] {


### PR DESCRIPTION
## Motivation

Replacement of the error `failed to post query` with a more precise error message revealed the origin of some errors.

## Proposal

Two entries of `process_queries` are added to the `matching_engine`.
It is possible that the iterative loop for `make_application` needs to be eliminated.

## Test Plan

An improved CI is the objective of this work.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
