### PR TITLE
Reenable test for the `non_fungible` and add a `process_inbox`

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -187,20 +187,8 @@ impl FungibleApp {
     }
 }
 
-#[cfg(any(
-    feature = "scylladb",
-    feature = "dynamodb",
-    feature = "kubernetes",
-    feature = "remote_net"
-))]
 struct NonFungibleApp(ApplicationWrapper<non_fungible::NonFungibleTokenAbi>);
 
-#[cfg(any(
-    feature = "scylladb",
-    feature = "dynamodb",
-    feature = "kubernetes",
-    feature = "remote_net"
-))]
 impl NonFungibleApp {
     pub fn create_token_id(
         chain_id: &ChainId,
@@ -952,15 +940,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     Ok(())
 }
 
-// TODO(#2051): The test `test_wasm_end_to_end_non_fungible::service_grpc` is frequently failing
-// with the error `Error: Could not find application URI: .... after 15 tries`.
-//#[cfg_attr(feature = "storage_service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc"))]
-#[cfg(any(
-    feature = "scylladb",
-    feature = "dynamodb",
-    feature = "kubernetes",
-    feature = "remote_net"
-))]
+#[cfg_attr(feature = "storage_service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -978,6 +978,9 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
             .await?,
     );
 
+    // Needed synchronization after the make_application
+    node_service1.process_inbox(&chain1).await?;
+
     let nft1_name = "nft1".to_string();
     let nft1_minter = account_owner1;
     let nft1_payload = "nft1_data".as_bytes().to_vec();


### PR DESCRIPTION
## Motivation

The end-to-end test for `non-fungible` was disabled recently, but it has now appeared that missing `process_inbox` are a partial source of the problem.

## Proposal

Reenable the `non-fungible` test and add the `process_inbox`.

## Test Plan

The CI is the point. One criticism of the PR is that I could not reproduce the failure that led to the closing of the test.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
