### PR TITLE
Remove the loop in the `make_application` function.

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -871,7 +871,7 @@ impl NodeService {
                     .to_string();
                 Ok((id, link))
             })
-            .collect::<Result<HashMap<_,_>>>()?;
+            .collect::<Result<HashMap<_, _>>>()?;
         if let Some(link) = values.get(&application_id) {
             return Ok(ApplicationWrapper::from(link.to_string()));
         }


### PR DESCRIPTION
## Motivation

The `make_application` has an iterative loop for making it work, but this loop is not adequate and does not help the CI. 

## Proposal

We eliminate the inner loop. We keep the function `try_get_applications_uri` as it is used in tests.

## Test Plan

The CI should do the job.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
