### PR TITLE
Upgrade to Rust 1.79.0

### DIFF
--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -416,10 +416,7 @@ where
 
 impl CryptoHash {
     /// Computes a hash.
-    pub fn new<T: ?Sized>(value: &T) -> Self
-    where
-        T: BcsHashable,
-    {
+    pub fn new<T: ?Sized + BcsHashable>(value: &T) -> Self {
         use sha3::digest::Digest;
 
         let mut hasher = sha3::Sha3_256::default();

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -293,7 +293,7 @@ pub enum ChainClientError {
 
 impl From<Infallible> for ChainClientError {
     fn from(infallible: Infallible) -> Self {
-        infallible.into()
+        match infallible {}
     }
 }
 

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -199,12 +199,12 @@ where
         let mut result = Vec::new();
         let limit = limit.unwrap_or(20);
         for _ in 0..limit {
-            let Some(next_key) = key else { break };
-            let operation = plugin.operations.get(&next_key).await?;
+            let Some(next_key) = &key else { break };
+            let operation = plugin.operations.get(next_key).await?;
             match operation {
                 None => break,
                 Some(op) => {
-                    key = op.previous_operation.clone();
+                    key.clone_from(&op.previous_operation);
                     result.push(op)
                 }
             }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1265,7 +1265,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
         .await?;
 
     // Setting up the application crowd funding
-    let deadline = Timestamp::from(std::u64::MAX);
+    let deadline = Timestamp::from(u64::MAX);
     let target = Amount::ONE;
     let state_crowd = InstantiationArgument {
         owner: account_owner1,

--- a/linera-views/tests/queueview_tests.rs
+++ b/linera-views/tests/queueview_tests.rs
@@ -73,7 +73,7 @@ async fn queue_view_mutability_check() {
             if choice == 4 {
                 // Doing the rollback
                 view.rollback();
-                new_vector = vector.clone();
+                new_vector.clone_from(&vector);
             }
             let new_elements = view.queue.elements().await.unwrap();
             let new_hash = view.crypto_hash().await.unwrap();
@@ -86,7 +86,7 @@ async fn queue_view_mutability_check() {
             assert_eq!(new_elements, new_vector);
         }
         if save {
-            vector = new_vector.clone();
+            vector.clone_from(&new_vector);
             view.save().await.unwrap();
         }
     }

--- a/toolchains/build/rust-toolchain.toml
+++ b/toolchains/build/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.79.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

Rust 1.79.0 was released.

## Proposal

Upgrade, and fix a few new Clippy lints.

## Test Plan

Existing tests should catch any regressions.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
