### PR TITLE
`linera-core`: shared client state

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,7 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUST_BACKTRACE: short
+  RUST_BACKTRACE: full
   # We allow redundant explicit links because `cargo rdme` doesn't know how to resolve implicit intra-crate links.
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -56,7 +56,7 @@ where
 
 /// Sends a token from the first chain to the first chain's owner on chain 2, then
 /// reclaims that amount.
-pub async fn run_claim_bench<B>((mut chain1, mut chain2): (ChainClient<B>, ChainClient<B>))
+pub async fn run_claim_bench<B>((chain1, chain2): (ChainClient<B>, ChainClient<B>))
 where
     B: StorageBuilder,
     ViewError: From<<B::Storage as Storage>::ContextError>,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1371,7 +1371,7 @@ where
                         pending == &block,
                         ChainClientError::BlockProposalError(
                             "Client state has a different pending block; \
-                         use the `linera retry-pending-block` command to commit that first"
+                             use the `linera retry-pending-block` command to commit that first"
                         )
                     );
                 }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1787,10 +1787,13 @@ where
         }
         let manager = *info.manager;
         // Drop the pending block if it is outdated.
-        if let Some(block) = &self.state().pending_block {
-            if block.height != info.next_block_height {
-                self.clear_pending_block();
-            }
+        // Caveat editor: this cannot be an `if let` as the borrow of `state()` will be
+        // extended over the body, causing a deadlock.
+        if matches!(
+            self.state().pending_block,
+            Some(ref block) if block.height != info.next_block_height,
+        ) {
+            self.clear_pending_block();
         }
         // If there is a validated block in the current round, finalize it.
         if let Some(certificate) = &manager.requested_locked {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -647,17 +647,13 @@ where
         // Verify that our local storage contains enough history compared to the
         // expected block height. Otherwise, download the missing history from the
         // network.
+        let next_block_height = self.next_block_height();
         let nodes = self.validator_nodes().await?;
         let mut notifications = vec![];
         let mut info = self
             .client
             .local_node
-            .download_certificates(
-                nodes,
-                self.chain_id,
-                self.next_block_height(),
-                &mut notifications,
-            )
+            .download_certificates(nodes, self.chain_id, next_block_height, &mut notifications)
             .await?;
         self.handle_notifications(&mut notifications);
         if info.next_block_height == self.next_block_height {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -367,7 +367,7 @@ where
     S: Storage,
     ViewError: From<S::ContextError>,
 {
-    /// Get a shared reference to the chain's state.
+    /// Gets a shared reference to the chain's state.
     pub fn state(&self) -> ChainGuard<ChainState> {
         Unsend::new(
             self.client
@@ -377,7 +377,7 @@ where
         )
     }
 
-    /// Get a mutable reference to the state.
+    /// Gets a mutable reference to the state.
     /// Beware: this will block any other reference to any chain's state!
     fn state_mut(&self) -> ChainGuardMut<ChainState> {
         Unsend::new(
@@ -388,49 +388,45 @@ where
         )
     }
 
-    /// The per-`ChainClient` options.
+    /// Gets the per-`ChainClient` options.
     pub fn options_mut(&mut self) -> &mut ChainClientOptions {
         &mut self.options
     }
 
-    /// The ID of the associated chain.
+    /// Gets the ID of the associated chain.
     pub fn chain_id(&self) -> ChainId {
         self.chain_id
     }
 
-    /// Returns the hash of the latest known block.
+    /// Gets the hash of the latest known block.
     pub fn block_hash(&self) -> Option<CryptoHash> {
         self.state().block_hash
     }
 
-    /// Returns the earliest possible timestamp for the next block.
+    /// Gets the earliest possible timestamp for the next block.
     pub fn timestamp(&self) -> Timestamp {
         self.state().timestamp
     }
 
+    /// Gets the next block height.
     pub fn next_block_height(&self) -> BlockHeight {
         self.state().next_block_height
     }
 
+    /// Gets a guarded reference to the next pending block.
     pub fn pending_block(&self) -> ChainGuardMapped<Option<Block>> {
         Unsend::new(self.state().inner.map(|state| &state.pending_block))
     }
 
+    /// Gets a guarded reference to the set of pending blobs.
     pub fn pending_blobs(&self) -> ChainGuardMapped<BTreeMap<BlobId, HashedBlob>> {
         Unsend::new(self.state().inner.map(|state| &state.pending_blobs))
     }
 
+    /// Gets the ID of the admin chain.
     pub fn admin_id(&self) -> ChainId {
         self.state().admin_id
     }
-
-    // pub fn known_key_pairs(&self) -> impl Deref<Target = BTreeMap<Owner, KeyPair>> + '_ {
-    //     self.state().map(|state| &state.known_key_pairs)
-    // }
-
-    // pub fn known_key_pairs_mut(&self) -> impl DerefMut<Target = BTreeMap<Owner, KeyPair>> + '_ {
-    //     self.state_mut().map(|state| &mut state.known_key_pairs)
-    // }
 }
 
 enum ReceiveCertificateMode {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1187,9 +1187,8 @@ where
 
     /// Updates the latest block and next block height and round information from the chain info.
     fn update_from_info(&self, info: &ChainInfo) {
-        if info.chain_id == self.chain_id && info.next_block_height > self.state().next_block_height
-        {
-            let mut state = self.state_mut();
+        let mut state = self.state_mut();
+        if info.chain_id == self.chain_id && info.next_block_height > state.next_block_height {
             state.next_block_height = info.next_block_height;
             state.block_hash = info.block_hash;
             state.timestamp = info.timestamp;

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1075,13 +1075,17 @@ where
         // Now we should have a complete view of all committees in the system.
         let (committees, max_epoch) = self.known_committees().await?;
         // Proceed to downloading received certificates.
-        let trackers = &self.state().received_certificate_trackers;
         let result = communicate_with_quorum(
             &nodes,
             &local_committee,
             |_| (),
             |name, node| {
-                let tracker = *trackers.get(&name).unwrap_or(&0);
+                let tracker = self
+                    .state()
+                    .received_certificate_trackers
+                    .get(&name)
+                    .copied()
+                    .unwrap_or(0);
                 let committees = committees.clone();
                 let node_client = node_client.clone();
                 Box::pin(Self::synchronize_received_certificates_from_validator(

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -252,7 +252,11 @@ pub struct ChainClient<ValidatorNodeProvider, Storage> {
 
 impl<P, S> Clone for ChainClient<P, S> {
     fn clone(&self) -> Self {
-        Self { client: self.client.clone(), chain_id: self.chain_id, options: self.options.clone() }
+        Self {
+            client: self.client.clone(),
+            chain_id: self.chain_id,
+            options: self.options.clone(),
+        }
     }
 }
 
@@ -2498,10 +2502,8 @@ where
     {
         let (chain_id, nodes, local_node) = {
             let committee = self.local_committee().await?;
-            let nodes: HashMap<_, _> = self
-                .client
-                .validator_node_provider
-                .make_nodes(&committee)?;
+            let nodes: HashMap<_, _> =
+                self.client.validator_node_provider.make_nodes(&committee)?;
             (self.chain_id, nodes, self.client.local_node.clone())
         };
         // Drop removed validators.
@@ -2548,7 +2550,6 @@ where
         node_client: LocalNodeClient<S>,
     ) -> Result<(), ChainClientError> {
         let ((committees, max_epoch), chain_id, current_tracker) = {
-
             let (committees, max_epoch) = self.known_committees().await?;
             let chain_id = self.chain_id;
             let current_tracker: u64 = self

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -665,7 +665,7 @@ where
             .download_certificates(nodes, self.chain_id, next_block_height, &mut notifications)
             .await?;
         self.handle_notifications(&mut notifications);
-        if info.next_block_height == self.next_block_height {
+        if info.next_block_height == next_block_height {
             // Check that our local node has the expected block hash.
             ensure!(
                 self.state().block_hash == info.block_hash,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -151,9 +151,7 @@ where
             .map(|kp| (Owner::from(kp.public()), kp))
             .collect();
 
-        use dashmap::mapref::entry::Entry;
-
-        let Entry::Vacant(e) = self.chains.entry(chain_id) else {
+        let dashmap::mapref::entry::Entry::Vacant(e) = self.chains.entry(chain_id) else {
             panic!("Inserting already-existing chain {chain_id}");
         };
         e.insert(ChainState {
@@ -1093,7 +1091,6 @@ where
             }
         }
         // Update tracker.
-        // TODO (a) this deadlocks with (b)
         self.state_mut()
             .received_certificate_trackers
             .entry(name)
@@ -1240,7 +1237,6 @@ where
 
     /// Updates the latest block and next block height and round information from the chain info.
     fn update_from_info(&self, info: &ChainInfo) {
-        // TODO (b) this deadlocks with (a)
         if info.chain_id == self.chain_id {
             let mut state = self.state_mut();
             if info.next_block_height > state.next_block_height {
@@ -1867,8 +1863,8 @@ where
         // Caveat editor: this cannot be an `if let` as the borrow of `state()` will be
         // extended over the body, causing a deadlock.
         if matches!(
-            self.state().pending_block,
-            Some(ref block) if block.height != info.next_block_height,
+            &self.state().pending_block,
+            Some(block) if block.height != info.next_block_height,
         ) {
             self.clear_pending_block();
         }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -242,7 +242,7 @@ pub struct ChainClientOptions {
 /// * As a rule, operations are considered successful (and communication may stop) when
 /// they succeeded in gathering a quorum of responses.
 pub struct ChainClient<ValidatorNodeProvider, Storage> {
-    /// The Linera [`Client`] that manages operations on this chain.
+    /// The Linera [`Client`] that manages operations for this chain client.
     client: Arc<Client<ValidatorNodeProvider, Storage>>,
     /// The off-chain chain ID.
     chain_id: ChainId,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1281,9 +1281,9 @@ where
         for blob_id in blob_ids {
             if let Some(blob) = self.client.local_node.recent_blob(&blob_id).await {
                 blobs.push(blob);
-            } else if let Some(blob) = self.state().pending_blobs.get(&blob_id) {
-                self.client.local_node.cache_recent_blob(blob).await;
-                blobs.push(blob.to_owned());
+            } else if let Some(blob) = self.state().pending_blobs.get(&blob_id).cloned() {
+                self.client.local_node.cache_recent_blob(&blob).await;
+                blobs.push(blob);
             } else {
                 return Err(LocalNodeError::CannotReadLocalBlob {
                     chain_id: self.chain_id,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1886,8 +1886,9 @@ where
 
     /// Clears the information on any operation that previously failed.
     pub fn clear_pending_block(&self) {
-        self.state_mut().pending_block = None;
-        self.state_mut().pending_blobs.clear();
+        let mut state = self.state_mut();
+        state.pending_block = None;
+        state.pending_blobs.clear();
     }
 
     /// Processes confirmed operation for which this chain is a recipient.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -73,7 +73,7 @@ where
     let (listener, _listen_handle, _) = sender.listen().await?;
     tokio::spawn(listener);
     {
-        let mut sender = sender.lock().await;
+        let sender = sender.lock().await;
         let certificate = sender
             .transfer_to_account(
                 None,
@@ -84,8 +84,8 @@ where
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(sender.next_block_height, BlockHeight::from(1));
-        assert!(sender.pending_block.is_none());
+        assert_eq!(sender.next_block_height(), BlockHeight::from(1));
+        assert!(sender.pending_block().is_none());
         assert_eq!(
             sender.local_balance().await.unwrap(),
             Amount::from_millis(999)
@@ -123,11 +123,11 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::fuel_and_block());
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let owner = sender.identity().await?;
-    let mut receiver = builder
+    let receiver = builder
         .add_initial_chain(ChainDescription::Root(2), Amount::ZERO)
         .await?;
     let friend = receiver.identity().await?;
@@ -250,14 +250,14 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::fuel_and_block());
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let new_key_pair = KeyPair::generate();
     let new_owner = Owner::from(new_key_pair.public());
     let certificate = sender.rotate_key_pair(new_key_pair).await.unwrap().unwrap();
-    assert_eq!(sender.next_block_height, BlockHeight::from(1));
-    assert!(sender.pending_block.is_none());
+    assert_eq!(sender.next_block_height(), BlockHeight::from(1));
+    assert!(sender.pending_block().is_none());
     assert_eq!(sender.identity().await.unwrap(), new_owner);
     assert_eq!(
         builder
@@ -299,7 +299,7 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::fuel_and_block());
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
 
@@ -309,10 +309,10 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(sender.next_block_height, BlockHeight::from(1));
-    assert!(sender.pending_block.is_none());
+    assert_eq!(sender.next_block_height(), BlockHeight::from(1));
+    assert!(sender.pending_block().is_none());
     assert_matches!(
-        sender.key_pair().await.map(KeyPair::public), // KeyPair isn't Debug; using PublicKey.
+        sender.key_pair().await.map(|kp| KeyPair::public(&kp)), // KeyPair isn't Debug; using PublicKey.
         Err(ChainClientError::CannotFindKeyForChain(_))
     );
     assert_eq!(
@@ -355,7 +355,7 @@ where
     ViewError: From<<B::Storage as Storage>::ContextError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let new_key_pair = KeyPair::generate();
@@ -364,8 +364,8 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(sender.next_block_height, BlockHeight::from(1));
-    assert!(sender.pending_block.is_none());
+    assert_eq!(sender.next_block_height(), BlockHeight::from(1));
+    assert!(sender.pending_block().is_none());
     assert!(sender.key_pair().await.is_ok());
     assert_eq!(
         builder
@@ -390,13 +390,13 @@ where
         )
         .await
         .unwrap();
-    assert_eq!(sender.next_block_height, BlockHeight::from(2));
+    assert_eq!(sender.next_block_height(), BlockHeight::from(2));
     // Make a client to try the new key.
-    let mut client = builder
+    let client = builder
         .make_client(
             sender.chain_id,
             new_key_pair,
-            sender.block_hash,
+            sender.block_hash(),
             BlockHeight::from(2),
         )
         .await?;
@@ -506,7 +506,7 @@ where
     builder
         .add_initial_chain(ChainDescription::Root(0), Amount::ZERO)
         .await?;
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let new_key_pair = KeyPair::generate();
@@ -520,12 +520,12 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(sender.next_block_height, BlockHeight::from(1));
-    assert!(sender.pending_block.is_none());
+    assert_eq!(sender.next_block_height(), BlockHeight::from(1));
+    assert!(sender.pending_block().is_none());
     assert!(sender.key_pair().await.is_ok());
     // Make a client to try the new chain.
     let new_id = ChainId::child(message_id);
-    let mut client = builder
+    let client = builder
         .make_client(new_id, new_key_pair, None, BlockHeight::ZERO)
         .await?;
     client.receive_certificate(certificate).await.unwrap();
@@ -550,10 +550,10 @@ where
     builder
         .add_initial_chain(ChainDescription::Root(0), Amount::ZERO)
         .await?;
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
-    let mut parent = builder
+    let parent = builder
         .add_initial_chain(ChainDescription::Root(2), Amount::ZERO)
         .await?;
     let new_key_pair = KeyPair::generate();
@@ -584,9 +584,9 @@ where
         .unwrap();
     let new_id2 = ChainId::child(open_chain_message_id);
     assert_eq!(new_id, new_id2);
-    assert_eq!(sender.next_block_height, BlockHeight::from(1));
-    assert_eq!(parent.next_block_height, BlockHeight::from(1));
-    assert!(sender.pending_block.is_none());
+    assert_eq!(sender.next_block_height(), BlockHeight::from(1));
+    assert_eq!(parent.next_block_height(), BlockHeight::from(1));
+    assert!(sender.pending_block().is_none());
     assert!(sender.key_pair().await.is_ok());
     assert_eq!(
         builder
@@ -605,7 +605,7 @@ where
         "Unexpected certificate value",
     );
     // Make a client to try the new chain.
-    let mut client = builder
+    let client = builder
         .make_client(new_id, new_key_pair, None, BlockHeight::ZERO)
         .await?;
     client.receive_certificate(certificate).await.unwrap();
@@ -654,7 +654,7 @@ where
     builder
         .add_initial_chain(ChainDescription::Root(0), Amount::ZERO)
         .await?;
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let new_key_pair = KeyPair::generate();
@@ -685,8 +685,8 @@ where
         .unwrap();
     let new_id2 = ChainId::child(open_chain_message_id);
     assert_eq!(new_id, new_id2);
-    assert_eq!(sender.next_block_height, BlockHeight::from(2));
-    assert!(sender.pending_block.is_none());
+    assert_eq!(sender.next_block_height(), BlockHeight::from(2));
+    assert!(sender.pending_block().is_none());
     assert!(sender.key_pair().await.is_ok());
     assert_eq!(
         builder
@@ -705,7 +705,7 @@ where
         "Unexpected certificate value",
     );
     // Make a client to try the new chain.
-    let mut client = builder
+    let client = builder
         .make_client(new_id, new_key_pair, None, BlockHeight::ZERO)
         .await?;
     client.receive_certificate(certificate).await.unwrap();
@@ -744,7 +744,7 @@ where
     builder
         .add_initial_chain(ChainDescription::Root(0), Amount::ZERO)
         .await?;
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let new_key_pair = KeyPair::generate();
@@ -768,11 +768,11 @@ where
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(sender.next_block_height, BlockHeight::from(2));
-    assert!(sender.pending_block.is_none());
+    assert_eq!(sender.next_block_height(), BlockHeight::from(2));
+    assert!(sender.pending_block().is_none());
     assert!(sender.key_pair().await.is_ok());
     // Make a client to try the new chain.
-    let mut client = builder
+    let client = builder
         .make_client(new_id, new_key_pair, None, BlockHeight::ZERO)
         .await?;
     // Must process the creation certificate before using the new chain.
@@ -816,10 +816,10 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
-    let mut client1 = builder
+    let client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
-    let mut client2 = builder
+    let client2 = builder
         .add_initial_chain(ChainDescription::Root(2), Amount::from_tokens(4))
         .await?;
 
@@ -831,8 +831,8 @@ where
         ),
         "Unexpected certificate value",
     );
-    assert_eq!(client1.next_block_height, BlockHeight::from(1));
-    assert!(client1.pending_block.is_none());
+    assert_eq!(client1.next_block_height(), BlockHeight::from(1));
+    assert!(client1.pending_block().is_none());
     assert!(client1.key_pair().await.is_ok());
     assert_eq!(
         builder
@@ -930,7 +930,7 @@ where
     ViewError: From<<B::Storage as Storage>::ContextError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 2).await?;
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let result = sender
@@ -948,8 +948,8 @@ where
         )),
         "unexpected result"
     );
-    assert_eq!(sender.next_block_height, BlockHeight::ZERO);
-    assert!(sender.pending_block.is_some());
+    assert_eq!(sender.next_block_height(), BlockHeight::ZERO);
+    assert!(sender.pending_block().is_some());
     assert_eq!(
         sender.local_balance().await.unwrap(),
         Amount::from_tokens(4)
@@ -969,10 +969,10 @@ where
     ViewError: From<<B::Storage as Storage>::ContextError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
-    let mut client1 = builder
+    let client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;
-    let mut client2 = builder
+    let client2 = builder
         .add_initial_chain(ChainDescription::Root(2), Amount::ZERO)
         .await?;
     assert_eq!(
@@ -997,8 +997,8 @@ where
         .unwrap()
         .unwrap();
 
-    assert_eq!(client1.next_block_height, BlockHeight::from(1));
-    assert!(client1.pending_block.is_none());
+    assert_eq!(client1.next_block_height(), BlockHeight::from(1));
+    assert!(client1.pending_block().is_none());
     assert_eq!(client1.local_balance().await.unwrap(), Amount::ZERO);
     assert_eq!(
         client1.query_system_application(SystemQuery).await.unwrap(),
@@ -1030,7 +1030,7 @@ where
     );
 
     // Process the inbox and send back some money.
-    assert_eq!(client2.next_block_height, BlockHeight::ZERO);
+    assert_eq!(client2.next_block_height(), BlockHeight::ZERO);
     client2
         .transfer_to_account(
             None,
@@ -1040,8 +1040,8 @@ where
         )
         .await
         .unwrap();
-    assert_eq!(client2.next_block_height, BlockHeight::from(1));
-    assert!(client2.pending_block.is_none());
+    assert_eq!(client2.next_block_height(), BlockHeight::from(1));
+    assert!(client2.pending_block().is_none());
     assert_eq!(
         client2.local_balance().await.unwrap(),
         Amount::from_tokens(2)
@@ -1074,10 +1074,10 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::fuel_and_block());
-    let mut client1 = builder
+    let client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;
-    let mut client2 = builder
+    let client2 = builder
         .add_initial_chain(ChainDescription::Root(2), Amount::ZERO)
         .await?;
     let certificate = client1
@@ -1095,8 +1095,8 @@ where
         client1.local_balance().await.unwrap(),
         Amount::from_millis(999)
     );
-    assert_eq!(client1.next_block_height, BlockHeight::from(1));
-    assert!(client1.pending_block.is_none());
+    assert_eq!(client1.next_block_height(), BlockHeight::from(1));
+    assert!(client1.pending_block().is_none());
     // The receiver doesn't know about the transfer.
     client2.process_inbox().await.unwrap();
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
@@ -1123,13 +1123,13 @@ where
     ViewError: From<<B::Storage as Storage>::ContextError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
-    let mut client1 = builder
+    let client1 = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;
-    let mut client2 = builder
+    let client2 = builder
         .add_initial_chain(ChainDescription::Root(2), Amount::ZERO)
         .await?;
-    let mut client3 = builder
+    let client3 = builder
         .add_initial_chain(ChainDescription::Root(3), Amount::ZERO)
         .await?;
 
@@ -1157,7 +1157,7 @@ where
         .communicate_chain_updates(
             &builder.initial_committee,
             client1.chain_id,
-            client1.next_block_height,
+            client1.next_block_height(),
             CrossChainMessageDelivery::NonBlocking,
         )
         .await
@@ -1197,11 +1197,11 @@ where
         .unwrap();
     // Blocks were executed locally.
     assert_eq!(client1.local_balance().await.unwrap(), Amount::ONE);
-    assert_eq!(client1.next_block_height, BlockHeight::from(2));
-    assert!(client1.pending_block.is_none());
+    assert_eq!(client1.next_block_height(), BlockHeight::from(2));
+    assert!(client1.pending_block().is_none());
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
-    assert_eq!(client2.next_block_height, BlockHeight::from(1));
-    assert!(client2.pending_block.is_none());
+    assert_eq!(client2.next_block_height(), BlockHeight::from(1));
+    assert!(client2.pending_block().is_none());
     // Last one was not confirmed remotely, hence a conservative balance.
     assert_eq!(client2.local_balance().await.unwrap(), Amount::ZERO);
     // Let the receiver confirm in last resort.
@@ -1225,10 +1225,10 @@ where
     ViewError: From<<B::Storage as Storage>::ContextError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
-    let mut admin = builder
+    let admin = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
         .await?;
-    let mut user = builder
+    let user = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::ZERO)
         .await?;
     let validators = builder.initial_committee.validators().clone();
@@ -1254,8 +1254,8 @@ where
     // Create a new committee.
     let committee = Committee::new(validators, ResourceControlPolicy::only_fuel());
     admin.stage_new_committee(committee).await.unwrap();
-    assert_eq!(admin.next_block_height, BlockHeight::from(4));
-    assert!(admin.pending_block.is_none());
+    assert_eq!(admin.next_block_height(), BlockHeight::from(4));
+    assert!(admin.pending_block().is_none());
     assert!(admin.key_pair().await.is_ok());
     assert_eq!(admin.epoch().await.unwrap(), Epoch::from(2));
 
@@ -1356,7 +1356,7 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::fuel_and_block());
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(3))
         .await?;
     let obtained_error = sender
@@ -1413,7 +1413,7 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let description = ChainDescription::Root(1);
     let chain_id = ChainId::from(description);
-    let mut client_a = builder
+    let client_a = builder
         .add_initial_chain(description, Amount::from_tokens(10))
         .await?;
     let pub_key0 = client_a.public_key().await.unwrap();
@@ -1430,11 +1430,11 @@ where
     }
     .into();
     client_a.execute_operation(owner_change_op).await.unwrap();
-    let mut client_b = builder
+    let client_b = builder
         .make_client(
             chain_id,
             key_pair1,
-            client_a.block_hash,
+            client_a.block_hash(),
             BlockHeight::from(1),
         )
         .await?;
@@ -1447,7 +1447,7 @@ where
     client_a.synchronize_from_validators().await.unwrap();
     assert_eq!(expected_blob_id, blob_id);
     assert_eq!(certificate.round, Round::MultiLeader(0));
-    let previous_block_hash = client_a.block_hash.unwrap();
+    let previous_block_hash = client_a.block_hash().unwrap();
 
     // Validators goes back up
     builder.set_fault_type([0], FaultType::Honest).await;
@@ -1495,7 +1495,7 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let description = ChainDescription::Root(1);
     let chain_id = ChainId::from(description);
-    let mut client = builder
+    let client = builder
         .add_initial_chain(description, Amount::from_tokens(3))
         .await?;
     let pub_key0 = client.public_key().await.unwrap();
@@ -1621,7 +1621,7 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let description = ChainDescription::Root(1);
     let chain_id = ChainId::from(description);
-    let mut client0 = builder
+    let client0 = builder
         .add_initial_chain(description, Amount::from_tokens(10))
         .await?;
     let pub_key0 = client0.public_key().await.unwrap();
@@ -1638,11 +1638,11 @@ where
     }
     .into();
     client0.execute_operation(owner_change_op).await.unwrap();
-    let mut client1 = builder
+    let client1 = builder
         .make_client(
             chain_id,
             key_pair1,
-            client0.block_hash,
+            client0.block_hash(),
             BlockHeight::from(1),
         )
         .await?;
@@ -1670,8 +1670,8 @@ where
     assert_eq!(manager.current_round, Round::MultiLeader(0));
     let result = client1.publish_blob(HashedBlob::test_blob("blob1")).await;
     assert!(result.is_err());
-    assert!(client1.pending_block.is_some());
-    assert!(!client1.pending_blobs.is_empty());
+    assert!(client1.pending_block().is_some());
+    assert!(!client1.pending_blobs().is_empty());
 
     // Finally, the validators are online and honest again.
     builder.set_fault_type([1, 2], FaultType::Honest).await;
@@ -1685,7 +1685,7 @@ where
         manager.requested_locked.unwrap().round,
         Round::MultiLeader(1)
     );
-    assert!(client0.pending_block.is_some());
+    assert!(client0.pending_block().is_some());
 
     // Client 0 now only tries to burn 1 token. Before that, they automatically finalize the
     // pending block, which publishes the blob, leaving 10 - 1 = 9.
@@ -1699,7 +1699,7 @@ where
         client0.local_balance().await.unwrap(),
         Amount::from_tokens(9)
     );
-    assert!(client0.pending_block.is_none());
+    assert!(client0.pending_block().is_none());
 
     // Burn another token so Client 1 sees that the blob is already published
     client1
@@ -1712,8 +1712,8 @@ where
         client1.local_balance().await.unwrap(),
         Amount::from_tokens(8)
     );
-    assert!(client1.pending_block.is_none());
-    assert!(client1.pending_blobs.is_empty());
+    assert!(client1.pending_block().is_none());
+    assert!(client1.pending_blobs().is_empty());
     Ok(())
 }
 
@@ -1730,7 +1730,7 @@ where
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let description = ChainDescription::Root(1);
-    let mut client = builder
+    let client = builder
         .add_initial_chain(description, Amount::from_tokens(10))
         .await?;
 
@@ -1777,7 +1777,7 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let description = ChainDescription::Root(1);
     let chain_id = ChainId::from(description);
-    let mut client0 = builder
+    let client0 = builder
         .add_initial_chain(description, Amount::from_tokens(10))
         .await?;
     let pub_key0 = client0.public_key().await.unwrap();
@@ -1794,11 +1794,11 @@ where
     }
     .into();
     client0.execute_operation(owner_change_op).await.unwrap();
-    let mut client1 = builder
+    let client1 = builder
         .make_client(
             chain_id,
             key_pair1,
-            client0.block_hash,
+            client0.block_hash(),
             BlockHeight::from(1),
         )
         .await?;
@@ -1867,7 +1867,7 @@ where
         Round::MultiLeader(0)
     );
     assert_eq!(manager.current_round, Round::MultiLeader(1));
-    assert!(client1.pending_block.is_some());
+    assert!(client1.pending_block().is_some());
     client1
         .burn(None, Amount::from_tokens(4), UserData::default())
         .await
@@ -1893,7 +1893,7 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::only_fuel());
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
     let mut receiver = builder
@@ -1910,7 +1910,7 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.message_policy = MessagePolicy::Ignore;
+    receiver.options_mut().message_policy = MessagePolicy::Ignore;
     receiver.receive_certificate(cert).await?;
     assert!(receiver.process_inbox().await?.0.is_empty());
     // The message was ignored.
@@ -1921,7 +1921,7 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.message_policy = MessagePolicy::Reject;
+    receiver.options_mut().message_policy = MessagePolicy::Reject;
     let certs = receiver.process_inbox().await?.0;
     assert_eq!(certs.len(), 1);
     sender

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -36,7 +36,7 @@ use crate::test_utils::ScyllaDbStorageBuilder;
 #[cfg(feature = "storage_service")]
 use crate::test_utils::ServiceStorageBuilder;
 use crate::{
-    client::{ArcChainClient, ChainClientError, ClientOutcome, MessageAction, MessagePolicy},
+    client::{ChainClientError, ClientOutcome, MessageAction, MessagePolicy},
     local_node::LocalNodeError,
     node::{
         CrossChainMessageDelivery,
@@ -67,13 +67,11 @@ where
     let sender = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(4))
         .await?;
-    let sender = ArcChainClient::new(sender);
     // Listen to the notifications on the sender chain.
-    let mut notifications = sender.lock().await.subscribe().await?;
+    let mut notifications = sender.subscribe().await?;
     let (listener, _listen_handle, _) = sender.listen().await?;
     tokio::spawn(listener);
     {
-        let sender = sender.lock().await;
         let certificate = sender
             .transfer_to_account(
                 None,

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -726,7 +726,7 @@ where
             10,
             CrossChainMessageDelivery::NonBlocking,
         ));
-        Ok(builder.build(
+        Ok(builder.create_chain(
             chain_id,
             vec![key_pair],
             self.admin_id,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -94,10 +94,10 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
-    let mut publisher = builder
+    let publisher = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
         .await?;
-    let mut creator = builder
+    let creator = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::ONE)
         .await?;
 
@@ -260,15 +260,15 @@ where
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
     // Will publish the bytecodes.
-    let mut publisher = builder
+    let publisher = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
         .await?;
     // Will create the apps and use them to send a message.
-    let mut creator = builder
+    let creator = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::ONE)
         .await?;
     // Will receive the message.
-    let mut receiver = builder
+    let receiver = builder
         .add_initial_chain(ChainDescription::Root(2), Amount::ONE)
         .await?;
     let receiver_id = ChainId::root(2);
@@ -499,10 +499,10 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::from_tokens(3))
         .await?;
-    let mut receiver = builder
+    let receiver = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::ONE)
         .await?;
 
@@ -709,10 +709,10 @@ where
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
         .with_policy(ResourceControlPolicy::all_categories());
-    let mut sender = builder
+    let sender = builder
         .add_initial_chain(ChainDescription::Root(0), Amount::ONE)
         .await?;
-    let mut receiver = builder
+    let receiver = builder
         .add_initial_chain(ChainDescription::Root(1), Amount::ONE)
         .await?;
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -322,23 +322,8 @@ where
         }
     }
 
-    pub fn new_for_client(
-        nickname: String,
-        storage: StorageClient,
-        recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
-        recent_hashed_blobs: Arc<ValueCache<BlobId, HashedBlob>>,
-        delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
-    ) -> Self {
-        WorkerState {
-            nickname,
-            storage,
-            chain_worker_config: ChainWorkerConfig::default(),
-            recent_hashed_certificate_values,
-            recent_hashed_blobs,
-            delivery_notifiers,
-            chain_worker_tasks: Arc::default(),
-            chain_workers: Arc::new(Mutex::new(LruCache::new(*CHAIN_WORKER_LIMIT))),
-        }
+    pub fn new_for_client(nickname: String, storage: StorageClient) -> Self {
+        Self::new(nickname, None, storage)
     }
 
     pub fn with_allow_inactive_chains(mut self, value: bool) -> Self {

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -63,9 +63,9 @@ pub trait ClientContext {
         timestamp: Timestamp,
     );
 
-    async fn update_wallet<'a>(
-        &'a mut self,
-        client: &'a mut ChainClient<Self::ValidatorNodeProvider, Self::Storage>,
+    async fn update_wallet(
+        &mut self,
+        client: &ChainClient<Self::ValidatorNodeProvider, Self::Storage>,
     ) where
         ViewError: From<<Self::Storage as Storage>::ContextError>;
 }

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -191,8 +191,8 @@ where
                 continue;
             };
             {
-                let mut client_guard = client.lock().await;
-                context.lock().await.update_wallet(&mut *client_guard).await;
+                let client_guard = client.lock().await;
+                context.lock().await.update_wallet(&*client_guard).await;
             }
             let value = storage.read_hashed_certificate_value(hash).await?;
             let Some(executed_block) = value.inner().executed_block() else {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -1045,38 +1045,6 @@ impl NodeService {
         }
     }
 
-    /// Waits until this node service has the certificate with the provided `certificate_hash` in
-    /// storage.
-    ///
-    /// This is usually used to check that the block from the `certificate_hash` has been
-    /// processed, and consequently its messages have been placed in the inbox of the
-    /// `receiver_chain`. Note that if the sender chain does not send a message to the
-    /// `receiver_chain` in the block referenced by the `certificate_hash` (or to any of the chains
-    /// tracked by this node service) the node service will never receive a notification for the
-    /// block, and consequently wait forever.
-    ///
-    /// In practice, the `receiver_chain` is only used by the node service to access the storage.
-    pub async fn wait_for_messages(
-        &self,
-        receiver_chain: ChainId,
-        certificate_hash: CryptoHash,
-    ) -> Result<()> {
-        let query = format!(
-            r#"query {{
-                block(hash: "{certificate_hash}", chainId: "{receiver_chain}") {{ hash }}
-            }}"#
-        );
-
-        let data = self.query_node(query).await?;
-
-        assert_eq!(
-            data["block"]["hash"].as_str(),
-            Some(&*certificate_hash.to_string())
-        );
-
-        Ok(())
-    }
-
     /// Subscribes to the node service and returns a stream of notifications about a chain.
     pub async fn notifications(
         &self,

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -151,8 +151,8 @@ impl ClientWrapper {
                 "--max-pending-messages",
                 &self.max_pending_messages.to_string(),
             ])
-            .args(["--send-timeout-ms", "10000"])
-            .args(["--recv-timeout-ms", "10000"])
+            .args(["--send-timeout-ms", "500000"])
+            .args(["--recv-timeout-ms", "500000"])
             .arg("--wait-for-outgoing-messages");
         Ok(command)
     }

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -142,7 +142,7 @@ where
     ViewError: From<S::ContextError>,
 {
     async fn do_claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
-        let mut client = self.client.lock().await;
+        let client = self.client.lock().await;
 
         if self.start_timestamp < self.end_timestamp {
             let local_time = client.storage_client().clock().current_time();
@@ -172,7 +172,7 @@ where
         let result = client
             .open_chain(ownership, ApplicationPermissions::default(), self.amount)
             .await;
-        self.context.lock().await.update_wallet(&mut *client).await;
+        self.context.lock().await.update_wallet(&*client).await;
         let (message_id, certificate) = match result? {
             ClientOutcome::Committed(result) => result,
             ClientOutcome::WaitForTimeout(timeout) => {

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -105,7 +105,7 @@ where
 
     /// Returns the current committee's validators.
     async fn current_validators(&self) -> Result<Vec<Validator>, Error> {
-        let mut client = self.client.lock().await;
+        let client = self.client.lock().await;
         let committee = client.local_committee().await?;
         Ok(committee
             .validators()
@@ -253,7 +253,7 @@ where
     /// Creates a new instance of the faucet service.
     pub async fn new(
         port: NonZeroU16,
-        mut client: ChainClient<P, S>,
+        client: ChainClient<P, S>,
         context: C,
         amount: Amount,
         end_timestamp: Timestamp,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -27,7 +27,7 @@ use linera_views::common::CommonStoreConfig;
 
 use crate::{GenesisConfig, Job};
 
-#[derive(clap::Parser)]
+#[derive(Clone, clap::Parser)]
 #[command(
     name = "linera",
     version = linera_version::VersionInfo::default_clap_str(),

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -747,8 +747,8 @@ impl Runnable for Job {
                 join_set.spawn_task(listener);
                 while let Some(notification) = notifications.next().await {
                     if let Reason::NewBlock { .. } = notification.reason {
-                        let mut guard = chain_client.lock().await;
-                        context.update_and_save_wallet(&mut *guard).await;
+                        let guard = chain_client.lock().await;
+                        context.update_and_save_wallet(&*guard).await;
                     }
                     if raw {
                         println!("{}", serde_json::to_string(&notification)?);

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -271,9 +271,7 @@ impl Runnable for Job {
                 let certificate = context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();
-                        async move {
-                            chain_client.close_chain().await
-                        }
+                        async move { chain_client.close_chain().await }
                     })
                     .await
                     .context("Failed to close chain")?;
@@ -475,9 +473,8 @@ impl Runnable for Job {
                 // Make sure genesis chains are subscribed to the admin chain.
                 let context = Arc::new(Mutex::new(context));
                 let mut context = context.lock().await;
-                let chain_client = context
-                    .make_chain_client(context.wallet().genesis_admin_chain())
-                    ;
+                let chain_client =
+                    context.make_chain_client(context.wallet().genesis_admin_chain());
                 let n = context
                     .process_inbox(&chain_client)
                     .await
@@ -641,9 +638,7 @@ impl Runnable for Job {
                 context
                     .apply_client_command(&chain_client, |chain_client| {
                         let chain_client = chain_client.clone();
-                        async move {
-                            chain_client.finalize_committee().await
-                        }
+                        async move { chain_client.finalize_committee().await }
                     })
                     .await
                     .context("Failed to finalize committee")?;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -106,7 +106,7 @@ impl Runnable for Job {
         ViewError: From<S::ContextError>,
     {
         let Job(options, wallet) = self;
-        let mut context = ClientContext::new(storage.clone(), &options, wallet);
+        let mut context = ClientContext::new(storage.clone(), options.clone(), wallet);
         let command = options.command;
 
         use ClientCommand::*;

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -93,10 +93,7 @@ where
         Some(self.0.lock().await.get(chain_id)?.clone())
     }
 
-    pub(crate) async fn client_lock(
-        &self,
-        chain_id: &ChainId,
-    ) -> Option<ChainClient<P, S>> {
+    pub(crate) async fn client_lock(&self, chain_id: &ChainId) -> Option<ChainClient<P, S>> {
         self.client(chain_id).await
     }
 
@@ -276,12 +273,7 @@ where
     ) -> Result<T, Error>
     where
         F: FnMut(ChainClient<P, S>) -> Fut,
-        Fut: Future<
-            Output = (
-                Result<ClientOutcome<T>, Error>,
-                ChainClient<P, S>,
-            ),
-        >,
+        Fut: Future<Output = (Result<ClientOutcome<T>, Error>, ChainClient<P, S>)>,
     {
         loop {
             let client = self.clients.try_client_lock(chain_id).await?;

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -143,7 +143,7 @@ impl<P: LocalValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientConte
 
     fn update_wallet_for_new_chain(&mut self, _: ChainId, _: Option<KeyPair>, _: Timestamp) {}
 
-    async fn update_wallet<'a>(&'a mut self, _: &'a mut ChainClient<P, S>)
+    async fn update_wallet(&mut self, _: &ChainClient<P, S>)
     where
         ViewError: From<S::ContextError>,
     {

--- a/linera-service/src/unit_tests/chain_listener.rs
+++ b/linera-service/src/unit_tests/chain_listener.rs
@@ -63,7 +63,7 @@ impl chain_listener::ClientContext for ClientContext {
             .map(|kp| kp.copy())
             .into_iter()
             .collect();
-        self.client.build(
+        self.client.create_chain(
             chain_id,
             known_key_pairs,
             self.wallet.genesis_admin_chain(),
@@ -94,10 +94,7 @@ impl chain_listener::ClientContext for ClientContext {
         }
     }
 
-    async fn update_wallet<'a>(
-        &'a mut self,
-        client: &'a mut ChainClient<TestProvider, TestStorage>,
-    ) {
+    async fn update_wallet(&mut self, client: &ChainClient<TestProvider, TestStorage>) {
         self.wallet.update_from_state(client).await;
     }
 }
@@ -139,8 +136,8 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     let description0 = ChainDescription::Root(0);
     let description1 = ChainDescription::Root(1);
     let chain_id0 = ChainId::from(description0);
-    let mut client0 = builder.add_initial_chain(description0, Amount::ONE).await?;
-    let mut client1 = builder.add_initial_chain(description1, Amount::ONE).await?;
+    let client0 = builder.add_initial_chain(description0, Amount::ONE).await?;
+    let client1 = builder.add_initial_chain(description1, Amount::ONE).await?;
 
     // Start a chain listener for chain 0 with a new key.
     let genesis_config = make_genesis_config(&builder);

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -46,7 +46,7 @@ impl chain_listener::ClientContext for ClientContext {
         self.update_calls += 1;
     }
 
-    async fn update_wallet<'a>(&'a mut self, _: &'a mut ChainClient<TestProvider, TestStorage>) {
+    async fn update_wallet(&mut self, _: &ChainClient<TestProvider, TestStorage>) {
         self.update_calls += 1;
     }
 }

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -166,7 +166,7 @@ impl Wallet {
         Ok(())
     }
 
-    pub async fn update_from_state<P, S>(&mut self, state: &mut ChainClient<P, S>)
+    pub async fn update_from_state<P, S>(&mut self, state: &ChainClient<P, S>)
     where
         P: ValidatorNodeProvider + Sync + 'static,
         S: Storage + Clone + Send + Sync + 'static,

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -166,22 +166,24 @@ impl Wallet {
         Ok(())
     }
 
-    pub async fn update_from_state<P, S>(&mut self, state: &ChainClient<P, S>)
+    pub async fn update_from_state<P, S>(&mut self, chain_client: &ChainClient<P, S>)
     where
         P: ValidatorNodeProvider + Sync + 'static,
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::ContextError>,
     {
+        let key_pair = chain_client.key_pair().await.map(|k| k.copy()).ok();
+        let state = chain_client.state();
         self.chains.insert(
-            state.chain_id(),
+            chain_client.chain_id(),
             UserChain {
-                chain_id: state.chain_id(),
-                key_pair: state.key_pair().await.map(|k| k.copy()).ok(),
-                block_hash: state.block_hash(),
-                next_block_height: state.next_block_height(),
-                timestamp: state.timestamp(),
-                pending_block: state.pending_block().clone(),
-                pending_blobs: state.pending_blobs().clone(),
+                chain_id: chain_client.chain_id(),
+                key_pair,
+                block_hash: state.block_hash.clone(),
+                next_block_height: state.next_block_height.clone(),
+                timestamp: state.timestamp.clone(),
+                pending_block: state.pending_block.clone(),
+                pending_blobs: state.pending_blobs.clone(),
             },
         );
     }

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -179,9 +179,9 @@ impl Wallet {
             UserChain {
                 chain_id: chain_client.chain_id(),
                 key_pair,
-                block_hash: state.block_hash.clone(),
-                next_block_height: state.next_block_height.clone(),
-                timestamp: state.timestamp.clone(),
+                block_hash: state.block_hash,
+                next_block_height: state.next_block_height,
+                timestamp: state.timestamp,
                 pending_block: state.pending_block.clone(),
                 pending_blobs: state.pending_blobs.clone(),
             },

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1615,18 +1615,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             .await;
     }
 
-    let chain_a_tip_after_cancel = node_service_a
-        .chain_tip_hash(chain_a)
-        .await?
-        .expect("Missing blocks from chain A");
-    node_service_admin
-        .wait_for_messages(chain_admin, chain_a_tip_after_cancel)
-        .await?;
-
-    let chain_a_refund_admin_tip = node_service_admin
-        .chain_tip_hash(chain_admin)
-        .await?
-        .expect("Missing blocks from admin chain");
+    node_service_admin.process_inbox(&chain_a).await?;
 
     for order_id in order_ids_b {
         app_matching_b
@@ -1637,32 +1626,9 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             .await;
     }
 
-    let chain_b_tip_after_cancel = node_service_b
-        .chain_tip_hash(chain_b)
-        .await?
-        .expect("Missing blocks from chain B");
-
-    node_service_admin
-        .wait_for_messages(chain_admin, chain_b_tip_after_cancel)
-        .await?;
-
-    let chain_b_refund_admin_tip = node_service_admin
-        .chain_tip_hash(chain_admin)
-        .await?
-        .expect("Missing blocks from admin chain");
-
-    node_service_a
-        .wait_for_messages(chain_a, chain_a_refund_admin_tip)
-        .await?;
-
-    node_service_b
-        .wait_for_messages(chain_b, chain_b_refund_admin_tip)
-        .await?;
-
+    node_service_admin.process_inbox(&chain_admin).await?;
     node_service_a.process_inbox(&chain_a).await?;
     node_service_b.process_inbox(&chain_b).await?;
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_admin.process_inbox(&chain_admin).await?;
 
     // Check balances
     app_fungible0_a

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1659,6 +1659,11 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
         .wait_for_messages(chain_b, chain_b_refund_admin_tip)
         .await?;
 
+    node_service_a.process_inbox(&chain_a).await?;
+    node_service_b.process_inbox(&chain_b).await?;
+    node_service_a.process_inbox(&chain_a).await?;
+    node_service_admin.process_inbox(&chain_admin).await?;
+
     // Check balances
     app_fungible0_a
         .assert_balances([(owner_a, Amount::from_tokens(4)), (owner_b, Amount::ZERO)])


### PR DESCRIPTION
## Motivation

In order to facilitate the creation of `ChainClient`s, move protocol- or chain-global state off the `ChainClient` and into the `Client`.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Add a `DashMap<ChainId, ChainState>` to the `Client`, and allow individual `ChainClient`s to access their state through their client reference.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
