### PR TITLE
Create new chains from admin chain for integration tests

### DIFF
--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -35,8 +35,8 @@ use crate::ContractAbi;
 /// # use linera_sdk::test::*;
 /// # use linera_base::identifiers::ChainId;
 /// # tokio_test::block_on(async {
-/// let validator = TestValidator::default();
-/// assert_eq!(validator.new_chain().await.id(), ChainId::root(0));
+/// let validator = TestValidator::new().await;
+/// assert_eq!(validator.new_chain().await.get_tip_height(), BlockHeight(0));
 /// # });
 /// ```
 pub struct TestValidator {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The SDK integration test framework would allow creating new chains, but to do so it would call `Storage::create_chain`. That call acquires a chain guard for the admin chain, which can hang if there's a chain worker loaded for the admin chain already.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create sub-chains from the admin chain using the worker instead.

## Test Plan

<!-- How to test that the changes are correct. -->
Existing integration tests were executed with the chain workers, and they passed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This may change the semantics of integration tests that rely on the first call to `new_chain` to return the admin chain. So I'd suggest:
- Need to bump the major/minor version number in the next release of the crates.


## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
