### PR TITLE
Create `ChainWorkerActor`

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -92,6 +92,12 @@ pub enum ChainWorkerRequest {
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 
+    /// Process a validated block issued for this multi-owner chain.
+    ProcessValidatedBlock {
+        certificate: Certificate,
+        callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions, bool), WorkerError>>,
+    },
+
     /// Process a cross-chain update.
     ProcessCrossChainUpdate {
         origin: Origin,
@@ -209,6 +215,12 @@ where
                 }
                 ChainWorkerRequest::HandleBlockProposal { proposal, callback } => {
                     let _ = callback.send(self.worker.handle_block_proposal(proposal).await);
+                }
+                ChainWorkerRequest::ProcessValidatedBlock {
+                    certificate,
+                    callback,
+                } => {
+                    let _ = callback.send(self.worker.process_validated_block(certificate).await);
                 }
                 ChainWorkerRequest::ProcessCrossChainUpdate {
                     origin,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -98,6 +98,14 @@ pub enum ChainWorkerRequest {
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions, bool), WorkerError>>,
     },
 
+    /// Process a confirmed block (a commit).
+    ProcessConfirmedBlock {
+        certificate: Certificate,
+        hashed_certificate_values: Vec<HashedCertificateValue>,
+        hashed_blobs: Vec<HashedBlob>,
+        callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
+    },
+
     /// Process a cross-chain update.
     ProcessCrossChainUpdate {
         origin: Origin,
@@ -221,6 +229,22 @@ where
                     callback,
                 } => {
                     let _ = callback.send(self.worker.process_validated_block(certificate).await);
+                }
+                ChainWorkerRequest::ProcessConfirmedBlock {
+                    certificate,
+                    hashed_certificate_values,
+                    hashed_blobs,
+                    callback,
+                } => {
+                    let _ = callback.send(
+                        self.worker
+                            .process_confirmed_block(
+                                certificate,
+                                &hashed_certificate_values,
+                                &hashed_blobs,
+                            )
+                            .await,
+                    );
                 }
                 ChainWorkerRequest::ProcessCrossChainUpdate {
                     origin,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -10,7 +10,9 @@ use linera_base::{
     data_types::{BlockHeight, HashedBlob},
     identifiers::{BlobId, ChainId},
 };
-use linera_chain::data_types::{Block, ExecutedBlock, HashedCertificateValue, Target};
+use linera_chain::data_types::{
+    Block, ExecutedBlock, HashedCertificateValue, MessageBundle, Origin, Target,
+};
 use linera_execution::{Query, Response, UserApplicationDescription, UserApplicationId};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
@@ -43,6 +45,13 @@ pub enum ChainWorkerRequest {
     StageBlockExecution {
         block: Block,
         callback: oneshot::Sender<Result<(ExecutedBlock, ChainInfoResponse), WorkerError>>,
+    },
+
+    /// Process a cross-chain update.
+    ProcessCrossChainUpdate {
+        origin: Origin,
+        bundles: Vec<MessageBundle>,
+        callback: oneshot::Sender<Result<Option<BlockHeight>, WorkerError>>,
     },
 
     /// Handle cross-chain request to confirm that the recipient was updated.
@@ -115,6 +124,17 @@ where
                 }
                 ChainWorkerRequest::StageBlockExecution { block, callback } => {
                     let _ = callback.send(self.worker.stage_block_execution(block).await);
+                }
+                ChainWorkerRequest::ProcessCrossChainUpdate {
+                    origin,
+                    bundles,
+                    callback,
+                } => {
+                    let _ = callback.send(
+                        self.worker
+                            .process_cross_chain_update(origin, bundles)
+                            .await,
+                    );
                 }
                 ChainWorkerRequest::ConfirmUpdatedRecipient {
                     latest_heights,

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -11,7 +11,7 @@ use linera_base::{
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{Block, ExecutedBlock, HashedCertificateValue};
-use linera_execution::{Query, Response};
+use linera_execution::{Query, Response, UserApplicationDescription, UserApplicationId};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use tokio::{
@@ -31,6 +31,12 @@ pub enum ChainWorkerRequest {
     QueryApplication {
         query: Query,
         callback: oneshot::Sender<Result<Response, WorkerError>>,
+    },
+
+    /// Describe an application.
+    DescribeApplication {
+        application_id: UserApplicationId,
+        callback: oneshot::Sender<Result<UserApplicationDescription, WorkerError>>,
     },
 
     /// Execute a block but discard any changes to the chain state.
@@ -94,6 +100,12 @@ where
             match request {
                 ChainWorkerRequest::QueryApplication { query, callback } => {
                     let _ = callback.send(self.worker.query_application(query).await);
+                }
+                ChainWorkerRequest::DescribeApplication {
+                    application_id,
+                    callback,
+                } => {
+                    let _ = callback.send(self.worker.describe_application(application_id).await);
                 }
                 ChainWorkerRequest::StageBlockExecution { block, callback } => {
                     let _ = callback.send(self.worker.stage_block_execution(block).await);

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! An actor that runs a chain worker.
+
+use std::sync::Arc;
+
+use linera_base::{
+    crypto::CryptoHash,
+    data_types::HashedBlob,
+    identifiers::{BlobId, ChainId},
+};
+use linera_chain::data_types::HashedCertificateValue;
+use linera_storage::Storage;
+use linera_views::views::ViewError;
+use tokio::{sync::mpsc, task::JoinSet};
+use tracing::{instrument, trace};
+
+use super::{config::ChainWorkerConfig, state::ChainWorkerState};
+use crate::{value_cache::ValueCache, worker::WorkerError, JoinSetExt as _};
+
+/// A request for the [`ChainWorkerActor`].
+pub enum ChainWorkerRequest {}
+
+/// The actor worker type.
+pub struct ChainWorkerActor<StorageClient>
+where
+    StorageClient: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    worker: ChainWorkerState<StorageClient>,
+    incoming_requests: mpsc::UnboundedReceiver<ChainWorkerRequest>,
+}
+
+impl<StorageClient> ChainWorkerActor<StorageClient>
+where
+    StorageClient: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    /// Spawns a new task to run the [`ChainWorkerActor`], returning an endpoint for sending
+    /// requests to the worker.
+    pub async fn spawn(
+        config: ChainWorkerConfig,
+        storage: StorageClient,
+        certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
+        blob_cache: Arc<ValueCache<BlobId, HashedBlob>>,
+        chain_id: ChainId,
+        join_set: &mut JoinSet<()>,
+    ) -> Result<mpsc::UnboundedSender<ChainWorkerRequest>, WorkerError> {
+        let worker = ChainWorkerState::load(
+            config,
+            storage,
+            certificate_value_cache,
+            blob_cache,
+            chain_id,
+        )
+        .await?;
+        let (sender, receiver) = mpsc::unbounded_channel();
+
+        let actor = ChainWorkerActor {
+            worker,
+            incoming_requests: receiver,
+        };
+
+        join_set.spawn_task(actor.run());
+
+        Ok(sender)
+    }
+
+    /// Runs the worker until there are no more incoming requests.
+    #[instrument(skip_all, fields(chain_id = format!("{:.8}", self.worker.chain_id())))]
+    async fn run(mut self) {
+        trace!("Starting `ChainWorkerActor`");
+
+        while let Some(request) = self.incoming_requests.recv().await {
+            match request {}
+        }
+
+        trace!("`ChainWorkerActor` finished");
+    }
+}

--- a/linera-core/src/chain_worker/mod.rs
+++ b/linera-core/src/chain_worker/mod.rs
@@ -3,9 +3,14 @@
 
 //! A worker to handle a single chain.
 
+mod actor;
 mod config;
 mod state;
 
 #[cfg(test)]
 pub(crate) use self::state::CrossChainUpdateHelper;
-pub use self::{config::ChainWorkerConfig, state::ChainWorkerState};
+pub use self::{
+    actor::{ChainWorkerActor, ChainWorkerRequest},
+    config::ChainWorkerConfig,
+    state::ChainWorkerState,
+};

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -729,7 +729,7 @@ where
         chain_id: ChainId,
         request_builder: impl FnOnce(
             oneshot::Sender<Result<Response, WorkerError>>,
-        ) -> ChainWorkerRequest,
+        ) -> ChainWorkerRequest<StorageClient::Context>,
     ) -> Result<Response, WorkerError> {
         let chain_actor = ChainWorkerActor::spawn(
             self.chain_worker_config.clone(),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -704,8 +704,10 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<OwnedRwLockReadGuard<ChainStateView<StorageClient::Context>>, WorkerError> {
-        let mut worker = self.create_chain_worker(chain_id).await?;
-        worker.chain_state_view().await
+        self.query_chain_worker(chain_id, |callback| ChainWorkerRequest::GetChainStateView {
+            callback,
+        })
+        .await
     }
 
     /// Creates a [`ChainWorkerState`] instance for a specific chain.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -660,14 +660,16 @@ where
         let origin = Origin { sender, medium };
 
         let Some(event) = self
-            .create_chain_worker(chain_id)
-            .await?
-            .find_event_in_inbox(
-                origin.clone(),
-                certificate.hash(),
-                message_id.height,
-                message_id.index,
-            )
+            .query_chain_worker(chain_id, {
+                let origin = origin.clone();
+                move |callback| ChainWorkerRequest::FindEventInInbox {
+                    inbox_id: origin,
+                    certificate_hash: certificate.hash(),
+                    height: message_id.height,
+                    index: message_id.index,
+                    callback,
+                }
+            })
             .await?
         else {
             return Ok(None);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -536,9 +536,14 @@ where
         let height = executed_block.block.height;
 
         let (response, actions) = self
-            .create_chain_worker(chain_id)
-            .await?
-            .process_confirmed_block(certificate, hashed_certificate_values, hashed_blobs)
+            .query_chain_worker(chain_id, move |callback| {
+                ChainWorkerRequest::ProcessConfirmedBlock {
+                    certificate,
+                    hashed_certificate_values: hashed_certificate_values.to_owned(),
+                    hashed_blobs: hashed_blobs.to_owned(),
+                    callback,
+                }
+            })
             .await?;
 
         self.register_delivery_notifier(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -442,24 +442,10 @@ where
         &mut self,
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
-        let chain_actor = ChainWorkerActor::spawn(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            self.recent_hashed_certificate_values.clone(),
-            self.recent_hashed_blobs.clone(),
-            block.chain_id,
-            &mut *self.chain_worker_tasks.lock().await,
-        )
-        .await?;
-        let (callback, response) = oneshot::channel();
-
-        chain_actor
-            .send(ChainWorkerRequest::StageBlockExecution { block, callback })
-            .expect("`ChainWorkerActor` stopped executing unexpectedly");
-
-        response
-            .await
-            .expect("`ChainWorkerActor` stopped executing without responding")
+        self.query_chain_worker(block.chain_id, move |callback| {
+            ChainWorkerRequest::StageBlockExecution { block, callback }
+        })
+        .await
     }
 
     // Schedule a notification when cross-chain messages are delivered up to the given height.
@@ -500,24 +486,10 @@ where
         chain_id: ChainId,
         query: Query,
     ) -> Result<Response, WorkerError> {
-        let chain_actor = ChainWorkerActor::spawn(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            self.recent_hashed_certificate_values.clone(),
-            self.recent_hashed_blobs.clone(),
-            chain_id,
-            &mut *self.chain_worker_tasks.lock().await,
-        )
-        .await?;
-        let (callback, response) = oneshot::channel();
-
-        chain_actor
-            .send(ChainWorkerRequest::QueryApplication { query, callback })
-            .expect("`ChainWorkerActor` stopped executing unexpectedly");
-
-        response
-            .await
-            .expect("`ChainWorkerActor` stopped executing without responding")
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::QueryApplication { query, callback }
+        })
+        .await
     }
 
     #[cfg(with_testing)]
@@ -726,6 +698,34 @@ where
             chain_id,
         )
         .await
+    }
+
+    /// Sends a request to the [`ChainWorker`] for a [`ChainId`] and waits for the `Response`.
+    async fn query_chain_worker<Response>(
+        &self,
+        chain_id: ChainId,
+        request_builder: impl FnOnce(
+            oneshot::Sender<Result<Response, WorkerError>>,
+        ) -> ChainWorkerRequest,
+    ) -> Result<Response, WorkerError> {
+        let chain_actor = ChainWorkerActor::spawn(
+            self.chain_worker_config.clone(),
+            self.storage.clone(),
+            self.recent_hashed_certificate_values.clone(),
+            self.recent_hashed_blobs.clone(),
+            chain_id,
+            &mut *self.chain_worker_tasks.lock().await,
+        )
+        .await?;
+        let (callback, response) = oneshot::channel();
+
+        chain_actor
+            .send(request_builder(callback))
+            .expect("`ChainWorkerActor` stopped executing unexpectedly");
+
+        response
+            .await
+            .expect("`ChainWorkerActor` stopped executing without responding")
     }
 }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -619,10 +619,10 @@ where
         chain_id: ChainId,
         height: BlockHeight,
     ) -> Result<Option<Certificate>, WorkerError> {
-        self.create_chain_worker(chain_id)
-            .await?
-            .read_certificate(height)
-            .await
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::ReadCertificate { height, callback }
+        })
+        .await
     }
 
     /// Returns an [`IncomingMessage`] that's awaiting to be received by the chain specified by

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -782,9 +782,9 @@ where
         #[cfg(with_metrics)]
         let round = proposal.content.round;
         let response = self
-            .create_chain_worker(proposal.content.block.chain_id)
-            .await?
-            .handle_block_proposal(proposal)
+            .query_chain_worker(proposal.content.block.chain_id, move |callback| {
+                ChainWorkerRequest::HandleBlockProposal { proposal, callback }
+            })
             .await?;
         #[cfg(with_metrics)]
         NUM_ROUNDS_IN_BLOCK_PROPOSAL

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -580,10 +580,13 @@ where
         let CertificateValue::Timeout { chain_id, .. } = certificate.value() else {
             panic!("Expecting a leader timeout certificate");
         };
-        self.create_chain_worker(*chain_id)
-            .await?
-            .process_timeout(certificate)
-            .await
+        self.query_chain_worker(*chain_id, move |callback| {
+            ChainWorkerRequest::ProcessTimeout {
+                certificate,
+                callback,
+            }
+        })
+        .await
     }
 
     async fn process_cross_chain_update(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -498,10 +498,13 @@ where
         chain_id: ChainId,
         bytecode_id: BytecodeId,
     ) -> Result<Option<BytecodeLocation>, WorkerError> {
-        self.create_chain_worker(chain_id)
-            .await?
-            .read_bytecode_location(bytecode_id)
-            .await
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::ReadBytecodeLocation {
+                bytecode_id,
+                callback,
+            }
+        })
+        .await
     }
 
     pub async fn describe_application(

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -895,13 +895,11 @@ where
         query: ChainInfoQuery,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, query);
-        let result = async move {
-            self.create_chain_worker(query.chain_id)
-                .await?
-                .handle_chain_info_query(query)
-                .await
-        }
-        .await;
+        let result = self
+            .query_chain_worker(query.chain_id, move |callback| {
+                ChainWorkerRequest::HandleChainInfoQuery { query, callback }
+            })
+            .await;
         trace!("{} --> {:?}", self.nickname, result);
         result
     }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -589,10 +589,14 @@ where
         recipient: ChainId,
         bundles: Vec<MessageBundle>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
-        self.create_chain_worker(recipient)
-            .await?
-            .process_cross_chain_update(origin, bundles)
-            .await
+        self.query_chain_worker(recipient, move |callback| {
+            ChainWorkerRequest::ProcessCrossChainUpdate {
+                origin,
+                bundles,
+                callback,
+            }
+        })
+        .await
     }
 
     /// Inserts a [`HashedCertificateValue`] into the worker's cache.

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -954,9 +954,12 @@ where
                     .map(|(medium, height)| (Target { recipient, medium }, height))
                     .collect();
                 let height_with_fully_delivered_messages = self
-                    .create_chain_worker(sender)
-                    .await?
-                    .confirm_updated_recipient(latest_heights)
+                    .query_chain_worker(sender, move |callback| {
+                        ChainWorkerRequest::ConfirmUpdatedRecipient {
+                            latest_heights,
+                            callback,
+                        }
+                    })
                     .await?;
                 // Handle delivery notifiers for this chain, if any.
                 if let hash_map::Entry::Occupied(mut map) =

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -51,7 +51,7 @@ use {
 };
 
 use crate::{
-    chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest, ChainWorkerState},
+    chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
     value_cache::ValueCache,
 };
@@ -707,21 +707,6 @@ where
         self.query_chain_worker(chain_id, |callback| ChainWorkerRequest::GetChainStateView {
             callback,
         })
-        .await
-    }
-
-    /// Creates a [`ChainWorkerState`] instance for a specific chain.
-    async fn create_chain_worker(
-        &self,
-        chain_id: ChainId,
-    ) -> Result<ChainWorkerState<StorageClient>, WorkerError> {
-        ChainWorkerState::load(
-            self.chain_worker_config.clone(),
-            self.storage.clone(),
-            self.recent_hashed_certificate_values.clone(),
-            self.recent_hashed_blobs.clone(),
-            chain_id,
-        )
         .await
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -509,10 +509,13 @@ where
         chain_id: ChainId,
         application_id: UserApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
-        self.create_chain_worker(chain_id)
-            .await?
-            .describe_application(application_id)
-            .await
+        self.query_chain_worker(chain_id, move |callback| {
+            ChainWorkerRequest::DescribeApplication {
+                application_id,
+                callback,
+            }
+        })
+        .await
     }
 
     /// Processes a confirmed block (aka a commit).

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -566,10 +566,13 @@ where
         else {
             panic!("Expecting a validation certificate");
         };
-        self.create_chain_worker(block.chain_id)
-            .await?
-            .process_validated_block(certificate)
-            .await
+        self.query_chain_worker(block.chain_id, move |callback| {
+            ChainWorkerRequest::ProcessValidatedBlock {
+                certificate,
+                callback,
+            }
+        })
+        .await
     }
 
     /// Processes a leader timeout issued from a multi-owner chain.


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Currently the `ChainStateView` is reloaded for every worker operation. This is inefficient because it involves deserializing data every time.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Create a `ChainWorkerActor` that wraps a `ChainWorkerState` and keeps it loaded while the actor is running. For now, even though actors run on new tasks, they only handle one operation and then finish the task. A separate PR will make them long-lived.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, so existing tests should catch any regressions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is an internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
