### PR TITLE
Use the message policy specified on the CLI.

### DIFF
--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -132,12 +132,15 @@ where
         };
         let node_provider = NodeProvider::new(node_options);
         let delivery = CrossChainMessageDelivery::new(options.wait_for_outgoing_messages);
-        let client = Arc::new(Client::new(
-            node_provider,
-            storage,
-            options.max_pending_messages,
-            delivery,
-        ));
+        let client = Arc::new(
+            Client::new(
+                node_provider,
+                storage,
+                options.max_pending_messages,
+                delivery,
+            )
+            .with_message_policy(options.message_policy),
+        );
         ClientContext {
             client,
             wallet_state,


### PR DESCRIPTION
## Motivation

The message policy from the client options is not actually used.

## Proposal

Set it when creating the client builder.

## Test Plan

There are already client tests for the message policy; it just wasn't set as specified on the CLI.

## Links

- Original PR: https://github.com/linera-io/linera-protocol/issues/1842
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
