### PR TITLE
Correct the paths for the computation of the `RPC API hash` and `WIT API hash`

### DIFF
--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -191,8 +191,13 @@ impl VersionInfo {
         }
         .into();
 
-        let rpc_hash =
-            get_hash(paths, &metadata, "linera-rpc", "proto/rpc.proto")?.into();
+        let rpc_hash = get_hash(
+            paths,
+            &metadata,
+            "linera-rpc",
+            "tests/snapshots/format__format.yaml.snap",
+        )?
+        .into();
 
         let graphql_hash = get_hash(
             paths,

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -103,14 +103,17 @@ fn get_hash(
 
     let package_glob = format!("{}/{}", package_root.display(), glob);
 
+    let mut n_file = 0;
     for path in glob::glob(&package_glob)? {
         let path = path?;
         let mut file = std::fs::File::open(&path)?;
         relevant_paths.push(path);
+        n_file += 1;
         while file.read(&mut buffer)? != 0 {
             hasher.update(buffer);
         }
     }
+    assert!(n_file > 0);
 
     Ok(STANDARD_NO_PAD.encode(hasher.finalize()))
 }

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -203,6 +203,7 @@ impl VersionInfo {
         .into();
 
         let wit_hash = get_hash(paths, &metadata, "linera-sdk", "wit/*.wit")?.into();
+        assert_ne!(rpc_hash, wit_hash);
 
         Ok(Self {
             crate_version,

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -192,7 +192,7 @@ impl VersionInfo {
         .into();
 
         let rpc_hash =
-            get_hash(paths, &metadata, "linera-rpc", "tests/staged/formats.yaml")?.into();
+            get_hash(paths, &metadata, "linera-rpc", "proto/rpc.proto")?.into();
 
         let graphql_hash = get_hash(
             paths,
@@ -202,7 +202,7 @@ impl VersionInfo {
         )?
         .into();
 
-        let wit_hash = get_hash(paths, &metadata, "linera-sdk", "*.wit")?.into();
+        let wit_hash = get_hash(paths, &metadata, "linera-sdk", "wit/*.wit")?.into();
 
         Ok(Self {
             crate_version,


### PR DESCRIPTION
## Motivation

The `RPC API hash` and `WIT API hash` were showing the same value which is not what one expects.

## Proposal

The explanation was that the paths were incorrect. Once corrected, we obtained reasonable values.

## Test Plan

We check that the hashes are different.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
