### PR TITLE
Docker compose works for MacOS

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ on:
       - "**"
     paths:
       - 'docker/Dockerfile'
+      - 'docker/compose.sh'
       - 'Cargo.toml'
       - '.github/workflows/docker.yml'
   workflow_dispatch:

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -28,7 +28,21 @@ cleanup() {
 trap cleanup EXIT INT
 
 cd "$ROOT_DIR"
-docker build -f docker/Dockerfile . -t linera-test
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    docker build -f docker/Dockerfile . -t linera-test
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+        CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
+        if [[ "$CPU_ARCH" == *"Apple"* ]]; then
+            docker build --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera-test .
+        else
+            echo "Unsupported Architecture: $CPU_ARCH"
+            exit 1;
+        fi
+else
+    echo "Unsupported OS: $OSTYPE"
+    exit 1;
+fi
 
 cd "$SCRIPT_DIR"
 


### PR DESCRIPTION
## Motivation

Docker compose validators do not work on MacOS.

## Proposal

Add the appropriate Build args to make it work locally.

## Test Plan

This _has_ been tested locally and will be tested by CI on Linux, however due to the limited size of MacOS runners, testing on CI is not currently possible as building the container will OOM.
