### PR TITLE
Remove retry loop from make_application.

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -854,16 +854,11 @@ impl NodeService {
         application_id: &ApplicationId<A>,
     ) -> Result<ApplicationWrapper<A>> {
         let application_id = application_id.forget_abi().to_string();
-        let n_try = 15;
-        for i in 0..n_try {
-            tokio::time::sleep(Duration::from_secs(i)).await;
-            let values = self.try_get_applications_uri(chain_id).await?;
-            if let Some(link) = values.get(&application_id) {
-                return Ok(ApplicationWrapper::from(link.to_string()));
-            }
-            warn!("Waiting for application {application_id:?} to be visible on chain {chain_id:?}");
-        }
-        bail!("Could not find application URI: {application_id} after {n_try} tries");
+        let values = self.try_get_applications_uri(chain_id).await?;
+        let Some(link) = values.get(&application_id) else {
+            bail!("Could not find application URI: {application_id}");
+        };
+        Ok(ApplicationWrapper::from(link.to_string()))
     }
 
     pub async fn try_get_applications_uri(


### PR DESCRIPTION
This should make the end-to-end tests less flaky and slightly faster by making sure cross-chain messages have been processed when the test observes the result.

## Motivation

Suppose an application is registered on chain A:

* If chain B requests that application from chain A, we have to wait for
  - chain A to process the request, and
  - chain B to process the response…
* If chain A sends an application message to chain B, we have to wait for
  - chain B to process the message…

…before we can expect the application to be registered on chain B.

In the tests, we currently just retry in a loop until this has happened.

## Proposal

Call `process_inbox` in the right places, and remove the retry loop.

## Test Plan

All affected tests run in CI.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
