### PR TITLE
Disable the cache for the objects used in the NodeService and Faucet

### DIFF
--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -78,7 +78,7 @@ pub struct Validator {
     pub network_address: String,
 }
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
@@ -110,7 +110,7 @@ where
     }
 }
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -271,7 +271,7 @@ where
     }
 }
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
@@ -699,7 +699,7 @@ where
     }
 }
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
@@ -793,7 +793,7 @@ where
 
 struct ChainStateViewExtension(ChainId);
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl ChainStateViewExtension {
     async fn chain_id(&self) -> ChainId {
         self.0


### PR DESCRIPTION
## Motivation

The instability in CI and in particular for `make_application` is a constant problem. The GraphQL cache could be an explanation for our problems. This PR closes the possibility.

## Proposal

Replace the `#[Object]` by `#[Object(cache_control(no_cache))]`. 

## Test Plan

Putting `n_try = 1` for the `make_application` and running the end-to-end tests locally did not reveal a change of behavior. However, the PR is still interesting as it removes one explanation for the CI problems.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
