### PR TITLE
Disable the assert statements for the `RPC API hash` and `WIT API hash`.

### DIFF
--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -211,7 +211,6 @@ impl VersionInfo {
         .into();
 
         let wit_hash = get_hash(paths, &metadata, "linera-sdk", "wit/*.wit")?.into();
-        assert_ne!(rpc_hash, wit_hash);
 
         Ok(Self {
             crate_version,


### PR DESCRIPTION
## Motivation

The additional assert statements for the `RPC API hash` and the `WIT API hash` are creating issues with some other checks. So, we disable them here.

## Proposal

Direct removal of the assert statements.

## Test Plan

No change.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
