### PR TITLE
Don't retry proposal if the block got confirmed, even with different oracle values.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1426,7 +1426,7 @@ where
             .await?;
         match self.process_pending_block_without_prepare().await? {
             ClientOutcome::Committed(Some(certificate))
-                if certificate.hash() == confirmed_value.hash() =>
+                if certificate.value().block() == confirmed_value.inner().block() =>
             {
                 Ok(ExecuteBlockOutcome::Executed(certificate))
             }


### PR DESCRIPTION
## Motivation

Client commands (e.g. `transfer`) automatically retry if a conflicting block gets confirmed at the same height. Since the validators might see different oracle values than the local node, even in the case of success, the confirmed block might look different than the one that was computed locally. This would currently make the client retry the command that already succeeded.

## Proposal

Compare only the `Block`, not the `ExecutedBlock`, since the former doesn't contain oracle records.

## Test Plan

A test will be added in https://github.com/linera-io/linera-protocol/issues/2154.

## Links

- #2154 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
