### PR TITLE
Track the certified block that published a blob last

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use thiserror::Error;
 
 use crate::{
-    crypto::BcsHashable,
+    crypto::{BcsHashable, CryptoHash},
     doc_scalar,
     identifiers::{ApplicationId, BlobId, Destination, GenericApplicationId},
     time::{Duration, SystemTime},
@@ -798,6 +798,13 @@ impl From<HashedBlob> for Blob {
 pub struct HashedBlob {
     id: BlobId,
     blob: Blob,
+}
+
+/// The state of a blob of binary data.
+#[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize, Deserialize)]
+pub struct BlobState {
+    /// Hash of the last `Certificate` that published or used this blob.
+    pub last_used_by: CryptoHash,
 }
 
 impl HashedBlob {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -521,10 +521,12 @@ where
         }
 
         let blobs_in_block = self.get_blobs(block.blob_ids()).await?;
+        let certificate_hash = certificate.hash();
         let (result_hashed_certificate_value, result_blobs, result_certificate) = tokio::join!(
             self.storage
                 .write_hashed_certificate_values(hashed_certificate_values),
-            self.storage.write_hashed_blobs(&blobs_in_block),
+            self.storage
+                .write_hashed_blobs(&blobs_in_block, &certificate_hash),
             self.storage.write_certificate(&certificate)
         );
         result_hashed_certificate_value?;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -25,7 +25,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, HashedBlob, Timestamp},
+    data_types::{Amount, BlobState, BlockHeight, HashedBlob, Timestamp},
     identifiers::{BlobId, ChainDescription, ChainId, GenericApplicationId},
     ownership::ChainOwnership,
 };
@@ -105,6 +105,9 @@ pub trait Storage: Sized {
     /// Reads the blob with the given blob ID.
     async fn read_hashed_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ViewError>;
 
+    /// Reads the blob state with the given blob ID.
+    async fn read_blob_state(&self, blob_id: BlobId) -> Result<BlobState, ViewError>;
+
     /// Reads the hashed certificate values in descending order from the given hash.
     async fn read_hashed_certificate_values_downward(
         &self,
@@ -119,16 +122,24 @@ pub trait Storage: Sized {
     ) -> Result<(), ViewError>;
 
     /// Writes the given blob.
-    async fn write_hashed_blob(&self, blob: &HashedBlob) -> Result<(), ViewError>;
+    async fn write_hashed_blob(
+        &self,
+        blob: &HashedBlob,
+        last_used_by: &CryptoHash,
+    ) -> Result<(), ViewError>;
 
-    /// Writes several hashed certificate values
+    /// Writes several hashed certificate values.
     async fn write_hashed_certificate_values(
         &self,
         values: &[HashedCertificateValue],
     ) -> Result<(), ViewError>;
 
-    /// Writes several blobs
-    async fn write_hashed_blobs(&self, blobs: &[HashedBlob]) -> Result<(), ViewError>;
+    /// Writes several blobs.
+    async fn write_hashed_blobs(
+        &self,
+        blobs: &[HashedBlob],
+        last_used_by: &CryptoHash,
+    ) -> Result<(), ViewError>;
 
     /// Tests existence of the certificate with the given hash.
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError>;


### PR DESCRIPTION
## Motivation

For example, if we know a certain blob was published, and we try to use it, but some of the validators don't have it, we need to be able to know the certificate that last used the blob so that we can sync validators to also have that blob. That's one use case for this, but there are more. Part of #2033

## Proposal

Track what `Certificate` last used the blob. As of right now, the only "usage" is publishing a blob, but in the future we'll also use it in the `read_blob` system API call, when we replace `Bytecode` with blobs, etc.

## Test Plan

CI + will use this in following PRs

