### PR TITLE
Endpoint to request which certificate published a blob last in a given validator

### DIFF
--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -89,6 +89,9 @@ pub trait LocalValidatorNode {
     ) -> Result<HashedCertificateValue, NodeError>;
 
     async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError>;
+
+    /// Returns the hash of the `Certificate` that last used a blob.
+    async fn blob_last_used_by(&mut self, blob_id: BlobId) -> Result<CryptoHash, NodeError>;
 }
 
 /// Turn an address into a validator node.

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -60,6 +60,9 @@ service ValidatorNode {
 
   // Downloads a certificate.
   rpc DownloadCertificate(CryptoHash) returns (Certificate);
+
+  // Returns the hash of the `Certificate` that last used a blob.
+  rpc BlobLastUsedBy(BlobId) returns (CryptoHash);
 }
 
 // Information about the Linera crate version the validator is running

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -175,4 +175,13 @@ impl ValidatorNode for Client {
             Client::Simple(simple_client) => simple_client.download_certificate(hash).await?,
         })
     }
+
+    async fn blob_last_used_by(&mut self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.blob_last_used_by(blob_id).await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.blob_last_used_by(blob_id).await?,
+        })
+    }
 }

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -299,6 +299,16 @@ impl ValidatorNode for GrpcClient {
             .into_inner()
             .try_into()?)
     }
+
+    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
+    async fn blob_last_used_by(&mut self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+        Ok(self
+            .client
+            .blob_last_used_by(<BlobId as Into<api::BlobId>>::into(blob_id))
+            .await?
+            .into_inner()
+            .try_into()?)
+    }
 }
 
 #[cfg(not(web))]

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -28,6 +28,7 @@ pub enum RpcMessage {
     DownloadBlob(Box<BlobId>),
     DownloadCertificateValue(Box<CryptoHash>),
     DownloadCertificate(Box<CryptoHash>),
+    BlobLastUsedBy(Box<BlobId>),
     VersionInfoQuery,
 
     // Outbound
@@ -38,6 +39,7 @@ pub enum RpcMessage {
     DownloadBlobResponse(Box<Blob>),
     DownloadCertificateValueResponse(Box<CertificateValue>),
     DownloadCertificateResponse(Box<Certificate>),
+    BlobLastUsedByResponse(Box<CryptoHash>),
 
     // Internal to a validator
     CrossChainRequest(Box<CrossChainRequest>),
@@ -66,6 +68,8 @@ impl RpcMessage {
             | DownloadCertificateValue(_)
             | DownloadCertificateValueResponse(_)
             | DownloadCertificate(_)
+            | BlobLastUsedBy(_)
+            | BlobLastUsedByResponse(_)
             | DownloadCertificateResponse(_) => {
                 return None;
             }
@@ -83,6 +87,7 @@ impl RpcMessage {
             VersionInfoQuery
             | DownloadBlob(_)
             | DownloadCertificateValue(_)
+            | BlobLastUsedBy(_)
             | DownloadCertificate(_) => true,
             BlockProposal(_)
             | LiteCertificate(_)
@@ -95,6 +100,7 @@ impl RpcMessage {
             | VersionInfoResponse(_)
             | DownloadBlobResponse(_)
             | DownloadCertificateValueResponse(_)
+            | BlobLastUsedByResponse(_)
             | DownloadCertificateResponse(_) => false,
         }
     }
@@ -154,6 +160,18 @@ impl TryFrom<RpcMessage> for Certificate {
         use RpcMessage::*;
         match message {
             DownloadCertificateResponse(certificate) => Ok(*certificate),
+            Error(error) => Err(*error),
+            _ => Err(NodeError::UnexpectedMessage),
+        }
+    }
+}
+
+impl TryFrom<RpcMessage> for CryptoHash {
+    type Error = NodeError;
+    fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
+        use RpcMessage::*;
+        match message {
+            BlobLastUsedByResponse(hash) => Ok(*hash),
             Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -156,6 +156,11 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::DownloadCertificate(Box::new(hash)))
             .await
     }
+
+    async fn blob_last_used_by(&mut self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+        self.query(RpcMessage::BlobLastUsedBy(Box::new(blob_id)))
+            .await
+    }
 }
 
 #[derive(Clone)]

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -302,6 +302,8 @@ where
             | RpcMessage::DownloadBlobResponse(_)
             | RpcMessage::DownloadCertificateValue(_)
             | RpcMessage::DownloadCertificateValueResponse(_)
+            | RpcMessage::BlobLastUsedBy(_)
+            | RpcMessage::BlobLastUsedByResponse(_)
             | RpcMessage::DownloadCertificate(_)
             | RpcMessage::DownloadCertificateResponse(_) => Err(NodeError::UnexpectedMessage),
         };

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -770,36 +770,44 @@ RpcMessage:
         NEWTYPE:
           TYPENAME: CryptoHash
     7:
-      VersionInfoQuery: UNIT
+      BlobLastUsedBy:
+        NEWTYPE:
+          TYPENAME: BlobId
     8:
+      VersionInfoQuery: UNIT
+    9:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    9:
+    10:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    10:
+    11:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    11:
+    12:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    12:
+    13:
       DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: Blob
-    13:
+    14:
       DownloadCertificateValueResponse:
         NEWTYPE:
           TYPENAME: CertificateValue
-    14:
+    15:
       DownloadCertificateResponse:
         NEWTYPE:
           TYPENAME: Certificate
-    15:
+    16:
+      BlobLastUsedByResponse:
+        NEWTYPE:
+          TYPENAME: CryptoHash
+    17:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -441,6 +441,21 @@ where
             .map_err(|err| Status::from_error(Box::new(err)))?;
         Ok(Response::new(certificate.try_into()?))
     }
+
+    #[instrument(skip_all, err(Display))]
+    async fn blob_last_used_by(
+        &self,
+        request: Request<BlobId>,
+    ) -> Result<Response<CryptoHash>, Status> {
+        let blob_id = request.into_inner().try_into()?;
+        let blob_state = self
+            .0
+            .storage
+            .read_blob_state(blob_id)
+            .await
+            .map_err(|err| Status::from_error(Box::new(err)))?;
+        Ok(Response::new(blob_state.last_used_by.into()))
+    }
 }
 
 #[async_trait]

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -304,6 +304,9 @@ where
             DownloadCertificate(hash) => {
                 Ok(Some(self.storage.read_certificate(*hash).await?.into()))
             }
+            BlobLastUsedBy(blob_id) => Ok(Some(RpcMessage::BlobLastUsedByResponse(Box::new(
+                self.storage.read_blob_state(*blob_id).await?.last_used_by,
+            )))),
             BlockProposal(_)
             | LiteCertificate(_)
             | Certificate(_)
@@ -314,6 +317,7 @@ where
             | ChainInfoResponse(_)
             | VersionInfoResponse(_)
             | DownloadBlobResponse(_)
+            | BlobLastUsedByResponse(_)
             | DownloadCertificateValueResponse(_)
             | DownloadCertificateResponse(_) => {
                 Err(anyhow::Error::from(NodeError::UnexpectedMessage))

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -88,6 +88,10 @@ impl ValidatorNode for DummyValidatorNode {
     async fn download_certificate(&mut self, _: CryptoHash) -> Result<Certificate, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
+
+    async fn blob_last_used_by(&mut self, _: BlobId) -> Result<CryptoHash, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
 }
 
 struct DummyValidatorNodeProvider;


### PR DESCRIPTION
## Motivation

Building on top of #2156, there we will need this endpoint for the client to communicate with the validators. Fixes #2030

## Proposal

Adds an endpoint to get what `Certificate` last used a blob.

## Test Plan

CI for now, but will use this in following PRs

