### PR TITLE
Remove redundant local chain info query from `propose_block`.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1336,8 +1336,7 @@ where
         let certificate = self
             .submit_block_proposal(&committee, proposal, hashed_value)
             .await?;
-        self.pending_block = None;
-        self.pending_blobs.clear();
+        self.clear_pending_block();
         // Communicate the new certificate now.
         self.communicate_chain_updates(
             &committee,
@@ -1737,8 +1736,7 @@ where
         // Drop the pending block if it is outdated.
         if let Some(block) = &self.pending_block {
             if block.height != info.next_block_height {
-                self.pending_block = None;
-                self.pending_blobs.clear();
+                self.clear_pending_block();
             }
         }
         // If there is a validated block in the current round, finalize it.


### PR DESCRIPTION
Minor optimization: Remove a redundant call (involving a database query or at least requesting data from another task).

## Motivation

The chain info query in `propose_block` is redundant: The function is called in only one place, and at the call site we already have the chain info.

## Proposal

Remove the query, pass the required data (the chain manager info) into `propose_block`.

Also, deduplicate clearing the pending block in a few places.

## Test Plan

The existing tests should catch any regression.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
