### PR TITLE
Add blobs as oracle records

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -355,9 +355,11 @@ where
                 .ok_or_else(|| WorkerError::InvalidLiteCertificate)?;
         }
         if round.is_fast() {
-            let mut records = outcome.oracle_records.iter();
             ensure!(
-                records.all(|record| record.responses.is_empty()),
+                outcome
+                    .oracle_records
+                    .iter()
+                    .all(|record| record.is_permitted_in_fast_blocks()),
                 WorkerError::FastBlockUsingOracles
             );
         }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -296,7 +296,7 @@ where
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match operation {
             Operation::System(op) => {
-                let (mut result, new_application) =
+                let (mut result, new_application, returned_oracle_record) =
                     self.system.execute_operation(context, op).await?;
                 result.authenticated_signer = context.authenticated_signer;
                 result.refund_grant_to = context.refund_grant_to();
@@ -318,7 +318,7 @@ where
                     outcomes.extend(user_outcomes);
                     return Ok((outcomes, oracle_record));
                 }
-                Ok((outcomes, OracleRecord::default()))
+                Ok((outcomes, returned_oracle_record))
             }
             Operation::User {
                 application_id,

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -651,6 +651,10 @@ OracleResponse:
         NEWTYPE:
           SEQ: U8
     2:
+      Blob:
+        NEWTYPE:
+          TYPENAME: BlobId
+    3:
       Assert: UNIT
 Origin:
   STRUCT:


### PR DESCRIPTION
## Motivation

We'll need blobs are oracles to be able to properly check things for #2151. Fixes #2032

## Proposal

Add blobs as oracles

## Test Plan

CI + will be used in following PRs

