### PR TITLE
Keep `ChainWorkerActor` running in an LRU cache

### DIFF
--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -33,13 +33,21 @@ use crate::{
 };
 
 /// A local node with a single worker, typically used by clients.
-pub struct LocalNode<S> {
+pub struct LocalNode<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     state: WorkerState<S>,
 }
 
 /// A client to a local node.
 #[derive(Clone)]
-pub struct LocalNodeClient<S> {
+pub struct LocalNodeClient<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     node: Arc<Mutex<LocalNode<S>>>,
 }
 
@@ -142,7 +150,11 @@ where
     }
 }
 
-impl<S> LocalNodeClient<S> {
+impl<S> LocalNodeClient<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     pub fn new(state: WorkerState<S>) -> Self {
         let node = LocalNode { state };
 
@@ -154,7 +166,8 @@ impl<S> LocalNodeClient<S> {
 
 impl<S> LocalNodeClient<S>
 where
-    S: Clone,
+    S: Storage + Clone,
+    ViewError: From<S::ContextError>,
 {
     pub(crate) async fn storage_client(&self) -> S {
         let node = self.node.lock().await;

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -76,14 +76,22 @@ pub enum FaultType {
 /// All methods are executed in spawned Tokio tasks, so that canceling a client task doesn't cause
 /// the validator's tasks to be canceled: In a real network, a validator also wouldn't cancel
 /// tasks if the client stopped waiting for the response.
-struct LocalValidator<S> {
+struct LocalValidator<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     state: WorkerState<S>,
     fault_type: FaultType,
     notifier: Notifier<Notification>,
 }
 
 #[derive(Clone)]
-pub struct LocalValidatorClient<S> {
+pub struct LocalValidatorClient<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     name: ValidatorName,
     client: Arc<Mutex<LocalValidator<S>>>,
 }
@@ -415,7 +423,10 @@ where
 }
 
 #[derive(Clone)]
-pub struct NodeProvider<S>(BTreeMap<ValidatorName, Arc<Mutex<LocalValidator<S>>>>);
+pub struct NodeProvider<S>(BTreeMap<ValidatorName, Arc<Mutex<LocalValidator<S>>>>)
+where
+    S: Storage,
+    ViewError: From<S::ContextError>;
 
 impl<S> LocalValidatorNodeProvider for NodeProvider<S>
 where
@@ -452,7 +463,11 @@ where
     }
 }
 
-impl<S> FromIterator<LocalValidatorClient<S>> for NodeProvider<S> {
+impl<S> FromIterator<LocalValidatorClient<S>> for NodeProvider<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = LocalValidatorClient<S>>,
@@ -468,7 +483,10 @@ impl<S> FromIterator<LocalValidatorClient<S>> for NodeProvider<S> {
 // * When using `LocalValidatorClient`, clients communicate with an exact quorum then stop.
 // * Most tests have 1 faulty validator out 4 so that there is exactly only 1 quorum to
 // communicate with.
-pub struct TestBuilder<B: StorageBuilder> {
+pub struct TestBuilder<B: StorageBuilder>
+where
+    ViewError: From<<B::Storage as Storage>::ContextError>,
+{
     storage_builder: B,
     pub initial_committee: Committee,
     admin_id: ChainId,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -125,7 +125,11 @@ fn make_certificate<S>(
     committee: &Committee,
     worker: &WorkerState<S>,
     value: HashedCertificateValue,
-) -> Certificate {
+) -> Certificate
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     make_certificate_with_round(committee, worker, value, Round::Fast)
 }
 
@@ -134,7 +138,11 @@ fn make_certificate_with_round<S>(
     worker: &WorkerState<S>,
     value: HashedCertificateValue,
     round: Round,
-) -> Certificate {
+) -> Certificate
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     let vote = LiteVote::new(
         value.lite(),
         round,
@@ -158,7 +166,11 @@ async fn make_simple_transfer_certificate<S>(
     balance: Amount,
     worker: &WorkerState<S>,
     previous_confirmed_block: Option<&Certificate>,
-) -> Certificate {
+) -> Certificate
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     make_transfer_certificate_for_epoch(
         chain_description,
         key_pair,
@@ -189,7 +201,11 @@ async fn make_transfer_certificate<S>(
     balances: BTreeMap<Owner, Amount>,
     worker: &WorkerState<S>,
     previous_confirmed_block: Option<&Certificate>,
-) -> Certificate {
+) -> Certificate
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     make_transfer_certificate_for_epoch(
         chain_description,
         key_pair,
@@ -221,7 +237,11 @@ async fn make_transfer_certificate_for_epoch<S>(
     balances: BTreeMap<Owner, Amount>,
     worker: &WorkerState<S>,
     previous_confirmed_block: Option<&Certificate>,
-) -> Certificate {
+) -> Certificate
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     let chain_id = chain_description.into();
     let system_state = SystemExecutionState {
         committees: [(epoch, committee.clone())].into_iter().collect(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -422,14 +422,9 @@ where
             .await,
             Err(WorkerError::CryptoError(error)) if matches!(error, CryptoError::InvalidSignature {..})
     );
-    assert!(worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .is_none());
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    assert!(chain.manager.get().pending().is_none());
     Ok(())
 }
 
@@ -478,14 +473,9 @@ where
             )
         )
     );
-    assert!(worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .is_none());
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    assert!(chain.manager.get().pending().is_none());
     Ok(())
 }
 
@@ -597,14 +587,9 @@ where
             .await,
         Err(WorkerError::InvalidOwner)
     );
-    assert!(worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .is_none());
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    assert!(chain.manager.get().pending().is_none());
     Ok(())
 }
 
@@ -651,38 +636,26 @@ where
         worker.handle_block_proposal(block_proposal1.clone()).await,
         Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::UnexpectedBlockHeight {..})
     );
-    assert!(worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .is_none());
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    assert!(chain.manager.get().pending().is_none());
 
+    drop(chain);
     worker
         .handle_block_proposal(block_proposal0.clone())
         .await?;
-    assert!(worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .is_some());
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    assert!(chain.manager.get().pending().is_some());
+    drop(chain);
     worker
         .handle_certificate(certificate0, vec![], vec![], None)
         .await?;
     worker.handle_block_proposal(block_proposal1).await?;
-    assert!(worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .is_some());
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    assert!(chain.manager.get().pending().is_some());
+    drop(chain);
     assert_matches!(
         worker.handle_block_proposal(block_proposal0.clone()).await,
         Err(WorkerError::ChainError(error)) if matches!(*error, ChainError::UnexpectedBlockHeight {..})
@@ -1121,14 +1094,9 @@ where
             )
         )
     );
-    assert!(worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .is_none());
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    assert!(chain.manager.get().pending().is_none());
     Ok(())
 }
 
@@ -1158,15 +1126,9 @@ where
 
     let (chain_info_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
     chain_info_response.check(ValidatorName(worker.public_key()))?;
-    let pending_value = worker
-        .storage
-        .load_active_chain(ChainId::root(1))
-        .await?
-        .manager
-        .get()
-        .pending()
-        .unwrap()
-        .lite();
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
+    let pending_value = chain.manager.get().pending().unwrap().lite();
     assert_eq!(
         chain_info_response.info.manager.pending.unwrap(),
         pending_value
@@ -1489,7 +1451,8 @@ where
     worker
         .fully_handle_certificate(certificate.clone(), vec![], vec![])
         .await?;
-    let mut chain = worker.storage.load_active_chain(ChainId::root(1)).await?;
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
     assert_eq!(Amount::ZERO, *chain.execution_state.system.balance.get());
     assert_eq!(
         BlockHeight::from(1),
@@ -1497,8 +1460,9 @@ where
     );
     let inbox = chain
         .inboxes
-        .try_load_entry_mut(&Origin::chain(ChainId::root(3)))
-        .await?;
+        .try_load_entry(&Origin::chain(ChainId::root(3)))
+        .await?
+        .expect("Missing inbox for `ChainId::root(3)` in `ChainId::root(1)`");
     assert_eq!(BlockHeight::ZERO, inbox.next_block_height_to_receive()?);
     assert_eq!(inbox.added_events.count(), 0);
     assert_matches!(
@@ -1525,7 +1489,8 @@ where
     );
     assert_eq!(chain.confirmed_log.count(), 1);
     assert_eq!(Some(certificate.hash()), chain.tip_state.get().block_hash);
-    worker.storage.load_active_chain(ChainId::root(2)).await?;
+    let chain = worker.chain_state_view(ChainId::root(2)).await?;
+    assert!(chain.is_active());
     Ok(())
 }
 
@@ -1574,7 +1539,8 @@ where
     worker
         .fully_handle_certificate(certificate.clone(), vec![], vec![])
         .await?;
-    let new_sender_chain = worker.storage.load_active_chain(ChainId::root(1)).await?;
+    let new_sender_chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(new_sender_chain.is_active());
     assert_eq!(
         Amount::ZERO,
         *new_sender_chain.execution_state.system.balance.get()
@@ -1588,7 +1554,8 @@ where
         Some(certificate.hash()),
         new_sender_chain.tip_state.get().block_hash
     );
-    let new_recipient_chain = worker.storage.load_active_chain(ChainId::root(2)).await?;
+    let new_recipient_chain = worker.chain_state_view(ChainId::root(2)).await?;
+    assert!(new_recipient_chain.is_active());
     assert_eq!(
         Amount::MAX,
         *new_recipient_chain.execution_state.system.balance.get()
@@ -1629,12 +1596,14 @@ where
     worker
         .fully_handle_certificate(certificate.clone(), vec![], vec![])
         .await?;
-    let mut chain = worker.storage.load_active_chain(ChainId::root(1)).await?;
+    let chain = worker.chain_state_view(ChainId::root(1)).await?;
+    assert!(chain.is_active());
     assert_eq!(Amount::ZERO, *chain.execution_state.system.balance.get());
     let inbox = chain
         .inboxes
-        .try_load_entry_mut(&Origin::chain(ChainId::root(1)))
-        .await?;
+        .try_load_entry(&Origin::chain(ChainId::root(1)))
+        .await?
+        .expect("Missing inbox for `ChainId::root(1)` in `ChainId::root(1)`");
     assert_eq!(BlockHeight::from(1), inbox.next_block_height_to_receive()?);
     assert_matches!(
         inbox.added_events.front().await?.unwrap(),
@@ -1698,13 +1667,15 @@ where
     worker
         .handle_cross_chain_request(update_recipient_direct(ChainId::root(2), &certificate))
         .await?;
-    let mut chain = worker.storage.load_active_chain(ChainId::root(2)).await?;
+    let chain = worker.chain_state_view(ChainId::root(2)).await?;
+    assert!(chain.is_active());
     assert_eq!(Amount::ONE, *chain.execution_state.system.balance.get());
     assert_eq!(BlockHeight::ZERO, chain.tip_state.get().next_block_height);
     let inbox = chain
         .inboxes
-        .try_load_entry_mut(&Origin::chain(ChainId::root(1)))
-        .await?;
+        .try_load_entry(&Origin::chain(ChainId::root(1)))
+        .await?
+        .expect("Missing inbox for `ChainId::root(1)` in `ChainId::root(2)`");
     assert_eq!(BlockHeight::from(1), inbox.next_block_height_to_receive()?);
     assert_matches!(
         inbox
@@ -1766,7 +1737,7 @@ where
         .await?
         .cross_chain_requests
         .is_empty());
-    let chain = worker.storage.load_chain(ChainId::root(2)).await?;
+    let chain = worker.chain_state_view(ChainId::root(2)).await?;
     // The target chain did not receive the message
     assert!(chain.inboxes.indices().await?.is_empty());
     Ok(())
@@ -1817,7 +1788,7 @@ where
             }
         }]
     );
-    let chain = worker.storage.load_chain(ChainId::root(2)).await?;
+    let chain = worker.chain_state_view(ChainId::root(2)).await?;
     assert!(!chain.inboxes.indices().await?.is_empty());
     Ok(())
 }
@@ -1945,7 +1916,8 @@ where
     );
 
     {
-        let recipient_chain = worker.storage.load_active_chain(ChainId::root(2)).await?;
+        let recipient_chain = worker.chain_state_view(ChainId::root(2)).await?;
+        assert!(recipient_chain.is_active());
         assert_eq!(
             *recipient_chain.execution_state.system.balance.get(),
             Amount::from_tokens(4)
@@ -2127,7 +2099,8 @@ where
         .await?;
 
     {
-        let chain = worker.storage.load_active_chain(ChainId::root(1)).await?;
+        let chain = worker.chain_state_view(ChainId::root(1)).await?;
+        assert!(chain.is_active());
         chain.validate_incoming_messages().await?;
     }
 
@@ -2230,7 +2203,8 @@ where
         .await?;
 
     {
-        let chain = worker.storage.load_active_chain(ChainId::root(2)).await?;
+        let chain = worker.chain_state_view(ChainId::root(2)).await?;
+        assert!(chain.is_active());
         chain.validate_incoming_messages().await?;
     }
 
@@ -2273,7 +2247,8 @@ where
         .await?;
 
     {
-        let chain = worker.storage.load_active_chain(ChainId::root(1)).await?;
+        let chain = worker.chain_state_view(ChainId::root(1)).await?;
+        assert!(chain.is_active());
         chain.validate_incoming_messages().await?;
     }
     Ok(())
@@ -2377,7 +2352,8 @@ where
         .fully_handle_certificate(certificate0.clone(), vec![], vec![])
         .await?;
     {
-        let admin_chain = worker.storage.load_active_chain(admin_id).await?;
+        let admin_chain = worker.chain_state_view(admin_id).await?;
+        assert!(admin_chain.is_active());
         admin_chain.validate_incoming_messages().await?;
         assert_eq!(
             BlockHeight::from(1),
@@ -2487,13 +2463,15 @@ where
         .await?;
     {
         // The root chain has 1 subscribers.
-        let mut admin_chain = worker.storage.load_active_chain(admin_id).await?;
+        let admin_chain = worker.chain_state_view(admin_id).await?;
+        assert!(admin_chain.is_active());
         admin_chain.validate_incoming_messages().await?;
         assert_eq!(
             admin_chain
                 .channels
-                .try_load_entry_mut(&admin_channel_full_name)
+                .try_load_entry(&admin_channel_full_name)
                 .await?
+                .expect("Missing channel for admin channel in `ChainId::root(1)`")
                 .subscribers
                 .indices()
                 .await?
@@ -2503,7 +2481,8 @@ where
     }
     {
         // The child is active and has not migrated yet.
-        let mut user_chain = worker.storage.load_active_chain(user_id).await?;
+        let user_chain = worker.chain_state_view(user_id).await?;
+        assert!(user_chain.is_active());
         assert_eq!(
             BlockHeight::ZERO,
             user_chain.tip_state.get().next_block_height
@@ -2526,8 +2505,9 @@ where
         matches!(
             user_chain
                 .inboxes
-                .try_load_entry_mut(&Origin::chain(admin_id))
+                .try_load_entry(&Origin::chain(admin_id))
                 .await?
+                .expect("Missing inbox for admin chain in user chain")
                 .added_events
                 .read_front(10)
                 .await?[..],
@@ -2548,8 +2528,9 @@ where
         );
         let channel_inbox = user_chain
             .inboxes
-            .try_load_entry_mut(&admin_channel_origin)
-            .await?;
+            .try_load_entry(&admin_channel_origin)
+            .await?
+            .expect("Missing inbox for admin channel in user chain");
         matches!(
             channel_inbox.added_events.read_front(10).await?[..],
             [Event {
@@ -2663,7 +2644,8 @@ where
         .fully_handle_certificate(certificate3, vec![], vec![])
         .await?;
     {
-        let mut user_chain = worker.storage.load_active_chain(user_id).await?;
+        let user_chain = worker.chain_state_view(user_id).await?;
+        assert!(user_chain.is_active());
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -2687,8 +2669,9 @@ where
         {
             let inbox = user_chain
                 .inboxes
-                .try_load_entry_mut(&Origin::chain(admin_id))
-                .await?;
+                .try_load_entry(&Origin::chain(admin_id))
+                .await?
+                .expect("Missing inbox for admin chain in user chain");
             assert_eq!(inbox.next_block_height_to_receive()?, BlockHeight(3));
             assert_eq!(inbox.added_events.count(), 0);
             assert_eq!(inbox.removed_events.count(), 0);
@@ -2696,8 +2679,9 @@ where
         {
             let inbox = user_chain
                 .inboxes
-                .try_load_entry_mut(&admin_channel_origin)
-                .await?;
+                .try_load_entry(&admin_channel_origin)
+                .await?
+                .expect("Missing inbox for admin channel in user chain");
             assert_eq!(inbox.next_block_height_to_receive()?, BlockHeight(2));
             assert_eq!(inbox.added_events.count(), 0);
             assert_eq!(inbox.removed_events.count(), 0);
@@ -2798,7 +2782,8 @@ where
         .await?;
 
     // The transfer was started..
-    let user_chain = worker.storage.load_active_chain(user_id).await?;
+    let user_chain = worker.chain_state_view(user_id).await?;
+    assert!(user_chain.is_active());
     assert_eq!(
         BlockHeight::from(1),
         user_chain.tip_state.get().next_block_height
@@ -2813,13 +2798,15 @@ where
     );
 
     // .. and the message has gone through.
-    let mut admin_chain = worker.storage.load_active_chain(admin_id).await?;
+    let admin_chain = worker.chain_state_view(admin_id).await?;
+    assert!(admin_chain.is_active());
     assert_eq!(admin_chain.inboxes.indices().await?.len(), 1);
     matches!(
         admin_chain
             .inboxes
-            .try_load_entry_mut(&Origin::chain(user_id))
+            .try_load_entry(&Origin::chain(user_id))
             .await?
+            .expect("Missing inbox for user chain in admin chain")
             .added_events
             .read_front(10)
             .await?[..],
@@ -2933,7 +2920,8 @@ where
 
     {
         // The transfer was started..
-        let user_chain = worker.storage.load_active_chain(user_id).await?;
+        let user_chain = worker.chain_state_view(user_id).await?;
+        assert!(user_chain.is_active());
         assert_eq!(
             BlockHeight::from(1),
             user_chain.tip_state.get().next_block_height
@@ -2948,7 +2936,8 @@ where
         );
 
         // .. but the message hasn't gone through.
-        let admin_chain = worker.storage.load_active_chain(admin_id).await?;
+        let admin_chain = worker.chain_state_view(admin_id).await?;
+        assert!(admin_chain.is_active());
         assert!(admin_chain.inboxes.indices().await?.is_empty());
     }
 
@@ -2996,7 +2985,8 @@ where
 
     {
         // The admin chain has an anticipated message.
-        let admin_chain = worker.storage.load_active_chain(admin_id).await?;
+        let admin_chain = worker.chain_state_view(admin_id).await?;
+        assert!(admin_chain.is_active());
         assert_matches!(
             admin_chain.validate_incoming_messages().await,
             Err(ChainError::MissingCrossChainUpdate { .. })
@@ -3011,7 +3001,8 @@ where
 
     {
         // The admin chain has no more anticipated messages.
-        let admin_chain = worker.storage.load_active_chain(admin_id).await?;
+        let admin_chain = worker.chain_state_view(admin_id).await?;
+        assert!(admin_chain.is_active());
         admin_chain.validate_incoming_messages().await?;
     }
     Ok(())

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3393,7 +3393,7 @@ where
     // from a past round.
     let certificate =
         make_certificate_with_round(&committee, &worker, value1, Round::SingleLeader(7));
-    let mut worker = worker.with_key_pair(None); // Forget validator keys.
+    let mut worker = worker.with_key_pair(None).await; // Forget validator keys.
     worker
         .handle_certificate(certificate.clone(), vec![], vec![], None)
         .await?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -65,7 +65,11 @@ pub enum CommunicateAction {
     },
 }
 
-pub struct ValidatorUpdater<A, S> {
+pub struct ValidatorUpdater<A, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     pub name: ValidatorName,
     pub node: A,
     pub local_node: LocalNodeClient<S>,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -383,8 +383,9 @@ where
     }
 
     #[cfg(test)]
-    pub(crate) fn with_key_pair(mut self, key_pair: Option<Arc<KeyPair>>) -> Self {
+    pub(crate) async fn with_key_pair(mut self, key_pair: Option<Arc<KeyPair>>) -> Self {
         self.chain_worker_config.key_pair = key_pair;
+        self.chain_workers.lock().await.clear();
         self
     }
 

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -266,7 +266,11 @@ impl From<linera_chain::ChainError> for WorkerError {
 
 /// State of a worker in a validator or a local node.
 #[derive(Clone)]
-pub struct WorkerState<StorageClient> {
+pub struct WorkerState<StorageClient>
+where
+    StorageClient: Storage,
+    ViewError: From<StorageClient::ContextError>,
+{
     /// A name used for logging
     nickname: String,
     /// Access to local persistent storage.
@@ -287,7 +291,11 @@ pub struct WorkerState<StorageClient> {
 pub(crate) type DeliveryNotifiers =
     HashMap<ChainId, BTreeMap<BlockHeight, Vec<oneshot::Sender<()>>>>;
 
-impl<StorageClient> WorkerState<StorageClient> {
+impl<StorageClient> WorkerState<StorageClient>
+where
+    StorageClient: Storage,
+    ViewError: From<StorageClient::ContextError>,
+{
     pub fn new(nickname: String, key_pair: Option<KeyPair>, storage: StorageClient) -> Self {
         WorkerState {
             nickname,
@@ -736,7 +744,11 @@ where
 }
 
 #[cfg(with_testing)]
-impl<StorageClient> WorkerState<StorageClient> {
+impl<StorageClient> WorkerState<StorageClient>
+where
+    StorageClient: Storage,
+    ViewError: From<StorageClient::ContextError>,
+{
     /// Gets a reference to the validator's [`PublicKey`].
     ///
     /// # Panics

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -5,6 +5,7 @@
 use std::{
     borrow::Cow,
     collections::{hash_map, BTreeMap, HashMap, VecDeque},
+    num::NonZeroUsize,
     sync::Arc,
     time::Duration,
 };
@@ -15,6 +16,7 @@ use linera_base::{
     data_types::{ArithmeticError, BlockHeight, HashedBlob, Round},
     doc_scalar, ensure,
     identifiers::{BlobId, ChainId, Owner},
+    sync::Lazy,
 };
 use linera_chain::{
     data_types::{
@@ -29,13 +31,19 @@ use linera_execution::{
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
+use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
-    sync::{oneshot, Mutex, OwnedRwLockReadGuard},
+    sync::{mpsc, oneshot, Mutex, OwnedRwLockReadGuard},
     task::JoinSet,
 };
 use tracing::{error, instrument, trace, warn};
+#[cfg(with_metrics)]
+use {
+    linera_base::prometheus_util,
+    prometheus::{HistogramVec, IntCounterVec},
+};
 #[cfg(with_testing)]
 use {
     linera_base::{
@@ -43,11 +51,6 @@ use {
         identifiers::{BytecodeId, Destination, MessageId},
     },
     linera_chain::data_types::{ChannelFullName, IncomingMessage, Medium, MessageAction},
-};
-#[cfg(with_metrics)]
-use {
-    linera_base::{prometheus_util, sync::Lazy},
-    prometheus::{HistogramVec, IntCounterVec},
 };
 
 use crate::{
@@ -59,6 +62,10 @@ use crate::{
 #[cfg(test)]
 #[path = "unit_tests/worker_tests.rs"]
 mod worker_tests;
+
+/// The maximum number of [`ChainWorkerActor`]s to keep running.
+static CHAIN_WORKER_LIMIT: Lazy<NonZeroUsize> =
+    Lazy::new(|| NonZeroUsize::new(1_000).expect("`CHAIN_WORKER_LIMIT` should not be zero"));
 
 #[cfg(with_metrics)]
 static NUM_ROUNDS_IN_CERTIFICATE: Lazy<HistogramVec> = Lazy::new(|| {
@@ -286,7 +293,13 @@ where
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
     /// The set of spawned [`ChainWorkerActor`] tasks.
     chain_worker_tasks: Arc<Mutex<JoinSet<()>>>,
+    /// The cache of running [`ChainWorkerActor`]s.
+    chain_workers: Arc<Mutex<LruCache<ChainId, ChainActorEndpoint<StorageClient>>>>,
 }
+
+/// The sender endpoint for [`ChainWorkerRequest`]s.
+type ChainActorEndpoint<StorageClient> =
+    mpsc::UnboundedSender<ChainWorkerRequest<<StorageClient as Storage>::Context>>;
 
 pub(crate) type DeliveryNotifiers =
     HashMap<ChainId, BTreeMap<BlockHeight, Vec<oneshot::Sender<()>>>>;
@@ -305,6 +318,7 @@ where
             recent_hashed_blobs: Arc::new(ValueCache::default()),
             delivery_notifiers: Arc::default(),
             chain_worker_tasks: Arc::default(),
+            chain_workers: Arc::new(Mutex::new(LruCache::new(*CHAIN_WORKER_LIMIT))),
         }
     }
 
@@ -323,6 +337,7 @@ where
             recent_hashed_blobs,
             delivery_notifiers,
             chain_worker_tasks: Arc::default(),
+            chain_workers: Arc::new(Mutex::new(LruCache::new(*CHAIN_WORKER_LIMIT))),
         }
     }
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -101,7 +101,11 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: Lazy<HistogramVec> = Lazy::new(|
 });
 
 #[derive(Clone)]
-pub struct GrpcServer<S> {
+pub struct GrpcServer<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     state: WorkerState<S>,
     shard_id: ShardId,
     network: ValidatorInternalNetworkConfig,

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -24,7 +24,11 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct Server<S> {
+pub struct Server<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     network: ValidatorInternalNetworkPreConfig<TransportProtocol>,
     host: String,
     port: u16,
@@ -36,7 +40,11 @@ pub struct Server<S> {
     user_errors: u64,
 }
 
-impl<S> Server<S> {
+impl<S> Server<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         network: ValidatorInternalNetworkPreConfig<TransportProtocol>,
@@ -172,7 +180,11 @@ where
 }
 
 #[derive(Clone)]
-struct RunningServerState<S> {
+struct RunningServerState<S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     server: Server<S>,
     cross_chain_sender: mpsc::Sender<(RpcMessage, ShardId)>,
 }
@@ -338,7 +350,8 @@ where
 
 impl<S> RunningServerState<S>
 where
-    S: Send,
+    S: Storage + Send,
+    ViewError: From<S::ContextError>,
 {
     fn handle_network_actions(&mut self, actions: NetworkActions) {
         for request in actions.cross_chain_requests {

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -52,7 +52,9 @@ pub trait ClientContext {
     fn make_chain_client(
         &self,
         chain_id: ChainId,
-    ) -> ChainClient<Self::ValidatorNodeProvider, Self::Storage>;
+    ) -> ChainClient<Self::ValidatorNodeProvider, Self::Storage>
+    where
+        ViewError: From<<Self::Storage as Storage>::ContextError>;
 
     fn update_wallet_for_new_chain(
         &mut self,
@@ -64,12 +66,17 @@ pub trait ClientContext {
     async fn update_wallet<'a>(
         &'a mut self,
         client: &'a mut ChainClient<Self::ValidatorNodeProvider, Self::Storage>,
-    );
+    ) where
+        ViewError: From<<Self::Storage as Storage>::ContextError>;
 }
 
 /// A `ChainListener` is a process that listens to notifications from validators and reacts
 /// appropriately.
-pub struct ChainListener<P, S> {
+pub struct ChainListener<P, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     config: ChainListenerConfig,
     clients: ChainClients<P, S>,
 }

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -34,13 +34,21 @@ use crate::{chain_listener::ClientContext, config::GenesisConfig, util};
 mod tests;
 
 /// The root GraphQL query type.
-pub struct QueryRoot<P, S> {
+pub struct QueryRoot<P, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     genesis_config: Arc<GenesisConfig>,
     client: Arc<Mutex<ChainClient<P, S>>>,
 }
 
 /// The root GraphQL mutation type.
-pub struct MutationRoot<P, S, C> {
+pub struct MutationRoot<P, S, C>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     client: Arc<Mutex<ChainClient<P, S>>>,
     context: Arc<Mutex<C>>,
     amount: Amount,
@@ -184,7 +192,11 @@ where
     }
 }
 
-impl<P, S, C> MutationRoot<P, S, C> {
+impl<P, S, C> MutationRoot<P, S, C>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     /// Multiplies a `u128` with a `u64` and returns the result as a 192-bit number.
     fn multiply(a: u128, b: u64) -> [u64; 3] {
         let lower = u128::from(u64::MAX);
@@ -197,7 +209,11 @@ impl<P, S, C> MutationRoot<P, S, C> {
 }
 
 /// A GraphQL interface to request a new chain with tokens.
-pub struct FaucetService<P, S, C> {
+pub struct FaucetService<P, S, C>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     client: Arc<Mutex<ChainClient<P, S>>>,
     context: Arc<Mutex<C>>,
     genesis_config: Arc<GenesisConfig>,
@@ -208,7 +224,11 @@ pub struct FaucetService<P, S, C> {
     start_balance: Amount,
 }
 
-impl<P, S: Clone, C> Clone for FaucetService<P, S, C> {
+impl<P, S: Clone, C> Clone for FaucetService<P, S, C>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -66,7 +66,11 @@ use {
 
 use crate::{client_options::ChainOwnershipConfig, ClientOptions};
 
-pub struct ClientContext<Storage> {
+pub struct ClientContext<Storage>
+where
+    Storage: linera_storage::Storage,
+    ViewError: From<Storage::ContextError>,
+{
     pub(crate) wallet_state: WalletState,
     pub(crate) client: Arc<Client<NodeProvider, Storage>>,
     pub(crate) send_timeout: Duration,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -59,21 +59,36 @@ pub struct Chains {
 }
 
 pub type ClientMapInner<P, S> = BTreeMap<ChainId, ArcChainClient<P, S>>;
-pub(crate) struct ChainClients<P, S>(Arc<Mutex<ClientMapInner<P, S>>>);
+pub(crate) struct ChainClients<P, S>(Arc<Mutex<ClientMapInner<P, S>>>)
+where
+    S: Storage,
+    ViewError: From<S::ContextError>;
 
-impl<P, S> Clone for ChainClients<P, S> {
+impl<P, S> Clone for ChainClients<P, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     fn clone(&self) -> Self {
         ChainClients(self.0.clone())
     }
 }
 
-impl<P, S> Default for ChainClients<P, S> {
+impl<P, S> Default for ChainClients<P, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     fn default() -> Self {
         Self(Arc::new(Mutex::new(BTreeMap::new())))
     }
 }
 
-impl<P, S> ChainClients<P, S> {
+impl<P, S> ChainClients<P, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     async fn client(&self, chain_id: &ChainId) -> Option<ArcChainClient<P, S>> {
         Some(self.0.lock().await.get(chain_id)?.clone())
     }
@@ -100,19 +115,31 @@ impl<P, S> ChainClients<P, S> {
 }
 
 /// Our root GraphQL query type.
-pub struct QueryRoot<P, S> {
+pub struct QueryRoot<P, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     clients: ChainClients<P, S>,
     port: NonZeroU16,
     default_chain: Option<ChainId>,
 }
 
 /// Our root GraphQL subscription type.
-pub struct SubscriptionRoot<P, S> {
+pub struct SubscriptionRoot<P, S>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     clients: ChainClients<P, S>,
 }
 
 /// Our root GraphQL mutation type.
-pub struct MutationRoot<P, S, C> {
+pub struct MutationRoot<P, S, C>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     clients: ChainClients<P, S>,
     context: Arc<Mutex<C>>,
 }
@@ -942,7 +969,11 @@ fn bytes_from_list(list: &[async_graphql::Value]) -> Option<Vec<u8>> {
 
 /// The `NodeService` is a server that exposes a web-server to the client.
 /// The node service is primarily used to explore the state of a chain in GraphQL.
-pub struct NodeService<P, S, C> {
+pub struct NodeService<P, S, C>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     clients: ChainClients<P, S>,
     config: ChainListenerConfig,
     port: NonZeroU16,
@@ -951,7 +982,11 @@ pub struct NodeService<P, S, C> {
     context: Arc<Mutex<C>>,
 }
 
-impl<P, S: Clone, C> Clone for NodeService<P, S, C> {
+impl<P, S: Clone, C> Clone for NodeService<P, S, C>
+where
+    S: Storage,
+    ViewError: From<S::ContextError>,
+{
     fn clone(&self) -> Self {
         Self {
             clients: self.clients.clone(),

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -187,6 +187,7 @@ where
 impl<S> MessageHandler for SimpleProxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
 {
     #[instrument(skip_all, fields(chain_id = ?message.target_chain_id()))]
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
@@ -231,6 +232,7 @@ where
 impl<S> SimpleProxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<S::ContextError>,
 {
     #[instrument(skip_all, fields(port = self.public_config.port, metrics_port = self.internal_config.metrics_port), err)]
     async fn run(self, shutdown_signal: CancellationToken) -> Result<()> {

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -26,7 +26,10 @@ use linera_service::{
 };
 use linera_storage::{MemoryStorage, Storage};
 use linera_version::VersionInfo;
-use linera_views::memory::{MemoryStoreConfig, TEST_MEMORY_MAX_STREAM_QUERIES};
+use linera_views::{
+    memory::{MemoryStoreConfig, TEST_MEMORY_MAX_STREAM_QUERIES},
+    views::ViewError,
+};
 
 #[derive(Clone)]
 struct DummyValidatorNode;
@@ -131,13 +134,20 @@ impl<P: LocalValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientConte
         unimplemented!()
     }
 
-    fn make_chain_client(&self, _: ChainId) -> ChainClient<P, S> {
+    fn make_chain_client(&self, _: ChainId) -> ChainClient<P, S>
+    where
+        ViewError: From<S::ContextError>,
+    {
         unimplemented!()
     }
 
     fn update_wallet_for_new_chain(&mut self, _: ChainId, _: Option<KeyPair>, _: Timestamp) {}
 
-    async fn update_wallet<'a>(&'a mut self, _: &'a mut ChainClient<P, S>) {}
+    async fn update_wallet<'a>(&'a mut self, _: &'a mut ChainClient<P, S>)
+    where
+        ViewError: From<S::ContextError>,
+    {
+    }
 }
 
 #[tokio::main]

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -52,6 +52,7 @@ impl ServerContext {
     ) -> (WorkerState<S>, ShardId, ShardConfig)
     where
         S: Storage + Clone + Send + Sync + 'static,
+        ViewError: From<S::ContextError>,
     {
         let shard = self.server_config.internal_network.shard(shard_id);
         info!("Shard booted on {}", shard.host);

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -91,7 +91,7 @@ async fn test_faucet_rate_limiting() {
 
 #[test]
 fn test_multiply() {
-    let mul = MutationRoot::<(), (), ()>::multiply;
+    let mul = MutationRoot::<(), MemoryStorage<TestClock>, ()>::multiply;
     assert_eq!(mul((1 << 127) + (1 << 63), 1 << 63), [1 << 62, 1 << 62, 0]);
     assert_eq!(mul(u128::MAX, u64::MAX), [u64::MAX - 1, u64::MAX, 1]);
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The worker spawns a `ChainWorkerActor` to handle each request. This is inefficient because it loads from storage the chain state every time. This should be cached in memory in order to avoid paying the overhead of deserializing the chain state every time.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Keep an LRU cache with some running `ChainWorkerActor`s, each responsible for a different chain.

The size of the cache should be configurable by the validators, because there's a tradeoff between chain execution latency and memory usage.

## Test Plan

<!-- How to test that the changes are correct. -->
This is an internal refactor, so existing tests should catch any regressions.

I manually ran the Crowd-Funding `collect_pledges` integration test and collected some metrics before and after this PR.

Before:

```
# HELP linera_load_view The metric counting how often a view is read from storage
# TYPE linera_load_view counter
linera_load_view{base_key="001db1936dad0717597a7743a8353c9c0191c14c3a129b258e9743aec2b4f05d03",type="ChainStateView"} 21
linera_load_view{base_key="0036137b1ddac30eb9d0d4821a1560e66795dbdad6dbf4b708a8d81ca3df866e1b",type="ChainStateView"} 67
linera_load_view{base_key="00a393137daba303e8b561cb3a5bff50efba1fb7f24950db28f1844b7ac2c1cf27",type="ChainStateView"} 37
linera_load_view{base_key="00ae41b40b288a1e7ed064e2ff749a9ce3e780a5742dca074e6015e77e9dd373f8",type="ChainStateView"} 37
linera_load_view{base_key="00be20093606a7296fbda537060becfecc62b5441fa784b3d26d6742152a80a1f9",type="ChainStateView"} 61
linera_load_view{base_key="00e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65",type="ChainStateView"} 36
linera_load_view{base_key="00fc9384defb0bcd8f6e206ffda32599e24ba715f45ec88d4ac81ec47eb84fa111",type="ChainStateView"} 21
linera_load_view{base_key="00feeeed172c74027e2675311c4ec3239dbe8e4b4fcf46b12e6f775523a002d64e",type="ChainStateView"} 37
# HELP linera_load_chain_latency The latency to load a chain state
# TYPE linera_load_chain_latency histogram
linera_load_chain_latency_bucket{le="0.001"} 0
linera_load_chain_latency_bucket{le="0.0025"} 0
linera_load_chain_latency_bucket{le="0.005"} 0
linera_load_chain_latency_bucket{le="0.01"} 0
linera_load_chain_latency_bucket{le="0.025"} 2
linera_load_chain_latency_bucket{le="0.05"} 71
linera_load_chain_latency_bucket{le="0.1"} 313
linera_load_chain_latency_bucket{le="0.25"} 317
linera_load_chain_latency_bucket{le="0.5"} 317
linera_load_chain_latency_bucket{le="1"} 317
linera_load_chain_latency_bucket{le="+Inf"} 317
linera_load_chain_latency_sum 19.172113999999997
linera_load_chain_latency_count 317
```

After:
```
# HELP linera_load_view The metric counting how often a view is read from storage
# TYPE linera_load_view counter
linera_load_view{base_key="001db1936dad0717597a7743a8353c9c0191c14c3a129b258e9743aec2b4f05d03",type="ChainStateView"} 1
linera_load_view{base_key="0036137b1ddac30eb9d0d4821a1560e66795dbdad6dbf4b708a8d81ca3df866e1b",type="ChainStateView"} 1
linera_load_view{base_key="00a393137daba303e8b561cb3a5bff50efba1fb7f24950db28f1844b7ac2c1cf27",type="ChainStateView"} 1
linera_load_view{base_key="00ae41b40b288a1e7ed064e2ff749a9ce3e780a5742dca074e6015e77e9dd373f8",type="ChainStateView"} 1
linera_load_view{base_key="00be20093606a7296fbda537060becfecc62b5441fa784b3d26d6742152a80a1f9",type="ChainStateView"} 1
linera_load_view{base_key="00e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65",type="ChainStateView"} 2
linera_load_view{base_key="00fc9384defb0bcd8f6e206ffda32599e24ba715f45ec88d4ac81ec47eb84fa111",type="ChainStateView"} 1
linera_load_view{base_key="00feeeed172c74027e2675311c4ec3239dbe8e4b4fcf46b12e6f775523a002d64e",type="ChainStateView"} 1
# HELP linera_load_chain_latency The latency to load a chain state
# TYPE linera_load_chain_latency histogram
linera_load_chain_latency_bucket{le="0.001"} 0
linera_load_chain_latency_bucket{le="0.0025"} 0
linera_load_chain_latency_bucket{le="0.005"} 0
linera_load_chain_latency_bucket{le="0.01"} 0
linera_load_chain_latency_bucket{le="0.025"} 0
linera_load_chain_latency_bucket{le="0.05"} 5
linera_load_chain_latency_bucket{le="0.1"} 9
linera_load_chain_latency_bucket{le="0.25"} 9
linera_load_chain_latency_bucket{le="0.5"} 9
linera_load_chain_latency_bucket{le="1"} 9
linera_load_chain_latency_bucket{le="+Inf"} 9
linera_load_chain_latency_sum 0.492632
linera_load_chain_latency_count 9
```

In summary, the time spent loading chains during the test went from 19.2ms to 0.5ms. And that was possible because this PR reduced the number of chain load events from 317 to 9.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is an internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
