### PR TITLE
Do not merge message bundles from different transactions

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -538,10 +538,6 @@ where
         local_time: Timestamp,
     ) -> Result<(), ChainError> {
         let chain_id = self.chain_id();
-        ensure!(
-            bundle.height >= self.next_block_height_to_receive(origin).await?,
-            ChainError::InternalError("Trying to receive messages in the wrong order".to_string())
-        );
         tracing::trace!(
             "Processing new messages to {:?} from {:?} at height {}",
             chain_id,


### PR DESCRIPTION
## Motivation

First step towards #1475

## Proposal

Outgoing messages are already grouped by transaction. Do not flatten them when creating the `MessageBundle`s.

## Test Plan

CI