### PR TITLE
Replace [Blobs|ApplicationBytecodes|ApplicationBytecodesAndBlobs]NotFound by ApplicationBytecodesOrBlobsNotFound

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -788,20 +788,14 @@ where
             .await?;
         let missing_blobs = self.get_missing_blobs(block, hashed_blobs).await?;
 
-        if missing_bytecodes.is_empty() {
-            if missing_blobs.is_empty() {
-                Ok(())
-            } else {
-                Err(WorkerError::BlobsNotFound(missing_blobs))
-            }
-        } else if missing_blobs.is_empty() {
-            Err(WorkerError::ApplicationBytecodesNotFound(missing_bytecodes))
-        } else {
-            Err(WorkerError::ApplicationBytecodesAndBlobsNotFound(
-                missing_bytecodes,
-                missing_blobs,
-            ))
+        if missing_bytecodes.is_empty() && missing_blobs.is_empty() {
+            return Ok(());
         }
+
+        Err(WorkerError::ApplicationBytecodesOrBlobsNotFound(
+            missing_bytecodes,
+            missing_blobs,
+        ))
     }
 
     /// Returns the blobs required by the block that we don't have, or an error if unrelated blobs were provided.

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -837,25 +837,7 @@ where
             .await
         {
             match &err {
-                LocalNodeError::WorkerError(WorkerError::ApplicationBytecodesNotFound(
-                    locations,
-                )) => {
-                    let values = self
-                        .find_missing_application_bytecodes(locations, &nodes)
-                        .await;
-
-                    ensure!(values.len() == locations.len(), err);
-                    self.process_certificate(certificate.clone(), values.clone(), vec![])
-                        .await?;
-                }
-                LocalNodeError::WorkerError(WorkerError::BlobsNotFound(blob_ids)) => {
-                    let blobs = self.find_missing_blobs(blob_ids, &nodes).await;
-
-                    ensure!(blobs.len() == blob_ids.len(), err);
-                    self.process_certificate(certificate.clone(), vec![], blobs)
-                        .await?;
-                }
-                LocalNodeError::WorkerError(WorkerError::ApplicationBytecodesAndBlobsNotFound(
+                LocalNodeError::WorkerError(WorkerError::ApplicationBytecodesOrBlobsNotFound(
                     locations,
                     blob_ids,
                 )) => {

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -240,31 +240,8 @@ where
                 .await;
 
             result = match &result {
-                Err(LocalNodeError::WorkerError(WorkerError::ApplicationBytecodesNotFound(
-                    locations,
-                ))) => {
-                    let values = self
-                        .find_missing_application_bytecodes(locations, node, name)
-                        .await;
-
-                    if values.len() != locations.len() {
-                        result
-                    } else {
-                        self.handle_certificate(certificate, values, vec![], notifications)
-                            .await
-                    }
-                }
-                Err(LocalNodeError::WorkerError(WorkerError::BlobsNotFound(blob_ids))) => {
-                    let blobs = self.find_missing_blobs(blob_ids, node, name).await;
-                    if blobs.len() != blob_ids.len() {
-                        result
-                    } else {
-                        self.handle_certificate(certificate, vec![], blobs, notifications)
-                            .await
-                    }
-                }
                 Err(LocalNodeError::WorkerError(
-                    WorkerError::ApplicationBytecodesAndBlobsNotFound(locations, blob_ids),
+                    WorkerError::ApplicationBytecodesOrBlobsNotFound(locations, blob_ids),
                 )) => {
                     let values = self
                         .find_missing_application_bytecodes(locations, node, name)

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -172,16 +172,8 @@ pub enum NodeError {
         height: BlockHeight,
     },
 
-    // This error must be normalized during conversions.
-    #[error("The following values containing application bytecode are missing: {0:?}.")]
-    ApplicationBytecodesNotFound(Vec<BytecodeLocation>),
-
-    // This error must be normalized during conversions.
-    #[error("The following blobs are missing: {0:?}.")]
-    BlobsNotFound(Vec<BlobId>),
-
     #[error("The following values containing application bytecode are missing: {0:?} and the following blobs are missing: {1:?}.")]
-    ApplicationBytecodesAndBlobsNotFound(Vec<BytecodeLocation>, Vec<BlobId>),
+    ApplicationBytecodesOrBlobsNotFound(Vec<BytecodeLocation>, Vec<BlobId>),
 
     // This error must be normalized during conversions.
     #[error("We don't have the value for the certificate.")]
@@ -294,12 +286,8 @@ impl From<WorkerError> for NodeError {
         match error {
             WorkerError::ChainError(error) => (*error).into(),
             WorkerError::MissingCertificateValue => Self::MissingCertificateValue,
-            WorkerError::ApplicationBytecodesNotFound(locations) => {
-                NodeError::ApplicationBytecodesNotFound(locations)
-            }
-            WorkerError::BlobsNotFound(blob_ids) => NodeError::BlobsNotFound(blob_ids),
-            WorkerError::ApplicationBytecodesAndBlobsNotFound(locations, blob_ids) => {
-                NodeError::ApplicationBytecodesAndBlobsNotFound(locations, blob_ids)
+            WorkerError::ApplicationBytecodesOrBlobsNotFound(locations, blob_ids) => {
+                NodeError::ApplicationBytecodesOrBlobsNotFound(locations, blob_ids)
             }
             error => Self::WorkerError {
                 error: error.to_string(),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -248,16 +248,12 @@ pub enum WorkerError {
     UnneededValue { value_hash: CryptoHash },
     #[error("An additional blob was provided that is not required: {blob_id}.")]
     UnneededBlob { blob_id: BlobId },
-    #[error("The following values containing application bytecode are missing: {0:?}.")]
-    ApplicationBytecodesNotFound(Vec<BytecodeLocation>),
     #[error("The certificate in the block proposal is not a ValidatedBlock")]
     MissingExecutedBlockInProposal,
     #[error("Fast blocks cannot query oracles")]
     FastBlockUsingOracles,
-    #[error("The following blobs are missing: {0:?}.")]
-    BlobsNotFound(Vec<BlobId>),
     #[error("The following values containing application bytecode are missing: {0:?} and the following blobs are missing: {1:?}.")]
-    ApplicationBytecodesAndBlobsNotFound(Vec<BytecodeLocation>, Vec<BlobId>),
+    ApplicationBytecodesOrBlobsNotFound(Vec<BytecodeLocation>, Vec<BlobId>),
     #[error("The block proposal is invalid: {0}")]
     InvalidBlockProposal(String),
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -551,57 +551,47 @@ NodeError:
           - height:
               TYPENAME: BlockHeight
     7:
-      ApplicationBytecodesNotFound:
-        NEWTYPE:
-          SEQ:
-            TYPENAME: BytecodeLocation
-    8:
-      BlobsNotFound:
-        NEWTYPE:
-          SEQ:
-            TYPENAME: BlobId
-    9:
-      ApplicationBytecodesAndBlobsNotFound:
+      ApplicationBytecodesOrBlobsNotFound:
         TUPLE:
           - SEQ:
               TYPENAME: BytecodeLocation
           - SEQ:
               TYPENAME: BlobId
-    10:
+    8:
       MissingCertificateValue: UNIT
-    11:
+    9:
       MissingVoteInValidatorResponse: UNIT
-    12:
+    10:
       InactiveLocalChain:
         NEWTYPE:
           TYPENAME: ChainId
-    13:
+    11:
       InvalidChainInfoResponse: UNIT
-    14:
+    12:
       InvalidDecoding: UNIT
-    15:
+    13:
       UnexpectedMessage: UNIT
-    16:
+    14:
       GrpcError:
         STRUCT:
           - error: STR
-    17:
+    15:
       ClientIoError:
         STRUCT:
           - error: STR
-    18:
+    16:
       CannotResolveValidatorAddress:
         STRUCT:
           - address: STR
-    19:
+    17:
       SubscriptionError:
         STRUCT:
           - transport: STR
-    20:
+    18:
       SubscriptionFailed:
         STRUCT:
           - status: STR
-    21:
+    19:
       LocalNodeQuery:
         STRUCT:
           - error: STR


### PR DESCRIPTION
## Motivation

This cleans up the three error types that were partially introduced in this PR #2014. We don't need the three error types, we can cover all cases with just one

## Proposal

Replace the three errors with one

## Test Plan

CI

