### PR TITLE
`linera-core`: handle notifications exactly once

### DIFF
--- a/linera-core/src/notifier.rs
+++ b/linera-core/src/notifier.rs
@@ -6,6 +6,8 @@ use linera_base::identifiers::ChainId;
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tracing::trace;
 
+// TODO(#2171): replace this with a Tokio broadcast channel
+
 /// A `Notifier` holds references to clients waiting to receive notifications
 /// from the validator.
 /// Clients will be evicted if their connections are terminated.


### PR DESCRIPTION
## Motivation

Notifications may sometimes be processed twice (which is fine, if inefficient) or missed (which is not fine).

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Make sure we process all notifications exactly once, by clearing the notification queue.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
