### PR TITLE
Allow open-chain messages to be rejected

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -981,7 +981,7 @@ where
         // Finally, charge for the block fee, except if the chain is closed and the block
         // was used to reject some incoming messages (and only that).
         if !self.is_closed()
-            || !block.incoming_messages.is_empty()
+            || block.incoming_messages.is_empty()
             || !block.has_only_rejected_messages()
         {
             resource_controller

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -140,7 +140,7 @@ pub enum ChainError {
     MissingMandatoryApplications(Vec<ApplicationId>),
     #[error("Can't use grant across different broadcast messages")]
     GrantUseOnBroadcast,
-    #[error("ExecutedBlock contains fewer oracle responses than requests")]
+    #[error("ExecutedBlock contains fewer oracle records than transactions")]
     MissingOracleRecord,
     #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
     CertificateValueHashMismatch {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -79,7 +79,6 @@ fn make_open_chain_config() -> OpenChainConfig {
         admin_id: admin_id(),
         epoch: Epoch::ZERO,
         committees: iter::once((Epoch::ZERO, committee)).collect(),
-        balance: Amount::from_tokens(10),
         application_permissions: Default::default(),
     }
 }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1950,10 +1950,9 @@ where
                 committees,
                 admin_id: self.admin_id,
                 epoch,
-                balance,
                 application_permissions: application_permissions.clone(),
             };
-            let operation = Operation::System(SystemOperation::OpenChain(config));
+            let operation = Operation::System(SystemOperation::OpenChain { config, balance });
             let certificate = match self.execute_block(messages, vec![operation]).await? {
                 ExecuteBlockOutcome::Executed(certificate) => certificate,
                 ExecuteBlockOutcome::Conflict(_) => continue,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -600,7 +600,7 @@ where
         certificate.value(),
         CertificateValue::ConfirmedBlock { executed_block, .. } if matches!(
             executed_block.block.operations[open_chain_message_id.index as usize],
-            Operation::System(SystemOperation::OpenChain(_)),
+            Operation::System(SystemOperation::OpenChain {..}),
         ),
         "Unexpected certificate value",
     );
@@ -700,7 +700,7 @@ where
         &certificate.value(),
         CertificateValue::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
             block.operations[open_chain_message_id.index as usize],
-            Operation::System(SystemOperation::OpenChain(_)),
+            Operation::System(SystemOperation::OpenChain { .. }),
         ),
         "Unexpected certificate value",
     );

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -908,13 +908,12 @@ where
         } if sender == ChainId::root(2)
     );
 
-    // Since blocks are free of charge on closed chains, empty blocks are not allowed.
-    assert_matches!(
-        client1.execute_operations(vec![]).await,
-        Err(ChainClientError::LocalNodeError(
-            LocalNodeError::WorkerError(WorkerError::ChainError(error))
-        )) if matches!(*error, ChainError::ClosedChain)
-    );
+    // Empty blocks are allowed on closed chains but they must pay the block fee.
+    {
+        let balance = client1.local_balance().await.unwrap();
+        client1.execute_operations(vec![]).await.unwrap();
+        assert!(client1.local_balance().await.unwrap() < balance);
+    }
     Ok(())
 }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -242,10 +242,9 @@ where
                     admin_id: self.system.admin_id.get().ok_or_else(inactive_err)?,
                     epoch: self.system.epoch.get().ok_or_else(inactive_err)?,
                     committees: self.system.committees.get().clone(),
-                    balance,
                     application_permissions,
                 };
-                let messages = self.system.open_chain(config, next_message_id)?;
+                let messages = self.system.open_chain(config, balance, next_message_id)?;
                 callback.respond(messages)
             }
 
@@ -384,7 +383,7 @@ pub enum Request {
         balance: Amount,
         next_message_id: MessageId,
         application_permissions: ApplicationPermissions,
-        callback: Sender<[RawOutgoingMessage<SystemMessage, Amount>; 2]>,
+        callback: Sender<Vec<RawOutgoingMessage<SystemMessage, Amount>>>,
     },
 
     CloseChain {

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1236,7 +1236,7 @@ impl ContractRuntime for ContractSyncRuntime {
             index: this.next_message_index()?,
         };
         let chain_id = ChainId::child(next_message_id);
-        let [open_chain_message, subscribe_message] = this
+        let messages = this
             .execution_state_sender
             .send_request(|callback| Request::OpenChain {
                 ownership,
@@ -1246,9 +1246,10 @@ impl ContractRuntime for ContractSyncRuntime {
                 callback,
             })?
             .recv_response()?;
-        let outcome = RawExecutionOutcome::default()
-            .with_message(open_chain_message)
-            .with_message(subscribe_message);
+        let outcome = RawExecutionOutcome {
+            messages,
+            ..RawExecutionOutcome::default()
+        };
         this.execution_outcomes
             .push(ExecutionOutcome::System(outcome));
         Ok(chain_id)

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -102,7 +102,6 @@ pub struct OpenChainConfig {
     pub admin_id: ChainId,
     pub epoch: Epoch,
     pub committees: BTreeMap<Epoch, Committee>,
-    pub balance: Amount,
     pub application_permissions: ApplicationPermissions,
 }
 
@@ -129,7 +128,10 @@ pub enum SystemOperation {
     },
     /// Creates (or activates) a new chain.
     /// This will automatically subscribe to the future committees created by `admin_id`.
-    OpenChain(OpenChainConfig),
+    OpenChain {
+        config: OpenChainConfig,
+        balance: Amount,
+    },
     /// Closes the chain.
     CloseChain,
     /// Changes the ownership of the chain.
@@ -456,9 +458,9 @@ where
             responses: Vec::new(),
         };
         match operation {
-            OpenChain(config) => {
+            OpenChain { config, balance } => {
                 let next_message_id = context.next_message_id();
-                let messages = self.open_chain(config, next_message_id)?;
+                let messages = self.open_chain(config, balance, next_message_id)?;
                 outcome.messages.extend(messages);
                 #[cfg(with_metrics)]
                 OPEN_CHAIN_COUNT.with_label_values(&[]).inc();
@@ -932,7 +934,6 @@ where
             admin_id,
             epoch,
             committees,
-            balance,
             application_permissions,
         } = config;
         let description = ChainDescription::Child(message_id);
@@ -948,7 +949,6 @@ where
             .expect("serialization failed");
         self.ownership.set(ownership);
         self.timestamp.set(timestamp);
-        self.balance.set(balance);
         self.application_permissions.set(application_permissions);
     }
 
@@ -969,8 +969,9 @@ where
     pub fn open_chain(
         &mut self,
         config: OpenChainConfig,
+        amount: Amount,
         next_message_id: MessageId,
-    ) -> Result<[RawOutgoingMessage<SystemMessage, Amount>; 2], SystemExecutionError> {
+    ) -> Result<Vec<RawOutgoingMessage<SystemMessage, Amount>>, SystemExecutionError> {
         let child_id = ChainId::child(next_message_id);
         ensure!(
             self.admin_id.get().as_ref() == Some(&config.admin_id),
@@ -990,20 +991,34 @@ where
         );
         let balance = self.balance.get_mut();
         balance
-            .try_sub_assign(config.balance)
+            .try_sub_assign(amount)
             .map_err(|_| SystemExecutionError::InsufficientFunding { balance: *balance })?;
-        let open_chain_message = RawOutgoingMessage {
+        let mut messages = Vec::new();
+        messages.push(RawOutgoingMessage {
             destination: Destination::Recipient(child_id),
             authenticated: false,
             grant: Amount::ZERO,
-            kind: MessageKind::Protected,
+            kind: MessageKind::Simple,
             message: SystemMessage::OpenChain(config),
-        };
+        });
+        if amount > Amount::ZERO {
+            messages.push(RawOutgoingMessage {
+                destination: Destination::Recipient(child_id),
+                authenticated: false,
+                grant: Amount::ZERO,
+                kind: MessageKind::Tracked,
+                message: SystemMessage::Credit {
+                    amount,
+                    target: None,
+                    source: None,
+                },
+            });
+        }
         let subscription = ChannelSubscription {
             chain_id: admin_id,
             name: SystemChannel::Admin.name(),
         };
-        let subscribe_message = RawOutgoingMessage {
+        messages.push(RawOutgoingMessage {
             destination: Destination::Recipient(admin_id),
             authenticated: false,
             grant: Amount::ZERO,
@@ -1012,8 +1027,8 @@ where
                 id: child_id,
                 subscription,
             },
-        };
-        Ok([open_chain_message, subscribe_message])
+        });
+        Ok(messages)
     }
 
     pub async fn close_chain(
@@ -1153,10 +1168,12 @@ mod tests {
             committees,
             epoch,
             admin_id,
-            balance: Amount::ZERO,
             application_permissions: Default::default(),
         };
-        let operation = SystemOperation::OpenChain(config.clone());
+        let operation = SystemOperation::OpenChain {
+            config: config.clone(),
+            balance: Amount::ZERO,
+        };
         let (result, new_application, _) = view
             .system
             .execute_operation(context, operation)

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1520,9 +1520,26 @@ async fn test_open_chain() {
         panic!("Unexpected message at index {}: {:?}", index, message);
     };
     assert_eq!(*recipient_id, ChainId::child(message_id));
-    assert_eq!(config.balance, Amount::ONE);
     assert_eq!(config.ownership, child_ownership);
     assert_eq!(config.committees, committees);
+
+    let message = outcomes
+        .iter()
+        .flat_map(|outcome| match outcome {
+            ExecutionOutcome::System(outcome) => &outcome.messages,
+            ExecutionOutcome::User(_, _) => panic!("Unexpected message"),
+        })
+        .nth((index - context.next_message_index + 1) as usize)
+        .unwrap();
+    let RawOutgoingMessage {
+        message: SystemMessage::Credit { .. },
+        destination: Destination::Recipient(recipient_id),
+        ..
+    } = message
+    else {
+        panic!("Unexpected message at index {}: {:?}", index, message);
+    };
+    assert_eq!(*recipient_id, ChainId::child(message_id));
 
     // Initialize the child chain using the config from the message.
     let mut child_view = SystemExecutionState::default()
@@ -1531,7 +1548,7 @@ async fn test_open_chain() {
     child_view
         .system
         .initialize_chain(message_id, Timestamp::from(0), config.clone());
-    assert_eq!(*child_view.system.balance.get(), Amount::ONE);
+    assert_eq!(*child_view.system.balance.get(), Amount::ZERO);
     assert_eq!(*child_view.system.ownership.get(), child_ownership);
     assert_eq!(*child_view.system.committees.get(), committees);
     assert_eq!(

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -619,8 +619,6 @@ OpenChainConfig:
             TYPENAME: Epoch
           VALUE:
             TYPENAME: Committee
-    - balance:
-        TYPENAME: Amount
     - application_permissions:
         TYPENAME: ApplicationPermissions
 Operation:
@@ -937,8 +935,11 @@ SystemOperation:
               TYPENAME: UserData
     2:
       OpenChain:
-        NEWTYPE:
-          TYPENAME: OpenChainConfig
+        STRUCT:
+          - config:
+              TYPENAME: OpenChainConfig
+          - balance:
+              TYPENAME: Amount
     3:
       CloseChain: UNIT
     4:

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -187,13 +187,15 @@ impl TestValidator {
                 .collect(),
             admin_id,
             epoch: Epoch::ZERO,
-            balance: 0.into(),
             application_permissions: ApplicationPermissions::default(),
         };
 
         let messages = admin_chain
             .add_block(|block| {
-                block.with_system_operation(SystemOperation::OpenChain(new_chain_config));
+                block.with_system_operation(SystemOperation::OpenChain {
+                    config: new_chain_config,
+                    balance: 0.into(),
+                });
             })
             .await;
 

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -479,12 +479,14 @@ where
                 committees,
                 admin_id: self.wallet().genesis_admin_chain(),
                 epoch,
-                balance,
                 application_permissions: Default::default(),
             };
-            let operations = iter::repeat(Operation::System(SystemOperation::OpenChain(config)))
-                .take(num_new_chains)
-                .collect();
+            let operations = iter::repeat(Operation::System(SystemOperation::OpenChain {
+                config,
+                balance,
+            }))
+            .take(num_new_chains)
+            .collect();
             let certificate = chain_client
                 .execute_with_messages(operations)
                 .await?

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2994,12 +2994,12 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
 
     let account2 = Account::chain(chain2);
     assert_eq!(
-        client1.local_balance(account2).await?,
-        Amount::from_tokens(6),
+        client1.query_balance(account2).await?,
+        Amount::from_millis(5999),
     );
     assert_eq!(
-        client2.local_balance(account2).await?,
-        Amount::from_tokens(6),
+        client2.query_balance(account2).await?,
+        Amount::from_millis(5999),
     );
 
     // Transfer 2 + 1 units from Chain 2 to Chain 1 using both clients, leaving 3 (minus fees).
@@ -3163,17 +3163,22 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 
     // Clients 2 and 3 should have the tokens, and own the chain.
     client2.sync(chain2).await?;
+    // We haven't process incoming messages yet.
     assert_eq!(
         client2.local_balance(Account::chain(chain2)).await?,
-        Amount::from_tokens(2),
+        Amount::from_tokens(0),
+    );
+    assert_eq!(
+        client2.query_balance(Account::chain(chain2)).await?,
+        Amount::from_millis(1999),
     );
     client2.transfer(Amount::ONE, chain2, chain1).await?;
     assert!(client2.local_balance(Account::chain(chain2)).await? <= Amount::ONE);
 
     client3.sync(chain3).await?;
     assert_eq!(
-        client3.local_balance(Account::chain(chain3)).await?,
-        Amount::from_tokens(2),
+        client3.query_balance(Account::chain(chain3)).await?,
+        Amount::from_millis(1999),
     );
     client3.transfer(Amount::ONE, chain3, chain1).await?;
     assert!(client3.query_balance(Account::chain(chain3)).await? <= Amount::ONE);


### PR DESCRIPTION
## Motivation

`OpenChain` messages can be created by user operations. After #1475, they could be grouped with user messages in a fallible transaction. Therefore, `OpenChain` messages have to be rejectable.

## Proposal

* Make `OpenChain` messages "simple" instead of "protected".
* Rejecting an `OpenChain` message is allowed and close the chain immediately.
* When closing a chain in the middle of a block, operations or accepted messages are now disallowed right after the chain is closed (not at the next block).
* Empty blocks on closed chains are allowed but they have to pay a block fee.

I didn't change the `open_chain` syscall or the `OpenChain`operation but after #1475, we should probably remove the initial transfer entirely. (This transfer is redundant and restricted to chain-to-chain accounts)

## Test Plan

CI

## Release Plan

- Contains breaking changes.
- Next devnet ok