### PR TITLE
Fix client block proposal race condition

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1358,9 +1358,8 @@ where
         operations: Vec<Operation>,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         loop {
-            let messages = self.pending_messages().await?;
             // TODO(#2066): Remove boxing once the call-stack is shallower
-            match Box::pin(self.execute_block(messages, operations.clone())).await? {
+            match Box::pin(self.execute_block(operations.clone())).await? {
                 ExecuteBlockOutcome::Executed(certificate) => {
                     return Ok(ClientOutcome::Committed(certificate));
                 }
@@ -1390,7 +1389,6 @@ where
     /// This must be preceded by a call to `prepare_chain()`.
     async fn execute_block(
         &mut self,
-        incoming_messages: Vec<IncomingMessage>,
         operations: Vec<Operation>,
     ) -> Result<ExecuteBlockOutcome, ChainClientError> {
         match self.process_pending_block_without_prepare().await? {
@@ -1402,6 +1400,7 @@ where
                 return Ok(ExecuteBlockOutcome::WaitForTimeout(timeout))
             }
         }
+        let incoming_messages = self.pending_messages().await?;
         let confirmed_value = self
             .set_pending_block(incoming_messages, operations)
             .await?;
@@ -1858,7 +1857,6 @@ where
                 ownership.is_active(),
                 ChainError::InactiveChain(self.chain_id)
             );
-            let messages = self.pending_messages().await?;
             let mut owners = ownership.owners.values().copied().collect::<Vec<_>>();
             owners.extend(
                 ownership
@@ -1874,7 +1872,7 @@ where
                 multi_leader_rounds: ownership.multi_leader_rounds,
                 timeout_config: ownership.timeout_config,
             })];
-            match self.execute_block(messages, operations).await? {
+            match self.execute_block(operations).await? {
                 ExecuteBlockOutcome::Executed(certificate) => {
                     return Ok(ClientOutcome::Committed(certificate));
                 }
@@ -1926,7 +1924,6 @@ where
         loop {
             let (epoch, committees) = self.epoch_and_committees(self.chain_id).await?;
             let epoch = epoch.ok_or(LocalNodeError::InactiveChain(self.chain_id))?;
-            let messages = self.pending_messages().await?;
             let config = OpenChainConfig {
                 ownership: ownership.clone(),
                 committees,
@@ -1936,7 +1933,7 @@ where
                 application_permissions: application_permissions.clone(),
             };
             let operation = Operation::System(SystemOperation::OpenChain(config));
-            let certificate = match self.execute_block(messages, vec![operation]).await? {
+            let certificate = match self.execute_block(vec![operation]).await? {
                 ExecuteBlockOutcome::Executed(certificate) => certificate,
                 ExecuteBlockOutcome::Conflict(_) => continue,
                 ExecuteBlockOutcome::WaitForTimeout(timeout) => {
@@ -2065,17 +2062,13 @@ where
         loop {
             self.prepare_chain().await?;
             let epoch = self.epoch().await?;
-            let messages = self.pending_messages().await?;
             match self
-                .execute_block(
-                    messages,
-                    vec![Operation::System(SystemOperation::Admin(
-                        AdminOperation::CreateCommittee {
-                            epoch: epoch.try_add_one()?,
-                            committee: committee.clone(),
-                        },
-                    ))],
-                )
+                .execute_block(vec![Operation::System(SystemOperation::Admin(
+                    AdminOperation::CreateCommittee {
+                        epoch: epoch.try_add_one()?,
+                        committee: committee.clone(),
+                    },
+                ))])
                 .await?
             {
                 ExecuteBlockOutcome::Executed(certificate) => {
@@ -2103,7 +2096,7 @@ where
             if incoming_messages.is_empty() {
                 return Ok((certificates, None));
             }
-            match self.execute_block(incoming_messages, vec![]).await {
+            match self.execute_block(vec![]).await {
                 Ok(ExecuteBlockOutcome::Executed(certificate))
                 | Ok(ExecuteBlockOutcome::Conflict(certificate)) => certificates.push(certificate),
                 Ok(ExecuteBlockOutcome::WaitForTimeout(timeout)) => {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1349,11 +1349,11 @@ where
         operations: Vec<Operation>,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
         self.prepare_chain().await?;
-        self.execute_with_messages(operations).await
+        self.execute_without_prepare(operations).await
     }
 
     /// Executes a list of operations, without calling `prepare_chain`.
-    pub async fn execute_with_messages(
+    pub async fn execute_without_prepare(
         &mut self,
         operations: Vec<Operation>,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
@@ -2189,7 +2189,7 @@ where
                 }
             })
             .collect();
-        self.execute_with_messages(operations).await
+        self.execute_without_prepare(operations).await
     }
 
     /// Sends money to a chain.

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -486,7 +486,7 @@ where
                 .take(num_new_chains)
                 .collect();
             let certificate = chain_client
-                .execute_with_messages(operations)
+                .execute_without_prepare(operations)
                 .await?
                 .expect("should execute block with OpenChain operations");
             let executed_block = certificate
@@ -549,7 +549,7 @@ where
         // Put at most 1000 fungible token operations in each block.
         for operations in operations.chunks(1000) {
             chain_client
-                .execute_with_messages(operations.to_vec())
+                .execute_without_prepare(operations.to_vec())
                 .await?
                 .expect("should execute block with OpenChain operations");
         }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
There were some occasional test failures with the error message saying that messages were out of order on the local node. After some discussion and debugging during the offsite, @afck suggested it could be a race condition because the client may try to propose a block with some messages that are already in a pending block that will be proposed first.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Retrieve the list of incoming messages to include in the block proposal _after_ handling the pending block. That way the messages are not repeated in both blocks.

## Test Plan

<!-- How to test that the changes are correct. -->
After this fix, I could not reproduce the error that I was running into periodically.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Fixes a bug. There are no visible changes, so nothing is needed besides publishing a patch version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
