### PR TITLE
Fix unrelated error in test due to a chain with zero balance

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2605,7 +2605,8 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     let query = format!(
         "mutation {{ openChain(\
             chainId:\"{chain1}\", \
-            publicKey:\"{public_key}\"\
+            publicKey:\"{public_key}\", \
+            balance: \"1\"\
         ) }}"
     );
     node_service.query_node(query).await?;


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When running `test_open_chain_node_service`, sometimes an error message would appear saying that there was a failure to receive a message due to insufficient funds. This happened because the test would create a new chain without providing it any tokens and ignore it for the rest of the chain. The error could be ignored, but while debugging another issue in the test, the error message led to a false lead that took some time away from the root cause.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Provide 1 token to the newly created chain.

## Test Plan

<!-- How to test that the changes are correct. -->
After this fix, the error message does not appear anymore.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Only fixes a bug in a test, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
