### PR TITLE
Fix handling of chain state changes in `ChainWorkerState`

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -426,19 +426,6 @@ where
         Ok(())
     }
 
-    /// Returns an error if the block is not at the expected epoch.
-    fn check_block_epoch(chain_epoch: Epoch, block: &Block) -> Result<(), WorkerError> {
-        ensure!(
-            block.epoch == chain_epoch,
-            WorkerError::InvalidEpoch {
-                chain_id: block.chain_id,
-                epoch: block.epoch,
-                chain_epoch
-            }
-        );
-        Ok(())
-    }
-
     /// Returns an error if the block requires bytecode or a blob we don't have, or if unrelated bytecode
     /// hashed certificate values or blobs were provided.
     async fn check_no_missing_blobs(
@@ -725,7 +712,7 @@ where
             .system
             .current_committee()
             .expect("chain is active");
-        ChainWorkerState::<StorageClient>::check_block_epoch(epoch, block)?;
+        check_block_epoch(epoch, block)?;
         // Check the authentication of the block.
         let public_key = self
             .state
@@ -968,7 +955,7 @@ where
             .system
             .current_committee()
             .expect("chain is active");
-        ChainWorkerState::<StorageClient>::check_block_epoch(epoch, block)?;
+        check_block_epoch(epoch, block)?;
         certificate.check(committee)?;
         let mut actions = NetworkActions::default();
         let already_validated_block = self
@@ -1071,7 +1058,7 @@ where
             .system
             .current_committee()
             .expect("chain is active");
-        ChainWorkerState::<StorageClient>::check_block_epoch(epoch, block)?;
+        check_block_epoch(epoch, block)?;
         certificate.check(committee)?;
         // This should always be true for valid certificates.
         ensure!(
@@ -1259,4 +1246,17 @@ impl<'a> CrossChainUpdateHelper<'a> {
         };
         Ok(certificates)
     }
+}
+
+/// Returns an error if the block is not at the expected epoch.
+fn check_block_epoch(chain_epoch: Epoch, block: &Block) -> Result<(), WorkerError> {
+    ensure!(
+        block.epoch == chain_epoch,
+        WorkerError::InvalidEpoch {
+            chain_id: block.chain_id,
+            epoch: block.epoch,
+            chain_epoch
+        }
+    );
+    Ok(())
 }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -985,6 +985,25 @@ where
     }
 }
 
+/// Wrapper type that rolls back changes to the `chain` state when dropped.
+pub struct ChainWorkerStateWithTemporaryChanges<'state, StorageClient>
+where
+    StorageClient: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    state: &'state mut ChainWorkerState<StorageClient>,
+}
+
+impl<StorageClient> Drop for ChainWorkerStateWithTemporaryChanges<'_, StorageClient>
+where
+    StorageClient: Storage + Clone + Send + Sync + 'static,
+    ViewError: From<StorageClient::ContextError>,
+{
+    fn drop(&mut self) {
+        self.state.chain.rollback();
+    }
+}
+
 /// Helper type for handling cross-chain updates.
 pub(crate) struct CrossChainUpdateHelper<'a> {
     pub allow_messages_from_deprecated_epochs: bool,

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -228,60 +228,9 @@ where
         &mut self,
         certificate: Certificate,
     ) -> Result<(ChainInfoResponse, NetworkActions, bool), WorkerError> {
-        let block = match certificate.value() {
-            CertificateValue::ValidatedBlock {
-                executed_block: ExecutedBlock { block, .. },
-            } => block,
-            _ => panic!("Expecting a validation certificate"),
-        };
-        let height = block.height;
-        // Check that the chain is active and ready for this validated block.
-        // Verify the certificate. Returns a catch-all error to make client code more robust.
-        self.ensure_is_active()?;
-        let (epoch, committee) = self
-            .chain
-            .execution_state
-            .system
-            .current_committee()
-            .expect("chain is active");
-        Self::check_block_epoch(epoch, block)?;
-        certificate.check(committee)?;
-        let mut actions = NetworkActions::default();
-        let already_validated_block = self.chain.tip_state.get().already_validated_block(height)?;
-        let should_skip_validated_block = || {
-            self.chain
-                .manager
-                .get()
-                .check_validated_block(&certificate)
-                .map(|outcome| outcome == manager::Outcome::Skip)
-        };
-        if already_validated_block || should_skip_validated_block()? {
-            // If we just processed the same pending block, return the chain info unchanged.
-            return Ok((
-                ChainInfoResponse::new(&self.chain, self.config.key_pair()),
-                actions,
-                true,
-            ));
-        }
-        self.recent_hashed_certificate_values
-            .insert(Cow::Borrowed(&certificate.value))
-            .await;
-        let old_round = self.chain.manager.get().current_round;
-        self.chain.manager.get_mut().create_final_vote(
-            certificate,
-            self.config.key_pair(),
-            self.storage.clock().current_time(),
-        );
-        let info = ChainInfoResponse::new(&self.chain, self.config.key_pair());
-        self.save().await?;
-        let round = self.chain.manager.get().current_round;
-        if round > old_round {
-            actions.notifications.push(Notification {
-                chain_id: self.chain_id(),
-                reason: Reason::NewRound { height, round },
-            })
-        }
-        Ok((info, actions, false))
+        ChainWorkerStateWithAttemptedChanges::from(self)
+            .process_validated_block(certificate)
+            .await
     }
 
     /// Processes a confirmed block (aka a commit).
@@ -1115,6 +1064,75 @@ where
         }
         self.save().await?;
         Ok(())
+    }
+
+    /// Processes a validated block issued for this multi-owner chain.
+    pub async fn process_validated_block(
+        &mut self,
+        certificate: Certificate,
+    ) -> Result<(ChainInfoResponse, NetworkActions, bool), WorkerError> {
+        let block = match certificate.value() {
+            CertificateValue::ValidatedBlock {
+                executed_block: ExecutedBlock { block, .. },
+            } => block,
+            _ => panic!("Expecting a validation certificate"),
+        };
+        let height = block.height;
+        // Check that the chain is active and ready for this validated block.
+        // Verify the certificate. Returns a catch-all error to make client code more robust.
+        self.state.ensure_is_active()?;
+        let (epoch, committee) = self
+            .state
+            .chain
+            .execution_state
+            .system
+            .current_committee()
+            .expect("chain is active");
+        ChainWorkerState::<StorageClient>::check_block_epoch(epoch, block)?;
+        certificate.check(committee)?;
+        let mut actions = NetworkActions::default();
+        let already_validated_block = self
+            .state
+            .chain
+            .tip_state
+            .get()
+            .already_validated_block(height)?;
+        let should_skip_validated_block = || {
+            self.state
+                .chain
+                .manager
+                .get()
+                .check_validated_block(&certificate)
+                .map(|outcome| outcome == manager::Outcome::Skip)
+        };
+        if already_validated_block || should_skip_validated_block()? {
+            // If we just processed the same pending block, return the chain info unchanged.
+            return Ok((
+                ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair()),
+                actions,
+                true,
+            ));
+        }
+        self.state
+            .recent_hashed_certificate_values
+            .insert(Cow::Borrowed(&certificate.value))
+            .await;
+        let old_round = self.state.chain.manager.get().current_round;
+        self.state.chain.manager.get_mut().create_final_vote(
+            certificate,
+            self.state.config.key_pair(),
+            self.state.storage.clock().current_time(),
+        );
+        let info = ChainInfoResponse::new(&self.state.chain, self.state.config.key_pair());
+        self.save().await?;
+        let round = self.state.chain.manager.get().current_round;
+        if round > old_round {
+            actions.notifications.push(Notification {
+                chain_id: self.state.chain_id(),
+                reason: Reason::NewRound { height, round },
+            })
+        }
+        Ok((info, actions, false))
     }
 
     /// Stores the chain state in persistent storage.


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
#2163 makes the `ChainWorkerActor` be reused across requests to the `WorkerState`. This improves performance because the `ChainStateView` does not need to be reloaded for every request. However, the PR was causing the `test_open_chain_node_service` test would fail, and the normal logs would show that the validators rejected a block because messages were out of order.

The trace log however, would show that first the validators would reject a block because it was missing the incoming messages (this is normal). After the cross-chain messages had been propagated, reproposing the block failed because the validator complained that those messages were already received.

The cause was that the chain state was not being properly discarded on error conditions. The `ChainWorkerActor` owns a `ChainWorkerState`, which has the `ChainStateView` instance. When the `ChainWorkerState` returns an error, it did not rollback the changes to the `ChainStateView`, so they were kept in memory. When the next request was handled, the state would start off with invalid data.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Force rollback to be done automatically with some helper types. `ChainWorkerStateWithTemporaryChanges` always rolls back all changes when it is dropped. `ChainWorkerStateWithAttemptedChanges` has a `save` method, which persists the changes. If the changes aren't persisted (e.g., when an error occurs) then the `ChainStateView` has its changes rolled back when the wrapper type is dropped.

Both types are wrappers around `&mut ChainWorkerState`, and simply represent the "lifetime" of a transaction of changes to the chain state.

## Test Plan

<!-- How to test that the changes are correct. -->
After this PR and with #2163, the `test_open_chain_node_service` stopped failing. Without this PR, it fails consistently.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is an internal refactor, so nothing is needed.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
