### PR TITLE
Add option `--policy-config` to `linera net up`

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -847,6 +847,12 @@ Start a Local Linera Network
 * `--shards <SHARDS>` — The number of shards per validator in the local test network. Default is 1
 
   Default value: `1`
+* `--policy-config <POLICY_CONFIG>` — Configure the resource control policy (notably fees) according to pre-defined settings
+
+  Default value: `default`
+
+  Possible values: `default`, `only-fuel`, `fuel-and-block`, `all-categories`, `devnet`
+
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY
 * `--table-name <TABLE_NAME>` — The name for the database table to store the chain data in
 

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -120,7 +120,6 @@ impl ResourceControlPolicy {
     }
 }
 
-#[cfg(with_testing)]
 impl ResourceControlPolicy {
     /// Creates a policy with no cost for anything except fuel.
     ///

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1350,6 +1350,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                 shards,
                 testing_prng_seed,
                 table_name: _,
+                policy_config,
                 kubernetes: true,
                 binaries,
             } => {
@@ -1361,6 +1362,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                     *shards,
                     *testing_prng_seed,
                     binaries,
+                    policy_config.into_policy(),
                 )
                 .await
             }
@@ -1373,6 +1375,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                 shards,
                 testing_prng_seed,
                 table_name,
+                policy_config,
                 ..
             } => {
                 net_up_utils::handle_net_up_service(
@@ -1383,6 +1386,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                     *shards,
                     *testing_prng_seed,
                     table_name,
+                    policy_config.into_policy(),
                 )
                 .await
             }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1364,6 +1364,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                     binaries,
                     policy_config.into_policy(),
                 )
+                .boxed()
                 .await
             }
 
@@ -1388,6 +1389,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                     table_name,
                     policy_config.into_policy(),
                 )
+                .boxed()
                 .await
             }
 

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -26,6 +26,7 @@ use {
     std::path::PathBuf,
 };
 
+#[allow(clippy::too_many_arguments)]
 #[cfg(feature = "kubernetes")]
 pub async fn handle_net_up_kubernetes(
     extra_wallets: Option<usize>,
@@ -35,6 +36,7 @@ pub async fn handle_net_up_kubernetes(
     num_shards: usize,
     testing_prng_seed: Option<u64>,
     binaries: &Option<Option<PathBuf>>,
+    policy: ResourceControlPolicy,
 ) -> anyhow::Result<()> {
     if num_initial_validators < 1 {
         panic!("The local test network must have at least one validator.");
@@ -54,13 +56,14 @@ pub async fn handle_net_up_kubernetes(
         num_initial_validators,
         num_shards,
         binaries: binaries.clone().into(),
-        policy: ResourceControlPolicy::default(),
+        policy,
     };
     let (mut net, client1) = config.instantiate().await?;
     net_up(extra_wallets, &mut net, client1).await?;
     wait_for_shutdown(shutdown_notifier, &mut net).await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_net_up_service(
     extra_wallets: Option<usize>,
     num_other_initial_chains: u32,
@@ -69,6 +72,7 @@ pub async fn handle_net_up_service(
     num_shards: usize,
     testing_prng_seed: Option<u64>,
     table_name: &str,
+    policy: ResourceControlPolicy,
 ) -> anyhow::Result<()> {
     if num_initial_validators < 1 {
         panic!("The local test network must have at least one validator.");
@@ -102,7 +106,7 @@ pub async fn handle_net_up_service(
         initial_amount: Amount::from_tokens(initial_amount),
         num_initial_validators,
         num_shards,
-        policy: ResourceControlPolicy::default(),
+        policy,
         storage_config_builder,
         path_provider,
     };


### PR DESCRIPTION
## Motivation

Simulate a devnet-like configuration locally with `linera net up`

## Proposal

Add an option `ResourceControlPolicyConfig`

## Test Plan

Tested manually
```
cargo run --release --bin storage_service_server memory --endpoint 127.0.0.1:1235 &
cargo run --bin linera -- --storage service:tcp:127.0.0.1:1235:TEST net up --policy-config devnet
# copy wallet env variables, then in a separate shell
cargo run --bin linera -- faucet --amount 1000 --port 8079 &
export LINERA_FAUCET_URL=http://localhost:8079/
cargo test -p linera-service --features remote_net
```