### PR TITLE
Switch the wallet to the storage service

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,4 +59,4 @@ jobs:
           # Docker compose can take some time to start
           max_attempts: 5
           timeout_minutes: 2
-          command: sleep 60 && linera --wallet docker/wallet.json --storage rocksdb:docker/linera.db sync-balance
+          command: sleep 60 && linera --wallet docker/wallet.json --storage service:tcp:127.0.0.1:1235:linera_docker_db sync-balance

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,4 +59,4 @@ jobs:
           # Docker compose can take some time to start
           max_attempts: 5
           timeout_minutes: 2
-          command: sleep 60 && linera --wallet docker/wallet.json --storage service:tcp:127.0.0.1:1235:linera_docker_db sync-balance
+          command: sleep 60 && linera --wallet docker/wallet.json --storage service:tcp:0.0.0.0:1235:linera_docker_db sync-balance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,6 +4314,7 @@ dependencies = [
  "linera-chain",
  "linera-core",
  "linera-service-graphql-client",
+ "linera-storage-service",
  "linera-version",
  "linera-views",
  "reqwest 0.11.27",

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -53,10 +53,14 @@ set -xe
 # * `committee.json` is the public description of the Linera committee.
 linera-server generate --validators "$CONF_DIR/validator.toml" --committee committee.json --testing-prng-seed 1
 
+# creating the linera-storage-service
+storage_service_server memory --endpoint 127.0.0.1:1235 &
+sleep 2
+
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
 
-linera --wallet wallet.json --storage rocksdb:linera.db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
+linera --wallet wallet.json --storage service:tcp:127.0.0.1:1235:linera_docker_db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
 
 docker compose up

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -54,13 +54,13 @@ set -xe
 linera-server generate --validators "$CONF_DIR/validator.toml" --committee committee.json --testing-prng-seed 1
 
 # creating the linera-storage-service
-storage_service_server memory --endpoint 127.0.0.1:1235 &
+storage_service_server memory --endpoint 0.0.0.0:1235 &
 sleep 2
 
 # Create configuration files for 10 user chains.
 # * Private chain states are stored in one local wallet `wallet.json`.
 # * `genesis.json` will contain the initial balances of chains as well as the initial committee.
 
-linera --wallet wallet.json --storage service:tcp:127.0.0.1:1235:linera_docker_db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
+linera --wallet wallet.json --storage service:tcp:0.0.0.0:1235:linera_docker_db create-genesis-config 10 --genesis genesis.json --initial-funding 10 --committee committee.json --testing-prng-seed 2
 
 docker compose up

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-default = ["rocksdb"]
 benchmark = ["linera-base/test", "linera-indexer/benchmark"]
 rocksdb = ["linera-indexer/rocksdb", "linera-indexer-plugins/rocksdb"]
 dynamodb = ["linera-indexer/dynamodb", "linera-indexer-plugins/dynamodb"]

--- a/linera-indexer/example/Cargo.toml
+++ b/linera-indexer/example/Cargo.toml
@@ -31,7 +31,7 @@ anyhow.workspace = true
 async-graphql.workspace = true
 linera-base.workspace = true
 linera-indexer-graphql-client.workspace = true
-linera-service = { workspace = true, features = ["rocksdb", "test"] }
+linera-service = { workspace = true, features = ["test"] }
 linera-service-graphql-client.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/linera-indexer/example/src/main.rs
+++ b/linera-indexer/example/src/main.rs
@@ -3,7 +3,7 @@
 
 //! An example of an indexer with the operations plugin.
 
-use linera_indexer::{common::IndexerError, plugin::Plugin, rocks_db::RocksDbRunner};
+use linera_indexer::{common::IndexerError, plugin::Plugin, storage_service::StorageServiceRunner};
 use linera_indexer_plugins::operations::OperationsPlugin;
 
 #[tokio::main]
@@ -16,7 +16,7 @@ async fn main() -> Result<(), IndexerError> {
         .with_env_filter(env_filter)
         .init();
 
-    let mut runner = RocksDbRunner::load().await?;
+    let mut runner = StorageServiceRunner::load().await?;
     runner
         .add_plugin(OperationsPlugin::load(runner.store.clone()).await?)
         .await?;

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -33,6 +33,7 @@ linera-base.workspace = true
 linera-chain.workspace = true
 linera-core.workspace = true
 linera-service-graphql-client.workspace = true
+linera-storage-service.workspace = true
 linera-version.workspace = true
 linera-views.workspace = true
 reqwest.workspace = true

--- a/linera-indexer/lib/Cargo.toml
+++ b/linera-indexer/lib/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-default = ["rocksdb"]
 benchmark = ["linera-base/test"]
 rocksdb = ["linera-views/rocksdb", "linera-core/rocksdb"]
 dynamodb = ["linera-views/dynamodb", "linera-core/dynamodb"]

--- a/linera-indexer/lib/src/common.rs
+++ b/linera-indexer/lib/src/common.rs
@@ -47,6 +47,8 @@ pub enum IndexerError {
     #[error("Invalid certificate content: {0:?}")]
     InvalidCertificateValue(CryptoHash),
 
+    #[error(transparent)]
+    StorageServiceError(#[from] linera_storage_service::common::ServiceContextError),
     #[cfg(feature = "rocksdb")]
     #[error(transparent)]
     RocksDbError(#[from] linera_views::rocks_db::RocksDbContextError),

--- a/linera-indexer/lib/src/lib.rs
+++ b/linera-indexer/lib/src/lib.rs
@@ -13,6 +13,7 @@ pub mod plugin;
 pub mod runner;
 pub mod service;
 
+pub mod storage_service;
 #[cfg(feature = "rocksdb")]
 pub mod rocks_db;
 #[cfg(feature = "scylladb")]

--- a/linera-indexer/lib/src/lib.rs
+++ b/linera-indexer/lib/src/lib.rs
@@ -13,8 +13,8 @@ pub mod plugin;
 pub mod runner;
 pub mod service;
 
-pub mod storage_service;
 #[cfg(feature = "rocksdb")]
 pub mod rocks_db;
 #[cfg(feature = "scylladb")]
 pub mod scylla_db;
+pub mod storage_service;

--- a/linera-indexer/lib/src/storage_service.rs
+++ b/linera-indexer/lib/src/storage_service.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser as _;
-use linera_views::common::{AdminKeyValueStore, CommonStoreConfig};
 use linera_storage_service::{client::ServiceStoreClient, common::ServiceStoreConfig};
+use linera_views::common::{AdminKeyValueStore, CommonStoreConfig};
 
 use crate::{
     common::IndexerError,

--- a/linera-indexer/lib/src/storage_service.rs
+++ b/linera-indexer/lib/src/storage_service.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use clap::Parser as _;
+use linera_views::common::{AdminKeyValueStore, CommonStoreConfig};
+use linera_storage_service::{client::ServiceStoreClient, common::ServiceStoreConfig};
+
+use crate::{
+    common::IndexerError,
+    runner::{IndexerConfig, Runner},
+};
+
+#[derive(clap::Parser, Clone, Debug)]
+#[command(version = linera_version::VersionInfo::default_clap_str())]
+pub struct ServiceConfig {
+    /// ServiceStorage endpoint
+    #[arg(long, default_value = "127.0.0.1:1235")]
+    pub endpoint: String,
+    #[arg(long, default_value = "linera")]
+    pub table: String,
+    /// The maximal number of simultaneous queries to the database
+    #[arg(long)]
+    max_concurrent_queries: Option<usize>,
+    /// The maximal number of simultaneous stream queries to the database
+    #[arg(long, default_value = "10")]
+    pub max_stream_queries: usize,
+    /// The maximal number of entries in the storage cache.
+    #[arg(long, default_value = "1000")]
+    cache_size: usize,
+}
+
+pub type StorageServiceRunner = Runner<ServiceStoreClient, ServiceConfig>;
+
+impl StorageServiceRunner {
+    pub async fn load() -> Result<Self, IndexerError> {
+        let config = IndexerConfig::<ServiceConfig>::parse();
+        let common_config = CommonStoreConfig {
+            max_concurrent_queries: config.client.max_concurrent_queries,
+            max_stream_queries: config.client.max_stream_queries,
+            cache_size: config.client.cache_size,
+        };
+        let store_config = ServiceStoreConfig {
+            endpoint: config.client.endpoint.clone(),
+            common_config,
+        };
+        let namespace = config.client.table.clone();
+        let store = ServiceStoreClient::maybe_create_and_connect(&store_config, &namespace).await?;
+        Self::new(config, store).await
+    }
+}

--- a/linera-indexer/plugins/Cargo.toml
+++ b/linera-indexer/plugins/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-default = ["rocksdb"]
 benchmark = ["linera-base/test"]
 rocksdb = ["linera-views/rocksdb", "linera-indexer/rocksdb"]
 dynamodb = ["linera-views/dynamodb", "linera-indexer/dynamodb"]

--- a/linera-service-graphql-client/Cargo.toml
+++ b/linera-service-graphql-client/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-default = ["rocksdb"]
 rocksdb = ["linera-service/rocksdb"]
 dynamodb = ["linera-service/dynamodb"]
 scylladb = ["linera-service/scylladb"]

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -62,7 +62,7 @@ k8s-openapi = { workspace = true, optional = true }
 kube = { workspace = true, optional = true }
 linera-base = { workspace = true, features = ["metrics"] }
 linera-chain = { workspace = true, features = ["metrics"] }
-linera-core = { workspace = true, features = ["metrics", "rocksdb", "wasmer"] }
+linera-core = { workspace = true, features = ["metrics", "wasmer"] }
 linera-execution = { workspace = true, features = ["fs", "metrics", "wasmer"] }
 linera-rpc = { workspace = true, features = ["server", "simple-network"] }
 linera-sdk = { workspace = true, optional = true }

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 
 [features]
 ethereum = []
-default = ["wasmer", "rocksdb"]
+default = ["wasmer"]
 test = ["linera-views/test", "linera-execution/test", "dep:stdext"]
 benchmark = ["linera-base/test", "dep:linera-sdk"]
 wasmer = ["linera-execution/wasmer", "linera-storage/wasmer"]

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -69,8 +69,14 @@ impl ClientWrapper {
         testing_prng_seed: Option<u64>,
         id: usize,
     ) -> Self {
-        let endpoint = std::env::var("LINERA_STORAGE_SERVICE").expect("missing LINERA_STORAGE_SERVICE environment variable");
-        let storage = format!("service:tcp:{}:client_{}.db", endpoint, id);
+        let endpoint = std::env::var("LINERA_STORAGE_SERVICE")
+            .expect("missing LINERA_STORAGE_SERVICE environment variable");
+        let storage = format!(
+            "service:tcp:{}:{}_client_{}.db",
+            endpoint,
+            path_provider.path().display(),
+            id
+        );
         let wallet = format!("wallet_{}.json", id);
         Self {
             testing_prng_seed,

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -69,11 +69,8 @@ impl ClientWrapper {
         testing_prng_seed: Option<u64>,
         id: usize,
     ) -> Self {
-        let storage = format!(
-            "rocksdb:{}/client_{}.db",
-            path_provider.path().display(),
-            id
-        );
+        let endpoint = std::env::var("LINERA_STORAGE_SERVICE").expect("missing LINERA_STORAGE_SERVICE environment variable");
+        let storage = format!("service:tcp:{}:client_{}.db", endpoint, id);
         let wallet = format!("wallet_{}.json", id);
         Self {
             testing_prng_seed,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -150,9 +150,7 @@ impl ClientOptions {
             Some(config) => config.parse(),
             None => {
                 let endpoint = std::env::var("LINERA_STORAGE_SERVICE")?;
-                let storage_config = linera_service::storage::StorageConfig::Service {
-                    endpoint,
-                };
+                let storage_config = linera_service::storage::StorageConfig::Service { endpoint };
                 let namespace = "default".to_string();
                 Ok(StorageConfigNamespace {
                     storage_config,

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -148,10 +148,10 @@ impl ClientOptions {
     pub fn storage_config(&self) -> Result<StorageConfigNamespace, anyhow::Error> {
         match &self.storage_config {
             Some(config) => config.parse(),
-            #[cfg(feature = "rocksdb")]
             None => {
-                let storage_config = linera_service::storage::StorageConfig::RocksDb {
-                    path: self.config_path()?.join("wallet.db"),
+                let endpoint = std::env::var("LINERA_STORAGE_SERVICE")?;
+                let storage_config = linera_service::storage::StorageConfig::Service {
+                    endpoint,
                 };
                 let namespace = "default".to_string();
                 Ok(StorageConfigNamespace {
@@ -159,8 +159,6 @@ impl ClientOptions {
                     namespace,
                 })
             }
-            #[cfg(not(feature = "rocksdb"))]
-            None => anyhow::bail!("A storage option must be provided"),
         }
     }
 

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-default = ["rocksdb"]
 metrics = ["linera-views/metrics"]
 rocksdb = ["linera-views/rocksdb"]
 storage_service = []


### PR DESCRIPTION
## Motivation

The use of RocksDb for the wallet forces compiling with RocksDb which is bad for the CI. 

## Proposal

The following are done:
* The RocksDb is no longer a default feature.
* The default storage for the wallet switches from `RocksDb` to `storage_service`.
* The path for the wallet is assigned to `{path}_cliend_{id}.db` which is maybe not a nice table name. But it works here.

## Test Plan

The CI is the goal here.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
