### PR TITLE
Disable all graphql caches

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -293,7 +293,7 @@ pub enum CertificateValue {
     },
 }
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl CertificateValue {
     #[graphql(derived(name = "executed_block"))]
     async fn _executed_block(&self) -> Option<ExecutedBlock> {
@@ -317,7 +317,7 @@ pub struct HashedCertificateValue {
     hash: CryptoHash,
 }
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl HashedCertificateValue {
     #[graphql(derived(name = "hash"))]
     async fn _hash(&self) -> CryptoHash {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -4,7 +4,7 @@
 
 use std::{borrow::Cow, collections::HashSet};
 
-use async_graphql::{Object, SimpleObject};
+use async_graphql::SimpleObject;
 use linera_base::{
     crypto::{BcsHashable, BcsSignable, CryptoError, CryptoHash, KeyPair, PublicKey, Signature},
     data_types::{Amount, BlockHeight, HashedBlob, OracleRecord, Round, Timestamp},
@@ -293,7 +293,7 @@ pub enum CertificateValue {
     },
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl CertificateValue {
     #[graphql(derived(name = "executed_block"))]
     async fn _executed_block(&self) -> Option<ExecutedBlock> {
@@ -317,7 +317,7 @@ pub struct HashedCertificateValue {
     hash: CryptoHash,
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl HashedCertificateValue {
     #[graphql(derived(name = "hash"))]
     async fn _hash(&self) -> CryptoHash {

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -32,7 +32,7 @@ doc_scalar!(
 doc_scalar!(UserData, "Optional user message attached to a transfer");
 doc_scalar!(ValidatorName, "The identity of a validator");
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl Committee {
     #[graphql(derived(name = "validators"))]
     async fn _validators(&self) -> &BTreeMap<ValidatorName, ValidatorState> {
@@ -55,7 +55,7 @@ impl Committee {
     }
 }
 
-#[async_graphql::Object]
+#[Object(cache_control(no_cache))]
 impl<C: Send + Sync + Context> ExecutionStateView<C>
 where
     ViewError: From<C::Error>,
@@ -66,7 +66,7 @@ where
     }
 }
 
-#[async_graphql::Object]
+#[Object(cache_control(no_cache))]
 impl<C: Send + Sync + Context> SystemExecutionStateView<C>
 where
     ViewError: From<C::Error>,

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -3,7 +3,6 @@
 
 use std::collections::BTreeMap;
 
-use async_graphql::{Error, Object};
 use linera_base::{
     data_types::{Amount, Timestamp},
     doc_scalar,
@@ -32,7 +31,7 @@ doc_scalar!(
 doc_scalar!(UserData, "Optional user message attached to a transfer");
 doc_scalar!(ValidatorName, "The identity of a validator");
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl Committee {
     #[graphql(derived(name = "validators"))]
     async fn _validators(&self) -> &BTreeMap<ValidatorName, ValidatorState> {
@@ -55,7 +54,7 @@ impl Committee {
     }
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<C: Send + Sync + Context> ExecutionStateView<C>
 where
     ViewError: From<C::Error>,
@@ -66,7 +65,7 @@ where
     }
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<C: Send + Sync + Context> SystemExecutionStateView<C>
 where
     ViewError: From<C::Error>,
@@ -87,7 +86,7 @@ where
     }
 
     #[graphql(derived(name = "subscription"))]
-    async fn _subscriptions(&self) -> Result<Vec<ChannelSubscription>, Error> {
+    async fn _subscriptions(&self) -> Result<Vec<ChannelSubscription>, async_graphql::Error> {
         Ok(self.subscriptions.indices().await?)
     }
 

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -209,7 +209,7 @@ pub struct HighestBlock {
     height: Option<BlockHeight>,
 }
 
-#[Object]
+#[Object(cache_control(no_cache))]
 impl<C> State<C>
 where
     C: Context + Clone + Send + Sync + 'static,

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -5,7 +5,7 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use async_graphql::{EmptyMutation, EmptySubscription, Object, Schema, SimpleObject};
+use async_graphql::{EmptyMutation, EmptySubscription, Schema, SimpleObject};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
 use axum::{extract::Extension, routing::get, Router};
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
@@ -209,7 +209,7 @@ pub struct HighestBlock {
     height: Option<BlockHeight>,
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<C> State<C>
 where
     C: Context + Clone + Send + Sync + 'static,

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -58,7 +58,7 @@ pub fn sdl<Q: ObjectType + 'static>(query: Q) -> String {
     schema(query).sdl()
 }
 
-pub fn route<Q: async_graphql::ObjectType + 'static>(
+pub fn route<Q: ObjectType + 'static>(
     name: &str,
     query: Q,
     app: axum::Router,

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -58,11 +58,7 @@ pub fn sdl<Q: ObjectType + 'static>(query: Q) -> String {
     schema(query).sdl()
 }
 
-pub fn route<Q: ObjectType + 'static>(
-    name: &str,
-    query: Q,
-    app: axum::Router,
-) -> axum::Router {
+pub fn route<Q: ObjectType + 'static>(name: &str, query: Q, app: axum::Router) -> axum::Router {
     app.route(
         &format!("/{}", name),
         axum::routing::get(crate::common::graphiql).post(handler::<Q>),

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -160,7 +160,7 @@ where
 }
 
 /// Implements `ObjectType`
-#[Object]
+#[Object(cache_control(no_cache))]
 impl<C> OperationsPlugin<C>
 where
     C: Context + Send + Sync + 'static + Clone,

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -6,7 +6,7 @@ use std::{
     sync::Arc,
 };
 
-use async_graphql::{Object, OneofObject, SimpleObject};
+use async_graphql::{OneofObject, SimpleObject};
 use axum::Router;
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, doc_scalar, identifiers::ChainId};
 use linera_chain::data_types::HashedCertificateValue;
@@ -160,7 +160,7 @@ where
 }
 
 /// Implements `ObjectType`
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<C> OperationsPlugin<C>
 where
     C: Context + Send + Sync + 'static + Clone,

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -3,7 +3,7 @@
 
 use std::{net::SocketAddr, num::NonZeroU16, sync::Arc};
 
-use async_graphql::{EmptySubscription, Error, Object, Schema, SimpleObject};
+use async_graphql::{EmptySubscription, Error, Schema, SimpleObject};
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use axum::{http::StatusCode, response, response::IntoResponse, Extension, Router};
 use futures::lock::Mutex;
@@ -78,7 +78,7 @@ pub struct Validator {
     pub network_address: String,
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
@@ -110,7 +110,7 @@ where
     }
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -7,8 +7,8 @@ use async_graphql::{
     futures_util::Stream,
     parser::types::{DocumentOperations, ExecutableDocument, OperationType},
     resolver_utils::ContainerType,
-    Error, MergedObject, Object, OutputType, Request, ScalarType, Schema, ServerError,
-    SimpleObject, Subscription,
+    Error, MergedObject, OutputType, Request, ScalarType, Schema, ServerError, SimpleObject,
+    Subscription,
 };
 use async_graphql_axum::{GraphQLRequest, GraphQLResponse, GraphQLSubscription};
 use axum::{extract::Path, http::StatusCode, response, response::IntoResponse, Extension, Router};
@@ -271,7 +271,7 @@ where
     }
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<P, S, C> MutationRoot<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
@@ -699,7 +699,7 @@ where
     }
 }
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
@@ -793,7 +793,7 @@ where
 
 struct ChainStateViewExtension(ChainId);
 
-#[Object(cache_control(no_cache))]
+#[async_graphql::Object(cache_control(no_cache))]
 impl ChainStateViewExtension {
     async fn chain_id(&self) -> ChainId {
         self.0

--- a/linera-views/src/graphql.rs
+++ b/linera-views/src/graphql.rs
@@ -229,7 +229,7 @@ impl<C: Send + Sync, V: async_graphql::OutputType> async_graphql::TypeName for B
         .into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C, V> ByteMapView<C, V>
 where
     C: Context + Send + Sync,
@@ -299,7 +299,7 @@ impl<C: Send + Sync, I: async_graphql::OutputType, V: async_graphql::OutputType>
         .into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C, I, V> MapView<C, I, V>
 where
     C: Context + Send + Sync,
@@ -371,7 +371,7 @@ impl<C: Send + Sync, I: async_graphql::OutputType, V: async_graphql::OutputType>
         format!("CustomMapView_{}_{}", I::type_name(), V::type_name()).into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C, I, V> CustomMapView<C, I, V>
 where
     C: Context + Send + Sync,
@@ -494,7 +494,7 @@ impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
         .into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C, K, V> CollectionView<C, K, V>
 where
     C: Send + Sync + Context,
@@ -561,7 +561,7 @@ impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
         .into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C, K, V> CustomCollectionView<C, K, V>
 where
     C: Send + Sync + Context,
@@ -654,7 +654,7 @@ fn missing_key_error(key: &impl std::fmt::Debug) -> async_graphql::Error {
     }
 }
 
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C, K, V> ReentrantCollectionView<C, K, V>
 where
     C: Send + Sync + Context,
@@ -724,7 +724,7 @@ impl<C: Send + Sync, K: async_graphql::OutputType, V: async_graphql::OutputType>
         .into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C, K, V> ReentrantCustomCollectionView<C, K, V>
 where
     C: Send + Sync + Context,
@@ -858,7 +858,7 @@ impl<C: Send + Sync, T: async_graphql::OutputType> async_graphql::TypeName for L
         .into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C: Context, T: async_graphql::OutputType> LogView<C, T>
 where
     C: Send + Sync,
@@ -915,7 +915,7 @@ impl<C: Send + Sync, T: async_graphql::OutputType> async_graphql::TypeName for Q
         .into()
     }
 }
-#[async_graphql::Object(name_type)]
+#[async_graphql::Object(cache_control(no_cache), name_type)]
 impl<C: Context, T: async_graphql::OutputType> QueueView<C, T>
 where
     C: Send + Sync,


### PR DESCRIPTION
## Motivation

The use case of graphQL caches is to cases where the data consistency is not that important (social media, etc.). But that is not the case for blockchains.

## Proposal

The following is done:
* The `async_graph::`prefix is removed in 3 instances.
* To, the `#[Object]` entries, a `cache_control(no_cache)` is added.
* It has not been added to the `examples` which may be needed.



## Test Plan

This may remove some errors occurring in the CI, though at the present time we cannot point out CI failures to GraphQL errors.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
