### PR TITLE
Fix further incorrect leftover changes to `ChainStateView`

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -150,9 +150,9 @@ where
         &mut self,
         bytecode_id: BytecodeId,
     ) -> Result<Option<BytecodeLocation>, WorkerError> {
-        self.ensure_is_active()?;
-        let response = self.chain.read_bytecode_location(bytecode_id).await?;
-        Ok(response)
+        ChainWorkerStateWithTemporaryChanges { state: self }
+            .read_bytecode_location(bytecode_id)
+            .await
     }
 
     /// Returns an application's description.
@@ -613,6 +613,18 @@ where
             .chain
             .query_application(local_time, query)
             .await?;
+        Ok(response)
+    }
+
+    /// Returns the [`BytecodeLocation`] for the requested [`BytecodeId`], if it is known by the
+    /// chain.
+    #[cfg(with_testing)]
+    pub async fn read_bytecode_location(
+        &mut self,
+        bytecode_id: BytecodeId,
+    ) -> Result<Option<BytecodeLocation>, WorkerError> {
+        self.state.ensure_is_active()?;
+        let response = self.state.chain.read_bytecode_location(bytecode_id).await?;
         Ok(response)
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -160,9 +160,9 @@ where
         &mut self,
         application_id: UserApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
-        self.ensure_is_active()?;
-        let response = self.chain.describe_application(application_id).await?;
-        Ok(response)
+        ChainWorkerStateWithTemporaryChanges { state: self }
+            .describe_application(application_id)
+            .await
     }
 
     /// Executes a block without persisting any changes to the state.
@@ -625,6 +625,20 @@ where
     ) -> Result<Option<BytecodeLocation>, WorkerError> {
         self.state.ensure_is_active()?;
         let response = self.state.chain.read_bytecode_location(bytecode_id).await?;
+        Ok(response)
+    }
+
+    /// Returns an application's description.
+    pub async fn describe_application(
+        &mut self,
+        application_id: UserApplicationId,
+    ) -> Result<UserApplicationDescription, WorkerError> {
+        self.state.ensure_is_active()?;
+        let response = self
+            .state
+            .chain
+            .describe_application(application_id)
+            .await?;
         Ok(response)
     }
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -131,18 +131,9 @@ where
         height: BlockHeight,
         index: u32,
     ) -> Result<Option<Event>, WorkerError> {
-        self.ensure_is_active()?;
-
-        let mut inbox = self.chain.inboxes.try_load_entry_mut(&inbox_id).await?;
-        let mut events = inbox.added_events.iter_mut().await?;
-
-        Ok(events
-            .find(|event| {
-                event.certificate_hash == certificate_hash
-                    && event.height == height
-                    && event.index == index
-            })
-            .cloned())
+        ChainWorkerStateWithTemporaryChanges { state: self }
+            .find_event_in_inbox(inbox_id, certificate_hash, height, index)
+            .await
     }
 
     /// Queries an application's state on the chain.
@@ -584,6 +575,34 @@ where
             .read_certificate(certificate_hash)
             .await?;
         Ok(Some(certificate))
+    }
+
+    /// Searches for an event in one of the chain's inboxes.
+    #[cfg(with_testing)]
+    pub async fn find_event_in_inbox(
+        &mut self,
+        inbox_id: Origin,
+        certificate_hash: CryptoHash,
+        height: BlockHeight,
+        index: u32,
+    ) -> Result<Option<Event>, WorkerError> {
+        self.state.ensure_is_active()?;
+
+        let mut inbox = self
+            .state
+            .chain
+            .inboxes
+            .try_load_entry_mut(&inbox_id)
+            .await?;
+        let mut events = inbox.added_events.iter_mut().await?;
+
+        Ok(events
+            .find(|event| {
+                event.certificate_hash == certificate_hash
+                    && event.height == height
+                    && event.index == index
+            })
+            .cloned())
     }
 
     /// Executes a block without persisting any changes to the state.


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
PR #2180 created some wrapper types to ensure that changes to the `ChainStateView` in the `ChainWorkerState` are rolled back on early termination. However, the heuristic I used to select which methods to move to the wrapper types was incomplete. I only checked the methods that had calls to `chain.save()` or `chain.rollback()`, but some methods still perform changes that were assumed to be dropped after the request completed.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use a broader and more cautious heuristic instead: every method that has a `&mut self` receiver and uses the `ChainStateView`'s fields or methods *must* use one of the wrapper types. The only exception to the rule is the `get_chain_state_view`, which uses `chain.clone_unchecked()`. This is an exception because that method is derived on the `ChainStateView` and does not change it.

## Test Plan

<!-- How to test that the changes are correct. -->
This bug was only found because the Matching Engine integration test failed in CI in PR #2163. After rebasing that changes from that PR on top of the changes from this PR, the test succeeds again.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Internal refactor and bug fix, nothing is needed except releasing a new patch version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
