### PR TITLE
read_blob system API

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -784,7 +784,7 @@ impl std::str::FromStr for OracleResponse {
 }
 
 /// A blob of binary data.
-#[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize, Deserialize)]
+#[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize, Deserialize, WitType, WitStore)]
 pub struct Blob {
     /// Bytes of the binary blob.
     #[serde(with = "serde_bytes")]
@@ -815,11 +815,13 @@ impl From<HashedBlob> for Blob {
     }
 }
 
-/// A blob of binary data, with its content-addressed blob ID
-#[derive(Eq, PartialEq, Debug, Hash, Clone)]
+/// A blob of binary data, with its content-addressed blob ID.
+#[derive(Eq, PartialEq, Debug, Hash, Clone, WitType, WitStore)]
 pub struct HashedBlob {
-    id: BlobId,
-    blob: Blob,
+    /// ID of the blob.
+    pub id: BlobId,
+    /// A blob of binary data.
+    pub blob: Blob,
 }
 
 /// The state of a blob of binary data.

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -824,13 +824,6 @@ pub struct HashedBlob {
     pub blob: Blob,
 }
 
-/// The state of a blob of binary data.
-#[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize, Deserialize)]
-pub struct BlobState {
-    /// Hash of the last `Certificate` that published or used this blob.
-    pub last_used_by: CryptoHash,
-}
-
 impl HashedBlob {
     /// Loads a hashed blob from a file.
     pub async fn load_from_file(path: impl AsRef<std::path::Path>) -> std::io::Result<Self> {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -166,12 +166,6 @@ impl BlobId {
     pub fn new(blob: &Blob) -> Self {
         BlobId(CryptoHash::new(blob))
     }
-
-    /// Returns the blob ID of `TestString(s)`, for testing purposes.
-    #[cfg(with_testing)]
-    pub fn test_blob_id(s: impl Into<String>) -> Self {
-        BlobId(CryptoHash::test_hash(s))
-    }
 }
 
 impl Display for BlobId {

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -143,7 +143,21 @@ impl ChainDescription {
 pub struct ChainId(pub CryptoHash);
 
 /// A content-addressed blob ID i.e. the hash of the Blob.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Clone,
+    Copy,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitType,
+    WitStore,
+    WitLoad,
+)]
 #[cfg_attr(with_testing, derive(test_strategy::Arbitrary, Default))]
 pub struct BlobId(pub CryptoHash);
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -166,6 +166,12 @@ impl BlobId {
     pub fn new(blob: &Blob) -> Self {
         BlobId(CryptoHash::new(blob))
     }
+
+    /// Returns the blob ID of `TestString(s)`, for testing purposes.
+    #[cfg(with_testing)]
+    pub fn test_blob_id(s: impl Into<String>) -> Self {
+        BlobId(CryptoHash::test_hash(s))
+    }
 }
 
 impl Display for BlobId {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, collections::HashSet};
 use async_graphql::SimpleObject;
 use linera_base::{
     crypto::{BcsHashable, BcsSignable, CryptoError, CryptoHash, KeyPair, PublicKey, Signature},
-    data_types::{Amount, BlockHeight, HashedBlob, OracleRecord, Round, Timestamp},
+    data_types::{Amount, BlockHeight, HashedBlob, OracleRecord, OracleResponse, Round, Timestamp},
     doc_scalar, ensure,
     identifiers::{
         Account, BlobId, ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner,
@@ -743,6 +743,19 @@ impl ExecutedBlock {
             height: self.block.height,
             index,
         }
+    }
+
+    pub fn required_blob_ids(&self) -> HashSet<BlobId> {
+        let mut required_blob_ids = HashSet::new();
+        for record in &self.outcome.oracle_records {
+            for response in &record.responses {
+                if let OracleResponse::Blob(blob_id) = response {
+                    required_blob_ids.insert(*blob_id);
+                }
+            }
+        }
+
+        required_blob_ids
     }
 }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -71,7 +71,7 @@ impl Block {
     }
 
     /// Returns all the blob IDs referred to in this block's operations.
-    pub fn blob_ids(&self) -> HashSet<BlobId> {
+    pub fn published_blob_ids(&self) -> HashSet<BlobId> {
         let mut blob_ids = HashSet::new();
         for operation in &self.operations {
             if let Operation::System(SystemOperation::PublishBlob { blob_id }) = operation {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -15,9 +15,7 @@ use futures::{
 };
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{
-        ArithmeticError, BlockHeight, HashedBlob, OracleRecord, OracleResponse, Timestamp,
-    },
+    data_types::{ArithmeticError, BlockHeight, HashedBlob, Timestamp},
     ensure,
     identifiers::{BlobId, ChainId},
 };
@@ -31,8 +29,8 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    BytecodeLocation, ExecutionRequest, Query, QueryContext, Response, ServiceRuntimeRequest,
-    UserApplicationDescription, UserApplicationId,
+    BlobState, BytecodeLocation, ExecutionRequest, Query, QueryContext, Response,
+    ServiceRuntimeRequest, UserApplicationDescription, UserApplicationId,
 };
 use linera_storage::Storage;
 use linera_views::{
@@ -309,13 +307,14 @@ where
     async fn check_no_missing_blobs(
         &self,
         block: &Block,
+        blobs_in_block: HashSet<BlobId>,
         hashed_certificate_values: &[HashedCertificateValue],
         hashed_blobs: &[HashedBlob],
     ) -> Result<(), WorkerError> {
         let missing_bytecodes = self
             .get_missing_bytecodes(block, hashed_certificate_values)
             .await?;
-        let missing_blobs = self.get_missing_blobs(block, hashed_blobs).await?;
+        let missing_blobs = self.get_missing_blobs(blobs_in_block, hashed_blobs).await?;
 
         if missing_bytecodes.is_empty() && missing_blobs.is_empty() {
             return Ok(());
@@ -330,10 +329,9 @@ where
     /// Returns the blobs required by the block that we don't have, or an error if unrelated blobs were provided.
     async fn get_missing_blobs(
         &self,
-        block: &Block,
+        mut required_blob_ids: HashSet<BlobId>,
         hashed_blobs: &[HashedBlob],
     ) -> Result<Vec<BlobId>, WorkerError> {
-        let mut required_blob_ids = block.published_blob_ids();
         // Find all certificates containing blobs used when executing this block.
         for hashed_blob in hashed_blobs {
             let blob_id = hashed_blob.id();
@@ -344,13 +342,26 @@ where
         }
 
         let pending_blobs = &self.chain.manager.get().pending_blobs;
-        Ok(self
+        let tasks = self
             .recent_hashed_blobs
             .subtract_cached_items_from::<_, Vec<_>>(required_blob_ids, |id| id)
             .await
             .into_iter()
             .filter(|blob_id| !pending_blobs.contains_key(blob_id))
-            .collect())
+            .map(|blob_id| {
+                self.storage
+                    .contains_blob(blob_id)
+                    .map(move |result| (blob_id, result))
+            });
+
+        let mut missing_blobs = vec![];
+        for (blob_id, result) in future::join_all(tasks).await {
+            if !result? {
+                missing_blobs.push(blob_id);
+            }
+        }
+
+        Ok(missing_blobs)
     }
 
     /// Returns the blobs requested by their `blob_ids` that are either in pending in the
@@ -406,10 +417,8 @@ where
             .collect::<Vec<_>>();
         let mut missing_locations = vec![];
         for (location, result) in future::join_all(tasks).await {
-            match result {
-                Ok(true) => {}
-                Ok(false) => missing_locations.push(location),
-                Err(err) => Err(err)?,
+            if !result? {
+                missing_locations.push(location);
             }
         }
 
@@ -685,7 +694,12 @@ where
         // Verify that all required bytecode hashed certificate values and blobs are available, and no
         // unrelated ones provided.
         self.0
-            .check_no_missing_blobs(block, hashed_certificate_values, hashed_blobs)
+            .check_no_missing_blobs(
+                block,
+                block.published_blob_ids(),
+                hashed_certificate_values,
+                hashed_blobs,
+            )
             .await?;
         // Write the values so that the bytecode is available during execution.
         // TODO(#2199): We should not persist anything in storage before the block is confirmed.
@@ -1070,7 +1084,12 @@ where
         // Verify that all required bytecode hashed certificate values and blobs are available, and no
         // unrelated ones provided.
         self.state
-            .check_no_missing_blobs(block, hashed_certificate_values, hashed_blobs)
+            .check_no_missing_blobs(
+                block,
+                required_blob_ids.clone(),
+                hashed_certificate_values,
+                hashed_blobs,
+            )
             .await?;
         // Persist certificate and hashed certificate values.
         self.state
@@ -1083,31 +1102,7 @@ where
                 .await;
         }
 
-        let blob_ids_in_oracle_records = oracle_records
-            .iter()
-            .flat_map(|record| {
-                record.responses.iter().filter_map(|response| {
-                    if let OracleResponse::Blob(blob_id) = response {
-                        Some(blob_id)
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect::<HashSet<_>>();
-
-        let block_blob_ids = block.published_blob_ids();
-        let missing_blobs_from_oracles = block_blob_ids
-            .iter()
-            .filter(|block_blob_id| !blob_ids_in_oracle_records.contains(block_blob_id))
-            .cloned()
-            .collect::<Vec<_>>();
-        ensure!(
-            missing_blobs_from_oracles.is_empty(),
-            WorkerError::MissingBlockBlobsInOracles(missing_blobs_from_oracles)
-        );
-
-        let blobs_in_block = self.state.get_blobs(block_blob_ids).await?;
+        let blobs_in_block = self.state.get_blobs(required_blob_ids.clone()).await?;
         let certificate_hash = certificate.hash();
 
         let (result_hashed_certificate_value, result_blobs, result_certificate) = tokio::join!(
@@ -1122,10 +1117,14 @@ where
         result_certificate?;
 
         // Update the blob state with last used certificate hash.
-        try_join_all(blob_ids_in_oracle_records.into_iter().map(|blob_id| {
-            self.state
-                .storage
-                .write_blob_state(*blob_id, certificate_hash)
+        try_join_all(required_blob_ids.into_iter().map(|blob_id| {
+            self.state.storage.maybe_write_blob_state(
+                blob_id,
+                BlobState {
+                    last_used_by: certificate_hash,
+                    epoch: certificate.value().epoch(),
+                },
+            )
         }))
         .await?;
 

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -331,7 +331,7 @@ where
         block: &Block,
         hashed_blobs: &[HashedBlob],
     ) -> Result<Vec<BlobId>, WorkerError> {
-        let mut required_blob_ids = block.blob_ids();
+        let mut required_blob_ids = block.published_blob_ids();
         // Find all certificates containing blobs used when executing this block.
         for hashed_blob in hashed_blobs {
             let blob_id = hashed_blob.id();
@@ -1087,7 +1087,7 @@ where
             })
             .collect::<HashSet<_>>();
 
-        let block_blob_ids = block.blob_ids();
+        let block_blob_ids = block.published_blob_ids();
         let missing_blobs_from_oracles = block_blob_ids
             .iter()
             .filter(|block_blob_id| !blob_ids_in_oracle_records.contains(block_blob_id))

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1441,7 +1441,7 @@ where
             .local_node
             .read_or_download_hashed_certificate_values(nodes.clone(), block.bytecode_locations())
             .await?;
-        let hashed_blobs = self.read_local_blobs(block.blob_ids()).await?;
+        let hashed_blobs = self.read_local_blobs(block.published_blob_ids()).await?;
         // Create the final block proposal.
         let key_pair = self.key_pair().await?;
         let proposal = if let Some(cert) = manager.requested_locked {

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1445,6 +1445,16 @@ where
     client_a.synchronize_from_validators().await.unwrap();
     assert_eq!(expected_blob_id, blob_id);
     assert_eq!(certificate.round, Round::MultiLeader(0));
+    assert!(certificate
+        .value()
+        .executed_block()
+        .unwrap()
+        .outcome
+        .oracle_records
+        .iter()
+        .any(|record| record
+            .responses
+            .contains(&OracleResponse::Blob(expected_blob_id))));
     let previous_block_hash = client_a.block_hash().unwrap();
 
     // Validators goes back up

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -114,25 +114,49 @@ where
 
     let contract_blob = HashedBlob::load_from_file(contract_path.clone()).await?;
     let expected_contract_blob_id = contract_blob.id();
-    let (blob_id, _) = publisher
+    let (blob_id, certificate) = publisher
         .publish_blob(contract_blob.clone())
         .await
         .unwrap()
         .unwrap();
     assert_eq!(expected_contract_blob_id, blob_id);
+    assert!(certificate
+        .value()
+        .executed_block()
+        .unwrap()
+        .outcome
+        .oracle_records
+        .iter()
+        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
 
     let service_blob = HashedBlob::load_from_file(service_path.clone()).await?;
     let expected_service_blob_id = service_blob.id();
-    let (blob_id, _) = publisher.publish_blob(service_blob).await.unwrap().unwrap();
+    let (blob_id, certificate) = publisher.publish_blob(service_blob).await.unwrap().unwrap();
     assert_eq!(expected_service_blob_id, blob_id);
+    assert!(certificate
+        .value()
+        .executed_block()
+        .unwrap()
+        .outcome
+        .oracle_records
+        .iter()
+        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
 
     // If I try to upload the contract blob again, I should get the same blob ID
-    let (blob_id, _) = publisher
+    let (blob_id, certificate) = publisher
         .publish_blob(contract_blob)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(expected_contract_blob_id, blob_id);
+    assert!(certificate
+        .value()
+        .executed_block()
+        .unwrap()
+        .outcome
+        .oracle_records
+        .iter()
+        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
 
     let (bytecode_id, cert) = publisher
         .publish_bytecode(

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -366,15 +366,15 @@ where
             Err(
                 ref e @ NodeError::ApplicationBytecodesOrBlobsNotFound(ref locations, ref blob_ids),
             ) => {
+                if !blob_ids.is_empty() {
+                    return Err(e.clone());
+                }
+
                 if !locations.is_empty() {
                     // Some received certificates may be missing for this validator
                     // (e.g. to create the chain or make the balance sufficient) so we are going to
                     // synchronize them now and retry.
                     self.send_chain_information_for_senders(chain_id).await?;
-                }
-
-                if !blob_ids.is_empty() {
-                    return Err(e.clone());
                 }
 
                 self.node.handle_block_proposal(proposal.clone()).await?

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -266,7 +266,7 @@ where
         let required = match certificate.value() {
             CertificateValue::ConfirmedBlock { executed_block, .. }
             | CertificateValue::ValidatedBlock { executed_block, .. } => {
-                executed_block.block.blob_ids()
+                executed_block.block.published_blob_ids()
             }
             CertificateValue::Timeout { .. } => HashSet::new(),
         };

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -263,9 +263,6 @@ pub enum WorkerError {
     ApplicationBytecodesOrBlobsNotFound(Vec<BytecodeLocation>, Vec<BlobId>),
     #[error("The block proposal is invalid: {0}")]
     InvalidBlockProposal(String),
-
-    #[error("Block blobs missing from oracles: {0:?}")]
-    MissingBlockBlobsInOracles(Vec<BlobId>),
 }
 
 impl From<linera_chain::ChainError> for WorkerError {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -263,6 +263,9 @@ pub enum WorkerError {
     ApplicationBytecodesOrBlobsNotFound(Vec<BytecodeLocation>, Vec<BlobId>),
     #[error("The block proposal is invalid: {0}")]
     InvalidBlockProposal(String),
+
+    #[error("Block blobs missing from oracles: {0:?}")]
+    MissingBlockBlobsInOracles(Vec<BlobId>),
 }
 
 impl From<linera_chain::ChainError> for WorkerError {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -547,6 +547,7 @@ impl Debug for ExecutionRequest {
                 .field("url", url)
                 .field("content_type", content_type)
                 .finish_non_exhaustive(),
+
             Request::ReadBlob { blob_id, .. } => formatter
                 .debug_struct("Request::ReadBlob")
                 .field("blob_id", blob_id)

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -7,8 +7,8 @@ use std::fmt::{self, Debug, Formatter};
 
 use futures::channel::mpsc;
 use linera_base::{
-    data_types::{Amount, ApplicationPermissions, Timestamp},
-    identifiers::{Account, MessageId, Owner},
+    data_types::{Amount, ApplicationPermissions, HashedBlob, Timestamp},
+    identifiers::{Account, BlobId, MessageId, Owner},
     ownership::ChainOwnership,
 };
 #[cfg(with_metrics)]
@@ -287,6 +287,11 @@ where
                 let bytes = body.as_ref().to_vec();
                 callback.respond(bytes);
             }
+
+            ReadBlob { blob_id, callback } => {
+                let blob = self.context().extra().get_blob(blob_id).await?;
+                callback.respond(blob);
+            }
         }
 
         Ok(())
@@ -405,6 +410,11 @@ pub enum ExecutionRequest {
         content_type: String,
         payload: Vec<u8>,
         callback: oneshot::Sender<Vec<u8>>,
+    },
+
+    ReadBlob {
+        blob_id: BlobId,
+        callback: Sender<HashedBlob>,
     },
 }
 
@@ -531,6 +541,10 @@ impl Debug for ExecutionRequest {
                 .debug_struct("ExecutionRequest::HttpPost")
                 .field("url", url)
                 .field("content_type", content_type)
+                .finish_non_exhaustive(),
+            Request::ReadBlob { blob_id, .. } => formatter
+                .debug_struct("Request::ReadBlob")
+                .field("blob_id", blob_id)
                 .finish_non_exhaustive(),
         }
     }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -548,8 +548,8 @@ impl Debug for ExecutionRequest {
                 .field("content_type", content_type)
                 .finish_non_exhaustive(),
 
-            Request::ReadBlob { blob_id, .. } => formatter
-                .debug_struct("Request::ReadBlob")
+            ExecutionRequest::ReadBlob { blob_id, .. } => formatter
+                .debug_struct("ExecutionRequest::ReadBlob")
                 .field("blob_id", blob_id)
                 .finish_non_exhaustive(),
         }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -289,7 +289,12 @@ where
             }
 
             ReadBlob { blob_id, callback } => {
-                let blob = self.context().extra().get_blob(blob_id).await?;
+                let blob = self
+                    .context()
+                    .extra()
+                    .get_blob(blob_id)
+                    .await
+                    .map_err(|_| ExecutionError::BlobNotFoundOnRead(blob_id))?;
                 callback.respond(blob);
             }
         }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -133,8 +133,6 @@ pub enum ExecutionError {
     ServiceWriteAttempt,
     #[error("Failed to load bytecode from storage {0:?}")]
     ApplicationBytecodeNotFound(Box<UserApplicationDescription>),
-    #[error("Failed to load blob from storage {0:?}")]
-    BlobNotFound(Box<BlobId>),
 
     #[error("Excessive number of bytes read from storage")]
     ExcessiveRead,
@@ -875,7 +873,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
         Ok(self
             .blobs
             .get(&blob_id)
-            .ok_or_else(|| ExecutionError::BlobNotFound(Box::new(blob_id)))?
+            .ok_or_else(|| ExecutionError::BlobNotFoundOnRead(blob_id))?
             .clone())
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -23,6 +23,7 @@ use std::{fmt, str::FromStr, sync::Arc};
 
 use async_graphql::SimpleObject;
 use async_trait::async_trait;
+use committee::Epoch;
 use custom_debug_derive::Debug;
 use dashmap::DashMap;
 use derive_more::Display;
@@ -1015,6 +1016,15 @@ impl std::fmt::Debug for Bytecode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.debug_tuple("Bytecode").finish()
     }
+}
+
+/// The state of a blob of binary data.
+#[derive(Eq, PartialEq, Debug, Hash, Clone, Serialize, Deserialize)]
+pub struct BlobState {
+    /// Hash of the last `Certificate` that published or used this blob.
+    pub last_used_by: CryptoHash,
+    /// Epoch of the `last_used_by` certificate.
+    pub epoch: Epoch,
 }
 
 /// The runtime to use for running the application.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -163,6 +163,9 @@ pub enum ExecutionError {
         timestamp: Timestamp,
         local_time: Timestamp,
     },
+
+    #[error("Blob not found on storage read: {0}")]
+    BlobNotFoundOnRead(BlobId),
 }
 
 /// The public entry points provided by the contract part of an application.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -987,7 +987,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         }
         let blob = self
             .execution_state_sender
-            .send_request(|callback| Request::ReadBlob {
+            .send_request(|callback| ExecutionRequest::ReadBlob {
                 blob_id: *blob_id,
                 callback,
             })?

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -4,8 +4,10 @@
 use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
-    data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
-    identifiers::{Account, ApplicationId, ChainId, ChannelName, MessageId, Owner},
+    data_types::{
+        Amount, ApplicationPermissions, BlockHeight, HashedBlob, SendMessageRequest, Timestamp,
+    },
+    identifiers::{Account, ApplicationId, BlobId, ChainId, ChannelName, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError},
 };
 use linera_views::batch::{Batch, WriteOperation};
@@ -338,6 +340,15 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Reads a blob from storage.
+    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<HashedBlob, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .read_blob(&blob_id)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Logs a `message` with the provided information `level`.
     fn log(_caller: &mut Caller, message: String, level: log::Level) -> Result<(), RuntimeError> {
         match level {
@@ -500,6 +511,15 @@ where
             .user_data_mut()
             .runtime
             .http_post(&query, content_type, payload)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Reads a blob from storage.
+    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<HashedBlob, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .read_blob(&blob_id)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -10,8 +10,8 @@ use futures::{stream, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::PublicKey,
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, OracleRecord, Resources, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, HashedBlob, OracleRecord, Resources,
+        SendMessageRequest, Timestamp,
     },
     identifiers::{Account, ChainDescription, ChainId, Destination, MessageId, Owner},
     ownership::ChainOwnership,
@@ -1624,4 +1624,53 @@ async fn test_close_chain() {
     .await
     .unwrap();
     assert!(view.system.closed.get());
+}
+
+/// Tests the system API call `read_blob``.
+#[tokio::test]
+async fn test_failing_read_blob() {
+    let committee = Committee::make_simple(vec![PublicKey::test_key(0).into()]);
+    let committees = BTreeMap::from([(Epoch::ZERO, committee)]);
+    let ownership = ChainOwnership::single(PublicKey::test_key(1));
+    let state = SystemExecutionState {
+        committees: committees.clone(),
+        ownership: ownership.clone(),
+        balance: Amount::from_tokens(5),
+        ..SystemExecutionState::new(Epoch::ZERO, ChainDescription::Root(0), ChainId::root(0))
+    };
+    let mut view = state.into_view().await;
+    let mut applications = register_mock_applications(&mut view, 1).await.unwrap();
+    let (application_id, application) = applications.next().unwrap();
+
+    // The application is not authorized to close the chain.
+    let context = make_operation_context();
+    let blob = HashedBlob::test_blob("test");
+    let blob_id = blob.id();
+    application.expect_call(ExpectedCall::execute_operation(
+        move |runtime, _context, _operation| {
+            assert_matches!(
+                runtime.read_blob(&blob_id),
+                Err(ExecutionError::MissingRuntimeResponse)
+            );
+            Ok(vec![])
+        },
+    ));
+    application.expect_call(ExpectedCall::default_finalize());
+
+    let mut controller = ResourceController::default();
+    let operation = Operation::User {
+        application_id,
+        bytes: vec![],
+    };
+    assert_matches!(
+        view.execute_operation(
+            context,
+            Timestamp::from(0),
+            operation,
+            None,
+            &mut controller,
+        )
+        .await,
+        Err(ExecutionError::BlobNotFoundOnRead(_))
+    );
 }

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,8 +5,8 @@
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    data_types::{Amount, Blob, BlockHeight, HashedBlob, TimeDelta, Timestamp},
+    identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
 };
 
@@ -33,6 +33,27 @@ impl From<wit_system_api::ApplicationId> for ApplicationId {
         ApplicationId {
             bytecode_id: application_id.bytecode_id.into(),
             creation: application_id.creation.into(),
+        }
+    }
+}
+
+impl From<wit_system_api::BlobId> for BlobId {
+    fn from(blob_id: wit_system_api::BlobId) -> Self {
+        BlobId(blob_id.inner0.into())
+    }
+}
+
+impl From<wit_system_api::Blob> for Blob {
+    fn from(blob: wit_system_api::Blob) -> Self {
+        Blob { bytes: blob.bytes }
+    }
+}
+
+impl From<wit_system_api::HashedBlob> for HashedBlob {
+    fn from(hashed_blob: wit_system_api::HashedBlob) -> Self {
+        HashedBlob {
+            id: hashed_blob.id.into(),
+            blob: hashed_blob.blob.into(),
         }
     }
 }

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -7,7 +7,8 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, Resources, SendMessageRequest, Timestamp},
     identifiers::{
-        Account, ApplicationId, BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner,
+        Account, ApplicationId, BlobId, BytecodeId, ChainId, ChannelName, Destination, MessageId,
+        Owner,
     },
 };
 
@@ -36,6 +37,14 @@ impl From<Owner> for wit_system_api::Owner {
     fn from(owner: Owner) -> Self {
         wit_system_api::Owner {
             inner0: owner.0.into(),
+        }
+    }
+}
+
+impl From<BlobId> for wit_system_api::BlobId {
+    fn from(blob_id: BlobId) -> Self {
+        wit_system_api::BlobId {
+            inner0: blob_id.0.into(),
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -5,8 +5,10 @@
 
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
-    data_types::{Amount, BlockHeight, Resources, SendMessageRequest, Timestamp},
-    identifiers::{Account, ApplicationId, ChainId, ChannelName, Destination, MessageId, Owner},
+    data_types::{Amount, BlockHeight, HashedBlob, Resources, SendMessageRequest, Timestamp},
+    identifiers::{
+        Account, ApplicationId, BlobId, ChainId, ChannelName, Destination, MessageId, Owner,
+    },
     ownership::{ChainOwnership, CloseChainError},
 };
 use serde::Serialize;
@@ -242,6 +244,11 @@ where
     /// owner, not a super owner.
     pub fn assert_before(&mut self, timestamp: Timestamp) {
         wit::assert_before(timestamp.into());
+    }
+
+    /// Reads a blob with the given `BlobId` from storage.
+    pub fn read_blob(&mut self, blob_id: BlobId) -> HashedBlob {
+        wit::read_blob(blob_id.into()).into()
     }
 }
 

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -5,8 +5,8 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    data_types::{Amount, Blob, BlockHeight, HashedBlob, Timestamp},
+    identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
 };
 
 use super::wit::service_system_api as wit_system_api;
@@ -20,6 +20,27 @@ impl From<wit_system_api::CryptoHash> for ChainId {
 impl From<wit_system_api::Owner> for Owner {
     fn from(owner: wit_system_api::Owner) -> Self {
         Owner(owner.inner0.into())
+    }
+}
+
+impl From<wit_system_api::HashedBlob> for HashedBlob {
+    fn from(hashed_blob: wit_system_api::HashedBlob) -> Self {
+        HashedBlob {
+            id: hashed_blob.id.into(),
+            blob: hashed_blob.blob.into(),
+        }
+    }
+}
+
+impl From<wit_system_api::BlobId> for BlobId {
+    fn from(blob_id: wit_system_api::BlobId) -> Self {
+        BlobId(blob_id.inner0.into())
+    }
+}
+
+impl From<wit_system_api::Blob> for Blob {
+    fn from(blob: wit_system_api::Blob) -> Self {
+        Blob { bytes: blob.bytes }
     }
 }
 

--- a/linera-sdk/src/service/conversions_to_wit.rs
+++ b/linera-sdk/src/service/conversions_to_wit.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::BlockHeight,
-    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
 };
 
 use super::wit::service_system_api as wit_system_api;
@@ -40,6 +40,14 @@ impl From<Owner> for wit_system_api::Owner {
     fn from(owner: Owner) -> Self {
         wit_system_api::Owner {
             inner0: owner.0.into(),
+        }
+    }
+}
+
+impl From<BlobId> for wit_system_api::BlobId {
+    fn from(blob_id: BlobId) -> Self {
+        wit_system_api::BlobId {
+            inner0: blob_id.0.into(),
         }
     }
 }

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -7,8 +7,8 @@ use std::cell::Cell;
 
 use linera_base::{
     abi::ServiceAbi,
-    data_types::{Amount, BlockHeight, Timestamp},
-    identifiers::{ApplicationId, ChainId, Owner},
+    data_types::{Amount, BlockHeight, HashedBlob, Timestamp},
+    identifiers::{ApplicationId, BlobId, ChainId, Owner},
 };
 
 use super::wit::service_system_api as wit;
@@ -143,5 +143,10 @@ where
         let value = cell.take().unwrap_or_else(fetch);
         cell.set(Some(value.clone()));
         value
+    }
+
+    /// Reads a blob with the given `BlobId` from storage.
+    pub fn read_blob(&mut self, blob_id: BlobId) -> HashedBlob {
+        wit::read_blob(blob_id.into()).into()
     }
 }

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -24,6 +24,7 @@ interface contract-system-api {
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
+    read-blob: func(blob-id: blob-id) -> hashed-blob;
     log: func(message: string, level: log-level);
     consume-fuel: func(fuel: u64);
 
@@ -45,6 +46,14 @@ interface contract-system-api {
         execute-operations: option<list<application-id>>,
         mandatory-applications: list<application-id>,
         close-chain: list<application-id>,
+    }
+
+    record blob {
+        bytes: list<u8>,
+    }
+
+    record blob-id {
+        inner0: crypto-hash,
     }
 
     record block-height {
@@ -84,6 +93,11 @@ interface contract-system-api {
     variant destination {
         recipient(chain-id),
         subscribers(channel-name),
+    }
+
+    record hashed-blob {
+        id: blob-id,
+        blob: blob,
     }
 
     enum log-level {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,6 +14,7 @@ interface service-system-api {
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
+    read-blob: func(blob-id: blob-id) -> hashed-blob;
     assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
 
@@ -24,6 +25,14 @@ interface service-system-api {
     record application-id {
         bytecode-id: bytecode-id,
         creation: message-id,
+    }
+
+    record blob {
+        bytes: list<u8>,
+    }
+
+    record blob-id {
+        inner0: crypto-hash,
     }
 
     record block-height {
@@ -43,6 +52,11 @@ interface service-system-api {
         part2: u64,
         part3: u64,
         part4: u64,
+    }
+
+    record hashed-blob {
+        id: blob-id,
+        blob: blob,
     }
 
     enum log-level {

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -414,4 +414,8 @@ where
             }
         }
     }
+
+    async fn get_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ExecutionError> {
+        Ok(self.storage.read_hashed_blob(blob_id).await?)
+    }
 }

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -122,10 +122,13 @@ pub trait Storage: Sized {
     ) -> Result<(), ViewError>;
 
     /// Writes the given blob.
-    async fn write_hashed_blob(
+    async fn write_hashed_blob(&self, blob: &HashedBlob) -> Result<(), ViewError>;
+
+    /// Writes the given blob state.
+    async fn write_blob_state(
         &self,
-        blob: &HashedBlob,
-        last_used_by: &CryptoHash,
+        blob_id: BlobId,
+        last_used_by: CryptoHash,
     ) -> Result<(), ViewError>;
 
     /// Writes several hashed certificate values.
@@ -135,11 +138,7 @@ pub trait Storage: Sized {
     ) -> Result<(), ViewError>;
 
     /// Writes several blobs.
-    async fn write_hashed_blobs(
-        &self,
-        blobs: &[HashedBlob],
-        last_used_by: &CryptoHash,
-    ) -> Result<(), ViewError>;
+    async fn write_hashed_blobs(&self, blobs: &[HashedBlob]) -> Result<(), ViewError>;
 
     /// Tests existence of the certificate with the given hash.
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError>;


### PR DESCRIPTION
## Motivation

We need a `read_blob` system API so that users are able to use blobs that were already published before. This is part of #2073

## Proposal

This implements the `read_blob` system API, handling the oracle records properly for it as well. For this PR we're not dealing with lagging validators, we'll do that in a following PR. For now if a validator doesn't have the blob, it'll just fail the block proposal.

## Test Plan

Added a test for when we try to read a blob that wasn't published yet, and making sure we fail in that case.

