### PR TITLE
Generalize client storage from the filesystem

### DIFF
--- a/linera-service/src/cli_wrappers/remote_net.rs
+++ b/linera-service/src/cli_wrappers/remote_net.rs
@@ -14,7 +14,7 @@ use crate::{
         local_net::PathProvider, ClientWrapper, Faucet, FaucetOption, LineraNet, LineraNetConfig,
         Network,
     },
-    persistent::{self, Persistent},
+    persistent::{self, Persist},
 };
 
 pub struct RemoteNetTestingConfig {
@@ -117,7 +117,7 @@ impl RemoteNet {
     async fn new(testing_prng_seed: Option<u64>, faucet: &Faucet) -> Result<Self> {
         let tmp_dir = Arc::new(tempdir()?);
         // Write json config to disk
-        Persistent::save(&mut persistent::File::new(
+        Persist::persist(&mut persistent::File::new(
             tmp_dir.path().join("genesis.json").as_path(),
             faucet.genesis_config().await?,
         )?)?;

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -688,7 +688,7 @@ impl ClientWrapper {
     }
 
     pub fn load_wallet(&self) -> Result<Wallet> {
-        Ok(WalletState::from_file(self.wallet_path().as_path())?.into_inner())
+        Ok(WalletState::from_file(self.wallet_path().as_path())?.into_value())
     }
 
     pub fn wallet_path(&self) -> PathBuf {

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -2,15 +2,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    io::{BufRead, BufReader, BufWriter, Write},
-    iter::IntoIterator,
-    path::{Path, PathBuf},
-};
+use std::{iter::IntoIterator, path::Path};
 
-use anyhow::{bail, Context as _};
-use fs4::FileExt as _;
-use fs_err::{self, File, OpenOptions};
 use linera_base::{
     crypto::{BcsSignable, CryptoRng, KeyPair, PublicKey},
     data_types::{Amount, Timestamp},
@@ -23,27 +16,12 @@ use linera_execution::{
 use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
-use crate::wallet::{UserChain, Wallet};
-
-pub trait Import: DeserializeOwned {
-    fn read(path: &Path) -> Result<Self, std::io::Error> {
-        let data = fs_err::read(path)?;
-        Ok(serde_json::from_slice(data.as_slice())?)
-    }
-}
-
-pub trait Export: Serialize {
-    fn write(&self, path: &Path) -> Result<(), std::io::Error> {
-        let file = OpenOptions::new().create(true).write(true).open(path)?;
-        let mut writer = BufWriter::new(file);
-        let data = serde_json::to_string_pretty(self).unwrap();
-        writer.write_all(data.as_ref())?;
-        writer.write_all(b"\n")?;
-        Ok(())
-    }
-}
+use crate::{
+    persistent::{self, Persistent},
+    wallet::{UserChain, Wallet},
+};
 
 /// The public configuration of a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -62,17 +40,11 @@ pub struct ValidatorServerConfig {
     pub internal_network: ValidatorInternalNetworkConfig,
 }
 
-impl Import for ValidatorServerConfig {}
-impl Export for ValidatorServerConfig {}
-
 /// The (public) configuration for all validators.
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct CommitteeConfig {
     pub validators: Vec<ValidatorConfig>,
 }
-
-impl Import for CommitteeConfig {}
-impl Export for CommitteeConfig {}
 
 impl CommitteeConfig {
     pub fn into_committee(self, policy: ResourceControlPolicy) -> Committee {
@@ -93,147 +65,68 @@ impl CommitteeConfig {
     }
 }
 
-/// A guard that keeps an exclusive lock on a file.
-pub struct FileLock {
-    file: File,
-}
-
-impl FileLock {
-    /// Acquires an exclusive lock on a provided `file`, returning a [`FileLock`] which will
-    /// release the lock when dropped.
-    pub fn new(file: File, path: &Path) -> Result<Self, anyhow::Error> {
-        file.file().try_lock_exclusive().with_context(|| {
-            format!(
-                "Error getting write lock to wallet \"{}\". Please make sure the file exists \
-                 and that it is not in use by another process already.",
-                path.display()
-            )
-        })?;
-
-        Ok(FileLock { file })
-    }
-}
-
-impl Drop for FileLock {
-    fn drop(&mut self) {
-        if let Err(error) = self.file.file().unlock() {
-            tracing::warn!("Failed to unlock wallet file: {error}");
-        }
-    }
-}
-
-/// A wrapper around `Wallet` which owns a [`FileLock`] to prevent
-/// two processes accessing it at the same time.
+/// The runtime state of the wallet, persisted atomically on change via an instance of
+/// [`Persistent`].
 pub struct WalletState {
-    inner: Wallet,
+    wallet: persistent::File<Wallet>,
     prng: Box<dyn CryptoRng>,
-    wallet_path: PathBuf,
-    _lock: FileLock,
+}
+
+impl std::ops::Deref for WalletState {
+    type Target = Wallet;
+
+    fn deref(&self) -> &Wallet {
+        &self.wallet
+    }
+}
+
+impl Persistent for WalletState {
+    type Error = anyhow::Error;
+
+    fn save(this: &mut Self) -> anyhow::Result<()> {
+        Persistent::as_mut(&mut this.wallet).refresh_prng_seed(&mut this.prng);
+        Persistent::save(&mut this.wallet)?;
+        tracing::debug!("Persisted user chains");
+        Ok(())
+    }
+
+    fn as_mut(this: &mut Self) -> &mut Wallet {
+        Persistent::as_mut(&mut this.wallet)
+    }
 }
 
 impl Extend<UserChain> for WalletState {
     fn extend<Chains: IntoIterator<Item = UserChain>>(&mut self, chains: Chains) {
-        self.inner.extend(chains);
+        Persistent::mutate(&mut self.wallet).extend(chains);
     }
 }
 
 impl WalletState {
-    pub fn inner(&self) -> &Wallet {
-        &self.inner
-    }
-
-    pub fn inner_mut(&mut self) -> &mut Wallet {
-        &mut self.inner
-    }
-
-    pub fn into_inner(self) -> Wallet {
-        self.inner
+    fn new(wallet: persistent::File<Wallet>) -> Self {
+        Self {
+            prng: wallet.make_prng(),
+            wallet,
+        }
     }
 
     pub fn from_file(path: &Path) -> Result<Self, anyhow::Error> {
-        let file = OpenOptions::new().read(true).write(true).open(path)?;
-        let file_lock = FileLock::new(file, path)?;
-        let inner: Wallet = serde_json::from_reader(BufReader::new(&file_lock.file))?;
-        Ok(Self {
-            prng: inner.make_prng(),
-            inner,
-            wallet_path: path.into(),
-            _lock: file_lock,
-        })
+        Ok(Self::new(persistent::File::read_or_create(path, || {
+            anyhow::bail!("wallet file not found: {}", path.display())
+        })?))
     }
 
-    pub fn create(
-        path: &Path,
-        genesis_config: GenesisConfig,
-        testing_prng_seed: Option<u64>,
-    ) -> Result<Self, anyhow::Error> {
-        let file = Self::open_options().read(true).open(path)?;
-        let file_lock = FileLock::new(file, path)?;
-        let mut reader = BufReader::new(&file_lock.file);
-        let inner = if reader.fill_buf()?.is_empty() {
-            Wallet::new(genesis_config, testing_prng_seed)
-        } else {
-            serde_json::from_reader(reader)?
-        };
-
-        Ok(Self {
-            prng: inner.make_prng(),
-            inner,
-            wallet_path: path.into(),
-            _lock: file_lock,
-        })
-    }
-
-    /// Writes the wallet to disk.
-    ///
-    /// The contents of the wallet need to be over-written completely, so
-    /// a temporary file is created as a backup in case a crash occurs while
-    /// writing to disk.
-    ///
-    /// The temporary file is then renamed to the original wallet name. If
-    /// serialization or writing to disk fails, the temporary filed is
-    /// deleted.
-    pub fn write(&mut self) -> Result<(), anyhow::Error> {
-        let mut temp_file_path = self.wallet_path.clone();
-        temp_file_path.set_extension("json.bak");
-        let backup_file = Self::open_options().open(&temp_file_path)?;
-        let mut temp_file_writer = BufWriter::new(backup_file);
-        if let Err(e) = serde_json::to_writer_pretty(&mut temp_file_writer, &self.inner) {
-            fs_err::remove_file(&temp_file_path)?;
-            bail!("failed to serialize the wallet state: {}", e)
-        }
-        if let Err(e) = temp_file_writer.flush() {
-            fs_err::remove_file(&temp_file_path)?;
-            bail!("failed to write the wallet state: {}", e);
-        }
-        fs_err::rename(&temp_file_path, &self.wallet_path)?;
-        Ok(())
+    pub fn create(path: &Path, wallet: Wallet) -> Result<Self, anyhow::Error> {
+        Ok(Self::new(persistent::File::read_or_create(path, || {
+            Ok(wallet)
+        })?))
     }
 
     pub fn generate_key_pair(&mut self) -> KeyPair {
         KeyPair::generate_from(&mut self.prng)
     }
 
-    pub fn save(&mut self) -> anyhow::Result<()> {
-        self.inner.refresh_prng_seed(&mut self.prng);
-        self.write()?;
-        tracing::info!("Saved user chain states");
-        Ok(())
-    }
-
-    pub fn refresh_prng_seed(&mut self) {
-        self.inner.refresh_prng_seed(&mut self.prng)
-    }
-
-    /// Returns options for opening and writing to the wallet file, creating it if it doesn't
-    /// exist. On Unix, this restricts read and write permissions to the current user.
-    // TODO(#1924): Implement better key management.
-    fn open_options() -> OpenOptions {
-        let mut options = OpenOptions::new();
-        #[cfg(target_family = "unix")]
-        fs_err::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
-        options.create(true).write(true);
-        options
+    pub fn into_value(self) -> Wallet {
+        self.wallet.into_value()
     }
 }
 
@@ -247,8 +140,6 @@ pub struct GenesisConfig {
     pub network_name: String,
 }
 
-impl Import for GenesisConfig {}
-impl Export for GenesisConfig {}
 impl BcsSignable for GenesisConfig {}
 
 impl GenesisConfig {

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -19,7 +19,7 @@ use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    persistent::{self, Persistent},
+    persistent::{self, Persist},
     wallet::{UserChain, Wallet},
 };
 
@@ -66,7 +66,7 @@ impl CommitteeConfig {
 }
 
 /// The runtime state of the wallet, persisted atomically on change via an instance of
-/// [`Persistent`].
+/// [`Persist`].
 pub struct WalletState {
     wallet: persistent::File<Wallet>,
     prng: Box<dyn CryptoRng>,
@@ -80,23 +80,23 @@ impl std::ops::Deref for WalletState {
     }
 }
 
-impl Persistent for WalletState {
+impl Persist for WalletState {
     type Error = anyhow::Error;
 
-    fn save(this: &mut Self) -> anyhow::Result<()> {
-        Persistent::mutate(&mut this.wallet).refresh_prng_seed(&mut this.prng);
+    fn persist(this: &mut Self) -> anyhow::Result<()> {
+        Persist::mutate(&mut this.wallet).refresh_prng_seed(&mut this.prng);
         tracing::debug!("Persisted user chains");
         Ok(())
     }
 
     fn as_mut(this: &mut Self) -> &mut Wallet {
-        Persistent::as_mut(&mut this.wallet)
+        Persist::as_mut(&mut this.wallet)
     }
 }
 
 impl Extend<UserChain> for WalletState {
     fn extend<Chains: IntoIterator<Item = UserChain>>(&mut self, chains: Chains) {
-        Persistent::mutate(self).extend(chains);
+        Persist::mutate(self).extend(chains);
     }
 }
 

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -84,8 +84,7 @@ impl Persistent for WalletState {
     type Error = anyhow::Error;
 
     fn save(this: &mut Self) -> anyhow::Result<()> {
-        Persistent::as_mut(&mut this.wallet).refresh_prng_seed(&mut this.prng);
-        Persistent::save(&mut this.wallet)?;
+        Persistent::mutate(&mut this.wallet).refresh_prng_seed(&mut this.prng);
         tracing::debug!("Persisted user chains");
         Ok(())
     }
@@ -97,7 +96,7 @@ impl Persistent for WalletState {
 
 impl Extend<UserChain> for WalletState {
     fn extend<Chains: IntoIterator<Item = UserChain>>(&mut self, chains: Chains) {
-        Persistent::mutate(&mut self.wallet).extend(chains);
+        Persistent::mutate(self).extend(chains);
     }
 }
 

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -12,6 +12,7 @@ pub mod config;
 pub mod faucet;
 pub mod grpc_proxy;
 pub mod node_service;
+pub mod persistent;
 pub mod project;
 #[cfg(with_metrics)]
 pub mod prometheus_server;

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -66,7 +66,7 @@ use {
 
 use crate::{
     client_options::{ChainOwnershipConfig, ClientOptions},
-    persistent::Persistent,
+    persistent::Persist,
 };
 
 pub struct ClientContext<Storage>
@@ -122,7 +122,7 @@ where
 {
     /// Returns the [`Wallet`] as a mutable reference.
     pub fn wallet_mut(&mut self) -> impl std::ops::DerefMut<Target = Wallet> + '_ {
-        Persistent::mutate(&mut self.wallet)
+        Persist::mutate(&mut self.wallet)
     }
 
     pub fn new(storage: S, options: &ClientOptions, wallet: WalletState) -> Self {
@@ -204,7 +204,7 @@ where
     }
 
     pub fn save_wallet(&mut self) {
-        Persistent::save(&mut self.wallet).expect("Unable to write user chains");
+        Persist::persist(&mut self.wallet).expect("Unable to write user chains");
     }
 
     async fn update_wallet_from_client(&mut self, state: &mut ChainClient<NodeProvider, S>) {

--- a/linera-service/src/linera/client_options.rs
+++ b/linera-service/src/linera/client_options.rs
@@ -21,6 +21,7 @@ use linera_service::{
     config::WalletState,
     storage::{full_initialize_storage, run_with_storage, StorageConfigNamespace},
     util,
+    wallet::Wallet,
 };
 use linera_views::common::CommonStoreConfig;
 
@@ -136,7 +137,7 @@ impl ClientOptions {
             self.storage_config()?
                 .add_common_config(self.common_config())
                 .await?,
-            &wallet.inner().genesis_config().clone(),
+            &wallet.genesis_config().clone(),
             self.wasm_runtime.with_wasm_default(),
             Job(self, wallet),
         )
@@ -170,7 +171,7 @@ impl ClientOptions {
             self.storage_config()?
                 .add_common_config(self.common_config())
                 .await?,
-            wallet.inner().genesis_config(),
+            wallet.genesis_config(),
         )
         .await?;
         Ok(())
@@ -211,7 +212,7 @@ impl ClientOptions {
             "Wallet already exists at {}. Aborting",
             wallet_path.display()
         );
-        WalletState::create(&wallet_path, genesis_config, testing_prng_seed)
+        WalletState::create(&wallet_path, Wallet::new(genesis_config, testing_prng_seed))
     }
 }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -39,7 +39,7 @@ use linera_service::{
     config::{CommitteeConfig, GenesisConfig, WalletState},
     faucet::FaucetService,
     node_service::NodeService,
-    persistent::{self, Persistent},
+    persistent::{self, Persist},
     project::{self, Project},
     storage::Runnable,
     util,
@@ -1298,7 +1298,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                 genesis_config_path,
                 GenesisConfig::new(committee_config, admin_id, timestamp, policy, network_name),
             )?;
-            let mut genesis_config_ref = Persistent::mutate(&mut genesis_config);
+            let mut genesis_config_ref = Persist::mutate(&mut genesis_config);
             let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
             let mut chains = vec![];
             for i in 0..*num_other_initial_chains {
@@ -1336,7 +1336,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
             let mut wallet = options.wallet()?;
             let key_pair = wallet.generate_key_pair();
             let public = key_pair.public();
-            Persistent::mutate(&mut wallet).add_unassigned_key_pair(key_pair);
+            Persist::mutate(&mut wallet).add_unassigned_key_pair(key_pair);
             println!("{}", public);
             Ok(())
         }
@@ -1412,17 +1412,17 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
             }
 
             WalletCommand::SetDefault { chain_id } => {
-                Persistent::mutate(&mut options.wallet()?).set_default_chain(*chain_id)?;
+                Persist::mutate(&mut options.wallet()?).set_default_chain(*chain_id)?;
                 Ok(())
             }
 
             WalletCommand::ForgetKeys { chain_id } => {
-                Persistent::mutate(&mut options.wallet()?).forget_keys(chain_id)?;
+                Persist::mutate(&mut options.wallet()?).forget_keys(chain_id)?;
                 Ok(())
             }
 
             WalletCommand::ForgetChain { chain_id } => {
-                Persistent::mutate(&mut options.wallet()?).forget_chain(chain_id)?;
+                Persist::mutate(&mut options.wallet()?).forget_chain(chain_id)?;
                 Ok(())
             }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -36,11 +36,13 @@ use linera_execution::{
 use linera_service::{
     chain_listener::ClientContext as _,
     cli_wrappers,
-    config::{CommitteeConfig, Export, GenesisConfig, Import, WalletState},
+    config::{CommitteeConfig, GenesisConfig, WalletState},
     faucet::FaucetService,
     node_service::NodeService,
+    persistent::{self, Persistent},
     project::{self, Project},
     storage::Runnable,
+    util,
     wallet::UserChain,
 };
 use linera_storage::Storage;
@@ -144,7 +146,7 @@ impl Runnable for Job {
                 let (new_public_key, key_pair) = match public_key {
                     Some(key) => (key, None),
                     None => {
-                        let key_pair = context.wallet_state.generate_key_pair();
+                        let key_pair = context.wallet.generate_key_pair();
                         (key_pair.public(), Some(key_pair))
                     }
                 };
@@ -170,7 +172,6 @@ impl Runnable for Job {
                     _ => panic!("Unexpected certificate."),
                 };
                 context.update_wallet_for_new_chain(id, key_pair, timestamp);
-                context.save_wallet();
                 let time_total = time_start.elapsed();
                 info!("Operation confirmed after {} ms", time_total.as_millis());
                 debug!("{:?}", certificate);
@@ -218,7 +219,6 @@ impl Runnable for Job {
                     _ => panic!("Unexpected certificate."),
                 };
                 context.update_wallet_for_new_chain(id, key_pair, timestamp);
-                context.save_wallet();
                 let time_total = time_start.elapsed();
                 info!("Operation confirmed after {} ms", time_total.as_millis());
                 debug!("{:?}", certificate);
@@ -1026,7 +1026,7 @@ impl Runnable for Job {
                 with_other_chains,
                 ..
             }) => {
-                let key_pair = context.wallet_state.generate_key_pair();
+                let key_pair = context.wallet.generate_key_pair();
                 let public_key = key_pair.public();
                 info!(
                     "Requesting a new chain for owner {} using the faucet at address {}",
@@ -1055,7 +1055,6 @@ impl Runnable for Job {
                     .chain([admin_id, outcome.chain_id]);
                 Self::print_peg_certificate_hash(storage, chains, &context).await?;
                 context.wallet_mut().set_default_chain(outcome.chain_id)?;
-                context.save_wallet();
             }
 
             CreateGenesisConfig { .. } | Keygen | Net(_) | Wallet(_) | HelpMarkdown => {
@@ -1258,7 +1257,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
             testing_prng_seed,
             network_name,
         } => {
-            let committee_config = CommitteeConfig::read(committee_config_path)
+            let committee_config: CommitteeConfig = util::read_json(committee_config_path)
                 .expect("Unable to read committee config file");
             let maximum_bytes_read_per_block = match *maximum_bytes_read_per_block {
                 Some(value) => value,
@@ -1295,8 +1294,11 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                 // Default: e.g. "linera-test-2023-11-14T23:13:20"
                 format!("linera-test-{}", Utc::now().naive_utc().format("%FT%T"))
             });
-            let mut genesis_config =
-                GenesisConfig::new(committee_config, admin_id, timestamp, policy, network_name);
+            let mut genesis_config = persistent::File::new(
+                genesis_config_path,
+                GenesisConfig::new(committee_config, admin_id, timestamp, policy, network_name),
+            )?;
+            let mut genesis_config_ref = Persistent::mutate(&mut genesis_config);
             let mut rng = Box::<dyn CryptoRng>::from(*testing_prng_seed);
             let mut chains = vec![];
             for i in 0..*num_other_initial_chains {
@@ -1305,14 +1307,14 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                 let chain = UserChain::make_initial(&mut rng, description, timestamp);
                 // Public "genesis" state.
                 let key = chain.key_pair.as_ref().unwrap().public();
-                genesis_config.chains.push((key, *initial_funding));
+                genesis_config_ref.chains.push((key, *initial_funding));
                 // Private keys.
                 chains.push(chain);
             }
-            genesis_config.write(genesis_config_path)?;
-            let mut wallet_state = options.create_wallet(genesis_config, *testing_prng_seed)?;
-            wallet_state.extend(chains);
-            wallet_state.save()?;
+            drop(genesis_config_ref);
+            options
+                .create_wallet(genesis_config.into_value(), *testing_prng_seed)?
+                .extend(chains);
             options.initialize_storage().boxed().await?;
             Ok(())
         }
@@ -1334,8 +1336,7 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
             let mut wallet = options.wallet()?;
             let key_pair = wallet.generate_key_pair();
             let public = key_pair.public();
-            wallet.inner_mut().add_unassigned_key_pair(key_pair);
-            wallet.save()?;
+            Persistent::mutate(&mut wallet).add_unassigned_key_pair(key_pair);
             println!("{}", public);
             Ok(())
         }
@@ -1406,28 +1407,22 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
 
         ClientCommand::Wallet(wallet_command) => match wallet_command {
             WalletCommand::Show { chain_id } => {
-                options.wallet()?.inner().pretty_print(*chain_id);
+                options.wallet()?.pretty_print(*chain_id);
                 Ok(())
             }
 
             WalletCommand::SetDefault { chain_id } => {
-                let mut wallet = options.wallet()?;
-                wallet.inner_mut().set_default_chain(*chain_id)?;
-                wallet.save()?;
+                Persistent::mutate(&mut options.wallet()?).set_default_chain(*chain_id)?;
                 Ok(())
             }
 
             WalletCommand::ForgetKeys { chain_id } => {
-                let mut wallet = options.wallet()?;
-                wallet.inner_mut().forget_keys(chain_id)?;
-                wallet.save()?;
+                Persistent::mutate(&mut options.wallet()?).forget_keys(chain_id)?;
                 Ok(())
             }
 
             WalletCommand::ForgetChain { chain_id } => {
-                let mut wallet = options.wallet()?;
-                wallet.inner_mut().forget_chain(chain_id)?;
-                wallet.save()?;
+                Persistent::mutate(&mut options.wallet()?).forget_chain(chain_id)?;
                 Ok(())
             }
 
@@ -1438,8 +1433,8 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                 with_other_chains,
                 testing_prng_seed,
             } => {
-                let genesis_config = match (genesis_config_path, faucet) {
-                    (Some(genesis_config_path), None) => GenesisConfig::read(genesis_config_path)?,
+                let genesis_config: GenesisConfig = match (genesis_config_path, faucet) {
+                    (Some(genesis_config_path), None) => util::read_json(genesis_config_path)?,
                     (None, Some(url)) => {
                         let faucet = cli_wrappers::Faucet::new(url.clone());
                         let version_info = faucet
@@ -1474,7 +1469,6 @@ Make sure to use a Linera client compatible with this network.
                         .iter()
                         .map(|chain_id| UserChain::make_other(*chain_id, timestamp)),
                 );
-                wallet.save()?;
                 options.initialize_storage().boxed().await?;
                 if *with_new_chain {
                     ensure!(

--- a/linera-service/src/persistent/file.rs
+++ b/linera-service/src/persistent/file.rs
@@ -51,14 +51,14 @@ impl<T> std::ops::Deref for File<T> {
     }
 }
 
-/// Returns options for opening and writing to the wallet file, creating it if it doesn't
+/// Returns options for opening and writing to the file, creating it if it doesn't
 /// exist. On Unix, this restricts read and write permissions to the current user.
 // TODO(#1924): Implement better key management.
 fn open_options() -> fs_err::OpenOptions {
     let mut options = fs_err::OpenOptions::new();
     #[cfg(target_family = "unix")]
     fs_err::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
-    options.create(true).write(true);
+    options.create(true).read(true).write(true);
     options
 }
 
@@ -69,6 +69,7 @@ impl<T: serde::de::DeserializeOwned> File<T> {
                 fs_err::OpenOptions::new()
                     .read(true)
                     .write(true)
+                    .create(true)
                     .open(path)?,
                 path,
             )?,

--- a/linera-service/src/persistent/file.rs
+++ b/linera-service/src/persistent/file.rs
@@ -58,6 +58,7 @@ impl<T> std::ops::Deref for File<T> {
 /// Returns options for opening and writing to the file, creating it if it doesn't
 /// exist. On Unix, this restricts read and write permissions to the current user.
 // TODO(#1924): Implement better key management.
+// BUG(#2053): Use a separate lock file per staging file.
 fn open_options() -> fs_err::OpenOptions {
     let mut options = fs_err::OpenOptions::new();
     #[cfg(target_family = "unix")]

--- a/linera-service/src/persistent/file.rs
+++ b/linera-service/src/persistent/file.rs
@@ -1,0 +1,143 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    io::{self, BufRead as _, Write as _},
+    path::Path,
+};
+
+use anyhow::Context as _;
+use fs4::FileExt as _;
+
+use super::Persistent;
+
+/// A guard that keeps an exclusive lock on a file.
+pub struct Lock(fs_err::File);
+
+impl Lock {
+    /// Acquires an exclusive lock on a provided `file`, returning a [`Lock`] which will
+    /// release the lock when dropped.
+    pub fn new(file: fs_err::File, path: &Path) -> anyhow::Result<Self> {
+        file.file().try_lock_exclusive().with_context(|| {
+            format!(
+                "Error getting write lock \"{}\". Please make sure the file exists \
+                 and that it is not in use by another process already.",
+                path.display()
+            )
+        })?;
+
+        Ok(Lock(file))
+    }
+}
+
+impl Drop for Lock {
+    fn drop(&mut self) {
+        if let Err(error) = self.0.file().unlock() {
+            tracing::warn!("Failed to unlock wallet file: {error}");
+        }
+    }
+}
+
+pub struct File<T> {
+    _lock: Lock,
+    path: std::path::PathBuf,
+    value: T,
+}
+
+impl<T> std::ops::Deref for File<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.value
+    }
+}
+
+/// Returns options for opening and writing to the wallet file, creating it if it doesn't
+/// exist. On Unix, this restricts read and write permissions to the current user.
+// TODO(#1924): Implement better key management.
+fn open_options() -> fs_err::OpenOptions {
+    let mut options = fs_err::OpenOptions::new();
+    #[cfg(target_family = "unix")]
+    fs_err::os::unix::fs::OpenOptionsExt::mode(&mut options, 0o600);
+    options.create(true).write(true);
+    options
+}
+
+impl<T: serde::de::DeserializeOwned> File<T> {
+    pub fn new(path: &Path, value: T) -> anyhow::Result<Self> {
+        Ok(Self {
+            _lock: Lock::new(
+                fs_err::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(path)?,
+                path,
+            )?,
+            path: path.into(),
+            value,
+        })
+    }
+
+    pub fn read(path: &Path) -> anyhow::Result<Self> {
+        Self::read_or_create(path, || {
+            Err(anyhow::anyhow!("Path does not exist: {}", path.display()))
+        })
+    }
+
+    pub fn read_or_create(
+        path: &Path,
+        value: impl FnOnce() -> anyhow::Result<T>,
+    ) -> anyhow::Result<Self> {
+        let lock = Lock::new(open_options().read(true).open(path)?, path)?;
+        let mut reader = io::BufReader::new(&lock.0);
+
+        Ok(Self {
+            value: if reader.fill_buf()?.is_empty() {
+                value()?
+            } else {
+                serde_json::from_reader(reader)?
+            },
+            path: path.into(),
+            _lock: lock,
+        })
+    }
+
+    pub fn into_value(self) -> T {
+        self.value
+    }
+}
+
+impl<T: serde::Serialize + serde::de::DeserializeOwned> Persistent for File<T> {
+    type Error = anyhow::Error;
+
+    fn as_mut(this: &mut Self) -> &mut T {
+        &mut this.value
+    }
+
+    /// Writes the value to disk.
+    ///
+    /// The contents of the file need to be over-written completely, so
+    /// a temporary file is created as a backup in case a crash occurs while
+    /// writing to disk.
+    ///
+    /// The temporary file is then renamed to the original filename. If
+    /// serialization or writing to disk fails, the temporary file is
+    /// deleted.
+    fn save(this: &mut Self) -> anyhow::Result<()> {
+        let mut temp_file_path = this.path.clone();
+        temp_file_path.set_extension("json.new");
+        let temp_file = open_options().open(&temp_file_path)?;
+        let mut temp_file_writer = std::io::BufWriter::new(temp_file);
+
+        if let Err(e) = serde_json::to_writer_pretty(&mut temp_file_writer, &this.value) {
+            // TODO this should capture both errors, not abort on the first one
+            fs_err::remove_file(&temp_file_path)?;
+            anyhow::bail!("failed to serialize the wallet state: {}", e)
+        }
+        if let Err(e) = temp_file_writer.flush() {
+            fs_err::remove_file(&temp_file_path)?;
+            anyhow::bail!("failed to write the wallet state: {}", e);
+        }
+        fs_err::rename(&temp_file_path, &this.path)?;
+        Ok(())
+    }
+}

--- a/linera-service/src/persistent/file.rs
+++ b/linera-service/src/persistent/file.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Context as _;
 use fs4::FileExt as _;
 
-use super::Persistent;
+use super::Persist;
 
 /// A guard that keeps an exclusive lock on a file.
 pub struct Lock(fs_err::File);
@@ -107,7 +107,7 @@ impl<T: serde::de::DeserializeOwned> File<T> {
     }
 }
 
-impl<T: serde::Serialize + serde::de::DeserializeOwned> Persistent for File<T> {
+impl<T: serde::Serialize + serde::de::DeserializeOwned> Persist for File<T> {
     type Error = anyhow::Error;
 
     fn as_mut(this: &mut Self) -> &mut T {
@@ -123,7 +123,7 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Persistent for File<T> {
     /// The temporary file is then renamed to the original filename. If
     /// serialization or writing to disk fails, the temporary file is
     /// deleted.
-    fn save(this: &mut Self) -> anyhow::Result<()> {
+    fn persist(this: &mut Self) -> anyhow::Result<()> {
         let mut temp_file_path = this.path.clone();
         temp_file_path.set_extension("json.new");
         let temp_file = open_options().open(&temp_file_path)?;

--- a/linera-service/src/persistent/file.rs
+++ b/linera-service/src/persistent/file.rs
@@ -68,7 +68,7 @@ fn open_options() -> fs_err::OpenOptions {
 }
 
 impl<T: serde::de::DeserializeOwned> File<T> {
-    /// Create a new persistent file at `path` containing `value`.
+    /// Creates a new persistent file at `path` containing `value`.
     pub fn new(path: &Path, value: T) -> anyhow::Result<Self> {
         Ok(Self {
             _lock: Lock::new(
@@ -84,15 +84,15 @@ impl<T: serde::de::DeserializeOwned> File<T> {
         })
     }
 
-    /// Read the value from a file at `path`, returning an error if it does not exist.
+    /// Reads the value from a file at `path`, returning an error if it does not exist.
     pub fn read(path: &Path) -> anyhow::Result<Self> {
         Self::read_or_create(path, || {
             Err(anyhow::anyhow!("Path does not exist: {}", path.display()))
         })
     }
 
-    /// Read the value from a file at `path`, calling the `value` function to create it if
-    /// it does not exist.  If it does exist, `value` will not be called.
+    /// Reads the value from a file at `path`, calling the `value` function to create it
+    /// if it does not exist.  If it does exist, `value` will not be called.
     pub fn read_or_create(
         path: &Path,
         value: impl FnOnce() -> anyhow::Result<T>,
@@ -111,7 +111,7 @@ impl<T: serde::de::DeserializeOwned> File<T> {
         })
     }
 
-    /// Take the value out, releasing the lock on the persistent file.
+    /// Takes the value out, releasing the lock on the persistent file.
     pub fn into_value(self) -> T {
         self.value
     }

--- a/linera-service/src/persistent/file.rs
+++ b/linera-service/src/persistent/file.rs
@@ -139,13 +139,12 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Persist for File<T> {
         let mut temp_file_writer = std::io::BufWriter::new(temp_file);
 
         if let Err(e) = serde_json::to_writer_pretty(&mut temp_file_writer, &this.value) {
-            // TODO this should capture both errors, not abort on the first one
-            fs_err::remove_file(&temp_file_path)?;
-            anyhow::bail!("failed to serialize the wallet state: {}", e)
+            fs_err::remove_file(&temp_file_path).context("handling writing error {e}")?;
+            anyhow::bail!("failed to serialize the wallet state: {e}")
         }
         if let Err(e) = temp_file_writer.flush() {
-            fs_err::remove_file(&temp_file_path)?;
-            anyhow::bail!("failed to write the wallet state: {}", e);
+            fs_err::remove_file(&temp_file_path).context("handling flushing error {e}")?;
+            anyhow::bail!("failed to write the wallet state: {e}");
         }
         fs_err::rename(&temp_file_path, &this.path)?;
         Ok(())

--- a/linera-service/src/persistent/mod.rs
+++ b/linera-service/src/persistent/mod.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+mod file;
+
+use std::ops::{Deref, DerefMut};
+
+pub use file::File;
+
+pub trait Persistent: Deref {
+    type Error: std::fmt::Debug;
+
+    fn as_mut(_: &mut Self) -> &mut Self::Target;
+    fn save(_: &mut Self) -> Result<(), Self::Error>;
+    fn mutate(this: &mut Self) -> RefMut<Self> {
+        RefMut(this)
+    }
+}
+
+pub struct RefMut<'a, P: Persistent + ?Sized>(&'a mut P);
+
+impl<P: Persistent> Deref for RefMut<'_, P> {
+    type Target = P::Target;
+    fn deref(&self) -> &P::Target {
+        self.0.deref()
+    }
+}
+
+impl<P: Persistent> DerefMut for RefMut<'_, P> {
+    fn deref_mut(&mut self) -> &mut P::Target {
+        Persistent::as_mut(self.0)
+    }
+}
+
+impl<P: Persistent + ?Sized> Drop for RefMut<'_, P> {
+    fn drop(&mut self) {
+        if let Err(e) = Persistent::save(self.0) {
+            tracing::warn!("failed to persist value: {e:#?}");
+        }
+    }
+}

--- a/linera-service/src/persistent/mod.rs
+++ b/linera-service/src/persistent/mod.rs
@@ -8,7 +8,7 @@ use std::ops::{Deref, DerefMut};
 pub use file::File;
 
 /// The `Persist` trait provides a wrapper around a value that can be saved in a
-/// persistent way.  A minimal implementation provides an `Error` type, a `persist`
+/// persistent way. A minimal implementation provides an `Error` type, a `persist`
 /// function to persist the value, and an `as_mut` function to get a mutable reference to
 /// the value in memory.
 pub trait Persist: Deref {

--- a/linera-service/src/persistent/mod.rs
+++ b/linera-service/src/persistent/mod.rs
@@ -14,13 +14,13 @@ pub use file::File;
 pub trait Persist: Deref {
     type Error: std::fmt::Debug;
 
-    /// Get a mutable reference to the value.
+    /// Gets a mutable reference to the value.
     fn as_mut(_: &mut Self) -> &mut Self::Target;
 
-    /// Save the value to persistent storage.
+    /// Saves the value to persistent storage.
     fn persist(_: &mut Self) -> Result<(), Self::Error>;
 
-    /// Get a mutable reference to the value which, on drop, will automatically persist
+    /// Gets a mutable reference to the value which, on drop, will automatically persist
     /// the new value.
     fn mutate(this: &mut Self) -> RefMut<Self> {
         RefMut(this)

--- a/linera-service/src/persistent/mod.rs
+++ b/linera-service/src/persistent/mod.rs
@@ -7,34 +7,34 @@ use std::ops::{Deref, DerefMut};
 
 pub use file::File;
 
-pub trait Persistent: Deref {
+pub trait Persist: Deref {
     type Error: std::fmt::Debug;
 
     fn as_mut(_: &mut Self) -> &mut Self::Target;
-    fn save(_: &mut Self) -> Result<(), Self::Error>;
+    fn persist(_: &mut Self) -> Result<(), Self::Error>;
     fn mutate(this: &mut Self) -> RefMut<Self> {
         RefMut(this)
     }
 }
 
-pub struct RefMut<'a, P: Persistent + ?Sized>(&'a mut P);
+pub struct RefMut<'a, P: Persist + ?Sized>(&'a mut P);
 
-impl<P: Persistent> Deref for RefMut<'_, P> {
+impl<P: Persist> Deref for RefMut<'_, P> {
     type Target = P::Target;
     fn deref(&self) -> &P::Target {
         self.0.deref()
     }
 }
 
-impl<P: Persistent> DerefMut for RefMut<'_, P> {
+impl<P: Persist> DerefMut for RefMut<'_, P> {
     fn deref_mut(&mut self) -> &mut P::Target {
-        Persistent::as_mut(self.0)
+        Persist::as_mut(self.0)
     }
 }
 
-impl<P: Persistent + ?Sized> Drop for RefMut<'_, P> {
+impl<P: Persist + ?Sized> Drop for RefMut<'_, P> {
     fn drop(&mut self) {
-        if let Err(e) = Persistent::save(self.0) {
+        if let Err(e) = Persist::persist(self.0) {
             tracing::warn!("failed to persist value: {e:#?}");
         }
     }

--- a/linera-service/src/persistent/mod.rs
+++ b/linera-service/src/persistent/mod.rs
@@ -7,11 +7,21 @@ use std::ops::{Deref, DerefMut};
 
 pub use file::File;
 
+/// The `Persist` trait provides a wrapper around a value that can be saved in a
+/// persistent way.  A minimal implementation provides an `Error` type, a `persist`
+/// function to persist the value, and an `as_mut` function to get a mutable reference to
+/// the value in memory.
 pub trait Persist: Deref {
     type Error: std::fmt::Debug;
 
+    /// Get a mutable reference to the value.
     fn as_mut(_: &mut Self) -> &mut Self::Target;
+
+    /// Save the value to persistent storage.
     fn persist(_: &mut Self) -> Result<(), Self::Error>;
+
+    /// Get a mutable reference to the value which, on drop, will automatically persist
+    /// the new value.
     fn mutate(this: &mut Self) -> RefMut<Self> {
         RefMut(this)
     }

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -351,11 +351,7 @@ fn main() -> Result<()> {
         builder
     };
 
-    runtime
-        .enable_all()
-        .build()
-        .expect("Failed to create Tokio runtime")
-        .block_on(options.run())
+    runtime.enable_all().build()?.block_on(options.run())
 }
 
 impl ProxyOptions {
@@ -366,8 +362,7 @@ impl ProxyOptions {
             cache_size: self.cache_size,
         };
         let full_storage_config = self.storage_config.add_common_config(common_config).await?;
-        let genesis_config: GenesisConfig =
-            util::read_json(&self.genesis_config_path).expect("Fail to read initial chain config");
+        let genesis_config: GenesisConfig = util::read_json(&self.genesis_config_path)?;
         run_with_storage(
             full_storage_config,
             &genesis_config,

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -20,7 +20,7 @@ use linera_rpc::{
 #[cfg(with_metrics)]
 use linera_service::prometheus_server;
 use linera_service::{
-    config::{GenesisConfig, Import, ValidatorServerConfig},
+    config::{GenesisConfig, ValidatorServerConfig},
     grpc_proxy::GrpcProxy,
     storage::{run_with_storage, Runnable, StorageConfigNamespace},
     util,
@@ -94,7 +94,7 @@ struct ProxyContext {
 
 impl ProxyContext {
     pub fn from_options(options: &ProxyOptions) -> Result<Self> {
-        let config = ValidatorServerConfig::read(&options.config_path)?;
+        let config = util::read_json(&options.config_path)?;
         Ok(Self {
             config,
             send_timeout: options.send_timeout,
@@ -366,8 +366,8 @@ impl ProxyOptions {
             cache_size: self.cache_size,
         };
         let full_storage_config = self.storage_config.add_common_config(common_config).await?;
-        let genesis_config = GenesisConfig::read(&self.genesis_config_path)
-            .expect("Fail to read initial chain config");
+        let genesis_config: GenesisConfig =
+            util::read_json(&self.genesis_config_path).expect("Fail to read initial chain config");
         run_with_storage(
             full_storage_config,
             &genesis_config,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -4,7 +4,10 @@
 
 #![deny(clippy::large_futures)]
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use anyhow::bail;
 use async_trait::async_trait;
@@ -22,9 +25,8 @@ use linera_rpc::{
 #[cfg(with_metrics)]
 use linera_service::prometheus_server;
 use linera_service::{
-    config::{
-        CommitteeConfig, Export, GenesisConfig, Import, ValidatorConfig, ValidatorServerConfig,
-    },
+    config::{CommitteeConfig, GenesisConfig, ValidatorConfig, ValidatorServerConfig},
+    persistent::{self, Persistent},
     storage::{full_initialize_storage, run_with_storage, Runnable, StorageConfigNamespace},
     util,
 };
@@ -273,9 +275,10 @@ struct ValidatorOptions {
 }
 
 fn make_server_config<R: CryptoRng>(
+    path: &Path,
     rng: &mut R,
     options: ValidatorOptions,
-) -> ValidatorServerConfig {
+) -> anyhow::Result<persistent::File<ValidatorServerConfig>> {
     let network = ValidatorPublicNetworkConfig {
         protocol: options.external_protocol,
         host: options.host,
@@ -292,11 +295,14 @@ fn make_server_config<R: CryptoRng>(
     let key = KeyPair::generate_from(rng);
     let name = ValidatorName(key.public());
     let validator = ValidatorConfig { network, name };
-    ValidatorServerConfig {
-        validator,
-        key,
-        internal_network,
-    }
+    persistent::File::new(
+        path,
+        ValidatorServerConfig {
+            validator,
+            key,
+            internal_network,
+        },
+    )
 }
 
 #[derive(clap::Parser)]
@@ -439,10 +445,10 @@ async fn run(options: ServerOptions) {
             max_stream_queries,
             cache_size,
         } => {
-            let genesis_config = GenesisConfig::read(&genesis_config_path)
-                .expect("Fail to read initial chain config");
-            let server_config = ValidatorServerConfig::read(&server_config_path)
-                .expect("Fail to read server config");
+            let genesis_config: GenesisConfig =
+                util::read_json(&genesis_config_path).expect("Fail to read initial chain config");
+            let server_config: ValidatorServerConfig =
+                util::read_json(&server_config_path).expect("Fail to read server config");
 
             #[cfg(feature = "rocksdb")]
             if server_config.internal_network.shards.len() > 1
@@ -488,21 +494,24 @@ async fn run(options: ServerOptions) {
                 let options: ValidatorOptions =
                     toml::from_str(&options_string).expect("Invalid options file format");
                 let path = options.server_config_path.clone();
-                let server = make_server_config(&mut rng, options);
-                server
-                    .write(&path)
-                    .expect("Unable to write server config file");
+                let mut server = make_server_config(&path, &mut rng, options)
+                    .expect("Unable to open server config file");
+                Persistent::save(&mut server).expect("Unable to write server config file");
                 info!("Wrote server config {}", path.to_str().unwrap());
                 println!("{}", server.validator.name);
-                config_validators.push(server.validator);
+                config_validators.push(server.into_value().validator);
             }
             if let Some(committee) = committee {
-                let config = CommitteeConfig {
-                    validators: config_validators,
-                };
-                config
-                    .write(&committee)
-                    .expect("Unable to write committee description");
+                Persistent::save(
+                    &mut persistent::File::new(
+                        &committee,
+                        CommitteeConfig {
+                            validators: config_validators,
+                        },
+                    )
+                    .expect("Unable to open committee configuration"),
+                )
+                .expect("Unable to write committee description");
                 info!("Wrote committee config {}", committee.to_str().unwrap());
             }
         }
@@ -514,8 +523,8 @@ async fn run(options: ServerOptions) {
             max_stream_queries,
             cache_size,
         } => {
-            let genesis_config = GenesisConfig::read(&genesis_config_path)
-                .expect("Fail to read initial chain config");
+            let genesis_config: GenesisConfig =
+                util::read_json(&genesis_config_path).expect("Fail to read initial chain config");
             let common_config = CommonStoreConfig {
                 max_concurrent_queries,
                 max_stream_queries,

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -26,7 +26,7 @@ use linera_rpc::{
 use linera_service::prometheus_server;
 use linera_service::{
     config::{CommitteeConfig, GenesisConfig, ValidatorConfig, ValidatorServerConfig},
-    persistent::{self, Persistent},
+    persistent::{self, Persist},
     storage::{full_initialize_storage, run_with_storage, Runnable, StorageConfigNamespace},
     util,
 };
@@ -496,13 +496,13 @@ async fn run(options: ServerOptions) {
                 let path = options.server_config_path.clone();
                 let mut server = make_server_config(&path, &mut rng, options)
                     .expect("Unable to open server config file");
-                Persistent::save(&mut server).expect("Unable to write server config file");
+                Persist::persist(&mut server).expect("Unable to write server config file");
                 info!("Wrote server config {}", path.to_str().unwrap());
                 println!("{}", server.validator.name);
                 config_validators.push(server.into_value().validator);
             }
             if let Some(committee) = committee {
-                Persistent::save(
+                Persist::persist(
                     &mut persistent::File::new(
                         &committee,
                         CommitteeConfig {

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -183,6 +183,10 @@ pub fn parse_millis_delta(s: &str) -> Result<TimeDelta, ParseIntError> {
     Ok(TimeDelta::from_millis(s.parse()?))
 }
 
+pub fn read_json<T: serde::de::DeserializeOwned>(path: &std::path::Path) -> anyhow::Result<T> {
+    Ok(serde_json::from_reader(fs_err::File::open(path)?)?)
+}
+
 #[test]
 fn test_parse_version_message() {
     let s = "something\n . . . version12\nother things";

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -378,7 +378,7 @@ async fn test_storage_service_wallet_lock() -> Result<()> {
     let (_net, client) = config.instantiate().await?;
 
     let wallet_state = WalletState::from_file(client.wallet_path().as_path())?;
-    let chain_id = wallet_state.inner().default_chain().unwrap();
+    let chain_id = wallet_state.default_chain().unwrap();
 
     let lock = wallet_state;
     assert!(client.process_inbox(chain_id).await.is_err());


### PR DESCRIPTION
## Motivation

The browser doesn't have access to a filesystem.  In order to store and load wallet configuration, we must use a different backend, such as [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage).  Currently, though, the `linera-service` crate assumes filesystem access, and stores configuration as JSON on the filesystem.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Generalize the `WalletState` struct with a new trait that represents any data that can be persisted.  Move the previous behaviour into an implementation of that trait specialized to filesystem storage.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
