### PR TITLE
Implement multi key reading in one single requests in ScyllaDb.

### DIFF
--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -15,8 +15,11 @@
 //! [trait1]: common::KeyValueStore
 //! [trait2]: common::Context
 
-use std::{ops::Deref, sync::Arc};
-use std::collections::{hash_map::Entry, HashMap};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    ops::Deref,
+    sync::Arc,
+};
 
 use async_lock::{Semaphore, SemaphoreGuard};
 use async_trait::async_trait;
@@ -159,7 +162,7 @@ impl ScyllaDbClient {
         }
         let session = &self.session;
         let mut group_query = "?".to_string();
-        group_query.push_str(&",?".repeat(num_keys-1));
+        group_query.push_str(&",?".repeat(num_keys - 1));
         let query = format!(
             "SELECT k,v FROM kv.{} WHERE dummy = 0 AND k IN ({}) ALLOW FILTERING",
             self.namespace, group_query
@@ -168,20 +171,20 @@ impl ScyllaDbClient {
         let mut rows = session.query_iter(read_multi_value, &keys).await?;
         let mut values = Vec::with_capacity(num_keys);
         values.resize(num_keys, None);
-        let mut map = HashMap::<Vec<u8>,Vec<usize>>::new();
+        let mut map = HashMap::<Vec<u8>, Vec<usize>>::new();
         for (i_key, key) in keys.into_iter().enumerate() {
             match map.entry(key) {
                 Entry::Occupied(entry) => {
                     let entry = entry.into_mut();
                     entry.push(i_key);
-                },
+                }
                 Entry::Vacant(entry) => {
                     entry.insert(vec![i_key]);
-                },
+                }
             }
         }
         while let Some(row) = rows.next().await {
-            let value = row?.into_typed::<(Vec<u8>,Vec<u8>)>()?;
+            let value = row?.into_typed::<(Vec<u8>, Vec<u8>)>()?;
             let key = value.0;
             for i_key in map.get(&key).unwrap().clone() {
                 let value = Some(value.1.clone());
@@ -719,7 +722,7 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStore {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
-        self.store.read_multi_values_bytes(keys).await
+        Box::pin(self.store.read_multi_values_bytes(keys)).await
     }
 
     async fn find_keys_by_prefix(

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -160,19 +160,19 @@ pub fn get_random_key_values_prefix<R: Rng>(
     key_prefix: Vec<u8>,
     len_key: usize,
     len_value: usize,
-    n: usize,
+    num_entries: usize,
 ) -> Vec<(Vec<u8>, Vec<u8>)> {
     loop {
         let mut v_ret = Vec::new();
         let mut vector_set = HashSet::new();
-        for _ in 0..n {
+        for _ in 0..num_entries {
             let v1 = get_random_byte_vector(rng, &key_prefix, len_key);
             let v2 = get_random_byte_vector(rng, &Vec::new(), len_value);
             let v12 = (v1.clone(), v2);
             vector_set.insert(v1);
             v_ret.push(v12);
         }
-        if vector_set.len() == n {
+        if vector_set.len() == num_entries {
             return v_ret;
         }
     }
@@ -180,15 +180,19 @@ pub fn get_random_key_values_prefix<R: Rng>(
 
 /// Takes a random number generator rng, a number n and returns n random `(key, value)`
 /// which are all distinct with key and value being of length 8.
-pub fn get_random_key_values<R: Rng>(rng: &mut R, n: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
-    get_random_key_values_prefix(rng, Vec::new(), 8, 8, n)
+pub fn get_random_key_values<R: Rng>(rng: &mut R, num_entries: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+    get_random_key_values_prefix(rng, Vec::new(), 8, 8, num_entries)
 }
 
 type VectorPutDelete = (Vec<(Vec<u8>, Vec<u8>)>, usize);
 
 /// A bunch of puts and some deletes.
-pub fn get_random_key_value_operations<R: Rng>(rng: &mut R, n: usize, k: usize) -> VectorPutDelete {
-    let key_value_vector = get_random_key_values_prefix(rng, Vec::new(), 8, 8, n);
+pub fn get_random_key_value_operations<R: Rng>(
+    rng: &mut R,
+    num_entries: usize,
+    k: usize,
+) -> VectorPutDelete {
+    let key_value_vector = get_random_key_values_prefix(rng, Vec::new(), 8, 8, num_entries);
     (key_value_vector, k)
 }
 
@@ -319,18 +323,18 @@ pub async fn run_reads<S: LocalKeyValueStore>(store: S, key_values: Vec<(Vec<u8>
     }
 }
 
-fn get_random_key_values1(n: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+fn get_random_key_values1(num_entries: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let key_prefix = vec![0];
     let mut rng = make_deterministic_rng();
-    get_random_key_values_prefix(&mut rng, key_prefix, 8, len_value, n)
+    get_random_key_values_prefix(&mut rng, key_prefix, 8, len_value, num_entries)
 }
 
-fn get_random_key_values2(n: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+fn get_random_key_values2(num_entries: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut rng = make_deterministic_rng();
     let key_prefix = vec![0];
     let mut key_values = Vec::new();
     let mut key_set = HashSet::new();
-    for _ in 0..n {
+    for _ in 0..num_entries {
         let key = get_small_key_space(&mut rng, &key_prefix, 4);
         if !key_set.contains(&key) {
             key_set.insert(key.clone());

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -343,12 +343,12 @@ fn get_random_key_values2(n: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)>
 
 /// We build a number of scenarios for testing the reads.
 pub fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {
-    let mut scenarios = Vec::new();
-    scenarios.push(get_random_key_values1(7, 3));
-    scenarios.push(get_random_key_values1(30, 10));
-    scenarios.push(get_random_key_values2(30, 10));
-    scenarios.push(get_random_key_values2(30, 100));
-    scenarios
+    vec![
+        get_random_key_values1(7, 3),
+        get_random_key_values1(30, 10),
+        get_random_key_values2(30, 10),
+        get_random_key_values2(30, 100),
+    ]
 }
 
 fn generate_random_batch<R: Rng>(rng: &mut R, key_prefix: &[u8], batch_size: usize) -> Batch {

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -306,27 +306,28 @@ pub async fn run_reads<S: LocalKeyValueStore>(store: S, key_values: Vec<(Vec<u8>
             }
         }
         let mut test_exists = Vec::new();
+        let mut values_single_read = Vec::new();
         for key in &keys {
             test_exists.push(store.contains_key(key).await.unwrap());
+            values_single_read.push(store.read_value_bytes(key).await.unwrap());
         }
         let values_read = store.read_multi_values_bytes(keys).await.unwrap();
         assert_eq!(values, values_read);
+        assert_eq!(values, values_single_read);
         let values_read_stat = values_read.iter().map(|x| x.is_some()).collect::<Vec<_>>();
         assert_eq!(values_read_stat, test_exists);
     }
 }
 
-fn get_random_key_values1(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+fn get_random_key_values1(n: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let key_prefix = vec![0];
-    let n = 30;
     let mut rng = make_deterministic_rng();
     get_random_key_values_prefix(&mut rng, key_prefix, 8, len_value, n)
 }
 
-fn get_random_key_values2(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+fn get_random_key_values2(n: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut rng = make_deterministic_rng();
     let key_prefix = vec![0];
-    let n = 30;
     let mut key_values = Vec::new();
     let mut key_set = HashSet::new();
     for _ in 0..n {
@@ -343,10 +344,10 @@ fn get_random_key_values2(len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
 /// We build a number of scenarios for testing the reads.
 pub fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {
     let mut scenarios = Vec::new();
-    for len_value in [10, 100] {
-        scenarios.push(get_random_key_values1(len_value));
-        scenarios.push(get_random_key_values2(len_value));
-    }
+    scenarios.push(get_random_key_values1(7, 3));
+    scenarios.push(get_random_key_values1(30, 10));
+    scenarios.push(get_random_key_values2(30, 10));
+    scenarios.push(get_random_key_values2(30, 100));
     scenarios
 }
 


### PR DESCRIPTION
## Motivation

In ScyllaDb, we are currently doing the multi-key reading with a `join_all` which is suboptimal.

## Proposal

The following was done:
* The `run_reads` was updated by adding the reading of keys. Curiously the `read_value_bytes`was not tested before.
* Premature terminations if the set of keys is empty have been added. Several levels are needed since the LruCaching means that the final query could be empty while the initial one was not.
* The scenario code has been changed to get a larger variety of examples.
* The entry `k IN (?,?,?,?)` construction is used and this returns the values in disorder.
* Therefore a `HashMap<Vec<u8>,Vec<usize>>`Rust cannot deduce the types)  is needed to determine if a key is missing and the query of `k,v` allows to match the result with the queries.

The `Box::pin` is needed for a large stack identified by clippy. Maybe we could do that to other functions.

## Test Plan

The CI was slightly updated. Note that during the development process, the Lrucache had to be disabled as it led to code  passing the tests while a bug was known to be present.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
