### PR TITLE
Fix rollback making cached hash value incorrect

### DIFF
--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -75,7 +75,8 @@ where
         if delete_view {
             let mut key_prefix = self.inner.context().base_key();
             key_prefix.pop();
-            batch.delete_key_prefix(key_prefix)
+            batch.delete_key_prefix(key_prefix);
+            self.stored_hash = None;
         } else {
             let hash = *self.hash.get_mut();
             if self.stored_hash != hash {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When a view wrapped in a `WrappedHashableContainverView` is cleared and flushed, its state in the persistent storage was cleared. However, the value of the persisted hash value that was cached in memory was not cleared, making it different than the value that was actually persisted (which was an empty value, because it was also cleared). When `rollback` is called, it uses the cached stored value to update the cached staged value, which set it to an invalid value.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Clear the cached value of the stored hash value when it is cleared from disk.

## Test Plan

<!-- How to test that the changes are correct. -->
A unit test was added that reproduces a minimal scenario, and that fails without the fix and passes with the fix.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is a bug fix, so nothing is needed except releasing a new patch version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
