### PR TITLE
Rename instances of linera-test to linera

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cargo install --path linera-service --bin linera --bin linera-server --debug
       - name: Build Docker image
-        run: docker build . -f docker/Dockerfile -t linera-test
+        run: docker build . -f docker/Dockerfile -t linera
       - name: Run Compose
         run: cd docker && ./compose.sh &
       - name: Sync

--- a/docker/compose.sh
+++ b/docker/compose.sh
@@ -30,11 +30,11 @@ trap cleanup EXIT INT
 cd "$ROOT_DIR"
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-    docker build -f docker/Dockerfile . -t linera-test
+    docker build -f docker/Dockerfile . -t linera
 elif [[ "$OSTYPE" == "darwin"* ]]; then
         CPU_ARCH=$(sysctl -n machdep.cpu.brand_string)
         if [[ "$CPU_ARCH" == *"Apple"* ]]; then
-            docker build --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera-test .
+            docker build --build-arg target=aarch64-unknown-linux-gnu -f docker/Dockerfile -t linera .
         else
             echo "Unsupported Architecture: $CPU_ARCH"
             exit 1;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       SCYLLA_AUTO_CONF: 1
       SCYLLA_ENABLE_EXPERIMENTAL: 1
   proxy:
-    image: linera-test
+    image: linera
     container_name: proxy
     ports:
       - "19100:19100"
@@ -18,7 +18,7 @@ services:
       - .:/config
       - linera-shared:/shared
   shard:
-    image: linera-test
+    image: linera
     container_name: shard
     command: [ "./compose-server-entrypoint.sh" ]
     volumes:
@@ -27,7 +27,7 @@ services:
     depends_on:
       - shard-init
   shard-init:
-    image: linera-test
+    image: linera
     container_name: shard-init
     command: [ "./compose-server-init.sh" ]
     volumes:

--- a/kubernetes/linera-validator/helmfile.yaml
+++ b/kubernetes/linera-validator/helmfile.yaml
@@ -27,7 +27,7 @@ releases:
       - name: numShards
         value: {{ env "LINERA_HELMFILE_SET_NUM_SHARDS" | default 10 }}
       - name: lineraImage
-        value: {{ env "LINERA_HELMFILE_LINERA_IMAGE" | default "linera-test:latest" }}
+        value: {{ env "LINERA_HELMFILE_LINERA_IMAGE" | default "linera:latest" }}
       - name: staticIpGcpName
         value: {{ env "LINERA_HELMFILE_STATIC_IP_GCP_NAME" | default "" }}
       - name: validatorDomainName

--- a/linera-service/src/cli_wrappers/local_kubernetes_net.rs
+++ b/linera-service/src/cli_wrappers/local_kubernetes_net.rs
@@ -393,12 +393,8 @@ impl LocalKubernetesNet {
     async fn run(&mut self) -> Result<()> {
         let github_root = get_github_root().await?;
         // Build Docker image
-        let docker_image = DockerImage::build(
-            String::from("linera-test:latest"),
-            &self.binaries,
-            &github_root,
-        )
-        .await?;
+        let docker_image =
+            DockerImage::build(String::from("linera:latest"), &self.binaries, &github_root).await?;
 
         let base_dir = github_root
             .join("kubernetes")

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1292,8 +1292,8 @@ async fn run(options: ClientOptions) -> anyhow::Result<()> {
                 .unwrap_or_else(Timestamp::now);
             let admin_id = ChainId::root(*admin_root);
             let network_name = network_name.clone().unwrap_or_else(|| {
-                // Default: e.g. "linera-test-2023-11-14T23:13:20"
-                format!("linera-test-{}", Utc::now().naive_utc().format("%FT%T"))
+                // Default: e.g. "linera-2023-11-14T23:13:20"
+                format!("linera-{}", Utc::now().naive_utc().format("%FT%T"))
             });
             let mut genesis_config =
                 GenesisConfig::new(committee_config, admin_id, timestamp, policy, network_name);


### PR DESCRIPTION
## Motivation

The name `linera-test` for the Linera Docker image is no longer representative of the function of the image.

## Proposal

Rename the Linera Docker image from `linera-test` to `linera`.

## Test Plan

CI should catch any regressions.
