### PR TITLE
Don't use `Some(OracleRecord::default())` as oracle in tests

### DIFF
--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -488,7 +488,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await?;

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, vec};
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
@@ -206,7 +206,7 @@ async fn test_fee_consumption(
             } else {
                 None
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -10,7 +10,7 @@ use futures::{stream, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::PublicKey,
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, OracleRecord, Resources, SendMessageRequest,
+        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest,
         Timestamp,
     },
     identifiers::{Account, ChainDescription, ChainId, Destination, MessageId, Owner},
@@ -59,7 +59,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: *app_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await;
@@ -155,7 +155,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: dummy_operation.clone(),
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await
@@ -309,7 +309,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await?;
@@ -410,7 +410,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await;
@@ -451,7 +451,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
                 application_id: id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await;
@@ -522,7 +522,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await;
@@ -639,7 +639,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await?;
@@ -746,7 +746,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await;
@@ -806,7 +806,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await;
@@ -865,7 +865,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await;
@@ -922,7 +922,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await,
@@ -976,7 +976,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
                 application_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await?;
@@ -1078,7 +1078,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await?;
@@ -1194,7 +1194,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await?;
@@ -1355,7 +1355,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await?;
@@ -1496,7 +1496,7 @@ async fn test_open_chain() {
             context,
             Timestamp::from(0),
             operation,
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await
@@ -1578,7 +1578,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(OracleRecord::default()),
+        None,
         &mut controller,
     )
     .await
@@ -1592,7 +1592,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation.into(),
-        Some(OracleRecord::default()),
+        None,
         &mut controller,
     )
     .await
@@ -1614,7 +1614,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(OracleRecord::default()),
+        None,
         &mut controller,
     )
     .await

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
@@ -42,7 +42,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
             context,
             Timestamp::from(0),
             Operation::System(operation),
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await
@@ -92,7 +92,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
             Timestamp::from(0),
             Message::System(message),
             None,
-            Some(OracleRecord::default()),
+            None,
             &mut controller,
         )
         .await

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -93,7 +93,7 @@ async fn test_fuel_for_counter_wasm_application(
                 context,
                 Timestamp::from(0),
                 Operation::user(app_id, increment).unwrap(),
-                Some(OracleRecord::default()),
+                None,
                 &mut controller,
             )
             .await?;


### PR DESCRIPTION
## Motivation

Right now for user actions if the `OracleRecord` is `Some`, we set `OracleResponses` to `Replay`, regardless of what the `OracleRecord` contains. On the system API calls that deal with `Replay`, the pattern we see is that if the `OracleResponses` is set to `Replay`, we'll try to replay the `OracleResponse`s inside. If we have no `OracleResponse`s inside, we'll error out with `ExecutionError::MissingOracleResponse`.
The pattern we see on tests right now is to pass `Some(OracleRecord::default())` as the `OracleRecord`, which will generate a set of empty `OracleResponses`, which would fail. The reason it doesn't fail right now is that we don't test these system API calls using this pattern.

## Proposal

All that is to say that I believe the pattern we should use is `None` as the `OracleRecord`, because we should always be "recording" in tests, because it'll likely be the first time we're running things. So I'm altering the code to follow that pattern instead, as I believe it's more correct.
There's a chance we're setting `Replay`/`Record` in a wrong way, but I'm not sure, so open to comments if that's the case.

## Test Plan

CI

