### PR TITLE
Give validators weight 100 by default.

### DIFF
--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -84,7 +84,7 @@ impl CommitteeConfig {
                     v.name,
                     ValidatorState {
                         network_address: v.network.to_string(),
-                        votes: 1,
+                        votes: 100,
                     },
                 )
             })

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2490,8 +2490,13 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     client.query_validators(Some(chain_1)).await?;
 
     // Add 6th validator
+    // TODO(#2212): Use weight 100.
     client
-        .set_validator(net.validator_name(5).unwrap(), LocalNet::proxy_port(5), 100)
+        .set_validator(
+            net.validator_name(5).unwrap(),
+            LocalNet::proxy_port(5),
+            10000,
+        )
         .await?;
 
     // Remove 5th validator
@@ -2508,7 +2513,9 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         let name = net.validator_name(i).unwrap();
         client.remove_validator(name).await?;
         net.remove_validator(i)?;
-        if node_service_2.is_none() {
+        if let Some(service) = &node_service_2 {
+            service.process_inbox(&chain_2).await?;
+        } else {
             client_2.process_inbox(chain_2).await?;
         }
     }


### PR DESCRIPTION
## Motivation

In CLI commands, if no weights are specified, each new validator gets weight 100. This was done so that it's easy to later add e.g. a "half-weight" validator.

However, at genesis, validators are still assigned weight 1.

## Proposal

Assign weight 100 to each genesis validator, too.

## Test Plan

Any regressions should be caught by existing tests.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
