### PR TITLE
Make `SyncRuntime` represent the execution lifetime (second attempt)

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -46,6 +46,7 @@ use thiserror::Error;
 
 #[cfg(with_testing)]
 pub use crate::applications::ApplicationRegistry;
+use crate::runtime::{ContractSyncRuntime, ServiceSyncRuntime};
 #[cfg(all(with_testing, with_wasm_runtime))]
 pub use crate::wasm::test as wasm_test;
 #[cfg(with_wasm_runtime)]
@@ -60,7 +61,7 @@ pub use crate::{
     execution::ExecutionStateView,
     policy::ResourceControlPolicy,
     resources::{ResourceController, ResourceTracker},
-    runtime::{ContractSyncRuntime, ServiceSyncRuntime},
+    runtime::{ContractSyncRuntimeHandle, ServiceSyncRuntimeHandle},
     system::{
         SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation,
         SystemQuery, SystemResponse,
@@ -83,7 +84,7 @@ pub type UserServiceInstance = Box<dyn UserService + 'static>;
 pub trait UserContractModule {
     fn instantiate(
         &self,
-        runtime: ContractSyncRuntime,
+        runtime: ContractSyncRuntimeHandle,
     ) -> Result<UserContractInstance, ExecutionError>;
 }
 
@@ -91,7 +92,7 @@ pub trait UserContractModule {
 pub trait UserServiceModule {
     fn instantiate(
         &self,
-        runtime: ServiceSyncRuntime,
+        runtime: ServiceSyncRuntimeHandle,
     ) -> Result<UserServiceInstance, ExecutionError>;
 }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -290,6 +290,16 @@ impl<UserInstance> DerefMut for SyncRuntime<UserInstance> {
     }
 }
 
+impl<UserInstance> Drop for SyncRuntime<UserInstance> {
+    fn drop(&mut self) {
+        // Ensure the `loaded_applications` are cleared to prevent circular references in
+        // the runtime
+        if let Some(mut handle) = self.0.take() {
+            handle.inner().loaded_applications.clear();
+        }
+    }
+}
+
 impl<UserInstance> SyncRuntimeInternal<UserInstance> {
     #[allow(clippy::too_many_arguments)]
     fn new(

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1327,8 +1327,10 @@ impl ServiceSyncRuntime {
             ResourceController::default(),
             OracleResponses::Forget,
         );
+        let mut handle = ServiceSyncRuntimeHandle::new(runtime_internal);
+        let _guard = SyncRuntime(Some(handle.clone()));
 
-        ServiceSyncRuntimeHandle::new(runtime_internal).try_query_application(application_id, query)
+        handle.try_query_application(application_id, query)
     }
 }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -37,7 +37,7 @@ use crate::{
 mod tests;
 
 #[derive(Debug)]
-pub struct SyncRuntime<UserInstance>(SyncRuntimeHandle<UserInstance>);
+pub struct SyncRuntime<UserInstance>(Option<SyncRuntimeHandle<UserInstance>>);
 
 pub type ContractSyncRuntime = SyncRuntime<UserContractInstance>;
 pub type ServiceSyncRuntime = SyncRuntime<UserServiceInstance>;
@@ -276,13 +276,17 @@ impl<UserInstance> Deref for SyncRuntime<UserInstance> {
     type Target = SyncRuntimeHandle<UserInstance>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0.as_ref().expect(
+            "`SyncRuntime` should not be used after its `inner` contents have been moved out",
+        )
     }
 }
 
 impl<UserInstance> DerefMut for SyncRuntime<UserInstance> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        self.0.as_mut().expect(
+            "`SyncRuntime` should not be used after its `inner` contents have been moved out",
+        )
     }
 }
 
@@ -523,16 +527,21 @@ impl SyncRuntimeInternal<UserServiceInstance> {
     }
 }
 
+impl<UserInstance> SyncRuntime<UserInstance> {
+    fn into_inner(mut self) -> Option<SyncRuntimeInternal<UserInstance>> {
+        let handle = self.0.take().expect(
+            "`SyncRuntime` should not be used after its `inner` contents have been moved out",
+        );
+        let runtime = Arc::into_inner(handle.0)?
+            .into_inner()
+            .expect("`SyncRuntime` should run in a single thread which should not panic");
+        Some(runtime)
+    }
+}
+
 impl<UserInstance> SyncRuntimeHandle<UserInstance> {
     fn new(runtime: SyncRuntimeInternal<UserInstance>) -> Self {
         SyncRuntimeHandle(Arc::new(Mutex::new(runtime)))
-    }
-
-    fn into_inner(self) -> Option<SyncRuntimeInternal<UserInstance>> {
-        let runtime = Arc::into_inner(self.0)?
-            .into_inner()
-            .expect("thread should not have panicked");
-        Some(runtime)
     }
 
     fn inner(&mut self) -> std::sync::MutexGuard<'_, SyncRuntimeInternal<UserInstance>> {
@@ -984,17 +993,19 @@ impl ContractSyncRuntime {
         } else {
             OracleResponses::Record(Vec::new())
         };
-        let mut runtime = SyncRuntime(ContractSyncRuntimeHandle::new(SyncRuntimeInternal::new(
-            chain_id,
-            height,
-            local_time,
-            signer,
-            next_message_index,
-            executing_message,
-            execution_state_sender,
-            refund_grant_to,
-            resource_controller,
-            oracle_record,
+        let mut runtime = SyncRuntime(Some(ContractSyncRuntimeHandle::new(
+            SyncRuntimeInternal::new(
+                chain_id,
+                height,
+                local_time,
+                signer,
+                next_message_index,
+                executing_message,
+                execution_state_sender,
+                refund_grant_to,
+                resource_controller,
+                oracle_record,
+            ),
         )));
         let finalize_context = FinalizeContext {
             authenticated_signer: signer,
@@ -1011,7 +1022,6 @@ impl ContractSyncRuntime {
         })?;
         runtime.finalize(finalize_context)?;
         let runtime = runtime
-            .0
             .into_inner()
             .expect("Runtime clones should have been freed by now");
         let oracle_record = if let OracleResponses::Record(responses) = runtime.oracle_responses {
@@ -1077,9 +1087,11 @@ impl ContractSyncRuntime {
         closure: impl FnOnce(&mut UserContractInstance) -> Result<(), ExecutionError>,
     ) -> Result<(), ExecutionError> {
         let contract = {
-            let cloned_runtime = self.0 .0.clone();
+            let cloned_runtime = self.0.clone().expect(
+                "`SyncRuntime` should not be used after its `inner` contents have been moved out",
+            );
             let mut runtime = self.inner();
-            let application = runtime.load_contract_instance(cloned_runtime, application_id)?;
+            let application = runtime.load_contract_instance(cloned_runtime.0, application_id)?;
 
             let status = ApplicationStatus {
                 caller_id: None,
@@ -1330,14 +1342,8 @@ impl ServiceSyncRuntime {
             ResourceController::default(),
             OracleResponses::Forget,
         );
-        let mut runtime = ServiceSyncRuntimeHandle::new(runtime_internal);
 
-        let result = runtime.try_query_application(application_id, query);
-
-        // Ensure the `loaded_applications` are cleared to remove circular references in
-        // `runtime_internal`
-        runtime.inner().loaded_applications.clear();
-        result
+        ServiceSyncRuntimeHandle::new(runtime_internal).try_query_application(application_id, query)
     }
 }
 

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -13,8 +13,8 @@ use std::{
 };
 
 use crate::{
-    ContractSyncRuntime, ExecutionError, FinalizeContext, MessageContext, OperationContext,
-    QueryContext, ServiceSyncRuntime, UserContract, UserContractModule, UserService,
+    ContractSyncRuntimeHandle, ExecutionError, FinalizeContext, MessageContext, OperationContext,
+    QueryContext, ServiceSyncRuntimeHandle, UserContract, UserContractModule, UserService,
     UserServiceModule,
 };
 
@@ -57,13 +57,17 @@ impl MockApplication {
 }
 
 type InstantiateHandler = Box<
-    dyn FnOnce(&mut ContractSyncRuntime, OperationContext, Vec<u8>) -> Result<(), ExecutionError>
+    dyn FnOnce(
+            &mut ContractSyncRuntimeHandle,
+            OperationContext,
+            Vec<u8>,
+        ) -> Result<(), ExecutionError>
         + Send
         + Sync,
 >;
 type ExecuteOperationHandler = Box<
     dyn FnOnce(
-            &mut ContractSyncRuntime,
+            &mut ContractSyncRuntimeHandle,
             OperationContext,
             Vec<u8>,
         ) -> Result<Vec<u8>, ExecutionError>
@@ -71,17 +75,25 @@ type ExecuteOperationHandler = Box<
         + Sync,
 >;
 type ExecuteMessageHandler = Box<
-    dyn FnOnce(&mut ContractSyncRuntime, MessageContext, Vec<u8>) -> Result<(), ExecutionError>
+    dyn FnOnce(
+            &mut ContractSyncRuntimeHandle,
+            MessageContext,
+            Vec<u8>,
+        ) -> Result<(), ExecutionError>
         + Send
         + Sync,
 >;
 type FinalizeHandler = Box<
-    dyn FnOnce(&mut ContractSyncRuntime, FinalizeContext) -> Result<(), ExecutionError>
+    dyn FnOnce(&mut ContractSyncRuntimeHandle, FinalizeContext) -> Result<(), ExecutionError>
         + Send
         + Sync,
 >;
 type HandleQueryHandler = Box<
-    dyn FnOnce(&mut ServiceSyncRuntime, QueryContext, Vec<u8>) -> Result<Vec<u8>, ExecutionError>
+    dyn FnOnce(
+            &mut ServiceSyncRuntimeHandle,
+            QueryContext,
+            Vec<u8>,
+        ) -> Result<Vec<u8>, ExecutionError>
         + Send
         + Sync,
 >;
@@ -119,7 +131,7 @@ impl ExpectedCall {
     /// [`UserContract::instantiate`] implementation, which is handled by the provided `handler`.
     pub fn instantiate(
         handler: impl FnOnce(
-                &mut ContractSyncRuntime,
+                &mut ContractSyncRuntimeHandle,
                 OperationContext,
                 Vec<u8>,
             ) -> Result<(), ExecutionError>
@@ -135,7 +147,7 @@ impl ExpectedCall {
     /// `handler`.
     pub fn execute_operation(
         handler: impl FnOnce(
-                &mut ContractSyncRuntime,
+                &mut ContractSyncRuntimeHandle,
                 OperationContext,
                 Vec<u8>,
             ) -> Result<Vec<u8>, ExecutionError>
@@ -150,7 +162,11 @@ impl ExpectedCall {
     /// [`UserContract::execute_message`] implementation, which is handled by the provided
     /// `handler`.
     pub fn execute_message(
-        handler: impl FnOnce(&mut ContractSyncRuntime, MessageContext, Vec<u8>) -> Result<(), ExecutionError>
+        handler: impl FnOnce(
+                &mut ContractSyncRuntimeHandle,
+                MessageContext,
+                Vec<u8>,
+            ) -> Result<(), ExecutionError>
             + Send
             + Sync
             + 'static,
@@ -161,7 +177,7 @@ impl ExpectedCall {
     /// Creates an [`ExpectedCall`] to the [`MockApplicationInstance`]'s [`UserContract::finalize`]
     /// implementation, which is handled by the provided `handler`.
     pub fn finalize(
-        handler: impl FnOnce(&mut ContractSyncRuntime, FinalizeContext) -> Result<(), ExecutionError>
+        handler: impl FnOnce(&mut ContractSyncRuntimeHandle, FinalizeContext) -> Result<(), ExecutionError>
             + Send
             + Sync
             + 'static,
@@ -179,7 +195,7 @@ impl ExpectedCall {
     /// [`UserService::handle_query`] implementation, which is handled by the provided `handler`.
     pub fn handle_query(
         handler: impl FnOnce(
-                &mut ServiceSyncRuntime,
+                &mut ServiceSyncRuntimeHandle,
                 QueryContext,
                 Vec<u8>,
             ) -> Result<Vec<u8>, ExecutionError>
@@ -194,7 +210,7 @@ impl ExpectedCall {
 impl UserContractModule for MockApplication {
     fn instantiate(
         &self,
-        runtime: ContractSyncRuntime,
+        runtime: ContractSyncRuntimeHandle,
     ) -> Result<Box<dyn UserContract + 'static>, ExecutionError> {
         Ok(Box::new(self.create_mock_instance(runtime)))
     }
@@ -203,7 +219,7 @@ impl UserContractModule for MockApplication {
 impl UserServiceModule for MockApplication {
     fn instantiate(
         &self,
-        runtime: ServiceSyncRuntime,
+        runtime: ServiceSyncRuntimeHandle,
     ) -> Result<Box<dyn UserService + 'static>, ExecutionError> {
         Ok(Box::new(self.create_mock_instance(runtime)))
     }
@@ -216,7 +232,7 @@ impl<Runtime> MockApplicationInstance<Runtime> {
     }
 }
 
-impl UserContract for MockApplicationInstance<ContractSyncRuntime> {
+impl UserContract for MockApplicationInstance<ContractSyncRuntimeHandle> {
     fn instantiate(
         &mut self,
         context: OperationContext,
@@ -276,7 +292,7 @@ impl UserContract for MockApplicationInstance<ContractSyncRuntime> {
     }
 }
 
-impl UserService for MockApplicationInstance<ServiceSyncRuntime> {
+impl UserService for MockApplicationInstance<ServiceSyncRuntimeHandle> {
     fn handle_query(
         &mut self,
         context: QueryContext,

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -86,11 +86,27 @@ fn create_contract_runtime() -> (
     SyncRuntimeInternal<UserContractInstance>,
     mpsc::UnboundedReceiver<Request>,
 ) {
+    let (mut runtime, execution_state_receiver) = create_runtime();
+
+    runtime.push_application(create_dummy_application());
+
+    (runtime, execution_state_receiver)
+}
+
+/// Creates a [`SyncRuntimeInternal`] instance for custom `Application` types (which can
+/// be invalid types).
+///
+/// Returns the [`SyncRuntimeInternal`] instance and the receiver endpoint for the requests the
+/// runtime sends to the [`ExecutionStateView`] actor.
+fn create_runtime<Application>() -> (
+    SyncRuntimeInternal<Application>,
+    mpsc::UnboundedReceiver<Request>,
+) {
     let chain_id = ChainDescription::Root(0).into();
     let (execution_state_sender, execution_state_receiver) = mpsc::unbounded();
     let resource_controller = ResourceController::default();
 
-    let mut runtime = SyncRuntimeInternal::new(
+    let runtime = SyncRuntimeInternal::new(
         chain_id,
         BlockHeight(0),
         Timestamp::from(0),
@@ -102,8 +118,6 @@ fn create_contract_runtime() -> (
         resource_controller,
         super::OracleResponses::Record(Vec::new()),
     );
-
-    runtime.push_application(create_dummy_application());
 
     (runtime, execution_state_receiver)
 }

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -12,7 +12,7 @@ use linera_base::{
 };
 use linera_views::batch::Batch;
 
-use super::{ApplicationStatus, SyncRuntime, SyncRuntimeInternal};
+use super::{ApplicationStatus, SyncRuntimeHandle, SyncRuntimeInternal};
 use crate::{
     execution_state_actor::Request, runtime::ResourceController, ContractRuntime,
     RawExecutionOutcome, UserContractInstance,
@@ -24,7 +24,7 @@ use crate::{
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_write_batch() {
     let (runtime, mut execution_state_receiver) = create_contract_runtime();
-    let mut runtime = SyncRuntime::new(runtime);
+    let mut runtime = SyncRuntimeHandle::new(runtime);
     let mut batch = Batch::new();
 
     let write_key = vec![1, 2, 3, 4, 5];

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -110,8 +110,20 @@ fn create_contract_runtime() -> (
 
 /// Creates an [`ApplicationStatus`] for a dummy application.
 fn create_dummy_application() -> ApplicationStatus {
+    ApplicationStatus {
+        caller_id: None,
+        id: create_dummy_application_id(),
+        parameters: vec![],
+        signer: None,
+        outcome: RawExecutionOutcome::default(),
+    }
+}
+
+/// Creates a dummy [`ApplicationId`].
+fn create_dummy_application_id() -> ApplicationId {
     let chain_id = ChainDescription::Root(1).into();
-    let id = ApplicationId {
+
+    ApplicationId {
         bytecode_id: BytecodeId::new(MessageId {
             chain_id,
             height: BlockHeight(1),
@@ -122,13 +134,5 @@ fn create_dummy_application() -> ApplicationStatus {
             height: BlockHeight(1),
             index: 1,
         },
-    };
-
-    ApplicationStatus {
-        caller_id: None,
-        id,
-        parameters: vec![],
-        signer: None,
-        outcome: RawExecutionOutcome::default(),
     }
 }

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -108,7 +108,7 @@ fn create_contract_runtime() -> (
     (runtime, execution_state_receiver)
 }
 
-/// Create an [`ApplicationStatus`] for a dummy application.
+/// Creates an [`ApplicationStatus`] for a dummy application.
 fn create_dummy_application() -> ApplicationStatus {
     let chain_id = ChainDescription::Root(1).into();
     let id = ApplicationId {

--- a/linera-execution/src/wasm/mod.rs
+++ b/linera-execution/src/wasm/mod.rs
@@ -41,8 +41,8 @@ pub use self::{
     system_api::{ContractSystemApi, ServiceSystemApi, SystemApiData, ViewSystemApi},
 };
 use crate::{
-    Bytecode, ContractSyncRuntime, ExecutionError, ServiceSyncRuntime, UserContractInstance,
-    UserContractModule, UserServiceInstance, UserServiceModule, WasmRuntime,
+    Bytecode, ContractSyncRuntimeHandle, ExecutionError, ServiceSyncRuntimeHandle,
+    UserContractInstance, UserContractModule, UserServiceInstance, UserServiceModule, WasmRuntime,
 };
 
 #[cfg(with_metrics)]
@@ -128,7 +128,7 @@ impl WasmContractModule {
 impl UserContractModule for WasmContractModule {
     fn instantiate(
         &self,
-        runtime: ContractSyncRuntime,
+        runtime: ContractSyncRuntimeHandle,
     ) -> Result<UserContractInstance, ExecutionError> {
         #[cfg(with_metrics)]
         let _instantiation_latency = CONTRACT_INSTANTIATION_LATENCY.measure_latency();
@@ -195,7 +195,7 @@ impl WasmServiceModule {
 impl UserServiceModule for WasmServiceModule {
     fn instantiate(
         &self,
-        runtime: ServiceSyncRuntime,
+        runtime: ServiceSyncRuntimeHandle,
     ) -> Result<UserServiceInstance, ExecutionError> {
         #[cfg(with_metrics)]
         let _instantiation_latency = SERVICE_INSTANTIATION_LATENCY.measure_latency();

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -14,8 +14,8 @@ use tracing::log;
 
 use super::WasmExecutionError;
 use crate::{
-    BaseRuntime, ContractRuntime, ContractSyncRuntime, ExecutionError, ServiceRuntime,
-    ServiceSyncRuntime,
+    BaseRuntime, ContractRuntime, ContractSyncRuntimeHandle, ExecutionError, ServiceRuntime,
+    ServiceSyncRuntimeHandle,
 };
 
 /// Common host data used as the `UserData` of the system API implementations.
@@ -674,13 +674,13 @@ pub trait WriteBatch {
     fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError>;
 }
 
-impl WriteBatch for ContractSyncRuntime {
+impl WriteBatch for ContractSyncRuntimeHandle {
     fn write_batch(&mut self, batch: Batch) -> Result<(), ExecutionError> {
         ContractRuntime::write_batch(self, batch)
     }
 }
 
-impl WriteBatch for ServiceSyncRuntime {
+impl WriteBatch for ServiceSyncRuntimeHandle {
     fn write_batch(&mut self, _: Batch) -> Result<(), ExecutionError> {
         Err(ExecutionError::ServiceWriteAttempt)
     }

--- a/linera-sdk/src/bin/wit_generator.rs
+++ b/linera-sdk/src/bin/wit_generator.rs
@@ -15,8 +15,8 @@ use std::{
 use anyhow::{ensure, Context, Result};
 use clap::Parser as _;
 use linera_execution::{
-    ContractEntrypoints, ContractSyncRuntime, ContractSystemApi, ServiceEntrypoints,
-    ServiceSyncRuntime, ServiceSystemApi, SystemApiData, ViewSystemApi,
+    ContractEntrypoints, ContractSyncRuntimeHandle, ContractSystemApi, ServiceEntrypoints,
+    ServiceSyncRuntimeHandle, ServiceSystemApi, SystemApiData, ViewSystemApi,
 };
 use linera_witty::{
     wit_generation::{WitInterfaceWriter, WitWorldWriter},
@@ -54,23 +54,23 @@ fn run_operation(options: WitGeneratorOptions, mut operation: impl Operation) ->
     let service_entrypoints = WitInterfaceWriter::new::<ServiceEntrypoints<MockInstance<()>>>();
 
     let contract_system_api = WitInterfaceWriter::new::<
-        ContractSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>,
+        ContractSystemApi<MockInstance<SystemApiData<ContractSyncRuntimeHandle>>>,
     >();
     let service_system_api = WitInterfaceWriter::new::<
-        ServiceSystemApi<MockInstance<SystemApiData<ServiceSyncRuntime>>>,
+        ServiceSystemApi<MockInstance<SystemApiData<ServiceSyncRuntimeHandle>>>,
     >();
     let view_system_api = WitInterfaceWriter::new::<
-        ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>,
+        ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntimeHandle>>>,
     >();
 
     let contract_world = WitWorldWriter::new("linera:app", "contract")
         .export::<ContractEntrypoints<MockInstance<()>>>()
-        .import::<ContractSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>()
-        .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>();
+        .import::<ContractSystemApi<MockInstance<SystemApiData<ContractSyncRuntimeHandle>>>>()
+        .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntimeHandle>>>>();
     let service_world = WitWorldWriter::new("linera:app", "service")
         .export::<ServiceEntrypoints<MockInstance<()>>>()
-        .import::<ServiceSystemApi<MockInstance<SystemApiData<ServiceSyncRuntime>>>>()
-        .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntime>>>>();
+        .import::<ServiceSystemApi<MockInstance<SystemApiData<ServiceSyncRuntimeHandle>>>>()
+        .import::<ViewSystemApi<MockInstance<SystemApiData<ContractSyncRuntimeHandle>>>>();
 
     operation.run_for_file(
         &options.base_directory.join("contract-entrypoints.wit"),


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
PR #2192 was merged when GitHub Actions was a bit flaky, and I didn't realize that no checks had been executed. The PR introduced a bug which CI caught on later PRs. PR #2205 reverted the buggy PR in order to unblock development.

The bug was that inside `ServiceSyncRuntime::run_query` the new `SyncRuntime` wrapper type wasn't used. This meant that the `Drop` implementation for that type wasn't used, so it didn't properly clear the map of loaded applications. That meant that the service runtime ended up leaking, and this prevents it from closing the endpoint to the execution state actor, so it never finishes running the query.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Restore the original contents of PR #2192, and use an instance of the `SyncRuntime` in `run_query`, so that it clears the loaded applications when the function finishes. This is temporary, because an upcoming PR will change the associated function to receive `self`, which forces the use of the `SyncRuntime` wrapper type.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should now pass.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, as this is mostly an internal refactor.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
