### PR TITLE
Set the `self.hash` to `None` in the `hashable_wrapper`

### DIFF
--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -72,24 +72,22 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError> {
         let delete_view = self.inner.flush(batch)?;
+        let hash = self.hash.get_mut();
         if delete_view {
             let mut key_prefix = self.inner.context().base_key();
             key_prefix.pop();
             batch.delete_key_prefix(key_prefix);
             self.stored_hash = None;
-            *self.hash.get_mut() = None;
-        } else {
-            let hash = *self.hash.get_mut();
-            if self.stored_hash != hash {
-                let mut key = self.inner.context().base_key();
-                let tag = key.last_mut().unwrap();
-                *tag = KeyTag::Hash as u8;
-                match hash {
-                    None => batch.delete_key(key),
-                    Some(hash) => batch.put_key_value(key, &hash)?,
-                }
-                self.stored_hash = hash;
+            *hash = None;
+        } else if self.stored_hash != *hash {
+            let mut key = self.inner.context().base_key();
+            let tag = key.last_mut().unwrap();
+            *tag = KeyTag::Hash as u8;
+            match hash {
+                None => batch.delete_key(key),
+                Some(hash) => batch.put_key_value(key, hash)?,
             }
+            self.stored_hash = *hash;
         }
         Ok(delete_view)
     }

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -77,6 +77,7 @@ where
             key_prefix.pop();
             batch.delete_key_prefix(key_prefix);
             self.stored_hash = None;
+            *self.hash.get_mut() = None;
         } else {
             let hash = *self.hash.get_mut();
             if self.stored_hash != hash {

--- a/linera-views/tests/hashable_tests.rs
+++ b/linera-views/tests/hashable_tests.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use linera_views::{
     common::HasherOutput,
     hashable_wrapper::WrappedHashableContainerView,
     memory::create_memory_context,
-    register_view::RegisterView,
+    register_view::{HashedRegisterView, RegisterView},
     views::{HashableView, View},
 };
 use linera_views_derive::CryptoHashRootView;
@@ -18,10 +19,25 @@ struct TestType<C> {
 
 // TODO(#560): Implement the same for CryptoHash
 #[tokio::test]
-async fn check_hashable_container_hash() {
+async fn check_hashable_container_hash() -> Result<()> {
     let context = create_memory_context();
-    let test = TestType::load(context).await.unwrap();
-    let hash1 = test.inner.hash().await.unwrap();
-    let hash2 = test.wrap.hash().await.unwrap();
+    let test = TestType::load(context).await?;
+    let hash1 = test.inner.hash().await?;
+    let hash2 = test.wrap.hash().await?;
     assert_eq!(hash1, hash2);
+    Ok(())
+}
+
+#[tokio::test]
+async fn check_hashable_hash() -> Result<()> {
+    let context = create_memory_context();
+    let mut view = HashedRegisterView::<_, u32>::load(context).await?;
+    let hash0 = view.hash().await?;
+    let val = view.get_mut();
+    *val = 32;
+    let hash32 = view.hash().await?;
+    assert_ne!(hash0, hash32);
+    view.clear();
+    assert_eq!(hash0, view.hash().await?);
+    Ok(())
 }


### PR DESCRIPTION
## Motivation

The hashable wrapper did not invalidate the hash when the view is deleted which is potentially dangerous. This is an obstacle to the implementation of `has_pending_changes`.

The `fn flush` returns true if the views is deleted. This can happen in two scenarios:
* The view is cleared
* The `QueueView` is used and the `load_all`commend is used with a `new_back_values` that is empty.
In both scenarios, the view is deleted from the storage.

So, there is a scenario where we could get a value of `self.hash` in `hashable_wrapper` which is not trivial while it has been cleared:
* We call `clear` which sets `self.hash` to `None` in the hashable_wrapper.
* We compute the hash in hashable_wrapper which resets the hash to a value that is the value of the default.
* We do a `save` that calls the flush of hashable_wrapper. That flush sets the `stored_hash` to `None` but it leaves the `self.hash` to the hash of the default.

The result of the operation is fine. However, it prevents the implementation of the `has_pending_changes`operation.
It can be argued that we are losing something since we are invalidating a perfectly valid hash. However, this is fine since we are very unlikely to compute a hash just after doing a clear. That scenario showed up only in tests.

## Proposal

The problem is corrected.

## Test Plan

The problem was revealed in another PR that implements `has_pending_changes`. One test has been added to the code, though this does really reveal what is going on but may be of independent interest.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
