### PR TITLE
Run service runtime as an actor spawned by the chain worker

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -367,6 +367,7 @@ where
     ViewError: From<C::Error>,
     C::Extra: ExecutionRuntimeContext,
 {
+    /// Returns the [`ChainId`] of the chain this [`ChainStateView`] represents.
     pub fn chain_id(&self) -> ChainId {
         self.context().extra().chain_id()
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -26,7 +26,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, Epoch},
-    BytecodeLocation, Query, Response, UserApplicationDescription, UserApplicationId,
+    BytecodeLocation, Query, QueryContext, Response, UserApplicationDescription, UserApplicationId,
 };
 use linera_storage::Storage;
 use linera_views::{
@@ -89,6 +89,15 @@ where
     /// Returns the [`ChainId`] of the chain handled by this worker.
     pub fn chain_id(&self) -> ChainId {
         self.chain.chain_id()
+    }
+
+    /// Returns the current [`QueryContext`] for the current chain state.
+    pub fn current_query_context(&self) -> QueryContext {
+        QueryContext {
+            chain_id: self.chain_id(),
+            next_block_height: self.chain.tip_state.get().next_block_height,
+            local_time: self.storage.clock().current_time(),
+        }
     }
 
     /// Returns a read-only view of the [`ChainStateView`].

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -474,7 +474,8 @@ where
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
         let query_result_future = tokio::task::spawn_blocking(move || {
-            ServiceSyncRuntime::run_query(execution_state_sender, application_id, context, query)
+            ServiceSyncRuntime::new(execution_state_sender, context)
+                .run_query(application_id, query)
         });
         while let Some(request) = execution_state_receiver.next().await {
             self.handle_request(request).await?;

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -64,7 +64,7 @@ static LOAD_SERVICE_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     .expect("Histogram creation should not fail")
 });
 
-pub(crate) type ExecutionStateSender = mpsc::UnboundedSender<Request>;
+pub(crate) type ExecutionStateSender = mpsc::UnboundedSender<ExecutionRequest>;
 
 impl<C> ExecutionStateView<C>
 where
@@ -73,8 +73,11 @@ where
     C::Extra: ExecutionRuntimeContext,
 {
     // TODO(#1416): Support concurrent I/O.
-    pub(crate) async fn handle_request(&mut self, request: Request) -> Result<(), ExecutionError> {
-        use Request::*;
+    pub(crate) async fn handle_request(
+        &mut self,
+        request: ExecutionRequest,
+    ) -> Result<(), ExecutionError> {
+        use ExecutionRequest::*;
         match request {
             LoadContract { id, callback } => {
                 #[cfg(with_metrics)]
@@ -291,7 +294,7 @@ where
 }
 
 /// Requests to the execution state.
-pub enum Request {
+pub enum ExecutionRequest {
     LoadContract {
         id: UserApplicationId,
         callback: Sender<(UserContractCode, UserApplicationDescription)>,
@@ -405,127 +408,127 @@ pub enum Request {
     },
 }
 
-impl Debug for Request {
+impl Debug for ExecutionRequest {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {
-            Request::LoadContract { id, .. } => formatter
-                .debug_struct("Request::LoadContract")
+            ExecutionRequest::LoadContract { id, .. } => formatter
+                .debug_struct("ExecutionRequest::LoadContract")
                 .field("id", id)
                 .finish_non_exhaustive(),
 
-            Request::LoadService { id, .. } => formatter
-                .debug_struct("Request::LoadService")
+            ExecutionRequest::LoadService { id, .. } => formatter
+                .debug_struct("ExecutionRequest::LoadService")
                 .field("id", id)
                 .finish_non_exhaustive(),
 
-            Request::ChainBalance { .. } => formatter
-                .debug_struct("Request::ChainBalance")
+            ExecutionRequest::ChainBalance { .. } => formatter
+                .debug_struct("ExecutionRequest::ChainBalance")
                 .finish_non_exhaustive(),
 
-            Request::OwnerBalance { owner, .. } => formatter
-                .debug_struct("Request::OwnerBalance")
+            ExecutionRequest::OwnerBalance { owner, .. } => formatter
+                .debug_struct("ExecutionRequest::OwnerBalance")
                 .field("owner", owner)
                 .finish_non_exhaustive(),
 
-            Request::OwnerBalances { .. } => formatter
-                .debug_struct("Request::OwnerBalances")
+            ExecutionRequest::OwnerBalances { .. } => formatter
+                .debug_struct("ExecutionRequest::OwnerBalances")
                 .finish_non_exhaustive(),
 
-            Request::BalanceOwners { .. } => formatter
-                .debug_struct("Request::BalanceOwners")
+            ExecutionRequest::BalanceOwners { .. } => formatter
+                .debug_struct("ExecutionRequest::BalanceOwners")
                 .finish_non_exhaustive(),
 
-            Request::Transfer {
+            ExecutionRequest::Transfer {
                 source,
                 destination,
                 amount,
                 signer,
                 ..
             } => formatter
-                .debug_struct("Request::Transfer")
+                .debug_struct("ExecutionRequest::Transfer")
                 .field("source", source)
                 .field("destination", destination)
                 .field("amount", amount)
                 .field("signer", signer)
                 .finish_non_exhaustive(),
 
-            Request::Claim {
+            ExecutionRequest::Claim {
                 source,
                 destination,
                 amount,
                 signer,
                 ..
             } => formatter
-                .debug_struct("Request::Claim")
+                .debug_struct("ExecutionRequest::Claim")
                 .field("source", source)
                 .field("destination", destination)
                 .field("amount", amount)
                 .field("signer", signer)
                 .finish_non_exhaustive(),
 
-            Request::SystemTimestamp { .. } => formatter
-                .debug_struct("Request::SystemTimestamp")
+            ExecutionRequest::SystemTimestamp { .. } => formatter
+                .debug_struct("ExecutionRequest::SystemTimestamp")
                 .finish_non_exhaustive(),
 
-            Request::ChainOwnership { .. } => formatter
-                .debug_struct("Request::ChainOwnership")
+            ExecutionRequest::ChainOwnership { .. } => formatter
+                .debug_struct("ExecutionRequest::ChainOwnership")
                 .finish_non_exhaustive(),
 
-            Request::ReadValueBytes { id, key, .. } => formatter
-                .debug_struct("Request::ReadValueBytes")
+            ExecutionRequest::ReadValueBytes { id, key, .. } => formatter
+                .debug_struct("ExecutionRequest::ReadValueBytes")
                 .field("id", id)
                 .field("key", key)
                 .finish_non_exhaustive(),
 
-            Request::ContainsKey { id, key, .. } => formatter
-                .debug_struct("Request::ContainsKey")
+            ExecutionRequest::ContainsKey { id, key, .. } => formatter
+                .debug_struct("ExecutionRequest::ContainsKey")
                 .field("id", id)
                 .field("key", key)
                 .finish_non_exhaustive(),
 
-            Request::ReadMultiValuesBytes { id, keys, .. } => formatter
-                .debug_struct("Request::ReadMultiValuesBytes")
+            ExecutionRequest::ReadMultiValuesBytes { id, keys, .. } => formatter
+                .debug_struct("ExecutionRequest::ReadMultiValuesBytes")
                 .field("id", id)
                 .field("keys", keys)
                 .finish_non_exhaustive(),
 
-            Request::FindKeysByPrefix { id, key_prefix, .. } => formatter
-                .debug_struct("Request::FindKeysByPrefix")
+            ExecutionRequest::FindKeysByPrefix { id, key_prefix, .. } => formatter
+                .debug_struct("ExecutionRequest::FindKeysByPrefix")
                 .field("id", id)
                 .field("key_prefix", key_prefix)
                 .finish_non_exhaustive(),
 
-            Request::FindKeyValuesByPrefix { id, key_prefix, .. } => formatter
-                .debug_struct("Request::FindKeyValuesByPrefix")
+            ExecutionRequest::FindKeyValuesByPrefix { id, key_prefix, .. } => formatter
+                .debug_struct("ExecutionRequest::FindKeyValuesByPrefix")
                 .field("id", id)
                 .field("key_prefix", key_prefix)
                 .finish_non_exhaustive(),
 
-            Request::WriteBatch { id, batch, .. } => formatter
-                .debug_struct("Request::WriteBatch")
+            ExecutionRequest::WriteBatch { id, batch, .. } => formatter
+                .debug_struct("ExecutionRequest::WriteBatch")
                 .field("id", id)
                 .field("batch", batch)
                 .finish_non_exhaustive(),
 
-            Request::OpenChain { balance, .. } => formatter
-                .debug_struct("Request::OpenChain")
+            ExecutionRequest::OpenChain { balance, .. } => formatter
+                .debug_struct("ExecutionRequest::OpenChain")
                 .field("balance", balance)
                 .finish_non_exhaustive(),
 
-            Request::CloseChain { application_id, .. } => formatter
-                .debug_struct("Request::CloseChain")
+            ExecutionRequest::CloseChain { application_id, .. } => formatter
+                .debug_struct("ExecutionRequest::CloseChain")
                 .field("application_id", application_id)
                 .finish_non_exhaustive(),
 
-            Request::FetchUrl { url, .. } => formatter
-                .debug_struct("Request::FetchUrl")
+            ExecutionRequest::FetchUrl { url, .. } => formatter
+                .debug_struct("ExecutionRequest::FetchUrl")
                 .field("url", url)
                 .finish_non_exhaustive(),
 
-            Request::HttpPost {
+            ExecutionRequest::HttpPost {
                 url, content_type, ..
             } => formatter
-                .debug_struct("Request::HttpPost")
+                .debug_struct("ExecutionRequest::HttpPost")
                 .field("url", url)
                 .field("content_type", content_type)
                 .finish_non_exhaustive(),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -46,7 +46,7 @@ use thiserror::Error;
 
 #[cfg(with_testing)]
 pub use crate::applications::ApplicationRegistry;
-use crate::runtime::{ContractSyncRuntime, ServiceSyncRuntime};
+use crate::runtime::ContractSyncRuntime;
 #[cfg(all(with_testing, with_wasm_runtime))]
 pub use crate::wasm::test as wasm_test;
 #[cfg(with_wasm_runtime)]
@@ -59,9 +59,13 @@ pub use crate::{
         ApplicationRegistryView, BytecodeLocation, UserApplicationDescription, UserApplicationId,
     },
     execution::ExecutionStateView,
+    execution_state_actor::ExecutionRequest,
     policy::ResourceControlPolicy,
     resources::{ResourceController, ResourceTracker},
-    runtime::{ContractSyncRuntimeHandle, ServiceSyncRuntimeHandle},
+    runtime::{
+        ContractSyncRuntimeHandle, ServiceRuntimeRequest, ServiceSyncRuntime,
+        ServiceSyncRuntimeHandle,
+    },
     system::{
         SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation,
         SystemQuery, SystemResponse,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1312,7 +1312,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
 
 impl ServiceSyncRuntime {
     /// Creates a new [`ServiceSyncRuntime`] ready to execute using a provided [`QueryContext`].
-    pub(crate) fn new(execution_state_sender: ExecutionStateSender, context: QueryContext) -> Self {
+    pub fn new(execution_state_sender: ExecutionStateSender, context: QueryContext) -> Self {
         SyncRuntime(Some(
             SyncRuntimeInternal::new(
                 context.chain_id,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -24,7 +24,7 @@ use oneshot::Receiver;
 
 use crate::{
     execution::UserAction,
-    execution_state_actor::{ExecutionStateSender, Request},
+    execution_state_actor::{ExecutionRequest, ExecutionStateSender},
     resources::ResourceController,
     util::{ReceiverExt, UnboundedSenderExt},
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, FinalizeContext,
@@ -411,7 +411,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
             hash_map::Entry::Vacant(entry) => {
                 let (code, description) = self
                     .execution_state_sender
-                    .send_request(|callback| Request::LoadContract { id, callback })?
+                    .send_request(|callback| ExecutionRequest::LoadContract { id, callback })?
                     .recv_response()?;
 
                 let instance = code.instantiate(SyncRuntimeHandle(this))?;
@@ -524,7 +524,7 @@ impl SyncRuntimeInternal<UserServiceInstance> {
             hash_map::Entry::Vacant(entry) => {
                 let (code, description) = self
                     .execution_state_sender
-                    .send_request(|callback| Request::LoadService { id, callback })?
+                    .send_request(|callback| ExecutionRequest::LoadService { id, callback })?
                     .recv_response()?;
 
                 let instance = code.instantiate(SyncRuntimeHandle(this))?;
@@ -725,37 +725,37 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
 
     fn read_system_timestamp(&mut self) -> Result<Timestamp, ExecutionError> {
         self.execution_state_sender
-            .send_request(|callback| Request::SystemTimestamp { callback })?
+            .send_request(|callback| ExecutionRequest::SystemTimestamp { callback })?
             .recv_response()
     }
 
     fn read_chain_balance(&mut self) -> Result<Amount, ExecutionError> {
         self.execution_state_sender
-            .send_request(|callback| Request::ChainBalance { callback })?
+            .send_request(|callback| ExecutionRequest::ChainBalance { callback })?
             .recv_response()
     }
 
     fn read_owner_balance(&mut self, owner: Owner) -> Result<Amount, ExecutionError> {
         self.execution_state_sender
-            .send_request(|callback| Request::OwnerBalance { owner, callback })?
+            .send_request(|callback| ExecutionRequest::OwnerBalance { owner, callback })?
             .recv_response()
     }
 
     fn read_owner_balances(&mut self) -> Result<Vec<(Owner, Amount)>, ExecutionError> {
         self.execution_state_sender
-            .send_request(|callback| Request::OwnerBalances { callback })?
+            .send_request(|callback| ExecutionRequest::OwnerBalances { callback })?
             .recv_response()
     }
 
     fn read_balance_owners(&mut self) -> Result<Vec<Owner>, ExecutionError> {
         self.execution_state_sender
-            .send_request(|callback| Request::BalanceOwners { callback })?
+            .send_request(|callback| ExecutionRequest::BalanceOwners { callback })?
             .recv_response()
     }
 
     fn chain_ownership(&mut self) -> Result<ChainOwnership, ExecutionError> {
         self.execution_state_sender
-            .send_request(|callback| Request::ChainOwnership { callback })?
+            .send_request(|callback| ExecutionRequest::ChainOwnership { callback })?
             .recv_response()
     }
 
@@ -765,7 +765,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         self.resource_controller.track_read_operations(1)?;
         let receiver = self
             .execution_state_sender
-            .send_request(move |callback| Request::ContainsKey { id, key, callback })?;
+            .send_request(move |callback| ExecutionRequest::ContainsKey { id, key, callback })?;
         state.contains_key_queries.register(receiver)
     }
 
@@ -783,9 +783,9 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         let id = self.application_id()?;
         let state = self.view_user_states.entry(id).or_default();
         self.resource_controller.track_read_operations(1)?;
-        let receiver = self
-            .execution_state_sender
-            .send_request(move |callback| Request::ReadMultiValuesBytes { id, keys, callback })?;
+        let receiver = self.execution_state_sender.send_request(move |callback| {
+            ExecutionRequest::ReadMultiValuesBytes { id, keys, callback }
+        })?;
         state.read_multi_values_queries.register(receiver)
     }
 
@@ -814,7 +814,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         self.resource_controller.track_read_operations(1)?;
         let receiver = self
             .execution_state_sender
-            .send_request(move |callback| Request::ReadValueBytes { id, key, callback })?;
+            .send_request(move |callback| ExecutionRequest::ReadValueBytes { id, key, callback })?;
         state.read_value_queries.register(receiver)
     }
 
@@ -840,7 +840,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         let state = self.view_user_states.entry(id).or_default();
         self.resource_controller.track_read_operations(1)?;
         let receiver = self.execution_state_sender.send_request(move |callback| {
-            Request::FindKeysByPrefix {
+            ExecutionRequest::FindKeysByPrefix {
                 id,
                 key_prefix,
                 callback,
@@ -873,7 +873,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         let state = self.view_user_states.entry(id).or_default();
         self.resource_controller.track_read_operations(1)?;
         let receiver = self.execution_state_sender.send_request(move |callback| {
-            Request::FindKeyValuesByPrefix {
+            ExecutionRequest::FindKeyValuesByPrefix {
                 id,
                 key_prefix,
                 callback,
@@ -939,7 +939,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         let url = url.to_string();
         let bytes = self
             .execution_state_sender
-            .send_request(|callback| Request::HttpPost {
+            .send_request(|callback| ExecutionRequest::HttpPost {
                 url,
                 content_type,
                 payload,
@@ -1184,7 +1184,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let execution_outcome = self
             .inner()
             .execution_state_sender
-            .send_request(|callback| Request::Transfer {
+            .send_request(|callback| ExecutionRequest::Transfer {
                 source,
                 destination,
                 amount,
@@ -1208,7 +1208,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let execution_outcome = self
             .inner()
             .execution_state_sender
-            .send_request(|callback| Request::Claim {
+            .send_request(|callback| ExecutionRequest::Claim {
                 source,
                 destination,
                 amount,
@@ -1259,7 +1259,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let chain_id = ChainId::child(next_message_id);
         let [open_chain_message, subscribe_message] = this
             .execution_state_sender
-            .send_request(|callback| Request::OpenChain {
+            .send_request(|callback| ExecutionRequest::OpenChain {
                 ownership,
                 balance,
                 next_message_id,
@@ -1279,7 +1279,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let mut this = self.inner();
         let application_id = this.current_application().id;
         this.execution_state_sender
-            .send_request(|callback| Request::CloseChain {
+            .send_request(|callback| ExecutionRequest::CloseChain {
                 application_id,
                 callback,
             })?
@@ -1300,7 +1300,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         this.resource_controller
             .track_bytes_written(batch.size() as u64)?;
         this.execution_state_sender
-            .send_request(|callback| Request::WriteBatch {
+            .send_request(|callback| ExecutionRequest::WriteBatch {
                 id,
                 batch,
                 callback,
@@ -1403,7 +1403,7 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
         let this = self.inner();
         let url = url.to_string();
         this.execution_state_sender
-            .send_request(|callback| Request::FetchUrl { url, callback })?
+            .send_request(|callback| ExecutionRequest::FetchUrl { url, callback })?
             .recv_response()
     }
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -28,7 +28,7 @@ use crate::{
     resources::ResourceController,
     util::{ReceiverExt, UnboundedSenderExt},
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, FinalizeContext,
-    MessageContext, OperationContext, RawExecutionOutcome, ServiceRuntime,
+    MessageContext, OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime,
     UserApplicationDescription, UserApplicationId, UserContractInstance, UserServiceInstance,
 };
 
@@ -910,7 +910,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 None => Err(ExecutionError::MissingOracleResponse),
             };
         }
-        let context = crate::QueryContext {
+        let context = QueryContext {
             chain_id: self.chain_id,
             next_block_height: self.height,
             local_time: self.local_time,
@@ -1314,7 +1314,7 @@ impl ServiceSyncRuntime {
     pub(crate) fn run_query(
         execution_state_sender: ExecutionStateSender,
         application_id: UserApplicationId,
-        context: crate::QueryContext,
+        context: QueryContext,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let runtime_internal = SyncRuntimeInternal::new(
@@ -1350,7 +1350,7 @@ impl ServiceRuntime for ServiceSyncRuntimeHandle {
             // Load the application.
             let application = this.load_service_instance(cloned_self, queried_id)?;
             // Make the call to user code.
-            let query_context = crate::QueryContext {
+            let query_context = QueryContext {
                 chain_id: this.chain_id,
                 next_block_height: this.height,
                 local_time: this.local_time,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -549,11 +549,13 @@ impl<UserInstance> SyncRuntime<UserInstance> {
     }
 }
 
-impl<UserInstance> SyncRuntimeHandle<UserInstance> {
-    fn new(runtime: SyncRuntimeInternal<UserInstance>) -> Self {
+impl<UserInstance> From<SyncRuntimeInternal<UserInstance>> for SyncRuntimeHandle<UserInstance> {
+    fn from(runtime: SyncRuntimeInternal<UserInstance>) -> Self {
         SyncRuntimeHandle(Arc::new(Mutex::new(runtime)))
     }
+}
 
+impl<UserInstance> SyncRuntimeHandle<UserInstance> {
     fn inner(&mut self) -> std::sync::MutexGuard<'_, SyncRuntimeInternal<UserInstance>> {
         self.0
             .try_lock()
@@ -1003,7 +1005,7 @@ impl ContractSyncRuntime {
         } else {
             OracleResponses::Record(Vec::new())
         };
-        let mut runtime = SyncRuntime(Some(ContractSyncRuntimeHandle::new(
+        let mut runtime = SyncRuntime(Some(ContractSyncRuntimeHandle::from(
             SyncRuntimeInternal::new(
                 chain_id,
                 height,
@@ -1327,7 +1329,7 @@ impl ServiceSyncRuntime {
             ResourceController::default(),
             OracleResponses::Forget,
         );
-        let mut handle = ServiceSyncRuntimeHandle::new(runtime_internal);
+        let mut handle = ServiceSyncRuntimeHandle::from(runtime_internal);
         let _guard = SyncRuntime(Some(handle.clone()));
 
         handle.try_query_application(application_id, query)

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -19,7 +19,7 @@ use linera_views::batch::Batch;
 
 use super::{ApplicationStatus, SyncRuntimeHandle, SyncRuntimeInternal};
 use crate::{
-    execution_state_actor::Request,
+    execution_state_actor::ExecutionRequest,
     runtime::{LoadedApplication, ResourceController, SyncRuntime},
     ContractRuntime, RawExecutionOutcome, UserContractInstance,
 };
@@ -117,13 +117,13 @@ async fn test_write_batch() {
             .await
             .expect("Missing expected request to write a batch");
 
-        let Request::WriteBatch {
+        let ExecutionRequest::WriteBatch {
             id,
             batch,
             callback,
         } = request
         else {
-            panic!("Expected a `Request::WriteBatch` but got {request:?} instead");
+            panic!("Expected a `ExecutionRequest::WriteBatch` but got {request:?} instead");
         };
 
         assert_eq!(id, expected_application_id);
@@ -152,7 +152,7 @@ async fn test_write_batch() {
 /// endpoint for the requests the runtime sends to the [`ExecutionStateView`] actor.
 fn create_contract_runtime() -> (
     SyncRuntimeInternal<UserContractInstance>,
-    mpsc::UnboundedReceiver<Request>,
+    mpsc::UnboundedReceiver<ExecutionRequest>,
 ) {
     let (mut runtime, execution_state_receiver) = create_runtime();
 
@@ -168,7 +168,7 @@ fn create_contract_runtime() -> (
 /// runtime sends to the [`ExecutionStateView`] actor.
 fn create_runtime<Application>() -> (
     SyncRuntimeInternal<Application>,
-    mpsc::UnboundedReceiver<Request>,
+    mpsc::UnboundedReceiver<ExecutionRequest>,
 ) {
     let chain_id = ChainDescription::Root(0).into();
     let (execution_state_sender, execution_state_receiver) = mpsc::unbounded();

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -28,7 +28,7 @@ use crate::{
 #[test_log::test(tokio::test)]
 async fn test_dropping_sync_runtime_clears_loaded_applications() -> anyhow::Result<()> {
     let (runtime, _receiver) = create_runtime();
-    let handle = SyncRuntimeHandle::new(runtime);
+    let handle = SyncRuntimeHandle::from(runtime);
     let weak_handle = Arc::downgrade(&handle.0);
 
     let fake_application = create_fake_application_with_runtime(&handle);
@@ -51,7 +51,7 @@ async fn test_dropping_sync_runtime_clears_loaded_applications() -> anyhow::Resu
 #[test_log::test(tokio::test)]
 async fn test_into_inner_without_clearing_applications() {
     let (runtime, _receiver) = create_runtime();
-    let handle = SyncRuntimeHandle::new(runtime);
+    let handle = SyncRuntimeHandle::from(runtime);
 
     let fake_application = create_fake_application_with_runtime(&handle);
 
@@ -69,7 +69,7 @@ async fn test_into_inner_without_clearing_applications() {
 #[test_log::test(tokio::test)]
 async fn test_into_inner_after_clearing_applications() {
     let (runtime, _receiver) = create_runtime();
-    let handle = SyncRuntimeHandle::new(runtime);
+    let handle = SyncRuntimeHandle::from(runtime);
     let weak_handle = Arc::downgrade(&handle.0);
 
     let fake_application = create_fake_application_with_runtime(&handle);
@@ -92,7 +92,7 @@ async fn test_into_inner_after_clearing_applications() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_write_batch() {
     let (runtime, mut execution_state_receiver) = create_contract_runtime();
-    let mut runtime = SyncRuntimeHandle::new(runtime);
+    let mut runtime = SyncRuntimeHandle::from(runtime);
     let mut batch = Batch::new();
 
     let write_key = vec![1, 2, 3, 4, 5];

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -208,13 +208,17 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
+    let (execution_request_receiver, runtime_request_sender) =
+        context.spawn_service_runtime_actor();
     assert_eq!(
         view.query_application(
             context,
             Query::User {
                 application_id: caller_id,
                 bytes: vec![]
-            }
+            },
+            execution_request_receiver,
+            runtime_request_sender,
         )
         .await
         .unwrap(),

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -117,7 +117,12 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         local_time: Timestamp::from(0),
     };
     let response = view
-        .query_application(context, Query::System(SystemQuery))
+        .query_application(
+            context,
+            Query::System(SystemQuery),
+            futures::channel::mpsc::unbounded().1,
+            std::sync::mpsc::channel().0,
+        )
         .await
         .unwrap();
     assert_eq!(

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -124,13 +124,20 @@ async fn test_fuel_for_counter_wasm_application(
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
+    let (execution_request_receiver, runtime_request_sender) =
+        context.spawn_service_runtime_actor();
     let expected_value = async_graphql::Response::new(
         async_graphql::Value::from_json(json!({"value" : increments.into_iter().sum::<u64>()}))
             .unwrap(),
     );
     let request = async_graphql::Request::new("query { value }");
     let Response::User(serialized_value) = view
-        .query_application(context, Query::user(app_id, &request).unwrap())
+        .query_application(
+            context,
+            Query::user(app_id, &request).unwrap(),
+            execution_request_receiver,
+            runtime_request_sender,
+        )
         .await?
     else {
         panic!("unexpected response")


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
In order to keep services running across different queries, the `ServiceSyncRuntime` type must outlive the queries it handles. The runtime must run in a single thread and does not implement `Send` (because the `User{Contract,Service}Instance` types used for the `loaded_applications` does not implement `Send`). Therefore, the current approach of `spawn_blocking` the runtime thread only before handling a query does not work.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Make the service runtime run as an actor, executing on its own `spawn_blocking` thread and waiting for `ServiceRuntimeRequest`s to handle. The thread is started by the `ChainWorkerActor`, in preparation for the next PR which will use the incoming chain worker requests to determine if the runtime should be restarted or not.

## Test Plan

<!-- How to test that the changes are correct. -->
Existing CI tests should catch any regressions, as this is an internal refactor.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this is an internal refactor.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
