### PR TITLE
Fix conflicting `ChainWorkerActor`s when running benchmarks

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -137,6 +137,11 @@ where
         &self.storage
     }
 
+    /// Returns a reference to the [`LocalNodeClient`] of the client.
+    pub fn local_node(&self) -> &LocalNodeClient<S> {
+        &self.local_node
+    }
+
     /// Creates a new `ChainClient`.
     #[allow(clippy::too_many_arguments)]
     pub fn build(

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -180,7 +180,7 @@ where
     S: Storage + Clone + Send + Sync + 'static,
     ViewError: From<S::ContextError>,
 {
-    pub(crate) async fn stage_block_execution(
+    pub async fn stage_block_execution(
         &self,
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), LocalNodeError> {

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -45,7 +45,7 @@ use {
         data_types::Amount,
         identifiers::{AccountOwner, ApplicationId, Owner},
     },
-    linera_chain::data_types::{Block, BlockProposal, SignatureAggregator, Vote},
+    linera_chain::data_types::{Block, BlockProposal, ExecutedBlock, SignatureAggregator, Vote},
     linera_core::{data_types::ChainInfoQuery, local_node::LocalNodeClient, worker::WorkerState},
     linera_execution::{
         committee::Epoch,
@@ -807,5 +807,15 @@ where
             application_id,
             bytes,
         }
+    }
+
+    /// Stages the execution of a block proposal.
+    pub async fn stage_block_execution(&self, block: Block) -> anyhow::Result<ExecutedBlock> {
+        Ok(self
+            .client
+            .local_node()
+            .stage_block_execution(block)
+            .await?
+            .0)
     }
 }

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -46,7 +46,7 @@ use {
         identifiers::{AccountOwner, ApplicationId, Owner},
     },
     linera_chain::data_types::{Block, BlockProposal, ExecutedBlock, SignatureAggregator, Vote},
-    linera_core::{data_types::ChainInfoQuery, local_node::LocalNodeClient, worker::WorkerState},
+    linera_core::data_types::ChainInfoQuery,
     linera_execution::{
         committee::Epoch,
         system::{OpenChainConfig, Recipient, SystemOperation, UserData, OPEN_CHAIN_MESSAGE_INDEX},
@@ -759,16 +759,8 @@ where
     }
 
     pub async fn update_wallet_from_certificates(&mut self, certificates: Vec<Certificate>) {
-        // First instantiate a local node on top of storage.
-        let worker = WorkerState::new(
-            "Temporary client node".to_string(),
-            None,
-            self.client.storage_client().clone(),
-        )
-        .with_allow_inactive_chains(true)
-        .with_allow_messages_from_deprecated_epochs(true);
-        let node = LocalNodeClient::new(worker);
-        // Second replay the certificates locally.
+        let node = self.client.local_node().clone();
+        // Replay the certificates locally.
         for certificate in certificates {
             // No required certificates from other chains: This is only used with benchmark.
             node.handle_certificate(certificate, vec![], vec![], &mut vec![])

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -669,10 +669,9 @@ impl Runnable for Job {
 
                 for rpc_msg in &proposals {
                     if let RpcMessage::BlockProposal(proposal) = rpc_msg {
-                        let (executed_block, _) =
-                            WorkerState::new("staging".to_string(), None, storage.clone())
-                                .stage_block_execution(proposal.content.block.clone())
-                                .await?;
+                        let executed_block = context
+                            .stage_block_execution(proposal.content.block.clone())
+                            .await?;
                         let value =
                             HashedCertificateValue::from(CertificateValue::ConfirmedBlock {
                                 executed_block,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
The command `linera benchmark` was hanging because multiple `ChainWorkerActor`s were created to handle the same chain. This led to them attempting to acquire the chain guard, and blocking forever when it failed. The duplicate actors were created because the same process created more than one `WorkerState` instance.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use the local node in the client instead of creating temporary `WorkerState` instances.

## Test Plan

<!-- How to test that the changes are correct. -->
After this PR, `linera benchmark` now executes correctly.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Fixes a user visible bug, so at least a new patch version should be released.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
