### PR TITLE
Implement `pre_load`/ `post_load`for the views.

### DIFF
--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -117,9 +117,6 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
         .extend(context_constraints.predicates);
 
     let mut name_quotes = Vec::new();
-    let mut load_future_quotes = Vec::new();
-    let mut load_ident_quotes = Vec::new();
-    let mut load_result_quotes = Vec::new();
     let mut rollback_quotes = Vec::new();
     let mut flush_quotes = Vec::new();
     let mut test_flush_quotes = Vec::new();
@@ -134,17 +131,6 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
         let test_flush_ident = format_ident!("deleted{}", idx);
         let idx_lit = syn::LitInt::new(&idx.to_string(), Span::call_site());
         let type_ident = get_type_field(e.clone()).expect("Failed to find the type");
-        load_future_quotes.push(quote! {
-            let index = #idx_lit;
-            let base_key = context.derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-            let #fut = #type_ident::load(context.clone_with_base_key(base_key));
-        });
-        load_ident_quotes.push(quote! {
-            #fut
-        });
-        load_result_quotes.push(quote! {
-            let #name = result.#idx_lit?;
-        });
         let g = get_extended_entry(e.ty.clone());
         name_quotes.push(quote! { #name });
         rollback_quotes.push(quote! { self.#name.rollback(); });

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -21,18 +21,6 @@ fn get_seq_parameter(generics: syn::Generics) -> Vec<syn::Ident> {
     generic_vect
 }
 
-fn get_type_field(field: syn::Field) -> Option<syn::Ident> {
-    match field.ty {
-        syn::Type::Path(typepath) => {
-            if let Some(x) = typepath.path.segments.into_iter().next() {
-                return Some(x.ident);
-            }
-            None
-        }
-        _ => None,
-    }
-}
-
 fn custom_attribute(attributes: &[Attribute], key: &str) -> Option<LitStr> {
     attributes
         .iter()
@@ -127,10 +115,8 @@ fn generate_view_code(input: ItemStruct, root: bool) -> TokenStream2 {
     let mut post_load_keys_quotes = Vec::new();
     for (idx, e) in input.fields.into_iter().enumerate() {
         let name = e.clone().ident.unwrap();
-        let fut = format_ident!("{}_fut", name.to_string());
         let test_flush_ident = format_ident!("deleted{}", idx);
         let idx_lit = syn::LitInt::new(&idx.to_string(), Span::call_site());
-        let type_ident = get_type_field(e.clone()).expect("Failed to find the type");
         let g = get_extended_entry(e.ty.clone());
         name_quotes.push(quote! { #name });
         rollback_quotes.push(quote! { self.#name.rollback(); });

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C.snap
@@ -8,24 +8,66 @@ where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
     linera_views::views::ViewError: From<C::Error>,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
+        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
     fn context(&self) -> &C {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                C,
+                usize,
+                RegisterView<C, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: C,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            C,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_C_with_where.snap
@@ -9,24 +9,66 @@ where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
     linera_views::views::ViewError: From<C::Error>,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
+        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
     fn context(&self) -> &C {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                C,
+                usize,
+                RegisterView<C, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: C,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            C,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext.snap
@@ -4,26 +4,81 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 #[linera_views::async_trait]
 impl linera_views::views::View<CustomContext> for TestView {
+    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
+        + CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(
-        context: CustomContext,
-    ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(
+        context: &CustomContext,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<
+                CustomContext,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: CustomContext,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            CustomContext,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(
+        context: CustomContext,
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_CustomContext_with_where.snap
@@ -7,26 +7,81 @@ impl<MyParam> linera_views::views::View<CustomContext> for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
+        + CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(
-        context: CustomContext,
-    ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(
+        context: &CustomContext,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<
+                CustomContext,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: CustomContext,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            CustomContext,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(
+        context: CustomContext,
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T_.snap
@@ -4,26 +4,85 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 #[linera_views::async_trait]
 impl linera_views::views::View<custom::GenericContext<T>> for TestView {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::GenericContext<T>,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(
-        context: custom::GenericContext<T>,
-    ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(
+        context: &custom::GenericContext<T>,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<
+                custom::GenericContext<T>,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::GenericContext<T>,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::GenericContext<T>,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(
+        context: custom::GenericContext<T>,
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__GenericContext_T__with_where.snap
@@ -7,26 +7,85 @@ impl<MyParam> linera_views::views::View<custom::GenericContext<T>> for TestView<
 where
     MyParam: Send + Sync + 'static,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::GenericContext<T>,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(
-        context: custom::GenericContext<T>,
-    ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(
+        context: &custom::GenericContext<T>,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<
+                custom::GenericContext<T>,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::GenericContext<T>,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::GenericContext<T>,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(
+        context: custom::GenericContext<T>,
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType.snap
@@ -4,26 +4,85 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 #[linera_views::async_trait]
 impl linera_views::views::View<custom::path::to::ContextType> for TestView {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::path::to::ContextType,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(
-        context: custom::path::to::ContextType,
-    ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(
+        context: &custom::path::to::ContextType,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<
+                custom::path::to::ContextType,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::path::to::ContextType,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::path::to::ContextType,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(
+        context: custom::path::to::ContextType,
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_custom__path__to__ContextType_with_where.snap
@@ -8,26 +8,85 @@ for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::path::to::ContextType,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()
     }
-    async fn load(
-        context: custom::path::to::ContextType,
-    ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+    fn pre_load(
+        context: &custom::path::to::ContextType,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
         let index = 0;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
+        keys.extend(
+            RegisterView::<
+                custom::path::to::ContextType,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
         let index = 1;
         let base_key = context
             .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
+        keys.extend(
+            CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::path::to::ContextType,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::path::to::ContextType,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
         Ok(Self { register, collection })
+    }
+    async fn load(
+        context: custom::path::to::ContextType,
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -8,30 +8,75 @@ where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
     linera_views::views::ViewError: From<C::Error>,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
+        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
     fn context(&self) -> &C {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                C,
+                usize,
+                RegisterView<C, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: C,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            C,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -9,30 +9,75 @@ where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
     linera_views::views::ViewError: From<C::Error>,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
+        + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
     fn context(&self) -> &C {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<C, usize>::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                C,
+                usize,
+                RegisterView<C, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: C,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<C, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            C,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            C,
+            usize,
+            RegisterView<C, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(context: C) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext.snap
@@ -4,32 +4,90 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 #[linera_views::async_trait]
 impl linera_views::views::View<CustomContext> for TestView {
+    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
+        + CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(
+        context: &CustomContext,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<
+                CustomContext,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: CustomContext,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            CustomContext,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(
         context: CustomContext,
     ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_CustomContext_with_where.snap
@@ -7,32 +7,90 @@ impl<MyParam> linera_views::views::View<CustomContext> for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<CustomContext, usize>::NUM_INIT_KEYS
+        + CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &CustomContext {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(
+        context: &CustomContext,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<
+                CustomContext,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: CustomContext,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos + RegisterView::<CustomContext, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            CustomContext,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                CustomContext,
+                usize,
+                RegisterView<CustomContext, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            CustomContext,
+            usize,
+            RegisterView<CustomContext, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(
         context: CustomContext,
     ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T_.snap
@@ -4,32 +4,94 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 #[linera_views::async_trait]
 impl linera_views::views::View<custom::GenericContext<T>> for TestView {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::GenericContext<T>,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(
+        context: &custom::GenericContext<T>,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<
+                custom::GenericContext<T>,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::GenericContext<T>,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::GenericContext<T>,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(
         context: custom::GenericContext<T>,
     ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__GenericContext_T__with_where.snap
@@ -7,32 +7,94 @@ impl<MyParam> linera_views::views::View<custom::GenericContext<T>> for TestView<
 where
     MyParam: Send + Sync + 'static,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::GenericContext<T>,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::GenericContext<T> {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(
+        context: &custom::GenericContext<T>,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<
+                custom::GenericContext<T>,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::GenericContext<T>,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::GenericContext<T>, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::GenericContext<T>,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::GenericContext<T>,
+                usize,
+                RegisterView<custom::GenericContext<T>, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::GenericContext<T>,
+            usize,
+            RegisterView<custom::GenericContext<T>, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(
         context: custom::GenericContext<T>,
     ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType.snap
@@ -4,32 +4,94 @@ expression: "pretty(generate_view_code(input, true))"
 ---
 #[linera_views::async_trait]
 impl linera_views::views::View<custom::path::to::ContextType> for TestView {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::path::to::ContextType,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(
+        context: &custom::path::to::ContextType,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<
+                custom::path::to::ContextType,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::path::to::ContextType,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::path::to::ContextType,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(
         context: custom::path::to::ContextType,
     ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_custom__path__to__ContextType_with_where.snap
@@ -8,32 +8,94 @@ for TestView<MyParam>
 where
     MyParam: Send + Sync + 'static,
 {
+    const NUM_INIT_KEYS: usize = RegisterView::<
+        custom::path::to::ContextType,
+        usize,
+    >::NUM_INIT_KEYS
+        + CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::NUM_INIT_KEYS;
     fn context(&self) -> &custom::path::to::ContextType {
         use linera_views::views::View;
         self.register.context()
     }
+    fn pre_load(
+        context: &custom::path::to::ContextType,
+    ) -> Result<Vec<Vec<u8>>, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut keys = Vec::new();
+        let index = 0;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            RegisterView::<
+                custom::path::to::ContextType,
+                usize,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        let index = 1;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        keys.extend(
+            CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::pre_load(&context.clone_with_base_key(base_key))?,
+        );
+        Ok(keys)
+    }
+    fn post_load(
+        context: custom::path::to::ContextType,
+        values: &[Option<Vec<u8>>],
+    ) -> Result<Self, linera_views::views::ViewError> {
+        use linera_views::common::Context as _;
+        let mut pos = 0;
+        let index = 0;
+        let pos_next = pos
+            + RegisterView::<custom::path::to::ContextType, usize>::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let register = RegisterView::<
+            custom::path::to::ContextType,
+            usize,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        let index = 1;
+        let pos_next = pos
+            + CollectionView::<
+                custom::path::to::ContextType,
+                usize,
+                RegisterView<custom::path::to::ContextType, usize>,
+            >::NUM_INIT_KEYS;
+        let base_key = context
+            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
+        let collection = CollectionView::<
+            custom::path::to::ContextType,
+            usize,
+            RegisterView<custom::path::to::ContextType, usize>,
+        >::post_load(context.clone_with_base_key(base_key), &values[pos..pos_next])?;
+        pos = pos_next;
+        Ok(Self { register, collection })
+    }
     async fn load(
         context: custom::path::to::ContextType,
     ) -> Result<Self, linera_views::views::ViewError> {
-        use linera_views::{futures::join, common::Context};
+        use linera_views::common::Context as _;
         #[cfg(not(target_arch = "wasm32"))]
         linera_views::increment_counter(
             &linera_views::LOAD_VIEW_COUNTER,
             stringify!(TestView),
             &context.base_key(),
         );
-        let index = 0;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let register_fut = RegisterView::load(context.clone_with_base_key(base_key));
-        let index = 1;
-        let base_key = context
-            .derive_tag_key(linera_views::common::MIN_VIEW_TAG, &index)?;
-        let collection_fut = CollectionView::load(context.clone_with_base_key(base_key));
-        let result = join!(register_fut, collection_fut);
-        let register = result.0?;
-        let collection = result.1?;
-        Ok(Self { register, collection })
+        #[cfg(not(target_arch = "wasm32"))]
+        use linera_views::prometheus_util::MeasureLatency as _;
+        let _latency = linera_views::LOAD_VIEW_LATENCY.measure_latency();
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
     fn rollback(&mut self) {
         self.register.rollback();

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -89,16 +89,26 @@ where
     ViewError: From<C::Error>,
     W: View<C> + Send + Sync,
 {
+    const NUM_INIT_KEYS: usize = 0;
+
     fn context(&self) -> &C {
         &self.context
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![])
+    }
+
+    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         Ok(Self {
             context,
             delete_storage_first: false,
             updates: RwLock::new(BTreeMap::new()),
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -635,16 +645,26 @@ where
     I: Send + Sync + Debug + Serialize + DeserializeOwned,
     W: View<C> + Send + Sync,
 {
+    const NUM_INIT_KEYS: usize = ByteCollectionView::<C, W>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.collection.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let collection = ByteCollectionView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteCollectionView::<C, W>::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let collection = ByteCollectionView::post_load(context, values)?;
         Ok(CollectionView {
             collection,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -974,16 +994,26 @@ where
     I: Send + Sync + Debug,
     W: View<C> + Send + Sync,
 {
+    const NUM_INIT_KEYS: usize = ByteCollectionView::<C, W>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.collection.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let collection = ByteCollectionView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteCollectionView::<C, W>::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let collection = ByteCollectionView::post_load(context, values)?;
         Ok(CustomCollectionView {
             collection,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -116,6 +116,18 @@ where
     }
 }
 
+pub(crate) fn from_bytes_option_or_default<V: DeserializeOwned + Default, E>(
+    key_opt: &Option<Vec<u8>>,
+) -> Result<V, E>
+where
+    E: From<bcs::Error>,
+{
+    match key_opt {
+        Some(bytes) => Ok(bcs::from_bytes(bytes)?),
+        None => Ok(V::default()),
+    }
+}
+
 /// `SuffixClosedSetIterator` iterates over the entries of a container ordered
 /// lexicographically.
 ///

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -101,7 +101,7 @@ pub fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
     (Included(key_prefix), upper_bound)
 }
 
-pub(crate) fn from_bytes_opt<V: DeserializeOwned, E>(
+pub(crate) fn from_bytes_option<V: DeserializeOwned, E>(
     key_opt: &Option<Vec<u8>>,
 ) -> Result<Option<V>, E>
 where
@@ -337,7 +337,7 @@ pub trait LocalReadableKeyValueStore<E> {
         Self: Sync,
         E: From<bcs::Error>,
     {
-        async { from_bytes_opt(&self.read_value_bytes(key).await?) }
+        async { from_bytes_option(&self.read_value_bytes(key).await?) }
     }
 
     /// Reads multiple `keys` and deserializes the results if present.
@@ -352,7 +352,7 @@ pub trait LocalReadableKeyValueStore<E> {
         async {
             let mut values = Vec::with_capacity(keys.len());
             for entry in self.read_multi_values_bytes(keys).await? {
-                values.push(from_bytes_opt(&entry)?);
+                values.push(from_bytes_option(&entry)?);
             }
             Ok(values)
         }
@@ -656,7 +656,7 @@ pub trait Context: Clone {
     where
         Item: DeserializeOwned,
     {
-        from_bytes_opt(&self.read_value_bytes(key).await?)
+        from_bytes_option(&self.read_value_bytes(key).await?)
     }
 
     /// Reads multiple `keys` and deserializes the results if present.
@@ -669,7 +669,7 @@ pub trait Context: Clone {
     {
         let mut values = Vec::with_capacity(keys.len());
         for entry in self.read_multi_values_bytes(keys).await? {
-            values.push(from_bytes_opt(&entry)?);
+            values.push(from_bytes_option(&entry)?);
         }
         Ok(values)
     }

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -12,7 +12,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     batch::Batch,
-    common::{from_bytes_opt, Context, MIN_VIEW_TAG},
+    common::{from_bytes_option, Context, MIN_VIEW_TAG},
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 
@@ -58,7 +58,7 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let hash = from_bytes_opt(values.first().unwrap())?;
+        let hash = from_bytes_option(values.first().unwrap())?;
         let base_key = context.base_tag(KeyTag::Inner as u8);
         let context = context.clone_with_base_key(base_key);
         let inner = W::post_load(context, &values[1..])?;

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -8,12 +8,11 @@ use std::{
 
 use async_lock::Mutex;
 use async_trait::async_trait;
-use futures::join;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     batch::Batch,
-    common::{Context, MIN_VIEW_TAG},
+    common::{from_bytes_opt, Context, MIN_VIEW_TAG},
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
 
@@ -44,25 +43,37 @@ where
     O: Serialize + DeserializeOwned + Send + Sync + Copy + PartialEq,
     W::Hasher: Hasher<Output = O>,
 {
+    const NUM_INIT_KEYS: usize = 1 + W::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.inner.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let hash_key = context.base_tag(KeyTag::Hash as u8);
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        let mut v = vec![context.base_tag(KeyTag::Hash as u8)];
         let base_key = context.base_tag(KeyTag::Inner as u8);
-        let (hash, inner) = join!(
-            context.read_value(&hash_key),
-            W::load(context.clone_with_base_key(base_key))
-        );
-        let hash = hash?;
-        let inner = inner?;
+        let context = context.clone_with_base_key(base_key);
+        v.extend(W::pre_load(&context)?);
+        Ok(v)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let hash = from_bytes_opt(values.first().unwrap())?;
+        let base_key = context.base_tag(KeyTag::Inner as u8);
+        let context = context.clone_with_base_key(base_key);
+        let inner = W::post_load(context, &values[1..])?;
         Ok(Self {
             _phantom: PhantomData,
             stored_hash: hash,
             hash: Mutex::new(hash),
             inner,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/hashable_wrapper.rs
+++ b/linera-views/src/hashable_wrapper.rs
@@ -58,10 +58,13 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let hash = from_bytes_option(values.first().unwrap())?;
+        let hash = from_bytes_option(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
         let base_key = context.base_tag(KeyTag::Inner as u8);
         let context = context.clone_with_base_key(base_key);
-        let inner = W::post_load(context, &values[1..])?;
+        let inner = W::post_load(
+            context,
+            values.get(1..).ok_or(ViewError::PostLoadValuesError)?,
+        )?;
         Ok(Self {
             _phantom: PhantomData,
             stored_hash: hash,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -176,10 +176,14 @@ where
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         let hash = from_bytes_option(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
-        let total_size = from_bytes_option_or_default(values.get(1).ok_or(ViewError::PostLoadValuesError)?)?;
+        let total_size =
+            from_bytes_option_or_default(values.get(1).ok_or(ViewError::PostLoadValuesError)?)?;
         let base_key = context.base_tag(KeyTag::Sizes as u8);
         let context_sizes = context.clone_with_base_key(base_key);
-        let sizes = ByteMapView::post_load(context_sizes, values.get(2..).ok_or(ViewError::PostLoadValuesError)?)?;
+        let sizes = ByteMapView::post_load(
+            context_sizes,
+            values.get(2..).ok_or(ViewError::PostLoadValuesError)?,
+        )?;
         Ok(Self {
             context,
             delete_storage_first: false,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -22,7 +22,7 @@ use {
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        contains_key, from_bytes_opt, get_interval, get_upper_bound, insert_key_prefix, Context,
+        contains_key, from_bytes_option, get_interval, get_upper_bound, insert_key_prefix, Context,
         HasherOutput, KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
@@ -174,8 +174,8 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let hash = from_bytes_opt(values.first().unwrap())?;
-        let total_size = from_bytes_opt(values.get(1).unwrap())?.unwrap_or_default();
+        let hash = from_bytes_option(values.first().unwrap())?;
+        let total_size = from_bytes_option(values.get(1).unwrap())?.unwrap_or_default();
         let base_key = context.base_tag(KeyTag::Sizes as u8);
         let context_sizes = context.clone_with_base_key(base_key);
         let sizes = ByteMapView::post_load(context_sizes, &values[2..])?;

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -22,8 +22,8 @@ use {
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        contains_key, get_interval, get_upper_bound, insert_key_prefix, Context, HasherOutput,
-        KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
+        contains_key, from_bytes_opt, get_interval, get_upper_bound, insert_key_prefix, Context,
+        HasherOutput, KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
@@ -157,18 +157,28 @@ where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
 {
+    const NUM_INIT_KEYS: usize = 2 + ByteMapView::<C, u32>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         &self.context
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let key = context.base_tag(KeyTag::Hash as u8);
-        let hash = context.read_value(&key).await?;
-        let key = context.base_tag(KeyTag::TotalSize as u8);
-        let total_size = context.read_value(&key).await?.unwrap_or_default();
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        let key_hash = context.base_tag(KeyTag::Hash as u8);
+        let key_total_size = context.base_tag(KeyTag::TotalSize as u8);
+        let mut v = vec![key_hash, key_total_size];
         let base_key = context.base_tag(KeyTag::Sizes as u8);
         let context_sizes = context.clone_with_base_key(base_key);
-        let sizes = ByteMapView::load(context_sizes).await?;
+        v.extend(ByteMapView::<C, u32>::pre_load(&context_sizes)?);
+        Ok(v)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let hash = from_bytes_opt(values.first().unwrap())?;
+        let total_size = from_bytes_opt(values.get(1).unwrap())?.unwrap_or_default();
+        let base_key = context.base_tag(KeyTag::Sizes as u8);
+        let context_sizes = context.clone_with_base_key(base_key);
+        let sizes = ByteMapView::post_load(context_sizes, &values[2..])?;
         Ok(Self {
             context,
             delete_storage_first: false,
@@ -180,6 +190,12 @@ where
             stored_hash: hash,
             hash: Mutex::new(hash),
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -22,8 +22,9 @@ use {
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        contains_key, from_bytes_option, get_interval, get_upper_bound, insert_key_prefix, Context,
-        HasherOutput, KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
+        contains_key, from_bytes_option, from_bytes_option_or_default, get_interval,
+        get_upper_bound, insert_key_prefix, Context, HasherOutput, KeyIterable, KeyValueIterable,
+        SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
@@ -175,7 +176,7 @@ where
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         let hash = from_bytes_option(values.first().unwrap())?;
-        let total_size = from_bytes_option(values.get(1).unwrap())?.unwrap_or_default();
+        let total_size = from_bytes_option_or_default(values.get(1).unwrap())?;
         let base_key = context.base_tag(KeyTag::Sizes as u8);
         let context_sizes = context.clone_with_base_key(base_key);
         let sizes = ByteMapView::post_load(context_sizes, &values[2..])?;

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -175,11 +175,11 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let hash = from_bytes_option(values.first().unwrap())?;
-        let total_size = from_bytes_option_or_default(values.get(1).unwrap())?;
+        let hash = from_bytes_option(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
+        let total_size = from_bytes_option_or_default(values.get(1).ok_or(ViewError::PostLoadValuesError)?)?;
         let base_key = context.base_tag(KeyTag::Sizes as u8);
         let context_sizes = context.clone_with_base_key(base_key);
-        let sizes = ByteMapView::post_load(context_sizes, &values[2..])?;
+        let sizes = ByteMapView::post_load(context_sizes, values.get(2..).ok_or(ViewError::PostLoadValuesError)?)?;
         Ok(Self {
             context,
             delete_storage_first: false,

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -60,10 +60,9 @@ The `LogView` can be seen as an analog of `VecDeque` while `MapView` is an analo
 #![deny(clippy::large_futures)]
 
 #[cfg(with_metrics)]
-use {
-    linera_base::{prometheus_util, sync::Lazy},
-    prometheus::IntCounterVec,
-};
+pub use linera_base::prometheus_util;
+#[cfg(with_metrics)]
+use {linera_base::sync::Lazy, prometheus::IntCounterVec};
 
 /// The definition of the batches for writing in the database.
 pub mod batch;
@@ -152,6 +151,15 @@ pub fn increment_counter(counter: &Lazy<IntCounterVec>, struct_name: &str, base_
     let labels = [struct_name, &base_key];
     counter.with_label_values(&labels).inc();
 }
+
+/// The metric tracking the latency of the loading of views.
+#[cfg(with_metrics)]
+#[doc(hidden)]
+pub static LOAD_VIEW_LATENCY: Lazy<prometheus::HistogramVec> = Lazy::new(|| {
+    use prometheus::register_histogram_vec;
+    register_histogram_vec!("load_view_latency", "Load view latency", &[])
+        .expect("Load view latency should not fail")
+});
 
 /// The metric counting how often a view is read from storage.
 #[cfg(with_metrics)]

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -17,7 +17,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{from_bytes_option, Context, HasherOutput, MIN_VIEW_TAG},
+    common::{from_bytes_option_or_default, Context, HasherOutput, MIN_VIEW_TAG},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -72,8 +72,7 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let value = from_bytes_option(values.first().unwrap())?;
-        let stored_count = value.unwrap_or_default();
+        let stored_count = from_bytes_option_or_default(values.first().unwrap())?;
         Ok(Self {
             context,
             delete_storage_first: false,

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -17,7 +17,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{from_bytes_opt, Context, HasherOutput, MIN_VIEW_TAG},
+    common::{from_bytes_option, Context, HasherOutput, MIN_VIEW_TAG},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -72,7 +72,7 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let value = from_bytes_opt(values.first().unwrap())?;
+        let value = from_bytes_option(values.first().unwrap())?;
         let stored_count = value.unwrap_or_default();
         Ok(Self {
             context,

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -17,7 +17,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{Context, HasherOutput, MIN_VIEW_TAG},
+    common::{from_bytes_opt, Context, HasherOutput, MIN_VIEW_TAG},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -61,13 +61,18 @@ where
     ViewError: From<C::Error>,
     T: Send + Sync + Serialize,
 {
+    const NUM_INIT_KEYS: usize = 1;
+
     fn context(&self) -> &C {
         &self.context
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let key = context.base_tag(KeyTag::Count as u8);
-        let value = context.read_value(&key).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![context.base_tag(KeyTag::Count as u8)])
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let value = from_bytes_opt(values.first().unwrap())?;
         let stored_count = value.unwrap_or_default();
         Ok(Self {
             context,
@@ -75,6 +80,12 @@ where
             stored_count,
             new_values: Vec::new(),
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -72,7 +72,7 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let stored_count = from_bytes_option_or_default(values.first().unwrap())?;
+        let stored_count = from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
         Ok(Self {
             context,
             delete_storage_first: false,

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -72,7 +72,8 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let stored_count = from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
+        let stored_count =
+            from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
         Ok(Self {
             context,
             delete_storage_first: false,

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -74,17 +74,27 @@ where
     ViewError: From<C::Error>,
     V: Send + Sync + Serialize,
 {
+    const NUM_INIT_KEYS: usize = 0;
+
     fn context(&self) -> &C {
         &self.context
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(Vec::new())
+    }
+
+    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         Ok(Self {
             context,
             delete_storage_first: false,
             updates: BTreeMap::new(),
             deleted_prefixes: BTreeSet::new(),
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -808,16 +818,26 @@ where
     I: Send + Sync + Serialize,
     V: Send + Sync + Serialize,
 {
+    const NUM_INIT_KEYS: usize = ByteMapView::<C, V>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.map.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let map = ByteMapView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteMapView::<C, V>::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let map = ByteMapView::post_load(context, values)?;
         Ok(MapView {
             map,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -1226,16 +1246,26 @@ where
     I: Send + Sync + CustomSerialize,
     V: Clone + Send + Sync + Serialize,
 {
+    const NUM_INIT_KEYS: usize = ByteMapView::<C, V>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.map.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let map = ByteMapView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteMapView::<C, V>::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let map = ByteMapView::post_load(context, values)?;
         Ok(CustomMapView {
             map,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -18,7 +18,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{from_bytes_option, Context, HasherOutput, MIN_VIEW_TAG},
+    common::{from_bytes_option_or_default, Context, HasherOutput, MIN_VIEW_TAG},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -74,8 +74,7 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let value = from_bytes_option(values.first().unwrap())?;
-        let stored_indices = value.unwrap_or_default();
+        let stored_indices = from_bytes_option_or_default(values.first().unwrap())?;
         Ok(Self {
             context,
             stored_indices,

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -74,7 +74,8 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let stored_indices = from_bytes_option_or_default(values.first().unwrap())?;
+        let stored_indices =
+            from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
         Ok(Self {
             context,
             stored_indices,

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -18,7 +18,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{from_bytes_opt, Context, HasherOutput, MIN_VIEW_TAG},
+    common::{from_bytes_option, Context, HasherOutput, MIN_VIEW_TAG},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -74,7 +74,7 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let value = from_bytes_opt(values.first().unwrap())?;
+        let value = from_bytes_option(values.first().unwrap())?;
         let stored_indices = value.unwrap_or_default();
         Ok(Self {
             context,

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -102,16 +102,26 @@ where
     ViewError: From<C::Error>,
     W: View<C> + Send + Sync,
 {
+    const NUM_INIT_KEYS: usize = 0;
+
     fn context(&self) -> &C {
         &self.context
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(Vec::new())
+    }
+
+    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         Ok(Self {
             context,
             delete_storage_first: false,
             updates: Mutex::new(BTreeMap::new()),
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -843,16 +853,26 @@ where
     I: Send + Sync + Debug + Serialize + DeserializeOwned,
     W: View<C> + Send + Sync,
 {
+    const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<C, W>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.collection.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let collection = ReentrantByteCollectionView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ReentrantByteCollectionView::<C, W>::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let collection = ReentrantByteCollectionView::post_load(context, values)?;
         Ok(ReentrantCollectionView {
             collection,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -1273,16 +1293,26 @@ where
     I: Send + Sync + Debug + CustomSerialize,
     W: View<C> + Send + Sync,
 {
+    const NUM_INIT_KEYS: usize = ReentrantByteCollectionView::<C, W>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.collection.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let collection = ReentrantByteCollectionView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ReentrantByteCollectionView::<C, W>::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let collection = ReentrantByteCollectionView::post_load(context, values)?;
         Ok(ReentrantCustomCollectionView {
             collection,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -60,7 +60,8 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let value = from_bytes_option_or_default(values.first().unwrap())?;
+        let value =
+            from_bytes_option_or_default(values.first().ok_or(ViewError::PostLoadValuesError)?)?;
         let stored_value = Box::new(value);
         Ok(Self {
             delete_storage_first: false,

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -14,7 +14,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{Context, HasherOutput},
+    common::{from_bytes_opt, Context, HasherOutput},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -49,13 +49,18 @@ where
     ViewError: From<C::Error>,
     T: Default + Send + Sync + Serialize + DeserializeOwned,
 {
+    const NUM_INIT_KEYS: usize = 1;
+
     fn context(&self) -> &C {
         &self.context
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let key = context.base_key();
-        let value = context.read_value(&key).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(vec![context.base_key()])
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let value = from_bytes_opt(values.first().unwrap())?;
         let stored_value = Box::new(value.unwrap_or_default());
         Ok(Self {
             delete_storage_first: false,
@@ -63,6 +68,12 @@ where
             stored_value,
             update: None,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        let keys = Self::pre_load(&context)?;
+        let values = context.read_multi_values_bytes(keys).await?;
+        Self::post_load(context, &values)
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -14,7 +14,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{from_bytes_option, Context, HasherOutput},
+    common::{from_bytes_option_or_default, Context, HasherOutput},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -60,8 +60,8 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let value = from_bytes_option(values.first().unwrap())?;
-        let stored_value = Box::new(value.unwrap_or_default());
+        let value = from_bytes_option_or_default(values.first().unwrap())?;
+        let stored_value = Box::new(value);
         Ok(Self {
             delete_storage_first: false,
             context,

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -14,7 +14,7 @@ use {
 
 use crate::{
     batch::Batch,
-    common::{from_bytes_opt, Context, HasherOutput},
+    common::{from_bytes_option, Context, HasherOutput},
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
 };
@@ -60,7 +60,7 @@ where
     }
 
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
-        let value = from_bytes_opt(values.first().unwrap())?;
+        let value = from_bytes_option(values.first().unwrap())?;
         let stored_value = Box::new(value.unwrap_or_default());
         Ok(Self {
             delete_storage_first: false,

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -47,16 +47,26 @@ where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
 {
+    const NUM_INIT_KEYS: usize = 0;
+
     fn context(&self) -> &C {
         &self.context
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
+    fn pre_load(_context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        Ok(Vec::new())
+    }
+
+    fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         Ok(Self {
             context,
             delete_storage_first: false,
             updates: BTreeMap::new(),
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -359,16 +369,26 @@ where
     ViewError: From<C::Error>,
     I: Send + Sync + Serialize,
 {
+    const NUM_INIT_KEYS: usize = ByteSetView::<C>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.set.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let set = ByteSetView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteSetView::<C>::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let set = ByteSetView::post_load(context, values)?;
         Ok(Self {
             set,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {
@@ -612,16 +632,26 @@ where
     ViewError: From<C::Error>,
     I: Send + Sync + CustomSerialize,
 {
+    const NUM_INIT_KEYS: usize = ByteSetView::<C>::NUM_INIT_KEYS;
+
     fn context(&self) -> &C {
         self.set.context()
     }
 
-    async fn load(context: C) -> Result<Self, ViewError> {
-        let set = ByteSetView::load(context).await?;
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError> {
+        ByteSetView::pre_load(context)
+    }
+
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
+        let set = ByteSetView::post_load(context, values)?;
         Ok(Self {
             set,
             _phantom: PhantomData,
         })
+    }
+
+    async fn load(context: C) -> Result<Self, ViewError> {
+        Self::post_load(context, &[])
     }
 
     fn rollback(&mut self) {

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -21,10 +21,19 @@ mod tests;
 /// address in storage.
 #[async_trait]
 pub trait View<C>: Sized {
+    /// The number of keys used for the initialization
+    const NUM_INIT_KEYS: usize;
+
     /// Obtains a mutable reference to the internal context.
     fn context(&self) -> &C;
 
-    /// Creates a view or a subview.
+    /// Creates the keys needed for loading the view
+    fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError>;
+
+    /// Load a view from the values
+    fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError>;
+
+    /// Loads a view
     async fn load(context: C) -> Result<Self, ViewError>;
 
     /// Discards all pending changes. After that `flush` should have no effect to storage.

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -30,7 +30,7 @@ pub trait View<C>: Sized {
     /// Creates the keys needed for loading the view
     fn pre_load(context: &C) -> Result<Vec<Vec<u8>>, ViewError>;
 
-    /// Load a view from the values
+    /// Loads a view from the values
     fn post_load(context: C, values: &[Option<Vec<u8>>]) -> Result<Self, ViewError>;
 
     /// Loads a view
@@ -109,6 +109,10 @@ pub enum ViewError {
     /// The database is corrupt: Some entries are missing
     #[error("Missing database entries")]
     MissingEntries,
+
+    /// The values are incoherent.
+    #[error("Post load values error")]
+    PostLoadValuesError,
 
     /// The value is too large for the client
     #[error("The value is too large for the client")]


### PR DESCRIPTION
## Motivation

The loading of the views leads to a flurry of independent `read_value_bytes` which strain the storage. This PR groups the access into a single query.

## Proposal

The following was done:
* The `pre_load` and `post_load` are introduced.
* The `NUM_INIT_KEYS` static variable is introduced because so far the loading leads to a constant number of reads per view.
* The `fn load` was changed to use the `pre_load` / `post_load`.

Next steps:
* Possibly put the `fn load` as a trait function. But we have now 3 kinds of such load functions so maybe the unification is not a good idea.
* Change the `try_load_entries_mut` of `reentrant_collection_view` so that it uses the `pre_load` / `post_load`.

## Test Plan

The CI of the view is already challenging enough and do not need to be expanded.
How much of an improvement has been computed:
* With the old code, the loading of views takes between 45 and 64 milliseconds
* With the pre_load/post_load, the loading of views takes between 5 and 20 milliseconds.

## Release Plan

This should be documented as it is an API change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
