### PR TITLE
Split `read_multi_values_bytes` queries for ScyllaDb in chunks of 100

### DIFF
--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -15,6 +15,9 @@
 //! [trait1]: common::KeyValueStore
 //! [trait2]: common::Context
 
+/// Fundamental constant in ScyllaDB: The maximum size of a multi keys query
+const MAX_MULTI_KEYS: usize = 100;
+
 use std::{
     collections::{hash_map::Entry, HashMap},
     ops::Deref,
@@ -420,10 +423,8 @@ impl ReadableKeyValueStore<ScyllaDbContextError> for ScyllaDbStoreInternal {
         }
         let store = self.store.deref();
         let _guard = self.acquire().await;
-        // This is the maximal size of a query in ScyllaDb with current settings.
-        let max_size_queries = 100;
         let handles = keys
-            .chunks(max_size_queries)
+            .chunks(MAX_MULTI_KEYS)
             .map(|keys| store.read_multi_values_internal(keys.to_vec()));
         let results: Vec<_> = join_all(handles)
             .await

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -287,7 +287,7 @@ pub async fn run_reads<S: LocalKeyValueStore>(store: S, key_values: Vec<(Vec<u8>
     }
     // Now checking the read_multi_values_bytes
     let mut rng = make_deterministic_rng();
-    for _ in 0..10 {
+    for _ in 0..3 {
         let mut keys = Vec::new();
         let mut values = Vec::new();
         for (key, value) in &key_values {
@@ -349,6 +349,7 @@ fn get_random_key_values2(num_entries: usize, len_value: usize) -> Vec<(Vec<u8>,
 pub fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {
     vec![
         get_random_key_values1(7, 3),
+        get_random_key_values1(150, 3),
         get_random_key_values1(30, 10),
         get_random_key_values2(30, 10),
         get_random_key_values2(30, 100),


### PR DESCRIPTION
## Motivation

The recently merged PR about the `read_multi_values_bytes` for ScyllaDb is sometimes the limit that queries need to have a size of at most 100.

## Proposal

The solution is to split queries into chunks of at most 100. This is done with the `join` logic that was used before.

## Test Plan

A test with 150 entries has been added to the CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
