### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -36,6 +36,7 @@ permissions:
 jobs:
   kind-deployment-e2e-tests:
     runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v3
@@ -60,9 +61,11 @@ jobs:
         with:
           # Port forwarding sometimes dies, which makes all requests timeout
           # Which is why we need retries
-          max_attempts: 10
-          timeout_minutes: 45
-          command: kind get clusters | xargs -I {} kind delete cluster --name {} && cargo test --locked -p linera-service --features scylladb,kubernetes --test end_to_end_tests -- kubernetes
+          max_attempts: 3
+          timeout_minutes: 30
+          command: |
+            kind get clusters | xargs -I {} kind delete cluster --name {}
+            RUST_LOG=linera=info cargo test --locked -p linera-service --features scylladb,kubernetes --test end_to_end_tests -- kubernetes --nocapture
       - name: Port forward Prometheus
         run: |
           kubectl port-forward prometheus-linera-core-kube-prometheu-prometheus-0 9090 &

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,12 +56,6 @@ jobs:
       uses: arduino/setup-protoc@v1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Install chromedriver
-      uses: nanasess/setup-chromedriver@v2
-    - name: Install wasm-pack
-      uses: jetli/wasm-pack-action@v0.4.0
-      with:
-        version: 'latest'
     - name: Set environment variables
       run: |
         echo "LINERA_STORAGE_SERVICE=127.0.0.1:1235" >> "$GITHUB_ENV"
@@ -70,13 +64,6 @@ jobs:
       run: |
         cd examples
         cargo build --locked --release --target wasm32-unknown-unknown
-    - name: Compile `linera-core` for the browser
-      run: |
-        cargo build -p linera-core \
-          --locked \
-          --target wasm32-unknown-unknown \
-          --no-default-features \
-          --features web,wasmer
     - name: Run end-to-end tests
       run: |
         cargo build --release -p linera-storage-service
@@ -98,10 +85,6 @@ jobs:
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime
-    - name: Run the browser tests
-      run: |
-        cd linera-views
-        WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --chrome --headless --features web,indexeddb
     - name: Run the benchmark test
       run: |
         cargo build --locked -p linera-service --bin linera-benchmark --features benchmark
@@ -121,6 +104,31 @@ jobs:
           echo 'Run `linera help-markdown > CLI.md` to update it.'
           exit 1
         fi
+
+  web:
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 15
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Compile `linera-core` for the browser
+      run: |
+        cargo build -p linera-core \
+          --locked \
+          --target wasm32-unknown-unknown \
+          --no-default-features \
+          --features web,wasmer
+    - name: Install chromedriver
+      uses: nanasess/setup-chromedriver@v2
+    - name: Install wasm-pack
+      uses: jetli/wasm-pack-action@v0.4.0
+      with:
+        version: 'latest'
+    - name: Run the browser tests
+      run: |
+        cd linera-views
+        WASM_BINDGEN_TEST_TIMEOUT=300 wasm-pack test --chrome --headless --features web,indexeddb
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest-16-cores
-    timeout-minutes: 95
+    timeout-minutes: 75
 
     steps:
     - uses: actions/checkout@v3
@@ -70,9 +70,6 @@ jobs:
       run: |
         cd examples
         cargo build --locked --release --target wasm32-unknown-unknown
-    - name: Compile the workspace with the default features (test)
-      run: |
-        cargo test --locked --no-run
     - name: Compile `linera-core` for the browser
       run: |
         cargo build -p linera-core \
@@ -80,12 +77,10 @@ jobs:
           --target wasm32-unknown-unknown \
           --no-default-features \
           --features web,wasmer
-    - name: Compile the workspace with the default features (build)
-      run: |
-        cargo build --locked
     - name: Run end-to-end tests
       run: |
-        ./target/debug/storage_service_server memory --endpoint $LINERA_STORAGE_SERVICE &
+        cargo build --release -p linera-storage-service
+        RUST_LOG=info target/release/storage_service_server memory --endpoint $LINERA_STORAGE_SERVICE &
         RUST_LOG=info cargo test --features storage_service -- storage_service --nocapture
     - name: Run Ethereum tests
       run: |
@@ -129,6 +124,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     continue-on-error: true
 
     steps:

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -56,4 +56,4 @@ jobs:
         docker run --name my_scylla_container -d -p 9042:9042 scylladb/scylla
     - name: Run ScyllaDB tests
       run: |
-        cargo test --locked --features scylladb -- scylla
+        RUST_LOG=linera=info cargo test --locked --features scylladb -- scylla --nocapture

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-default = ["rocksdb"]
 metrics = ["linera-views/metrics"]
 rocksdb = ["linera-views/rocksdb"]
 storage_service = []


### PR DESCRIPTION
## Motivation

* Avoid wasting $$ with long timeouts
* Shorten wait time

## Proposal

- restore global timeouts
- more verbose logs
- do not active the feature "rocksdb" by default in linera-storage-service
- remove preliminary build steps (whose features may not match the tests)
- ~~avoid recompiling linera CLI~~
- move web tests to a separate action

## Test Plan

CI
