### PR TITLE
Make application services keep running across queries

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -376,8 +376,10 @@ where
         &mut self,
         local_time: Timestamp,
         query: Query,
-        incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-        runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+        incoming_execution_requests: &mut futures::channel::mpsc::UnboundedReceiver<
+            ExecutionRequest,
+        >,
+        runtime_request_sender: &mut std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     ) -> Result<Response, ChainError> {
         let context = QueryContext {
             chain_id: self.chain_id(),

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -240,6 +240,7 @@ where
         trace!("Starting `ChainWorkerActor`");
 
         while let Some(request) = self.incoming_requests.recv().await {
+            // TODO(#2237): Spawn concurrent tasks for read-only operations
             trace!("Handling `ChainWorkerRequest`: {request:?}");
 
             let responded = match request {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -10,7 +10,7 @@ use std::{
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, HashedBlob},
+    data_types::{BlockHeight, HashedBlob, Timestamp},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -21,13 +21,14 @@ use linera_chain::{
     ChainStateView,
 };
 use linera_execution::{
-    Query, Response, ServiceSyncRuntime, UserApplicationDescription, UserApplicationId,
+    ExecutionRequest, Query, QueryContext, Response, ServiceRuntimeRequest, ServiceSyncRuntime,
+    UserApplicationDescription, UserApplicationId,
 };
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use tokio::{
     sync::{mpsc, oneshot, OwnedRwLockReadGuard},
-    task::JoinSet,
+    task::{JoinHandle, JoinSet},
 };
 use tracing::{instrument, trace, warn};
 #[cfg(with_testing)]
@@ -152,6 +153,7 @@ where
 {
     worker: ChainWorkerState<StorageClient>,
     incoming_requests: mpsc::UnboundedReceiver<ChainWorkerRequest<StorageClient::Context>>,
+    service_runtime_thread: JoinHandle<()>,
 }
 
 impl<StorageClient> ChainWorkerActor<StorageClient>
@@ -170,24 +172,61 @@ where
         join_set: &mut JoinSet<()>,
     ) -> Result<mpsc::UnboundedSender<ChainWorkerRequest<StorageClient::Context>>, WorkerError>
     {
+        let (service_runtime_thread, execution_state_receiver, runtime_request_sender) =
+            Self::spawn_service_runtime_actor(chain_id);
+
         let worker = ChainWorkerState::load(
             config,
             storage,
             certificate_value_cache,
             blob_cache,
             chain_id,
+            execution_state_receiver,
+            runtime_request_sender,
         )
         .await?;
-        let (sender, receiver) = mpsc::unbounded_channel();
 
+        let (sender, receiver) = mpsc::unbounded_channel();
         let actor = ChainWorkerActor {
             worker,
             incoming_requests: receiver,
+            service_runtime_thread,
         };
 
         join_set.spawn_task(actor.run(tracing::Span::current()));
 
         Ok(sender)
+    }
+
+    /// Spawns a blocking task to execute the service runtime actor.
+    ///
+    /// Returns the task handle and the endpoints to interact with the actor.
+    fn spawn_service_runtime_actor(
+        chain_id: ChainId,
+    ) -> (
+        JoinHandle<()>,
+        futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
+        std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+    ) {
+        let context = QueryContext {
+            chain_id,
+            next_block_height: BlockHeight(0),
+            local_time: Timestamp::from(0),
+        };
+
+        let (execution_state_sender, execution_state_receiver) =
+            futures::channel::mpsc::unbounded();
+        let (runtime_request_sender, runtime_request_receiver) = std::sync::mpsc::channel();
+
+        let service_runtime_thread = tokio::task::spawn_blocking(move || {
+            ServiceSyncRuntime::new(execution_state_sender, context).run(runtime_request_receiver)
+        });
+
+        (
+            service_runtime_thread,
+            execution_state_receiver,
+            runtime_request_sender,
+        )
     }
 
     /// Runs the worker until there are no more incoming requests.
@@ -225,27 +264,9 @@ where
                 ChainWorkerRequest::GetChainStateView { callback } => {
                     callback.send(self.worker.chain_state_view().await).is_ok()
                 }
-                ChainWorkerRequest::QueryApplication { query, callback } => {
-                    let (execution_state_sender, execution_state_receiver) =
-                        futures::channel::mpsc::unbounded();
-                    let (request_sender, request_receiver) = std::sync::mpsc::channel();
-                    let context = self.worker.current_query_context();
-
-                    let runtime_thread = tokio::task::spawn_blocking(move || {
-                        ServiceSyncRuntime::new(execution_state_sender, context)
-                            .run(request_receiver)
-                    });
-
-                    let response = self
-                        .worker
-                        .query_application(query, execution_state_receiver, request_sender)
-                        .await;
-
-                    runtime_thread
-                        .await
-                        .expect("Service runtime thread should not panic");
-                    callback.send(response).is_ok()
-                }
+                ChainWorkerRequest::QueryApplication { query, callback } => callback
+                    .send(self.worker.query_application(query).await)
+                    .is_ok(),
                 #[cfg(with_testing)]
                 ChainWorkerRequest::ReadBytecodeLocation {
                     bytecode_id,
@@ -319,6 +340,11 @@ where
                 warn!("Callback for `ChainWorkerActor` was dropped before a response was sent");
             }
         }
+
+        drop(self.worker);
+        self.service_runtime_thread
+            .await
+            .expect("Service runtime thread should not panic");
 
         trace!("`ChainWorkerActor` finished");
     }

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -560,8 +560,10 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
-        incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-        runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+        mut incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<
+            ExecutionRequest,
+        >,
+        mut runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     ) -> Result<Response, WorkerError> {
         self.0.ensure_is_active()?;
         let local_time = self.0.storage.clock().current_time();
@@ -571,8 +573,8 @@ where
             .query_application(
                 local_time,
                 query,
-                incoming_execution_requests,
-                runtime_request_sender,
+                &mut incoming_execution_requests,
+                &mut runtime_request_sender,
             )
             .await?;
         Ok(response)

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -59,6 +59,8 @@ where
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
     shared_chain_view: Option<Arc<RwLock<ChainStateView<StorageClient::Context>>>>,
+    execution_state_receiver: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
+    runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
     recent_hashed_blobs: Arc<ValueCache<BlobId, HashedBlob>>,
     knows_chain_is_active: bool,
@@ -76,6 +78,8 @@ where
         certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
         blob_cache: Arc<ValueCache<BlobId, HashedBlob>>,
         chain_id: ChainId,
+        execution_state_receiver: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
+        runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
@@ -84,6 +88,8 @@ where
             storage,
             chain,
             shared_chain_view: None,
+            execution_state_receiver,
+            runtime_request_sender,
             recent_hashed_certificate_values: certificate_value_cache,
             recent_hashed_blobs: blob_cache,
             knows_chain_is_active: false,
@@ -153,11 +159,9 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
-        incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-        runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     ) -> Result<Response, WorkerError> {
         ChainWorkerStateWithTemporaryChanges(self)
-            .query_application(query, incoming_execution_requests, runtime_request_sender)
+            .query_application(query)
             .await
     }
 
@@ -560,10 +564,6 @@ where
     pub(super) async fn query_application(
         &mut self,
         query: Query,
-        mut incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<
-            ExecutionRequest,
-        >,
-        mut runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     ) -> Result<Response, WorkerError> {
         self.0.ensure_is_active()?;
         let local_time = self.0.storage.clock().current_time();
@@ -573,8 +573,8 @@ where
             .query_application(
                 local_time,
                 query,
-                &mut incoming_execution_requests,
-                &mut runtime_request_sender,
+                &mut self.0.execution_state_receiver,
+                &mut self.0.runtime_request_sender,
             )
             .await?;
         Ok(response)

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -39,12 +39,12 @@ use linera_execution::{
     },
     test_utils::{register_mock_applications, ExpectedCall, SystemExecutionState},
     ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, Response,
-    SystemExecutionError, SystemQuery, SystemResponse,
+    SystemExecutionError, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
 use linera_storage::{MemoryStorage, Storage, TestClock};
 use linera_views::{
-    memory::TEST_MEMORY_MAX_STREAM_QUERIES,
-    views::{RootView, ViewError},
+    memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    views::{CryptoHashView, RootView, ViewError},
 };
 use test_case::test_case;
 use test_log::test;
@@ -3733,6 +3733,167 @@ where
     };
     for query_time in query_times {
         clock.set(query_time);
+
+        assert_eq!(
+            worker.query_application(chain_id, query.clone()).await?,
+            Response::User(vec![])
+        );
+    }
+
+    drop(worker);
+    tokio::task::yield_now().await;
+    application.assert_no_more_expected_calls();
+
+    Ok(())
+}
+
+/// Tests if a service is restarted when a block is added to the chain.
+///
+/// A new block must force the service to restart, because the context will have changed and the
+/// application state may have changed.
+#[test_case(MemoryStorageBuilder::default(); "memory")]
+#[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
+#[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
+#[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
+#[test_log::test(tokio::test(start_paused = true))]
+async fn test_new_block_causes_service_restart<B>(mut storage_builder: B) -> anyhow::Result<()>
+where
+    B: StorageBuilder,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
+{
+    const NUM_QUERIES: usize = 2;
+    const BLOCK_TIMESTAMP: u64 = 10;
+
+    let storage = storage_builder.build().await?;
+    let clock = storage_builder.clock();
+    let chain_description = ChainDescription::Root(1);
+    let chain_id = ChainId::from(chain_description);
+    let key_pair = KeyPair::generate();
+    let balance = Amount::ZERO;
+
+    let (committee, mut worker) = init_worker_with_chain(
+        storage.clone(),
+        chain_description,
+        key_pair.public(),
+        balance,
+    )
+    .await;
+
+    let mut applications;
+    {
+        let mut chain = storage.load_chain(chain_id).await?;
+        applications = register_mock_applications(&mut chain.execution_state, 1).await?;
+        chain.save().await?;
+    }
+
+    let (application_id, application) = applications
+        .next()
+        .expect("Mock application should be registered");
+
+    let queries_before_proposal = (0..NUM_QUERIES as u64).map(Timestamp::from);
+    let queries_before_confirmation =
+        (0..NUM_QUERIES as u64).map(|delta| Timestamp::from(NUM_QUERIES as u64 + delta));
+
+    let queries_before_new_block = queries_before_proposal
+        .clone()
+        .chain(queries_before_confirmation.clone());
+    let queries_after_new_block =
+        (1..=NUM_QUERIES as u64).map(|delta| Timestamp::from(BLOCK_TIMESTAMP + delta));
+
+    let query = Query::User {
+        application_id,
+        bytes: vec![],
+    };
+
+    let query_contexts_before_new_block =
+        queries_before_new_block
+            .clone()
+            .map(|local_time| QueryContext {
+                chain_id,
+                next_block_height: BlockHeight(0),
+                local_time,
+            });
+    let query_contexts_after_new_block =
+        queries_after_new_block
+            .clone()
+            .map(|local_time| QueryContext {
+                chain_id,
+                next_block_height: BlockHeight(1),
+                local_time,
+            });
+
+    for query_context in query_contexts_before_new_block {
+        application.expect_call(ExpectedCall::handle_query(
+            move |_runtime, context, query| {
+                assert_eq!(context, query_context);
+                assert!(query.is_empty());
+                Ok(vec![])
+            },
+        ));
+    }
+
+    for local_time in queries_before_proposal {
+        clock.set(local_time);
+
+        assert_eq!(
+            worker.query_application(chain_id, query.clone()).await?,
+            Response::User(vec![])
+        );
+    }
+
+    clock.set(Timestamp::from(BLOCK_TIMESTAMP));
+    let block = make_first_block(chain_id).with_timestamp(Timestamp::from(BLOCK_TIMESTAMP));
+
+    let block_proposal = block.clone().into_fast_proposal(&key_pair);
+    let _ = worker.handle_block_proposal(block_proposal).await?;
+
+    for local_time in queries_before_confirmation {
+        clock.set(local_time);
+
+        assert_eq!(
+            worker.query_application(chain_id, query.clone()).await?,
+            Response::User(vec![])
+        );
+    }
+
+    let epoch = Epoch::ZERO;
+    let admin_id = ChainId::root(0);
+    let mut state = SystemExecutionState {
+        committees: BTreeMap::from_iter([(epoch, committee.clone())]),
+        ownership: ChainOwnership::single(key_pair.public()),
+        balance,
+        timestamp: Timestamp::from(BLOCK_TIMESTAMP),
+        ..SystemExecutionState::new(epoch, chain_description, admin_id)
+    }
+    .into_view()
+    .await;
+    register_mock_applications::<MemoryContext<TestExecutionRuntimeContext>>(&mut state, 1).await?;
+
+    let value = HashedCertificateValue::new_confirmed(
+        BlockExecutionOutcome {
+            messages: vec![],
+            state_hash: state.crypto_hash_mut().await?,
+            oracle_responses: vec![],
+        }
+        .with(block),
+    );
+    let certificate = make_certificate(&committee, &worker, value);
+    worker
+        .handle_certificate(certificate, vec![], vec![], None)
+        .await?;
+
+    for query_context in query_contexts_after_new_block.clone() {
+        application.expect_call(ExpectedCall::handle_query(
+            move |_runtime, context, query| {
+                assert_eq!(context, query_context);
+                assert!(query.is_empty());
+                Ok(vec![])
+            },
+        ));
+    }
+
+    for local_time in queries_after_new_block {
+        clock.set(local_time);
 
         assert_eq!(
             worker.query_application(chain_id, query.clone()).await?,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -465,6 +465,7 @@ where
                 let response = self
                     .query_user_application(
                         application_id,
+                        context,
                         bytes,
                         incoming_execution_requests,
                         runtime_request_sender,
@@ -478,6 +479,7 @@ where
     async fn query_user_application(
         &mut self,
         application_id: UserApplicationId,
+        context: QueryContext,
         query: Vec<u8>,
         mut incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<
             ExecutionRequest,
@@ -490,6 +492,7 @@ where
         runtime_request_sender
             .send(ServiceRuntimeRequest::Query {
                 application_id,
+                context,
                 query,
                 callback: response_sender,
             })

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -448,8 +448,10 @@ where
         &mut self,
         context: QueryContext,
         query: Query,
-        incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-        runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+        incoming_execution_requests: &mut futures::channel::mpsc::UnboundedReceiver<
+            ExecutionRequest,
+        >,
+        runtime_request_sender: &mut std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     ) -> Result<Response, ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match query {
@@ -481,10 +483,10 @@ where
         application_id: UserApplicationId,
         context: QueryContext,
         query: Vec<u8>,
-        mut incoming_execution_requests: futures::channel::mpsc::UnboundedReceiver<
+        incoming_execution_requests: &mut futures::channel::mpsc::UnboundedReceiver<
             ExecutionRequest,
         >,
-        runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+        runtime_request_sender: &mut std::sync::mpsc::Sender<ServiceRuntimeRequest>,
     ) -> Result<Vec<u8>, ExecutionError> {
         let (response_sender, response_receiver) = oneshot::channel();
         let mut response_receiver = response_receiver.fuse();

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -300,7 +300,7 @@ pub struct FinalizeContext {
     pub next_message_index: u32,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct QueryContext {
     /// The current chain ID.
     pub chain_id: ChainId,

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1339,15 +1339,13 @@ impl ServiceSyncRuntime {
     /// Runs the service runtime actor, waiting for `incoming_requests` to respond to.
     pub fn run(&mut self, incoming_requests: std::sync::mpsc::Receiver<ServiceRuntimeRequest>) {
         while let Ok(request) = incoming_requests.recv() {
-            match request {
-                ServiceRuntimeRequest::Query {
-                    application_id,
-                    query,
-                    callback,
-                } => {
-                    let _ = callback.send(self.run_query(application_id, query));
-                }
-            }
+            let ServiceRuntimeRequest::Query {
+                application_id,
+                query,
+                callback,
+            } = request;
+
+            let _ = callback.send(self.run_query(application_id, query));
         }
     }
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1336,22 +1336,6 @@ impl ServiceSyncRuntime {
         ))
     }
 
-    /// Queries an application specified by its [`UserApplicationId`].
-    pub(crate) fn run_query(
-        &mut self,
-        application_id: UserApplicationId,
-        query: Vec<u8>,
-    ) -> Result<Vec<u8>, ExecutionError> {
-        self.0
-            .as_mut()
-            .expect(
-                "`SyncRuntimeHandle` should be available while `SyncRuntime` hasn't been dropped",
-            )
-            .try_query_application(application_id, query)
-    }
-}
-
-impl ServiceSyncRuntime {
     /// Runs the service runtime actor, waiting for `incoming_requests` to respond to.
     pub fn run(&mut self, incoming_requests: std::sync::mpsc::Receiver<ServiceRuntimeRequest>) {
         while let Ok(request) = incoming_requests.recv() {
@@ -1365,6 +1349,20 @@ impl ServiceSyncRuntime {
                 }
             }
         }
+    }
+
+    /// Queries an application specified by its [`UserApplicationId`].
+    pub(crate) fn run_query(
+        &mut self,
+        application_id: UserApplicationId,
+        query: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        self.0
+            .as_mut()
+            .expect(
+                "`SyncRuntimeHandle` should be available while `SyncRuntime` hasn't been dropped",
+            )
+            .try_query_application(application_id, query)
     }
 }
 

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -68,7 +68,8 @@ pub async fn register_mock_applications<C>(
     count: u64,
 ) -> anyhow::Result<vec::IntoIter<(UserApplicationId, MockApplication)>>
 where
-    C: Context<Extra = TestExecutionRuntimeContext> + Clone + Send + Sync + 'static,
+    C: Context + Clone + Send + Sync + 'static,
+    C::Extra: ExecutionRuntimeContext,
     ViewError: From<C::Error>,
 {
     let mock_applications: Vec<_> =

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -207,7 +207,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
-    let (execution_request_receiver, runtime_request_sender) =
+    let (mut execution_request_receiver, mut runtime_request_sender) =
         context.spawn_service_runtime_actor();
     assert_eq!(
         view.query_application(
@@ -216,8 +216,8 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![]
             },
-            execution_request_receiver,
-            runtime_request_sender,
+            &mut execution_request_receiver,
+            &mut runtime_request_sender,
         )
         .await
         .unwrap(),

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -120,8 +120,8 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         .query_application(
             context,
             Query::System(SystemQuery),
-            futures::channel::mpsc::unbounded().1,
-            std::sync::mpsc::channel().0,
+            &mut futures::channel::mpsc::unbounded().1,
+            &mut std::sync::mpsc::channel().0,
         )
         .await
         .unwrap();

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -124,7 +124,7 @@ async fn test_fuel_for_counter_wasm_application(
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
-    let (execution_request_receiver, runtime_request_sender) =
+    let (mut execution_request_receiver, mut runtime_request_sender) =
         context.spawn_service_runtime_actor();
     let expected_value = async_graphql::Response::new(
         async_graphql::Value::from_json(json!({"value" : increments.into_iter().sum::<u64>()}))
@@ -135,8 +135,8 @@ async fn test_fuel_for_counter_wasm_application(
         .query_application(
             context,
             Query::user(app_id, &request).unwrap(),
-            execution_request_receiver,
-            runtime_request_sender,
+            &mut execution_request_receiver,
+            &mut runtime_request_sender,
         )
         .await?
     else {

--- a/linera-sdk/src/service/mod.rs
+++ b/linera-sdk/src/service/mod.rs
@@ -12,8 +12,6 @@ mod test_runtime;
 #[doc(hidden)]
 pub mod wit;
 
-use std::future::Future;
-
 #[cfg(not(with_testing))]
 pub use self::runtime::ServiceRuntime;
 #[cfg(with_testing)]
@@ -34,18 +32,22 @@ pub type ServiceRuntime<Application> = MockServiceRuntime<Application>;
 #[macro_export]
 macro_rules! service {
     ($service:ident) => {
+        #[doc(hidden)]
+        static mut SERVICE: Option<$service> = None;
+
         /// Export the service interface.
         $crate::export_service!($service with_types_in $crate::service::wit);
 
         /// Mark the service type to be exported.
         impl $crate::service::wit::exports::linera::app::service_entrypoints::Guest for $service {
             fn handle_query(argument: Vec<u8>) -> Vec<u8> {
+                use $crate::util::BlockingWait;
                 let request = $crate::serde_json::from_slice(&argument)
                     .expect("Query is invalid and could not be deserialized");
-                let response = $crate::service::run_async_entrypoint(move |runtime| async move {
-                    let service = <$service as $crate::Service>::new(runtime).await;
-                    service.handle_query(request).await
-                });
+                let response = $crate::service::run_async_entrypoint(
+                    unsafe { &mut SERVICE },
+                    move |service| service.handle_query(request).blocking_wait(),
+                );
                 $crate::serde_json::to_vec(&response)
                     .expect("Failed to deserialize query response")
             }
@@ -60,14 +62,17 @@ macro_rules! service {
 
 /// Runs an asynchronous entrypoint in a blocking manner, by repeatedly polling the entrypoint
 /// future.
-pub fn run_async_entrypoint<Service, Entrypoint, Output>(
-    entrypoint: impl FnOnce(ServiceRuntime<Service>) -> Entrypoint,
+pub fn run_async_entrypoint<Service, Output>(
+    service: &mut Option<Service>,
+    entrypoint: impl FnOnce(&mut Service) -> Output,
 ) -> Output
 where
     Service: crate::Service,
-    Entrypoint: Future<Output = Output>,
 {
     ServiceLogger::install();
 
-    entrypoint(ServiceRuntime::new()).blocking_wait()
+    let service =
+        service.get_or_insert_with(|| Service::new(ServiceRuntime::new()).blocking_wait());
+
+    entrypoint(service)
 }


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Application services have a read-only view of the application state on a chain. They were initially designed to be short-lived, handling a single query per execution. However, that is inefficient for some applications that may want to cache data in memory to handle multiple queries (e.g., the LLM example could store the AI model weights in memory).

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Make services long-lived, restarting them only if the worker executes an operation that may change the chain state.

## Test Plan

<!-- How to test that the changes are correct. -->
Two new unit tests were written for long-lived services.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
A new major version (or equivalent version representing a breaking change) should be released, because this new feature can lead to incompatible behavior with applications that expect the service to restart after every query.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #1804
