### PR TITLE
Add another entry to `CommunicationError`.

### DIFF
--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -79,6 +79,10 @@ where
 /// An error result for [`communicate_with_quorum`].
 #[derive(Error, Debug)]
 pub enum CommunicationError<E: fmt::Debug> {
+    /// No consensus is possible since validators returned different possibilities
+    /// for the next block
+    #[error("No error but failed to find a consensus block. Consensus threshold: {}, Proposals: {:?}", .0, .1)]
+    NoConsensus(u64, Vec<(u64, usize)>),
     /// A single error that was returned by a sufficient number of nodes to be trusted as
     /// valid.
     #[error("Failed to communicate with a quorum of validators: {0}")]
@@ -165,12 +169,23 @@ where
         }
     }
 
+    let scores = value_scores
+        .iter()
+        .map(|x| (x.1 .0, x.1 .1.len()))
+        .collect();
     // If a key has a quorum, return it with its values.
     if let Some((key, (_, values))) = value_scores
         .into_iter()
         .find(|(_, (score, _))| *score >= committee.quorum_threshold())
     {
         return Ok((key, values));
+    }
+
+    if error_scores.is_empty() {
+        return Err(CommunicationError::NoConsensus(
+            committee.quorum_threshold(),
+            scores,
+        ));
     }
 
     // No specific error is available to report reliably.

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -171,7 +171,7 @@ where
 
     let scores = value_scores
         .values()
-        .map(|(weight, values)| (weight, values.len()))
+        .map(|(weight, values)| (*weight, values.len()))
         .collect();
     // If a key has a quorum, return it with its values.
     if let Some((key, (_, values))) = value_scores

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -170,8 +170,8 @@ where
     }
 
     let scores = value_scores
-        .iter()
-        .map(|x| (x.1 .0, x.1 .1.len()))
+        .values()
+        .map(|(weight, values)| (weight, values.len()))
         .collect();
     // If a key has a quorum, return it with its values.
     if let Some((key, (_, values))) = value_scores


### PR DESCRIPTION
## Motivation

During investigations of end-to-end test failures, it has appeared that in some cases no error occurred but the validators returned two different proposals. This error pattern was not covered.

## Proposal

The `NoConsensus` error is added to the enum statements.
The error contains the committee threshold and the obtained weights and the number of validators that proposed it.

## Test Plan

That error sometimes occurred in tests but relatively rarely. The CI remains unchanged.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
