### PR TITLE
Rename storage errors

### DIFF
--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -33,7 +33,7 @@ mod recorder;
 pub fn setup_claim_bench<B>() -> (ChainClient<B>, ChainClient<B>)
 where
     B: StorageBuilder + Default,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage_builder = B::default();
     // Criterion doesn't allow setup functions to be async, but it runs them inside an async
@@ -59,7 +59,7 @@ where
 pub async fn run_claim_bench<B>((chain1, chain2): (ChainClient<B>, ChainClient<B>))
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let owner1 = chain1.identity().await.unwrap();
     let amt = Amount::ONE;

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -145,7 +145,7 @@ where
 pub struct ChainWorkerActor<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     worker: ChainWorkerState<StorageClient>,
     incoming_requests: mpsc::UnboundedReceiver<ChainWorkerRequest<StorageClient::Context>>,
@@ -154,7 +154,7 @@ where
 impl<StorageClient> ChainWorkerActor<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     /// Spawns a new task to run the [`ChainWorkerActor`], returning an endpoint for sending
     /// requests to the worker.

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -50,7 +50,7 @@ use crate::{
 pub struct ChainWorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     config: ChainWorkerConfig,
     storage: StorageClient,
@@ -64,7 +64,7 @@ where
 impl<StorageClient> ChainWorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
     pub async fn load(
@@ -497,12 +497,12 @@ pub struct ChainWorkerStateWithTemporaryChanges<'state, StorageClient>(
 )
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>;
+    ViewError: From<StorageClient::StoreError>;
 
 impl<StorageClient> ChainWorkerStateWithTemporaryChanges<'_, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     /// Returns a stored [`Certificate`] for the chain's block at the requested [`BlockHeight`].
     #[cfg(with_testing)]
@@ -798,7 +798,7 @@ where
 impl<StorageClient> Drop for ChainWorkerStateWithTemporaryChanges<'_, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     fn drop(&mut self) {
         self.0.chain.rollback();
@@ -810,7 +810,7 @@ where
 pub struct ChainWorkerStateWithAttemptedChanges<'state, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     state: &'state mut ChainWorkerState<StorageClient>,
     succeeded: bool,
@@ -820,7 +820,7 @@ impl<'state, StorageClient> From<&'state mut ChainWorkerState<StorageClient>>
     for ChainWorkerStateWithAttemptedChanges<'state, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     fn from(state: &'state mut ChainWorkerState<StorageClient>) -> Self {
         ChainWorkerStateWithAttemptedChanges {
@@ -833,7 +833,7 @@ where
 impl<StorageClient> ChainWorkerStateWithAttemptedChanges<'_, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     /// Processes a leader timeout issued for this multi-owner chain.
     pub(super) async fn process_timeout(
@@ -1279,7 +1279,7 @@ where
 impl<StorageClient> Drop for ChainWorkerStateWithAttemptedChanges<'_, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     fn drop(&mut self) {
         if !self.succeeded {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -75,7 +75,7 @@ mod client_tests;
 pub struct Client<ValidatorNodeProvider, Storage>
 where
     Storage: linera_storage::Storage,
-    ViewError: From<Storage::ContextError>,
+    ViewError: From<Storage::StoreError>,
 {
     /// How to talk to the validators.
     validator_node_provider: ValidatorNodeProvider,
@@ -99,7 +99,7 @@ where
 
 impl<P, S: Storage + Clone> Client<P, S>
 where
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Creates a new `Client` with a new cache and notifiers.
     pub fn new(
@@ -149,7 +149,7 @@ where
         pending_blobs: BTreeMap<BlobId, HashedBlob>,
     ) -> ChainClient<P, S>
     where
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let known_key_pairs = known_key_pairs
             .into_iter()
@@ -248,7 +248,7 @@ pub struct ChainClientOptions {
 pub struct ChainClient<ValidatorNodeProvider, Storage>
 where
     Storage: linera_storage::Storage,
-    ViewError: From<<Storage as linera_storage::Storage>::ContextError>,
+    ViewError: From<<Storage as linera_storage::Storage>::StoreError>,
 {
     /// The Linera [`Client`] that manages operations for this chain client.
     client: Arc<Client<ValidatorNodeProvider, Storage>>,
@@ -261,7 +261,7 @@ where
 impl<P, S> Clone for ChainClient<P, S>
 where
     S: linera_storage::Storage,
-    ViewError: From<<S as linera_storage::Storage>::ContextError>,
+    ViewError: From<<S as linera_storage::Storage>::StoreError>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -370,7 +370,7 @@ pub type ChainGuardMapped<'a, T> = Unsend<DashMapMappedRef<'a, ChainId, ChainSta
 impl<P, S> ChainClient<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Gets a shared reference to the chain's state.
     pub fn state(&self) -> ChainGuard<ChainState> {
@@ -443,7 +443,7 @@ impl<P, S> ChainClient<P, S>
 where
     P: LocalValidatorNodeProvider + Sync,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Obtains a `ChainStateView` for a given `ChainId`.
     pub async fn chain_state_view(

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -36,7 +36,7 @@ use crate::{
 pub struct LocalNode<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     state: WorkerState<S>,
 }
@@ -46,7 +46,7 @@ where
 pub struct LocalNodeClient<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     node: Arc<Mutex<LocalNode<S>>>,
 }
@@ -88,7 +88,7 @@ pub enum LocalNodeError {
 impl<S> LocalNodeClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     pub async fn handle_block_proposal(
         &self,
@@ -153,7 +153,7 @@ where
 impl<S> LocalNodeClient<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     pub fn new(state: WorkerState<S>) -> Self {
         let node = LocalNode { state };
@@ -167,7 +167,7 @@ where
 impl<S> LocalNodeClient<S>
 where
     S: Storage + Clone,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     pub(crate) async fn storage_client(&self) -> S {
         let node = self.node.lock().await;
@@ -178,7 +178,7 @@ where
 impl<S> LocalNodeClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     pub async fn stage_block_execution(
         &self,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -59,7 +59,7 @@ async fn test_initiating_valid_transfer_with_notifications<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -116,7 +116,7 @@ where
 async fn test_claim_amount<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -243,7 +243,7 @@ where
 async fn test_rotate_key_pair<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -292,7 +292,7 @@ where
 async fn test_transfer_ownership<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -350,7 +350,7 @@ where
 async fn test_share_ownership<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let sender = builder
@@ -497,7 +497,7 @@ where
 async fn test_open_chain_then_close_it<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -541,7 +541,7 @@ where
 async fn test_transfer_then_open_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -645,7 +645,7 @@ where
 async fn test_open_chain_must_be_first<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -735,7 +735,7 @@ where
 async fn test_open_chain_then_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -809,7 +809,7 @@ where
 async fn test_close_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -925,7 +925,7 @@ where
 async fn test_initiating_valid_transfer_too_many_faults<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 2).await?;
     let sender = builder
@@ -964,7 +964,7 @@ where
 async fn test_bidirectional_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let client1 = builder
@@ -1067,7 +1067,7 @@ where
 async fn test_receiving_unconfirmed_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -1118,7 +1118,7 @@ async fn test_receiving_unconfirmed_transfer_with_lagging_sender_balances<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let client1 = builder
@@ -1220,7 +1220,7 @@ where
 async fn test_change_voting_rights<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let admin = builder
@@ -1349,7 +1349,7 @@ where
 async fn test_insufficient_balance<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -1405,7 +1405,7 @@ where
 async fn test_publish_blob<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     // Configure a chain with two regular and no super owners.
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
@@ -1487,7 +1487,7 @@ where
 async fn test_request_leader_timeout<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
@@ -1613,7 +1613,7 @@ where
 async fn test_finalize_validated<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     // Configure a chain with two regular and no super owners.
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
@@ -1724,7 +1724,7 @@ where
 async fn test_propose_pending_block<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let description = ChainDescription::Root(1);
@@ -1769,7 +1769,7 @@ where
 async fn test_re_propose_validated<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     // Configure a chain with two regular and no super owners.
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
@@ -1886,7 +1886,7 @@ where
 async fn test_message_policy<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -79,7 +79,7 @@ pub enum FaultType {
 struct LocalValidator<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     state: WorkerState<S>,
     fault_type: FaultType,
@@ -90,7 +90,7 @@ where
 pub struct LocalValidatorClient<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     name: ValidatorName,
     client: Arc<Mutex<LocalValidator<S>>>,
@@ -99,7 +99,7 @@ where
 impl<S> ValidatorNode for LocalValidatorClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     type NotificationStream = NotificationStream;
 
@@ -195,7 +195,7 @@ where
 impl<S> LocalValidatorClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     fn new(name: ValidatorName, state: WorkerState<S>) -> Self {
         let client = LocalValidator {
@@ -426,12 +426,12 @@ where
 pub struct NodeProvider<S>(BTreeMap<ValidatorName, Arc<Mutex<LocalValidator<S>>>>)
 where
     S: Storage,
-    ViewError: From<S::ContextError>;
+    ViewError: From<S::StoreError>;
 
 impl<S> LocalValidatorNodeProvider for NodeProvider<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     type Node = LocalValidatorClient<S>;
 
@@ -466,7 +466,7 @@ where
 impl<S> FromIterator<LocalValidatorClient<S>> for NodeProvider<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     fn from_iter<T>(iter: T) -> Self
     where
@@ -485,7 +485,7 @@ where
 // communicate with.
 pub struct TestBuilder<B: StorageBuilder>
 where
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     storage_builder: B,
     pub initial_committee: Committee,
@@ -528,7 +528,7 @@ impl GenesisStorageBuilder {
     async fn build<S>(&self, storage: S, initial_committee: Committee, admin_id: ChainId) -> S
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         for account in &self.accounts {
             storage
@@ -550,7 +550,7 @@ impl GenesisStorageBuilder {
 impl<B> TestBuilder<B>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     pub async fn new(
         mut storage_builder: B,

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -89,7 +89,7 @@ async fn test_scylla_db_create_application(wasm_runtime: WasmRuntime) -> anyhow:
 async fn run_test_create_application<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -254,7 +254,7 @@ async fn test_scylla_db_run_application_with_dependency(
 async fn run_test_run_application_with_dependency<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -494,7 +494,7 @@ async fn test_scylla_db_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow
 async fn run_test_cross_chain_message<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -704,7 +704,7 @@ async fn test_scylla_db_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyh
 async fn run_test_user_pub_sub_channels<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -96,7 +96,7 @@ async fn run_test_handle_certificates_to_create_application<S>(
 ) -> anyhow::Result<()>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     let admin_id = ChainDescription::Root(0);
     let publisher_key_pair = KeyPair::generate();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -71,7 +71,7 @@ const TEST_GRACE_PERIOD_MICROS: u64 = 500_000;
 fn init_worker<S>(storage: S, is_client: bool) -> (Committee, WorkerState<S>)
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     let key_pair = KeyPair::generate();
     let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
@@ -87,7 +87,7 @@ async fn init_worker_with_chains<S, I>(storage: S, balances: I) -> (Committee, W
 where
     I: IntoIterator<Item = (ChainDescription, PublicKey, Amount)>,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     let (committee, worker) = init_worker(storage, /* is_client */ false);
     for (description, pubk, balance) in balances {
@@ -116,7 +116,7 @@ async fn init_worker_with_chain<S>(
 ) -> (Committee, WorkerState<S>)
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     init_worker_with_chains(storage, [(description, owner, balance)]).await
 }
@@ -128,7 +128,7 @@ fn make_certificate<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     make_certificate_with_round(committee, worker, value, Round::Fast)
 }
@@ -141,7 +141,7 @@ fn make_certificate_with_round<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     let vote = LiteVote::new(
         value.lite(),
@@ -169,7 +169,7 @@ async fn make_simple_transfer_certificate<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     make_transfer_certificate_for_epoch(
         chain_description,
@@ -204,7 +204,7 @@ async fn make_transfer_certificate<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     make_transfer_certificate_for_epoch(
         chain_description,
@@ -240,7 +240,7 @@ async fn make_transfer_certificate_for_epoch<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     let chain_id = chain_description.into();
     let system_state = SystemExecutionState {
@@ -390,7 +390,7 @@ fn update_recipient_direct(recipient: ChainId, certificate: &Certificate) -> Cro
 async fn test_handle_block_proposal_bad_signature<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
@@ -436,7 +436,7 @@ where
 async fn test_handle_block_proposal_zero_amount<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
@@ -487,7 +487,7 @@ where
 async fn test_handle_block_proposal_ticks<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -558,7 +558,7 @@ where
 async fn test_handle_block_proposal_unknown_sender<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
@@ -601,7 +601,7 @@ where
 async fn test_handle_block_proposal_with_chaining<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -673,7 +673,7 @@ async fn test_handle_block_proposal_with_incoming_messages<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
@@ -1060,7 +1060,7 @@ where
 async fn test_handle_block_proposal_exceed_balance<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
@@ -1108,7 +1108,7 @@ where
 async fn test_handle_block_proposal<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
@@ -1144,7 +1144,7 @@ where
 async fn test_handle_block_proposal_replay<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, mut worker) = init_worker_with_chains(
@@ -1186,7 +1186,7 @@ where
 async fn test_handle_certificate_unknown_sender<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1227,7 +1227,7 @@ where
 async fn test_handle_certificate_with_open_chain<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1308,7 +1308,7 @@ where
 async fn test_handle_certificate_wrong_owner<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1351,7 +1351,7 @@ where
 async fn test_handle_certificate_bad_block_height<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1402,7 +1402,7 @@ async fn test_handle_certificate_with_anticipated_incoming_message<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1504,7 +1504,7 @@ async fn test_handle_certificate_receiver_balance_overflow<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1573,7 +1573,7 @@ async fn test_handle_certificate_receiver_equal_sender<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let key_pair = KeyPair::generate();
@@ -1640,7 +1640,7 @@ where
 async fn test_handle_cross_chain_request<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -1715,7 +1715,7 @@ async fn test_handle_cross_chain_request_no_recipient_chain<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = KeyPair::generate();
@@ -1753,7 +1753,7 @@ async fn test_handle_cross_chain_request_no_recipient_chain_on_client<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = KeyPair::generate();
@@ -1803,7 +1803,7 @@ async fn test_handle_certificate_to_active_recipient<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
@@ -1960,7 +1960,7 @@ async fn test_handle_certificate_to_inactive_recipient<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -2007,7 +2007,7 @@ async fn test_handle_certificate_with_rejected_transfer<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let sender = Owner::from(sender_key_pair.public());
@@ -2264,7 +2264,7 @@ async fn run_test_chain_creation_with_committee_creation<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair = KeyPair::generate();
     let (committee, mut worker) = init_worker_with_chains(
@@ -2698,7 +2698,7 @@ where
 async fn test_transfers_and_committee_creation<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
@@ -2826,7 +2826,7 @@ where
 async fn test_transfers_and_committee_removal<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
@@ -3209,7 +3209,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
 async fn test_timeouts<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -3413,7 +3413,7 @@ where
 async fn test_round_types<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -3501,7 +3501,7 @@ where
 async fn test_fast_proposal_is_locked<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -3605,7 +3605,7 @@ where
 async fn test_fallback<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::ContextError>,
+    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -68,7 +68,7 @@ pub enum CommunicateAction {
 pub struct ValidatorUpdater<A, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     pub name: ValidatorName,
     pub node: A,
@@ -184,7 +184,7 @@ impl<A, S> ValidatorUpdater<A, S>
 where
     A: LocalValidatorNode + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     async fn send_optimized_certificate(
         &mut self,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -276,7 +276,7 @@ impl From<linera_chain::ChainError> for WorkerError {
 pub struct WorkerState<StorageClient>
 where
     StorageClient: Storage,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     /// A name used for logging
     nickname: String,
@@ -307,7 +307,7 @@ pub(crate) type DeliveryNotifiers =
 impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     pub fn new(nickname: String, key_pair: Option<KeyPair>, storage: StorageClient) -> Self {
         WorkerState {
@@ -398,7 +398,7 @@ where
 impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     // NOTE: This only works for non-sharded workers!
     #[cfg(with_testing)]
@@ -771,7 +771,7 @@ where
 impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     /// Gets a reference to the validator's [`PublicKey`].
     ///
@@ -794,7 +794,7 @@ where
 impl<StorageClient> ValidatorWorker for WorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::ContextError>,
+    ViewError: From<StorageClient::StoreError>,
 {
     #[instrument(skip_all, fields(
         nick = self.nickname,

--- a/linera-indexer/lib/src/common.rs
+++ b/linera-indexer/lib/src/common.rs
@@ -49,10 +49,10 @@ pub enum IndexerError {
 
     #[cfg(feature = "rocksdb")]
     #[error(transparent)]
-    RocksDbError(#[from] linera_views::rocks_db::RocksDbContextError),
+    RocksDbError(#[from] linera_views::rocks_db::RocksDbStoreError),
     #[cfg(feature = "scylladb")]
     #[error(transparent)]
-    ScyllaDbError(#[from] linera_views::scylla_db::ScyllaDbContextError),
+    ScyllaDbError(#[from] linera_views::scylla_db::ScyllaDbStoreError),
 }
 
 pub async fn graphiql(uri: Uri) -> impl IntoResponse {

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -104,7 +104,7 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: Lazy<HistogramVec> = Lazy::new(|
 pub struct GrpcServer<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     state: WorkerState<S>,
     shard_id: ShardId,
@@ -178,7 +178,7 @@ where
 impl<S> GrpcServer<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn spawn(
@@ -436,7 +436,7 @@ where
 impl<S> ValidatorWorkerRpc for GrpcServer<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
     async fn handle_block_proposal(

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -27,7 +27,7 @@ use crate::{
 pub struct Server<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     network: ValidatorInternalNetworkPreConfig<TransportProtocol>,
     host: String,
@@ -43,7 +43,7 @@ where
 impl<S> Server<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -78,7 +78,7 @@ where
 impl<S> Server<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     #[allow(clippy::too_many_arguments)]
     async fn forward_cross_chain_queries(
@@ -183,7 +183,7 @@ where
 struct RunningServerState<S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     server: Server<S>,
     cross_chain_sender: mpsc::Sender<(RpcMessage, ShardId)>,
@@ -193,7 +193,7 @@ where
 impl<S> MessageHandler for RunningServerState<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     #[instrument(target = "simple_server", skip_all, fields(nickname = self.server.state.nickname(), chain_id = ?message.target_chain_id()))]
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
@@ -351,7 +351,7 @@ where
 impl<S> RunningServerState<S>
 where
     S: Storage + Send,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     fn handle_network_actions(&mut self, actions: NetworkActions) {
         for request in actions.cross_chain_requests {

--- a/linera-service/src/chain_listener.rs
+++ b/linera-service/src/chain_listener.rs
@@ -54,7 +54,7 @@ pub trait ClientContext {
         chain_id: ChainId,
     ) -> ChainClient<Self::ValidatorNodeProvider, Self::Storage>
     where
-        ViewError: From<<Self::Storage as Storage>::ContextError>;
+        ViewError: From<<Self::Storage as Storage>::StoreError>;
 
     fn update_wallet_for_new_chain(
         &mut self,
@@ -67,7 +67,7 @@ pub trait ClientContext {
         &mut self,
         client: &ChainClient<Self::ValidatorNodeProvider, Self::Storage>,
     ) where
-        ViewError: From<<Self::Storage as Storage>::ContextError>;
+        ViewError: From<<Self::Storage as Storage>::StoreError>;
 }
 
 /// A `ChainListener` is a process that listens to notifications from validators and reacts
@@ -75,7 +75,7 @@ pub trait ClientContext {
 pub struct ChainListener<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     config: ChainListenerConfig,
     clients: ChainClients<P, S>,
@@ -86,7 +86,7 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Creates a new chain listener given client chains.
     pub(crate) fn new(config: ChainListenerConfig, clients: ChainClients<P, S>) -> Self {

--- a/linera-service/src/config.rs
+++ b/linera-service/src/config.rs
@@ -162,7 +162,7 @@ impl GenesisConfig {
     pub async fn initialize_storage<S>(&self, storage: &mut S) -> Result<(), anyhow::Error>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let committee = self.create_committee();
         for (chain_number, (public_key, balance)) in (0..).zip(&self.chains) {

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -37,7 +37,7 @@ mod tests;
 pub struct QueryRoot<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     genesis_config: Arc<GenesisConfig>,
     client: Arc<Mutex<ChainClient<P, S>>>,
@@ -47,7 +47,7 @@ where
 pub struct MutationRoot<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     client: Arc<Mutex<ChainClient<P, S>>>,
     context: Arc<Mutex<C>>,
@@ -91,7 +91,7 @@ impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Returns the version information on this faucet service.
     async fn version(&self) -> linera_version::VersionInfo {
@@ -125,7 +125,7 @@ where
     <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Creates a new chain with the given authentication key, and transfers tokens to it.
     async fn claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
@@ -139,7 +139,7 @@ where
     <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     async fn do_claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
         let client = self.client.lock().await;
@@ -195,7 +195,7 @@ where
 impl<P, S, C> MutationRoot<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Multiplies a `u128` with a `u64` and returns the result as a 192-bit number.
     fn multiply(a: u128, b: u64) -> [u64; 3] {
@@ -212,7 +212,7 @@ where
 pub struct FaucetService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     client: Arc<Mutex<ChainClient<P, S>>>,
     context: Arc<Mutex<C>>,
@@ -227,7 +227,7 @@ where
 impl<P, S: Clone, C> Clone for FaucetService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -248,7 +248,7 @@ where
     P: ValidatorNodeProvider + Send + Sync + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Creates a new instance of the faucet service.
     pub async fn new(

--- a/linera-service/src/linera/client_context.rs
+++ b/linera-service/src/linera/client_context.rs
@@ -72,7 +72,7 @@ use crate::{
 pub struct ClientContext<Storage>
 where
     Storage: linera_storage::Storage,
-    ViewError: From<Storage::ContextError>,
+    ViewError: From<Storage::StoreError>,
 {
     pub wallet: WalletState,
     pub client: Arc<Client<NodeProvider, Storage>>,
@@ -88,7 +88,7 @@ where
 impl<S> chain_listener::ClientContext for ClientContext<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<<S as Storage>::ContextError>,
+    ViewError: From<<S as Storage>::StoreError>,
 {
     type ValidatorNodeProvider = NodeProvider;
     type Storage = S;
@@ -119,7 +119,7 @@ where
 impl<S> ClientContext<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Returns the [`Wallet`] as a mutable reference.
     pub fn wallet_mut(&mut self) -> impl std::ops::DerefMut<Target = Wallet> + '_ {
@@ -422,7 +422,7 @@ where
 impl<S> ClientContext<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     pub async fn process_inboxes_and_force_validator_updates(&mut self) {
         for chain_id in self.wallet.own_chain_ids() {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -103,7 +103,7 @@ impl Runnable for Job {
     async fn run<S>(self, storage: S) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let Job(options, wallet) = self;
         let mut context = ClientContext::new(storage.clone(), options.clone(), wallet);
@@ -1095,7 +1095,7 @@ impl Job {
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let state = WorkerState::new("Local node".to_string(), None, storage)
             .with_allow_inactive_chains(true)
@@ -1166,7 +1166,7 @@ impl Job {
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let mut chains = HashMap::new();
         for chain_id in chain_ids {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -62,12 +62,12 @@ pub type ClientMapInner<P, S> = BTreeMap<ChainId, ChainClient<P, S>>;
 pub(crate) struct ChainClients<P, S>(Arc<Mutex<ClientMapInner<P, S>>>)
 where
     S: Storage,
-    ViewError: From<S::ContextError>;
+    ViewError: From<S::StoreError>;
 
 impl<P, S> Clone for ChainClients<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     fn clone(&self) -> Self {
         ChainClients(self.0.clone())
@@ -77,7 +77,7 @@ where
 impl<P, S> Default for ChainClients<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     fn default() -> Self {
         Self(Arc::new(Mutex::new(BTreeMap::new())))
@@ -87,7 +87,7 @@ where
 impl<P, S> ChainClients<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     async fn client(&self, chain_id: &ChainId) -> Option<ChainClient<P, S>> {
         Some(self.0.lock().await.get(chain_id)?.clone())
@@ -115,7 +115,7 @@ where
 pub struct QueryRoot<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
     port: NonZeroU16,
@@ -126,7 +126,7 @@ where
 pub struct SubscriptionRoot<P, S>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
 }
@@ -135,7 +135,7 @@ where
 pub struct MutationRoot<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
     context: Arc<Mutex<C>>,
@@ -224,7 +224,7 @@ impl<P, S> SubscriptionRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Subscribes to notifications from the specified chain.
     async fn notifications(
@@ -241,7 +241,7 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     async fn execute_system_operation(
         &self,
@@ -296,7 +296,7 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Processes the inbox and returns the lists of certificate hashes that were created, if any.
     async fn process_inbox(&self, chain_id: ChainId) -> Result<Vec<CryptoHash>, Error> {
@@ -723,7 +723,7 @@ impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     async fn chain(&self, chain_id: ChainId) -> Result<ChainStateExtendedView<S::Context>, Error> {
         let client = self.clients.try_client_lock(&chain_id).await?;
@@ -964,7 +964,7 @@ fn bytes_from_list(list: &[async_graphql::Value]) -> Option<Vec<u8>> {
 pub struct NodeService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
     config: ChainListenerConfig,
@@ -977,7 +977,7 @@ where
 impl<P, S: Clone, C> Clone for NodeService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -997,7 +997,7 @@ where
     <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     /// Creates a new instance of the node service given a client chain and a port.
     pub fn new(

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -110,7 +110,7 @@ impl Runnable for ProxyContext {
     async fn run<S>(self, storage: S) -> Result<(), anyhow::Error>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let shutdown_notifier = CancellationToken::new();
         tokio::spawn(util::listen_for_shutdown_signals(shutdown_notifier.clone()));
@@ -187,7 +187,7 @@ where
 impl<S> MessageHandler for SimpleProxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     #[instrument(skip_all, fields(chain_id = ?message.target_chain_id()))]
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
@@ -232,7 +232,7 @@ where
 impl<S> SimpleProxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::ContextError>,
+    ViewError: From<S::StoreError>,
 {
     #[instrument(skip_all, fields(port = self.public_config.port, metrics_port = self.internal_config.metrics_port), err)]
     async fn run(self, shutdown_signal: CancellationToken) -> Result<()> {

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -136,7 +136,7 @@ impl<P: LocalValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientConte
 
     fn make_chain_client(&self, _: ChainId) -> ChainClient<P, S>
     where
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         unimplemented!()
     }
@@ -145,7 +145,7 @@ impl<P: LocalValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientConte
 
     async fn update_wallet(&mut self, _: &ChainClient<P, S>)
     where
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
     }
 }

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -54,7 +54,7 @@ impl ServerContext {
     ) -> (WorkerState<S>, ShardId, ShardConfig)
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let shard = self.server_config.internal_network.shard(shard_id);
         info!("Shard booted on {}", shard.host);
@@ -78,7 +78,7 @@ impl ServerContext {
     ) -> JoinSet<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let mut join_set = JoinSet::new();
         let handles = FuturesUnordered::new();
@@ -131,7 +131,7 @@ impl ServerContext {
     ) -> JoinSet<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let mut join_set = JoinSet::new();
         let handles = FuturesUnordered::new();
@@ -187,7 +187,7 @@ impl Runnable for ServerContext {
     async fn run<S>(self, storage: S) -> Result<(), anyhow::Error>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let shutdown_notifier = CancellationToken::new();
         let listen_address = self.get_listen_address();

--- a/linera-service/src/storage.rs
+++ b/linera-service/src/storage.rs
@@ -354,7 +354,7 @@ impl StoreConfig {
     /// Deletes all the entries in the database
     pub async fn delete_all(self) -> Result<(), ViewError> {
         match self {
-            StoreConfig::Memory(_, _) => Err(ViewError::ContextError {
+            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
                 backend: "memory".to_string(),
                 error: "delete_all does not make sense for memory storage".to_string(),
             }),
@@ -383,7 +383,7 @@ impl StoreConfig {
     /// Deletes only one table of the database
     pub async fn delete_namespace(self) -> Result<(), ViewError> {
         match self {
-            StoreConfig::Memory(_, _) => Err(ViewError::ContextError {
+            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
                 backend: "memory".to_string(),
                 error: "delete_namespace does not make sense for memory storage".to_string(),
             }),
@@ -412,7 +412,7 @@ impl StoreConfig {
     /// Test existence of one table in the database
     pub async fn test_existence(self) -> Result<bool, ViewError> {
         match self {
-            StoreConfig::Memory(_, _) => Err(ViewError::ContextError {
+            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
                 backend: "memory".to_string(),
                 error: "test_existence does not make sense for memory storage".to_string(),
             }),
@@ -437,7 +437,7 @@ impl StoreConfig {
     /// Initializes the database
     pub async fn initialize(self) -> Result<(), ViewError> {
         match self {
-            StoreConfig::Memory(_, _) => Err(ViewError::ContextError {
+            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
                 backend: "memory".to_string(),
                 error: "initialize does not make sense for memory storage".to_string(),
             }),
@@ -466,7 +466,7 @@ impl StoreConfig {
     /// Lists all the namespaces of the storage
     pub async fn list_all(self) -> Result<Vec<String>, ViewError> {
         match self {
-            StoreConfig::Memory(_, _) => Err(ViewError::ContextError {
+            StoreConfig::Memory(_, _) => Err(ViewError::StoreError {
                 backend: "memory".to_string(),
                 error: "list_all is not supported for the memory storage".to_string(),
             }),
@@ -500,7 +500,7 @@ pub trait Runnable {
     async fn run<S>(self, storage: S) -> Result<Self::Output, anyhow::Error>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>;
+        ViewError: From<S::StoreError>;
 }
 
 // The design is that the initialization of the accounts should be separate

--- a/linera-service/src/wallet.rs
+++ b/linera-service/src/wallet.rs
@@ -170,7 +170,7 @@ impl Wallet {
     where
         P: ValidatorNodeProvider + Sync + 'static,
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::ContextError>,
+        ViewError: From<S::StoreError>,
     {
         let key_pair = chain_client.key_pair().await.map(|k| k.copy()).ok();
         let state = chain_client.state();

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -44,7 +44,7 @@ pub enum KeyTag {
 }
 
 #[derive(Debug, Error)]
-pub enum ServiceContextError {
+pub enum ServiceStoreError {
     /// Not matching entry
     #[error("Not matching entry")]
     NotMatchingEntry,
@@ -74,9 +74,9 @@ pub enum ServiceContextError {
     DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
-impl From<ServiceContextError> for linera_views::views::ViewError {
-    fn from(error: ServiceContextError) -> Self {
-        Self::ContextError {
+impl From<ServiceStoreError> for linera_views::views::ViewError {
+    fn from(error: ServiceStoreError) -> Self {
+        Self::StoreError {
             backend: "service".to_string(),
             error: error.to_string(),
         }
@@ -107,7 +107,7 @@ pub struct ServiceStoreConfig {
 /// Obtains the binary of the executable.
 /// The path depends whether the test are run in the directory "linera-storage-service"
 /// or in the main directory
-pub async fn get_service_storage_binary() -> Result<PathBuf, ServiceContextError> {
+pub async fn get_service_storage_binary() -> Result<PathBuf, ServiceStoreError> {
     let binary = resolve_binary("storage_service_server", "linera-storage-service").await;
     if let Ok(binary) = binary {
         return Ok(binary);
@@ -116,5 +116,5 @@ pub async fn get_service_storage_binary() -> Result<PathBuf, ServiceContextError
     if let Ok(binary) = binary {
         return Ok(binary);
     }
-    Err(ServiceContextError::FailedToFindStorageServiceServerBinary)
+    Err(ServiceStoreError::FailedToFindStorageServiceServerBinary)
 }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -382,7 +382,7 @@ where
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     type Context = ContextFromStore<ChainRuntimeContext<Self>, Client>;
-    type ContextError = <Client as KeyValueStore>::Error;
+    type StoreError = <Client as KeyValueStore>::Error;
 
     fn clock(&self) -> &dyn Clock {
         &self.clock

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -7,7 +7,7 @@ use {
     crate::db_storage::{DbStorageInner, TestClock},
     linera_execution::WasmRuntime,
     linera_views::{
-        dynamo_db::{create_dynamo_db_test_config, DynamoDbContextError, DynamoDbStoreConfig},
+        dynamo_db::{create_dynamo_db_test_config, DynamoDbStoreConfig, DynamoDbStoreError},
         test_utils::generate_test_namespace,
     },
 };
@@ -35,7 +35,7 @@ impl DynamoDbStorage<TestClock> {
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
-    ) -> Result<Self, DynamoDbContextError> {
+    ) -> Result<Self, DynamoDbStoreError> {
         let storage =
             DbStorageInner::<DynamoDbStore>::new_for_testing(store_config, namespace, wasm_runtime)
                 .await?;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -73,14 +73,14 @@ pub use crate::{
 #[async_trait]
 pub trait Storage: Sized {
     /// The low-level storage implementation in use.
-    type Context: Context<Extra = ChainRuntimeContext<Self>, Error = Self::ContextError>
+    type Context: Context<Extra = ChainRuntimeContext<Self>, Error = Self::StoreError>
         + Clone
         + Send
         + Sync
         + 'static;
 
-    /// Alias to provide simpler trait bounds `ViewError: From<Self::ContextError>`
-    type ContextError: std::error::Error + Debug + Sync + Send;
+    /// Alias to provide simpler trait bounds `ViewError: From<Self::StoreError>`
+    type StoreError: std::error::Error + Debug + Sync + Send;
 
     /// Returns the current wall clock time.
     fn clock(&self) -> &dyn Clock;
@@ -88,7 +88,7 @@ pub trait Storage: Sized {
     /// Loads the view of a chain state.
     async fn load_chain(&self, id: ChainId) -> Result<ChainStateView<Self::Context>, ViewError>
     where
-        ViewError: From<Self::ContextError>;
+        ViewError: From<Self::StoreError>;
 
     /// Tests existence of a hashed certificate value with the given hash.
     async fn contains_hashed_certificate_value(&self, hash: CryptoHash) -> Result<bool, ViewError>;
@@ -160,7 +160,7 @@ pub trait Storage: Sized {
     ) -> Result<ChainStateView<Self::Context>, linera_chain::ChainError>
     where
         ChainRuntimeContext<Self>: ExecutionRuntimeContext,
-        ViewError: From<Self::ContextError>,
+        ViewError: From<Self::StoreError>,
     {
         let chain = self.load_chain(id).await?;
         chain.ensure_is_active()?;
@@ -203,7 +203,7 @@ pub trait Storage: Sized {
     ) -> Result<(), ChainError>
     where
         ChainRuntimeContext<Self>: ExecutionRuntimeContext,
-        ViewError: From<Self::ContextError>,
+        ViewError: From<Self::StoreError>,
     {
         let id = description.into();
         let mut chain = self.load_chain(id).await?;

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -6,7 +6,7 @@ use linera_views::memory::MemoryStore;
 use {
     crate::db_storage::DbStorageInner,
     linera_execution::WasmRuntime,
-    linera_views::memory::{MemoryContextError, MemoryStoreConfig},
+    linera_views::memory::{MemoryStoreConfig, MemoryStoreError},
 };
 
 use crate::db_storage::DbStorage;
@@ -30,7 +30,7 @@ impl MemoryStorage<crate::TestClock> {
         wasm_runtime: Option<WasmRuntime>,
         max_stream_queries: usize,
         clock: TestClock,
-    ) -> Result<Self, MemoryContextError> {
+    ) -> Result<Self, MemoryStoreError> {
         let store_config = MemoryStoreConfig::new(max_stream_queries);
         let namespace = "unused_namespace";
         let storage =

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -6,9 +6,7 @@ use linera_views::rocks_db::RocksDbStore;
 use {
     crate::db_storage::{DbStorageInner, TestClock},
     linera_execution::WasmRuntime,
-    linera_views::rocks_db::{
-        create_rocks_db_test_config, RocksDbContextError, RocksDbStoreConfig,
-    },
+    linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStoreConfig, RocksDbStoreError},
     linera_views::test_utils::generate_test_namespace,
     tempfile::TempDir,
 };
@@ -42,7 +40,7 @@ impl RocksDbStorage<TestClock> {
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
-    ) -> Result<Self, RocksDbContextError> {
+    ) -> Result<Self, RocksDbStoreError> {
         let storage =
             DbStorageInner::<RocksDbStore>::new_for_testing(store_config, namespace, wasm_runtime)
                 .await?;

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -7,7 +7,7 @@ use {
     crate::db_storage::{DbStorageInner, TestClock},
     linera_execution::WasmRuntime,
     linera_views::scylla_db::{
-        create_scylla_db_test_config, ScyllaDbContextError, ScyllaDbStoreConfig,
+        create_scylla_db_test_config, ScyllaDbStoreConfig, ScyllaDbStoreError,
     },
     linera_views::test_utils::generate_test_namespace,
 };
@@ -35,7 +35,7 @@ impl ScyllaDbStorage<TestClock> {
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
-    ) -> Result<Self, ScyllaDbContextError> {
+    ) -> Result<Self, ScyllaDbStoreError> {
         let storage =
             DbStorageInner::<ScyllaDbStore>::new_for_testing(store_config, namespace, wasm_runtime)
                 .await?;

--- a/linera-storage/src/service.rs
+++ b/linera-storage/src/service.rs
@@ -8,7 +8,7 @@ use {
     linera_execution::WasmRuntime,
     linera_storage_service::{
         client::service_config_from_endpoint,
-        common::{ServiceContextError, ServiceStoreConfig},
+        common::{ServiceStoreConfig, ServiceStoreError},
     },
     linera_views::test_utils::generate_test_namespace,
 };
@@ -33,7 +33,7 @@ impl ServiceStorage<TestClock> {
         namespace: &str,
         wasm_runtime: Option<WasmRuntime>,
         clock: TestClock,
-    ) -> Result<Self, ServiceContextError> {
+    ) -> Result<Self, ServiceStoreError> {
         let storage = DbStorageInner::<ServiceStoreClient>::new_for_testing(
             store_config,
             namespace,

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -71,7 +71,7 @@ pub enum ViewError {
 
     /// Errors within the context can occur and are presented as ViewError.
     #[error("Storage operation error in {backend}: {error}")]
-    ContextError {
+    StoreError {
         /// backend can be e.g. RocksDB / DynamoDB / Memory / etc.
         backend: String,
         /// error is the specific problem that occurred within that context


### PR DESCRIPTION
## Motivation

The concept of `DbContext` is an implementation detail. `(KeyValue)Store` is a real name for backends.

## Proposal

rename `*ContextError` into `*StoreError`

## Test Plan

CI