### PR TITLE
Update lagging validators on blob reads

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -71,7 +71,7 @@ impl Block {
         locations
     }
 
-    /// Returns all the blob IDs referred to in this block's operations.
+    /// Returns all the published blob IDs in this block's operations.
     pub fn published_blob_ids(&self) -> HashSet<BlobId> {
         let mut blob_ids = HashSet::new();
         for operation in &self.operations {
@@ -761,16 +761,11 @@ impl ExecutedBlock {
     }
 
     pub fn required_blob_ids(&self) -> HashSet<BlobId> {
-        let mut required_blob_ids = HashSet::new();
-        for responses in &self.outcome.oracle_responses {
-            for response in responses {
-                if let OracleResponse::Blob(blob_id) = response {
-                    required_blob_ids.insert(*blob_id);
-                }
-            }
-        }
+        self.outcome.required_blob_ids()
+    }
 
-        required_blob_ids
+    pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
+        self.required_blob_ids().contains(blob_id)
     }
 }
 
@@ -780,6 +775,19 @@ impl BlockExecutionOutcome {
             block,
             outcome: self,
         }
+    }
+
+    pub fn required_blob_ids(&self) -> HashSet<BlobId> {
+        let mut required_blob_ids = HashSet::new();
+        for responses in &self.oracle_responses {
+            for response in responses {
+                if let OracleResponse::Blob(blob_id) = response {
+                    required_blob_ids.insert(*blob_id);
+                }
+            }
+        }
+
+        required_blob_ids
     }
 }
 

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -112,7 +112,7 @@ pub enum ChainError {
     PreviousBlockMustBeConfirmedFirst,
     #[error("Round number should be at least {0:?}")]
     InsufficientRound(Round),
-    #[error("Round number should greater than {0:?}")]
+    #[error("Round number should be greater than {0:?}")]
     InsufficientRoundStrict(Round),
     #[error("Round number should be {0:?}")]
     WrongRound(Round),

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -71,7 +71,10 @@ where
         .unwrap()
         .unwrap();
 
-    chain2.receive_certificate(cert).await.unwrap();
+    chain2
+        .receive_certificate_and_update_validators(cert)
+        .await
+        .unwrap();
     chain2.process_inbox().await.unwrap();
     assert_eq!(
         chain1.local_balance().await.unwrap(),
@@ -85,10 +88,16 @@ where
         .unwrap()
         .unwrap();
 
-    chain2.receive_certificate(cert).await.unwrap();
+    chain2
+        .receive_certificate_and_update_validators(cert)
+        .await
+        .unwrap();
     let cert = chain2.process_inbox().await.unwrap().0.pop().unwrap();
 
-    chain1.receive_certificate(cert).await.unwrap();
+    chain1
+        .receive_certificate_and_update_validators(cert)
+        .await
+        .unwrap();
     chain1.process_inbox().await.unwrap();
     assert_eq!(
         chain1.local_balance().await.unwrap(),

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -14,7 +14,7 @@ use linera_chain::{
 };
 use linera_execution::{
     committee::{Committee, ValidatorName},
-    BytecodeLocation,
+    BytecodeLocation, ExecutionError, SystemExecutionError,
 };
 use linera_version::VersionInfo;
 use linera_views::views::ViewError;
@@ -213,6 +213,9 @@ pub enum NodeError {
 
     #[error("Failed to make a chain info query on the local node: {error}")]
     LocalNodeQuery { error: String },
+
+    #[error("Blob not found on storage read: {0}")]
+    BlobNotFoundOnRead(BlobId),
 }
 
 impl From<tonic::Status> for NodeError {
@@ -278,6 +281,10 @@ impl From<ChainError> for NodeError {
                 height,
             },
             ChainError::InactiveChain(chain_id) => Self::InactiveChain(chain_id),
+            ChainError::ExecutionError(
+                ExecutionError::SystemError(SystemExecutionError::BlobNotFoundOnRead(blob_id)),
+                _,
+            ) => Self::BlobNotFoundOnRead(blob_id),
             error => Self::ChainError {
                 error: error.to_string(),
             },

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -3,25 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     fmt,
     hash::Hash,
     ops::Range,
 };
 
-use futures::{future, Future, StreamExt};
+use futures::{Future, StreamExt};
 use linera_base::{
-    data_types::{BlockHeight, HashedBlob, Round},
-    identifiers::{BlobId, ChainId},
+    data_types::{BlockHeight, Round},
+    ensure,
+    identifiers::ChainId,
     time::{Duration, Instant},
 };
-use linera_chain::data_types::{
-    BlockProposal, Certificate, CertificateValue, HashedCertificateValue, LiteVote,
-};
-use linera_execution::{
-    committee::{Committee, ValidatorName},
-    BytecodeLocation,
-};
+use linera_chain::data_types::{BlockProposal, Certificate, LiteVote};
+use linera_execution::committee::{Committee, ValidatorName};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
 use thiserror::Error;
@@ -73,7 +69,6 @@ where
     pub name: ValidatorName,
     pub node: A,
     pub local_node: LocalNodeClient<S>,
-    pub local_node_chain_managers_pending_blobs: BTreeMap<BlobId, HashedBlob>,
 }
 
 /// An error result for [`communicate_with_quorum`].
@@ -228,115 +223,6 @@ where
             .await
     }
 
-    async fn find_missing_application_bytecodes(
-        &self,
-        certificate: &Certificate,
-        locations: &Vec<BytecodeLocation>,
-    ) -> Result<Vec<HashedCertificateValue>, NodeError> {
-        if locations.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Find the missing bytecodes locally and retry.
-        let required = match certificate.value() {
-            CertificateValue::ConfirmedBlock { executed_block, .. }
-            | CertificateValue::ValidatedBlock { executed_block, .. } => {
-                executed_block.block.bytecode_locations()
-            }
-            CertificateValue::Timeout { .. } => HashSet::new(),
-        };
-        for location in locations {
-            if !required.contains(location) {
-                let hash = location.certificate_hash;
-                warn!("validator requested {:?} but it is not required", hash);
-                return Err(NodeError::InvalidChainInfoResponse);
-            }
-        }
-        let unique_locations = locations.iter().cloned().collect::<HashSet<_>>();
-        if locations.len() > unique_locations.len() {
-            warn!("locations requested by validator contain duplicates");
-            return Err(NodeError::InvalidChainInfoResponse);
-        }
-        let storage = self.local_node.storage_client();
-        Ok(future::join_all(
-            unique_locations
-                .into_iter()
-                .map(|location| storage.read_hashed_certificate_value(location.certificate_hash)),
-        )
-        .await
-        .into_iter()
-        .collect::<Result<Vec<_>, _>>()?)
-    }
-
-    async fn find_missing_blobs(
-        &self,
-        certificate: &Certificate,
-        blob_ids: &Vec<BlobId>,
-    ) -> Result<Vec<HashedBlob>, NodeError> {
-        if blob_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Find the missing blobs locally and retry.
-        let required = match certificate.value() {
-            CertificateValue::ConfirmedBlock { executed_block, .. }
-            | CertificateValue::ValidatedBlock { executed_block, .. } => {
-                executed_block.block.published_blob_ids()
-            }
-            CertificateValue::Timeout { .. } => HashSet::new(),
-        };
-        for blob_id in blob_ids {
-            if !required.contains(blob_id) {
-                warn!(
-                    "validator requested blob {:?} but it is not required",
-                    blob_id
-                );
-                return Err(NodeError::InvalidChainInfoResponse);
-            }
-        }
-        let mut unique_blob_ids_to_find = blob_ids.iter().cloned().collect::<HashSet<_>>();
-        if blob_ids.len() > unique_blob_ids_to_find.len() {
-            warn!("blobs requested by validator contain duplicates");
-            return Err(NodeError::InvalidChainInfoResponse);
-        }
-
-        let (found_blobs, not_found_blobs): (HashMap<BlobId, HashedBlob>, Vec<BlobId>) = self
-            .local_node
-            .recent_hashed_blobs()
-            .await
-            .try_get_many(blob_ids.clone())
-            .await;
-        let mut missing_blobs = found_blobs.clone().into_values().collect::<Vec<_>>();
-
-        unique_blob_ids_to_find = unique_blob_ids_to_find
-            .difference(&found_blobs.into_keys().collect::<HashSet<_>>())
-            .copied()
-            .collect::<HashSet<BlobId>>();
-        for blob_id in not_found_blobs {
-            if let Some(blob) = self
-                .local_node_chain_managers_pending_blobs
-                .get(&blob_id)
-                .cloned()
-            {
-                missing_blobs.push(blob);
-                unique_blob_ids_to_find.remove(&blob_id);
-            }
-        }
-
-        let storage = self.local_node.storage_client();
-        missing_blobs.extend(
-            future::join_all(
-                unique_blob_ids_to_find
-                    .into_iter()
-                    .map(|blob_id| storage.read_hashed_blob(blob_id)),
-            )
-            .await
-            .into_iter()
-            .collect::<Result<Vec<_>, _>>()?,
-        );
-        Ok(missing_blobs)
-    }
-
     async fn send_certificate(
         &mut self,
         certificate: Certificate,
@@ -347,11 +233,21 @@ where
             .await;
 
         let response = match &result {
-            Err(NodeError::ApplicationBytecodesOrBlobsNotFound(locations, blob_ids)) => {
+            Err(
+                original_err @ NodeError::ApplicationBytecodesOrBlobsNotFound(locations, blob_ids),
+            ) => {
                 let values = self
+                    .local_node
                     .find_missing_application_bytecodes(&certificate, locations)
                     .await?;
-                let blobs = self.find_missing_blobs(&certificate, blob_ids).await?;
+                let blobs = self
+                    .local_node
+                    .find_missing_blobs(&certificate, blob_ids, certificate.value().chain_id())
+                    .await?;
+                ensure!(
+                    values.len() == locations.len() && blobs.len() == blob_ids.len(),
+                    original_err.clone()
+                );
                 self.node
                     .handle_certificate(certificate, values, blobs, delivery)
                     .await
@@ -391,6 +287,25 @@ where
                     // synchronize them now and retry.
                     self.send_chain_information_for_senders(chain_id).await?;
                 }
+
+                self.node.handle_block_proposal(proposal.clone()).await?
+            }
+            Err(NodeError::BlobNotFoundOnRead(blob_id)) => {
+                // For `BlobNotFoundOnRead`, we assume that the local node should already be
+                // updated with the needed blobs, so sending the chain information about the
+                // certificate that last used the blob to the validator node should be enough.
+                let local_storage = self.local_node.storage_client();
+                let last_used_by_hash = local_storage.read_blob_state(blob_id).await?.last_used_by;
+                let certificate = local_storage.read_certificate(last_used_by_hash).await?;
+
+                let block_chain_id = certificate.value().chain_id();
+                let block_height = certificate.value().height();
+                self.send_chain_information(
+                    block_chain_id,
+                    block_height.try_add_one()?,
+                    CrossChainMessageDelivery::Blocking,
+                )
+                .await?;
 
                 self.node.handle_block_proposal(proposal.clone()).await?
             }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -313,12 +313,7 @@ where
             }
 
             ReadBlob { blob_id, callback } => {
-                let blob = self
-                    .context()
-                    .extra()
-                    .get_blob(blob_id)
-                    .await
-                    .map_err(|_| ExecutionError::BlobNotFoundOnRead(blob_id))?;
+                let blob = self.system.read_blob(blob_id).await?;
                 callback.respond(blob);
             }
         }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -170,6 +170,7 @@ pub enum ExecutionError {
 
     #[error("Blob not found on storage read: {0}")]
     BlobNotFoundOnRead(BlobId),
+
     #[error("Event keys can be at most {MAX_EVENT_KEY_LEN} bytes.")]
     EventKeyTooLong,
     #[error("Stream names can be at most {MAX_STREAM_NAME_LEN} bytes.")]
@@ -916,7 +917,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
         Ok(self
             .blobs
             .get(&blob_id)
-            .ok_or_else(|| ExecutionError::BlobNotFoundOnRead(blob_id))?
+            .ok_or_else(|| SystemExecutionError::BlobNotFoundOnRead(blob_id))?
             .clone())
     }
 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -608,6 +608,10 @@ NodeError:
       LocalNodeQuery:
         STRUCT:
           - error: STR
+    20:
+      BlobNotFoundOnRead:
+        NEWTYPE:
+          TYPENAME: BlobId
 OpenChainConfig:
   STRUCT:
     - ownership:
@@ -999,6 +1003,11 @@ SystemOperation:
           - blob_id:
               TYPENAME: BlobId
     10:
+      ReadBlob:
+        STRUCT:
+          - blob_id:
+              TYPENAME: BlobId
+    11:
       CreateApplication:
         STRUCT:
           - bytecode_id:
@@ -1008,14 +1017,14 @@ SystemOperation:
           - required_application_ids:
               SEQ:
                 TYPENAME: ApplicationId
-    11:
+    12:
       RequestApplication:
         STRUCT:
           - chain_id:
               TYPENAME: ChainId
           - application_id:
               TYPENAME: ApplicationId
-    12:
+    13:
       Admin:
         NEWTYPE:
           TYPENAME: AdminOperation

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -597,14 +597,16 @@ where
 
     /// Publishes a new blob.
     async fn publish_blob(&self, chain_id: ChainId, blob: Blob) -> Result<BlobId, Error> {
+        let hashed_blob = blob.into_hashed();
         self.apply_client_command(&chain_id, move |client| {
-            let blob = blob.clone();
+            let hashed_blob = hashed_blob.clone();
             async move {
+                let blob_id = hashed_blob.id;
                 let result = client
-                    .publish_blob(blob.into_hashed())
+                    .publish_blob(hashed_blob)
                     .await
                     .map_err(Error::from)
-                    .map(|outcome| outcome.map(|(blob_id, _)| blob_id));
+                    .map(|outcome| outcome.map(|_| blob_id));
                 (result, client)
             }
         })

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -118,6 +118,12 @@ pub trait Storage: Sized {
     /// Reads the blob with the given blob ID.
     async fn read_hashed_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ViewError>;
 
+    /// Reads the blobs with the given blob IDs.
+    async fn read_hashed_blobs(
+        &self,
+        blob_ids: &[BlobId],
+    ) -> Result<Vec<Option<HashedBlob>>, ViewError>;
+
     /// Reads the blob state with the given blob ID.
     async fn read_blob_state(&self, blob_id: BlobId) -> Result<BlobState, ViewError>;
 


### PR DESCRIPTION
## Motivation

We need to update lagging validators if they're not aware of blobs that have already been published.

## Proposal

A few things had to be done here:
- Write the actual code to update the lagging validators. This is initially used in two places: when we're first staging block execution, and when we're synchronizing the chain state from the validators.
- Created test only `ReadBlob` `SystemOperation` to be able to test this without creating or modifying existing applications.
- Added `hashed_certificate_values` and `hashed_blobs` to `process_validated_block`. This was an existing bug because we check for missing blobs there, but didn't pass the information along on a retry.
- We had to move `synchronize_chain_state` and `try_synchronize_chain_state_from` to the client, so that we could properly call the lagging validator code on chain synchronization as well.
- Fixed a bug where our test `LocalValidatorClient` wasn't properly handling certificates: if `NoConfirm` and we're trying to handle a validated certificate, it wouldn't actually call the handle code like it should.

## Test Plan

3 tests were written (more to come in following PRs)

