### PR TITLE
`linera-client`: fix block height race

### DIFF
--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -632,6 +632,4 @@ impl ChainManagerInfo {
 
         None
     }
-
-
 }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -85,7 +85,7 @@ use tracing::error;
 
 use crate::{
     data_types::{
-        BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue,
+        Block, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue,
         HashedCertificateValue, LiteVote, ProposalContent, Vote,
     },
     ChainError,
@@ -614,4 +614,24 @@ impl ChainManagerInfo {
             .map(|vote| Box::new(vote.value.clone()));
         self.pending_blobs = manager.pending_blobs.clone();
     }
+
+    /// Gets the highest validated block.
+    pub fn highest_validated_block(&self) -> Option<&Block> {
+        if let Some(certificate) = &self.requested_locked {
+            let block = certificate.value().block();
+            if block.is_some() {
+                return block;
+            }
+        }
+
+        if let Some(proposal) = &self.requested_proposed {
+            if proposal.content.round.is_fast() {
+                return Some(&proposal.content.block);
+            }
+        }
+
+        None
+    }
+
+
 }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1899,18 +1899,9 @@ where
         }
 
         // The block we want to propose is either the highest validated, or our pending one.
-        let maybe_block = manager
-            .requested_locked
-            .as_ref()
-            .and_then(|certificate| certificate.value().block())
-            .cloned()
-            .or(manager
-                .requested_proposed
-                .as_ref()
-                .filter(|proposal| proposal.content.round.is_fast())
-                .map(|proposal| proposal.content.block.clone()))
-            .or_else(|| self.state().pending_block.clone());
-        let Some(block) = maybe_block else {
+        let Some(block) = manager.highest_validated_block().cloned()
+            .or_else(|| self.state().pending_block.clone())
+        else {
             return Ok(ClientOutcome::Committed(None)); // Nothing to propose.
         };
 


### PR DESCRIPTION
## Motivation

In #2133 I inadvertently introduced a race condition in which the client could propose two blocks at the same height at the same time.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Take a lock while building a block so that blocks are always strictly ordered.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI, repeatedly.

<!-- How to test that the changes are correct. -->

## Release Plan

Bugfix: no need.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
