### PR TITLE
Improve logging in README tests

### DIFF
--- a/linera-service/tests/readme_test.rs
+++ b/linera-service/tests/readme_test.rs
@@ -43,7 +43,7 @@ async fn test_script_in_readme_with_storage_service(path: &str) -> std::io::Resu
 
     if env::var_os("RUST_LOG").is_none() {
         // Increase log verbosity to verify that services can write to stderr.
-        command.env("RUST_LOG", "linera_service=debug");
+        command.env("RUST_LOG", "linera_execution::wasm=debug");
     }
 
     let status = command.status().await?;


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When running the README scripts tests, application logs were not being displayed. It also didn't work if the `RUST_LOG` environment variable was configured.

The cause was that the test always overrides the `RUST_LOG` environment variable with an incorrect value.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Fix the value configured for the `RUST_LOG` environment variable and only configure it if it's not already set, allowing the environment outside the test to configure the logging level.

## Test Plan

<!-- How to test that the changes are correct. -->
I manually added some logs to the Counter example application and ran the readme tests. The logs appeared correctly, both when `RUST_LOG` was overriden and when it was not.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this only affects tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
