### PR TITLE
`linera-client`: generalize over `Persist<Target = Wallet>` implementation

### DIFF
--- a/linera-client/src/persistent/file.rs
+++ b/linera-client/src/persistent/file.rs
@@ -110,11 +110,6 @@ impl<T: serde::de::DeserializeOwned> File<T> {
             _lock: lock,
         })
     }
-
-    /// Takes the value out, releasing the lock on the persistent file.
-    pub fn into_value(self) -> T {
-        self.value
-    }
 }
 
 impl<T: serde::Serialize + serde::de::DeserializeOwned> Persist for File<T> {
@@ -149,5 +144,10 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Persist for File<T> {
         }
         fs_err::rename(&temp_file_path, &this.path)?;
         Ok(())
+    }
+
+    /// Takes the value out, releasing the lock on the persistent file.
+    fn into_value(this: Self) -> T {
+        this.value
     }
 }

--- a/linera-client/src/persistent/mod.rs
+++ b/linera-client/src/persistent/mod.rs
@@ -20,6 +20,9 @@ pub trait Persist: Deref {
     /// Saves the value to persistent storage.
     fn persist(_: &mut Self) -> Result<(), Self::Error>;
 
+    /// Takes the value out.
+    fn into_value(this: Self) -> Self::Target;
+
     /// Gets a mutable reference to the value which, on drop, will automatically persist
     /// the new value.
     fn mutate(this: &mut Self) -> RefMut<Self> {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -22,10 +22,7 @@ use linera_base::{
     data_types::Amount,
     identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
-use linera_client::{
-    config::{GenesisConfig, WalletState},
-    wallet::Wallet,
-};
+use linera_client::{config::GenesisConfig, wallet::Wallet};
 use linera_core::worker::Notification;
 use linera_execution::{
     committee::ValidatorName, system::SystemChannel, Bytecode, ResourceControlPolicy,
@@ -40,7 +37,7 @@ use tracing::{info, warn};
 use crate::{
     cli_wrappers::{local_net::PathProvider, Network},
     faucet::ClaimOutcome,
-    util::ChildExt,
+    util::{self, ChildExt},
 };
 
 /// The name of the environment variable that allows specifying additional arguments to be passed
@@ -690,7 +687,7 @@ impl ClientWrapper {
     }
 
     pub fn load_wallet(&self) -> Result<Wallet> {
-        Ok(WalletState::from_file(self.wallet_path().as_path())?.into_value())
+        util::read_json(self.wallet_path())
     }
 
     pub fn wallet_path(&self) -> PathBuf {

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -499,7 +499,7 @@ async fn run(options: ServerOptions) {
                 Persist::persist(&mut server).expect("Unable to write server config file");
                 info!("Wrote server config {}", path.to_str().unwrap());
                 println!("{}", server.validator.name);
-                config_validators.push(server.into_value().validator);
+                config_validators.push(Persist::into_value(server).validator);
             }
             if let Some(committee) = committee {
                 Persist::persist(

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -55,7 +55,9 @@ pub async fn listen_for_shutdown_signals(shutdown_sender: CancellationToken) {
     }
 }
 
-pub fn read_json<T: serde::de::DeserializeOwned>(path: &std::path::Path) -> anyhow::Result<T> {
+pub fn read_json<T: serde::de::DeserializeOwned>(
+    path: impl Into<std::path::PathBuf>,
+) -> anyhow::Result<T> {
     Ok(serde_json::from_reader(fs_err::File::open(path)?)?)
 }
 


### PR DESCRIPTION
## Motivation

We would like to introduce a browser-compatible storage backend for the wallet in order to manage wallets inside the [Web wallet](https://github.com/linera-io/linera-web).  While #2194 introduced the general framework to do so, the implementations in `linera-client` remained specific to the filesystem backend.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Generalize the implementations of client functionality in `linera-client` to any implementation of `Persist<Target = Wallet>`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

<!-- How to test that the changes are correct. -->

CI, since `linera-client` will be tested by the existing `linera-service` tests.

## Release Plan

Backwards-compatible API change (minor bump).

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
