### PR TITLE
Clean `process_inbox` entries from the end-to-end tests

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -920,7 +920,12 @@ impl NodeService {
                 .json(&json!({ "query": query }))
                 .send()
                 .await
-                .with_context(|| format!("query_node: failed to post query={}", query.get(..200).unwrap_or(query)))?;
+                .with_context(|| {
+                    format!(
+                        "query_node: failed to post query={}",
+                        query.get(..200).unwrap_or(query)
+                    )
+                })?;
             anyhow::ensure!(
                 response.status().is_success(),
                 "Query \"{}\" failed: {}",
@@ -1220,7 +1225,12 @@ impl Faucet {
             .json(&json!({ "query": &query }))
             .send()
             .await
-            .with_context(|| format!("claim: failed to post query={}", query.get(..200).unwrap_or(&query)))?;
+            .with_context(|| {
+                format!(
+                    "claim: failed to post query={}",
+                    query.get(..200).unwrap_or(&query)
+                )
+            })?;
         anyhow::ensure!(
             response.status().is_success(),
             "Query \"{}\" failed: {}",
@@ -1314,7 +1324,12 @@ impl<A> ApplicationWrapper<A> {
             .json(&json!({ "query": query }))
             .send()
             .await
-            .with_context(|| format!("raw_query: failed to post query={}", query.get(..200).unwrap_or(query)))?;
+            .with_context(|| {
+                format!(
+                    "raw_query: failed to post query={}",
+                    query.get(..200).unwrap_or(query)
+                )
+            })?;
         anyhow::ensure!(
             response.status().is_success(),
             "Query \"{}\" failed: {}",

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -920,7 +920,7 @@ impl NodeService {
                 .json(&json!({ "query": query }))
                 .send()
                 .await
-                .with_context(|| format!("query_node: failed to post query={}", query))?;
+                .with_context(|| format!("query_node: failed to post query={}", query.get(..200).unwrap_or(query)))?;
             anyhow::ensure!(
                 response.status().is_success(),
                 "Query \"{}\" failed: {}",
@@ -1220,7 +1220,7 @@ impl Faucet {
             .json(&json!({ "query": &query }))
             .send()
             .await
-            .with_context(|| format!("claim: failed to post query={}", query))?;
+            .with_context(|| format!("claim: failed to post query={}", query.get(..200).unwrap_or(&query)))?;
         anyhow::ensure!(
             response.status().is_success(),
             "Query \"{}\" failed: {}",
@@ -1314,7 +1314,7 @@ impl<A> ApplicationWrapper<A> {
             .json(&json!({ "query": query }))
             .send()
             .await
-            .with_context(|| format!("raw_query: failed to post query={}", query))?;
+            .with_context(|| format!("raw_query: failed to post query={}", query.get(..200).unwrap_or(query)))?;
         anyhow::ensure!(
             response.status().is_success(),
             "Query \"{}\" failed: {}",

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -1610,9 +1610,6 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
             })
             .await;
     }
-
-    node_service_admin.process_inbox(&chain_a).await?;
-
     for order_id in order_ids_b {
         app_matching_b
             .order(matching_engine::Order::Cancel {


### PR DESCRIPTION
## Motivation

The CI is progressing in quality, but it still has some issues. This PR contains a number of corrections.

## Proposal

The following is done:
* The error messages of the `with_context` in `wallet.rs` is reduced to the first 200 which makes the logs easier to analyze.
* The while loop of the `test_open_chain_node_service` is eliminated and replaced by a `process_inbox`.
* The `process_inbox` is removed for the `cancel` operations in the `matching_engine` since it is not needed.
* Two `process_inbox` in the `test_wasm_end_to_end_non_fungible` are not needed because in a `transfer` operation, only the target chain needs to have a `process_inbox`.

## Test Plan

The CI is of course the objective. But the methodology for checking was different. Tests were run 10 times locally in order to identify if a problem was introduced by the removal of `process_inbox`. The result showed that no errors were introduced by doing that. It does not mean that there are no remaining errors.

## Release Plan

A priori is not relevant, but if `process_inbox` will continue to to exist in the future, then we need to document how to use it.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
