### PR TITLE
Use OracleResponses in more places, to clarify record-replay distinction.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 use anyhow::Context as _;
-use async_graphql::{InputObject, SimpleObject};
+use async_graphql::InputObject;
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -708,22 +708,6 @@ impl ApplicationPermissions {
     /// Returns whether the given application is allowed to close this chain.
     pub fn can_close_chain(&self, app_id: &ApplicationId) -> bool {
         self.close_chain.contains(app_id)
-    }
-}
-
-/// A record of oracle responses from the execution of a transaction.
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
-pub struct OracleRecord {
-    /// The list of responses to all the oracle queries made by a transaction.
-    pub responses: Vec<OracleResponse>,
-}
-
-impl OracleRecord {
-    /// Wether an `OracleRecord` is permitted in fast blocks or not.
-    pub fn is_permitted_in_fast_blocks(&self) -> bool {
-        self.responses
-            .iter()
-            .all(|oracle_response| oracle_response.is_permitted_in_fast_blocks())
     }
 }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -849,7 +849,11 @@ where
                         )
                         .await
                         .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
-                    new_oracle_responses.push(oracle_tape.try_into_responses().unwrap_or_default());
+                    new_oracle_responses.push(
+                        oracle_tape.into_responses().map_err(|err| {
+                            ChainError::ExecutionError(err, chain_execution_context)
+                        })?,
+                    );
                     if grant > Amount::ZERO {
                         if let Some(refund_grant_to) = message.event.refund_grant_to {
                             let outcome = self
@@ -964,7 +968,11 @@ where
                 )
                 .await
                 .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
-            new_oracle_responses.push(oracle_tape.try_into_responses().unwrap_or_default());
+            new_oracle_responses.push(
+                oracle_tape
+                    .into_responses()
+                    .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?,
+            );
             let messages_out = self
                 .process_execution_outcomes(context.height, outcomes)
                 .await?;

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -141,7 +141,7 @@ pub enum ChainError {
     #[error("Can't use grant across different broadcast messages")]
     GrantUseOnBroadcast,
     #[error("ExecutedBlock contains fewer oracle responses than requests")]
-    MissingOracleRecord,
+    MissingOracleResponseList,
     #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
     CertificateValueHashMismatch {
         expected: CryptoHash,

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -18,7 +18,7 @@ fn test_signed_values() {
     let executed_block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
-        oracle_records: vec![OracleRecord::default()],
+        oracle_responses: vec![Vec::new()],
     }
     .with(block);
     let value = HashedCertificateValue::new_confirmed(executed_block);
@@ -46,7 +46,7 @@ fn test_certificates() {
     let executed_block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
-        oracle_records: vec![OracleRecord::default()],
+        oracle_responses: vec![Vec::new()],
     }
     .with(block);
     let value = HashedCertificateValue::new_confirmed(executed_block);

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1450,11 +1450,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record
-            .responses
-            .contains(&OracleResponse::Blob(expected_blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(expected_blob_id))));
     let previous_block_hash = client_a.block_hash().unwrap();
 
     // Validators goes back up

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -19,7 +19,7 @@ use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, HashedBlob, OracleRecord, OracleResponse},
+    data_types::{Amount, HashedBlob, OracleResponse},
     identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -125,9 +125,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(blob_id))));
 
     let service_blob = HashedBlob::load_from_file(service_path.clone()).await?;
     let expected_service_blob_id = service_blob.id();
@@ -138,9 +138,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(blob_id))));
 
     // If I try to upload the contract blob again, I should get the same blob ID
     let (blob_id, certificate) = publisher
@@ -154,9 +154,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(blob_id))));
 
     let (bytecode_id, cert) = publisher
         .publish_bytecode(
@@ -389,9 +389,9 @@ where
     receiver.receive_certificate(cert).await.unwrap();
     let (cert, _) = receiver.process_inbox().await.unwrap();
     let executed_block = cert[0].value().executed_block().unwrap();
-    let records = &executed_block.outcome.oracle_records;
-    let [_, OracleRecord { responses }] = &records[..] else {
-        panic!("Unexpected oracle records: {:?}", records);
+    let responses = &executed_block.outcome.oracle_responses;
+    let [_, responses] = &responses[..] else {
+        panic!("Unexpected oracle responses: {:?}", responses);
     };
     let [OracleResponse::Service(json)] = &responses[..] else {
         panic!("Unexpected oracle responses: {:?}", responses);

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -32,8 +32,8 @@ use linera_execution::{
     system::{SystemChannel, SystemMessage, SystemOperation},
     test_utils::SystemExecutionState,
     Bytecode, BytecodeLocation, ChannelSubscription, Message, MessageKind, Operation,
-    OperationContext, ResourceController, UserApplicationDescription, UserApplicationId,
-    WasmContractModule, WasmRuntime,
+    OperationContext, OracleTape, ResourceController, UserApplicationDescription,
+    UserApplicationId, WasmContractModule, WasmRuntime,
 };
 #[cfg(feature = "dynamodb")]
 use linera_storage::DynamoDbStorage;
@@ -488,7 +488,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await?;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use linera_base::{
     crypto::KeyPair,
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{
         BytecodeId, ChainDescription, ChainId, Destination, GenericApplicationId, MessageId,
     },
@@ -148,7 +148,7 @@ where
                 message: Message::System(publish_message.clone()),
             }]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(publish_block),
     );
@@ -217,7 +217,7 @@ where
         BlockExecutionOutcome {
             messages: vec![vec![failing_broadcast_outgoing_message]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(broadcast_block.clone()),
     );
@@ -241,7 +241,7 @@ where
         BlockExecutionOutcome {
             messages: vec![vec![broadcast_outgoing_message]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(broadcast_block),
     );
@@ -295,7 +295,7 @@ where
                 message: Message::System(subscribe_message.clone()),
             }]],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(subscribe_block),
     );
@@ -347,7 +347,7 @@ where
                 }),
             }]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(accept_block),
     );
@@ -444,7 +444,7 @@ where
                 }],
             ],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_records: vec![OracleRecord::default(); 2],
+            oracle_responses: vec![Vec::new(); 2],
         }
         .with(create_block),
     );
@@ -488,7 +488,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -497,7 +497,7 @@ where
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(run_block),
     );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -296,7 +296,7 @@ where
         }
         Recipient::Burn => messages.push(Vec::new()),
     }
-    let oracle_records = iter::repeat_with(OracleRecord::default)
+    let oracle_responses = iter::repeat_with(Vec::new)
         .take(block.operations.len() + block.incoming_messages.len())
         .collect();
     let state_hash = system_state.into_hash().await;
@@ -304,7 +304,7 @@ where
         BlockExecutionOutcome {
             messages,
             state_hash,
-            oracle_records,
+            oracle_responses,
         }
         .with(block),
     );
@@ -716,7 +716,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 2],
+                oracle_responses: vec![Vec::new(); 2],
             }
             .with(
                 make_first_block(ChainId::root(1))
@@ -742,7 +742,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_child_block(&certificate0.value)
@@ -1004,7 +1004,7 @@ where
                     }
                     .into_hash()
                     .await,
-                    oracle_records: vec![OracleRecord::default(); 2],
+                    oracle_responses: vec![Vec::new(); 2],
                 }
                 .with(block_proposal.content.block),
             ),
@@ -1287,7 +1287,7 @@ where
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
             state_hash: state.into_hash().await,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(make_first_block(chain_id).with_incoming_message(open_chain_message)),
     );
@@ -2334,7 +2334,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(make_first_block(admin_id).with_operation(
                 SystemOperation::OpenChain(OpenChainConfig {
@@ -2397,7 +2397,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 2],
+                oracle_responses: vec![Vec::new(); 2],
             }
             .with(
                 make_child_block(&certificate0.value)
@@ -2432,7 +2432,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_child_block(&certificate1.value)
@@ -2563,7 +2563,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 4],
+                oracle_responses: vec![Vec::new(); 4],
             }
             .with(
                 make_first_block(user_id)
@@ -2734,7 +2734,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(make_first_block(user_id).with_simple_transfer(admin_id, Amount::ONE)),
         ),
@@ -2760,7 +2760,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_first_block(admin_id).with_operation(SystemOperation::Admin(
@@ -2862,7 +2862,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(make_first_block(user_id).with_simple_transfer(admin_id, Amount::ONE)),
         ),
@@ -2895,7 +2895,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 2],
+                oracle_responses: vec![Vec::new(); 2],
             }
             .with(
                 make_first_block(admin_id)
@@ -2956,7 +2956,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_child_block(&certificate1.value)

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -317,9 +317,9 @@ where
                         )
                         .await?;
                     outcomes.extend(user_outcomes);
-                    return Ok((outcomes, oracle_tape.into_record()));
+                    return Ok((outcomes, oracle_tape.try_into_record().unwrap_or_default()));
                 }
-                Ok((outcomes, oracle_tape.into_record()))
+                Ok((outcomes, oracle_tape.try_into_record().unwrap_or_default()))
             }
             Operation::User {
                 application_id,
@@ -337,7 +337,7 @@ where
                         resource_controller,
                     )
                     .await?;
-                Ok((outcomes, oracle_tape.into_record()))
+                Ok((outcomes, oracle_tape.try_into_record().unwrap_or_default()))
             }
         }
     }
@@ -376,7 +376,7 @@ where
                         resource_controller,
                     )
                     .await?;
-                Ok((outcomes, oracle_tape.into_record()))
+                Ok((outcomes, oracle_tape.try_into_record().unwrap_or_default()))
             }
         }
     }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1049,11 +1049,11 @@ impl OracleTape {
     }
 
     /// Returns the oracle record if `self` is `Record` and an empty record otherwise.
-    pub fn into_record(self) -> OracleRecord {
+    pub fn try_into_record(self) -> Option<OracleRecord> {
         if let OracleTape::Record(responses) = self {
-            OracleRecord { responses }
+            Some(OracleRecord { responses })
         } else {
-            OracleRecord::default()
+            None
         }
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1029,7 +1029,7 @@ pub struct BlobState {
 
 /// Responses to oracle queries that are being recorded or replayed.
 #[derive(Debug)]
-pub enum OracleResponses {
+pub enum OracleTape {
     /// When executing a block _proposal_, oracles can be used and their responses are recorded.
     Record(Vec<OracleResponse>),
     /// When re-executing a validated or confirmed block, recorded responses are used.
@@ -1038,19 +1038,19 @@ pub enum OracleResponses {
     Forget,
 }
 
-impl OracleResponses {
+impl OracleTape {
     /// Returns an empty `Record` if the argument is `None`, and `Replay` if it is `Some`.
     pub fn from_record(oracle_record: Option<OracleRecord>) -> Self {
         if let Some(responses) = oracle_record {
-            OracleResponses::Replay(responses.responses.into_iter())
+            OracleTape::Replay(responses.responses.into_iter())
         } else {
-            OracleResponses::Record(Vec::new())
+            OracleTape::Record(Vec::new())
         }
     }
 
     /// Returns the oracle record if `self` is `Record` and an empty record otherwise.
     pub fn into_record(self) -> OracleRecord {
-        if let OracleResponses::Record(responses) = self {
+        if let OracleTape::Record(responses) = self {
             OracleRecord { responses }
         } else {
             OracleRecord::default()

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -31,8 +31,8 @@ use linera_base::{
     abi::Abi,
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, BlockHeight, HashedBlob, OracleRecord,
-        OracleResponse, Resources, SendMessageRequest, Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, BlockHeight, HashedBlob, OracleResponse,
+        Resources, SendMessageRequest, Timestamp,
     },
     doc_scalar, hex_debug,
     identifiers::{
@@ -1040,18 +1040,18 @@ pub enum OracleTape {
 
 impl OracleTape {
     /// Returns an empty `Record` if the argument is `None`, and `Replay` if it is `Some`.
-    pub fn from_record(oracle_record: Option<OracleRecord>) -> Self {
-        if let Some(responses) = oracle_record {
-            OracleTape::Replay(responses.responses.into_iter())
+    pub fn from_responses(oracle_responses: Option<Vec<OracleResponse>>) -> Self {
+        if let Some(responses) = oracle_responses {
+            OracleTape::Replay(responses.into_iter())
         } else {
             OracleTape::Record(Vec::new())
         }
     }
 
-    /// Returns the oracle record if `self` is `Record` and an empty record otherwise.
-    pub fn try_into_record(self) -> Option<OracleRecord> {
+    /// Returns the oracle responses if `self` is `Record`.
+    pub fn try_into_responses(self) -> Option<Vec<OracleResponse>> {
         if let OracleTape::Record(responses) = self {
-            Some(OracleRecord { responses })
+            Some(responses)
         } else {
             None
         }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -37,7 +37,7 @@ use crate::test_utils::SystemExecutionState;
 use crate::{
     committee::{Committee, Epoch},
     ApplicationRegistryView, Bytecode, BytecodeLocation, ChannelName, ChannelSubscription,
-    Destination, MessageContext, MessageKind, OperationContext, OracleResponses, QueryContext,
+    Destination, MessageContext, MessageKind, OperationContext, OracleTape, QueryContext,
     RawExecutionOutcome, RawOutgoingMessage, UserApplicationDescription, UserApplicationId,
 };
 
@@ -439,7 +439,7 @@ where
         &mut self,
         context: OperationContext,
         operation: SystemOperation,
-        oracle_responses: &mut OracleResponses,
+        oracle_tape: &mut OracleTape,
     ) -> Result<
         (
             RawExecutionOutcome<SystemMessage, Amount>,
@@ -674,7 +674,7 @@ where
                 outcome.messages.push(message);
             }
             PublishBlob { blob_id } => {
-                if let OracleResponses::Record(responses) = oracle_responses {
+                if let OracleTape::Record(responses) = oracle_tape {
                     responses.push(OracleResponse::Blob(blob_id));
                 }
             }
@@ -1081,7 +1081,7 @@ mod tests {
         };
         let (result, new_application) = view
             .system
-            .execute_operation(context, operation, &mut OracleResponses::Forget)
+            .execute_operation(context, operation, &mut OracleTape::Forget)
             .await
             .unwrap();
         assert_eq!(new_application, None);
@@ -1119,7 +1119,7 @@ mod tests {
         };
         let (result, new_application) = view
             .system
-            .execute_operation(context, operation, &mut OracleResponses::Forget)
+            .execute_operation(context, operation, &mut OracleTape::Forget)
             .await
             .unwrap();
         assert_eq!(
@@ -1156,7 +1156,7 @@ mod tests {
         let operation = SystemOperation::OpenChain(config.clone());
         let (result, new_application) = view
             .system
-            .execute_operation(context, operation, &mut OracleResponses::Forget)
+            .execute_operation(context, operation, &mut OracleTape::Forget)
             .await
             .unwrap();
         assert_eq!(new_application, None);

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -184,7 +184,7 @@ fn create_runtime<Application>() -> (
         execution_state_sender,
         None,
         resource_controller,
-        super::OracleResponses::Record(Vec::new()),
+        super::OracleTape::Record(Vec::new()),
     );
 
     (runtime, execution_state_receiver)

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, vec};
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
@@ -206,7 +206,7 @@ async fn test_fee_consumption(
             } else {
                 None
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -14,7 +14,7 @@ use linera_base::{
 };
 use linera_execution::{
     test_utils::{register_mock_applications, ExpectedCall, SystemExecutionState},
-    ContractRuntime, ExecutionError, ExecutionOutcome, Message, MessageContext,
+    ContractRuntime, ExecutionError, ExecutionOutcome, Message, MessageContext, OracleTape,
     RawExecutionOutcome, ResourceControlPolicy, ResourceController,
 };
 use test_case::test_case;
@@ -206,7 +206,7 @@ async fn test_fee_consumption(
             } else {
                 None
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -23,7 +23,7 @@ use linera_execution::{
         SystemExecutionState,
     },
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, MessageKind, Operation,
-    OperationContext, Query, QueryContext, RawExecutionOutcome, RawOutgoingMessage,
+    OperationContext, OracleTape, Query, QueryContext, RawExecutionOutcome, RawOutgoingMessage,
     ResourceControlPolicy, ResourceController, Response, SystemOperation,
 };
 use linera_views::batch::Batch;
@@ -58,7 +58,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: *app_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await;
@@ -154,7 +154,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: dummy_operation.clone(),
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await
@@ -312,7 +312,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await?;
@@ -413,7 +413,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await;
@@ -454,7 +454,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
                 application_id: id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await;
@@ -525,7 +525,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await;
@@ -642,7 +642,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await?;
@@ -749,7 +749,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await;
@@ -809,7 +809,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await;
@@ -868,7 +868,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await;
@@ -925,7 +925,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await,
@@ -979,7 +979,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
                 application_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await?;
@@ -1081,7 +1081,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await?;
@@ -1197,7 +1197,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await?;
@@ -1358,7 +1358,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await?;
@@ -1499,7 +1499,7 @@ async fn test_open_chain() {
             context,
             Timestamp::from(0),
             operation,
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await
@@ -1581,7 +1581,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(Vec::new()),
+        OracleTape::Forget,
         &mut controller,
     )
     .await
@@ -1595,7 +1595,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation.into(),
-        Some(Vec::new()),
+        OracleTape::Forget,
         &mut controller,
     )
     .await
@@ -1617,7 +1617,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(Vec::new()),
+        OracleTape::Forget,
         &mut controller,
     )
     .await

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -10,8 +10,7 @@ use futures::{stream, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::PublicKey,
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, OracleRecord, Resources, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{Account, ChainDescription, ChainId, Destination, MessageId, Owner},
     ownership::ChainOwnership,
@@ -59,7 +58,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: *app_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -155,7 +154,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: dummy_operation.clone(),
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await
@@ -313,7 +312,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -414,7 +413,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -455,7 +454,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
                 application_id: id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -526,7 +525,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -643,7 +642,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -750,7 +749,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -810,7 +809,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -869,7 +868,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -926,7 +925,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await,
@@ -980,7 +979,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
                 application_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1082,7 +1081,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1198,7 +1197,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1359,7 +1358,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1500,7 +1499,7 @@ async fn test_open_chain() {
             context,
             Timestamp::from(0),
             operation,
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await
@@ -1582,7 +1581,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(OracleRecord::default()),
+        Some(Vec::new()),
         &mut controller,
     )
     .await
@@ -1596,7 +1595,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation.into(),
-        Some(OracleRecord::default()),
+        Some(Vec::new()),
         &mut controller,
     )
     .await
@@ -1618,7 +1617,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(OracleRecord::default()),
+        Some(Vec::new()),
         &mut controller,
     )
     .await

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
@@ -42,7 +42,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
             context,
             Timestamp::from(0),
             Operation::System(operation),
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await
@@ -92,7 +92,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
             Timestamp::from(0),
             Message::System(message),
             None,
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -11,9 +11,9 @@ use linera_base::{
 use linera_execution::{
     system::{Recipient, UserData},
     test_utils::SystemExecutionState,
-    ExecutionOutcome, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, ResourceController, Response, SystemMessage, SystemOperation, SystemQuery,
-    SystemResponse,
+    ExecutionOutcome, Message, MessageContext, Operation, OperationContext, OracleTape, Query,
+    QueryContext, RawExecutionOutcome, ResourceController, Response, SystemMessage,
+    SystemOperation, SystemQuery, SystemResponse,
 };
 
 #[tokio::test]
@@ -42,7 +42,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
             context,
             Timestamp::from(0),
             Operation::System(operation),
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await
@@ -92,7 +92,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
             Timestamp::from(0),
             Message::System(message),
             None,
-            Some(Vec::new()),
+            OracleTape::Forget,
             &mut controller,
         )
         .await

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -93,7 +93,7 @@ async fn test_fuel_for_counter_wasm_application(
                 context,
                 Timestamp::from(0),
                 Operation::user(app_id, increment).unwrap(),
-                Some(OracleRecord::default()),
+                Some(Vec::new()),
                 &mut controller,
             )
             .await?;

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -13,8 +13,9 @@ use linera_base::{
 use linera_execution::{
     test_utils::{create_dummy_user_application_description, SystemExecutionState},
     ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Operation, OperationContext,
-    Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy, ResourceController,
-    ResourceTracker, Response, WasmContractModule, WasmRuntime, WasmServiceModule,
+    OracleTape, Query, QueryContext, RawExecutionOutcome, ResourceControlPolicy,
+    ResourceController, ResourceTracker, Response, WasmContractModule, WasmRuntime,
+    WasmServiceModule,
 };
 use linera_views::views::View;
 use serde_json::json;
@@ -93,7 +94,7 @@ async fn test_fuel_for_counter_wasm_application(
                 context,
                 Timestamp::from(0),
                 Operation::user(app_id, increment).unwrap(),
-                Some(Vec::new()),
+                OracleTape::Forget,
                 &mut controller,
             )
             .await?;

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -57,7 +57,7 @@ test('Block mounting', () => {
                 }
               }]],
               stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              oracleRecords: []
+              oracleResponses: []
             }
           }
         }

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -59,7 +59,7 @@ test('Blocks mounting', () => {
                     }
                   }]],
                   stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  oracleRecords: []
+                  oracleResponses: []
                 }
               }
             }

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -853,7 +853,7 @@ pub mod tests {
             content: ProposalContent {
                 block: get_block(),
                 round: Round::SingleLeader(4),
-                forced_oracle_records: Some(Vec::new()),
+                forced_oracle_responses: Some(Vec::new()),
             },
             owner: Owner::from(KeyPair::generate().public()),
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -79,9 +79,10 @@ BlockExecutionOutcome:
             TYPENAME: OutgoingMessage
     - state_hash:
         TYPENAME: CryptoHash
-    - oracle_records:
+    - oracle_responses:
         SEQ:
-          TYPENAME: OracleRecord
+          SEQ:
+            TYPENAME: OracleResponse
 BlockHeight:
   NEWTYPESTRUCT: U64
 BlockHeightRange:
@@ -625,11 +626,6 @@ Operation:
           - application_id:
               TYPENAME: ApplicationId
           - bytes: BYTES
-OracleRecord:
-  STRUCT:
-    - responses:
-        SEQ:
-          TYPENAME: OracleResponse
 OracleResponse:
   ENUM:
     0:
@@ -677,10 +673,11 @@ ProposalContent:
         TYPENAME: Block
     - round:
         TYPENAME: Round
-    - forced_oracle_records:
+    - forced_oracle_responses:
         OPTION:
           SEQ:
-            TYPENAME: OracleRecord
+            SEQ:
+              TYPENAME: OracleResponse
 PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -181,9 +181,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
             message
           }
           stateHash
-          oracleRecords {
-            responses
-          }
+          oracleResponses
         }
       }
     }
@@ -220,9 +218,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
             message
           }
           stateHash
-          oracleRecords {
-            responses
-          }
+          oracleResponses
         }
       }
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -112,7 +112,7 @@ type BlockExecutionOutcome {
 	"""
 	The record of oracle responses for each transaction.
 	"""
-	oracleRecords: [OracleRecord!]!
+	oracleResponses: [[OracleResponse!]!]!
 }
 
 """
@@ -655,16 +655,6 @@ scalar Notification
 An operation to be executed in a block
 """
 scalar Operation
-
-"""
-A record of oracle responses from the execution of a transaction.
-"""
-type OracleRecord {
-	"""
-	The list of responses to all the oracle queries made by a transaction.
-	"""
-	responses: [OracleResponse!]!
-}
 
 """
 A record of a single oracle response.

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -129,7 +129,6 @@ pub struct Transfer;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
-    use linera_base::data_types::OracleRecord;
     use linera_chain::data_types::{
         BlockExecutionOutcome, ExecutedBlock, HashedCertificateValue, IncomingMessage,
         OutgoingMessage,
@@ -210,7 +209,7 @@ mod from {
                     block::BlockBlockValueExecutedBlockOutcome {
                         messages,
                         state_hash,
-                        oracle_records,
+                        oracle_responses,
                     },
             } = val;
             let messages = messages
@@ -222,16 +221,9 @@ mod from {
                 outcome: BlockExecutionOutcome {
                     messages,
                     state_hash,
-                    oracle_records: oracle_records.into_iter().map(Into::into).collect(),
+                    oracle_responses: oracle_responses.into_iter().map(Into::into).collect(),
                 },
             }
-        }
-    }
-
-    impl From<block::BlockBlockValueExecutedBlockOutcomeOracleRecords> for OracleRecord {
-        fn from(val: block::BlockBlockValueExecutedBlockOutcomeOracleRecords) -> Self {
-            let block::BlockBlockValueExecutedBlockOutcomeOracleRecords { responses } = val;
-            OracleRecord { responses }
         }
     }
 


### PR DESCRIPTION
This is a minor readability refactoring that doesn't affect functionality. It more clearly distinguishes in the code whether we are currently recording oracle values (like when we execute a proposed block for the first time) or replaying them (when executing a confirmed block).

## Motivation

Passing oracle records into and out of lots of functions is error-prone: We need to make sure we never consult oracles when replaying, and we never attempt to read oracle responses from the record while recording.

## Proposal

Use the `OracleResponses` enum in more places in `linera-execution`.

## Test Plan

No logic has changed, so existing tests should catch any regressions.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
