### PR TITLE
Remove the OracleRecord and OracleResponses types; never throw away responses.

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 
 use anyhow::Context as _;
-use async_graphql::{InputObject, SimpleObject};
+use async_graphql::InputObject;
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -708,22 +708,6 @@ impl ApplicationPermissions {
     /// Returns whether the given application is allowed to close this chain.
     pub fn can_close_chain(&self, app_id: &ApplicationId) -> bool {
         self.close_chain.contains(app_id)
-    }
-}
-
-/// A record of oracle responses from the execution of a transaction.
-#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
-pub struct OracleRecord {
-    /// The list of responses to all the oracle queries made by a transaction.
-    pub responses: Vec<OracleResponse>,
-}
-
-impl OracleRecord {
-    /// Wether an `OracleRecord` is permitted in fast blocks or not.
-    pub fn is_permitted_in_fast_blocks(&self) -> bool {
-        self.responses
-            .iter()
-            .all(|oracle_response| oracle_response.is_permitted_in_fast_blocks())
     }
 }
 

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -141,7 +141,7 @@ pub enum ChainError {
     #[error("Can't use grant across different broadcast messages")]
     GrantUseOnBroadcast,
     #[error("ExecutedBlock contains fewer oracle responses than requests")]
-    MissingOracleRecord,
+    MissingOracleResponseList,
     #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
     CertificateValueHashMismatch {
         expected: CryptoHash,

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -18,7 +18,7 @@ fn test_signed_values() {
     let executed_block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
-        oracle_records: vec![OracleRecord::default()],
+        oracle_responses: vec![Vec::new()],
     }
     .with(block);
     let value = HashedCertificateValue::new_confirmed(executed_block);
@@ -46,7 +46,7 @@ fn test_certificates() {
     let executed_block = BlockExecutionOutcome {
         messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
-        oracle_records: vec![OracleRecord::default()],
+        oracle_responses: vec![Vec::new()],
     }
     .with(block);
     let value = HashedCertificateValue::new_confirmed(executed_block);

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1450,11 +1450,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record
-            .responses
-            .contains(&OracleResponse::Blob(expected_blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(expected_blob_id))));
     let previous_block_hash = client_a.block_hash().unwrap();
 
     // Validators goes back up

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -19,7 +19,7 @@ use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, HashedBlob, OracleRecord, OracleResponse},
+    data_types::{Amount, HashedBlob, OracleResponse},
     identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -125,9 +125,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(blob_id))));
 
     let service_blob = HashedBlob::load_from_file(service_path.clone()).await?;
     let expected_service_blob_id = service_blob.id();
@@ -138,9 +138,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(blob_id))));
 
     // If I try to upload the contract blob again, I should get the same blob ID
     let (blob_id, certificate) = publisher
@@ -154,9 +154,9 @@ where
         .executed_block()
         .unwrap()
         .outcome
-        .oracle_records
+        .oracle_responses
         .iter()
-        .any(|record| record.responses.contains(&OracleResponse::Blob(blob_id))));
+        .any(|responses| responses.contains(&OracleResponse::Blob(blob_id))));
 
     let (bytecode_id, cert) = publisher
         .publish_bytecode(
@@ -389,9 +389,9 @@ where
     receiver.receive_certificate(cert).await.unwrap();
     let (cert, _) = receiver.process_inbox().await.unwrap();
     let executed_block = cert[0].value().executed_block().unwrap();
-    let records = &executed_block.outcome.oracle_records;
-    let [_, OracleRecord { responses }] = &records[..] else {
-        panic!("Unexpected oracle records: {:?}", records);
+    let responses = &executed_block.outcome.oracle_responses;
+    let [_, responses] = &responses[..] else {
+        panic!("Unexpected oracle responses: {:?}", responses);
     };
     let [OracleResponse::Service(json)] = &responses[..] else {
         panic!("Unexpected oracle responses: {:?}", responses);

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 
 use linera_base::{
     crypto::KeyPair,
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{
         BytecodeId, ChainDescription, ChainId, Destination, GenericApplicationId, MessageId,
     },
@@ -148,7 +148,7 @@ where
                 message: Message::System(publish_message.clone()),
             }]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(publish_block),
     );
@@ -217,7 +217,7 @@ where
         BlockExecutionOutcome {
             messages: vec![vec![failing_broadcast_outgoing_message]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(broadcast_block.clone()),
     );
@@ -241,7 +241,7 @@ where
         BlockExecutionOutcome {
             messages: vec![vec![broadcast_outgoing_message]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(broadcast_block),
     );
@@ -295,7 +295,7 @@ where
                 message: Message::System(subscribe_message.clone()),
             }]],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(subscribe_block),
     );
@@ -347,7 +347,7 @@ where
                 }),
             }]],
             state_hash: publisher_state_hash,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(accept_block),
     );
@@ -444,7 +444,7 @@ where
                 }],
             ],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_records: vec![OracleRecord::default(); 2],
+            oracle_responses: vec![Vec::new(); 2],
         }
         .with(create_block),
     );
@@ -488,7 +488,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -497,7 +497,7 @@ where
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(run_block),
     );

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1338,7 +1338,7 @@ where
         worker
             .fully_handle_certificate(certificate, vec![], vec![])
             .await,
-        Err(WorkerError::IncorrectStateHash)
+        Err(WorkerError::IncorrectOutcome { .. })
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -296,7 +296,7 @@ where
         }
         Recipient::Burn => messages.push(Vec::new()),
     }
-    let oracle_records = iter::repeat_with(OracleRecord::default)
+    let oracle_responses = iter::repeat_with(Vec::new)
         .take(block.operations.len() + block.incoming_messages.len())
         .collect();
     let state_hash = system_state.into_hash().await;
@@ -304,7 +304,7 @@ where
         BlockExecutionOutcome {
             messages,
             state_hash,
-            oracle_records,
+            oracle_responses,
         }
         .with(block),
     );
@@ -716,7 +716,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 2],
+                oracle_responses: vec![Vec::new(); 2],
             }
             .with(
                 make_first_block(ChainId::root(1))
@@ -742,7 +742,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_child_block(&certificate0.value)
@@ -1004,7 +1004,7 @@ where
                     }
                     .into_hash()
                     .await,
-                    oracle_records: vec![OracleRecord::default(); 2],
+                    oracle_responses: vec![Vec::new(); 2],
                 }
                 .with(block_proposal.content.block),
             ),
@@ -1287,7 +1287,7 @@ where
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
             state_hash: state.into_hash().await,
-            oracle_records: vec![OracleRecord::default()],
+            oracle_responses: vec![Vec::new()],
         }
         .with(make_first_block(chain_id).with_incoming_message(open_chain_message)),
     );
@@ -2334,7 +2334,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(make_first_block(admin_id).with_operation(
                 SystemOperation::OpenChain(OpenChainConfig {
@@ -2397,7 +2397,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 2],
+                oracle_responses: vec![Vec::new(); 2],
             }
             .with(
                 make_child_block(&certificate0.value)
@@ -2432,7 +2432,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_child_block(&certificate1.value)
@@ -2563,7 +2563,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 4],
+                oracle_responses: vec![Vec::new(); 4],
             }
             .with(
                 make_first_block(user_id)
@@ -2734,7 +2734,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(make_first_block(user_id).with_simple_transfer(admin_id, Amount::ONE)),
         ),
@@ -2760,7 +2760,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_first_block(admin_id).with_operation(SystemOperation::Admin(
@@ -2862,7 +2862,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(make_first_block(user_id).with_simple_transfer(admin_id, Amount::ONE)),
         ),
@@ -2895,7 +2895,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default(); 2],
+                oracle_responses: vec![Vec::new(); 2],
             }
             .with(
                 make_first_block(admin_id)
@@ -2956,7 +2956,7 @@ where
                 }
                 .into_hash()
                 .await,
-                oracle_records: vec![OracleRecord::default()],
+                oracle_responses: vec![Vec::new()],
             }
             .with(
                 make_child_block(&certificate1.value)

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -20,8 +20,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockProposal, Certificate, CertificateValue, ExecutedBlock, HashedCertificateValue,
-        LiteCertificate, MessageBundle, Origin, OutgoingMessage, Target,
+        Block, BlockExecutionOutcome, BlockProposal, Certificate, CertificateValue, ExecutedBlock,
+        HashedCertificateValue, LiteCertificate, MessageBundle, Origin, Target,
     },
     ChainStateView,
 };
@@ -232,18 +232,16 @@ pub enum WorkerError {
     InvalidCrossChainRequest,
     #[error("The block does contain the hash that we expected for the previous block")]
     InvalidBlockChaining,
-    #[error("The given state hash is not what we computed after executing the block")]
-    IncorrectStateHash,
     #[error(
         "
-        The given messages are not what we computed after executing the block.\n\
+        The given outcome is not what we computed after executing the block.\n\
         Computed: {computed:#?}\n\
         Submitted: {submitted:#?}\n
     "
     )]
-    IncorrectMessages {
-        computed: Vec<Vec<OutgoingMessage>>,
-        submitted: Vec<Vec<OutgoingMessage>>,
+    IncorrectOutcome {
+        computed: BlockExecutionOutcome,
+        submitted: BlockExecutionOutcome,
     },
     #[error("The timestamp of a Tick operation is in the future.")]
     InvalidTimestamp,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -295,7 +295,7 @@ where
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match operation {
             Operation::System(op) => {
-                let (mut result, new_application, returned_oracle_responses) =
+                let (mut result, new_application, mut returned_oracle_responses) =
                     self.system.execute_operation(context, op).await?;
                 result.authenticated_signer = context.authenticated_signer;
                 result.refund_grant_to = context.refund_grant_to();
@@ -315,7 +315,7 @@ where
                         )
                         .await?;
                     outcomes.extend(user_outcomes);
-                    return Ok((outcomes, oracle_responses));
+                    returned_oracle_responses.extend(oracle_responses);
                 }
                 Ok((outcomes, returned_oracle_responses))
             }

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
 use linera_base::{
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
     identifiers::{Account, ChainId, Destination, Owner},
 };
 use linera_views::{
@@ -151,11 +151,11 @@ where
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
-        oracle_record: Option<OracleRecord>,
+        oracle_responses: Option<Vec<OracleResponse>>,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, OracleRecord), ExecutionError> {
+    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
-        let (execution_outcomes, oracle_record) = self
+        let (execution_outcomes, oracle_responses) = self
             .run_user_action_with_runtime(
                 application_id,
                 chain_id,
@@ -163,14 +163,14 @@ where
                 action,
                 refund_grant_to,
                 grant,
-                oracle_record,
+                oracle_responses,
                 resource_controller,
             )
             .await?;
         let execution_outcomes = self
             .update_execution_outcomes_with_app_registrations(execution_outcomes)
             .await?;
-        Ok((execution_outcomes, oracle_record))
+        Ok((execution_outcomes, oracle_responses))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -182,9 +182,9 @@ where
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
-        oracle_record: Option<OracleRecord>,
+        oracle_responses: Option<Vec<OracleResponse>>,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, OracleRecord), ExecutionError> {
+    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         let mut cloned_grant = grant.as_ref().map(|x| **x);
         let initial_balance = resource_controller
             .with_state_and_grant(self, cloned_grant.as_mut())
@@ -206,19 +206,20 @@ where
                 refund_grant_to,
                 controller,
                 action,
-                oracle_record,
+                oracle_responses,
             )
         });
         while let Some(request) = execution_state_receiver.next().await {
             self.handle_request(request).await?;
         }
-        let (execution_outcomes, oracle_record, controller) = execution_outcomes_future.await??;
+        let (execution_outcomes, oracle_responses, controller) =
+            execution_outcomes_future.await??;
         resource_controller
             .with_state_and_grant(self, grant)
             .await?
             .merge_balance(initial_balance, controller.balance()?)?;
         resource_controller.tracker = controller.tracker;
-        Ok((execution_outcomes, oracle_record))
+        Ok((execution_outcomes, oracle_responses))
     }
 
     /// Schedules application registration messages when needed.
@@ -288,20 +289,20 @@ where
         context: OperationContext,
         local_time: Timestamp,
         operation: Operation,
-        oracle_record: Option<OracleRecord>,
+        oracle_responses: Option<Vec<OracleResponse>>,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, OracleRecord), ExecutionError> {
+    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match operation {
             Operation::System(op) => {
-                let (mut result, new_application, returned_oracle_record) =
+                let (mut result, new_application, returned_oracle_responses) =
                     self.system.execute_operation(context, op).await?;
                 result.authenticated_signer = context.authenticated_signer;
                 result.refund_grant_to = context.refund_grant_to();
                 let mut outcomes = vec![ExecutionOutcome::System(result)];
                 if let Some((application_id, argument)) = new_application {
                     let user_action = UserAction::Instantiate(context, argument);
-                    let (user_outcomes, oracle_record) = self
+                    let (user_outcomes, oracle_responses) = self
                         .run_user_action(
                             application_id,
                             context.chain_id,
@@ -309,30 +310,32 @@ where
                             user_action,
                             context.refund_grant_to(),
                             None,
-                            oracle_record,
+                            oracle_responses,
                             resource_controller,
                         )
                         .await?;
                     outcomes.extend(user_outcomes);
-                    return Ok((outcomes, oracle_record));
+                    return Ok((outcomes, oracle_responses));
                 }
-                Ok((outcomes, returned_oracle_record))
+                Ok((outcomes, returned_oracle_responses))
             }
             Operation::User {
                 application_id,
                 bytes,
             } => {
-                self.run_user_action(
-                    application_id,
-                    context.chain_id,
-                    local_time,
-                    UserAction::Operation(context, bytes),
-                    context.refund_grant_to(),
-                    None,
-                    oracle_record,
-                    resource_controller,
-                )
-                .await
+                let (outcomes, oracle_responses) = self
+                    .run_user_action(
+                        application_id,
+                        context.chain_id,
+                        local_time,
+                        UserAction::Operation(context, bytes),
+                        context.refund_grant_to(),
+                        None,
+                        oracle_responses,
+                        resource_controller,
+                    )
+                    .await?;
+                Ok((outcomes, oracle_responses))
             }
         }
     }
@@ -343,33 +346,32 @@ where
         local_time: Timestamp,
         message: Message,
         grant: Option<&mut Amount>,
-        oracle_record: Option<OracleRecord>,
+        oracle_responses: Option<Vec<OracleResponse>>,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, OracleRecord), ExecutionError> {
+    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match message {
             Message::System(message) => {
                 let outcome = self.system.execute_message(context, message).await?;
-                Ok((
-                    vec![ExecutionOutcome::System(outcome)],
-                    OracleRecord::default(),
-                ))
+                Ok((vec![ExecutionOutcome::System(outcome)], Vec::new()))
             }
             Message::User {
                 application_id,
                 bytes,
             } => {
-                self.run_user_action(
-                    application_id,
-                    context.chain_id,
-                    local_time,
-                    UserAction::Message(context, bytes),
-                    context.refund_grant_to,
-                    grant,
-                    oracle_record,
-                    resource_controller,
-                )
-                .await
+                let (outcomes, oracle_responses) = self
+                    .run_user_action(
+                        application_id,
+                        context.chain_id,
+                        local_time,
+                        UserAction::Message(context, bytes),
+                        context.refund_grant_to,
+                        grant,
+                        oracle_responses,
+                        resource_controller,
+                    )
+                    .await?;
+                Ok((outcomes, oracle_responses))
             }
         }
     }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -48,17 +48,6 @@ pub struct SyncRuntimeHandle<UserInstance>(Arc<Mutex<SyncRuntimeInternal<UserIns
 pub type ContractSyncRuntimeHandle = SyncRuntimeHandle<UserContractInstance>;
 pub type ServiceSyncRuntimeHandle = SyncRuntimeHandle<UserServiceInstance>;
 
-/// Responses to oracle queries that are being recorded or replayed.
-#[derive(Debug)]
-enum OracleResponses {
-    /// When executing a block _proposal_, oracles can be used and their responses are recorded.
-    Record(Vec<OracleResponse>),
-    /// When re-executing a validated or confirmed block, recorded responses are used.
-    Replay(vec::IntoIter<OracleResponse>),
-    /// In service queries, oracle responses are not recorded.
-    Forget,
-}
-
 /// Runtime data tracked during the execution of a transaction on the synchronous thread.
 #[derive(Debug)]
 pub struct SyncRuntimeInternal<UserInstance> {
@@ -94,8 +83,10 @@ pub struct SyncRuntimeInternal<UserInstance> {
     active_applications: HashSet<UserApplicationId>,
     /// Accumulate the externally visible results (e.g. cross-chain messages) of applications.
     execution_outcomes: Vec<ExecutionOutcome>,
-    /// Responses to oracle queries that are being recorded or replayed.
-    oracle_responses: OracleResponses,
+    /// Recorded responses to oracle queries.
+    recorded_oracle_responses: Vec<OracleResponse>,
+    /// Oracle responses that are being replayed.
+    replaying_oracle_responses: Option<vec::IntoIter<OracleResponse>>,
 
     /// Track application states based on views.
     view_user_states: BTreeMap<UserApplicationId, ViewUserState>,
@@ -312,7 +303,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
         execution_state_sender: ExecutionStateSender,
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
-        oracle_responses: OracleResponses,
+        replaying_oracle_responses: Option<vec::IntoIter<OracleResponse>>,
     ) -> Self {
         Self {
             chain_id,
@@ -331,7 +322,8 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
             view_user_states: BTreeMap::default(),
             refund_grant_to,
             resource_controller,
-            oracle_responses,
+            replaying_oracle_responses,
+            recorded_oracle_responses: Vec::new(),
         }
     }
 
@@ -907,7 +899,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         application_id: ApplicationId,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        if let OracleResponses::Replay(responses) = &mut self.oracle_responses {
+        if let Some(responses) = &mut self.replaying_oracle_responses {
             return match responses.next() {
                 Some(OracleResponse::Service(bytes)) => Ok(bytes),
                 Some(_) => Err(ExecutionError::OracleResponseMismatch),
@@ -921,9 +913,8 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         };
         let sender = self.execution_state_sender.clone();
         let response = ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?;
-        if let OracleResponses::Record(responses) = &mut self.oracle_responses {
-            responses.push(OracleResponse::Service(response.clone()));
-        }
+        self.recorded_oracle_responses
+            .push(OracleResponse::Service(response.clone()));
         Ok(response)
     }
 
@@ -933,7 +924,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         content_type: String,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        if let OracleResponses::Replay(responses) = &mut self.oracle_responses {
+        if let Some(responses) = &mut self.replaying_oracle_responses {
             return match responses.next() {
                 Some(OracleResponse::Post(bytes)) => Ok(bytes),
                 Some(_) => Err(ExecutionError::OracleResponseMismatch),
@@ -950,14 +941,13 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 callback,
             })?
             .recv_response()?;
-        if let OracleResponses::Record(responses) = &mut self.oracle_responses {
-            responses.push(OracleResponse::Post(bytes.clone()));
-        }
+        self.recorded_oracle_responses
+            .push(OracleResponse::Post(bytes.clone()));
         Ok(bytes)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {
-        if let OracleResponses::Replay(responses) = &mut self.oracle_responses {
+        if let Some(responses) = &mut self.replaying_oracle_responses {
             return match responses.next() {
                 Some(OracleResponse::Assert) => Ok(()),
                 Some(_) => Err(ExecutionError::OracleResponseMismatch),
@@ -971,14 +961,12 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 local_time: self.local_time,
             }
         );
-        if let OracleResponses::Record(responses) = &mut self.oracle_responses {
-            responses.push(OracleResponse::Assert);
-        }
+        self.recorded_oracle_responses.push(OracleResponse::Assert);
         Ok(())
     }
 
     fn read_blob(&mut self, blob_id: &BlobId) -> Result<HashedBlob, ExecutionError> {
-        if let OracleResponses::Replay(responses) = &mut self.oracle_responses {
+        if let Some(responses) = &mut self.replaying_oracle_responses {
             match responses.next() {
                 Some(OracleResponse::Blob(oracle_blob_id)) if oracle_blob_id == *blob_id => (),
                 Some(_) => return Err(ExecutionError::OracleResponseMismatch),
@@ -992,9 +980,8 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 callback,
             })?
             .recv_response()?;
-        if let OracleResponses::Record(responses) = &mut self.oracle_responses {
-            responses.push(OracleResponse::Blob(*blob_id));
-        }
+        self.recorded_oracle_responses
+            .push(OracleResponse::Blob(*blob_id));
         Ok(blob)
     }
 }
@@ -1032,11 +1019,7 @@ impl ContractSyncRuntime {
         let signer = action.signer();
         let height = action.height();
         let next_message_index = action.next_message_index();
-        let oracle_responses = if let Some(responses) = oracle_responses {
-            OracleResponses::Replay(responses.into_iter())
-        } else {
-            OracleResponses::Record(Vec::new())
-        };
+        let replaying_oracle_responses = oracle_responses.map(Vec::into_iter);
         let mut runtime = SyncRuntime(Some(ContractSyncRuntimeHandle::from(
             SyncRuntimeInternal::new(
                 chain_id,
@@ -1048,7 +1031,7 @@ impl ContractSyncRuntime {
                 execution_state_sender,
                 refund_grant_to,
                 resource_controller,
-                oracle_responses,
+                replaying_oracle_responses,
             ),
         )));
         let finalize_context = FinalizeContext {
@@ -1068,15 +1051,9 @@ impl ContractSyncRuntime {
         let runtime = runtime
             .into_inner()
             .expect("Runtime clones should have been freed by now");
-        let oracle_responses = if let OracleResponses::Record(responses) = runtime.oracle_responses
-        {
-            responses
-        } else {
-            Vec::default()
-        };
         Ok((
             runtime.execution_outcomes,
-            oracle_responses,
+            runtime.recorded_oracle_responses,
             runtime.resource_controller,
         ))
     }
@@ -1357,7 +1334,7 @@ impl ServiceSyncRuntime {
                 execution_state_sender,
                 None,
                 ResourceController::default(),
-                OracleResponses::Forget,
+                None,
             )
             .into(),
         ))

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -12,9 +12,7 @@ use async_graphql::Enum;
 use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, OracleRecord, OracleResponse, Timestamp,
-    },
+    data_types::{Amount, ApplicationPermissions, ArithmeticError, OracleResponse, Timestamp},
     ensure, hex_debug,
     identifiers::{Account, BlobId, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
@@ -445,16 +443,14 @@ where
         (
             RawExecutionOutcome<SystemMessage, Amount>,
             Option<(UserApplicationId, Vec<u8>)>,
-            OracleRecord,
+            Vec<OracleResponse>,
         ),
         SystemExecutionError,
     > {
         use SystemOperation::*;
         let mut outcome = RawExecutionOutcome::default();
         let mut new_application = None;
-        let mut oracle_record = OracleRecord {
-            responses: Vec::new(),
-        };
+        let mut oracle_responses = Vec::new();
         match operation {
             OpenChain(config) => {
                 let next_message_id = context.next_message_id();
@@ -679,11 +675,11 @@ where
                 outcome.messages.push(message);
             }
             PublishBlob { blob_id } => {
-                oracle_record.responses.push(OracleResponse::Blob(blob_id));
+                oracle_responses.push(OracleResponse::Blob(blob_id));
             }
         }
 
-        Ok((outcome, new_application, oracle_record))
+        Ok((outcome, new_application, oracle_responses))
     }
 
     pub async fn transfer(

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -184,7 +184,7 @@ fn create_runtime<Application>() -> (
         execution_state_sender,
         None,
         resource_controller,
-        super::OracleResponses::Record(Vec::new()),
+        None,
     );
 
     (runtime, execution_state_receiver)

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -9,7 +9,7 @@ use std::{sync::Arc, vec};
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
 };
 use linera_execution::{
@@ -206,7 +206,7 @@ async fn test_fee_consumption(
             } else {
                 None
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -10,8 +10,7 @@ use futures::{stream, StreamExt, TryStreamExt};
 use linera_base::{
     crypto::PublicKey,
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, OracleRecord, Resources, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{Account, ChainDescription, ChainId, Destination, MessageId, Owner},
     ownership::ChainOwnership,
@@ -59,7 +58,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: *app_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -155,7 +154,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: dummy_operation.clone(),
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await
@@ -313,7 +312,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -414,7 +413,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -455,7 +454,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
                 application_id: id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -526,7 +525,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -643,7 +642,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
                 application_id: first_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -750,7 +749,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -810,7 +809,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -869,7 +868,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await;
@@ -926,7 +925,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await,
@@ -980,7 +979,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
                 application_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1082,7 +1081,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1198,7 +1197,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1359,7 +1358,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
                 application_id: caller_id,
                 bytes: vec![],
             },
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await?;
@@ -1500,7 +1499,7 @@ async fn test_open_chain() {
             context,
             Timestamp::from(0),
             operation,
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await
@@ -1582,7 +1581,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(OracleRecord::default()),
+        Some(Vec::new()),
         &mut controller,
     )
     .await
@@ -1596,7 +1595,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation.into(),
-        Some(OracleRecord::default()),
+        Some(Vec::new()),
         &mut controller,
     )
     .await
@@ -1618,7 +1617,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        Some(OracleRecord::default()),
+        Some(Vec::new()),
         &mut controller,
     )
     .await

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId, MessageId},
 };
 use linera_execution::{
@@ -42,7 +42,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
             context,
             Timestamp::from(0),
             Operation::System(operation),
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await
@@ -92,7 +92,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
             Timestamp::from(0),
             Message::System(message),
             None,
-            Some(OracleRecord::default()),
+            Some(Vec::new()),
             &mut controller,
         )
         .await

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, BlockHeight, OracleRecord, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainDescription, ChainId},
 };
 use linera_execution::{
@@ -93,7 +93,7 @@ async fn test_fuel_for_counter_wasm_application(
                 context,
                 Timestamp::from(0),
                 Operation::user(app_id, increment).unwrap(),
-                Some(OracleRecord::default()),
+                Some(Vec::new()),
                 &mut controller,
             )
             .await?;

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -57,7 +57,7 @@ test('Block mounting', () => {
                 }
               }]],
               stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-              oracleRecords: []
+              oracleResponses: []
             }
           }
         }

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -59,7 +59,7 @@ test('Blocks mounting', () => {
                     }
                   }]],
                   stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
-                  oracleRecords: []
+                  oracleResponses: []
                 }
               }
             }

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -853,7 +853,7 @@ pub mod tests {
             content: ProposalContent {
                 block: get_block(),
                 round: Round::SingleLeader(4),
-                forced_oracle_records: Some(Vec::new()),
+                forced_oracle_responses: Some(Vec::new()),
             },
             owner: Owner::from(KeyPair::generate().public()),
             signature: Signature::new(&Foo("test".into()), &KeyPair::generate()),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -79,9 +79,10 @@ BlockExecutionOutcome:
             TYPENAME: OutgoingMessage
     - state_hash:
         TYPENAME: CryptoHash
-    - oracle_records:
+    - oracle_responses:
         SEQ:
-          TYPENAME: OracleRecord
+          SEQ:
+            TYPENAME: OracleResponse
 BlockHeight:
   NEWTYPESTRUCT: U64
 BlockHeightRange:
@@ -625,11 +626,6 @@ Operation:
           - application_id:
               TYPENAME: ApplicationId
           - bytes: BYTES
-OracleRecord:
-  STRUCT:
-    - responses:
-        SEQ:
-          TYPENAME: OracleResponse
 OracleResponse:
   ENUM:
     0:
@@ -677,10 +673,11 @@ ProposalContent:
         TYPENAME: Block
     - round:
         TYPENAME: Round
-    - forced_oracle_records:
+    - forced_oracle_responses:
         OPTION:
           SEQ:
-            TYPENAME: OracleRecord
+            SEQ:
+              TYPENAME: OracleResponse
 PublicKey:
   NEWTYPESTRUCT:
     TUPLEARRAY:

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -181,9 +181,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
             message
           }
           stateHash
-          oracleRecords {
-            responses
-          }
+          oracleResponses
         }
       }
     }
@@ -220,9 +218,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
             message
           }
           stateHash
-          oracleRecords {
-            responses
-          }
+          oracleResponses
         }
       }
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -112,7 +112,7 @@ type BlockExecutionOutcome {
 	"""
 	The record of oracle responses for each transaction.
 	"""
-	oracleRecords: [OracleRecord!]!
+	oracleResponses: [[OracleResponse!]!]!
 }
 
 """
@@ -655,16 +655,6 @@ scalar Notification
 An operation to be executed in a block
 """
 scalar Operation
-
-"""
-A record of oracle responses from the execution of a transaction.
-"""
-type OracleRecord {
-	"""
-	The list of responses to all the oracle queries made by a transaction.
-	"""
-	responses: [OracleResponse!]!
-}
 
 """
 A record of a single oracle response.

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -129,7 +129,6 @@ pub struct Transfer;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
-    use linera_base::data_types::OracleRecord;
     use linera_chain::data_types::{
         BlockExecutionOutcome, ExecutedBlock, HashedCertificateValue, IncomingMessage,
         OutgoingMessage,
@@ -210,7 +209,7 @@ mod from {
                     block::BlockBlockValueExecutedBlockOutcome {
                         messages,
                         state_hash,
-                        oracle_records,
+                        oracle_responses,
                     },
             } = val;
             let messages = messages
@@ -222,16 +221,9 @@ mod from {
                 outcome: BlockExecutionOutcome {
                     messages,
                     state_hash,
-                    oracle_records: oracle_records.into_iter().map(Into::into).collect(),
+                    oracle_responses: oracle_responses.into_iter().map(Into::into).collect(),
                 },
             }
-        }
-    }
-
-    impl From<block::BlockBlockValueExecutedBlockOutcomeOracleRecords> for OracleRecord {
-        fn from(val: block::BlockBlockValueExecutedBlockOutcomeOracleRecords) -> Self {
-            let block::BlockBlockValueExecutedBlockOutcomeOracleRecords { responses } = val;
-            OracleRecord { responses }
         }
     }
 


### PR DESCRIPTION
## Motivation

The `OracleResponses` and `OracleRecord` types were just wrappers for iterators or vectors of responses, and are not really needed. The former was also a source of potential bugs: When replaying, we _still_ want to return the replayed oracle responses together with the execution outcomes, so they end up in the `ExecutedBlock`. Also, when executing a system operation that created an application, we should still preserve the oracle responses returned by the initial system operation, rather than _overwriting_ them with the ones from the contract initialization. (This potential bug didn't manifest itself yet, since so far no system operation both uses an oracle and creates an application.)

## Proposal

Remove the two types, and fix the potential issues.

## Test Plan

I changed the assertion in `process_confirmed_block` to compare not only the state hash and the outgoing messages, but also the oracle responses, i.e. the complete block execution outcome.

I tried locally that without this fix, but with the assertion, `test_memory_run_application_with_dependency` fails.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
