### PR TITLE
Run Kubernetes workflow on `gcp-large`

### DIFF
--- a/.github/workflows/kubernetes.yml
+++ b/.github/workflows/kubernetes.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   kind-deployment-e2e-tests:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: gcp-large
     timeout-minutes: 90
 
     steps:


### PR DESCRIPTION
## Motivation

On GCP, we can control the machines that run the job better, with better isolation from other processes (e.g. in `aio-max-nr`).

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Run the Kubernetes tests on GCP instead of GitHub-provided runners.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required: this is a CI-only change.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
