### PR TITLE
Fix lints + disable non-compiling test module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7458,9 +7458,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "num-conv",
@@ -7478,9 +7478,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -11,19 +11,19 @@ be adding/removing liquidity and also performing a swap.
 It supports the following operations. All operations need to be executed remotely.
 
 - Swap: For a given input token and an input amount, it swaps that token amount for an
-amount of the other token calculated based on the current AMM ratio.
+  amount of the other token calculated based on the current AMM ratio.
 
 - Add Liquidity: This operation allows adding liquidity to the AMM. Given a maximum
-`token0` and `token1` amount that you're willing to add, it adds liquidity such that you'll be
-adding at most `max_token0_amount` of `token0` and `max_token1_amount` of `token1`. The amounts
-will be calculated based on the current AMM ratio. The owner, in this case, refers to the user
-adding liquidity, which currently can only be a chain owner.
+  `token0` and `token1` amount that you're willing to add, it adds liquidity such that you'll be
+  adding at most `max_token0_amount` of `token0` and `max_token1_amount` of `token1`. The amounts
+  will be calculated based on the current AMM ratio. The owner, in this case, refers to the user
+  adding liquidity, which currently can only be a chain owner.
 
 - Remove Liquidity: This withdraws tokens from the AMM. Given the index of the token you'd
-like to remove (can be 0 or 1), and an amount of that token that you'd like to remove, it calculates
-how much of the other token will also be removed based on the current AMM ratio. Then it removes
-the amounts from both tokens as a removal of liquidity. The owner, in this context, is the user
-removing liquidity, which currently can only be a chain owner.
+  like to remove (can be 0 or 1), and an amount of that token that you'd like to remove, it calculates
+  how much of the other token will also be removed based on the current AMM ratio. Then it removes
+  the amounts from both tokens as a removal of liquidity. The owner, in this context, is the user
+  removing liquidity, which currently can only be a chain owner.
 
 # Usage
 

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -13,19 +13,19 @@ be adding/removing liquidity and also performing a swap.
 It supports the following operations. All operations need to be executed remotely.
 
 - Swap: For a given input token and an input amount, it swaps that token amount for an
-amount of the other token calculated based on the current AMM ratio.
+  amount of the other token calculated based on the current AMM ratio.
 
 - Add Liquidity: This operation allows adding liquidity to the AMM. Given a maximum
-`token0` and `token1` amount that you're willing to add, it adds liquidity such that you'll be
-adding at most `max_token0_amount` of `token0` and `max_token1_amount` of `token1`. The amounts
-will be calculated based on the current AMM ratio. The owner, in this case, refers to the user
-adding liquidity, which currently can only be a chain owner.
+  `token0` and `token1` amount that you're willing to add, it adds liquidity such that you'll be
+  adding at most `max_token0_amount` of `token0` and `max_token1_amount` of `token1`. The amounts
+  will be calculated based on the current AMM ratio. The owner, in this case, refers to the user
+  adding liquidity, which currently can only be a chain owner.
 
 - Remove Liquidity: This withdraws tokens from the AMM. Given the index of the token you'd
-like to remove (can be 0 or 1), and an amount of that token that you'd like to remove, it calculates
-how much of the other token will also be removed based on the current AMM ratio. Then it removes
-the amounts from both tokens as a removal of liquidity. The owner, in this context, is the user
-removing liquidity, which currently can only be a chain owner.
+  like to remove (can be 0 or 1), and an amount of that token that you'd like to remove, it calculates
+  how much of the other token will also be removed based on the current AMM ratio. Then it removes
+  the amounts from both tokens as a removal of liquidity. The owner, in this context, is the user
+  removing liquidity, which currently can only be a chain owner.
 
 # Usage
 

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -165,7 +165,7 @@ impl CrowdFundingContract {
         );
 
         // TODO(#728): Remove this.
-        #[cfg(not(any(test, feature = "test")))]
+        #[cfg(not(test))]
         assert!(
             self.runtime.system_time() >= self.instantiation_argument().deadline,
             "Crowd-funding campaign has not reached its deadline yet"

--- a/examples/matching-engine/README.md
+++ b/examples/matching-engine/README.md
@@ -23,7 +23,7 @@ An `OrderId` is used to uniquely identify an order and enables the following fun
 When inserting an order it goes through the following steps:
 
 - Transfer of tokens from the `fungible` application to the `matching engine` application through a cross-application
-call so that it can be paid to the counterparty.
+  call so that it can be paid to the counterparty.
 
 - The engine selects the matching price levels for the inserted order. It then proceeds
   to clear these levels, executing trades and ensuring that at the end of the process,

--- a/examples/matching-engine/src/lib.rs
+++ b/examples/matching-engine/src/lib.rs
@@ -25,7 +25,7 @@ An `OrderId` is used to uniquely identify an order and enables the following fun
 When inserting an order it goes through the following steps:
 
 - Transfer of tokens from the `fungible` application to the `matching engine` application through a cross-application
-call so that it can be paid to the counterparty.
+  call so that it can be paid to the counterparty.
 
 - The engine selects the matching price levels for the inserted order. It then proceeds
   to clear these levels, executing trades and ensuring that at the end of the process,

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -15,7 +15,6 @@ version.workspace = true
 test = ["test-strategy", "proptest"]
 metrics = ["prometheus"]
 web = ["getrandom/js", "rand/getrandom", "rand/std", "rand/std_rng", "web-time"]
-rocksdb = []
 
 [dependencies]
 anyhow.workspace = true

--- a/linera-base/tests/command_tests.rs
+++ b/linera-base/tests/command_tests.rs
@@ -2,7 +2,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(feature = "rocksdb")]
+// TODO(#2239): these tests fail to build
+#![cfg(any())]
 
 use std::path::Path;
 

--- a/linera-service/src/cli_wrappers/helmfile.rs
+++ b/linera-service/src/cli_wrappers/helmfile.rs
@@ -23,10 +23,10 @@ impl HelmFile {
         fs_extra::copy_items(&[&chart_dir], temp_dir.path(), &CopyOptions::new())?;
 
         Command::new("helmfile")
-            .current_dir(&temp_dir.path().join("linera-validator"))
+            .current_dir(temp_dir.path().join("linera-validator"))
             .env(
                 "LINERA_HELMFILE_SET_SERVER_CONFIG",
-                &format!("working/server_{server_config_id}.json"),
+                format!("working/server_{server_config_id}.json"),
             )
             .env("LINERA_HELMFILE_SET_NUM_SHARDS", num_shards.to_string())
             .arg("sync")


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/2235 enabled some tests that had accidentally been disabled due to a missing feature flag.  However, those tests do not compile, thereby now breaking builds using `--all-targets`.

In addition, the `examples` directory contained some crates that are no longer `clippy`-clean.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Disable the tests, adding issue https://github.com/linera-io/linera-protocol/issues/2239 to track the fix.  Tweak the formatting of the `examples` crates to be `clippy`-clean.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
