### PR TITLE
Contracts can emit events, record them in blocks.

### DIFF
--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -40,8 +40,11 @@ impl Contract for MetaCounterContract {
         // Send a no-op message to ourselves. This is only for testing contracts that send messages
         // on initialization. Since the value is 0 it does not change the counter value.
         let this_chain = self.runtime.chain_id();
-        self.runtime
-            .emit(StreamName(b"announcements".to_vec()), b"instantiated");
+        self.runtime.emit(
+            StreamName(b"announcements".to_vec()),
+            b"updates",
+            b"instantiated",
+        );
         self.runtime.send_message(this_chain, Message::Increment(0));
     }
 

--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(target_arch = "wasm32", no_main)]
 
 use linera_sdk::{
-    base::{ApplicationId, WithContractAbi},
+    base::{ApplicationId, StreamName, WithContractAbi},
     Contract, ContractRuntime, Resources,
 };
 use meta_counter::{Message, MetaCounterAbi, Operation};
@@ -40,6 +40,8 @@ impl Contract for MetaCounterContract {
         // Send a no-op message to ourselves. This is only for testing contracts that send messages
         // on initialization. Since the value is 0 it does not change the counter value.
         let this_chain = self.runtime.chain_id();
+        self.runtime
+            .emit(StreamName(b"announcements".to_vec()), b"instantiated");
         self.runtime.send_message(this_chain, Message::Increment(0));
     }
 

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -278,7 +278,7 @@ pub struct ChannelName(#[serde(with = "serde_bytes")] Vec<u8>);
     WitStore,
     WitType,
 )]
-pub struct StreamName(#[serde(with = "serde_bytes")] Vec<u8>);
+pub struct StreamName(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 /// The destination of a message, relative to a particular application.
 #[derive(

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -832,6 +832,7 @@ doc_scalar!(
     ChainDescription."
 );
 doc_scalar!(ChannelName, "The name of a subscription channel");
+doc_scalar!(StreamName, "The name of an event stream");
 bcs_scalar!(MessageId, "The index of a message in a chain");
 doc_scalar!(
     Owner,

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Context};
+use async_graphql::SimpleObject;
 use linera_witty::{WitLoad, WitStore, WitType};
 use serde::{Deserialize, Serialize};
 
@@ -211,7 +212,21 @@ pub struct ApplicationId<A = ()> {
 }
 
 /// A unique identifier for an application.
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Debug, Serialize, Deserialize)]
+#[derive(
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
 pub enum GenericApplicationId {
     /// The system application.
     System,
@@ -279,6 +294,29 @@ pub struct ChannelName(#[serde(with = "serde_bytes")] Vec<u8>);
     WitType,
 )]
 pub struct StreamName(#[serde(with = "serde_bytes")] pub Vec<u8>);
+
+/// An event stream ID.
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+    SimpleObject,
+)]
+pub struct StreamId {
+    /// The application that can add events to this stream.
+    pub application_id: GenericApplicationId,
+    /// The name of this stream: an application can have multiple streams with different names.
+    pub stream_name: StreamName,
+}
 
 /// The destination of a message, relative to a particular application.
 #[derive(

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -263,6 +263,23 @@ pub struct BytecodeId<Abi = (), Parameters = (), InstantiationArgument = ()> {
 )]
 pub struct ChannelName(#[serde(with = "serde_bytes")] Vec<u8>);
 
+/// The name of an event stream.
+#[derive(
+    Clone,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    WitLoad,
+    WitStore,
+    WitType,
+)]
+pub struct StreamName(#[serde(with = "serde_bytes")] Vec<u8>);
+
 /// The destination of a message, relative to a particular application.
 #[derive(
     Clone,
@@ -317,7 +334,14 @@ impl From<Vec<u8>> for ChannelName {
 }
 
 impl ChannelName {
-    /// Turns the channel into bytes.
+    /// Turns the channel name into bytes.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl StreamName {
+    /// Turns the stream name into bytes.
     pub fn into_bytes(self) -> Vec<u8> {
         self.0
     }

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -12,7 +12,7 @@ use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, ArithmeticError, BlockHeight, OracleResponse, Timestamp},
     ensure,
-    identifiers::{ChainId, Destination, GenericApplicationId, MessageId},
+    identifiers::{ChainId, Destination, GenericApplicationId, MessageId, StreamId},
 };
 use linera_execution::{
     system::SystemMessage, ExecutionOutcome, ExecutionRequest, ExecutionRuntimeContext,
@@ -1096,8 +1096,10 @@ where
                 .events
                 .into_iter()
                 .map(|(stream_name, payload)| EventRecord {
-                    application_id,
-                    stream_name,
+                    stream_id: StreamId {
+                        application_id,
+                        stream_name,
+                    },
                     payload,
                 }),
         );

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -35,8 +35,8 @@ use {linera_base::identifiers::BytecodeId, linera_execution::BytecodeLocation};
 
 use crate::{
     data_types::{
-        Block, BlockExecutionOutcome, ChainAndHeight, ChannelFullName, Event, IncomingMessage,
-        MessageAction, MessageBundle, Origin, OutgoingMessage, Target,
+        Block, BlockExecutionOutcome, ChainAndHeight, ChannelFullName, Event, EventRecord,
+        IncomingMessage, MessageAction, MessageBundle, Origin, OutgoingMessage, Target,
     },
     inbox::{Cursor, InboxError, InboxStateView},
     manager::ChainManager,
@@ -805,6 +805,7 @@ where
         );
         let mut oracle_responses = oracle_responses.map(Vec::into_iter);
         let mut new_oracle_responses = Vec::new();
+        let mut events = Vec::new();
         let mut next_message_index = 0;
         for (index, message) in block.incoming_messages.iter().enumerate() {
             #[cfg(with_metrics)]
@@ -912,7 +913,7 @@ where
                 }
             };
             new_oracle_responses.push(oracle_responses);
-            let messages_out = self
+            let (messages_out, new_events) = self
                 .process_execution_outcomes(context.height, outcomes)
                 .await?;
             if let MessageAction::Accept = message.action {
@@ -927,6 +928,7 @@ where
             next_message_index +=
                 u32::try_from(messages_out.len()).map_err(|_| ArithmeticError::Overflow)?;
             messages.push(messages_out);
+            events.push(new_events);
         }
         // Second, execute the operations in the block and remember the recipients to notify.
         for (index, operation) in block.operations.iter().enumerate() {
@@ -961,7 +963,7 @@ where
                 .await
                 .map_err(|err| ChainError::ExecutionError(err, chain_execution_context))?;
             new_oracle_responses.push(oracle_responses);
-            let messages_out = self
+            let (messages_out, new_events) = self
                 .process_execution_outcomes(context.height, outcomes)
                 .await?;
             resource_controller
@@ -979,6 +981,7 @@ where
             next_message_index +=
                 u32::try_from(messages_out.len()).map_err(|_| ArithmeticError::Overflow)?;
             messages.push(messages_out);
+            events.push(new_events);
         }
 
         // Finally, charge for the block fee, except if the chain is closed. Closed chains should
@@ -1033,6 +1036,7 @@ where
             messages,
             state_hash,
             oracle_responses: new_oracle_responses,
+            events,
         })
     }
 
@@ -1040,8 +1044,9 @@ where
         &mut self,
         height: BlockHeight,
         results: Vec<ExecutionOutcome>,
-    ) -> Result<Vec<OutgoingMessage>, ChainError> {
+    ) -> Result<(Vec<OutgoingMessage>, Vec<EventRecord>), ChainError> {
         let mut messages = Vec::new();
+        let mut events = Vec::new();
         for result in results {
             match result {
                 ExecutionOutcome::System(result) => {
@@ -1049,6 +1054,7 @@ where
                         GenericApplicationId::System,
                         Message::System,
                         &mut messages,
+                        &mut events,
                         height,
                         result,
                     )
@@ -1062,6 +1068,7 @@ where
                             bytes,
                         },
                         &mut messages,
+                        &mut events,
                         height,
                         result,
                     )
@@ -1069,7 +1076,7 @@ where
                 }
             }
         }
-        Ok(messages)
+        Ok((messages, events))
     }
 
     async fn process_raw_execution_outcome<E, F>(
@@ -1077,12 +1084,23 @@ where
         application_id: GenericApplicationId,
         lift: F,
         messages: &mut Vec<OutgoingMessage>,
+        events: &mut Vec<EventRecord>,
         height: BlockHeight,
         raw_outcome: RawExecutionOutcome<E, Amount>,
     ) -> Result<(), ChainError>
     where
         F: Fn(E) -> Message,
     {
+        events.extend(
+            raw_outcome
+                .events
+                .into_iter()
+                .map(|(stream_name, payload)| EventRecord {
+                    application_id,
+                    stream_name,
+                    payload,
+                }),
+        );
         let max_stream_queries = self.context().max_stream_queries();
         // Record the messages of the execution. Messages are understood within an
         // application.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1095,12 +1095,13 @@ where
             raw_outcome
                 .events
                 .into_iter()
-                .map(|(stream_name, payload)| EventRecord {
+                .map(|(stream_name, key, value)| EventRecord {
                     stream_id: StreamId {
                         application_id,
                         stream_name,
                     },
-                    payload,
+                    key,
+                    value,
                 }),
         );
         let max_stream_queries = self.context().max_stream_queries();

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -286,8 +286,10 @@ pub struct BlockExecutionOutcome {
 pub struct EventRecord {
     /// The ID of the stream this event belongs to.
     pub stream_id: StreamId,
+    /// The event key.
+    pub key: Vec<u8>,
     /// The payload data.
-    pub payload: Vec<u8>,
+    pub value: Vec<u8>,
 }
 
 /// A statement to be certified by the validators.

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -11,6 +11,7 @@ use linera_base::{
     doc_scalar, ensure,
     identifiers::{
         Account, BlobId, ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner,
+        StreamName,
     },
 };
 use linera_execution::{
@@ -272,9 +273,23 @@ pub struct ExecutedBlock {
 pub struct BlockExecutionOutcome {
     /// The list of outgoing messages for each transaction.
     pub messages: Vec<Vec<OutgoingMessage>>,
+    /// The hash of the chain's execution state after this block.
     pub state_hash: CryptoHash,
     /// The record of oracle responses for each transaction.
     pub oracle_responses: Vec<Vec<OracleResponse>>,
+    /// The list of events produced by each transaction.
+    pub events: Vec<Vec<EventRecord>>,
+}
+
+/// An event recorded in an executed block.
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
+pub struct EventRecord {
+    /// The application that emitted this event.
+    pub application_id: GenericApplicationId,
+    /// The name of the event stream.
+    pub stream_name: StreamName,
+    /// The payload data.
+    pub payload: Vec<u8>,
 }
 
 /// A statement to be certified by the validators.

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -11,7 +11,7 @@ use linera_base::{
     doc_scalar, ensure,
     identifiers::{
         Account, BlobId, ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner,
-        StreamName,
+        StreamId,
     },
 };
 use linera_execution::{
@@ -284,10 +284,8 @@ pub struct BlockExecutionOutcome {
 /// An event recorded in an executed block.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct EventRecord {
-    /// The application that emitted this event.
-    pub application_id: GenericApplicationId,
-    /// The name of the event stream.
-    pub stream_name: StreamName,
+    /// The ID of the stream this event belongs to.
+    pub stream_id: StreamId,
     /// The payload data.
     pub payload: Vec<u8>,
 }

--- a/linera-chain/src/unit_tests/data_types_tests.rs
+++ b/linera-chain/src/unit_tests/data_types_tests.rs
@@ -19,6 +19,7 @@ fn test_signed_values() {
         messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
         oracle_responses: vec![Vec::new()],
+        events: vec![Vec::new()],
     }
     .with(block);
     let value = HashedCertificateValue::new_confirmed(executed_block);
@@ -47,6 +48,7 @@ fn test_certificates() {
         messages: vec![Vec::new()],
         state_hash: CryptoHash::test_hash("state"),
         oracle_responses: vec![Vec::new()],
+        events: vec![Vec::new()],
     }
     .with(block);
     let value = HashedCertificateValue::new_confirmed(executed_block);

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -21,7 +21,8 @@ use counter::CounterAbi;
 use linera_base::{
     data_types::{Amount, HashedBlob, OracleResponse},
     identifiers::{
-        AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner, StreamName,
+        AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner, StreamId,
+        StreamName,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -384,8 +385,10 @@ where
         vec![
             Vec::new(),
             vec![EventRecord {
-                application_id: application_id2.forget_abi().into(),
-                stream_name: StreamName(b"announcements".to_vec()),
+                stream_id: StreamId {
+                    application_id: application_id2.forget_abi().into(),
+                    stream_name: StreamName(b"announcements".to_vec()),
+                },
                 payload: b"instantiated".to_vec(),
             }]
         ]

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -389,7 +389,8 @@ where
                     application_id: application_id2.forget_abi().into(),
                     stream_name: StreamName(b"announcements".to_vec()),
                 },
-                payload: b"instantiated".to_vec(),
+                key: b"updates".to_vec(),
+                value: b"instantiated".to_vec(),
             }]
         ]
     );

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -20,10 +20,12 @@ use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
     data_types::{Amount, HashedBlob, OracleResponse},
-    identifiers::{AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner},
+    identifiers::{
+        AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner, StreamName,
+    },
     ownership::{ChainOwnership, TimeoutConfig},
 };
-use linera_chain::data_types::{CertificateValue, MessageAction, OutgoingMessage};
+use linera_chain::data_types::{CertificateValue, EventRecord, MessageAction, OutgoingMessage};
 use linera_execution::{
     Bytecode, Message, MessageKind, Operation, ResourceControlPolicy, SystemMessage,
     UserApplicationDescription, WasmRuntime,
@@ -367,7 +369,7 @@ where
         .await
         .unwrap()
         .unwrap();
-    let (application_id2, _) = creator
+    let (application_id2, certificate) = creator
         .create_application(
             bytecode_id2,
             &application_id1,
@@ -377,6 +379,17 @@ where
         .await
         .unwrap()
         .unwrap();
+    assert_eq!(
+        certificate.value().executed_block().unwrap().outcome.events,
+        vec![
+            Vec::new(),
+            vec![EventRecord {
+                application_id: application_id2.forget_abi().into(),
+                stream_name: StreamName(b"announcements".to_vec()),
+                payload: b"instantiated".to_vec(),
+            }]
+        ]
+    );
 
     let mut operation = meta_counter::Operation::increment(receiver_id, 5);
     operation.fuel_grant = 1000000;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -448,7 +448,7 @@ where
                     message: Message::System(SystemMessage::ApplicationCreated),
                 }],
             ],
-            events: vec![Vec::new()],
+            events: vec![Vec::new(); 2],
             state_hash: creator_state.crypto_hash().await?,
             oracle_responses: vec![Vec::new(); 2],
         }

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -147,6 +147,7 @@ where
                 kind: MessageKind::Protected,
                 message: Message::System(publish_message.clone()),
             }]],
+            events: vec![Vec::new()],
             state_hash: publisher_state_hash,
             oracle_responses: vec![Vec::new()],
         }
@@ -216,6 +217,7 @@ where
     let failing_broadcast_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages: vec![vec![failing_broadcast_outgoing_message]],
+            events: vec![Vec::new()],
             state_hash: publisher_state_hash,
             oracle_responses: vec![Vec::new()],
         }
@@ -240,6 +242,7 @@ where
     let broadcast_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages: vec![vec![broadcast_outgoing_message]],
+            events: vec![Vec::new()],
             state_hash: publisher_state_hash,
             oracle_responses: vec![Vec::new()],
         }
@@ -294,6 +297,7 @@ where
                 kind: MessageKind::Protected,
                 message: Message::System(subscribe_message.clone()),
             }]],
+            events: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
             oracle_responses: vec![Vec::new()],
         }
@@ -346,6 +350,7 @@ where
                     id: creator_chain.into(),
                 }),
             }]],
+            events: vec![Vec::new()],
             state_hash: publisher_state_hash,
             oracle_responses: vec![Vec::new()],
         }
@@ -443,6 +448,7 @@ where
                     message: Message::System(SystemMessage::ApplicationCreated),
                 }],
             ],
+            events: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
             oracle_responses: vec![Vec::new(); 2],
         }
@@ -496,6 +502,7 @@ where
     let run_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
+            events: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
             oracle_responses: vec![Vec::new()],
         }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -712,7 +712,7 @@ where
                         Amount::from_tokens(2),
                     )],
                 ],
-                events: vec![Vec::new(); 3],
+                events: vec![Vec::new(); 2],
                 state_hash: SystemExecutionState {
                     committees: [(epoch, committee.clone())].into_iter().collect(),
                     ownership: ChainOwnership::single(sender_key_pair.public()),
@@ -2334,7 +2334,7 @@ where
                         },
                     ),
                 ]],
-                events: vec![Vec::new(); 2],
+                events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair.public()),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -299,13 +299,14 @@ where
         }
         Recipient::Burn => messages.push(Vec::new()),
     }
-    let oracle_responses = iter::repeat_with(Vec::new)
-        .take(block.operations.len() + block.incoming_messages.len())
-        .collect();
+    let tx_count = block.operations.len() + block.incoming_messages.len();
+    let oracle_responses = iter::repeat_with(Vec::new).take(tx_count).collect();
+    let events = iter::repeat_with(Vec::new).take(tx_count).collect();
     let state_hash = system_state.into_hash().await;
     let value = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages,
+            events,
             state_hash,
             oracle_responses,
         }
@@ -711,6 +712,7 @@ where
                         Amount::from_tokens(2),
                     )],
                 ],
+                events: vec![Vec::new(); 3],
                 state_hash: SystemExecutionState {
                     committees: [(epoch, committee.clone())].into_iter().collect(),
                     ownership: ChainOwnership::single(sender_key_pair.public()),
@@ -738,6 +740,7 @@ where
                     ChainId::root(2),
                     Amount::from_tokens(3),
                 )]],
+                events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     committees: [(epoch, committee.clone())].into_iter().collect(),
                     ownership: ChainOwnership::single(sender_key_pair.public()),
@@ -1000,6 +1003,7 @@ where
                         Vec::new(),
                         vec![direct_credit_message(ChainId::root(3), Amount::ONE)],
                     ],
+                    events: vec![Vec::new(); 2],
                     state_hash: SystemExecutionState {
                         committees: [(epoch, committee.clone())].into_iter().collect(),
                         ownership: ChainOwnership::single(recipient_key_pair.public()),
@@ -1289,6 +1293,7 @@ where
     let value = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages: vec![Vec::new()],
+            events: vec![Vec::new()],
             state_hash: state.into_hash().await,
             oracle_responses: vec![Vec::new()],
         }
@@ -2329,6 +2334,7 @@ where
                         },
                     ),
                 ]],
+                events: vec![Vec::new(); 2],
                 state_hash: SystemExecutionState {
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair.public()),
@@ -2392,6 +2398,7 @@ where
                     })],
                     vec![direct_credit_message(user_id, Amount::from_tokens(2))],
                 ],
+                events: vec![Vec::new(); 2],
                 state_hash: SystemExecutionState {
                     // The root chain knows both committees at the end.
                     committees: committees2.clone(),
@@ -2427,6 +2434,7 @@ where
                     MessageKind::Protected,
                     SystemMessage::Notify { id: user_id },
                 )]],
+                events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     // The root chain knows both committees at the end.
                     committees: committees2.clone(),
@@ -2551,6 +2559,7 @@ where
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
                 messages: vec![Vec::new(); 4],
+                events: vec![Vec::new(); 4],
                 state_hash: SystemExecutionState {
                     subscriptions: [ChannelSubscription {
                         chain_id: admin_id,
@@ -2729,6 +2738,7 @@ where
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
                 messages: vec![vec![direct_credit_message(admin_id, Amount::ONE)]],
+                events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair1.public()),
@@ -2756,6 +2766,7 @@ where
                     epoch: Epoch::from(1),
                     committees: committees2.clone(),
                 })]],
+                events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     committees: committees2.clone(),
                     ownership: ChainOwnership::single(key_pair0.public()),
@@ -2857,6 +2868,7 @@ where
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
                 messages: vec![vec![direct_credit_message(admin_id, Amount::ONE)]],
+                events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     committees: committees.clone(),
                     ownership: ChainOwnership::single(key_pair1.public()),
@@ -2891,6 +2903,7 @@ where
                         committees: committees3.clone(),
                     })],
                 ],
+                events: vec![Vec::new(); 2],
                 state_hash: SystemExecutionState {
                     committees: committees3.clone(),
                     ownership: ChainOwnership::single(key_pair0.public()),
@@ -2951,6 +2964,7 @@ where
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
                 messages: vec![Vec::new()],
+                events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     committees: committees3.clone(),
                     ownership: ChainOwnership::single(key_pair0.public()),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3887,6 +3887,7 @@ where
     let value = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages: vec![],
+            events: vec![],
             state_hash: state.crypto_hash_mut().await?,
             oracle_responses: vec![],
         }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -75,6 +75,8 @@ pub use crate::{
 
 /// The maximum length of an event key in bytes.
 const MAX_EVENT_KEY_LEN: usize = 64;
+/// The maximum length of a stream name.
+const MAX_STREAM_NAME_LEN: usize = 64;
 
 /// An implementation of [`UserContractModule`].
 pub type UserContractCode = Arc<dyn UserContractModule + Send + Sync + 'static>;
@@ -170,6 +172,8 @@ pub enum ExecutionError {
     BlobNotFoundOnRead(BlobId),
     #[error("Event keys can be at most {MAX_EVENT_KEY_LEN} bytes.")]
     EventKeyTooLong,
+    #[error("Stream names can be at most {MAX_STREAM_NAME_LEN} bytes.")]
+    StreamNameTooLong,
 }
 
 /// The public entry points provided by the contract part of an application.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -532,7 +532,12 @@ pub trait ContractRuntime: BaseRuntime {
     ) -> Result<Vec<u8>, ExecutionError>;
 
     /// Adds a new item to an event stream.
-    fn emit(&mut self, name: StreamName, payload: Vec<u8>) -> Result<(), ExecutionError>;
+    fn emit(
+        &mut self,
+        name: StreamName,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> Result<(), ExecutionError>;
 
     /// Opens a new chain.
     fn open_chain(
@@ -674,7 +679,7 @@ pub struct RawExecutionOutcome<Message, Grant = Resources> {
     /// signer and including grant with the refund policy described above.
     pub messages: Vec<RawOutgoingMessage<Message, Grant>>,
     /// Events recorded by contracts' `emit` calls.
-    pub events: Vec<(StreamName, Vec<u8>)>,
+    pub events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
     /// Subscribe chains to channels.
     pub subscribe: Vec<(ChannelName, ChainId)>,
     /// Unsubscribe chains to channels.

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -73,6 +73,9 @@ pub use crate::{
     },
 };
 
+/// The maximum length of an event key in bytes.
+const MAX_EVENT_KEY_LEN: usize = 64;
+
 /// An implementation of [`UserContractModule`].
 pub type UserContractCode = Arc<dyn UserContractModule + Send + Sync + 'static>;
 
@@ -165,6 +168,8 @@ pub enum ExecutionError {
 
     #[error("Blob not found on storage read: {0}")]
     BlobNotFoundOnRead(BlobId),
+    #[error("Event keys can be at most {MAX_EVENT_KEY_LEN} bytes.")]
+    EventKeyTooLong,
 }
 
 /// The public entry points provided by the contract part of an application.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -32,7 +32,7 @@ use crate::{
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, FinalizeContext,
     MessageContext, OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime,
     UserApplicationDescription, UserApplicationId, UserContractInstance, UserServiceInstance,
-    MAX_EVENT_KEY_LEN,
+    MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]
@@ -1270,6 +1270,10 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         ensure!(
             key.len() <= MAX_EVENT_KEY_LEN,
             ExecutionError::EventKeyTooLong
+        );
+        ensure!(
+            name.0.len() <= MAX_STREAM_NAME_LEN,
+            ExecutionError::StreamNameTooLong
         );
         let application = this.current_application_mut();
         application.outcome.events.push((name, key, value));

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -32,6 +32,7 @@ use crate::{
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, FinalizeContext,
     MessageContext, OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime,
     UserApplicationDescription, UserApplicationId, UserContractInstance, UserServiceInstance,
+    MAX_EVENT_KEY_LEN,
 };
 
 #[cfg(test)]
@@ -1266,6 +1267,10 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         value: Vec<u8>,
     ) -> Result<(), ExecutionError> {
         let mut this = self.inner();
+        ensure!(
+            key.len() <= MAX_EVENT_KEY_LEN,
+            ExecutionError::EventKeyTooLong
+        );
         let application = this.current_application_mut();
         application.outcome.events.push((name, key, value));
         Ok(())

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1259,10 +1259,15 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         Ok(value)
     }
 
-    fn emit(&mut self, name: StreamName, payload: Vec<u8>) -> Result<(), ExecutionError> {
+    fn emit(
+        &mut self,
+        name: StreamName,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> Result<(), ExecutionError> {
         let mut this = self.inner();
         let application = this.current_application_mut();
-        application.outcome.events.push((name, payload));
+        application.outcome.events.push((name, key, value));
         Ok(())
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -305,11 +305,16 @@ where
     }
 
     /// Adds an item to an event stream.
-    fn emit(caller: &mut Caller, name: StreamName, payload: Vec<u8>) -> Result<(), RuntimeError> {
+    fn emit(
+        caller: &mut Caller,
+        name: StreamName,
+        key: Vec<u8>,
+        value: Vec<u8>,
+    ) -> Result<(), RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .emit(name, payload)
+            .emit(name, key, value)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -7,7 +7,9 @@ use linera_base::{
     data_types::{
         Amount, ApplicationPermissions, BlockHeight, HashedBlob, SendMessageRequest, Timestamp,
     },
-    identifiers::{Account, ApplicationId, BlobId, ChainId, ChannelName, MessageId, Owner},
+    identifiers::{
+        Account, ApplicationId, BlobId, ChainId, ChannelName, MessageId, Owner, StreamName,
+    },
     ownership::{ChainOwnership, CloseChainError},
 };
 use linera_views::batch::{Batch, WriteOperation};
@@ -299,6 +301,15 @@ where
             .user_data_mut()
             .runtime
             .try_call_application(authenticated, callee_id, argument)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Adds an item to an event stream.
+    fn emit(caller: &mut Caller, name: StreamName, payload: Vec<u8>) -> Result<(), RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .emit(name, payload)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -56,6 +56,7 @@ test('Block mounting', () => {
                   }
                 }
               }]],
+              events: [[]],
               stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
               oracleResponses: []
             }

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -58,6 +58,7 @@ test('Blocks mounting', () => {
                       }
                     }
                   }]],
+                  events: [[]],
                   stateHash: "5bcd40995283e74798c60e8dc7a93e8c61059440534070673dfb973b2b66f61a",
                   oracleResponses: []
                 }

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -399,10 +399,8 @@ Event:
         TYPENAME: Message
 EventRecord:
   STRUCT:
-    - application_id:
-        TYPENAME: GenericApplicationId
-    - stream_name:
-        TYPENAME: StreamName
+    - stream_id:
+        TYPENAME: StreamId
     - payload:
         SEQ: U8
 ExecutedBlock:
@@ -819,6 +817,12 @@ Signature:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 64
+StreamId:
+  STRUCT:
+    - application_id:
+        TYPENAME: GenericApplicationId
+    - stream_name:
+        TYPENAME: StreamName
 StreamName:
   NEWTYPESTRUCT: BYTES
 SystemChannel:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -83,6 +83,10 @@ BlockExecutionOutcome:
         SEQ:
           SEQ:
             TYPENAME: OracleResponse
+    - events:
+        SEQ:
+          SEQ:
+            TYPENAME: EventRecord
 BlockHeight:
   NEWTYPESTRUCT: U64
 BlockHeightRange:
@@ -393,6 +397,14 @@ Event:
         TYPENAME: Timestamp
     - message:
         TYPENAME: Message
+EventRecord:
+  STRUCT:
+    - application_id:
+        TYPENAME: GenericApplicationId
+    - stream_name:
+        TYPENAME: StreamName
+    - payload:
+        SEQ: U8
 ExecutedBlock:
   STRUCT:
     - block:
@@ -807,6 +819,8 @@ Signature:
     TUPLEARRAY:
       CONTENT: U8
       SIZE: 64
+StreamName:
+  NEWTYPESTRUCT: BYTES
 SystemChannel:
   ENUM:
     0:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -401,7 +401,9 @@ EventRecord:
   STRUCT:
     - stream_id:
         TYPENAME: StreamId
-    - payload:
+    - key:
+        SEQ: U8
+    - value:
         SEQ: U8
 ExecutedBlock:
   STRUCT:

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -8,7 +8,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, Resources, SendMessageRequest, Timestamp},
     identifiers::{
         Account, ApplicationId, BlobId, BytecodeId, ChainId, ChannelName, Destination, MessageId,
-        Owner,
+        Owner, StreamName,
     },
 };
 
@@ -145,6 +145,14 @@ impl From<Destination> for wit_system_api::Destination {
 impl From<ChannelName> for wit_system_api::ChannelName {
     fn from(name: ChannelName) -> Self {
         wit_system_api::ChannelName {
+            inner0: name.into_bytes(),
+        }
+    }
+}
+
+impl From<StreamName> for wit_system_api::StreamName {
+    fn from(name: StreamName) -> Self {
+        wit_system_api::StreamName {
             inner0: name.into_bytes(),
         }
     }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -8,6 +8,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, HashedBlob, Resources, SendMessageRequest, Timestamp},
     identifiers::{
         Account, ApplicationId, BlobId, ChainId, ChannelName, Destination, MessageId, Owner,
+        StreamName,
     },
     ownership::{ChainOwnership, CloseChainError},
 };
@@ -207,6 +208,11 @@ where
 
         bcs::from_bytes(&response_bytes)
             .expect("Failed to deserialize `Response` type from cross-application call")
+    }
+
+    /// Adds a new item to an event stream.
+    pub fn emit(&mut self, name: StreamName, payload: &[u8]) {
+        wit::emit(&name.into(), payload);
     }
 
     /// Queries our application service as an oracle and returns the response.

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -211,8 +211,8 @@ where
     }
 
     /// Adds a new item to an event stream.
-    pub fn emit(&mut self, name: StreamName, payload: &[u8]) {
-        wit::emit(&name.into(), payload);
+    pub fn emit(&mut self, name: StreamName, key: &[u8], value: &[u8]) {
+        wit::emit(&name.into(), key, value);
     }
 
     /// Queries our application service as an oracle and returns the response.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -13,6 +13,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, HashedBlob, Resources, SendMessageRequest, Timestamp},
     identifiers::{
         Account, ApplicationId, BlobId, ChainId, ChannelName, Destination, MessageId, Owner,
+        StreamName,
     },
     ownership::{ChainOwnership, CloseChainError},
 };
@@ -43,6 +44,7 @@ where
     subscribe_requests: Vec<(ChainId, ChannelName)>,
     unsubscribe_requests: Vec<(ChainId, ChannelName)>,
     outgoing_transfers: HashMap<Account, Amount>,
+    events: Vec<(StreamName, Vec<u8>)>,
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
     expected_post_requests: VecDeque<(String, Vec<u8>, Vec<u8>)>,
@@ -84,6 +86,7 @@ where
             subscribe_requests: Vec::new(),
             unsubscribe_requests: Vec::new(),
             outgoing_transfers: HashMap::new(),
+            events: Vec::new(),
             claim_requests: Vec::new(),
             expected_service_queries: VecDeque::new(),
             expected_post_requests: VecDeque::new(),
@@ -584,6 +587,11 @@ where
 
         bcs::from_bytes(&response_bytes)
             .expect("Failed to deserialize `Response` type from cross-application call")
+    }
+
+    /// Adds a new item to an event stream.
+    pub fn emit(&mut self, name: StreamName, payload: &[u8]) {
+        self.events.push((name, payload.to_vec()));
     }
 
     /// Adds an expected `query_service` call`, and the response it should return in the test.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -44,7 +44,7 @@ where
     subscribe_requests: Vec<(ChainId, ChannelName)>,
     unsubscribe_requests: Vec<(ChainId, ChannelName)>,
     outgoing_transfers: HashMap<Account, Amount>,
-    events: Vec<(StreamName, Vec<u8>)>,
+    events: Vec<(StreamName, Vec<u8>, Vec<u8>)>,
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
     expected_post_requests: VecDeque<(String, Vec<u8>, Vec<u8>)>,
@@ -590,8 +590,8 @@ where
     }
 
     /// Adds a new item to an event stream.
-    pub fn emit(&mut self, name: StreamName, payload: &[u8]) {
-        self.events.push((name, payload.to_vec()));
+    pub fn emit(&mut self, name: StreamName, key: &[u8], value: &[u8]) {
+        self.events.push((name, key.to_vec(), value.to_vec()));
     }
 
     /// Adds an expected `query_service` call`, and the response it should return in the test.

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -21,7 +21,7 @@ interface contract-system-api {
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
     close-chain: func() -> result<tuple<>, close-chain-error>;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
-    emit: func(name: stream-name, payload: list<u8>);
+    emit: func(name: stream-name, key: list<u8>, value: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -21,6 +21,7 @@ interface contract-system-api {
     open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
     close-chain: func() -> result<tuple<>, close-chain-error>;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
+    emit: func(name: stream-name, payload: list<u8>);
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
@@ -142,6 +143,10 @@ interface contract-system-api {
         is-tracked: bool,
         grant: resources,
         message: list<u8>,
+    }
+
+    record stream-name {
+        inner0: list<u8>,
     }
 
     record time-delta {

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -182,6 +182,11 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           }
           stateHash
           oracleResponses
+          events {
+            applicationId
+            streamName
+            payload
+          }
         }
       }
     }
@@ -219,6 +224,11 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
           }
           stateHash
           oracleResponses
+          events {
+            applicationId
+            streamName
+            payload
+          }
         }
       }
     }

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -183,8 +183,10 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           stateHash
           oracleResponses
           events {
-            applicationId
-            streamName
+            streamId {
+              applicationId
+              streamName
+            }
             payload
           }
         }
@@ -225,8 +227,10 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
           stateHash
           oracleResponses
           events {
-            applicationId
-            streamName
+            streamId {
+              applicationId
+              streamName
+            }
             payload
           }
         }

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -187,7 +187,8 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
               applicationId
               streamName
             }
-            payload
+            key
+            value
           }
         }
       }
@@ -231,7 +232,8 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
               applicationId
               streamName
             }
-            payload
+            key
+            value
           }
         }
       }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -108,11 +108,18 @@ type BlockExecutionOutcome {
 	The list of outgoing messages for each transaction.
 	"""
 	messages: [[OutgoingMessage!]!]!
+	"""
+	The hash of the chain's execution state after this block.
+	"""
 	stateHash: CryptoHash!
 	"""
 	The record of oracle responses for each transaction.
 	"""
 	oracleResponses: [[OracleResponse!]!]!
+	"""
+	The list of events produced by each transaction.
+	"""
+	events: [[EventRecord!]!]!
 }
 
 """
@@ -376,6 +383,24 @@ A message together with non replayable information to ensure uniqueness in a par
 scalar Event
 
 """
+An event recorded in an executed block.
+"""
+type EventRecord {
+	"""
+	The application that emitted this event.
+	"""
+	applicationId: GenericApplicationId!
+	"""
+	The name of the event stream.
+	"""
+	streamName: StreamName!
+	"""
+	The payload data.
+	"""
+	payload: [Int!]!
+}
+
+"""
 A [`Block`], together with the outcome from its execution.
 """
 type ExecutedBlock {
@@ -387,6 +412,11 @@ type ExecutionStateView {
 	system: SystemExecutionStateView!
 }
 
+
+"""
+A unique identifier for a user application or for the system application
+"""
+scalar GenericApplicationId
 
 type HashedCertificateValue {
 	hash: CryptoHash!
@@ -831,6 +861,11 @@ input ResourceControlPolicy {
 	"""
 	maximumBytesWrittenPerBlock: Int!
 }
+
+"""
+The name of an event stream
+"""
+scalar StreamName
 
 
 type SubscriptionRoot {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -391,9 +391,13 @@ type EventRecord {
 	"""
 	streamId: StreamId!
 	"""
+	The event key.
+	"""
+	key: [Int!]!
+	"""
 	The payload data.
 	"""
-	payload: [Int!]!
+	value: [Int!]!
 }
 
 """

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -387,13 +387,9 @@ An event recorded in an executed block.
 """
 type EventRecord {
 	"""
-	The application that emitted this event.
+	The ID of the stream this event belongs to.
 	"""
-	applicationId: GenericApplicationId!
-	"""
-	The name of the event stream.
-	"""
-	streamName: StreamName!
+	streamId: StreamId!
 	"""
 	The payload data.
 	"""
@@ -860,6 +856,20 @@ input ResourceControlPolicy {
 	The maximum data to write per block
 	"""
 	maximumBytesWrittenPerBlock: Int!
+}
+
+"""
+An event stream ID.
+"""
+type StreamId {
+	"""
+	The application that can add events to this stream.
+	"""
+	applicationId: GenericApplicationId!
+	"""
+	The name of this stream: an application can have multiple streams with different names.
+	"""
+	streamName: StreamName!
 }
 
 """

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -222,6 +222,7 @@ mod from {
                     messages,
                     state_hash,
                     oracle_responses: oracle_responses.into_iter().map(Into::into).collect(),
+                    events: vec![], // events.into_iter().map(Into::into).collect(),
                 },
             }
         }

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -7,7 +7,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
     identifiers::{
         Account, ChainDescription, ChainId, ChannelName, Destination, GenericApplicationId, Owner,
-        StreamId, StreamName,
+        StreamName,
     },
 };
 
@@ -132,6 +132,7 @@ pub struct Transfer;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod from {
+    use linera_base::identifiers::StreamId;
     use linera_chain::data_types::{
         BlockExecutionOutcome, EventRecord, ExecutedBlock, HashedCertificateValue, IncomingMessage,
         OutgoingMessage,

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -7,7 +7,7 @@ use linera_base::{
     data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
     identifiers::{
         Account, ChainDescription, ChainId, ChannelName, Destination, GenericApplicationId, Owner,
-        StreamName,
+        StreamId, StreamName,
     },
 };
 
@@ -238,9 +238,17 @@ mod from {
     impl From<block::BlockBlockValueExecutedBlockOutcomeEvents> for EventRecord {
         fn from(event: block::BlockBlockValueExecutedBlockOutcomeEvents) -> Self {
             EventRecord {
-                application_id: event.application_id,
-                stream_name: event.stream_name,
+                stream_id: event.stream_id.into(),
                 payload: event.payload.into_iter().map(|byte| byte as u8).collect(),
+            }
+        }
+    }
+
+    impl From<block::BlockBlockValueExecutedBlockOutcomeEventsStreamId> for StreamId {
+        fn from(stream_id: block::BlockBlockValueExecutedBlockOutcomeEventsStreamId) -> Self {
+            StreamId {
+                application_id: stream_id.application_id,
+                stream_name: stream_id.stream_name,
             }
         }
     }

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -239,7 +239,8 @@ mod from {
         fn from(event: block::BlockBlockValueExecutedBlockOutcomeEvents) -> Self {
             EventRecord {
                 stream_id: event.stream_id.into(),
-                payload: event.payload.into_iter().map(|byte| byte as u8).collect(),
+                key: event.key.into_iter().map(|byte| byte as u8).collect(),
+                value: event.value.into_iter().map(|byte| byte as u8).collect(),
             }
         }
     }


### PR DESCRIPTION
## Motivation

Event streams will in the future replace broadcast channels, and also enable other blockchains to more easily interpret Linera data, e.g. to facilitate bridges.

## Proposal

As a first step, add an `emit` method to the contract runtime, and record emitted events in blocks.

## Test Plan

An `emit` call was added to the meta-counter, and we assert that the event is in the resulting certificate.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2229.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
