### PR TITLE
Implement a `new` for views.

### DIFF
--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -245,10 +245,10 @@ where
         let key = context.base_tag_index(KeyTag::Subview as u8, short_key);
         let context = context.clone_with_base_key(key);
         // Obtain a view and set its pending state to the default (e.g. empty) state
-        let mut view = W::load(context).await?;
-        if delete_storage_first {
-            view.clear();
-        }
+        let view = match delete_storage_first {
+            true => W::new(context)?,
+            false => W::load(context).await?,
+        };
         Ok(Arc::new(RwLock::new(view)))
     }
 

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -52,6 +52,14 @@ pub trait View<C>: Sized {
     /// changes are simply lost.
     /// The returned boolean indicates whether the operation removes the view or not.
     fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError>;
+
+    /// Builds a trivial view that is already deleted
+    fn new(context: C) -> Result<Self, ViewError> {
+        let values = vec![None; Self::NUM_INIT_KEYS];
+        let mut view = Self::post_load(context, &values)?;
+        view.clear();
+        Ok(view)
+    }
 }
 
 /// Main error type for the crate.


### PR DESCRIPTION
## Motivation

The `collection_view` and `reentrant_collection_view` are in some circumstances loading and view and then clearing it immediately. This is inefficient.

## Proposal

The following was done:
* The `new` has been introduced as a trait function of views.
* The `collection_view` and `reentrant_collection_view` have been simplified.
* The `reset_view_to_default` has been removed to not be async anymore.

## Test Plan

The CI does the job.

## Release Plan

The documentation will have to be updated.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
