### PR TITLE
Introduce the function `contains_keys` for the `KeyValueStore` trait.

### DIFF
--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -194,8 +194,11 @@ where
             }
 
             ContainsKeys { id, keys, callback } => {
-                let view = self.users.try_load_entry_or_insert(&id).await?;
-                let result = view.contains_keys(keys).await?;
+                let view = self.users.try_load_entry(&id).await?;
+                let result = match view {
+                    Some(view) => view.contains_keys(keys).await?,
+                    None => vec![false; keys.len()],
+                };
                 callback.respond(result);
             }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -193,6 +193,12 @@ where
                 callback.respond(result);
             }
 
+            ContainKeys { id, keys, callback } => {
+                let view = self.users.try_load_entry_or_insert(&id).await?;
+                let result = view.contain_keys(keys).await?;
+                callback.respond(result);
+            }
+
             ReadMultiValuesBytes { id, keys, callback } => {
                 let view = self.users.try_load_entry(&id).await?;
                 let values = match view {
@@ -383,6 +389,12 @@ pub enum ExecutionRequest {
         callback: Sender<bool>,
     },
 
+    ContainKeys {
+        id: UserApplicationId,
+        keys: Vec<Vec<u8>>,
+        callback: Sender<Vec<bool>>,
+    },
+
     ReadMultiValuesBytes {
         id: UserApplicationId,
         keys: Vec<Vec<u8>>,
@@ -514,6 +526,12 @@ impl Debug for ExecutionRequest {
                 .debug_struct("ExecutionRequest::ContainsKey")
                 .field("id", id)
                 .field("key", key)
+                .finish_non_exhaustive(),
+
+            ExecutionRequest::ContainKeys { id, keys, .. } => formatter
+                .debug_struct("ExecutionRequest::ContainKeys")
+                .field("id", id)
+                .field("keys", keys)
                 .finish_non_exhaustive(),
 
             ExecutionRequest::ReadMultiValuesBytes { id, keys, .. } => formatter

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -193,9 +193,9 @@ where
                 callback.respond(result);
             }
 
-            ContainKeys { id, keys, callback } => {
+            ContainsKeys { id, keys, callback } => {
                 let view = self.users.try_load_entry_or_insert(&id).await?;
-                let result = view.contain_keys(keys).await?;
+                let result = view.contains_keys(keys).await?;
                 callback.respond(result);
             }
 
@@ -389,7 +389,7 @@ pub enum ExecutionRequest {
         callback: Sender<bool>,
     },
 
-    ContainKeys {
+    ContainsKeys {
         id: UserApplicationId,
         keys: Vec<Vec<u8>>,
         callback: Sender<Vec<bool>>,
@@ -528,8 +528,8 @@ impl Debug for ExecutionRequest {
                 .field("key", key)
                 .finish_non_exhaustive(),
 
-            ExecutionRequest::ContainKeys { id, keys, .. } => formatter
-                .debug_struct("ExecutionRequest::ContainKeys")
+            ExecutionRequest::ContainsKeys { id, keys, .. } => formatter
+                .debug_struct("ExecutionRequest::ContainsKeys")
                 .field("id", id)
                 .field("keys", keys)
                 .finish_non_exhaustive(),

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -322,6 +322,7 @@ pub struct QueryContext {
 pub trait BaseRuntime {
     type Read: fmt::Debug + Send + Sync;
     type ContainsKey: fmt::Debug + Send + Sync;
+    type ContainKeys: fmt::Debug + Send + Sync;
     type ReadMultiValuesBytes: fmt::Debug + Send + Sync;
     type ReadValueBytes: fmt::Debug + Send + Sync;
     type FindKeysByPrefix: fmt::Debug + Send + Sync;
@@ -369,6 +370,19 @@ pub trait BaseRuntime {
 
     /// Tests whether a key exists in the key-value store (wait)
     fn contains_key_wait(&mut self, promise: &Self::ContainsKey) -> Result<bool, ExecutionError>;
+
+    /// Tests whether keys exist in the key-value store
+    #[cfg(feature = "test")]
+    fn contain_keys(&mut self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ExecutionError> {
+        let promise = self.contain_keys_new(keys)?;
+        self.contain_keys_wait(&promise)
+    }
+
+    /// Tests whether keys exist in the key-value store (new)
+    fn contain_keys_new(&mut self, keys: Vec<Vec<u8>>) -> Result<Self::ContainKeys, ExecutionError>;
+
+    /// Tests whether keys exist in the key-value store (wait)
+    fn contain_keys_wait(&mut self, promise: &Self::ContainKeys) -> Result<Vec<bool>, ExecutionError>;
 
     /// Reads several keys from the key-value store
     #[cfg(feature = "test")]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -322,7 +322,7 @@ pub struct QueryContext {
 pub trait BaseRuntime {
     type Read: fmt::Debug + Send + Sync;
     type ContainsKey: fmt::Debug + Send + Sync;
-    type ContainKeys: fmt::Debug + Send + Sync;
+    type ContainsKeys: fmt::Debug + Send + Sync;
     type ReadMultiValuesBytes: fmt::Debug + Send + Sync;
     type ReadValueBytes: fmt::Debug + Send + Sync;
     type FindKeysByPrefix: fmt::Debug + Send + Sync;
@@ -373,19 +373,19 @@ pub trait BaseRuntime {
 
     /// Tests whether keys exist in the key-value store
     #[cfg(feature = "test")]
-    fn contain_keys(&mut self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ExecutionError> {
-        let promise = self.contain_keys_new(keys)?;
-        self.contain_keys_wait(&promise)
+    fn contains_keys(&mut self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ExecutionError> {
+        let promise = self.contains_keys_new(keys)?;
+        self.contains_keys_wait(&promise)
     }
 
     /// Tests whether keys exist in the key-value store (new)
-    fn contain_keys_new(&mut self, keys: Vec<Vec<u8>>)
-        -> Result<Self::ContainKeys, ExecutionError>;
+    fn contains_keys_new(&mut self, keys: Vec<Vec<u8>>)
+        -> Result<Self::ContainsKeys, ExecutionError>;
 
     /// Tests whether keys exist in the key-value store (wait)
-    fn contain_keys_wait(
+    fn contains_keys_wait(
         &mut self,
-        promise: &Self::ContainKeys,
+        promise: &Self::ContainsKeys,
     ) -> Result<Vec<bool>, ExecutionError>;
 
     /// Reads several keys from the key-value store

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -379,8 +379,10 @@ pub trait BaseRuntime {
     }
 
     /// Tests whether keys exist in the key-value store (new)
-    fn contains_keys_new(&mut self, keys: Vec<Vec<u8>>)
-        -> Result<Self::ContainsKeys, ExecutionError>;
+    fn contains_keys_new(
+        &mut self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Self::ContainsKeys, ExecutionError>;
 
     /// Tests whether keys exist in the key-value store (wait)
     fn contains_keys_wait(

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -365,10 +365,10 @@ pub trait BaseRuntime {
         self.contains_key_wait(&promise)
     }
 
-    /// Tests whether a key exists in the key-value store (new)
+    /// Creates the promise to test whether a key exists in the key-value store
     fn contains_key_new(&mut self, key: Vec<u8>) -> Result<Self::ContainsKey, ExecutionError>;
 
-    /// Tests whether a key exists in the key-value store (wait)
+    /// Resolves the promise to test whether a key exists in the key-value store
     fn contains_key_wait(&mut self, promise: &Self::ContainsKey) -> Result<bool, ExecutionError>;
 
     /// Tests whether multiple keys exist in the key-value store
@@ -378,13 +378,13 @@ pub trait BaseRuntime {
         self.contains_keys_wait(&promise)
     }
 
-    /// Tests whether multiple keys exist in the key-value store (new)
+    /// Creates the promise to test whether multiple keys exist in the key-value store
     fn contains_keys_new(
         &mut self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Self::ContainsKeys, ExecutionError>;
 
-    /// Tests whether multiple keys exist in the key-value store (wait)
+    /// Resolves the promise to test whether multiple keys exist in the key-value store
     fn contains_keys_wait(
         &mut self,
         promise: &Self::ContainsKeys,
@@ -400,13 +400,13 @@ pub trait BaseRuntime {
         self.read_multi_values_bytes_wait(&promise)
     }
 
-    /// Reads several keys from the key-value store (new)
+    /// Creates the promise to access several keys from the key-value store
     fn read_multi_values_bytes_new(
         &mut self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Self::ReadMultiValuesBytes, ExecutionError>;
 
-    /// Reads several keys from the key-value store (wait)
+    /// Resolves the promise to access several keys from the key-value store
     fn read_multi_values_bytes_wait(
         &mut self,
         promise: &Self::ReadMultiValuesBytes,
@@ -419,25 +419,25 @@ pub trait BaseRuntime {
         self.read_value_bytes_wait(&promise)
     }
 
-    /// Reads the key from the key-value store (new)
+    /// Creates the promise to access a key from the key-value store
     fn read_value_bytes_new(
         &mut self,
         key: Vec<u8>,
     ) -> Result<Self::ReadValueBytes, ExecutionError>;
 
-    /// Reads the key from the key-value store (wait)
+    /// Resolves the promise to access a key from the key-value store
     fn read_value_bytes_wait(
         &mut self,
         promise: &Self::ReadValueBytes,
     ) -> Result<Option<Vec<u8>>, ExecutionError>;
 
-    /// Reads the data from the keys having a specific prefix (new).
+    /// Creates the promise to access keys having a specific prefix
     fn find_keys_by_prefix_new(
         &mut self,
         key_prefix: Vec<u8>,
     ) -> Result<Self::FindKeysByPrefix, ExecutionError>;
 
-    /// Reads the data from the keys having a specific prefix (wait).
+    /// Resolves the promise to access keys having a specific prefix
     fn find_keys_by_prefix_wait(
         &mut self,
         promise: &Self::FindKeysByPrefix,
@@ -454,13 +454,13 @@ pub trait BaseRuntime {
         self.find_key_values_by_prefix_wait(&promise)
     }
 
-    /// Reads the data from the key/values having a specific prefix (new).
+    /// Creates the promise to access key/values having a specific prefix
     fn find_key_values_by_prefix_new(
         &mut self,
         key_prefix: Vec<u8>,
     ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError>;
 
-    /// Reads the data from the key/values having a specific prefix (wait).
+    /// Resolves the promise to access key/values having a specific prefix
     #[allow(clippy::type_complexity)]
     fn find_key_values_by_prefix_wait(
         &mut self,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -371,20 +371,20 @@ pub trait BaseRuntime {
     /// Tests whether a key exists in the key-value store (wait)
     fn contains_key_wait(&mut self, promise: &Self::ContainsKey) -> Result<bool, ExecutionError>;
 
-    /// Tests whether keys exist in the key-value store
+    /// Tests whether multiple keys exist in the key-value store
     #[cfg(feature = "test")]
     fn contains_keys(&mut self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ExecutionError> {
         let promise = self.contains_keys_new(keys)?;
         self.contains_keys_wait(&promise)
     }
 
-    /// Tests whether keys exist in the key-value store (new)
+    /// Tests whether multiple keys exist in the key-value store (new)
     fn contains_keys_new(
         &mut self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Self::ContainsKeys, ExecutionError>;
 
-    /// Tests whether keys exist in the key-value store (wait)
+    /// Tests whether multiple keys exist in the key-value store (wait)
     fn contains_keys_wait(
         &mut self,
         promise: &Self::ContainsKeys,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -379,10 +379,14 @@ pub trait BaseRuntime {
     }
 
     /// Tests whether keys exist in the key-value store (new)
-    fn contain_keys_new(&mut self, keys: Vec<Vec<u8>>) -> Result<Self::ContainKeys, ExecutionError>;
+    fn contain_keys_new(&mut self, keys: Vec<Vec<u8>>)
+        -> Result<Self::ContainKeys, ExecutionError>;
 
     /// Tests whether keys exist in the key-value store (wait)
-    fn contain_keys_wait(&mut self, promise: &Self::ContainKeys) -> Result<Vec<bool>, ExecutionError>;
+    fn contain_keys_wait(
+        &mut self,
+        promise: &Self::ContainKeys,
+    ) -> Result<Vec<bool>, ExecutionError>;
 
     /// Reads several keys from the key-value store
     #[cfg(feature = "test")]

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -621,11 +621,17 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().contains_key_wait(promise)
     }
 
-    fn contain_keys_new(&mut self, keys: Vec<Vec<u8>>) -> Result<Self::ContainKeys, ExecutionError> {
+    fn contain_keys_new(
+        &mut self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Self::ContainKeys, ExecutionError> {
         self.inner().contain_keys_new(keys)
     }
 
-    fn contain_keys_wait(&mut self, promise: &Self::ContainKeys) -> Result<Vec<bool>, ExecutionError> {
+    fn contain_keys_wait(
+        &mut self,
+        promise: &Self::ContainKeys,
+    ) -> Result<Vec<bool>, ExecutionError> {
         self.inner().contain_keys_wait(promise)
     }
 
@@ -789,7 +795,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(value)
     }
 
-    fn contain_keys_new(&mut self, keys: Vec<Vec<u8>>) -> Result<Self::ContainKeys, ExecutionError> {
+    fn contain_keys_new(
+        &mut self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Self::ContainKeys, ExecutionError> {
         let id = self.application_id()?;
         let state = self.view_user_states.entry(id).or_default();
         self.resource_controller.track_read_operations(1)?;
@@ -799,7 +808,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         state.contain_keys_queries.register(receiver)
     }
 
-    fn contain_keys_wait(&mut self, promise: &Self::ContainKeys) -> Result<Vec<bool>, ExecutionError> {
+    fn contain_keys_wait(
+        &mut self,
+        promise: &Self::ContainKeys,
+    ) -> Result<Vec<bool>, ExecutionError> {
         let id = self.application_id()?;
         let state = self.view_user_states.entry(id).or_default();
         let value = state.contain_keys_queries.wait(*promise)?;

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -245,8 +245,8 @@ type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 struct ViewUserState {
     /// The contains-key queries in progress.
     contains_key_queries: QueryManager<bool>,
-    /// The contain-keys queries in progress.
-    contain_keys_queries: QueryManager<Vec<bool>>,
+    /// The contains-keys queries in progress.
+    contains_keys_queries: QueryManager<Vec<bool>>,
     /// The read-value queries in progress.
     read_value_queries: QueryManager<Option<Value>>,
     /// The read-multi-values queries in progress.
@@ -260,7 +260,7 @@ struct ViewUserState {
 impl ViewUserState {
     fn force_all_pending_queries(&mut self) -> Result<(), ExecutionError> {
         self.contains_key_queries.force_all()?;
-        self.contain_keys_queries.force_all()?;
+        self.contains_keys_queries.force_all()?;
         self.read_value_queries.force_all()?;
         self.read_multi_values_queries.force_all()?;
         self.find_keys_queries.force_all()?;
@@ -566,7 +566,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
     type Read = <SyncRuntimeInternal<UserInstance> as BaseRuntime>::Read;
     type ReadValueBytes = <SyncRuntimeInternal<UserInstance> as BaseRuntime>::ReadValueBytes;
     type ContainsKey = <SyncRuntimeInternal<UserInstance> as BaseRuntime>::ContainsKey;
-    type ContainKeys = <SyncRuntimeInternal<UserInstance> as BaseRuntime>::ContainKeys;
+    type ContainsKeys = <SyncRuntimeInternal<UserInstance> as BaseRuntime>::ContainsKeys;
     type ReadMultiValuesBytes =
         <SyncRuntimeInternal<UserInstance> as BaseRuntime>::ReadMultiValuesBytes;
     type FindKeysByPrefix = <SyncRuntimeInternal<UserInstance> as BaseRuntime>::FindKeysByPrefix;
@@ -621,18 +621,18 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().contains_key_wait(promise)
     }
 
-    fn contain_keys_new(
+    fn contains_keys_new(
         &mut self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Self::ContainKeys, ExecutionError> {
-        self.inner().contain_keys_new(keys)
+    ) -> Result<Self::ContainsKeys, ExecutionError> {
+        self.inner().contains_keys_new(keys)
     }
 
-    fn contain_keys_wait(
+    fn contains_keys_wait(
         &mut self,
-        promise: &Self::ContainKeys,
+        promise: &Self::ContainsKeys,
     ) -> Result<Vec<bool>, ExecutionError> {
-        self.inner().contain_keys_wait(promise)
+        self.inner().contains_keys_wait(promise)
     }
 
     fn read_multi_values_bytes_new(
@@ -721,7 +721,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
     type Read = ();
     type ReadValueBytes = u32;
     type ContainsKey = u32;
-    type ContainKeys = u32;
+    type ContainsKeys = u32;
     type ReadMultiValuesBytes = u32;
     type FindKeysByPrefix = u32;
     type FindKeyValuesByPrefix = u32;
@@ -795,26 +795,26 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(value)
     }
 
-    fn contain_keys_new(
+    fn contains_keys_new(
         &mut self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Self::ContainKeys, ExecutionError> {
+    ) -> Result<Self::ContainsKeys, ExecutionError> {
         let id = self.application_id()?;
         let state = self.view_user_states.entry(id).or_default();
         self.resource_controller.track_read_operations(1)?;
         let receiver = self
             .execution_state_sender
-            .send_request(move |callback| ExecutionRequest::ContainKeys { id, keys, callback })?;
-        state.contain_keys_queries.register(receiver)
+            .send_request(move |callback| ExecutionRequest::ContainsKeys { id, keys, callback })?;
+        state.contains_keys_queries.register(receiver)
     }
 
-    fn contain_keys_wait(
+    fn contains_keys_wait(
         &mut self,
-        promise: &Self::ContainKeys,
+        promise: &Self::ContainsKeys,
     ) -> Result<Vec<bool>, ExecutionError> {
         let id = self.application_id()?;
         let state = self.view_user_states.entry(id).or_default();
-        let value = state.contain_keys_queries.wait(*promise)?;
+        let value = state.contains_keys_queries.wait(*promise)?;
         Ok(value)
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -595,23 +595,23 @@ where
     }
 
     /// Creates a new promise to check if the `keys` are in storage.
-    fn contain_keys_new(caller: &mut Caller, keys: Vec<Vec<u8>>) -> Result<u32, RuntimeError> {
+    fn contains_keys_new(caller: &mut Caller, keys: Vec<Vec<u8>>) -> Result<u32, RuntimeError> {
         let mut data = caller.user_data_mut();
         let promise = data
             .runtime
-            .contain_keys_new(keys)
+            .contains_keys_new(keys)
             .map_err(|error| RuntimeError::Custom(error.into()))?;
 
         data.register_promise(promise)
     }
 
     /// Waits for the promise to check if the `keys` are in storage.
-    fn contain_keys_wait(caller: &mut Caller, promise_id: u32) -> Result<Vec<bool>, RuntimeError> {
+    fn contains_keys_wait(caller: &mut Caller, promise_id: u32) -> Result<Vec<bool>, RuntimeError> {
         let mut data = caller.user_data_mut();
         let promise = data.take_promise(promise_id)?;
 
         data.runtime
-            .contain_keys_wait(&promise)
+            .contains_keys_wait(&promise)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -594,6 +594,27 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Creates a new promise to check if the `keys` are in storage.
+    fn contain_keys_new(caller: &mut Caller, keys: Vec<Vec<u8>>) -> Result<u32, RuntimeError> {
+        let mut data = caller.user_data_mut();
+        let promise = data
+            .runtime
+            .contain_keys_new(keys)
+            .map_err(|error| RuntimeError::Custom(error.into()))?;
+
+        data.register_promise(promise)
+    }
+
+    /// Waits for the promise to check if the `keys` are in storage.
+    fn contain_keys_wait(caller: &mut Caller, promise_id: u32) -> Result<Vec<bool>, RuntimeError> {
+        let mut data = caller.user_data_mut();
+        let promise = data.take_promise(promise_id)?;
+
+        data.runtime
+            .contain_keys_wait(&promise)
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Creates a new promise to read multiple entries from storage.
     fn read_multi_values_bytes_new(
         caller: &mut Caller,

--- a/linera-sdk/src/views/mock_key_value_store.rs
+++ b/linera-sdk/src/views/mock_key_value_store.rs
@@ -22,6 +22,7 @@ use linera_views::{
 pub(super) struct MockKeyValueStore {
     store: MemoryStore,
     contains_key_promises: PromiseRegistry<bool>,
+    contain_keys_promises: PromiseRegistry<Vec<bool>>,
     read_multi_promises: PromiseRegistry<Vec<Option<Vec<u8>>>>,
     read_single_promises: PromiseRegistry<Option<Vec<u8>>>,
     find_keys_promises: PromiseRegistry<Vec<Vec<u8>>>,
@@ -33,6 +34,7 @@ impl Default for MockKeyValueStore {
         MockKeyValueStore {
             store: create_memory_store(),
             contains_key_promises: PromiseRegistry::default(),
+            contain_keys_promises: PromiseRegistry::default(),
             read_multi_promises: PromiseRegistry::default(),
             read_single_promises: PromiseRegistry::default(),
             find_keys_promises: PromiseRegistry::default(),
@@ -85,6 +87,23 @@ impl MockKeyValueStore {
     /// Returns if the key used in the respective call to [`contains_key_new`] is present.
     pub(crate) fn contains_key_wait(&self, promise: u32) -> bool {
         self.contains_key_promises.take(promise)
+    }
+
+    /// Checks if `keys` are present in the storage, returning a promise to retrieve the final
+    /// value.
+    pub(crate) fn contain_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
+        self.contain_keys_promises.register(
+            self.store
+                .contain_keys(keys)
+                .now_or_never()
+                .expect("Memory store should never wait for anything")
+                .expect("Memory store should never fail"),
+        )
+    }
+
+    /// Returns if the key used in the respective call to [`contains_key_new`] is present.
+    pub(crate) fn contain_keys_wait(&self, promise: u32) -> Vec<bool> {
+        self.contain_keys_promises.take(promise)
     }
 
     /// Reads the values addressed by `keys` from the store, returning a promise to retrieve

--- a/linera-sdk/src/views/mock_key_value_store.rs
+++ b/linera-sdk/src/views/mock_key_value_store.rs
@@ -22,7 +22,7 @@ use linera_views::{
 pub(super) struct MockKeyValueStore {
     store: MemoryStore,
     contains_key_promises: PromiseRegistry<bool>,
-    contain_keys_promises: PromiseRegistry<Vec<bool>>,
+    contains_keys_promises: PromiseRegistry<Vec<bool>>,
     read_multi_promises: PromiseRegistry<Vec<Option<Vec<u8>>>>,
     read_single_promises: PromiseRegistry<Option<Vec<u8>>>,
     find_keys_promises: PromiseRegistry<Vec<Vec<u8>>>,
@@ -34,7 +34,7 @@ impl Default for MockKeyValueStore {
         MockKeyValueStore {
             store: create_memory_store(),
             contains_key_promises: PromiseRegistry::default(),
-            contain_keys_promises: PromiseRegistry::default(),
+            contains_keys_promises: PromiseRegistry::default(),
             read_multi_promises: PromiseRegistry::default(),
             read_single_promises: PromiseRegistry::default(),
             find_keys_promises: PromiseRegistry::default(),
@@ -91,19 +91,19 @@ impl MockKeyValueStore {
 
     /// Checks if `keys` are present in the storage, returning a promise to retrieve the final
     /// value.
-    pub(crate) fn contain_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
-        self.contain_keys_promises.register(
+    pub(crate) fn contains_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
+        self.contains_keys_promises.register(
             self.store
-                .contain_keys(keys.to_vec())
+                .contains_keys(keys.to_vec())
                 .now_or_never()
                 .expect("Memory store should never wait for anything")
                 .expect("Memory store should never fail"),
         )
     }
 
-    /// Returns if the key used in the respective call to [`contains_key_new`] is present.
-    pub(crate) fn contain_keys_wait(&self, promise: u32) -> Vec<bool> {
-        self.contain_keys_promises.take(promise)
+    /// Returns if the key used in the respective call to [`contains_keys_new`] is present.
+    pub(crate) fn contains_keys_wait(&self, promise: u32) -> Vec<bool> {
+        self.contains_keys_promises.take(promise)
     }
 
     /// Reads the values addressed by `keys` from the store, returning a promise to retrieve

--- a/linera-sdk/src/views/mock_key_value_store.rs
+++ b/linera-sdk/src/views/mock_key_value_store.rs
@@ -94,7 +94,7 @@ impl MockKeyValueStore {
     pub(crate) fn contain_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
         self.contain_keys_promises.register(
             self.store
-                .contain_keys(keys)
+                .contain_keys(keys.to_vec())
                 .now_or_never()
                 .expect("Memory store should never wait for anything")
                 .expect("Memory store should never fail"),

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -179,7 +179,7 @@ enum WitInterface {
 }
 
 impl WitInterface {
-    /// Calls the `contains_key_new` WIT function.
+    /// Creates a promise for testing if a key exist in the key-value store
     fn contains_key_new(&self, key: &[u8]) -> u32 {
         match self {
             WitInterface::Contract => contract_wit::contains_key_new(key),
@@ -189,7 +189,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `contains_key_wait` WIT function.
+    /// Resolves a promise for testing if a key exist in the key-value store
     fn contains_key_wait(&self, promise: u32) -> bool {
         match self {
             WitInterface::Contract => contract_wit::contains_key_wait(promise),
@@ -199,7 +199,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `contains_keys_new` WIT function.
+    /// Creates a promise for testing if multiple keys exist in the key-value store
     fn contains_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
         match self {
             WitInterface::Contract => contract_wit::contains_keys_new(keys),
@@ -209,7 +209,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `contains_keys_wait` WIT function.
+    /// Resolves a promise for testing if multiple keys exist in the key-value store
     fn contains_keys_wait(&self, promise: u32) -> Vec<bool> {
         match self {
             WitInterface::Contract => contract_wit::contains_keys_wait(promise),
@@ -219,7 +219,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `read_multi_values_bytes_new` WIT function.
+    /// Creates a promise for reading multiple keys in the key-value store
     fn read_multi_values_bytes_new(&self, keys: &[Vec<u8>]) -> u32 {
         match self {
             WitInterface::Contract => contract_wit::read_multi_values_bytes_new(keys),
@@ -229,7 +229,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `read_multi_values_bytes_wait` WIT function.
+    /// Resolves a promise for reading multiple keys in the key-value store
     fn read_multi_values_bytes_wait(&self, promise: u32) -> Vec<Option<Vec<u8>>> {
         match self {
             WitInterface::Contract => contract_wit::read_multi_values_bytes_wait(promise),
@@ -239,7 +239,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `read_value_bytes_new` WIT function.
+    /// Creates a promise for reading a key in the key-value store
     fn read_value_bytes_new(&self, key: &[u8]) -> u32 {
         match self {
             WitInterface::Contract => contract_wit::read_value_bytes_new(key),
@@ -249,7 +249,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `read_value_bytes_wait` WIT function.
+    /// Resolves a promise for reading a key in the key-value store
     fn read_value_bytes_wait(&self, promise: u32) -> Option<Vec<u8>> {
         match self {
             WitInterface::Contract => contract_wit::read_value_bytes_wait(promise),
@@ -259,7 +259,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `find_keys_new` WIT function.
+    /// Creates a promise for finding keys having a specified prefix in the key-value store
     fn find_keys_new(&self, key_prefix: &[u8]) -> u32 {
         match self {
             WitInterface::Contract => contract_wit::find_keys_new(key_prefix),
@@ -269,7 +269,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `find_keys_wait` WIT function.
+    /// Resolves a promise for finding keys having a specified prefix in the key-value store
     fn find_keys_wait(&self, promise: u32) -> Vec<Vec<u8>> {
         match self {
             WitInterface::Contract => contract_wit::find_keys_wait(promise),
@@ -279,7 +279,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `find_key_values_new` WIT function.
+    /// Creates a promise for finding the key/values having a specified prefix in the key-value store
     fn find_key_values_new(&self, key_prefix: &[u8]) -> u32 {
         match self {
             WitInterface::Contract => contract_wit::find_key_values_new(key_prefix),
@@ -289,7 +289,7 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `find_key_values_wait` WIT function.
+    /// Resolves a promise for finding the key/values having a specified prefix in the key-value store
     fn find_key_values_wait(&self, promise: u32) -> Vec<(Vec<u8>, Vec<u8>)> {
         match self {
             WitInterface::Contract => contract_wit::find_key_values_wait(promise),

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -97,13 +97,13 @@ impl ReadableKeyValueStore<ViewError> for KeyValueStore {
         Ok(self.wit_api.contains_key_wait(promise))
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
         for key in &keys {
             ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
         }
-        let promise = self.wit_api.contain_keys_new(&keys);
+        let promise = self.wit_api.contains_keys_new(&keys);
         yield_once().await;
-        Ok(self.wit_api.contain_keys_wait(promise))
+        Ok(self.wit_api.contains_keys_wait(promise))
     }
 
     async fn read_multi_values_bytes(
@@ -199,23 +199,23 @@ impl WitInterface {
         }
     }
 
-    /// Calls the `contain_keys_new` WIT function.
-    fn contain_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
+    /// Calls the `contains_keys_new` WIT function.
+    fn contains_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
         match self {
-            WitInterface::Contract => contract_wit::contain_keys_new(keys),
-            WitInterface::Service => service_wit::contain_keys_new(keys),
+            WitInterface::Contract => contract_wit::contains_keys_new(keys),
+            WitInterface::Service => service_wit::contains_keys_new(keys),
             #[cfg(with_testing)]
-            WitInterface::Mock { store, .. } => store.contain_keys_new(keys),
+            WitInterface::Mock { store, .. } => store.contains_keys_new(keys),
         }
     }
 
-    /// Calls the `contain_keys_wait` WIT function.
-    fn contain_keys_wait(&self, promise: u32) -> Vec<bool> {
+    /// Calls the `contains_keys_wait` WIT function.
+    fn contains_keys_wait(&self, promise: u32) -> Vec<bool> {
         match self {
-            WitInterface::Contract => contract_wit::contain_keys_wait(promise),
-            WitInterface::Service => service_wit::contain_keys_wait(promise),
+            WitInterface::Contract => contract_wit::contains_keys_wait(promise),
+            WitInterface::Service => service_wit::contains_keys_wait(promise),
             #[cfg(with_testing)]
-            WitInterface::Mock { store, .. } => store.contain_keys_wait(promise),
+            WitInterface::Mock { store, .. } => store.contains_keys_wait(promise),
         }
     }
 

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -97,6 +97,15 @@ impl ReadableKeyValueStore<ViewError> for KeyValueStore {
         Ok(self.wit_api.contains_key_wait(promise))
     }
 
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
+        for key in &keys {
+            ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
+        }
+        let promise = self.wit_api.contain_keys_new(&keys);
+        yield_once().await;
+        Ok(self.wit_api.contain_keys_wait(promise))
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -187,6 +196,26 @@ impl WitInterface {
             WitInterface::Service => service_wit::contains_key_wait(promise),
             #[cfg(with_testing)]
             WitInterface::Mock { store, .. } => store.contains_key_wait(promise),
+        }
+    }
+
+    /// Calls the `contain_keys_new` WIT function.
+    fn contain_keys_new(&self, keys: &[Vec<u8>]) -> u32 {
+        match self {
+            WitInterface::Contract => contract_wit::contain_keys_new(keys),
+            WitInterface::Service => service_wit::contain_keys_new(keys),
+            #[cfg(with_testing)]
+            WitInterface::Mock { store, .. } => store.contain_keys_new(key),
+        }
+    }
+
+    /// Calls the `contain_keys_wait` WIT function.
+    fn contain_keys_wait(&self, promise: u32) -> Vec<bool> {
+        match self {
+            WitInterface::Contract => contract_wit::contain_keys_wait(promise),
+            WitInterface::Service => service_wit::contain_keys_wait(promise),
+            #[cfg(with_testing)]
+            WitInterface::Mock { store, .. } => store.contain_keys_wait(promise),
         }
     }
 

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -205,7 +205,7 @@ impl WitInterface {
             WitInterface::Contract => contract_wit::contain_keys_new(keys),
             WitInterface::Service => service_wit::contain_keys_new(keys),
             #[cfg(with_testing)]
-            WitInterface::Mock { store, .. } => store.contain_keys_new(key),
+            WitInterface::Mock { store, .. } => store.contain_keys_new(keys),
         }
     }
 

--- a/linera-sdk/wit/view-system-api.wit
+++ b/linera-sdk/wit/view-system-api.wit
@@ -3,7 +3,7 @@ package linera:app;
 interface view-system-api {
     contains-key-new: func(key: list<u8>) -> u32;
     contains-key-wait: func(promise-id: u32) -> bool;
-    contains-keys-new: func(key: list<list<u8>>) -> u32;
+    contains-keys-new: func(keys: list<list<u8>>) -> u32;
     contains-keys-wait: func(promise-id: u32) -> list<bool>;
     read-multi-values-bytes-new: func(keys: list<list<u8>>) -> u32;
     read-multi-values-bytes-wait: func(promise-id: u32) -> list<option<list<u8>>>;

--- a/linera-sdk/wit/view-system-api.wit
+++ b/linera-sdk/wit/view-system-api.wit
@@ -3,8 +3,8 @@ package linera:app;
 interface view-system-api {
     contains-key-new: func(key: list<u8>) -> u32;
     contains-key-wait: func(promise-id: u32) -> bool;
-    contain-keys-new: func(key: list<list<u8>>) -> u32;
-    contain-keys-wait: func(promise-id: u32) -> list<bool>;
+    contains-keys-new: func(key: list<list<u8>>) -> u32;
+    contains-keys-wait: func(promise-id: u32) -> list<bool>;
     read-multi-values-bytes-new: func(keys: list<list<u8>>) -> u32;
     read-multi-values-bytes-wait: func(promise-id: u32) -> list<option<list<u8>>>;
     read-value-bytes-new: func(key: list<u8>) -> u32;

--- a/linera-sdk/wit/view-system-api.wit
+++ b/linera-sdk/wit/view-system-api.wit
@@ -3,6 +3,8 @@ package linera:app;
 interface view-system-api {
     contains-key-new: func(key: list<u8>) -> u32;
     contains-key-wait: func(promise-id: u32) -> bool;
+    contain-keys-new: func(key: list<list<u8>>) -> u32;
+    contain-keys-wait: func(promise-id: u32) -> list<bool>;
     read-multi-values-bytes-new: func(keys: list<list<u8>>) -> u32;
     read-multi-values-bytes-wait: func(promise-id: u32) -> list<option<list<u8>>>;
     read-value-bytes-new: func(key: list<u8>) -> u32;

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -46,11 +46,11 @@ message ReplyContainsKey {
 }
 
 
-message RequestContainKeys {
+message RequestContainsKeys {
   repeated bytes keys = 1;
 }
 
-message ReplyContainKeys {
+message ReplyContainsKeys {
   repeated bool tests = 1;
 }
 
@@ -148,7 +148,7 @@ message ReplyDeleteAll {
 service StoreProcessor {
   rpc ProcessReadValue (RequestReadValue) returns (ReplyReadValue) {}
   rpc ProcessContainsKey (RequestContainsKey) returns (ReplyContainsKey) {}
-  rpc ProcessContainKeys (RequestContainKeys) returns (ReplyContainKeys) {}
+  rpc ProcessContainsKeys (RequestContainsKeys) returns (ReplyContainsKeys) {}
   rpc ProcessReadMultiValues (RequestReadMultiValues) returns (ReplyReadMultiValues) {}
   rpc ProcessFindKeysByPrefix (RequestFindKeysByPrefix) returns (ReplyFindKeysByPrefix) {}
   rpc ProcessFindKeyValuesByPrefix (RequestFindKeyValuesByPrefix) returns (ReplyFindKeyValuesByPrefix) {}

--- a/linera-storage-service/proto/key_value_store.proto
+++ b/linera-storage-service/proto/key_value_store.proto
@@ -46,6 +46,15 @@ message ReplyContainsKey {
 }
 
 
+message RequestContainKeys {
+  repeated bytes keys = 1;
+}
+
+message ReplyContainKeys {
+  repeated bool tests = 1;
+}
+
+
 message RequestReadMultiValues {
   repeated bytes keys = 1;
 }
@@ -139,6 +148,7 @@ message ReplyDeleteAll {
 service StoreProcessor {
   rpc ProcessReadValue (RequestReadValue) returns (ReplyReadValue) {}
   rpc ProcessContainsKey (RequestContainsKey) returns (ReplyContainsKey) {}
+  rpc ProcessContainKeys (RequestContainKeys) returns (ReplyContainKeys) {}
   rpc ProcessReadMultiValues (RequestReadMultiValues) returns (ReplyReadMultiValues) {}
   rpc ProcessFindKeysByPrefix (RequestFindKeysByPrefix) returns (ReplyFindKeysByPrefix) {}
   rpc ProcessFindKeyValuesByPrefix (RequestFindKeyValuesByPrefix) returns (ReplyFindKeyValuesByPrefix) {}

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -25,12 +25,13 @@ use crate::{
     common::{KeyTag, ServiceStoreConfig, ServiceStoreError, MAX_PAYLOAD_SIZE},
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
-        KeyValueAppend, ReplyContainKeys, ReplyContainsKey, ReplyExistsNamespace, ReplyFindKeyValuesByPrefix,
-        ReplyFindKeysByPrefix, ReplyListAll, ReplyReadMultiValues, ReplyReadValue,
-        ReplySpecificChunk, RequestContainKeys, RequestContainsKey, RequestCreateNamespace, RequestDeleteAll,
-        RequestDeleteNamespace, RequestExistsNamespace, RequestFindKeyValuesByPrefix,
-        RequestFindKeysByPrefix, RequestListAll, RequestReadMultiValues, RequestReadValue,
-        RequestSpecificChunk, RequestWriteBatchExtended, Statement,
+        KeyValueAppend, ReplyContainKeys, ReplyContainsKey, ReplyExistsNamespace,
+        ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix, ReplyListAll, ReplyReadMultiValues,
+        ReplyReadValue, ReplySpecificChunk, RequestContainKeys, RequestContainsKey,
+        RequestCreateNamespace, RequestDeleteAll, RequestDeleteNamespace, RequestExistsNamespace,
+        RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix, RequestListAll,
+        RequestReadMultiValues, RequestReadValue, RequestSpecificChunk, RequestWriteBatchExtended,
+        Statement,
     },
 };
 

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -25,9 +25,9 @@ use crate::{
     common::{KeyTag, ServiceStoreConfig, ServiceStoreError, MAX_PAYLOAD_SIZE},
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
-        KeyValueAppend, ReplyContainsKeys, ReplyContainsKey, ReplyExistsNamespace,
+        KeyValueAppend, ReplyContainsKey, ReplyContainsKeys, ReplyExistsNamespace,
         ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix, ReplyListAll, ReplyReadMultiValues,
-        ReplyReadValue, ReplySpecificChunk, RequestContainsKeys, RequestContainsKey,
+        ReplyReadValue, ReplySpecificChunk, RequestContainsKey, RequestContainsKeys,
         RequestCreateNamespace, RequestDeleteAll, RequestDeleteNamespace, RequestExistsNamespace,
         RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix, RequestListAll,
         RequestReadMultiValues, RequestReadValue, RequestSpecificChunk, RequestWriteBatchExtended,

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -25,9 +25,9 @@ use crate::{
     common::{KeyTag, ServiceStoreConfig, ServiceStoreError, MAX_PAYLOAD_SIZE},
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
-        KeyValueAppend, ReplyContainKeys, ReplyContainsKey, ReplyExistsNamespace,
+        KeyValueAppend, ReplyContainsKeys, ReplyContainsKey, ReplyExistsNamespace,
         ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix, ReplyListAll, ReplyReadMultiValues,
-        ReplyReadValue, ReplySpecificChunk, RequestContainKeys, RequestContainsKey,
+        ReplyReadValue, ReplySpecificChunk, RequestContainsKeys, RequestContainsKey,
         RequestCreateNamespace, RequestDeleteAll, RequestDeleteNamespace, RequestExistsNamespace,
         RequestFindKeyValuesByPrefix, RequestFindKeysByPrefix, RequestListAll,
         RequestReadMultiValues, RequestReadValue, RequestSpecificChunk, RequestWriteBatchExtended,
@@ -107,7 +107,7 @@ impl ReadableKeyValueStore<ServiceStoreError> for ServiceStoreClientInternal {
         Ok(test)
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ServiceStoreError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ServiceStoreError> {
         let mut full_keys = Vec::new();
         for key in keys {
             ensure!(key.len() <= MAX_KEY_SIZE, ServiceStoreError::KeyTooLong);
@@ -115,13 +115,13 @@ impl ReadableKeyValueStore<ServiceStoreError> for ServiceStoreClientInternal {
             full_key.extend(&key);
             full_keys.push(full_key);
         }
-        let query = RequestContainKeys { keys: full_keys };
+        let query = RequestContainsKeys { keys: full_keys };
         let request = tonic::Request::new(query);
         let mut client = self.client.write().await;
         let _guard = self.acquire().await;
-        let response = client.process_contain_keys(request).await?;
+        let response = client.process_contains_keys(request).await?;
         let response = response.into_inner();
-        let ReplyContainKeys { tests } = response;
+        let ReplyContainsKeys { tests } = response;
         Ok(tests)
     }
 
@@ -521,8 +521,8 @@ impl ReadableKeyValueStore<ServiceStoreError> for ServiceStoreClient {
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ServiceStoreError> {
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ServiceStoreError> {
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -25,10 +25,10 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use crate::key_value_store::{
     statement::Operation,
     store_processor_server::{StoreProcessor, StoreProcessorServer},
-    KeyValue, OptValue, ReplyContainsKeys, ReplyContainsKey, ReplyCreateNamespace, ReplyDeleteAll,
+    KeyValue, OptValue, ReplyContainsKey, ReplyContainsKeys, ReplyCreateNamespace, ReplyDeleteAll,
     ReplyDeleteNamespace, ReplyExistsNamespace, ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix,
     ReplyListAll, ReplyReadMultiValues, ReplyReadValue, ReplySpecificChunk,
-    ReplyWriteBatchExtended, RequestContainsKeys, RequestContainsKey, RequestCreateNamespace,
+    ReplyWriteBatchExtended, RequestContainsKey, RequestContainsKeys, RequestCreateNamespace,
     RequestDeleteAll, RequestDeleteNamespace, RequestExistsNamespace, RequestFindKeyValuesByPrefix,
     RequestFindKeysByPrefix, RequestListAll, RequestReadMultiValues, RequestReadValue,
     RequestSpecificChunk, RequestWriteBatchExtended,

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -96,7 +96,7 @@ impl ServiceStoreServer {
                 .map_err(|_e| Status::not_found("contain_keys")),
             #[cfg(feature = "rocksdb")]
             ServiceStoreServerInternal::RocksDb(store) => store
-                .contain_keya(keys)
+                .contain_keys(keys)
                 .await
                 .map_err(|_e| Status::not_found("contain_keys")),
         }

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -25,10 +25,10 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use crate::key_value_store::{
     statement::Operation,
     store_processor_server::{StoreProcessor, StoreProcessorServer},
-    KeyValue, OptValue, ReplyContainKeys, ReplyContainsKey, ReplyCreateNamespace, ReplyDeleteAll,
+    KeyValue, OptValue, ReplyContainsKeys, ReplyContainsKey, ReplyCreateNamespace, ReplyDeleteAll,
     ReplyDeleteNamespace, ReplyExistsNamespace, ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix,
     ReplyListAll, ReplyReadMultiValues, ReplyReadValue, ReplySpecificChunk,
-    ReplyWriteBatchExtended, RequestContainKeys, RequestContainsKey, RequestCreateNamespace,
+    ReplyWriteBatchExtended, RequestContainsKeys, RequestContainsKey, RequestCreateNamespace,
     RequestDeleteAll, RequestDeleteNamespace, RequestExistsNamespace, RequestFindKeyValuesByPrefix,
     RequestFindKeysByPrefix, RequestListAll, RequestReadMultiValues, RequestReadValue,
     RequestSpecificChunk, RequestWriteBatchExtended,
@@ -88,17 +88,17 @@ impl ServiceStoreServer {
         }
     }
 
-    pub async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Status> {
+    pub async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Status> {
         match &self.store {
             ServiceStoreServerInternal::Memory(store) => store
-                .contain_keys(keys)
+                .contains_keys(keys)
                 .await
-                .map_err(|_e| Status::not_found("contain_keys")),
+                .map_err(|_e| Status::not_found("contains_keys")),
             #[cfg(feature = "rocksdb")]
             ServiceStoreServerInternal::RocksDb(store) => store
-                .contain_keys(keys)
+                .contains_keys(keys)
                 .await
-                .map_err(|_e| Status::not_found("contain_keys")),
+                .map_err(|_e| Status::not_found("contains_keys")),
         }
     }
 
@@ -284,14 +284,14 @@ impl StoreProcessor for ServiceStoreServer {
     }
 
     #[instrument(target = "store_server", skip_all, err, fields(key_len = ?request.get_ref().keys.len()))]
-    async fn process_contain_keys(
+    async fn process_contains_keys(
         &self,
-        request: Request<RequestContainKeys>,
-    ) -> Result<Response<ReplyContainKeys>, Status> {
+        request: Request<RequestContainsKeys>,
+    ) -> Result<Response<ReplyContainsKeys>, Status> {
         let request = request.into_inner();
-        let RequestContainKeys { keys } = request;
-        let tests = self.contain_keys(keys).await?;
-        let response = ReplyContainKeys { tests };
+        let RequestContainsKeys { keys } = request;
+        let tests = self.contains_keys(keys).await?;
+        let response = ReplyContainsKeys { tests };
         Ok(Response::new(response))
     }
 

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -28,8 +28,8 @@ use crate::key_value_store::{
     KeyValue, OptValue, ReplyContainKeys, ReplyContainsKey, ReplyCreateNamespace, ReplyDeleteAll,
     ReplyDeleteNamespace, ReplyExistsNamespace, ReplyFindKeyValuesByPrefix, ReplyFindKeysByPrefix,
     ReplyListAll, ReplyReadMultiValues, ReplyReadValue, ReplySpecificChunk,
-    ReplyWriteBatchExtended, RequestContainKeys, RequestContainsKey, RequestCreateNamespace, RequestDeleteAll,
-    RequestDeleteNamespace, RequestExistsNamespace, RequestFindKeyValuesByPrefix,
+    ReplyWriteBatchExtended, RequestContainKeys, RequestContainsKey, RequestCreateNamespace,
+    RequestDeleteAll, RequestDeleteNamespace, RequestExistsNamespace, RequestFindKeyValuesByPrefix,
     RequestFindKeysByPrefix, RequestListAll, RequestReadMultiValues, RequestReadValue,
     RequestSpecificChunk, RequestWriteBatchExtended,
 };

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -65,12 +65,12 @@ impl ServiceStoreServer {
             ServiceStoreServerInternal::Memory(store) => store
                 .read_value_bytes(key)
                 .await
-                .map_err(|_e| Status::not_found("read_value_bytes")),
+                .map_err(|e| Status::unknown(format!("Memory error {:?} at read_value_bytes", e))),
             #[cfg(feature = "rocksdb")]
             ServiceStoreServerInternal::RocksDb(store) => store
                 .read_value_bytes(key)
                 .await
-                .map_err(|_e| Status::not_found("read_value_bytes")),
+                .map_err(|e| Status::unknown(format!("RocksDB error {:?} at read_value_bytes", e))),
         }
     }
 
@@ -79,12 +79,12 @@ impl ServiceStoreServer {
             ServiceStoreServerInternal::Memory(store) => store
                 .contains_key(key)
                 .await
-                .map_err(|_e| Status::not_found("contains_key")),
+                .map_err(|e| Status::unknown(format!("Memory error {:?} at contains_key", e))),
             #[cfg(feature = "rocksdb")]
             ServiceStoreServerInternal::RocksDb(store) => store
                 .contains_key(key)
                 .await
-                .map_err(|_e| Status::not_found("contains_key")),
+                .map_err(|e| Status::unknown(format!("RocksDB error {:?} at contains_key", e))),
         }
     }
 
@@ -93,12 +93,12 @@ impl ServiceStoreServer {
             ServiceStoreServerInternal::Memory(store) => store
                 .contains_keys(keys)
                 .await
-                .map_err(|_e| Status::not_found("contains_keys")),
+                .map_err(|e| Status::unknown(format!("Memory error {:?} at contains_keys", e))),
             #[cfg(feature = "rocksdb")]
             ServiceStoreServerInternal::RocksDb(store) => store
                 .contains_keys(keys)
                 .await
-                .map_err(|_e| Status::not_found("contains_keys")),
+                .map_err(|e| Status::unknown(format!("RocksDB error {:?} at contains_keys", e))),
         }
     }
 
@@ -107,29 +107,33 @@ impl ServiceStoreServer {
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Status> {
         match &self.store {
-            ServiceStoreServerInternal::Memory(store) => store
-                .read_multi_values_bytes(keys)
-                .await
-                .map_err(|_e| Status::not_found("read_multi_values_bytes")),
+            ServiceStoreServerInternal::Memory(store) => {
+                store.read_multi_values_bytes(keys).await.map_err(|e| {
+                    Status::unknown(format!("Memory error {:?} at read_multi_values_bytes", e))
+                })
+            }
             #[cfg(feature = "rocksdb")]
-            ServiceStoreServerInternal::RocksDb(store) => store
-                .read_multi_values_bytes(keys)
-                .await
-                .map_err(|_e| Status::not_found("read_multi_values_bytes")),
+            ServiceStoreServerInternal::RocksDb(store) => {
+                store.read_multi_values_bytes(keys).await.map_err(|e| {
+                    Status::unknown(format!("RocksDB error {:?} at read_multi_values_bytes", e))
+                })
+            }
         }
     }
 
     pub async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Status> {
         match &self.store {
-            ServiceStoreServerInternal::Memory(store) => store
-                .find_keys_by_prefix(key_prefix)
-                .await
-                .map_err(|_e| Status::not_found("find_keys_by_prefix")),
+            ServiceStoreServerInternal::Memory(store) => {
+                store.find_keys_by_prefix(key_prefix).await.map_err(|e| {
+                    Status::unknown(format!("Memory error {:?} at find_keys_by_prefix", e))
+                })
+            }
             #[cfg(feature = "rocksdb")]
-            ServiceStoreServerInternal::RocksDb(store) => store
-                .find_keys_by_prefix(key_prefix)
-                .await
-                .map_err(|_e| Status::not_found("find_keys_by_prefix")),
+            ServiceStoreServerInternal::RocksDb(store) => {
+                store.find_keys_by_prefix(key_prefix).await.map_err(|e| {
+                    Status::unknown(format!("RocksDB error {:?} at find_keys_by_prefix", e))
+                })
+            }
         }
     }
 
@@ -141,12 +145,19 @@ impl ServiceStoreServer {
             ServiceStoreServerInternal::Memory(store) => store
                 .find_key_values_by_prefix(key_prefix)
                 .await
-                .map_err(|_e| Status::not_found("find_key_values_by_prefix")),
+                .map_err(|e| {
+                    Status::unknown(format!("Memory error {:?} at find_key_values_by_prefix", e))
+                }),
             #[cfg(feature = "rocksdb")]
             ServiceStoreServerInternal::RocksDb(store) => store
                 .find_key_values_by_prefix(key_prefix)
                 .await
-                .map_err(|_e| Status::not_found("find_key_values_by_prefix")),
+                .map_err(|e| {
+                    Status::unknown(format!(
+                        "RocksDB error {:?} at find_key_values_by_prefix",
+                        e
+                    ))
+                }),
         }
     }
 
@@ -155,12 +166,12 @@ impl ServiceStoreServer {
             ServiceStoreServerInternal::Memory(store) => store
                 .write_batch(batch, &[])
                 .await
-                .map_err(|_e| Status::not_found("write_batch")),
+                .map_err(|e| Status::unknown(format!("Memory error {:?} at write_batch", e))),
             #[cfg(feature = "rocksdb")]
             ServiceStoreServerInternal::RocksDb(store) => store
                 .write_batch(batch, &[])
                 .await
-                .map_err(|_e| Status::not_found("write_batch")),
+                .map_err(|e| Status::unknown(format!("RocksDB error {:?} at write_batch", e))),
         }
     }
 

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -324,10 +324,10 @@ pub trait LocalReadableKeyValueStore<E> {
     /// Retrieves a `Vec<u8>` from the database using the provided `key`.
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, E>;
 
-    /// Test whether a key exists in the database
+    /// Tests whether a key exists in the database
     async fn contains_key(&self, key: &[u8]) -> Result<bool, E>;
 
-    /// Test whether a set of keys exist in the database
+    /// Tests whether a list of keys exist in the database
     async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -327,7 +327,7 @@ pub trait LocalReadableKeyValueStore<E> {
     /// Test whether a key exists in the database
     async fn contains_key(&self, key: &[u8]) -> Result<bool, E>;
 
-    /// Test whether keys exist in the database
+    /// Test whether a set of keys exist in the database
     async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
@@ -582,6 +582,9 @@ pub trait Context: Clone {
     /// Test whether a key exists in the database
     async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error>;
 
+    /// Test whether a set of keys exist in the database
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error>;
+
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(
         &self,
@@ -782,6 +785,10 @@ where
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
         log_time_async(self.store.contains_key(key), "contains_key").await
+    }
+
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error> {
+        log_time_async(self.store.contain_keys(keys), "contain_keys").await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -328,7 +328,7 @@ pub trait LocalReadableKeyValueStore<E> {
     async fn contains_key(&self, key: &[u8]) -> Result<bool, E>;
 
     /// Test whether a set of keys exist in the database
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E>;
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, E>;
@@ -583,7 +583,7 @@ pub trait Context: Clone {
     async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error>;
 
     /// Test whether a set of keys exist in the database
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error>;
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(
@@ -787,8 +787,8 @@ where
         log_time_async(self.store.contains_key(key), "contains_key").await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error> {
-        log_time_async(self.store.contain_keys(keys), "contain_keys").await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error> {
+        log_time_async(self.store.contains_keys(keys), "contains_keys").await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -572,17 +572,17 @@ pub trait Context: Clone {
     /// Returns type for key-value search operations.
     type KeyValues: KeyValueIterable<Self::Error>;
 
-    /// Retrieve the number of stream queries.
+    /// Retrieves the number of stream queries.
     fn max_stream_queries(&self) -> usize;
 
     /// Retrieves a `Vec<u8>` from the database using the provided `key` prefixed by the current
     /// context.
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
-    /// Test whether a key exists in the database
+    /// Tests whether a key exists in the database
     async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error>;
 
-    /// Test whether a set of keys exist in the database
+    /// Tests whether a set of keys exist in the database
     async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -327,6 +327,9 @@ pub trait LocalReadableKeyValueStore<E> {
     /// Test whether a key exists in the database
     async fn contains_key(&self, key: &[u8]) -> Result<bool, E>;
 
+    /// Test whether keys exist in the database
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E>;
+
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, E>;
 

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -819,10 +819,7 @@ impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
         self.contains_key_general(key_db).await
     }
 
-    async fn contain_keys(
-        &self,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<bool>, DynamoDbStoreError> {
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, DynamoDbStoreError> {
         let mut handles = Vec::new();
         for key in keys {
             ensure!(key.len() <= MAX_KEY_SIZE, DynamoDbStoreError::KeyTooLong);

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -819,6 +819,23 @@ impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
         self.contains_key_general(key_db).await
     }
 
+    async fn contain_keys(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<bool>, DynamoDbStoreError> {
+        let mut handles = Vec::new();
+        for key in keys {
+            ensure!(key.len() <= MAX_KEY_SIZE, DynamoDbStoreError::KeyTooLong);
+            let key_db = build_key(key);
+            let handle = self.contains_key_general(key_db);
+            handles.push(handle);
+        }
+        join_all(handles)
+            .await
+            .into_iter()
+            .collect::<Result<_, _>>()
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -920,6 +937,10 @@ impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStore {
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, DynamoDbStoreError> {
         self.store.contains_key(key).await
+    }
+
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, DynamoDbStoreError> {
+        self.store.contain_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -819,7 +819,7 @@ impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
         self.contains_key_general(key_db).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, DynamoDbStoreError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, DynamoDbStoreError> {
         let mut handles = Vec::new();
         for key in keys {
             ensure!(key.len() <= MAX_KEY_SIZE, DynamoDbStoreError::KeyTooLong);
@@ -936,8 +936,8 @@ impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStore {
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, DynamoDbStoreError> {
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, DynamoDbStoreError> {
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -101,6 +101,14 @@ impl LocalReadableKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
         Ok(count == 1)
     }
 
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, IndexedDbStoreError> {
+        future::try_join_all(
+            keys.into_iter()
+                .map(|key| async move { self.contains_key(&key).await }),
+        )
+        .await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -140,6 +140,10 @@ where
         self.store.contains_key(key).await
     }
 
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
+        self.store.contain_keys(keys).await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -140,8 +140,8 @@ where
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -678,11 +678,11 @@ where
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]).await.unwrap();
     ///   let keys = vec![vec![0,1], vec![0,2]];
-    ///   let results = view.contain_keys(keys).await.unwrap();
+    ///   let results = view.contains_keys(keys).await.unwrap();
     ///   assert_eq!(results, vec![true, false]);
     /// # })
     /// ```
-    pub async fn contain_keys(&self, indices: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
+    pub async fn contains_keys(&self, indices: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
         let mut results = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
@@ -706,7 +706,7 @@ where
             }
         }
         if !self.delete_storage_first {
-            let values = self.context.contain_keys(vector_query).await?;
+            let values = self.context.contains_keys(vector_query).await?;
             for (i, value) in missed_indices.into_iter().zip(values) {
                 results[i] = value;
             }
@@ -1128,9 +1128,9 @@ where
         view.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
         let view = self.view.read().await;
-        view.contain_keys(keys).await
+        view.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -687,9 +687,7 @@ where
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
         for (i, index) in indices.into_iter().enumerate() {
-            if index.len() > self.max_key_size() {
-                return Err(ViewError::KeyTooLong);
-            }
+            ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
             if let Some(update) = self.updates.get(&index) {
                 let value = match update {
                     Update::Removed => false,
@@ -734,9 +732,7 @@ where
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
         for (i, index) in indices.into_iter().enumerate() {
-            if index.len() > self.max_key_size() {
-                return Err(ViewError::KeyTooLong);
-            }
+            ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
             if let Some(update) = self.updates.get(&index) {
                 let value = match update {
                     Update::Removed => None,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -636,7 +636,7 @@ where
         Ok(self.context.read_value_bytes(&key).await?)
     }
 
-    /// Test whether the store contains a specific index.
+    /// Tests whether the store contains a specific index.
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::create_memory_context;
@@ -668,7 +668,7 @@ where
         Ok(self.context.contains_key(&key).await?)
     }
 
-    /// Test whether the view contains a range of indices
+    /// Tests whether the view contains a range of indices
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::create_memory_context;

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -154,6 +154,30 @@ where
         self.store.contains_key(key).await
     }
 
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
+        if let Some(values) = &self.lru_read_values {
+            let values = values.lock().await;
+            let size = keys.len();
+            let mut results = vec![false; size];
+            let mut indices = Vec::new();
+            let mut keys_red = Vec::new();
+            for i in 0..size {
+                if let Some(value) = values.query(&keys[i]) {
+                    results[i] = value.is_some();
+                } else {
+                    indices.push(i);
+                    keys_red.push(keys[i].clone());
+                }
+            }
+            let results_red = self.store.contain_keys(keys_red).await?;
+            for (index, result) in indices.into_iter().zip(results_red) {
+                results[index] = result;
+            }
+            return Ok(results);
+        }
+        self.store.contain_keys(keys).await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -154,7 +154,7 @@ where
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
         if let Some(values) = &self.lru_read_values {
             let values = values.lock().await;
             let size = keys.len();
@@ -169,13 +169,13 @@ where
                     keys_red.push(keys[i].clone());
                 }
             }
-            let results_red = self.store.contain_keys(keys_red).await?;
+            let results_red = self.store.contains_keys(keys_red).await?;
             for (index, result) in indices.into_iter().zip(results_red) {
                 results[index] = result;
             }
             return Ok(results);
         }
-        self.store.contain_keys(keys).await
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -175,7 +175,7 @@ where
         for (index, result) in indices.into_iter().zip(key_results) {
             results[index] = result;
         }
-        return Ok(results);
+        Ok(results)
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -71,7 +71,7 @@ impl ReadableKeyValueStore<MemoryStoreError> for MemoryStore {
         Ok(map.contains_key(key))
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
         let map = self.map.read().await;
         Ok(keys
             .into_iter()

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -73,7 +73,10 @@ impl ReadableKeyValueStore<MemoryStoreError> for MemoryStore {
 
     async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
         let map = self.map.read().await;
-        Ok(keys.into_iter().map(|key| map.contains_key(&key)).collect::<Vec<_>>())
+        Ok(keys
+            .into_iter()
+            .map(|key| map.contains_key(&key))
+            .collect::<Vec<_>>())
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -71,6 +71,11 @@ impl ReadableKeyValueStore<MemoryStoreError> for MemoryStore {
         Ok(map.contains_key(key))
     }
 
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
+        let map = self.map.read().await;
+        Ok(keys.into_iter().map(|key| map.contains_key(&key)).collect::<Vec<_>>())
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -18,6 +18,7 @@ use crate::{
 pub struct KeyValueStoreMetrics {
     read_value_bytes: HistogramVec,
     contains_key: HistogramVec,
+    contain_keys: HistogramVec,
     read_multi_values_bytes: HistogramVec,
     find_keys_by_prefix: HistogramVec,
     find_key_values_by_prefix: HistogramVec,
@@ -67,6 +68,11 @@ impl KeyValueStoreMetrics {
         let contains_key = register_histogram_vec(&contains_key1, &contains_key2, &[], None)
             .expect("Counter creation should not fail");
 
+        let contain_keys1 = format!("{}_contain_keys", var_name);
+        let contain_keys2 = format!("{} contain keys", title_name);
+        let contain_keys = register_histogram_vec(&contain_keys1, &contain_keys2, &[], None)
+            .expect("Counter creation should not fail");
+
         let read_multi_values1 = format!("{}_read_multi_value_bytes", var_name);
         let read_multi_values2 = format!("{} read multi value bytes", title_name);
         let read_multi_values_bytes =
@@ -97,6 +103,7 @@ impl KeyValueStoreMetrics {
         KeyValueStoreMetrics {
             read_value_bytes,
             contains_key,
+            contain_keys,
             read_multi_values_bytes,
             find_keys_by_prefix,
             find_key_values_by_prefix,
@@ -135,6 +142,11 @@ where
     async fn contains_key(&self, key: &[u8]) -> Result<bool, E> {
         let _metric = self.counter.contains_key.measure_latency();
         self.store.contains_key(key).await
+    }
+
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E> {
+        let _metric = self.counter.contain_keys.measure_latency();
+        self.store.contain_keys(keys).await
     }
 
     async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, E> {

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -18,7 +18,7 @@ use crate::{
 pub struct KeyValueStoreMetrics {
     read_value_bytes: HistogramVec,
     contains_key: HistogramVec,
-    contain_keys: HistogramVec,
+    contains_keys: HistogramVec,
     read_multi_values_bytes: HistogramVec,
     find_keys_by_prefix: HistogramVec,
     find_key_values_by_prefix: HistogramVec,
@@ -68,9 +68,9 @@ impl KeyValueStoreMetrics {
         let contains_key = register_histogram_vec(&contains_key1, &contains_key2, &[], None)
             .expect("Counter creation should not fail");
 
-        let contain_keys1 = format!("{}_contain_keys", var_name);
-        let contain_keys2 = format!("{} contain keys", title_name);
-        let contain_keys = register_histogram_vec(&contain_keys1, &contain_keys2, &[], None)
+        let contains_keys1 = format!("{}_contains_keys", var_name);
+        let contains_keys2 = format!("{} contains keys", title_name);
+        let contains_keys = register_histogram_vec(&contains_keys1, &contains_keys2, &[], None)
             .expect("Counter creation should not fail");
 
         let read_multi_values1 = format!("{}_read_multi_value_bytes", var_name);
@@ -103,7 +103,7 @@ impl KeyValueStoreMetrics {
         KeyValueStoreMetrics {
             read_value_bytes,
             contains_key,
-            contain_keys,
+            contains_keys,
             read_multi_values_bytes,
             find_keys_by_prefix,
             find_key_values_by_prefix,
@@ -144,9 +144,9 @@ where
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E> {
-        let _metric = self.counter.contain_keys.measure_latency();
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E> {
+        let _metric = self.counter.contains_keys.measure_latency();
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, E> {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -103,7 +103,7 @@ impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStoreInternal {
         Ok(self.read_value_bytes(key).await?.is_some())
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, RocksDbStoreError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, RocksDbStoreError> {
         let size = keys.len();
         let mut results = vec![false; size];
         let mut handles = Vec::new();
@@ -434,8 +434,8 @@ impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStore {
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, RocksDbStoreError> {
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, RocksDbStoreError> {
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -8,6 +8,7 @@ use std::{
     sync::Arc,
 };
 
+use futures::future::join_all;
 use linera_base::ensure;
 use thiserror::Error;
 #[cfg(with_testing)]
@@ -100,6 +101,35 @@ impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStoreInternal {
             return Ok(false);
         }
         Ok(self.read_value_bytes(key).await?.is_some())
+    }
+
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, RocksDbStoreError> {
+        let size = keys.len();
+        let mut results = vec![false; size];
+        let mut handles = Vec::new();
+        for key in keys.clone() {
+            ensure!(key.len() <= MAX_KEY_SIZE, RocksDbStoreError::KeyTooLong);
+            let client = self.clone();
+            let handle = tokio::task::spawn_blocking(move || client.db.key_may_exist(&key));
+            handles.push(handle);
+        }
+        let may_results: Vec<_> = join_all(handles)
+            .await
+            .into_iter()
+            .collect::<Result<_, _>>()?;
+        let mut indices = Vec::new();
+        let mut keys_red = Vec::new();
+        for (i, key) in keys.into_iter().enumerate() {
+            if may_results[i] {
+                indices.push(i);
+                keys_red.push(key);
+            }
+        }
+        let values_red = self.read_multi_values_bytes(keys_red).await?;
+        for (index, value) in indices.into_iter().zip(values_red) {
+            results[index] = value.is_some();
+        }
+        Ok(results)
     }
 
     async fn read_multi_values_bytes(
@@ -402,6 +432,10 @@ impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStore {
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, RocksDbStoreError> {
         self.store.contains_key(key).await
+    }
+
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, RocksDbStoreError> {
+        self.store.contain_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -190,10 +190,9 @@ impl ScyllaDbClient {
         let mut rows = session.query_iter(read_multi_value, &unique_keys).await?;
         let mut values = vec![None; num_keys];
         while let Some(row) = rows.next().await {
-            let value = row?.into_typed::<(Vec<u8>, Vec<u8>)>()?;
-            let key = value.0;
+            let (key,value) = row?.into_typed::<(Vec<u8>, Vec<u8>)>()?;
             for i_key in map.get(&key).unwrap().clone() {
-                let value = Some(value.1.clone());
+                let value = Some(value.clone());
                 *values.get_mut(i_key).expect("an entry in values") = value;
             }
         }
@@ -235,8 +234,7 @@ impl ScyllaDbClient {
         let mut rows = session.query_iter(contains_keys, &unique_keys).await?;
         let mut values = vec![false; num_keys];
         while let Some(row) = rows.next().await {
-            let value = row?.into_typed::<(Vec<u8>,)>()?;
-            let key = value.0;
+            let (key,) = row?.into_typed::<(Vec<u8>,)>()?;
             for i_key in map.get(&key).unwrap().clone() {
                 *values.get_mut(i_key).expect("an entry in values") = true;
             }
@@ -320,8 +318,8 @@ impl ScyllaDbClient {
         };
         let mut keys = Vec::new();
         while let Some(row) = rows.next().await {
-            let key = row?.into_typed::<(Vec<u8>,)>()?;
-            let short_key = key.0[len..].to_vec();
+            let (key,) = row?.into_typed::<(Vec<u8>,)>()?;
+            let short_key = key[len..].to_vec();
             keys.push(short_key);
         }
         Ok(keys)
@@ -352,9 +350,9 @@ impl ScyllaDbClient {
         };
         let mut key_values = Vec::new();
         while let Some(row) = rows.next().await {
-            let key = row?.into_typed::<(Vec<u8>, Vec<u8>)>()?;
-            let short_key = key.0[len..].to_vec();
-            key_values.push((short_key, key.1));
+            let (key, value) = row?.into_typed::<(Vec<u8>, Vec<u8>)>()?;
+            let short_key = key[len..].to_vec();
+            key_values.push((short_key, value));
         }
         Ok(key_values)
     }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -190,7 +190,7 @@ impl ScyllaDbClient {
         let mut rows = session.query_iter(read_multi_value, &unique_keys).await?;
         let mut values = vec![None; num_keys];
         while let Some(row) = rows.next().await {
-            let (key,value) = row?.into_typed::<(Vec<u8>, Vec<u8>)>()?;
+            let (key, value) = row?.into_typed::<(Vec<u8>, Vec<u8>)>()?;
             for i_key in map.get(&key).unwrap().clone() {
                 let value = Some(value.clone());
                 *values.get_mut(i_key).expect("an entry in values") = value;

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -200,7 +200,7 @@ impl ScyllaDbClient {
         Ok(values)
     }
 
-    async fn contain_keys_internal(
+    async fn contains_keys_internal(
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<bool>, ScyllaDbStoreError> {
@@ -231,8 +231,8 @@ impl ScyllaDbClient {
             "SELECT k FROM kv.{} WHERE dummy = 0 AND k IN ({}) ALLOW FILTERING",
             self.namespace, group_query
         );
-        let contain_keys = Query::new(query);
-        let mut rows = session.query_iter(contain_keys, &unique_keys).await?;
+        let contains_keys = Query::new(query);
+        let mut rows = session.query_iter(contains_keys, &unique_keys).await?;
         let mut values = vec![false; num_keys];
         while let Some(row) = rows.next().await {
             let value = row?.into_typed::<(Vec<u8>,)>()?;
@@ -458,7 +458,7 @@ impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStoreInternal {
         store.contains_key_internal(key.to_vec()).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ScyllaDbStoreError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ScyllaDbStoreError> {
         if keys.is_empty() {
             return Ok(Vec::new());
         }
@@ -466,7 +466,7 @@ impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStoreInternal {
         let _guard = self.acquire().await;
         let handles = keys
             .chunks(MAX_MULTI_KEYS)
-            .map(|keys| store.contain_keys_internal(keys.to_vec()));
+            .map(|keys| store.contains_keys_internal(keys.to_vec()));
         let results: Vec<_> = join_all(handles)
             .await
             .into_iter()
@@ -785,8 +785,8 @@ impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ScyllaDbStoreError> {
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ScyllaDbStoreError> {
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -200,7 +200,10 @@ impl ScyllaDbClient {
         Ok(values)
     }
 
-    async fn contain_keys_internal(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ScyllaDbStoreError> {
+    async fn contain_keys_internal(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<bool>, ScyllaDbStoreError> {
         let num_keys = keys.len();
         if num_keys == 0 {
             return Ok(Vec::new());

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -315,7 +315,7 @@ pub async fn run_reads<S: LocalKeyValueStore>(store: S, key_values: Vec<(Vec<u8>
             test_exists.push(store.contains_key(key).await.unwrap());
             values_single_read.push(store.read_value_bytes(key).await.unwrap());
         }
-        let test_exists_direct = store.contain_keys(keys.clone()).await.unwrap();
+        let test_exists_direct = store.contains_keys(keys.clone()).await.unwrap();
         let values_read = store.read_multi_values_bytes(keys).await.unwrap();
         assert_eq!(values, values_read);
         assert_eq!(values, values_single_read);

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -315,11 +315,13 @@ pub async fn run_reads<S: LocalKeyValueStore>(store: S, key_values: Vec<(Vec<u8>
             test_exists.push(store.contains_key(key).await.unwrap());
             values_single_read.push(store.read_value_bytes(key).await.unwrap());
         }
+        let test_exists_direct = store.contain_keys(keys.clone()).await.unwrap();
         let values_read = store.read_multi_values_bytes(keys).await.unwrap();
         assert_eq!(values, values_read);
         assert_eq!(values, values_single_read);
         let values_read_stat = values_read.iter().map(|x| x.is_some()).collect::<Vec<_>>();
         assert_eq!(values_read_stat, test_exists);
+        assert_eq!(values_read_stat, test_exists_direct);
     }
 }
 

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -95,11 +95,14 @@ where
     }
 
     async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
-        let big_keys = keys.into_iter().map(|key| {
-            let mut big_key = key.clone();
-            big_key.extend(&[0, 0, 0, 0]);
-            big_key
-        }).collect::<Vec<_>>();
+        let big_keys = keys
+            .into_iter()
+            .map(|key| {
+                let mut big_key = key.clone();
+                big_key.extend(&[0, 0, 0, 0]);
+                big_key
+            })
+            .collect::<Vec<_>>();
         self.store.contain_keys(big_keys).await
     }
 

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -94,7 +94,7 @@ where
         self.store.contains_key(&big_key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
         let big_keys = keys
             .into_iter()
             .map(|key| {
@@ -103,7 +103,7 @@ where
                 big_key
             })
             .collect::<Vec<_>>();
-        self.store.contain_keys(big_keys).await
+        self.store.contains_keys(big_keys).await
     }
 
     async fn read_multi_values_bytes(
@@ -368,8 +368,8 @@ impl ReadableKeyValueStore<MemoryStoreError> for TestMemoryStoreInternal {
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(
@@ -454,8 +454,8 @@ impl ReadableKeyValueStore<MemoryStoreError> for TestMemoryStore {
         self.store.contains_key(key).await
     }
 
-    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
-        self.store.contain_keys(keys).await
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
+        self.store.contains_keys(keys).await
     }
 
     async fn read_multi_values_bytes(

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -94,6 +94,15 @@ where
         self.store.contains_key(&big_key).await
     }
 
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
+        let big_keys = keys.into_iter().map(|key| {
+            let mut big_key = key.clone();
+            big_key.extend(&[0, 0, 0, 0]);
+            big_key
+        }).collect::<Vec<_>>();
+        self.store.contain_keys(big_keys).await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -356,6 +365,10 @@ impl ReadableKeyValueStore<MemoryStoreError> for TestMemoryStoreInternal {
         self.store.contains_key(key).await
     }
 
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
+        self.store.contain_keys(keys).await
+    }
+
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
@@ -436,6 +449,10 @@ impl ReadableKeyValueStore<MemoryStoreError> for TestMemoryStore {
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, MemoryStoreError> {
         self.store.contains_key(key).await
+    }
+
+    async fn contain_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
+        self.store.contain_keys(keys).await
     }
 
     async fn read_multi_values_bytes(


### PR DESCRIPTION
## Motivation

It has emerged from code inspection that several `contains_key` operations can be grouped together to
bring speed improvement to the code. This PR introduces the trait function. The use in the code will come
in later PRs.

## Proposal

The implementation was done in a very straightforward way and without difficulties considering
that we already have the `contains_key` and the `read_multi_values_bytes` functions.

## Test Plan

For the test, only a few lines were added to the `run_reads` function that does the job in question.

## Release Plan

The documentation will need to be updated.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
