### PR TITLE
Implement the `multi_get` for the `MapView`-

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -58,7 +58,7 @@ impl DeletionPrefixes {
     }
 
     pub fn rollback(&mut self) {
-        self.delete_storage_first = true;
+        self.delete_storage_first = false;
         self.deleted_prefixes.clear();
     }
 

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -41,6 +41,46 @@ pub(crate) enum Update<T> {
     Set(T),
 }
 
+pub(crate) struct DeletionPrefixes {
+    delete_storage_first: bool,
+    deleted_prefixes: BTreeSet<Vec<u8>>,
+}
+
+impl DeletionPrefixes {
+    fn clear(&mut self) {
+        self.delete_storage_first = true;
+        self.deleted_prefixes.clear();
+    }
+
+    fn rollback(&mut self) {
+        self.delete_storage_first = true;
+        self.deleted_prefixes.clear();
+    }
+
+    fn contains_key(&self, index: &[u8]) -> bool {
+        if self.delete_storage_first {
+            return true;
+        }
+        contains_key(&self.deleted_prefixes, index)
+    }
+
+    fn has_pending_change(&self) -> bool {
+    	if self.delete_storage_first {
+            return true;
+        }
+        !self.deleted_prefixes.is_empty()
+    }
+
+    fn insert_key_prefix(&mut self, key_prefix: Vec<u8>) {
+        if !self.delete_storage_first {
+            insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
+        }
+    }
+}
+
+
+
+
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone)]
 pub struct CommonStoreConfig {

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -41,37 +41,42 @@ pub(crate) enum Update<T> {
     Set(T),
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct DeletionPrefixes {
-    delete_storage_first: bool,
-    deleted_prefixes: BTreeSet<Vec<u8>>,
+    pub delete_storage_first: bool,
+    pub deleted_prefixes: BTreeSet<Vec<u8>>,
 }
 
 impl DeletionPrefixes {
-    fn clear(&mut self) {
+    pub fn new() -> Self {
+        Self { delete_storage_first: false, deleted_prefixes: BTreeSet::new() }
+    }
+
+    pub fn clear(&mut self) {
         self.delete_storage_first = true;
         self.deleted_prefixes.clear();
     }
 
-    fn rollback(&mut self) {
+    pub fn rollback(&mut self) {
         self.delete_storage_first = true;
         self.deleted_prefixes.clear();
     }
 
-    fn contains_key(&self, index: &[u8]) -> bool {
+    pub fn contains_key(&self, index: &[u8]) -> bool {
         if self.delete_storage_first {
             return true;
         }
         contains_key(&self.deleted_prefixes, index)
     }
 
-    fn has_pending_change(&self) -> bool {
+    pub fn has_pending_changes(&self) -> bool {
     	if self.delete_storage_first {
             return true;
         }
         !self.deleted_prefixes.is_empty()
     }
 
-    fn insert_key_prefix(&mut self, key_prefix: Vec<u8>) {
+    pub fn insert_key_prefix(&mut self, key_prefix: Vec<u8>) {
         if !self.delete_storage_first {
             insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
         }

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -49,7 +49,10 @@ pub(crate) struct DeletionPrefixes {
 
 impl DeletionPrefixes {
     pub fn new() -> Self {
-        Self { delete_storage_first: false, deleted_prefixes: BTreeSet::new() }
+        Self {
+            delete_storage_first: false,
+            deleted_prefixes: BTreeSet::new(),
+        }
     }
 
     pub fn clear(&mut self) {
@@ -70,7 +73,7 @@ impl DeletionPrefixes {
     }
 
     pub fn has_pending_changes(&self) -> bool {
-    	if self.delete_storage_first {
+        if self.delete_storage_first {
             return true;
         }
         !self.deleted_prefixes.is_empty()
@@ -82,9 +85,6 @@ impl DeletionPrefixes {
         }
     }
 }
-
-
-
 
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone)]

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -1,12 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::BTreeMap,
-    fmt::Debug,
-    mem,
-    ops::Bound::Included,
-};
+use std::{collections::BTreeMap, fmt::Debug, mem, ops::Bound::Included};
 
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -22,9 +17,9 @@ use {
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        from_bytes_option, from_bytes_option_or_default, get_interval,
-        get_upper_bound, Context, DeletionPrefixes, HasherOutput, KeyIterable, KeyValueIterable,
-        SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
+        from_bytes_option, from_bytes_option_or_default, get_interval, get_upper_bound, Context,
+        DeletionPrefixes, HasherOutput, KeyIterable, KeyValueIterable, SuffixClosedSetIterator,
+        Update, MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
@@ -354,7 +349,8 @@ where
         let mut updates = self.updates.iter();
         let mut update = updates.next();
         if !self.delete_prefixes.delete_storage_first {
-            let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
             for index in self
                 .context
                 .find_keys_by_prefix(&key_prefix)
@@ -453,7 +449,8 @@ where
         let mut updates = self.updates.iter();
         let mut update = updates.next();
         if !self.delete_prefixes.delete_storage_first {
-            let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
             for entry in self
                 .context
                 .find_key_values_by_prefix(&key_prefix)
@@ -867,7 +864,8 @@ where
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
         if !self.delete_prefixes.delete_storage_first {
-            let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
             for key in self
                 .context
                 .find_keys_by_prefix(&key_prefix_full)
@@ -940,7 +938,8 @@ where
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
         if !self.delete_prefixes.delete_storage_first {
-            let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.delete_prefixes.deleted_prefixes.iter());
             for entry in self
                 .context
                 .find_key_values_by_prefix(&key_prefix_full)

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -97,7 +97,7 @@ where
 
     fn rollback(&mut self) {
         self.updates.clear();
-        self.delete_prefixes.clear();
+        self.delete_prefixes.rollback();
     }
 
     async fn has_pending_changes(&self) -> bool {
@@ -1457,6 +1457,7 @@ where
     /// # use crate::linera_views::views::View;
     /// # let context = create_memory_context();
     ///   let mut map : CustomMapView<MemoryContext<()>, u128, String> = CustomMapView::load(context).await.unwrap();
+    ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   let keys = vec![34 as u128, 37 as u128];
     ///   let values = map.multi_get(&keys).await.unwrap();
     ///   assert_eq!(values, vec![Some(String::from("Hello")), None]);


### PR DESCRIPTION
## Motivation

The `MapView` has a natural usage for the `multi_get` operation. This PR implements it.

## Proposal

The following was done:
* The `multi_get` was implemented for the `MapView`.
* The `DeltionPrefix` was introduced to simplify the pairs `delete_storage_first / deleted_prefixes` pairs in `KeyValueStoreView` and `MapView`.

## Test Plan

The tests were added to the random checks.

## Release Plan

The unit tests have been added adequately to the code.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
