### PR TITLE
Unfreeze time in long-lived service tests

### DIFF
--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3676,7 +3676,7 @@ where
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
-#[test_log::test(tokio::test(start_paused = true))]
+#[test_log::test(tokio::test)]
 async fn test_long_lived_service<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
@@ -3755,7 +3755,7 @@ where
 #[cfg_attr(feature = "rocksdb", test_case(RocksDbStorageBuilder::new().await; "rocks_db"))]
 #[cfg_attr(feature = "dynamodb", test_case(DynamoDbStorageBuilder::default(); "dynamo_db"))]
 #[cfg_attr(feature = "scylladb", test_case(ScyllaDbStorageBuilder::default(); "scylla_db"))]
-#[test_log::test(tokio::test(start_paused = true))]
+#[test_log::test(tokio::test)]
 async fn test_new_block_causes_service_restart<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3740,6 +3740,7 @@ where
         );
     }
 
+    // TODO(#2249): Split the assertion in two
     drop(worker);
     tokio::time::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();
@@ -3901,6 +3902,7 @@ where
         );
     }
 
+    // TODO(#2249): Split the assertion in two
     drop(worker);
     tokio::time::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3741,7 +3741,7 @@ where
     }
 
     drop(worker);
-    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();
 
     Ok(())
@@ -3902,7 +3902,7 @@ where
     }
 
     drop(worker);
-    tokio::task::yield_now().await;
+    tokio::time::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();
 
     Ok(())


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
After #2216 was merged, the Scylla DB tests in CI started failing on main. This happens because the test uses Tokio's paused time feature, where the clock is advanced as much as possible every time the workers become idle. This means that all timeouts fire immediately after a real packet is sent over the network, because the workers become idle while waiting for the response.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Don't pause time in the new tests.

## Test Plan

<!-- How to test that the changes are correct. -->
This fixes some tests in CI, so CI should pass with this PR.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because it only changes two tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
