### PR TITLE
Cache the LLM model inside the service

### DIFF
--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -13,9 +13,12 @@ CAVEAT:
   ([#1981](https://github.com/linera-io/linera-protocol/issues/1981)) or in an external
   decentralized storage.
 
-* We should also not download the model at every query ([#1999](https://github.com/linera-io/linera-protocol/issues/1999)).
-
 * Running larger LLMs with acceptable performance will likely require hardware acceleration ([#1931](https://github.com/linera-io/linera-protocol/issues/1931)).
+
+* The service currently is restarted when the wallet receives a new block for the chain where the
+  application is running from. That means it fetches the model again, which is inefficient. The
+  service should be allowed to continue executing in that case
+  ([#2160](https://github.com/linera-io/linera-protocol/issues/2160)).
 
 
 # How It Works
@@ -26,8 +29,8 @@ at `model.bin` and `tokenizer.json`.
 The application's service exposes a single GraphQL field called `prompt` which takes a prompt
 as input and returns a response.
 
-When a prompt is submitted, the application's service uses the `fetch_url`
-system API to inject the model and tokenizer. Subsequently, the model bytes are converted
+When the first prompt is submitted, the application's service uses the `fetch_url`
+system API to fetch the model and tokenizer. Subsequently, the model bytes are converted
 to the GGUF format where it can be used for inference.
 
 # Usage

--- a/examples/llm/src/lib.rs
+++ b/examples/llm/src/lib.rs
@@ -15,9 +15,12 @@ CAVEAT:
   ([#1981](https://github.com/linera-io/linera-protocol/issues/1981)) or in an external
   decentralized storage.
 
-* We should also not download the model at every query ([#1999](https://github.com/linera-io/linera-protocol/issues/1999)).
-
 * Running larger LLMs with acceptable performance will likely require hardware acceleration ([#1931](https://github.com/linera-io/linera-protocol/issues/1931)).
+
+* The service currently is restarted when the wallet receives a new block for the chain where the
+  application is running from. That means it fetches the model again, which is inefficient. The
+  service should be allowed to continue executing in that case
+  ([#2160](https://github.com/linera-io/linera-protocol/issues/2160)).
 
 
 # How It Works
@@ -28,8 +31,8 @@ at `model.bin` and `tokenizer.json`.
 The application's service exposes a single GraphQL field called `prompt` which takes a prompt
 as input and returns a response.
 
-When a prompt is submitted, the application's service uses the `fetch_url`
-system API to inject the model and tokenizer. Subsequently, the model bytes are converted
+When the first prompt is submitted, the application's service uses the `fetch_url`
+system API to fetch the model and tokenizer. Subsequently, the model bytes are converted
 to the GGUF format where it can be used for inference.
 
 # Usage


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
With the recent support to keep services running across queries (PR #2216), the LLM application can be optimized to not have to fetch the model weights on every query.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Fetch the model when the service is created, and reuse it in every query.

## Test Plan

<!-- How to test that the changes are correct. -->
Tested manually, and saw an expected decrease in latency after the first query (for which the service is initially created).

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because only changes an example application.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
