### PR TITLE
use CryptoHash instead of ChainAndHeight in received_log

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -35,8 +35,8 @@ use {linera_base::identifiers::BytecodeId, linera_execution::BytecodeLocation};
 
 use crate::{
     data_types::{
-        Block, BlockExecutionOutcome, ChainAndHeight, ChannelFullName, Event, EventRecord,
-        IncomingMessage, MessageAction, MessageBundle, Origin, OutgoingMessage, Target,
+        Block, BlockExecutionOutcome, ChannelFullName, Event, EventRecord, IncomingMessage,
+        MessageAction, MessageBundle, Origin, OutgoingMessage, Target,
     },
     inbox::{Cursor, InboxError, InboxStateView},
     manager::ChainManager,
@@ -252,8 +252,8 @@ where
     /// Hashes of all certified blocks for this sender.
     /// This ends with `block_hash` and has length `usize::from(next_block_height)`.
     pub confirmed_log: LogView<C, CryptoHash>,
-    /// Sender chain and height of all certified blocks known as a receiver (local ordering).
-    pub received_log: LogView<C, ChainAndHeight>,
+    /// The hash of all the certified blocks known as a receiver (local ordering).
+    pub received_log: LogView<C, CryptoHash>,
 
     /// Mailboxes used to receive messages indexed by their origin.
     pub inboxes: ReentrantCollectionView<C, Origin, InboxStateView<C>>,
@@ -630,10 +630,7 @@ where
             }
         }
         // Remember the certificate for future validator/client synchronizations.
-        self.received_log.push(ChainAndHeight {
-            chain_id: origin.sender,
-            height: bundle.height,
-        });
+        self.received_log.push(bundle.hash);
         Ok(())
     }
 

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -94,13 +94,6 @@ impl Block {
     }
 }
 
-/// A chain ID with a block height.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, SimpleObject)]
-pub struct ChainAndHeight {
-    pub chain_id: ChainId,
-    pub height: BlockHeight,
-}
-
 /// A message received from a block of another chain.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
 pub struct IncomingMessage {

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -10,7 +10,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_chain::{
-    data_types::{ChainAndHeight, IncomingMessage, Medium, MessageBundle},
+    data_types::{IncomingMessage, Medium, MessageBundle},
     manager::ChainManagerInfo,
     ChainStateView,
 };
@@ -162,7 +162,7 @@ pub struct ChainInfo {
     /// The current number of received certificates (useful for `request_received_log_excluding_first_nth`)
     pub count_received_log: usize,
     /// The response to `request_received_certificates_excluding_first_nth`
-    pub requested_received_log: Vec<ChainAndHeight>,
+    pub requested_received_log: Vec<CryptoHash>,
 }
 
 /// The response to an `ChainInfoQuery`

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -9,6 +9,7 @@ use futures::{
     lock::{Mutex, MutexGuard},
 };
 use linera_base::{
+    crypto::CryptoHash,
     data_types::{ArithmeticError, Blob, BlockHeight, HashedBlob},
     identifiers::{BlobId, ChainId, MessageId},
 };
@@ -186,6 +187,12 @@ where
     pub(crate) async fn storage_client(&self) -> S {
         let node = self.lock_node().await;
         node.state.storage_client().clone()
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub(crate) async fn has_certificate(&self, hash: CryptoHash) -> Result<bool, LocalNodeError> {
+        let client = self.storage_client().await;
+        Ok(client.contains_certificate(hash).await?)
     }
 }
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -25,8 +25,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        Block, BlockExecutionOutcome, BlockProposal, Certificate, ChainAndHeight, ChannelFullName,
-        Event, HashedCertificateValue, IncomingMessage, LiteVote, Medium, MessageAction, Origin,
+        Block, BlockExecutionOutcome, BlockProposal, Certificate, ChannelFullName, Event,
+        HashedCertificateValue, IncomingMessage, LiteVote, Medium, MessageAction, Origin,
         OutgoingMessage, SignatureAggregator,
     },
     test::{make_child_block, make_first_block, BlockTestExt, VoteTestExt},
@@ -1850,7 +1850,7 @@ where
         })
     );
 
-    let certificate = make_simple_transfer_certificate(
+    let transfer_certificate = make_simple_transfer_certificate(
         ChainDescription::Root(1),
         &sender_key_pair,
         ChainId::root(2),
@@ -1864,13 +1864,13 @@ where
     .await;
 
     let info = worker
-        .fully_handle_certificate(certificate.clone(), vec![], vec![])
+        .fully_handle_certificate(transfer_certificate.clone(), vec![], vec![])
         .await?
         .info;
     assert_eq!(ChainId::root(1), info.chain_id);
     assert_eq!(Amount::ZERO, info.chain_balance);
     assert_eq!(BlockHeight::from(1), info.next_block_height);
-    assert_eq!(Some(certificate.hash()), info.block_hash);
+    assert_eq!(Some(transfer_certificate.hash()), info.block_hash);
     assert!(info.manager.pending.is_none());
     assert_eq!(
         worker
@@ -1891,7 +1891,7 @@ where
         vec![IncomingMessage {
             origin: Origin::chain(ChainId::root(1)),
             event: Event {
-                certificate_hash: certificate.hash(),
+                certificate_hash: transfer_certificate.hash(),
                 height: BlockHeight::ZERO,
                 index: 0,
                 authenticated_signer: None,
@@ -1950,10 +1950,7 @@ where
     assert_eq!(response.info.requested_received_log.len(), 1);
     assert_eq!(
         response.info.requested_received_log[0],
-        ChainAndHeight {
-            chain_id: ChainId::root(1),
-            height: BlockHeight::ZERO
-        }
+        transfer_certificate.hash()
     );
     Ok(())
 }

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -93,10 +93,7 @@ query Chain(
       entries
     }
     receivedLog {
-      entries {
-        chainId
-        height
-      }
+      entries
     }
     inboxes {
       keys

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -144,14 +144,6 @@ type CertificateValue {
 }
 
 """
-A chain ID with a block height.
-"""
-type ChainAndHeight {
-	chainId: ChainId!
-	height: BlockHeight!
-}
-
-"""
 How to create a chain
 """
 scalar ChainDescription
@@ -195,9 +187,9 @@ type ChainStateExtendedView {
 	"""
 	confirmedLog: LogView_CryptoHash_b0541e41!
 	"""
-	Sender chain and height of all certified blocks known as a receiver (local ordering).
+	The hash of all the certified blocks known as a receiver (local ordering).
 	"""
-	receivedLog: LogView_ChainAndHeight_de85b393!
+	receivedLog: LogView_CryptoHash_b0541e41!
 	"""
 	Mailboxes used to receive messages indexed by their origin.
 	"""
@@ -495,10 +487,6 @@ type IncomingMessage {
 A scalar that can represent any JSON Object value.
 """
 scalar JSONObject
-
-type LogView_ChainAndHeight_de85b393 {
-	entries(start: Int, end: Int): [ChainAndHeight!]!
-}
 
 type LogView_CryptoHash_b0541e41 {
 	entries(start: Int, end: Int): [CryptoHash!]!

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -187,7 +187,6 @@ pub trait Storage: Sized {
     {
         let mut tasks = Vec::new();
         for key in keys {
-            // TODO: remove clone using scoped threads
             let client = self.clone();
             tasks.push(tokio::task::spawn(async move {
                 client.read_certificate(key).await


### PR DESCRIPTION
## Motivation

* Simplify code
* Reduce storage
* Avoid querying a `ChainStateView` in the local node (possibly more congested than storage) when we're downloading certificates
* Make parallel downloads slightly easier in the future

## Proposal

Use `CryptoHash` instead of `ChainAndHeight` in `received_log`.

Possible drawbacks:
* Cleaning up certificates from client storage in the future is still possible but it will require an index of all executed certificates by hash. Such an index could be larger than maintaining the height of each chain.
* The changes make it harder for a client to blacklist certain sender chains (i.e. refuse to synchronize their certificates and reject all their messages). This may require bringing back the chain ID of the senders in the `received_log`.

## Test Plan

CI

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
