### PR TITLE
Fix `ReentrantCollectionView::has_pending` returning `true` if it has cached but unchanged entries

### DIFF
--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -76,9 +76,13 @@ impl<T> std::ops::DerefMut for WriteGuardedView<T> {
 #[derive(Debug)]
 #[allow(clippy::type_complexity)]
 pub struct ReentrantByteCollectionView<C, W> {
+    /// The view [`Context`].
     context: C,
+    /// If the current persisted data will be completely erased and replaced on the next flush.
     delete_storage_first: bool,
+    /// Entries that may have staged changes.
     updates: BTreeMap<Vec<u8>, Update<Arc<RwLock<W>>>>,
+    /// Entries cached in memory that have the exact same state as in the persistent storage.
     cached_entries: Mutex<BTreeMap<Vec<u8>, Arc<RwLock<W>>>>,
 }
 

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -533,14 +533,14 @@ where
             }
         }
         let values = self.context.read_multi_values_bytes(keys).await?;
-        for (i_key, short_key) in short_keys_to_load.iter().enumerate() {
+        for (load_index, short_key) in short_keys_to_load.iter().enumerate() {
             let key = self
                 .context
                 .base_tag_index(KeyTag::Subview as u8, short_key);
             let context = self.context.clone_with_base_key(key);
             let view = W::post_load(
                 context,
-                &values[i_key * num_init_keys..(i_key + 1) * num_init_keys],
+                &values[load_index * num_init_keys..(load_index + 1) * num_init_keys],
             )?;
             let wrapped_view = Arc::new(RwLock::new(view));
             self.updates
@@ -688,14 +688,14 @@ where
             }
             let values = self.context.read_multi_values_bytes(keys).await?;
             let num_init_keys = W::NUM_INIT_KEYS;
-            for (i_key, short_key) in short_keys_to_load.into_iter().enumerate() {
+            for (load_index, short_key) in short_keys_to_load.into_iter().enumerate() {
                 let key = self
                     .context
                     .base_tag_index(KeyTag::Subview as u8, &short_key);
                 let context = self.context.clone_with_base_key(key);
                 let view = W::post_load(
                     context,
-                    &values[i_key * num_init_keys..(i_key + 1) * num_init_keys],
+                    &values[load_index * num_init_keys..(load_index + 1) * num_init_keys],
                 )?;
                 let wrapped_view = Arc::new(RwLock::new(view));
                 cached_entries.insert(short_key.to_vec(), wrapped_view);
@@ -760,14 +760,14 @@ where
             }
             let values = self.context.read_multi_values_bytes(keys).await?;
             let num_init_keys = W::NUM_INIT_KEYS;
-            for (i_key, short_key) in short_keys_to_load.into_iter().enumerate() {
+            for (load_index, short_key) in short_keys_to_load.into_iter().enumerate() {
                 let key = self
                     .context
                     .base_tag_index(KeyTag::Subview as u8, &short_key);
                 let context = self.context.clone_with_base_key(key);
                 let view = W::post_load(
                     context,
-                    &values[i_key * num_init_keys..(i_key + 1) * num_init_keys],
+                    &values[load_index * num_init_keys..(load_index + 1) * num_init_keys],
                 )?;
                 let wrapped_view = Arc::new(RwLock::new(view));
                 self.updates

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -378,7 +378,7 @@ async fn test_clearing_of_cached_stored_hash() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Check if a [`ReentrantCollectionView`] doesn't have pending changes after loading its
+/// Checks if a [`ReentrantCollectionView`] doesn't have pending changes after loading its
 /// entries.
 #[tokio::test]
 async fn test_reentrant_collection_view_has_no_pending_changes_after_try_load_entries(

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -462,6 +462,49 @@ async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entry
     Ok(())
 }
 
+/// Check if a acquiring multiple write-locks to sub-views causes the collection to have pending
+/// changes.
+#[tokio::test]
+async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entries_mut(
+) -> anyhow::Result<()> {
+    let context = create_memory_context();
+    let values = [
+        (1, "first".to_owned()),
+        (2, "second".to_owned()),
+        (3, "third".to_owned()),
+        (4, "fourth".to_owned()),
+    ];
+    let mut view =
+        ReentrantCollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
+
+    populate_reentrant_collection_view(&mut view, values.clone()).await?;
+    save_view(&context, &mut view).await?;
+    assert!(!view.has_pending_changes().await);
+
+    let entries = view.try_load_entries([&2, &3]).await?;
+    assert_eq!(entries.len(), 2);
+    assert!(entries[0].is_some());
+    assert!(entries[1].is_some());
+    assert_eq!(entries[0].as_ref().unwrap().get(), &values[1].1);
+    assert_eq!(entries[1].as_ref().unwrap().get(), &values[2].1);
+    assert!(!entries[0].as_ref().unwrap().has_pending_changes().await);
+    assert!(!entries[1].as_ref().unwrap().has_pending_changes().await);
+
+    assert!(!view.has_pending_changes().await);
+
+    drop(entries);
+    let entries = view.try_load_entries_mut([&2, &3]).await?;
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].get(), &values[1].1);
+    assert_eq!(entries[1].get(), &values[2].1);
+    assert!(!entries[0].has_pending_changes().await);
+    assert!(!entries[1].has_pending_changes().await);
+
+    assert!(view.has_pending_changes().await);
+
+    Ok(())
+}
+
 /// Saves a [`View`] into the [`MemoryContext<()>`] storage simulation.
 async fn save_view<C>(context: &C, view: &mut impl View<C>) -> anyhow::Result<()>
 where

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -406,6 +406,30 @@ async fn test_reentrant_collection_view_has_no_pending_changes_after_try_load_en
     Ok(())
 }
 
+/// Check if a [`ReentrantCollectionView`] has pending changes after adding an entry.
+#[tokio::test]
+async fn test_reentrant_collection_view_has_pending_changes_after_new_entry() -> anyhow::Result<()>
+{
+    let context = create_memory_context();
+    let values = [(1, "first".to_owned()), (2, "second".to_owned())];
+    let mut view =
+        ReentrantCollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
+
+    populate_reentrant_collection_view(&mut view, values.clone()).await?;
+    save_view(&context, &mut view).await?;
+    assert!(!view.has_pending_changes().await);
+
+    {
+        let entry = view.try_load_entry_mut(&3).await?;
+        assert_eq!(entry.get(), "");
+        assert!(!entry.has_pending_changes().await);
+    }
+
+    assert!(view.has_pending_changes().await);
+
+    Ok(())
+}
+
 /// Saves a [`View`] into the [`MemoryContext<()>`] storage simulation.
 async fn save_view<C>(context: &C, view: &mut impl View<C>) -> anyhow::Result<()>
 where


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
CI failed with PR #2273. The investigation showed that `ReentrantCollectionView::has_pending_changes` returns `true` if there was a previous call to `ReentrantCollectionView::try_load_entries`.

This happens because `has_pending_changes` checks if its `updates` map is empty, but `try_load_entries` needs to insert loaded entries into the map in order to ensure that they are safely accessed.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Keep track of the entries that have been loaded from disk but are unchanged, using a separate `BTreeMap`.

## Test Plan

<!-- How to test that the changes are correct. -->
A few of unit tests were added to reproduce the issue. The first test fails before this PR and passes with this PR, and the other two tests cover bugs temporarily introduced while implementing the proposed fix.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
