### PR TITLE
Remove the `try_load_entry_or_insert` from the `ReentrantCollectionView`.

### DIFF
--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::fmt::format::FmtSpan;
 
 fn fmt_span_from_str(events: &str) -> FmtSpan {
     let mut fmt_span = FmtSpan::NONE;
-    for event in events.split(",") {
+    for event in events.split(',') {
         fmt_span |= match event {
             "new" => FmtSpan::NEW,
             "enter" => FmtSpan::ENTER,

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -539,7 +539,7 @@ where
                 Some(event) => Ok(Some(event.height)),
                 None => Ok(None),
             },
-            None => Ok(None)
+            None => Ok(None),
         }
     }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -519,7 +519,7 @@ where
     }
 
     pub async fn next_block_height_to_receive(
-        &mut self,
+        &self,
         origin: &Origin,
     ) -> Result<BlockHeight, ChainError> {
         let inbox = self.inboxes.try_load_entry(origin).await?;
@@ -530,7 +530,7 @@ where
     }
 
     pub async fn last_anticipated_block_height(
-        &mut self,
+        &self,
         origin: &Origin,
     ) -> Result<Option<BlockHeight>, ChainError> {
         let inbox = self.inboxes.try_load_entry(origin).await?;

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -522,18 +522,24 @@ where
         &mut self,
         origin: &Origin,
     ) -> Result<BlockHeight, ChainError> {
-        let inbox = self.inboxes.try_load_entry_or_insert(origin).await?;
-        inbox.next_block_height_to_receive()
+        let inbox = self.inboxes.try_load_entry(origin).await?;
+        match inbox {
+            Some(inbox) => inbox.next_block_height_to_receive(),
+            None => Ok(BlockHeight::from(0)),
+        }
     }
 
     pub async fn last_anticipated_block_height(
         &mut self,
         origin: &Origin,
     ) -> Result<Option<BlockHeight>, ChainError> {
-        let inbox = self.inboxes.try_load_entry_or_insert(origin).await?;
-        match inbox.removed_events.back().await? {
-            Some(event) => Ok(Some(event.height)),
-            None => Ok(None),
+        let inbox = self.inboxes.try_load_entry(origin).await?;
+        match inbox {
+            Some(inbox) => match inbox.removed_events.back().await? {
+                Some(event) => Ok(Some(event.height)),
+                None => Ok(None),
+            },
+            None => Ok(None)
         }
     }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -186,22 +186,28 @@ where
 
             ContainsKey { id, key, callback } => {
                 let view = self.users.try_load_entry(&id).await?;
-                let view = view.unwrap();
-                let result = view.contains_key(&key).await?;
+                let result = match view {
+                    Some(view) => view.contains_key(&key).await?,
+                    None => false,
+                };
                 callback.respond(result);
             }
 
             ReadMultiValuesBytes { id, keys, callback } => {
                 let view = self.users.try_load_entry(&id).await?;
-                let view = view.unwrap();
-                let values = view.multi_get(keys).await?;
+                let values = match view {
+                    Some(view) => view.multi_get(keys).await?,
+                    None => vec![None; keys.len()],
+                };
                 callback.respond(values);
             }
 
             ReadValueBytes { id, key, callback } => {
                 let view = self.users.try_load_entry(&id).await?;
-                let view = view.unwrap();
-                let result = view.get(&key).await?;
+                let result = match view {
+                    Some(view) => view.get(&key).await?,
+                    None => None,
+                };
                 callback.respond(result);
             }
 
@@ -211,8 +217,10 @@ where
                 callback,
             } => {
                 let view = self.users.try_load_entry(&id).await?;
-                let view = view.unwrap();
-                let result = view.find_keys_by_prefix(&key_prefix).await?;
+                let result = match view {
+                    Some(view) => view.find_keys_by_prefix(&key_prefix).await?,
+                    None => Vec::new()
+                };
                 callback.respond(result);
             }
 
@@ -222,8 +230,10 @@ where
                 callback,
             } => {
                 let view = self.users.try_load_entry(&id).await?;
-                let view = view.unwrap();
-                let result = view.find_key_values_by_prefix(&key_prefix).await?;
+                let result = match view {
+                    Some(view) => view.find_key_values_by_prefix(&key_prefix).await?,
+                    None => Vec::new(),
+                };
                 callback.respond(result);
             }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -185,19 +185,22 @@ where
             }
 
             ContainsKey { id, key, callback } => {
-                let view = self.users.try_load_entry_or_insert(&id).await?;
+                let view = self.users.try_load_entry(&id).await?;
+                let view = view.unwrap();
                 let result = view.contains_key(&key).await?;
                 callback.respond(result);
             }
 
             ReadMultiValuesBytes { id, keys, callback } => {
-                let view = self.users.try_load_entry_or_insert(&id).await?;
+                let view = self.users.try_load_entry(&id).await?;
+                let view = view.unwrap();
                 let values = view.multi_get(keys).await?;
                 callback.respond(values);
             }
 
             ReadValueBytes { id, key, callback } => {
-                let view = self.users.try_load_entry_or_insert(&id).await?;
+                let view = self.users.try_load_entry(&id).await?;
+                let view = view.unwrap();
                 let result = view.get(&key).await?;
                 callback.respond(result);
             }
@@ -207,7 +210,8 @@ where
                 key_prefix,
                 callback,
             } => {
-                let view = self.users.try_load_entry_or_insert(&id).await?;
+                let view = self.users.try_load_entry(&id).await?;
+                let view = view.unwrap();
                 let result = view.find_keys_by_prefix(&key_prefix).await?;
                 callback.respond(result);
             }
@@ -217,7 +221,8 @@ where
                 key_prefix,
                 callback,
             } => {
-                let view = self.users.try_load_entry_or_insert(&id).await?;
+                let view = self.users.try_load_entry(&id).await?;
+                let view = view.unwrap();
                 let result = view.find_key_values_by_prefix(&key_prefix).await?;
                 callback.respond(result);
             }

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -219,7 +219,7 @@ where
                 let view = self.users.try_load_entry(&id).await?;
                 let result = match view {
                     Some(view) => view.find_keys_by_prefix(&key_prefix).await?,
-                    None => Vec::new()
+                    None => Vec::new(),
                 };
                 callback.respond(result);
             }

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -78,7 +78,7 @@ async fn classic_collection_view_check() -> Result<()> {
                 let n_load = rng.gen_range(0..5);
                 for _i in 0..n_load {
                     let pos = rng.gen_range(0..nmax);
-                    let _subview = view.v.load_entry_or_insert(&pos).await?;
+                    let _subview = view.v.load_entry_mut(&pos).await?;
                     new_map.entry(pos).or_insert(0);
                 }
             }
@@ -575,7 +575,7 @@ async fn reentrant_collection_view_check() -> Result<()> {
                     let test_view = view.v.contains_key(&pos).await?;
                     let test_map = new_map.contains_key(&pos);
                     assert_eq!(test_view, test_map);
-                    let _subview = view.v.try_load_entry_or_insert(&pos).await?;
+                    let _subview = view.v.try_load_entry_mut(&pos).await?;
                     new_map.entry(pos).or_insert(0);
                 }
             }


### PR DESCRIPTION
## Motivation

The `try_load_entry_or_insert` has the annoying feature that it takes a `&mut self` and returns a readable object.

## Proposal

The following is done:
* The `try_load_entry_or_insert` is eliminated.
* The tests are adjusted accordingly.
* The code is changed so that the missing is handled in the code.
* The `load_entry_or_insert` of `CollectionView` is removed as well.

## Test Plan

CI

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
