### PR TITLE
Fix contention for `WorkerState` in SDK integration test framework

### DIFF
--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -196,7 +196,6 @@ impl BlockBuilder {
         let (executed_block, _) = self
             .validator
             .worker()
-            .await
             .stage_block_execution(self.block)
             .await?;
 
@@ -230,7 +229,6 @@ impl BlockBuilder {
             let mut message = self
                 .validator
                 .worker()
-                .await
                 .find_incoming_message(chain_id, message_id)
                 .await
                 .expect("Failed to find message to receive in block")

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -119,7 +119,6 @@ impl ActiveChain {
 
         self.validator
             .worker()
-            .await
             .fully_handle_certificate(certificate.clone(), vec![], vec![])
             .await
             .expect("Rejected certificate");
@@ -138,7 +137,6 @@ impl ActiveChain {
         let (information, _) = self
             .validator
             .worker()
-            .await
             .handle_chain_info_query(ChainInfoQuery::new(chain_id).with_pending_messages())
             .await
             .expect("Failed to query chain's pending messages");
@@ -387,7 +385,6 @@ impl ActiveChain {
     ) -> bool {
         self.validator
             .worker()
-            .await
             .read_bytecode_location(self.id(), bytecode_id.forget_abi())
             .await
             .expect("Failed to check known bytecode locations")
@@ -403,7 +400,6 @@ impl ActiveChain {
             let certificate = self
                 .validator
                 .worker()
-                .await
                 .read_certificate(bytecode_id.message_id.chain_id, height.into())
                 .await
                 .expect("Failed to load certificate to search for bytecode location")
@@ -472,7 +468,6 @@ impl ActiveChain {
         let description_result = self
             .validator
             .worker()
-            .await
             .describe_application(self.id(), application_id.forget_abi())
             .await;
 
@@ -509,7 +504,6 @@ impl ActiveChain {
         let response = self
             .validator
             .worker()
-            .await
             .query_application(
                 self.id(),
                 Query::User {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
While writing a benchmark to attempt to stress the CPU, there was some contention to access the `WorkerState`. That happened because the integration test helpers in `linera-sdk` shared the same `WorkerState` instance using an `Arc<Mutex<_>>`. This is unnecessary, because the `WorkerState` was designed to be cloned for each request, and has internal fields which are properly shared.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Clone the `WorkerState` when needed, and don't wrap it in an `Arc<Mutex<_>>`.

## Test Plan

<!-- How to test that the changes are correct. -->
Tested manually with the benchmark, but CI should catch any regressions because this is an internal refactor.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed because this is an internal refactor.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
