### PR TITLE
Add test helpers for native token transfers

### DIFF
--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -9,7 +9,7 @@ use std::mem;
 
 use linera_base::{
     crypto::PublicKey,
-    data_types::{ApplicationPermissions, Round, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Round, Timestamp},
     identifiers::{ApplicationId, ChainId, MessageId, Owner},
     ownership::TimeoutConfig,
 };
@@ -17,7 +17,10 @@ use linera_chain::data_types::{
     Block, Certificate, HashedCertificateValue, IncomingMessage, LiteVote, MessageAction,
     SignatureAggregator,
 };
-use linera_execution::{system::SystemOperation, Operation};
+use linera_execution::{
+    system::{Recipient, SystemOperation, UserData},
+    Operation,
+};
 
 use super::TestValidator;
 use crate::ToBcsBytes;
@@ -79,6 +82,21 @@ impl BlockBuilder {
     pub fn with_timestamp(&mut self, timestamp: Timestamp) -> &mut Self {
         self.block.timestamp = timestamp;
         self
+    }
+
+    /// Adds a native token transfer to this block.
+    pub fn with_native_token_transfer(
+        &mut self,
+        sender: Option<Owner>,
+        recipient: Recipient,
+        amount: Amount,
+    ) -> &mut Self {
+        self.with_system_operation(SystemOperation::Transfer {
+            owner: sender,
+            recipient,
+            amount,
+            user_data: UserData(None),
+        })
     }
 
     /// Adds a [`SystemOperation`] to this block.

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -12,7 +12,7 @@ use dashmap::DashMap;
 use futures::FutureExt as _;
 use linera_base::{
     crypto::{KeyPair, PublicKey},
-    data_types::{ApplicationPermissions, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Timestamp},
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId},
     ownership::ChainOwnership,
 };
@@ -186,7 +186,7 @@ impl TestValidator {
                 .collect(),
             admin_id,
             epoch: Epoch::ZERO,
-            balance: 0.into(),
+            balance: Amount::ZERO,
             application_permissions: ApplicationPermissions::default(),
         };
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
During my attempts to create a benchmark with native token transfers, I leveraged the code from `linera-sdk`'s integration test framework. However, there was no way to do native token transfers, and this feature will likely be needed for application tests.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add a helper method that allows adding native token transfers to blocks. Also mint all native tokens at once and place them in the admin chain.

## Test Plan

<!-- How to test that the changes are correct. -->
Test manually, by running the benchmark that performs multiple transactions.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
A new minor SDK release to include the new feature.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
