### PR TITLE
Changes to `try_load_entries(_mut)`

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -504,12 +504,14 @@ where
         let max_stream_queries = self.context().max_stream_queries();
         let stream = stream::iter(stream)
             .map(|(origin, inbox)| async move {
-                if let Some(event) = inbox.removed_events.front().await? {
-                    return Err(ChainError::MissingCrossChainUpdate {
-                        chain_id,
-                        origin: origin.into(),
-                        height: event.height,
-                    });
+                if let Some(inbox) = inbox {
+                    if let Some(event) = inbox.removed_events.front().await? {
+                        return Err(ChainError::MissingCrossChainUpdate {
+                            chain_id,
+                            origin: origin.into(),
+                            height: event.height,
+                        });
+                    }
                 }
                 Ok::<(), ChainError>(())
             })

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -440,14 +440,13 @@ where
         let targets = self.chain.outboxes.indices().await?;
         let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
         for (target, outbox) in targets.into_iter().zip(outboxes) {
-            let heights = match outbox {
-                Some(outbox) => outbox.queue.elements().await?,
-                None => Vec::new(),
-            };
-            heights_by_recipient
-                .entry(target.recipient)
-                .or_default()
-                .insert(target.medium, heights);
+            if let Some(outbox) = outbox {
+                let heights = outbox.queue.elements().await?;
+                heights_by_recipient
+                    .entry(target.recipient)
+                    .or_default()
+                    .insert(target.medium, heights);
+            }
         }
         let mut actions = NetworkActions::default();
         for (recipient, height_map) in heights_by_recipient {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -442,7 +442,7 @@ where
         for (target, outbox) in targets.into_iter().zip(outboxes) {
             let heights = match outbox {
                 Some(outbox) => outbox.queue.elements().await?,
-                None => Vec::new()
+                None => Vec::new(),
             };
             heights_by_recipient
                 .entry(target.recipient)

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -461,10 +461,12 @@ where
             let origins = chain.inboxes.indices().await?;
             let inboxes = chain.inboxes.try_load_entries(&origins).await?;
             for (origin, inbox) in origins.into_iter().zip(inboxes) {
-                let next_height = sender_heights.entry(origin.sender).or_default();
-                let inbox_next_height = inbox.next_block_height_to_receive()?;
-                if inbox_next_height > *next_height {
-                    *next_height = inbox_next_height;
+                if let Some(inbox) = inbox {
+                    let next_height = sender_heights.entry(origin.sender).or_default();
+                    let inbox_next_height = inbox.next_block_height_to_receive()?;
+                    if inbox_next_height > *next_height {
+                        *next_height = inbox_next_height;
+                    }
                 }
             }
         }

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -553,12 +553,14 @@ where
     /// # use crate::linera_views::views::View;
     /// # let context = create_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
+    ///   {
+    ///     let _subview = view.try_load_entry_mut(&[0,1]).await.unwrap();
+    ///   }
     ///   let short_keys = vec![vec![0, 1], vec![2, 3]];
     ///   let subviews = view.try_load_entries(short_keys).await.unwrap();
-    ///   let value1 = subviews[0].get();
-    ///   let value2 = subviews[1].get();
-    ///   assert_eq!(*value1, String::default());
-    ///   assert_eq!(*value2, String::default());
+    ///   assert!(subviews[1].is_none());
+    ///   let value0 = subviews[0].as_ref().unwrap().get();
+    ///   assert_eq!(*value0, String::default());
     /// # })
     /// ```
     pub async fn try_load_entries(
@@ -609,7 +611,7 @@ where
             }
         }
         let values = self.context.read_multi_values_bytes(keys).await?;
-        for i_key in selected_indices_load {
+        for (index, i_key) in selected_indices_load.into_iter().enumerate() {
             selected_indices.push(i_key);
             let short_key = &short_keys[i_key];
             let key = self
@@ -618,7 +620,7 @@ where
             let context = self.context.clone_with_base_key(key);
             let view = W::post_load(
                 context,
-                &values[i_key * num_init_keys..(i_key + 1) * num_init_keys],
+                &values[index * num_init_keys..(index + 1) * num_init_keys],
             )?;
             let wrapped_view = Arc::new(RwLock::new(view));
             updates.insert(short_key.to_vec(), Update::Set(wrapped_view));
@@ -1113,12 +1115,14 @@ where
     /// # use crate::linera_views::views::View;
     /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
+    ///   {
+    ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
+    ///   }
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries(&indices).await.unwrap();
-    ///   let value1 = subviews[0].get();
-    ///   let value2 = subviews[1].get();
-    ///   assert_eq!(*value1, String::default());
-    ///   assert_eq!(*value2, String::default());
+    ///   assert!(subviews[1].is_none());
+    ///   let value0 = subviews[0].as_ref().unwrap().get();
+    ///   assert_eq!(*value0, String::default());
     /// # })
     /// ```
     pub async fn try_load_entries<'a, Q>(
@@ -1528,12 +1532,14 @@ where
     /// # use crate::linera_views::views::View;
     /// # let context = create_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
+    ///   {
+    ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
+    ///   }
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries(indices).await.unwrap();
-    ///   let value1 = subviews[0].get();
-    ///   let value2 = subviews[1].get();
-    ///   assert_eq!(*value1, String::default());
-    ///   assert_eq!(*value2, String::default());
+    ///   assert!(subviews[1].is_none());
+    ///   let value0 = subviews[0].as_ref().unwrap().get();
+    ///   assert_eq!(*value0, String::default());
     /// # })
     /// ```
     pub async fn try_load_entries<Q>(

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -588,7 +588,9 @@ where
                     if !self.delete_storage_first {
                         let context = self.context.clone();
                         let key_index = self.context.base_tag_index(KeyTag::Index as u8, short_key);
-                        handles.push(tokio::spawn(async move { context.contains_key(&key_index).await }));
+                        handles.push(tokio::spawn(async move {
+                            context.contains_key(&key_index).await
+                        }));
                         test_indices.push(i_key);
                     }
                 }

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -631,7 +631,8 @@ async fn reentrant_collection_view_check() -> Result<()> {
             let subviews = view.v.try_load_entries(&indices).await?;
             for i in 0..indices.len() {
                 let index = indices[i];
-                let value_view = *subviews[i].get();
+                let subview = subviews[i].as_ref().unwrap();
+                let value_view = *subview.get();
                 let value_map = match new_map.get(&index) {
                     None => 0,
                     Some(value) => *value,


### PR DESCRIPTION
## Motivation

The `try_load_entries` is inserting entry in the view which is not great for a `&self`. This was corrected. Also, the `pre_load` / `post_load` could be used to improve the code.

## Proposal

The implementation was straightforward. Now the `try_load_entries` is returning a `Vec<ReadGuarded<W>>`.
The next step would be to use the `contains_keys` operation in the `try_load_entries`.

## Test Plan

CI. The tests have been changed accordingly.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
