### PR TITLE
Mint all native tokens when creating admin chain

### DIFF
--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -216,7 +216,7 @@ impl TestValidator {
                 ChainId::root(0),
                 description,
                 key_pair.public(),
-                0.into(),
+                Amount::MAX,
                 Timestamp::from(0),
             )
             .await


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When running integration tests, there should be native tokens available for test transfers. The admin chain was supposed to have all minted tokens when the test starts in #2278, but the change was left out by mistake.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Set the admin chain's balance to `Amount::MAX` when it is created.

## Test Plan

<!-- How to test that the changes are correct. -->
Tested manually while running a transfers benchmark without IO.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this fixes a bug that is not present in any released versions.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
