### PR TITLE
Correct the ordering of the process_inbox operations for the NFT test

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -992,7 +992,6 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Result<()> {
     use non_fungible::{NftOutput, NonFungibleTokenAbi};
-
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -1103,8 +1102,8 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // Make sure that the cross-chain communication happens fast enough.
-    node_service1.process_inbox(&chain1).await?;
     node_service2.process_inbox(&chain2).await?;
+    node_service1.process_inbox(&chain1).await?;
 
     // Checking the NFT is removed from chain2
     assert!(app2.get_nft(&nft1_id).await.is_err());


### PR DESCRIPTION
## Motivation

Local running of the `test_wasm_end_to_end_non_fungible::scylladb_grpc` produced the error `Error: invalid type: null, expected struct NftOutput` in about 23% of the runs. This is an annoying problem.

## Proposal

The solution taken was to reorder the `process_inbox` operations after the

```
    app1.claim(
	&fungible::Account {
            chain_id: chain2,
            owner: account_owner1,
	},
        &nft1_id,
        &fungible::Account {
            chain_id: chain1,
            owner: account_owner1,
        },
    )
    .await;
```

When the code is run it bumps in the contract code of `execute_operation` with

```
                if source_account.chain_id == self.runtime.chain_id() {
                    let nft = self.get_nft(&token_id).await;
                    self.check_account_authentication(nft.owner);

                    self.transfer(nft, target_account).await;
                } else {
                    self.remote_claim(source_account, token_id, target_account)
                }
```

The `if` becomes `2 == 1`  since the source is from `chain2` while the `runtime.chain_id` is `chain1`. Therefore the `remote_chain` function is executed.

In `remote_chain` the key line is
```
            .send_to(source_account.chain_id);
```
Since `source_account.chain_id` is `chain2` that means that the first process inbox should be
```
node_service2.process_inbox(&chain2).await?;
```
Then the claimed message is a `Claim` and that led to the execution of `transfer`. In that code the first branch of the if test is not executed and the second branch is executed which led to a 
```
                .send_to(target_account.chain_id);
```
and so the second `process_inbox` should be:
```
node_service1.process_inbox(&chain1).await?;
```

And that is the end.

## Test Plan

When running 30 times the test locally, we got the error 7 times.  After the change, the error occurred 0 times in 15 runs.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
