### PR TITLE
rename storage_service_server into linera-storage-server

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Run end-to-end tests
       run: |
         cargo build --release -p linera-storage-service
-        RUST_LOG=info target/release/storage_service_server memory --endpoint $LINERA_STORAGE_SERVICE &
+        RUST_LOG=info target/release/linera-storage-server memory --endpoint $LINERA_STORAGE_SERVICE &
         RUST_LOG=info cargo test --features storage-service -- storage_service --nocapture
     - name: Run Ethereum tests
       run: |

--- a/linera-storage-service/Cargo.toml
+++ b/linera-storage-service/Cargo.toml
@@ -18,7 +18,7 @@ storage-service = []
 test = ["linera-views/test"]
 
 [[bin]]
-name = "storage_service_server"
+name = "linera-storage-server"
 path = "src/server.rs"
 
 [dependencies]

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -49,9 +49,9 @@ pub enum ServiceStoreError {
     #[error("Not matching entry")]
     NotMatchingEntry,
 
-    /// Failed to find the storage_service_server binary
-    #[error("Failed to find the storage_service_server binary")]
-    FailedToFindStorageServiceServerBinary,
+    /// Failed to find the linera-storage-server binary
+    #[error("Failed to find the linera-storage-server binary")]
+    FailedToFindStorageServerBinary,
 
     /// gRPC error
     #[error(transparent)]
@@ -108,13 +108,13 @@ pub struct ServiceStoreConfig {
 /// The path depends whether the test are run in the directory "linera-storage-service"
 /// or in the main directory
 pub async fn get_service_storage_binary() -> Result<PathBuf, ServiceStoreError> {
-    let binary = resolve_binary("storage_service_server", "linera-storage-service").await;
+    let binary = resolve_binary("linera-storage-server", "linera-storage-service").await;
     if let Ok(binary) = binary {
         return Ok(binary);
     }
-    let binary = resolve_binary("../storage_service_server", "linera-storage-service").await;
+    let binary = resolve_binary("../linera-storage-server", "linera-storage-service").await;
     if let Ok(binary) = binary {
         return Ok(binary);
     }
-    Err(ServiceStoreError::FailedToFindStorageServiceServerBinary)
+    Err(ServiceStoreError::FailedToFindStorageServerBinary)
 }

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -205,7 +205,7 @@ impl ServiceStoreServer {
 
 #[derive(clap::Parser)]
 #[command(
-    name = "storage_service_server",
+    name = "linera-storage-server",
     version = linera_version::VersionInfo::default_clap_str(),
     about = "A server providing storage service",
 )]

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -51,11 +51,11 @@ done
 ENDPOINT="127.0.0.1:$PORT"
 
 # Run Storage Service Server
-./storage_service_server memory --endpoint "$ENDPOINT" &
+./linera-storage-server memory --endpoint "$ENDPOINT" &
 SERVER_PID=$!
 sleep 2  # Wait a moment to ensure the server starts properly
 if ! kill -0 $SERVER_PID 2>/dev/null; then
-    echo "Failed to start storage_service_server. Exiting."
+    echo "Failed to start linera-storage-server. Exiting."
     exit 1
 fi
 


### PR DESCRIPTION
## Motivation

All Linera binaries follow the pattern `linera-xxx`

## Proposal

Rename `storage_service_server` into `linera-storage-server`

## Test Plan

CI

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
