### PR TITLE
Add option to skip "process_inbox" in the node service

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -513,6 +513,7 @@ Run a GraphQL service to explore and extend the chains of the wallet
 
 ###### **Options:**
 
+* `--listener-skip-process-inbox` — Do not create blocks automatically to receive incoming messages. Instead, wait for an explicit mutation `processInbox`
 * `--listener-delay-before-ms <DELAY_BEFORE_MS>` — Wait before processing any notification (useful for testing)
 
   Default value: `0`

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -23,7 +23,7 @@ use linera_core::{
 use linera_execution::{Message, SystemMessage};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
-use tracing::{error, info, warn, Instrument as _};
+use tracing::{debug, error, info, warn, Instrument as _};
 
 use crate::{chain_clients::ChainClients, wallet::Wallet};
 
@@ -33,12 +33,28 @@ mod tests;
 
 #[derive(Debug, Default, Clone, clap::Args)]
 pub struct ChainListenerConfig {
+    /// Do not create blocks automatically to receive incoming messages. Instead, wait for
+    /// an explicit mutation `processInbox`.
+    #[arg(
+        long = "listener-skip-process-inbox",
+        env = "LINERA_LISTENER_SKIP_PROCESS_INBOX"
+    )]
+    pub skip_process_inbox: bool,
+
     /// Wait before processing any notification (useful for testing).
-    #[arg(long = "listener-delay-before-ms", default_value = "0")]
+    #[arg(
+        long = "listener-delay-before-ms",
+        default_value = "0",
+        env = "LINERA_LISTENER_DELAY_BEFORE"
+    )]
     pub delay_before_ms: u64,
 
     /// Wait after processing any notification (useful for rate limiting).
-    #[arg(long = "listener-delay-after-ms", default_value = "0")]
+    #[arg(
+        long = "listener-delay-after-ms",
+        default_value = "0",
+        env = "LINERA_LISTENER_DELAY_AFTER"
+    )]
     pub delay_after_ms: u64,
 }
 
@@ -166,13 +182,26 @@ where
                 Either::Left((Some(notification), _)) => notification,
                 Either::Left((None, _)) => break,
                 Either::Right(((), _)) => {
+                    if config.skip_process_inbox {
+                        debug!("Not processing inbox due to listener configuration");
+                        timeout = Timestamp::from(u64::MAX);
+                        continue;
+                    }
+                    debug!("Processing inbox");
                     match client.process_inbox_if_owned().await {
                         Err(error) => {
                             warn!(%error, "Failed to process inbox.");
                             timeout = Timestamp::from(u64::MAX);
                         }
-                        Ok((_, None)) => timeout = Timestamp::from(u64::MAX),
-                        Ok((_, Some(new_timeout))) => timeout = new_timeout.timestamp,
+                        Ok((certs, None)) => {
+                            info!("Done processing inbox ({} blocks created)", certs.len());
+                            timeout = Timestamp::from(u64::MAX);
+                        }
+                        Ok((certs, Some(new_timeout))) => {
+                            info!("Done processing inbox ({} blocks created)", certs.len());
+                            info!("I will try processing the inbox later based on the given round timeout: {:?}", new_timeout);
+                            timeout = new_timeout.timestamp;
+                        }
                     }
                     context.lock().await.update_wallet(&client).await;
                     continue;

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -159,10 +159,7 @@ async fn main() -> std::io::Result<()> {
     let storage = MemoryStorage::new(store_config, namespace, None)
         .await
         .expect("storage");
-    let config = ChainListenerConfig {
-        delay_before_ms: 0,
-        delay_after_ms: 0,
-    };
+    let config = ChainListenerConfig::default();
     let context = DummyContext {
         _phantom: std::marker::PhantomData,
     };


### PR DESCRIPTION
## Motivation

Help debug missing or misplaced "process_inbox" commands in e2e tests (e.g. #2281)
* e2e tests cannot rely on the automatic process-inbox behavior of the node service because of race conditions.
* We are placing `process_inbox` commands manually but it's easy to make mistakes and unstable tests.

## Proposal

Create option `--listener-skip-process-inbox` to deactivate process inbox in the chain listener.

This forces deterministic block production in e2e tests

## Test Plan

* Cherry-pick https://github.com/linera-io/linera-protocol/pull/2283/commits/0c01a570e5fee3360e5813aca7c3ce00e8a2f54e from PR #2283 to reactivate the test below for the storage service
* Run
```
cargo run --release --bin storage_service_server memory -- --endpoint 127.0.0.1:1235

LINERA_CLIENT_SERVICE_PARAMS=--listener-skip-process-inbox LINERA_STORAGE_SERVICE=127.0.0.1:1235 RUST_LOG=info cargo test -p linera-service test_wasm_end_to_end_non_fungible --features storage-service -- --nocapture
```
* Revert https://github.com/linera-io/linera-protocol/commit/50448232ae02799d563387bed9da4753e363ff15 from PR #2281
* Run the test again. This time it fails

