### PR TITLE
Fix reconfiguration end-to-end test.

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -146,7 +146,7 @@ impl ClientWrapper {
             .current_dir(self.path_provider.path())
             .env(
                 "RUST_LOG",
-                std::env::var("RUST_LOG").unwrap_or(String::from("linera=default")),
+                std::env::var("RUST_LOG").unwrap_or(String::from("linera=debug")),
             )
             .args(["--wallet", &self.wallet])
             .args(["--storage", &self.storage])

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -146,7 +146,7 @@ impl ClientWrapper {
             .current_dir(self.path_provider.path())
             .env(
                 "RUST_LOG",
-                std::env::var("RUST_LOG").unwrap_or(String::from("linera=debug")),
+                std::env::var("RUST_LOG").unwrap_or(String::from("linera=default")),
             )
             .args(["--wallet", &self.wallet])
             .args(["--storage", &self.storage])

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -212,7 +212,7 @@ where
 
         match Self::try_proxy_message(
             message,
-            shard,
+            shard.clone(),
             protocol,
             self.send_timeout,
             self.recv_timeout,
@@ -221,7 +221,7 @@ where
         {
             Ok(maybe_response) => maybe_response,
             Err(error) => {
-                error!(error = %error, "Failed to proxy message");
+                error!(error = %error, "Failed to proxy message to {}", shard.address());
                 None
             }
         }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2440,8 +2440,8 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
 
     client.query_validators(None).await?;
 
-    // Restart the first shard for the 4th validator. The proxy currently only
-    // re-establishes the connection with gRPC.
+    // Restart the first shard for the 4th validator.
+    // TODO(#2286): The proxy currently only re-establishes the connection with gRPC.
     if matches!(network, Network::Grpc) {
         net.terminate_server(3, 0).await?;
         net.start_server(3, 0).await?;


### PR DESCRIPTION
## Motivation

`test_end_to_end_reconfiguration` in TCP mode is failing, unless validator 5 (which never gets removed in the test) has a very high voting weight.

## Proposal

Don't restart a validator's shard with TCP: The proxy only seems to reconnect successfully with gRPC.
(I also added the address to the log message when a proxy fails to forward a message to a shard, so that we know which shard can't be reached. It helped me debug this.)

In the loop where we remove the first four validators, always process the inbox _before_ shutting down the removed validator: If there are less than four validators left, removing one means the others don't have a quorum, so the clients must process the change while the validator is still up.

## Test Plan

The test now uses the same weight (100) for all validators.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2212.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
