### PR TITLE
Add query-validator command, and make set-validator check version.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -70,7 +70,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `sync-balance` — (DEPRECATED) Synchronize the local state of the chain with a quorum validators, then query the local balance
 * `sync` — Synchronize the local state of the chain with a quorum validators
 * `process-inbox` — Process all pending incoming messages from the inbox of the given chain by creating as many blocks as needed to execute all (non-failing) messages. Failing messages will be marked as rejected and may bounce to their sender depending on their configuration
-* `query-new-validator` — Show the version of a new validator, and print a warning if it is incompatible
+* `query-new-validator` — Show the version and genesis config hash of a new validator, and print a warning if it is incompatible
 * `query-validators` — Show the current set of validators for a chain
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
@@ -368,7 +368,7 @@ Process all pending incoming messages from the inbox of the given chain by creat
 
 ## `linera query-new-validator`
 
-Show the version of a new validator, and print a warning if it is incompatible
+Show the version and genesis config hash of a new validator, and print a warning if it is incompatible
 
 **Usage:** `linera query-new-validator <ADDRESS>`
 

--- a/CLI.md
+++ b/CLI.md
@@ -18,6 +18,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera sync-balance`↴](#linera-sync-balance)
 * [`linera sync`↴](#linera-sync)
 * [`linera process-inbox`↴](#linera-process-inbox)
+* [`linera query-new-validator`↴](#linera-query-new-validator)
 * [`linera query-validators`↴](#linera-query-validators)
 * [`linera set-validator`↴](#linera-set-validator)
 * [`linera remove-validator`↴](#linera-remove-validator)
@@ -69,6 +70,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `sync-balance` — (DEPRECATED) Synchronize the local state of the chain with a quorum validators, then query the local balance
 * `sync` — Synchronize the local state of the chain with a quorum validators
 * `process-inbox` — Process all pending incoming messages from the inbox of the given chain by creating as many blocks as needed to execute all (non-failing) messages. Failing messages will be marked as rejected and may bounce to their sender depending on their configuration
+* `query-new-validator` — Show the version of a new validator, and print a warning if it is incompatible
 * `query-validators` — Show the current set of validators for a chain
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
@@ -364,6 +366,18 @@ Process all pending incoming messages from the inbox of the given chain by creat
 
 
 
+## `linera query-new-validator`
+
+Show the version of a new validator, and print a warning if it is incompatible
+
+**Usage:** `linera query-new-validator <ADDRESS>`
+
+###### **Arguments:**
+
+* `<ADDRESS>` — The new validator's address
+
+
+
 ## `linera query-validators`
 
 Show the current set of validators for a chain
@@ -389,6 +403,7 @@ Add or modify a validator (admin only)
 * `--votes <VOTES>` — Voting power
 
   Default value: `1`
+* `--force` — Set the validator even if the version or genesis config check fails
 
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -18,7 +18,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera sync-balance`↴](#linera-sync-balance)
 * [`linera sync`↴](#linera-sync)
 * [`linera process-inbox`↴](#linera-process-inbox)
-* [`linera query-new-validator`↴](#linera-query-new-validator)
+* [`linera query-validator`↴](#linera-query-validator)
 * [`linera query-validators`↴](#linera-query-validators)
 * [`linera set-validator`↴](#linera-set-validator)
 * [`linera remove-validator`↴](#linera-remove-validator)
@@ -70,7 +70,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `sync-balance` — (DEPRECATED) Synchronize the local state of the chain with a quorum validators, then query the local balance
 * `sync` — Synchronize the local state of the chain with a quorum validators
 * `process-inbox` — Process all pending incoming messages from the inbox of the given chain by creating as many blocks as needed to execute all (non-failing) messages. Failing messages will be marked as rejected and may bounce to their sender depending on their configuration
-* `query-new-validator` — Show the version and genesis config hash of a new validator, and print a warning if it is incompatible
+* `query-validator` — Show the version and genesis config hash of a new validator, and print a warning if it is incompatible
 * `query-validators` — Show the current set of validators for a chain
 * `set-validator` — Add or modify a validator (admin only)
 * `remove-validator` — Remove a validator (admin only)
@@ -366,11 +366,11 @@ Process all pending incoming messages from the inbox of the given chain by creat
 
 
 
-## `linera query-new-validator`
+## `linera query-validator`
 
 Show the version and genesis config hash of a new validator, and print a warning if it is incompatible
 
-**Usage:** `linera query-new-validator <ADDRESS>`
+**Usage:** `linera query-validator <ADDRESS>`
 
 ###### **Arguments:**
 

--- a/CLI.md
+++ b/CLI.md
@@ -403,7 +403,7 @@ Add or modify a validator (admin only)
 * `--votes <VOTES>` — Voting power
 
   Default value: `1`
-* `--force` — Set the validator even if the version or genesis config check fails
+* `--skip-online-check` — Skip the version and genesis config checks
 
 
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -384,6 +384,12 @@ pub enum ClientCommand {
         chain_id: Option<ChainId>,
     },
 
+    /// Show the version of a new validator, and print a warning if it is incompatible.
+    QueryNewValidator {
+        /// The new validator's address.
+        address: String,
+    },
+
     /// Show the current set of validators for a chain.
     QueryValidators {
         /// The chain to query. If omitted, query the default chain of the wallet.
@@ -403,6 +409,10 @@ pub enum ClientCommand {
         /// Voting power
         #[arg(long, default_value = "1")]
         votes: u64,
+
+        /// Set the validator even if the version or genesis config check fails.
+        #[arg(long)]
+        force: bool,
     },
 
     /// Remove a validator (admin only)

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -386,7 +386,7 @@ pub enum ClientCommand {
 
     /// Show the version and genesis config hash of a new validator, and print a warning if it is
     /// incompatible.
-    QueryNewValidator {
+    QueryValidator {
         /// The new validator's address.
         address: String,
     },

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -411,9 +411,9 @@ pub enum ClientCommand {
         #[arg(long, default_value = "1")]
         votes: u64,
 
-        /// Set the validator even if the version or genesis config check fails.
+        /// Skip the version and genesis config checks.
         #[arg(long)]
-        force: bool,
+        skip_online_check: bool,
     },
 
     /// Remove a validator (admin only)

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -384,7 +384,8 @@ pub enum ClientCommand {
         chain_id: Option<ChainId>,
     },
 
-    /// Show the version of a new validator, and print a warning if it is incompatible.
+    /// Show the version and genesis config hash of a new validator, and print a warning if it is
+    /// incompatible.
     QueryNewValidator {
         /// The new validator's address.
         address: String,

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -5,7 +5,7 @@
 use std::{iter::IntoIterator, path::Path};
 
 use linera_base::{
-    crypto::{BcsSignable, CryptoRng, KeyPair, PublicKey},
+    crypto::{BcsSignable, CryptoHash, CryptoRng, KeyPair, PublicKey},
     data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
@@ -183,5 +183,9 @@ impl GenesisConfig {
 
     pub fn create_committee(&self) -> Committee {
         self.committee.clone().into_committee(self.policy.clone())
+    }
+
+    pub fn hash(&self) -> CryptoHash {
+        CryptoHash::new(self)
     }
 }

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -75,6 +75,9 @@ pub trait LocalValidatorNode {
     /// Gets the version info for this validator node.
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError>;
 
+    /// Gets the networks' genesis config hash.
+    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError>;
+
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -75,7 +75,7 @@ pub trait LocalValidatorNode {
     /// Gets the version info for this validator node.
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError>;
 
-    /// Gets the networks' genesis config hash.
+    /// Gets the network's genesis config hash.
     async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError>;
 
     /// Subscribes to receiving notifications for a collection of chains.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -76,7 +76,7 @@ pub trait LocalValidatorNode {
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError>;
 
     /// Gets the network's genesis config hash.
-    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError>;
+    async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError>;
 
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -162,7 +162,7 @@ where
         Ok(Default::default())
     }
 
-    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+    async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         Ok(CryptoHash::test_hash("genesis config"))
     }
 

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -162,6 +162,10 @@ where
         Ok(Default::default())
     }
 
+    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+        Ok(CryptoHash::test_hash("genesis config"))
+    }
+
     async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
         self.spawn_and_receive(move |validator, sender| validator.do_download_blob(blob_id, sender))
             .await

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -52,6 +52,9 @@ service ValidatorNode {
   // Request the node's version info.
   rpc GetVersionInfo(google.protobuf.Empty) returns (VersionInfo);
 
+  // Request the genesis configuration hash of the network this node is part of.
+  rpc GetGenesisConfigHash(google.protobuf.Empty) returns (CryptoHash);
+
   // Downloads a blob.
   rpc DownloadBlob(BlobId) returns (Blob);
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -143,6 +143,15 @@ impl ValidatorNode for Client {
         })
     }
 
+    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+        Ok(match self {
+            Client::Grpc(grpc_client) => grpc_client.get_genesis_config_hash().await?,
+
+            #[cfg(with_simple_network)]
+            Client::Simple(simple_client) => simple_client.get_genesis_config_hash().await?,
+        })
+    }
+
     async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.download_blob(blob_id).await?,

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -143,7 +143,7 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+    async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.get_genesis_config_hash().await?,
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -271,9 +271,10 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+    async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         Ok(self
             .client
+            .clone()
             .get_genesis_config_hash(())
             .await?
             .into_inner()

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -271,6 +271,16 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
+    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+        Ok(self
+            .client
+            .get_genesis_config_hash(())
+            .await?
+            .into_inner()
+            .try_into()?)
+    }
+
+    #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
     async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
         Ok(self
             .client

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -30,12 +30,14 @@ pub enum RpcMessage {
     DownloadCertificate(Box<CryptoHash>),
     BlobLastUsedBy(Box<BlobId>),
     VersionInfoQuery,
+    GenesisConfigHashQuery,
 
     // Outbound
     Vote(Box<LiteVote>),
     ChainInfoResponse(Box<ChainInfoResponse>),
     Error(Box<NodeError>),
     VersionInfoResponse(Box<VersionInfo>),
+    GenesisConfigHashResponse(Box<CryptoHash>),
     DownloadBlobResponse(Box<Blob>),
     DownloadCertificateValueResponse(Box<CertificateValue>),
     DownloadCertificateResponse(Box<Certificate>),
@@ -63,6 +65,8 @@ impl RpcMessage {
             | ChainInfoResponse(_)
             | VersionInfoQuery
             | VersionInfoResponse(_)
+            | GenesisConfigHashQuery
+            | GenesisConfigHashResponse(_)
             | DownloadBlob(_)
             | DownloadBlobResponse(_)
             | DownloadCertificateValue(_)
@@ -85,6 +89,7 @@ impl RpcMessage {
 
         match self {
             VersionInfoQuery
+            | GenesisConfigHashQuery
             | DownloadBlob(_)
             | DownloadCertificateValue(_)
             | BlobLastUsedBy(_)
@@ -98,6 +103,7 @@ impl RpcMessage {
             | Error(_)
             | ChainInfoResponse(_)
             | VersionInfoResponse(_)
+            | GenesisConfigHashResponse(_)
             | DownloadBlobResponse(_)
             | DownloadCertificateValueResponse(_)
             | BlobLastUsedByResponse(_)
@@ -172,6 +178,7 @@ impl TryFrom<RpcMessage> for CryptoHash {
         use RpcMessage::*;
         match message {
             BlobLastUsedByResponse(hash) => Ok(*hash),
+            GenesisConfigHashResponse(hash) => Ok(*hash),
             Error(error) => Err(*error),
             _ => Err(NodeError::UnexpectedMessage),
         }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -134,7 +134,7 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::VersionInfoQuery).await
     }
 
-    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+    async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         self.query(RpcMessage::GenesisConfigHashQuery).await
     }
 

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -134,6 +134,10 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::VersionInfoQuery).await
     }
 
+    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+        self.query(RpcMessage::GenesisConfigHashQuery).await
+    }
+
     async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
         self.query(RpcMessage::DownloadBlob(Box::new(blob_id)))
             .await

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -310,6 +310,8 @@ where
             | RpcMessage::Error(_)
             | RpcMessage::ChainInfoResponse(_)
             | RpcMessage::VersionInfoResponse(_)
+            | RpcMessage::GenesisConfigHashQuery
+            | RpcMessage::GenesisConfigHashResponse(_)
             | RpcMessage::DownloadBlob(_)
             | RpcMessage::DownloadBlobResponse(_)
             | RpcMessage::DownloadCertificateValue(_)

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -779,38 +779,44 @@ RpcMessage:
     8:
       VersionInfoQuery: UNIT
     9:
+      GenesisConfigHashQuery: UNIT
+    10:
       Vote:
         NEWTYPE:
           TYPENAME: LiteVote
-    10:
+    11:
       ChainInfoResponse:
         NEWTYPE:
           TYPENAME: ChainInfoResponse
-    11:
+    12:
       Error:
         NEWTYPE:
           TYPENAME: NodeError
-    12:
+    13:
       VersionInfoResponse:
         NEWTYPE:
           TYPENAME: VersionInfo
-    13:
+    14:
+      GenesisConfigHashResponse:
+        NEWTYPE:
+          TYPENAME: CryptoHash
+    15:
       DownloadBlobResponse:
         NEWTYPE:
           TYPENAME: Blob
-    14:
+    16:
       DownloadCertificateValueResponse:
         NEWTYPE:
           TYPENAME: CertificateValue
-    15:
+    17:
       DownloadCertificateResponse:
         NEWTYPE:
           TYPENAME: Certificate
-    16:
+    18:
       BlobLastUsedByResponse:
         NEWTYPE:
           TYPENAME: CryptoHash
-    17:
+    19:
       CrossChainRequest:
         NEWTYPE:
           TYPENAME: CrossChainRequest

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -444,6 +444,12 @@ impl LocalNet {
         Ok(command)
     }
 
+    #[cfg(with_testing)]
+    pub fn genesis_config(&self) -> Result<linera_client::config::GenesisConfig> {
+        let path = self.path_provider.path();
+        crate::util::read_json(path.join("genesis.json"))
+    }
+
     pub fn proxy_port(validator: usize) -> usize {
         9000 + validator * 100
     }

--- a/linera-service/src/cli_wrappers/mod.rs
+++ b/linera-service/src/cli_wrappers/mod.rs
@@ -81,7 +81,7 @@ impl Network {
         }
     }
 
-    fn external_short(&self) -> &'static str {
+    pub fn external_short(&self) -> &'static str {
         match self {
             Network::Grpc => "grpc",
             Network::Tcp => "tcp",

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -397,6 +397,18 @@ impl ClientWrapper {
         bail!("Failed to start node service");
     }
 
+    /// Runs `linera query-new-validator`
+    pub async fn query_new_validator(&self, address: &str) -> Result<CryptoHash> {
+        let mut command = self.command().await?;
+        command.arg("query-new-validator").arg(address);
+        let stdout = command.spawn_and_wait_for_stdout().await?;
+        let hash = stdout
+            .trim()
+            .parse()
+            .context("error while parsing the result of `linera local-balance`")?;
+        Ok(hash)
+    }
+
     /// Runs `linera query-validators`.
     pub async fn query_validators(&self, chain_id: Option<ChainId>) -> Result<()> {
         let mut command = self.command().await?;

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -397,10 +397,10 @@ impl ClientWrapper {
         bail!("Failed to start node service");
     }
 
-    /// Runs `linera query-new-validator`
-    pub async fn query_new_validator(&self, address: &str) -> Result<CryptoHash> {
+    /// Runs `linera query-validator`
+    pub async fn query_validator(&self, address: &str) -> Result<CryptoHash> {
         let mut command = self.command().await?;
-        command.arg("query-new-validator").arg(address);
+        command.arg("query-validator").arg(address);
         let stdout = command.spawn_and_wait_for_stdout().await?;
         let hash = stdout
             .trim()

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -428,7 +428,7 @@ impl Runnable for Job {
                 );
             }
 
-            QueryNewValidator { address } => {
+            QueryValidator { address } => {
                 use linera_core::node::ValidatorNode as _;
 
                 let mut node = context.make_node_provider().make_node(&address)?;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -503,7 +503,7 @@ impl Runnable for Job {
                     force,
                 } = &command
                 {
-                    let mut node = context.make_node_provider().make_node(address)?;
+                    let node = context.make_node_provider().make_node(address)?;
                     match node.get_version_info().await {
                         Ok(version_info)
                             if version_info.is_compatible_with(&linera_version::VERSION_INFO) => {}

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -458,6 +458,7 @@ impl Runnable for Job {
                         warn!("Failed to get genesis config hash for new validator:\n{error}")
                     }
                 }
+                println!("{}", genesis_config_hash);
             }
 
             QueryValidators { chain_id } => {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -428,6 +428,27 @@ impl Runnable for Job {
                 );
             }
 
+            QueryNewValidator { address } => {
+                use linera_core::node::ValidatorNode as _;
+
+                let node_provider = context.make_node_provider();
+                match node_provider.make_node(&address)?.get_version_info().await {
+                    Ok(version_info)
+                        if version_info.is_compatible_with(&linera_version::VERSION_INFO) =>
+                    {
+                        info!("Version information for new validator: {}", version_info);
+                    }
+                    Ok(version_info) => warn!(
+                        "Validator version {} is not compatible with local version {}.",
+                        version_info,
+                        linera_version::VERSION_INFO
+                    ),
+                    Err(error) => {
+                        warn!("Failed to get version information for new validator:\n{error}")
+                    }
+                }
+            }
+
             QueryValidators { chain_id } => {
                 use linera_core::node::ValidatorNode as _;
 
@@ -467,12 +488,43 @@ impl Runnable for Job {
             command @ (SetValidator { .. }
             | RemoveValidator { .. }
             | ResourceControlPolicy { .. }) => {
+                use linera_core::node::ValidatorNode as _;
+
                 info!("Starting operations to change validator set");
                 let time_start = Instant::now();
 
                 // Make sure genesis chains are subscribed to the admin chain.
                 let context = Arc::new(Mutex::new(context));
                 let mut context = context.lock().await;
+                if let SetValidator {
+                    name,
+                    address,
+                    votes: _,
+                    force,
+                } = &command
+                {
+                    let mut node = context.make_node_provider().make_node(address)?;
+                    match node.get_version_info().await {
+                        Ok(version_info)
+                            if version_info.is_compatible_with(&linera_version::VERSION_INFO) => {}
+                        Ok(version_info) if *force => warn!(
+                            "Validator version {} is not compatible with local version {}.",
+                            version_info,
+                            linera_version::VERSION_INFO
+                        ),
+                        Ok(version_info) => bail!(
+                            "Validator version {} is not compatible with local version {}.",
+                            version_info,
+                            linera_version::VERSION_INFO
+                        ),
+                        Err(error) if *force => warn!(
+                            "Failed to get version information for validator {name:?}:\n{error}"
+                        ),
+                        Err(error) => bail!(
+                            "Failed to get version information for validator {name:?}:\n{error}"
+                        ),
+                    }
+                }
                 let chain_client = context.make_chain_client(context.wallet.genesis_admin_chain());
                 let n = context
                     .process_inbox(&chain_client)
@@ -496,6 +548,7 @@ impl Runnable for Job {
                                     name,
                                     address,
                                     votes,
+                                    force: _,
                                 } => {
                                     validators.insert(
                                         name,

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -81,12 +81,13 @@ enum Proxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    Simple(SimpleProxy<S>),
+    Simple(Box<SimpleProxy<S>>),
     Grpc(GrpcProxy<S>),
 }
 
 struct ProxyContext {
     config: ValidatorServerConfig,
+    genesis_config: GenesisConfig,
     send_timeout: Duration,
     recv_timeout: Duration,
 }
@@ -94,10 +95,12 @@ struct ProxyContext {
 impl ProxyContext {
     pub fn from_options(options: &ProxyOptions) -> Result<Self> {
         let config = util::read_json(&options.config_path)?;
+        let genesis_config = util::read_json(&options.genesis_config_path)?;
         Ok(Self {
             config,
             send_timeout: options.send_timeout,
             recv_timeout: options.recv_timeout,
+            genesis_config,
         })
     }
 }
@@ -134,6 +137,7 @@ where
                 Self::Grpc(GrpcProxy::new(
                     context.config.validator.network,
                     context.config.internal_network,
+                    context.genesis_config,
                     context.send_timeout,
                     context.recv_timeout,
                     tls,
@@ -143,7 +147,7 @@ where
             (
                 NetworkProtocol::Simple(internal_transport),
                 NetworkProtocol::Simple(public_transport),
-            ) => Self::Simple(SimpleProxy {
+            ) => Self::Simple(Box::new(SimpleProxy {
                 internal_config: context
                     .config
                     .internal_network
@@ -153,10 +157,11 @@ where
                     .validator
                     .network
                     .clone_with_protocol(public_transport),
+                genesis_config: context.genesis_config,
                 send_timeout: context.send_timeout,
                 recv_timeout: context.recv_timeout,
                 storage,
-            }),
+            })),
             _ => {
                 bail!(
                     "network protocol mismatch: cannot have {} and {} ",
@@ -177,6 +182,7 @@ where
 {
     public_config: ValidatorPublicNetworkPreConfig<TransportProtocol>,
     internal_config: ValidatorInternalNetworkPreConfig<TransportProtocol>,
+    genesis_config: GenesisConfig,
     send_timeout: Duration,
     recv_timeout: Duration,
     storage: S,
@@ -288,6 +294,9 @@ where
                 // We assume each shard is running the same version as the proxy
                 Ok(Some(linera_version::VersionInfo::default().into()))
             }
+            GenesisConfigHashQuery => Ok(Some(RpcMessage::GenesisConfigHashResponse(
+                self.genesis_config.hash().into(),
+            ))),
             DownloadBlob(blob_id) => Ok(Some(
                 self.storage
                     .read_hashed_blob(*blob_id)
@@ -317,6 +326,7 @@ where
             | Error(_)
             | ChainInfoResponse(_)
             | VersionInfoResponse(_)
+            | GenesisConfigHashResponse(_)
             | DownloadBlobResponse(_)
             | BlobLastUsedByResponse(_)
             | DownloadCertificateValueResponse(_)

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -77,7 +77,7 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+    async fn get_genesis_config_hash(&self) -> Result<CryptoHash, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -77,6 +77,10 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
+    async fn get_genesis_config_hash(&mut self) -> Result<CryptoHash, NodeError> {
+        Err(NodeError::UnexpectedMessage)
+    }
+
     async fn download_blob(&self, _: BlobId) -> Result<Blob, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2461,7 +2461,7 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
         LocalNet::proxy_port(4)
     );
     assert_eq!(
-        client.query_new_validator(&address).await?,
+        client.query_validator(&address).await?,
         net.genesis_config()?.hash()
     );
 

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -2455,6 +2455,16 @@ async fn test_end_to_end_reconfiguration(config: LocalNetConfig) -> Result<()> {
     net.start_validator(4).await?;
     net.start_validator(5).await?;
 
+    let address = format!(
+        "{}:localhost:{}",
+        network.external_short(),
+        LocalNet::proxy_port(4)
+    );
+    assert_eq!(
+        client.query_new_validator(&address).await?,
+        net.genesis_config()?.hash()
+    );
+
     // Add 5th validator
     client
         .set_validator(net.validator_name(4).unwrap(), LocalNet::proxy_port(4), 100)


### PR DESCRIPTION
## Motivation

Before adding a new validator to a testnet we want to check whether they are online and have a compatible version and genesis config.

## Proposal

Make `set-validator` check the validator's version and genesis config before creating the new committee. (Can be omitted with `--skip-online-check`.)

Add a `query-validator` command that works just like `query-validators`, but instead of querying the current committee it queries a given address, and it prints a warning if the version or genesis config is incompatible.

## Test Plan

`set-validator` is already used, and `query-new-validator` was added to the reconfiguration end-to-end test.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2288
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
