### PR TITLE
`linera-core`: remove double-locking behaviour

### DIFF
--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -474,13 +474,13 @@ impl Signature {
     pub fn check_optional_signature<T>(
         signature: Option<&Self>,
         value: &T,
-        author: PublicKey,
+        author: &PublicKey,
     ) -> Result<(), CryptoError>
     where
         T: BcsSignable + std::fmt::Debug,
     {
         match signature {
-            Some(sig) => sig.check(value, author),
+            Some(sig) => sig.check(value, *author),
             None => Err(CryptoError::MissingSignature {
                 type_name: T::type_name().to_string(),
             }),

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -697,7 +697,7 @@ where
         info!("Broadcasting {} {}", proposals.len(), phase);
         let mut join_set = JoinSet::new();
         let mut handles = Vec::new();
-        for mut client in self.make_validator_mass_clients() {
+        for client in self.make_validator_mass_clients() {
             let proposals = proposals.clone();
             let handle = join_set.spawn_task(async move {
                 debug!("Sending {} requests", proposals.len());

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1058,7 +1058,7 @@ where
         tracker: u64,
         committees: BTreeMap<Epoch, Committee>,
         max_epoch: Epoch,
-        mut node: A,
+        node: A,
         node_client: LocalNodeClient<S>,
     ) -> Result<(ValidatorName, u64, Vec<Certificate>), NodeError>
     where
@@ -2725,7 +2725,7 @@ where
         });
         // Add tasks for new validators.
         let validator_tasks = FuturesUnordered::new();
-        for (name, mut node) in nodes {
+        for (name, node) in nodes {
             let hash_map::Entry::Vacant(entry) = senders.entry(name) else {
                 continue;
             };

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -258,8 +258,8 @@ impl ChainInfoResponse {
         self.signature = Some(Signature::new(&*self.info, key_pair));
     }
 
-    pub fn check(&self, name: ValidatorName) -> Result<(), CryptoError> {
-        Signature::check_optional_signature(self.signature.as_ref(), &*self.info, name.0)
+    pub fn check(&self, name: &ValidatorName) -> Result<(), CryptoError> {
+        Signature::check_optional_signature(self.signature.as_ref(), &*self.info, &name.0)
     }
 
     /// Returns the committee in the latest epoch.

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -32,7 +32,7 @@ use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery, ChainInfoResponse},
     node::{LocalValidatorNode, NodeError},
     value_cache::ValueCache,
-    worker::{Notification, ValidatorWorker, WorkerError, WorkerState},
+    worker::{Notification, WorkerError, WorkerState},
 };
 
 /// A local node with a single worker, typically used by clients.

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -128,16 +128,13 @@ where
         hashed_blobs: Vec<HashedBlob>,
         notifications: &mut impl Extend<Notification>,
     ) -> Result<ChainInfoResponse, LocalNodeError> {
-        let response = self
-            .node
-            .state
-            .fully_handle_certificate_with_notifications(
-                certificate,
-                hashed_certificate_values,
-                hashed_blobs,
-                Some(notifications),
-            )
-            .await?;
+        let response = Box::pin(self.node.state.fully_handle_certificate_with_notifications(
+            certificate,
+            hashed_certificate_values,
+            hashed_blobs,
+            Some(notifications),
+        ))
+        .await?;
         Ok(response)
     }
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -98,25 +98,29 @@ pub trait LocalValidatorNodeProvider {
 
     fn make_node(&self, address: &str) -> Result<Self::Node, NodeError>;
 
-    fn make_nodes<I>(&self, committee: &Committee) -> Result<I, NodeError>
-    where
-        I: FromIterator<(ValidatorName, Self::Node)>,
-    {
-        self.make_nodes_from_list(committee.validator_addresses())
+    fn make_nodes(
+        &self,
+        committee: &Committee,
+    ) -> Result<impl Iterator<Item = (ValidatorName, Self::Node)> + '_, NodeError> {
+        let validator_addresses: Vec<_> = committee
+            .validator_addresses()
+            .map(|(node, name)| (node, name.to_owned()))
+            .collect();
+        self.make_nodes_from_list(validator_addresses)
     }
 
-    fn make_nodes_from_list<I, A>(
+    fn make_nodes_from_list<A>(
         &self,
         validators: impl IntoIterator<Item = (ValidatorName, A)>,
-    ) -> Result<I, NodeError>
+    ) -> Result<impl Iterator<Item = (ValidatorName, Self::Node)>, NodeError>
     where
-        I: FromIterator<(ValidatorName, Self::Node)>,
         A: AsRef<str>,
     {
-        validators
+        Ok(validators
             .into_iter()
             .map(|(name, address)| Ok((name, self.make_node(address.as_ref())?)))
-            .collect()
+            .collect::<Result<Vec<_>, NodeError>>()?
+            .into_iter())
     }
 }
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -76,10 +76,7 @@ pub trait LocalValidatorNode {
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError>;
 
     /// Subscribes to receiving notifications for a collection of chains.
-    async fn subscribe(
-        &self,
-        chains: Vec<ChainId>,
-    ) -> Result<Self::NotificationStream, NodeError>;
+    async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;
 
     async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError>;
 

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -46,20 +46,20 @@ pub trait LocalValidatorNode {
 
     /// Proposes a new block.
     async fn handle_block_proposal(
-        &mut self,
+        &self,
         proposal: BlockProposal,
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a certificate without a value.
     async fn handle_lite_certificate(
-        &mut self,
+        &self,
         certificate: LiteCertificate<'_>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Processes a certificate.
     async fn handle_certificate(
-        &mut self,
+        &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
@@ -68,30 +68,30 @@ pub trait LocalValidatorNode {
 
     /// Handles information queries for this chain.
     async fn handle_chain_info_query(
-        &mut self,
+        &self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, NodeError>;
 
     /// Gets the version info for this validator node.
-    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError>;
+    async fn get_version_info(&self) -> Result<VersionInfo, NodeError>;
 
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(
-        &mut self,
+        &self,
         chains: Vec<ChainId>,
     ) -> Result<Self::NotificationStream, NodeError>;
 
-    async fn download_blob(&mut self, blob_id: BlobId) -> Result<Blob, NodeError>;
+    async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError>;
 
     async fn download_certificate_value(
-        &mut self,
+        &self,
         hash: CryptoHash,
     ) -> Result<HashedCertificateValue, NodeError>;
 
-    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError>;
+    async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError>;
 
     /// Returns the hash of the `Certificate` that last used a blob.
-    async fn blob_last_used_by(&mut self, blob_id: BlobId) -> Result<CryptoHash, NodeError>;
+    async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError>;
 }
 
 /// Turn an address into a validator node.

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -103,7 +103,7 @@ where
     let publisher_chain = ChainDescription::Root(1);
     let creator_key_pair = KeyPair::generate();
     let creator_chain = ChainDescription::Root(2);
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage,
         vec![
             (publisher_chain, publisher_key_pair.public(), Amount::ZERO),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -62,7 +62,7 @@ use crate::{
     worker::{
         Notification,
         Reason::{self, NewBlock, NewIncomingMessage},
-        ValidatorWorker, WorkerError, WorkerState,
+        WorkerError, WorkerState,
     },
 };
 
@@ -397,7 +397,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (_, mut worker) = init_worker_with_chains(
+    let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -443,7 +443,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (_, mut worker) = init_worker_with_chains(
+    let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -499,7 +499,7 @@ where
     let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public(), balance)];
     let epoch = Epoch::ZERO;
-    let (committee, mut worker) = init_worker_with_chains(storage, balances).await;
+    let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
     {
         let block_proposal = make_first_block(ChainId::root(1))
@@ -565,7 +565,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (_, mut worker) = init_worker_with_chains(
+    let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -608,7 +608,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(1),
@@ -681,7 +681,7 @@ where
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -1070,7 +1070,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (_, mut worker) = init_worker_with_chains(
+    let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -1118,7 +1118,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (_, mut worker) = init_worker_with_chains(
+    let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(1),
@@ -1154,7 +1154,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (_, mut worker) = init_worker_with_chains(
+    let (_, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -1196,7 +1196,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(2),
@@ -1237,7 +1237,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(2),
@@ -1319,7 +1319,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(2),
@@ -1362,7 +1362,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -1413,7 +1413,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -1515,7 +1515,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -1586,7 +1586,7 @@ where
     let storage = storage_builder.build().await?;
     let key_pair = KeyPair::generate();
     let name = key_pair.public();
-    let (committee, mut worker) =
+    let (committee, worker) =
         init_worker_with_chain(storage, ChainDescription::Root(1), name, Amount::ONE).await;
 
     let certificate = make_simple_transfer_certificate(
@@ -1651,7 +1651,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(2),
@@ -1727,7 +1727,7 @@ where
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker(storage, /* is_client */ false);
+    let (committee, worker) = init_worker(storage, /* is_client */ false);
     let certificate = make_simple_transfer_certificate(
         ChainDescription::Root(1),
         &sender_key_pair,
@@ -1765,7 +1765,7 @@ where
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker(storage, /* is_client */ true);
+    let (committee, worker) = init_worker(storage, /* is_client */ true);
     let certificate = make_simple_transfer_certificate(
         ChainDescription::Root(1),
         &sender_key_pair,
@@ -1815,7 +1815,7 @@ where
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -1971,7 +1971,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(1),
@@ -2031,7 +2031,7 @@ where
         owner: Some(recipient),
     };
 
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (
@@ -2275,7 +2275,7 @@ where
     ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![(
             ChainDescription::Root(0),
@@ -2714,7 +2714,7 @@ where
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (ChainDescription::Root(0), key_pair0.public(), Amount::ZERO),
@@ -2844,7 +2844,7 @@ where
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
-    let (committee, mut worker) = init_worker_with_chains(
+    let (committee, worker) = init_worker_with_chains(
         storage_builder.build().await?,
         vec![
             (ChainDescription::Root(0), key_pair0.public(), Amount::ZERO),
@@ -3234,7 +3234,7 @@ where
     let key_pairs = generate_key_pairs(2);
     let (pub_key0, pub_key1) = (key_pairs[0].public(), key_pairs[1].public());
     let balances = vec![(ChainDescription::Root(0), pub_key0, Amount::from_tokens(2))];
-    let (committee, mut worker) = init_worker_with_chains(storage, balances).await;
+    let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
     // Add another owner and use the leader-based protocol in all rounds.
     let block0 = make_first_block(chain_id).with_operation(SystemOperation::ChangeOwnership {
@@ -3410,7 +3410,7 @@ where
     // from a past round.
     let certificate =
         make_certificate_with_round(&committee, &worker, value1, Round::SingleLeader(7));
-    let mut worker = worker.with_key_pair(None).await; // Forget validator keys.
+    let worker = worker.with_key_pair(None).await; // Forget validator keys.
     worker
         .handle_certificate(certificate.clone(), vec![], vec![], None)
         .await?;
@@ -3438,7 +3438,7 @@ where
     let key_pairs = generate_key_pairs(2);
     let (pub_key0, pub_key1) = (key_pairs[0].public(), key_pairs[1].public());
     let balances = vec![(ChainDescription::Root(0), pub_key0, Amount::from_tokens(2))];
-    let (committee, mut worker) = init_worker_with_chains(storage, balances).await;
+    let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
     // Add another owner and configure two multi-leader rounds.
     let block0 = make_first_block(chain_id).with_operation(SystemOperation::ChangeOwnership {
@@ -3526,7 +3526,7 @@ where
     let key_pairs = generate_key_pairs(2);
     let (pub_key0, pub_key1) = (key_pairs[0].public(), key_pairs[1].public());
     let balances = vec![(ChainDescription::Root(0), pub_key0, Amount::from_tokens(2))];
-    let (committee, mut worker) = init_worker_with_chains(storage, balances).await;
+    let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
     // Add another owner and configure two multi-leader rounds.
     let block0 = make_first_block(chain_id).with_operation(SystemOperation::ChangeOwnership {
@@ -3630,7 +3630,7 @@ where
     let key_pair = KeyPair::generate();
     let balance = Amount::from_tokens(5);
     let balances = vec![(ChainDescription::Root(1), key_pair.public(), balance)];
-    let (committee, mut worker) = init_worker_with_chains(storage, balances).await;
+    let (committee, worker) = init_worker_with_chains(storage, balances).await;
 
     // At time 0 we don't vote for fallback mode.
     let query = ChainInfoQuery::new(chain_id).with_fallback();
@@ -3705,7 +3705,7 @@ where
     let key_pair = KeyPair::generate();
     let balance = Amount::ZERO;
 
-    let (_committee, mut worker) = init_worker_with_chain(
+    let (_committee, worker) = init_worker_with_chain(
         storage.clone(),
         chain_description,
         key_pair.public(),
@@ -3786,7 +3786,7 @@ where
     let key_pair = KeyPair::generate();
     let balance = Amount::ZERO;
 
-    let (committee, mut worker) = init_worker_with_chain(
+    let (committee, worker) = init_worker_with_chain(
         storage.clone(),
         chain_description,
         key_pair.public(),

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -1132,7 +1132,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (chain_info_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
-    chain_info_response.check(ValidatorName(worker.public_key()))?;
+    chain_info_response.check(&ValidatorName(worker.public_key()))?;
     let chain = worker.chain_state_view(ChainId::root(1)).await?;
     assert!(chain.is_active());
     let pending_value = chain.manager.get().pending().unwrap().lite();
@@ -1175,7 +1175,7 @@ where
         .into_fast_proposal(&sender_key_pair);
 
     let (response, _actions) = worker.handle_block_proposal(block_proposal.clone()).await?;
-    response.check(ValidatorName(worker.public_key()))?;
+    response.check(&ValidatorName(worker.public_key()))?;
     let (replay_response, _actions) = worker.handle_block_proposal(block_proposal).await?;
     // Workaround lack of equality.
     assert_eq!(

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -257,7 +257,7 @@ where
             warn!("locations requested by validator contain duplicates");
             return Err(NodeError::InvalidChainInfoResponse);
         }
-        let storage = self.local_node.storage_client().await;
+        let storage = self.local_node.storage_client();
         Ok(future::join_all(
             unique_locations
                 .into_iter()
@@ -323,7 +323,7 @@ where
             }
         }
 
-        let storage = self.local_node.storage_client().await;
+        let storage = self.local_node.storage_client();
         missing_blobs.extend(
             future::join_all(
                 unique_blob_ids_to_find
@@ -437,7 +437,7 @@ where
         if !keys.is_empty() {
             // Send the requested certificates in order.
             let storage = self.local_node.storage_client();
-            let certs = storage.await.read_certificates(keys.into_iter()).await?;
+            let certs = storage.read_certificates(keys.into_iter()).await?;
             for cert in certs {
                 self.send_certificate(cert, delivery).await?;
             }

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -359,7 +359,7 @@ where
             _ => result,
         }?;
 
-        response.check(self.name)?;
+        response.check(&self.name)?;
         // Succeed
         Ok(response.info)
     }
@@ -399,7 +399,7 @@ where
                 return Err(e);
             }
         };
-        response.check(self.name)?;
+        response.check(&self.name)?;
         Ok(response.info)
     }
 
@@ -413,7 +413,7 @@ where
         let query = ChainInfoQuery::new(chain_id);
         let initial_block_height = match self.node.handle_chain_info_query(query).await {
             Ok(response) => {
-                response.check(self.name)?;
+                response.check(&self.name)?;
                 response.info.next_block_height
             }
             Err(error) => {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -295,11 +295,11 @@ where
         self
     }
 
-    #[tracing::instrument(level = "trace", skip(self, grace_period))]
     /// Returns an instance with the specified grace period, in microseconds.
     ///
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
+    #[tracing::instrument(level = "trace", skip(self, grace_period))]
     pub fn with_grace_period(mut self, grace_period: Duration) -> Self {
         self.chain_worker_config.grace_period = grace_period;
         self
@@ -315,16 +315,16 @@ where
         self.recent_hashed_blobs.clone()
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     /// Returns the storage client so that it can be manipulated or queried.
+    #[tracing::instrument(level = "trace", skip(self))]
     #[cfg(not(feature = "test"))]
     pub(crate) fn storage_client(&self) -> &StorageClient {
         &self.storage
     }
 
-    #[tracing::instrument(level = "trace", skip(self))]
     /// Returns the storage client so that it can be manipulated or queried by tests in other
     /// crates.
+    #[tracing::instrument(level = "trace", skip(self))]
     #[cfg(feature = "test")]
     pub fn storage_client(&self) -> &StorageClient {
         &self.storage
@@ -423,8 +423,8 @@ where
         Ok(response)
     }
 
-    #[tracing::instrument(level = "trace", skip(self, block))]
     /// Tries to execute a block proposal without any verification other than block execution.
+    #[tracing::instrument(level = "trace", skip(self, block))]
     pub async fn stage_block_execution(
         &self,
         block: Block,
@@ -471,8 +471,8 @@ where
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self, chain_id, query))]
     /// Executes a [`Query`] for an application's state on a specific chain.
+    #[tracing::instrument(level = "trace", skip(self, chain_id, query))]
     pub async fn query_application(
         &self,
         chain_id: ChainId,
@@ -515,6 +515,7 @@ where
         .await
     }
 
+    /// Processes a confirmed block (aka a commit).
     #[tracing::instrument(
         level = "trace",
         skip(
@@ -525,7 +526,6 @@ where
             notify_when_messages_are_delivered
         )
     )]
-    /// Processes a confirmed block (aka a commit).
     async fn process_confirmed_block(
         &self,
         certificate: Certificate,
@@ -564,8 +564,8 @@ where
         Ok((response, actions))
     }
 
-    #[tracing::instrument(level = "trace", skip(self, certificate))]
     /// Processes a validated block issued from a multi-owner chain.
+    #[tracing::instrument(level = "trace", skip(self, certificate))]
     async fn process_validated_block(
         &self,
         certificate: Certificate,
@@ -585,8 +585,8 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, certificate))]
     /// Processes a leader timeout issued from a multi-owner chain.
+    #[tracing::instrument(level = "trace", skip(self, certificate))]
     async fn process_timeout(
         &self,
         certificate: Certificate,
@@ -620,8 +620,8 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, value))]
     /// Inserts a [`HashedCertificateValue`] into the worker's cache.
+    #[tracing::instrument(level = "trace", skip(self, value))]
     pub(crate) async fn cache_recent_hashed_certificate_value<'a>(
         &self,
         value: Cow<'a, HashedCertificateValue>,
@@ -629,14 +629,14 @@ where
         self.recent_hashed_certificate_values.insert(value).await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, hashed_blob))]
     /// Inserts a [`HashedBlob`] into the worker's cache.
+    #[tracing::instrument(level = "trace", skip(self, hashed_blob))]
     pub async fn cache_recent_blob<'a>(&self, hashed_blob: Cow<'a, HashedBlob>) -> bool {
         self.recent_hashed_blobs.insert(hashed_blob).await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, chain_id, height))]
     /// Returns a stored [`Certificate`] for a chain's block.
+    #[tracing::instrument(level = "trace", skip(self, chain_id, height))]
     #[cfg(with_testing)]
     pub async fn read_certificate(
         &self,
@@ -649,9 +649,9 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, chain_id, message_id))]
     /// Returns an [`IncomingMessage`] that's awaiting to be received by the chain specified by
     /// `chain_id`.
+    #[tracing::instrument(level = "trace", skip(self, chain_id, message_id))]
     #[cfg(with_testing)]
     pub async fn find_incoming_message(
         &self,
@@ -706,12 +706,12 @@ where
         }))
     }
 
-    #[tracing::instrument(level = "trace", skip(self, chain_id))]
     /// Returns a read-only view of the [`ChainStateView`] of a chain referenced by its
     /// [`ChainId`].
     ///
     /// The returned view holds a lock on the chain state, which prevents the worker from changing
     /// the state of that chain.
+    #[tracing::instrument(level = "trace", skip(self, chain_id))]
     pub async fn chain_state_view(
         &self,
         chain_id: ChainId,
@@ -743,9 +743,9 @@ where
             .expect("`ChainWorkerActor` stopped executing without responding")
     }
 
-    #[tracing::instrument(level = "trace", skip(self, chain_id))]
     /// Retrieves an endpoint to a [`ChainWorkerActor`] from the cache, creating one and adding it
     /// to the cache if needed.
+    #[tracing::instrument(level = "trace", skip(self, chain_id))]
     async fn get_chain_worker_endpoint(
         &self,
         chain_id: ChainId,
@@ -799,9 +799,9 @@ where
         Ok(response)
     }
 
+    /// Processes a certificate, e.g. to extend a chain with a confirmed block.
     // Other fields will be included in handle_certificate's span.
     #[instrument(skip_all, fields(hash = %certificate.value.value_hash))]
-    /// Processes a certificate, e.g. to extend a chain with a confirmed block.
     pub async fn handle_lite_certificate<'a>(
         &self,
         certificate: LiteCertificate<'a>,
@@ -1009,12 +1009,12 @@ where
     StorageClient: Storage,
     ViewError: From<StorageClient::StoreError>,
 {
-    #[tracing::instrument(level = "trace", skip(self))]
     /// Gets a reference to the validator's [`PublicKey`].
     ///
     /// # Panics
     ///
     /// If the validator doesn't have a key pair assigned to it.
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn public_key(&self) -> PublicKey {
         self.chain_worker_config
             .key_pair()

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -340,7 +340,7 @@ where
 
     #[tracing::instrument(level = "trace", skip(self, certificate))]
     pub(crate) async fn full_certificate(
-        &mut self,
+        &self,
         certificate: LiteCertificate<'_>,
     ) -> Result<Certificate, WorkerError> {
         self.recent_hashed_certificate_values
@@ -350,14 +350,14 @@ where
 
     #[tracing::instrument(level = "trace", skip(self, hash))]
     pub(crate) async fn recent_hashed_certificate_value(
-        &mut self,
+        &self,
         hash: &CryptoHash,
     ) -> Option<HashedCertificateValue> {
         self.recent_hashed_certificate_values.get(hash).await
     }
 
     #[tracing::instrument(level = "trace", skip(self, blob_id))]
-    pub(crate) async fn recent_blob(&mut self, blob_id: &BlobId) -> Option<HashedBlob> {
+    pub(crate) async fn recent_blob(&self, blob_id: &BlobId) -> Option<HashedBlob> {
         self.recent_hashed_blobs.get(blob_id).await
     }
 }
@@ -374,7 +374,7 @@ where
     )]
     #[cfg(with_testing)]
     pub async fn fully_handle_certificate(
-        &mut self,
+        &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
@@ -400,7 +400,7 @@ where
     )]
     #[inline]
     pub(crate) async fn fully_handle_certificate_with_notifications(
-        &mut self,
+        &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
@@ -426,7 +426,7 @@ where
     #[tracing::instrument(level = "trace", skip(self, block))]
     /// Tries to execute a block proposal without any verification other than block execution.
     pub async fn stage_block_execution(
-        &mut self,
+        &self,
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
         self.query_chain_worker(block.chain_id, move |callback| {
@@ -441,7 +441,7 @@ where
         skip(self, chain_id, height, actions, notify_when_messages_are_delivered)
     )]
     async fn register_delivery_notifier(
-        &mut self,
+        &self,
         chain_id: ChainId,
         height: BlockHeight,
         actions: &NetworkActions,
@@ -474,7 +474,7 @@ where
     #[tracing::instrument(level = "trace", skip(self, chain_id, query))]
     /// Executes a [`Query`] for an application's state on a specific chain.
     pub async fn query_application(
-        &mut self,
+        &self,
         chain_id: ChainId,
         query: Query,
     ) -> Result<Response, WorkerError> {
@@ -487,7 +487,7 @@ where
     #[tracing::instrument(level = "trace", skip(self, chain_id, bytecode_id))]
     #[cfg(with_testing)]
     pub async fn read_bytecode_location(
-        &mut self,
+        &self,
         chain_id: ChainId,
         bytecode_id: BytecodeId,
     ) -> Result<Option<BytecodeLocation>, WorkerError> {
@@ -502,7 +502,7 @@ where
 
     #[tracing::instrument(level = "trace", skip(self, chain_id, application_id))]
     pub async fn describe_application(
-        &mut self,
+        &self,
         chain_id: ChainId,
         application_id: UserApplicationId,
     ) -> Result<UserApplicationDescription, WorkerError> {
@@ -527,7 +527,7 @@ where
     )]
     /// Processes a confirmed block (aka a commit).
     async fn process_confirmed_block(
-        &mut self,
+        &self,
         certificate: Certificate,
         hashed_certificate_values: &[HashedCertificateValue],
         hashed_blobs: &[HashedBlob],
@@ -567,7 +567,7 @@ where
     #[tracing::instrument(level = "trace", skip(self, certificate))]
     /// Processes a validated block issued from a multi-owner chain.
     async fn process_validated_block(
-        &mut self,
+        &self,
         certificate: Certificate,
     ) -> Result<(ChainInfoResponse, NetworkActions, bool), WorkerError> {
         let CertificateValue::ValidatedBlock {
@@ -588,7 +588,7 @@ where
     #[tracing::instrument(level = "trace", skip(self, certificate))]
     /// Processes a leader timeout issued from a multi-owner chain.
     async fn process_timeout(
-        &mut self,
+        &self,
         certificate: Certificate,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         let CertificateValue::Timeout { chain_id, .. } = certificate.value() else {
@@ -605,7 +605,7 @@ where
 
     #[tracing::instrument(level = "trace", skip(self, origin, recipient, bundles))]
     async fn process_cross_chain_update(
-        &mut self,
+        &self,
         origin: Origin,
         recipient: ChainId,
         bundles: Vec<MessageBundle>,
@@ -623,7 +623,7 @@ where
     #[tracing::instrument(level = "trace", skip(self, value))]
     /// Inserts a [`HashedCertificateValue`] into the worker's cache.
     pub(crate) async fn cache_recent_hashed_certificate_value<'a>(
-        &mut self,
+        &self,
         value: Cow<'a, HashedCertificateValue>,
     ) -> bool {
         self.recent_hashed_certificate_values.insert(value).await
@@ -631,7 +631,7 @@ where
 
     #[tracing::instrument(level = "trace", skip(self, hashed_blob))]
     /// Inserts a [`HashedBlob`] into the worker's cache.
-    pub async fn cache_recent_blob<'a>(&mut self, hashed_blob: Cow<'a, HashedBlob>) -> bool {
+    pub async fn cache_recent_blob<'a>(&self, hashed_blob: Cow<'a, HashedBlob>) -> bool {
         self.recent_hashed_blobs.insert(hashed_blob).await
     }
 
@@ -781,7 +781,7 @@ where
         height = %proposal.content.block.height,
     ))]
     pub async fn handle_block_proposal(
-        &mut self,
+        &self,
         proposal: BlockProposal,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
         trace!("{} <-- {:?}", self.nickname, proposal);
@@ -803,7 +803,7 @@ where
     #[instrument(skip_all, fields(hash = %certificate.value.value_hash))]
     /// Processes a certificate, e.g. to extend a chain with a confirmed block.
     pub async fn handle_lite_certificate<'a>(
-        &mut self,
+        &self,
         certificate: LiteCertificate<'a>,
         notify_when_messages_are_delivered: Option<oneshot::Sender<()>>,
     ) -> Result<(ChainInfoResponse, NetworkActions), WorkerError> {
@@ -824,7 +824,7 @@ where
         height = %certificate.value().height(),
     ))]
     pub async fn handle_certificate(
-        &mut self,
+        &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
@@ -918,7 +918,7 @@ where
         chain_id = format!("{:.8}", request.target_chain_id())
     ))]
     pub async fn handle_cross_chain_request(
-        &mut self,
+        &self,
         request: CrossChainRequest,
     ) -> Result<NetworkActions, WorkerError> {
         trace!("{} <-- {:?}", self.nickname, request);

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -143,7 +143,7 @@ pub enum Reason {
     },
 }
 
-/// Error type for [`ValidatorWorker`].
+/// Error type for worker operations..
 #[derive(Debug, Error)]
 pub enum WorkerError {
     #[error(transparent)]

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -48,7 +48,7 @@ impl ValidatorNode for Client {
     type NotificationStream = NotificationStream;
 
     async fn handle_block_proposal(
-        &mut self,
+        &self,
         proposal: BlockProposal,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
@@ -60,7 +60,7 @@ impl ValidatorNode for Client {
     }
 
     async fn handle_lite_certificate(
-        &mut self,
+        &self,
         certificate: LiteCertificate<'_>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
@@ -81,7 +81,7 @@ impl ValidatorNode for Client {
     }
 
     async fn handle_certificate(
-        &mut self,
+        &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
@@ -114,7 +114,7 @@ impl ValidatorNode for Client {
     }
 
     async fn handle_chain_info_query(
-        &mut self,
+        &self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
@@ -126,7 +126,7 @@ impl ValidatorNode for Client {
     }
 
     async fn subscribe(
-        &mut self,
+        &self,
         chains: Vec<ChainId>,
     ) -> Result<Self::NotificationStream, NodeError> {
         Ok(match self {
@@ -137,7 +137,7 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn get_version_info(&mut self) -> Result<linera_version::VersionInfo, NodeError> {
+    async fn get_version_info(&self) -> Result<linera_version::VersionInfo, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.get_version_info().await?,
 
@@ -146,7 +146,7 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn download_blob(&mut self, blob_id: BlobId) -> Result<Blob, NodeError> {
+    async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.download_blob(blob_id).await?,
 
@@ -156,7 +156,7 @@ impl ValidatorNode for Client {
     }
 
     async fn download_certificate_value(
-        &mut self,
+        &self,
         hash: CryptoHash,
     ) -> Result<HashedCertificateValue, NodeError> {
         Ok(match self {
@@ -167,7 +167,7 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError> {
+    async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.download_certificate(hash).await?,
 
@@ -176,7 +176,7 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn blob_last_used_by(&mut self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+    async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.blob_last_used_by(blob_id).await?,
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -125,10 +125,7 @@ impl ValidatorNode for Client {
         }
     }
 
-    async fn subscribe(
-        &self,
-        chains: Vec<ChainId>,
-    ) -> Result<Self::NotificationStream, NodeError> {
+    async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => Box::pin(grpc_client.subscribe(chains).await?),
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -190,10 +190,7 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn subscribe(
-        &self,
-        chains: Vec<ChainId>,
-    ) -> Result<Self::NotificationStream, NodeError> {
+    async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError> {
         let notification_retry_delay = self.notification_retry_delay;
         let notification_retries = self.notification_retries;
         let mut retry_count = 0;
@@ -264,7 +261,13 @@ impl ValidatorNode for GrpcClient {
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
     async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
-        Ok(self.client.clone().get_version_info(()).await?.into_inner().into())
+        Ok(self
+            .client
+            .clone()
+            .get_version_info(())
+            .await?
+            .into_inner()
+            .into())
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -16,7 +16,7 @@ use futures::{
 use linera_base::identifiers::ChainId;
 use linera_core::{
     node::NodeError,
-    worker::{NetworkActions, Notification, ValidatorWorker, WorkerError, WorkerState},
+    worker::{NetworkActions, Notification, WorkerError, WorkerState},
     JoinSetExt as _, TaskHandle,
 };
 use linera_storage::Storage;

--- a/linera-rpc/src/mass_client.rs
+++ b/linera-rpc/src/mass_client.rs
@@ -21,7 +21,7 @@ pub enum MassClientError {
 #[async_trait]
 pub trait MassClient {
     async fn send(
-        &mut self,
+        &self,
         requests: Vec<RpcMessage>,
         max_in_flight: usize,
     ) -> Result<Vec<RpcMessage>, MassClientError>;

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -47,10 +47,7 @@ impl SimpleClient {
         }
     }
 
-    async fn send_recv_internal(
-        &self,
-        message: RpcMessage,
-    ) -> Result<RpcMessage, codec::Error> {
+    async fn send_recv_internal(&self, message: RpcMessage) -> Result<RpcMessage, codec::Error> {
         let address = format!("{}:{}", self.network.host, self.network.port);
         let mut stream = self.network.protocol.connect(address).await?;
         // Send message

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -48,7 +48,7 @@ impl SimpleClient {
     }
 
     async fn send_recv_internal(
-        &mut self,
+        &self,
         message: RpcMessage,
     ) -> Result<RpcMessage, codec::Error> {
         let address = format!("{}:{}", self.network.host, self.network.port);
@@ -65,7 +65,7 @@ impl SimpleClient {
             .ok_or_else(|| codec::Error::Io(std::io::ErrorKind::UnexpectedEof.into()))
     }
 
-    async fn query<Response>(&mut self, query: RpcMessage) -> Result<Response, Response::Error>
+    async fn query<Response>(&self, query: RpcMessage) -> Result<Response, Response::Error>
     where
         Response: TryFrom<RpcMessage>,
         Response::Error: From<codec::Error>,
@@ -79,7 +79,7 @@ impl ValidatorNode for SimpleClient {
 
     /// Initiates a new block.
     async fn handle_block_proposal(
-        &mut self,
+        &self,
         proposal: BlockProposal,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.query(proposal.into()).await
@@ -87,7 +87,7 @@ impl ValidatorNode for SimpleClient {
 
     /// Processes a hash certificate.
     async fn handle_lite_certificate(
-        &mut self,
+        &self,
         certificate: LiteCertificate<'_>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
@@ -101,7 +101,7 @@ impl ValidatorNode for SimpleClient {
 
     /// Processes a certificate.
     async fn handle_certificate(
-        &mut self,
+        &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
         hashed_blobs: Vec<HashedBlob>,
@@ -119,31 +119,31 @@ impl ValidatorNode for SimpleClient {
 
     /// Handles information queries for this chain.
     async fn handle_chain_info_query(
-        &mut self,
+        &self,
         query: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, NodeError> {
         self.query(query.into()).await
     }
 
     fn subscribe(
-        &mut self,
+        &self,
         _chains: Vec<ChainId>,
     ) -> impl Future<Output = Result<NotificationStream, NodeError>> + Send {
         let transport = self.network.protocol.to_string();
         async { Err(NodeError::SubscriptionError { transport }) }
     }
 
-    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError> {
+    async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
         self.query(RpcMessage::VersionInfoQuery).await
     }
 
-    async fn download_blob(&mut self, blob_id: BlobId) -> Result<Blob, NodeError> {
+    async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
         self.query(RpcMessage::DownloadBlob(Box::new(blob_id)))
             .await
     }
 
     async fn download_certificate_value(
-        &mut self,
+        &self,
         hash: CryptoHash,
     ) -> Result<HashedCertificateValue, NodeError> {
         let certificate_value: CertificateValue = self
@@ -152,12 +152,12 @@ impl ValidatorNode for SimpleClient {
         Ok(certificate_value.with_hash_checked(hash)?)
     }
 
-    async fn download_certificate(&mut self, hash: CryptoHash) -> Result<Certificate, NodeError> {
+    async fn download_certificate(&self, hash: CryptoHash) -> Result<Certificate, NodeError> {
         self.query(RpcMessage::DownloadCertificate(Box::new(hash)))
             .await
     }
 
-    async fn blob_last_used_by(&mut self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
+    async fn blob_last_used_by(&self, blob_id: BlobId) -> Result<CryptoHash, NodeError> {
         self.query(RpcMessage::BlobLastUsedBy(Box::new(blob_id)))
             .await
     }
@@ -187,7 +187,7 @@ impl SimpleMassClient {
 #[async_trait]
 impl mass_client::MassClient for SimpleMassClient {
     async fn send(
-        &mut self,
+        &self,
         requests: Vec<RpcMessage>,
         max_in_flight: usize,
     ) -> Result<Vec<RpcMessage>, mass_client::MassClientError> {

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use futures::{channel::mpsc, stream::StreamExt};
 use linera_core::{
     node::NodeError,
-    worker::{NetworkActions, ValidatorWorker, WorkerError, WorkerState},
+    worker::{NetworkActions, WorkerError, WorkerState},
     JoinSetExt as _,
 };
 use linera_storage::Storage;

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -18,10 +18,7 @@ use linera_base::{
     identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
 };
 use linera_chain::{data_types::Certificate, ChainError, ChainExecutionContext};
-use linera_core::{
-    data_types::ChainInfoQuery,
-    worker::{ValidatorWorker, WorkerError},
-};
+use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
     system::{SystemChannel, SystemExecutionError, SystemMessage, SystemOperation},
     Bytecode, ExecutionError, Message, Query, Response,

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -38,14 +38,14 @@ impl ValidatorNode for DummyValidatorNode {
     type NotificationStream = NotificationStream;
 
     async fn handle_block_proposal(
-        &mut self,
+        &self,
         _: BlockProposal,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
     async fn handle_lite_certificate(
-        &mut self,
+        &self,
         _: LiteCertificate<'_>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
@@ -53,7 +53,7 @@ impl ValidatorNode for DummyValidatorNode {
     }
 
     async fn handle_certificate(
-        &mut self,
+        &self,
         _: Certificate,
         _: Vec<HashedCertificateValue>,
         _: Vec<HashedBlob>,
@@ -63,36 +63,36 @@ impl ValidatorNode for DummyValidatorNode {
     }
 
     async fn handle_chain_info_query(
-        &mut self,
+        &self,
         _: ChainInfoQuery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn subscribe(&mut self, _: Vec<ChainId>) -> Result<NotificationStream, NodeError> {
+    async fn subscribe(&self, _: Vec<ChainId>) -> Result<NotificationStream, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn get_version_info(&mut self) -> Result<VersionInfo, NodeError> {
+    async fn get_version_info(&self) -> Result<VersionInfo, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn download_blob(&mut self, _: BlobId) -> Result<Blob, NodeError> {
+    async fn download_blob(&self, _: BlobId) -> Result<Blob, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
     async fn download_certificate_value(
-        &mut self,
+        &self,
         _: CryptoHash,
     ) -> Result<HashedCertificateValue, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn download_certificate(&mut self, _: CryptoHash) -> Result<Certificate, NodeError> {
+    async fn download_certificate(&self, _: CryptoHash) -> Result<Certificate, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn blob_last_used_by(&mut self, _: BlobId) -> Result<CryptoHash, NodeError> {
+    async fn blob_last_used_by(&self, _: BlobId) -> Result<CryptoHash, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 }

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -22,7 +22,7 @@ use linera_core::{
         ValidatorNode,
     },
 };
-use linera_execution::committee::Committee;
+use linera_execution::committee::{Committee, ValidatorName};
 use linera_service::node_service::NodeService;
 use linera_storage::{MemoryStorage, Storage};
 use linera_version::VersionInfo;
@@ -102,12 +102,15 @@ struct DummyValidatorNodeProvider;
 impl LocalValidatorNodeProvider for DummyValidatorNodeProvider {
     type Node = DummyValidatorNode;
 
-    fn make_node(&self, _: &str) -> Result<Self::Node, NodeError> {
+    fn make_node(&self, _address: &str) -> Result<Self::Node, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 
-    fn make_nodes<I>(&self, _: &Committee) -> Result<I, NodeError> {
-        Err(NodeError::UnexpectedMessage)
+    fn make_nodes(
+        &self,
+        _committee: &Committee,
+    ) -> Result<impl Iterator<Item = (ValidatorName, Self::Node)> + '_, NodeError> {
+        Err::<std::iter::Empty<_>, _>(NodeError::UnexpectedMessage)
     }
 }
 


### PR DESCRIPTION
## Motivation

We currently have a situation in `linera-core` in which we lock an async `Mutex` and then perform an async task (to communicate with validators over the network).  This makes it difficult to access different chain clients at the same time, as failure to drive the task holding the lock can result in deadlocks.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Remove the offending mutex entirely.  `tonic::client::Grpc` is the root cause of the mutability requirement, but can be easily and cheaply cloned, removing the need for the mutex.

Incidentally, there was a trait `linera_core::worker::ValidatorWorker` that was never abstracted over; I've removed this after confirming with @afck we had no plans to abstract over it in the future.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan
Refactor only: no special care required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
