### PR TITLE
Implement the use of `contains_keys` and other corrections.

### DIFF
--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -1101,16 +1101,7 @@ where
         let blobs_in_block = self.state.get_blobs(required_blob_ids.clone()).await?;
         let certificate_hash = certificate.hash();
 
-        let (result_hashed_certificate_value, result_blobs, result_certificate) = tokio::join!(
-            self.state
-                .storage
-                .write_hashed_certificate_values(hashed_certificate_values),
-            self.state.storage.write_hashed_blobs(&blobs_in_block),
-            self.state.storage.write_certificate(&certificate)
-        );
-        result_hashed_certificate_value?;
-        result_blobs?;
-        result_certificate?;
+        self.state.storage.write_hashed_certificate_values_hashed_blobs_certificate(hashed_certificate_values, &blobs_in_block, &certificate).await?;
 
         // Update the blob state with last used certificate hash.
         try_join_all(required_blob_ids.into_iter().map(|blob_id| {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -9,9 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use futures::{
-    future::try_join_all,
-};
+use futures::future::try_join_all;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{ArithmeticError, BlockHeight, HashedBlob, Timestamp},
@@ -409,10 +407,14 @@ where
             .await
             .into_iter()
             .collect::<Vec<_>>();
-        let hashes = locations.iter()
-            .map(|location| location.certificate_hash.clone())
+        let hashes = locations
+            .iter()
+            .map(|location| location.certificate_hash)
             .collect::<Vec<_>>();
-        let results = self.storage.contains_hashed_certificate_values(hashes).await?;
+        let results = self
+            .storage
+            .contains_hashed_certificate_values(hashes)
+            .await?;
         let mut missing_locations = vec![];
         for (location, result) in locations.into_iter().zip(results) {
             if !result {
@@ -1101,7 +1103,14 @@ where
         let blobs_in_block = self.state.get_blobs(required_blob_ids.clone()).await?;
         let certificate_hash = certificate.hash();
 
-        self.state.storage.write_hashed_certificate_values_hashed_blobs_certificate(hashed_certificate_values, &blobs_in_block, &certificate).await?;
+        self.state
+            .storage
+            .write_hashed_certificate_values_hashed_blobs_certificate(
+                hashed_certificate_values,
+                &blobs_in_block,
+                &certificate,
+            )
+            .await?;
 
         // Update the blob state with last used certificate hash.
         try_join_all(required_blob_ids.into_iter().map(|blob_id| {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -350,15 +350,7 @@ where
             .into_iter()
             .filter(|blob_id| !pending_blobs.contains_key(blob_id))
             .collect::<Vec<_>>();
-        let results = self.storage.contains_blobs(blob_ids.clone()).await?;
-        let mut missing_blobs = vec![];
-        for (blob_id, result) in blob_ids.into_iter().zip(results) {
-            if !result {
-                missing_blobs.push(blob_id);
-            }
-        }
-
-        Ok(missing_blobs)
+        Ok(self.storage.missing_blobs(blob_ids.clone()).await?)
     }
 
     /// Returns the blobs requested by their `blob_ids` that are either in pending in the

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -626,6 +626,23 @@ where
         self.write_batch(batch).await
     }
 
+    async fn write_hashed_certificate_values_hashed_blobs_certificate(
+        &self,
+        values: &[HashedCertificateValue],
+        blobs: &[HashedBlob],
+        certificate: &Certificate,
+    ) -> Result<(), ViewError> {
+        let mut batch = Batch::new();
+        for value in values {
+            self.add_hashed_cert_value_to_batch(value, &mut batch)?;
+        }
+        for blob in blobs {
+            self.add_blob_to_batch(&blob.id(), blob, &mut batch)?;
+        }
+        Self::add_certificate_to_batch(certificate, &mut batch)?;
+        self.write_batch(batch).await
+    }
+
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError> {
         let cert_key = bcs::to_bytes(&BaseKey::Certificate(hash))?;
         let value_key = bcs::to_bytes(&BaseKey::Value(hash))?;
@@ -657,14 +674,14 @@ where
 
     async fn write_certificate(&self, certificate: &Certificate) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        self.add_certificate_to_batch(certificate, &mut batch)?;
+        Self::add_certificate_to_batch(certificate, &mut batch)?;
         self.write_batch(batch).await
     }
 
     async fn write_certificates(&self, certificates: &[Certificate]) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for certificate in certificates {
-            self.add_certificate_to_batch(certificate, &mut batch)?;
+            Self::add_certificate_to_batch(certificate, &mut batch)?;
         }
         self.write_batch(batch).await
     }
@@ -720,7 +737,6 @@ where
     }
 
     fn add_certificate_to_batch(
-        &self,
         certificate: &Certificate,
         batch: &mut Batch,
     ) -> Result<(), ViewError> {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -74,7 +74,7 @@ static CONTAINS_BLOB_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     .expect("Counter creation should not fail")
 });
 
-/// The metric counting how often multiple blob are tested for existence from storage
+/// The metric counting how often multiple blobs are tested for existence from storage
 #[cfg(with_metrics)]
 static CONTAINS_BLOBS_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
     prometheus_util::register_int_counter_vec(
@@ -566,13 +566,13 @@ where
         value: &HashedCertificateValue,
     ) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        self.add_hashed_cert_value_to_batch(value, &mut batch)?;
+        Self::add_hashed_cert_value_to_batch(value, &mut batch)?;
         self.write_batch(batch).await
     }
 
     async fn write_hashed_blob(&self, blob: &HashedBlob) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        self.add_blob_to_batch(&blob.id(), blob, &mut batch)?;
+        Self::add_blob_to_batch(&blob.id(), blob, &mut batch)?;
         self.write_batch(batch).await?;
         Ok(())
     }
@@ -605,7 +605,7 @@ where
         blob_state: &BlobState,
     ) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        self.add_blob_state_to_batch(blob_id, blob_state, &mut batch)?;
+        Self::add_blob_state_to_batch(blob_id, blob_state, &mut batch)?;
         self.write_batch(batch).await?;
         Ok(())
     }
@@ -616,7 +616,7 @@ where
     ) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for value in values {
-            self.add_hashed_cert_value_to_batch(value, &mut batch)?;
+            Self::add_hashed_cert_value_to_batch(value, &mut batch)?;
         }
         self.write_batch(batch).await
     }
@@ -624,7 +624,7 @@ where
     async fn write_hashed_blobs(&self, blobs: &[HashedBlob]) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for blob in blobs {
-            self.add_blob_to_batch(&blob.id(), blob, &mut batch)?;
+            Self::add_blob_to_batch(&blob.id(), blob, &mut batch)?;
         }
         self.write_batch(batch).await
     }
@@ -637,10 +637,10 @@ where
     ) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for value in values {
-            self.add_hashed_cert_value_to_batch(value, &mut batch)?;
+            Self::add_hashed_cert_value_to_batch(value, &mut batch)?;
         }
         for blob in blobs {
-            self.add_blob_to_batch(&blob.id(), blob, &mut batch)?;
+            Self::add_blob_to_batch(&blob.id(), blob, &mut batch)?;
         }
         Self::add_certificate_to_batch(certificate, &mut batch)?;
         self.write_batch(batch).await
@@ -702,7 +702,6 @@ where
     <Client as KeyValueStore>::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
 {
     fn add_hashed_cert_value_to_batch(
-        &self,
         value: &HashedCertificateValue,
         batch: &mut Batch,
     ) -> Result<(), ViewError> {
@@ -716,7 +715,6 @@ where
     }
 
     fn add_blob_to_batch(
-        &self,
         blob_id: &BlobId,
         blob: &HashedBlob,
         batch: &mut Batch,
@@ -729,7 +727,6 @@ where
     }
 
     fn add_blob_state_to_batch(
-        &self,
         blob_id: BlobId,
         blob_state: &BlobState,
         batch: &mut Batch,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -454,7 +454,10 @@ where
         Ok(test)
     }
 
-    async fn contains_hashed_certificate_values(&self, hashes: Vec<CryptoHash>) -> Result<Vec<bool>, ViewError> {
+    async fn contains_hashed_certificate_values(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<bool>, ViewError> {
         let mut keys = Vec::new();
         for hash in hashes {
             let value_key = bcs::to_bytes(&BaseKey::Value(hash))?;
@@ -663,8 +666,8 @@ where
             READ_CERTIFICATE_COUNTER.with_label_values(&[]).inc();
         }
         let values = values?;
-        let cert_result = from_bytes_option::<LiteCertificate,_>(&values[0])?;
-        let value_result = from_bytes_option::<CertificateValue,_>(&values[1])?;
+        let cert_result = from_bytes_option::<LiteCertificate, _>(&values[0])?;
+        let value_result = from_bytes_option::<CertificateValue, _>(&values[1])?;
         let value = value_result.ok_or_else(|| ViewError::not_found("value for hash", hash))?;
         let cert = cert_result.ok_or_else(|| ViewError::not_found("certificate for hash", hash))?;
         Ok(cert

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -94,6 +94,9 @@ pub trait Storage: Sized {
     /// Tests existence of a hashed certificate value with the given hash.
     async fn contains_hashed_certificate_value(&self, hash: CryptoHash) -> Result<bool, ViewError>;
 
+    /// Tests existence of hashed certificate values with given hashes.
+    async fn contains_hashed_certificate_values(&self, hash: Vec<CryptoHash>) -> Result<Vec<bool>, ViewError>;
+
     /// Tests existence of a blob with the given hash.
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -103,8 +103,8 @@ pub trait Storage: Sized {
     /// Tests existence of a blob with the given hash.
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
-    /// Tests existence of several blobs with the given hashes.
-    async fn contains_blobs(&self, blob_ids: Vec<BlobId>) -> Result<Vec<bool>, ViewError>;
+    /// List the missing blobs from the storage.
+    async fn missing_blobs(&self, blob_ids: Vec<BlobId>) -> Result<Vec<BlobId>, ViewError>;
 
     /// Tests existence of a blob state with the given hash.
     async fn contains_blob_state(&self, blob_id: BlobId) -> Result<bool, ViewError>;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -97,6 +97,9 @@ pub trait Storage: Sized {
     /// Tests existence of a blob with the given hash.
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 
+    /// Tests existence of several blobs with the given hashes.
+    async fn contains_blobs(&self, blob_ids: Vec<BlobId>) -> Result<Vec<bool>, ViewError>;
+
     /// Tests existence of a blob state with the given hash.
     async fn contains_blob_state(&self, blob_id: BlobId) -> Result<bool, ViewError>;
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -95,7 +95,10 @@ pub trait Storage: Sized {
     async fn contains_hashed_certificate_value(&self, hash: CryptoHash) -> Result<bool, ViewError>;
 
     /// Tests existence of hashed certificate values with given hashes.
-    async fn contains_hashed_certificate_values(&self, hash: Vec<CryptoHash>) -> Result<Vec<bool>, ViewError>;
+    async fn contains_hashed_certificate_values(
+        &self,
+        hash: Vec<CryptoHash>,
+    ) -> Result<Vec<bool>, ViewError>;
 
     /// Tests existence of a blob with the given hash.
     async fn contains_blob(&self, blob_id: BlobId) -> Result<bool, ViewError>;
@@ -137,7 +140,7 @@ pub trait Storage: Sized {
     /// Writes hashed certificates, hashed blobs and certificate
     async fn write_hashed_certificate_values_hashed_blobs_certificate(
         &self,
-	values: &[HashedCertificateValue],
+        values: &[HashedCertificateValue],
         blobs: &[HashedBlob],
         certificate: &Certificate,
     ) -> Result<(), ViewError>;

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -134,6 +134,14 @@ pub trait Storage: Sized {
     /// Writes the given blob.
     async fn write_hashed_blob(&self, blob: &HashedBlob) -> Result<(), ViewError>;
 
+    /// Writes hashed certificates, hashed blobs and certificate
+    async fn write_hashed_certificate_values_hashed_blobs_certificate(
+        &self,
+	values: &[HashedCertificateValue],
+        blobs: &[HashedBlob],
+        certificate: &Certificate,
+    ) -> Result<(), ViewError>;
+
     /// Writes the given blob state.
     async fn write_blob_state(
         &self,

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -101,7 +101,8 @@ pub fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
     (Included(key_prefix), upper_bound)
 }
 
-pub(crate) fn from_bytes_option<V: DeserializeOwned, E>(
+/// Deserialize an Optional vector of u8
+pub fn from_bytes_option<V: DeserializeOwned, E>(
     key_opt: &Option<Vec<u8>>,
 ) -> Result<Option<V>, E>
 where

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -101,7 +101,7 @@ pub fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
     (Included(key_prefix), upper_bound)
 }
 
-/// Deserialize an Optional vector of u8
+/// Deserializes an Optional vector of u8
 pub fn from_bytes_option<V: DeserializeOwned, E>(key_opt: &Option<Vec<u8>>) -> Result<Option<V>, E>
 where
     E: From<bcs::Error>,

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -102,9 +102,7 @@ pub fn get_interval(key_prefix: Vec<u8>) -> (Bound<Vec<u8>>, Bound<Vec<u8>>) {
 }
 
 /// Deserialize an Optional vector of u8
-pub fn from_bytes_option<V: DeserializeOwned, E>(
-    key_opt: &Option<Vec<u8>>,
-) -> Result<Option<V>, E>
+pub fn from_bytes_option<V: DeserializeOwned, E>(key_opt: &Option<Vec<u8>>) -> Result<Option<V>, E>
 where
     E: From<bcs::Error>,
 {


### PR DESCRIPTION
## Motivation

After the merging of the PR implementing `contains_keys`, it is important to implement its usage over the code. This was done as well as other corrections.

## Proposal

The following was done:
* The `try_load_entries` is now using the `contains_keys` instead of a vector of handles and a `join`.
* In the storage, the function `write_hashed_certificate_values_hashed_blobs_certificate` was introduced which allows grouping 3 different writes into a single one. 
* The `contains_hashed_certificate_values` was introduced in order to group the contains operations.
* The `contains_blobs` was introduced in order to group the calls into a single one.
* The `contains_certificate` and `read_certificate` codes are grouped into a single operation. No more join.

## Test Plan

CI

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
