### PR TITLE
Implement `try_load_all_entries` for `ReentrantCollectionView`.

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -500,7 +500,7 @@ where
         let chain_id = self.chain_id();
         let pairs = self.inboxes.try_load_all_entries().await?;
         let max_stream_queries = self.context().max_stream_queries();
-        let stream = stream::iter(pairs.into_iter())
+        let stream = stream::iter(pairs)
             .map(|(origin, inbox)| async move {
                 if let Some(event) = inbox.removed_events.front().await? {
                     return Err(ChainError::MissingCrossChainUpdate {

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -438,7 +438,7 @@ where
     async fn create_network_actions(&self) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
         let pairs = self.chain.outboxes.try_load_all_entries().await?;
-        for (target, outbox) in pairs.into_iter() {
+        for (target, outbox) in pairs {
             let heights = outbox.queue.elements().await?;
             heights_by_recipient
                 .entry(target.recipient)
@@ -780,7 +780,7 @@ where
             } else {
                 MessageAction::Accept
             };
-            for (origin, inbox) in pairs.into_iter() {
+            for (origin, inbox) in pairs {
                 for event in inbox.added_events.elements().await? {
                     messages.push(IncomingMessage {
                         origin: origin.clone(),

--- a/linera-core/src/chain_worker/state.rs
+++ b/linera-core/src/chain_worker/state.rs
@@ -437,16 +437,13 @@ where
     /// Loads pending cross-chain requests.
     async fn create_network_actions(&self) -> Result<NetworkActions, WorkerError> {
         let mut heights_by_recipient: BTreeMap<_, BTreeMap<_, _>> = Default::default();
-        let targets = self.chain.outboxes.indices().await?;
-        let outboxes = self.chain.outboxes.try_load_entries(&targets).await?;
-        for (target, outbox) in targets.into_iter().zip(outboxes) {
-            if let Some(outbox) = outbox {
-                let heights = outbox.queue.elements().await?;
-                heights_by_recipient
-                    .entry(target.recipient)
-                    .or_default()
-                    .insert(target.medium, heights);
-            }
+        let pairs = self.chain.outboxes.try_load_all_entries().await?;
+        for (target, outbox) in pairs.into_iter() {
+            let heights = outbox.queue.elements().await?;
+            heights_by_recipient
+                .entry(target.recipient)
+                .or_default()
+                .insert(target.medium, heights);
         }
         let mut actions = NetworkActions::default();
         for (recipient, height_map) in heights_by_recipient {
@@ -777,22 +774,19 @@ where
         }
         if query.request_pending_messages {
             let mut messages = Vec::new();
-            let origins = chain.inboxes.indices().await?;
-            let inboxes = chain.inboxes.try_load_entries(&origins).await?;
+            let pairs = chain.inboxes.try_load_all_entries().await?;
             let action = if *chain.execution_state.system.closed.get() {
                 MessageAction::Reject
             } else {
                 MessageAction::Accept
             };
-            for (origin, inbox) in origins.into_iter().zip(inboxes) {
-                if let Some(inbox) = inbox {
-                    for event in inbox.added_events.elements().await? {
-                        messages.push(IncomingMessage {
-                            origin: origin.clone(),
-                            event: event.clone(),
-                            action,
-                        });
-                    }
+            for (origin, inbox) in pairs.into_iter() {
+                for event in inbox.added_events.elements().await? {
+                    messages.push(IncomingMessage {
+                        origin: origin.clone(),
+                        event: event.clone(),
+                        action,
+                    });
                 }
             }
 

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -459,7 +459,7 @@ where
         {
             let chain = self.local_node.chain_state_view(chain_id).await?;
             let pairs = chain.inboxes.try_load_all_entries().await?;
-            for (origin, inbox) in pairs.into_iter() {
+            for (origin, inbox) in pairs {
                 let next_height = sender_heights.entry(origin.sender).or_default();
                 let inbox_next_height = inbox.next_block_height_to_receive()?;
                 if inbox_next_height > *next_height {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -458,15 +458,12 @@ where
         let mut sender_heights = BTreeMap::new();
         {
             let chain = self.local_node.chain_state_view(chain_id).await?;
-            let origins = chain.inboxes.indices().await?;
-            let inboxes = chain.inboxes.try_load_entries(&origins).await?;
-            for (origin, inbox) in origins.into_iter().zip(inboxes) {
-                if let Some(inbox) = inbox {
-                    let next_height = sender_heights.entry(origin.sender).or_default();
-                    let inbox_next_height = inbox.next_block_height_to_receive()?;
-                    if inbox_next_height > *next_height {
-                        *next_height = inbox_next_height;
-                    }
+            let pairs = chain.inboxes.try_load_all_entries().await?;
+            for (origin, inbox) in pairs.into_iter() {
+                let next_height = sender_heights.entry(origin.sender).or_default();
+                let inbox_next_height = inbox.next_block_height_to_receive()?;
+                if inbox_next_height > *next_height {
+                    *next_height = inbox_next_height;
                 }
             }
         }

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -647,8 +647,7 @@ where
         let mut short_keys_to_load = Vec::new();
         for short_key in short_keys {
             if updates.get(short_key).is_none() {
-                let key = context
-                    .base_tag_index(KeyTag::Subview as u8, short_key);
+                let key = context.base_tag_index(KeyTag::Subview as u8, short_key);
                 let context = context.clone_with_base_key(key);
                 keys.extend(W::pre_load(&context)?);
                 short_keys_to_load.push(short_key.to_vec());
@@ -657,8 +656,7 @@ where
         let values = context.read_multi_values_bytes(keys).await?;
         let num_init_keys = W::NUM_INIT_KEYS;
         for (i_key, short_key) in short_keys_to_load.into_iter().enumerate() {
-            let key = context
-                .base_tag_index(KeyTag::Subview as u8, &short_key);
+            let key = context.base_tag_index(KeyTag::Subview as u8, &short_key);
             let context = context.clone_with_base_key(key);
             let view = W::post_load(
                 context,
@@ -688,7 +686,7 @@ where
     /// ```
     pub async fn try_load_all_entries(
         &self,
-    ) -> Result<Vec<(Vec<u8>,ReadGuardedView<W>)>, ViewError> {
+    ) -> Result<Vec<(Vec<u8>, ReadGuardedView<W>)>, ViewError> {
         let short_keys = self.keys().await?;
         let mut updates = self.updates.lock().await;
         if !self.delete_storage_first {
@@ -728,7 +726,7 @@ where
     /// ```
     pub async fn try_load_all_entries_mut(
         &self,
-    ) -> Result<Vec<(Vec<u8>,WriteGuardedView<W>)>, ViewError> {
+    ) -> Result<Vec<(Vec<u8>, WriteGuardedView<W>)>, ViewError> {
         let short_keys = self.keys().await?;
         let mut updates = self.updates.lock().await;
         if !self.delete_storage_first {
@@ -1276,7 +1274,7 @@ where
             .into_iter()
             .map(|(short_key, view)| {
                 let index = C::deserialize_value(&short_key)?;
-                Ok((index,view))
+                Ok((index, view))
             })
             .collect()
     }
@@ -1300,7 +1298,7 @@ where
     /// ```
     pub async fn try_load_all_entries<'a, Q>(
         &'a self,
-    ) -> Result<Vec<(I,ReadGuardedView<W>)>, ViewError>
+    ) -> Result<Vec<(I, ReadGuardedView<W>)>, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + 'a,
@@ -1310,7 +1308,7 @@ where
             .into_iter()
             .map(|(short_key, view)| {
                 let index = C::deserialize_value(&short_key)?;
-                Ok((index,view))
+                Ok((index, view))
             })
             .collect()
     }
@@ -1761,7 +1759,7 @@ where
             .into_iter()
             .map(|(short_key, view)| {
                 let index = I::from_custom_bytes(&short_key)?;
-                Ok((index,view))
+                Ok((index, view))
             })
             .collect()
     }
@@ -1783,9 +1781,7 @@ where
     ///   assert_eq!(subviews.len(), 1);
     /// # })
     /// ```
-    pub async fn try_load_all_entries<Q>(
-        &self,
-    ) -> Result<Vec<(I,ReadGuardedView<W>)>, ViewError>
+    pub async fn try_load_all_entries<Q>(&self) -> Result<Vec<(I, ReadGuardedView<W>)>, ViewError>
     where
         I: Borrow<Q>,
         Q: CustomSerialize,
@@ -1795,7 +1791,7 @@ where
             .into_iter()
             .map(|(short_key, view)| {
                 let index = I::from_custom_bytes(&short_key)?;
-                Ok((index,view))
+                Ok((index, view))
             })
             .collect()
     }

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -1300,7 +1300,7 @@ where
     /// ```
     pub async fn try_load_all_entries<'a, Q>(
         &'a self,
-    ) -> Result<Vec<(Vec<u8>,ReadGuardedView<W>)>, ViewError>
+    ) -> Result<Vec<(I,ReadGuardedView<W>)>, ViewError>
     where
         I: Borrow<Q>,
         Q: Serialize + 'a,
@@ -1661,7 +1661,7 @@ impl<C, I, W> ReentrantCustomCollectionView<C, I, W>
 where
     C: Context + Send + Clone + 'static,
     ViewError: From<C::Error>,
-    I: Sync + Clone + Send + Debug + Serialize + DeserializeOwned,
+    I: Sync + Clone + Send + Debug + CustomSerialize,
     W: View<C> + Send + Sync + 'static,
 {
     /// Load multiple entries for writing at once.
@@ -1730,6 +1730,74 @@ where
             .map(|index| index.to_custom_bytes())
             .collect::<Result<_, _>>()?;
         self.collection.try_load_entries(short_keys).await
+    }
+
+    /// Load all entries for writing at once.
+    /// The entries in indices have to be all distinct.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use crate::linera_views::views::View;
+    /// # let context = create_memory_context();
+    ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
+    ///   {
+    ///     let _subview = ivew.try_load_entry(&23).await.unwrap();
+    ///   }
+    ///   let subviews = view.try_load_all_entries_mut().await.unwrap();
+    ///   assert_eq!(subviews.len(), 1);
+    /// # })
+    /// ```
+    pub async fn try_load_all_entries_mut<Q>(
+        &mut self,
+    ) -> Result<Vec<(I, WriteGuardedView<W>)>, ViewError>
+    where
+        I: Borrow<Q>,
+        Q: CustomSerialize,
+    {
+        let results = self.collection.try_load_all_entries_mut().await?;
+        results
+            .into_iter()
+            .map(|(short_key, view)| {
+                let index = I::from_custom_bytes(&short_key)?;
+                Ok((index,view))
+            })
+            .collect()
+    }
+
+    /// Load multiple entries for reading at once.
+    /// The entries in indices have to be all distinct.
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
+    /// # use linera_views::register_view::RegisterView;
+    /// # use crate::linera_views::views::View;
+    /// # let context = create_memory_context();
+    ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
+    ///   {
+    ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
+    ///   }
+    ///   let subviews = view.try_load_all_entries().await.unwrap();
+    ///   assert!(subviews.len(), 1);
+    /// # })
+    /// ```
+    pub async fn try_load_all_entries<Q>(
+        &self,
+    ) -> Result<Vec<(I,ReadGuardedView<W>)>, ViewError>
+    where
+        I: Borrow<Q>,
+        Q: CustomSerialize,
+    {
+        let results = self.collection.try_load_all_entries().await?;
+        results
+            .into_iter()
+            .map(|(short_key, view)| {
+                let index = I::from_custom_bytes(&short_key)?;
+                Ok((index,view))
+            })
+            .collect()
     }
 }
 

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -668,7 +668,7 @@ where
         Ok(())
     }
 
-    /// Load all the entries for reading at once.
+    /// Loads all the entries for reading at once.
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::{create_memory_context, MemoryContext};
@@ -708,7 +708,7 @@ where
             .collect()
     }
 
-    /// Load all the entries for writing at once.
+    /// Loads all the entries for writing at once.
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::{create_memory_context, MemoryContext};
@@ -1245,7 +1245,7 @@ where
         self.collection.try_load_entries(short_keys).await
     }
 
-    /// Load all entries for writing at once.
+    /// Loads all entries for writing at once.
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
@@ -1730,16 +1730,16 @@ where
         self.collection.try_load_entries(short_keys).await
     }
 
-    /// Load all entries for writing at once.
+    /// Loads all entries for writing at once.
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::{create_memory_context, MemoryContext};
-    /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
+    /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_memory_context();
-    ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
+    ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   }
@@ -1769,11 +1769,11 @@ where
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::memory::{create_memory_context, MemoryContext};
-    /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
+    /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
     /// # let context = create_memory_context();
-    ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
+    ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   }

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -1258,7 +1258,7 @@ where
     /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
-    ///     let _subview = ivew.try_load_entry(&23).await.unwrap();
+    ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   }
     ///   let subviews = view.try_load_all_entries_mut().await.unwrap();
     ///   assert_eq!(subviews.len(), 1);
@@ -1295,7 +1295,7 @@ where
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   }
     ///   let subviews = view.try_load_all_entries().await.unwrap();
-    ///   assert!(subviews.len(), 1);
+    ///   assert_eq!(subviews.len(), 1);
     /// # })
     /// ```
     pub async fn try_load_all_entries<'a, Q>(
@@ -1743,7 +1743,7 @@ where
     /// # let context = create_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
-    ///     let _subview = ivew.try_load_entry(&23).await.unwrap();
+    ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   }
     ///   let subviews = view.try_load_all_entries_mut().await.unwrap();
     ///   assert_eq!(subviews.len(), 1);
@@ -1780,7 +1780,7 @@ where
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   }
     ///   let subviews = view.try_load_all_entries().await.unwrap();
-    ///   assert!(subviews.len(), 1);
+    ///   assert_eq!(subviews.len(), 1);
     /// # })
     /// ```
     pub async fn try_load_all_entries<Q>(


### PR DESCRIPTION
## Motivation

The code has several times the following pattern
```
let indices = view.indices().await?;
let subviews = view.try_load_all_entries(&indices).await?;
```

which is inherently inefficient. 

## Proposal

The `try_load_all_entries` and `try_load_all_entries_mut` are introduced and used in the code.
The `try_load_all_entries` is used appropriately in the code which results in an overall simplification of the code.

## Test Plan

The CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
