### PR TITLE
Improve logging output

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: warn
+  RUST_LOG: debug
   RUST_LOG_FORMAT: plain
 
 permissions:
@@ -68,8 +68,8 @@ jobs:
     - name: Run end-to-end tests
       run: |
         cargo build --release -p linera-storage-service
-        RUST_LOG=info target/release/linera-storage-server memory --endpoint $LINERA_STORAGE_SERVICE &
-        RUST_LOG=info cargo test --features storage-service -- storage_service --nocapture
+        target/release/linera-storage-server memory --endpoint $LINERA_STORAGE_SERVICE &
+        cargo test --features storage-service -- storage_service --nocapture
     - name: Run Ethereum tests
       run: |
         cargo test -p linera-ethereum --features ethereum

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: debug
+  RUST_LOG: linera=debug
   RUST_LOG_FORMAT: plain
 
 permissions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
+  RUST_LOG_FORMAT: plain
 
 permissions:
   contents: read

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -45,6 +45,7 @@ pub fn init() {
         match format.as_str() {
             "json" => subscriber.json().init(),
             "pretty" => subscriber.pretty().init(),
+            "plain" => subscriber.init(),
             _ => {
                 panic!("Invalid RUST_LOG_FORMAT: `{format}`.  Valid values are `json` or `pretty`.")
             }

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -54,13 +54,7 @@ enum Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let env_filter = tracing_subscriber::EnvFilter::builder()
-        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        .from_env_lossy();
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(env_filter)
-        .init();
+    linera_base::tracing::init();
 
     let args = Args::parse();
     match args {

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -146,7 +146,7 @@ impl ClientWrapper {
             .current_dir(self.path_provider.path())
             .env(
                 "RUST_LOG",
-                std::env::var("RUST_LOG").unwrap_or(String::from("linera=default")),
+                std::env::var("RUST_LOG").unwrap_or(String::from("linera=debug")),
             )
             .args(["--wallet", &self.wallet])
             .args(["--storage", &self.storage])

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -328,13 +328,7 @@ where
 }
 
 fn main() -> Result<()> {
-    let env_filter = tracing_subscriber::EnvFilter::builder()
-        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        .from_env_lossy();
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .with_env_filter(env_filter)
-        .init();
+    linera_base::tracing::init();
 
     let options = <ProxyOptions as clap::Parser>::parse();
 


### PR DESCRIPTION
## Motivation

There is currently a typo in the `linera-service` tests that [results in an error](https://github.com/linera-io/linera-protocol/pull/2257/files#r1686167112) and presumably fails to show debug logs from some parts of our tests.

Our tracing subscriber currently chooses a JSON output automatically if `stderr` is not connected to a TTY; I believe this is sensible behaviour in general but we should be able to override it, since sometimes we want human-readable output from subprocesses whose output is processed.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Fix the typo.  Add a `plain` log format and activate it explicitly in CI.  Set our CI log level to `DEBUG` so we see `INFO` and `DEBUG` messages that can be helpful for our developers to understand what's gone wrong in a CI run.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Check CI output.

<!-- How to test that the changes are correct. -->

## Release Plan

None needed.

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
