### PR TITLE
Refactor the `deleted_prefixes` in `MapView` and `KeyValueStoreView`.

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -86,7 +86,6 @@ impl DeletionSet {
     }
 }
 
-
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone)]
 pub struct CommonStoreConfig {

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -1,12 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fmt::Debug,
-    mem,
-    ops::Bound::Included,
-};
+use std::{collections::BTreeMap, fmt::Debug, mem, ops::Bound::Included};
 
 use async_lock::Mutex;
 use async_trait::async_trait;
@@ -22,9 +17,9 @@ use {
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        contains_key, from_bytes_option, from_bytes_option_or_default, get_interval,
-        get_upper_bound, insert_key_prefix, Context, HasherOutput, KeyIterable, KeyValueIterable,
-        SuffixClosedSetIterator, Update, MIN_VIEW_TAG,
+        from_bytes_option, from_bytes_option_or_default, get_interval, get_upper_bound, Context,
+        DeletionSet, HasherOutput, KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update,
+        MIN_VIEW_TAG,
     },
     map_view::ByteMapView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
@@ -142,12 +137,11 @@ impl SizeData {
 #[derive(Debug)]
 pub struct KeyValueStoreView<C> {
     context: C,
-    delete_storage_first: bool,
+    deletion_set: DeletionSet,
     updates: BTreeMap<Vec<u8>, Update<Vec<u8>>>,
     stored_total_size: SizeData,
     total_size: SizeData,
     sizes: ByteMapView<C, u32>,
-    deleted_prefixes: BTreeSet<Vec<u8>>,
     stored_hash: Option<HasherOutput>,
     hash: Mutex<Option<HasherOutput>>,
 }
@@ -186,12 +180,11 @@ where
         )?;
         Ok(Self {
             context,
-            delete_storage_first: false,
+            deletion_set: DeletionSet::new(),
             updates: BTreeMap::new(),
             stored_total_size: total_size,
             total_size,
             sizes,
-            deleted_prefixes: BTreeSet::new(),
             stored_hash: hash,
             hash: Mutex::new(hash),
         })
@@ -204,19 +197,15 @@ where
     }
 
     fn rollback(&mut self) {
-        self.delete_storage_first = false;
+        self.deletion_set.rollback();
         self.updates.clear();
-        self.deleted_prefixes.clear();
         self.total_size = self.stored_total_size;
         self.sizes.rollback();
         *self.hash.get_mut() = self.stored_hash;
     }
 
     async fn has_pending_changes(&self) -> bool {
-        if self.delete_storage_first {
-            return true;
-        }
-        if !self.deleted_prefixes.is_empty() {
+        if self.deletion_set.has_pending_changes() {
             return true;
         }
         if !self.updates.is_empty() {
@@ -234,7 +223,7 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError> {
         let mut delete_view = false;
-        if self.delete_storage_first {
+        if self.deletion_set.delete_storage_first {
             delete_view = true;
             self.stored_total_size = SizeData::default();
             batch.delete_key_prefix(self.context.base_key());
@@ -247,7 +236,7 @@ where
             }
             self.stored_hash = None
         } else {
-            for index in mem::take(&mut self.deleted_prefixes) {
+            for index in mem::take(&mut self.deletion_set.deleted_prefixes) {
                 let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
                 batch.delete_key_prefix(key);
             }
@@ -274,14 +263,13 @@ where
             batch.put_key_value(key, &self.total_size)?;
             self.stored_total_size = self.total_size;
         }
-        self.delete_storage_first = false;
+        self.deletion_set.delete_storage_first = false;
         Ok(delete_view)
     }
 
     fn clear(&mut self) {
-        self.delete_storage_first = true;
+        self.deletion_set.clear();
         self.updates.clear();
-        self.deleted_prefixes.clear();
         self.total_size = SizeData::default();
         self.sizes.clear();
         *self.hash.get_mut() = None;
@@ -296,12 +284,11 @@ where
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(KeyValueStoreView {
             context: self.context.clone(),
-            delete_storage_first: self.delete_storage_first,
+            deletion_set: self.deletion_set.clone(),
             updates: self.updates.clone(),
             stored_total_size: self.stored_total_size,
             total_size: self.total_size,
             sizes: self.sizes.clone_unchecked()?,
-            deleted_prefixes: self.deleted_prefixes.clone(),
             stored_hash: self.stored_hash,
             hash: Mutex::new(*self.hash.get_mut()),
         })
@@ -361,8 +348,9 @@ where
         let key_prefix = self.context.base_tag(KeyTag::Index as u8);
         let mut updates = self.updates.iter();
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
-        if !self.delete_storage_first {
+        if !self.deletion_set.delete_storage_first {
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
             for index in self
                 .context
                 .find_keys_by_prefix(&key_prefix)
@@ -460,8 +448,9 @@ where
         let key_prefix = self.context.base_tag(KeyTag::Index as u8);
         let mut updates = self.updates.iter();
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
-        if !self.delete_storage_first {
+        if !self.deletion_set.delete_storage_first {
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
             for entry in self
                 .context
                 .find_key_values_by_prefix(&key_prefix)
@@ -626,10 +615,7 @@ where
             };
             return Ok(value);
         }
-        if self.delete_storage_first {
-            return Ok(None);
-        }
-        if contains_key(&self.deleted_prefixes, index) {
+        if self.deletion_set.contains_key(index) {
             return Ok(None);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
@@ -658,10 +644,7 @@ where
             };
             return Ok(test);
         }
-        if self.delete_storage_first {
-            return Ok(false);
-        }
-        if contains_key(&self.deleted_prefixes, index) {
+        if self.deletion_set.contains_key(index) {
             return Ok(false);
         }
         let key = self.context.base_tag_index(KeyTag::Index as u8, index);
@@ -696,18 +679,16 @@ where
                 results.push(value);
             } else {
                 results.push(false);
-                if !contains_key(&self.deleted_prefixes, &index) {
+                if !self.deletion_set.contains_key(&index) {
                     missed_indices.push(i);
                     let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
                     vector_query.push(key);
                 }
             }
         }
-        if !self.delete_storage_first {
-            let values = self.context.contains_keys(vector_query).await?;
-            for (i, value) in missed_indices.into_iter().zip(values) {
-                results[i] = value;
-            }
+        let values = self.context.contains_keys(vector_query).await?;
+        for (i, value) in missed_indices.into_iter().zip(values) {
+            results[i] = value;
         }
         Ok(results)
     }
@@ -741,18 +722,16 @@ where
                 result.push(value);
             } else {
                 result.push(None);
-                if !contains_key(&self.deleted_prefixes, &index) {
+                if !self.deletion_set.contains_key(&index) {
                     missed_indices.push(i);
                     let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
                     vector_query.push(key);
                 }
             }
         }
-        if !self.delete_storage_first {
-            let values = self.context.read_multi_values_bytes(vector_query).await?;
-            for (i, value) in missed_indices.into_iter().zip(values) {
-                result[i] = value;
-            }
+        let values = self.context.read_multi_values_bytes(vector_query).await?;
+        for (i, value) in missed_indices.into_iter().zip(values) {
+            result[i] = value;
         }
         Ok(result)
     }
@@ -790,7 +769,7 @@ where
                         self.total_size.sub_assign(entry_size);
                     }
                     self.sizes.remove(key.clone());
-                    if self.delete_storage_first {
+                    if self.deletion_set.contains_key(&key) {
                         // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
                         self.updates.remove(&key);
                     } else {
@@ -834,9 +813,7 @@ where
                         self.sizes.remove(key);
                     }
                     self.sizes.remove_by_prefix(key_prefix.clone());
-                    if !self.delete_storage_first {
-                        insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
-                    }
+                    self.deletion_set.insert_key_prefix(key_prefix);
                 }
             }
         }
@@ -926,8 +903,9 @@ where
             .updates
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
-        if !self.delete_storage_first {
+        if !self.deletion_set.delete_storage_first {
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
             for key in self
                 .context
                 .find_keys_by_prefix(&key_prefix_full)
@@ -999,8 +977,9 @@ where
             .updates
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
-        let mut suffix_closed_set = SuffixClosedSetIterator::new(0, self.deleted_prefixes.iter());
-        if !self.delete_storage_first {
+        if !self.deletion_set.delete_storage_first {
+            let mut suffix_closed_set =
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
             for entry in self
                 .context
                 .find_key_values_by_prefix(&key_prefix_full)

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -39,7 +39,7 @@ static MAP_VIEW_HASH_RUNTIME: Lazy<HistogramVec> = Lazy::new(|| {
 
 use std::{
     borrow::Borrow,
-    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    collections::{btree_map::Entry, BTreeMap},
     fmt::Debug,
     marker::PhantomData,
     mem,
@@ -51,8 +51,8 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::{
     batch::Batch,
     common::{
-        contains_key, get_interval, insert_key_prefix, Context, CustomSerialize, HasherOutput,
-        KeyIterable, KeyValueIterable, SuffixClosedSetIterator, Update,
+        get_interval, Context, CustomSerialize, DeletionSet, HasherOutput, KeyIterable,
+        KeyValueIterable, SuffixClosedSetIterator, Update,
     },
     hashable_wrapper::WrappedHashableContainerView,
     views::{ClonableView, HashableView, Hasher, View, ViewError},
@@ -62,9 +62,8 @@ use crate::{
 #[derive(Debug)]
 pub struct ByteMapView<C, V> {
     context: C,
-    delete_storage_first: bool,
+    deletion_set: DeletionSet,
     updates: BTreeMap<Vec<u8>, Update<V>>,
-    deleted_prefixes: BTreeSet<Vec<u8>>,
 }
 
 #[async_trait]
@@ -87,9 +86,8 @@ where
     fn post_load(context: C, _values: &[Option<Vec<u8>>]) -> Result<Self, ViewError> {
         Ok(Self {
             context,
-            delete_storage_first: false,
             updates: BTreeMap::new(),
-            deleted_prefixes: BTreeSet::new(),
+            deletion_set: DeletionSet::new(),
         })
     }
 
@@ -98,16 +96,12 @@ where
     }
 
     fn rollback(&mut self) {
-        self.delete_storage_first = false;
         self.updates.clear();
-        self.deleted_prefixes.clear();
+        self.deletion_set.rollback();
     }
 
     async fn has_pending_changes(&self) -> bool {
-        if self.delete_storage_first {
-            return true;
-        }
-        if !self.deleted_prefixes.is_empty() {
+        if self.deletion_set.has_pending_changes() {
             return true;
         }
         !self.updates.is_empty()
@@ -115,7 +109,7 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError> {
         let mut delete_view = false;
-        if self.delete_storage_first {
+        if self.deletion_set.delete_storage_first {
             delete_view = true;
             batch.delete_key_prefix(self.context.base_key());
             for (index, update) in mem::take(&mut self.updates) {
@@ -126,7 +120,7 @@ where
                 }
             }
         } else {
-            for index in mem::take(&mut self.deleted_prefixes) {
+            for index in mem::take(&mut self.deletion_set.deleted_prefixes) {
                 let key = self.context.base_index(&index);
                 batch.delete_key_prefix(key);
             }
@@ -138,14 +132,13 @@ where
                 }
             }
         }
-        self.delete_storage_first = false;
+        self.deletion_set.delete_storage_first = false;
         Ok(delete_view)
     }
 
     fn clear(&mut self) {
-        self.delete_storage_first = true;
         self.updates.clear();
-        self.deleted_prefixes.clear();
+        self.deletion_set.clear();
     }
 }
 
@@ -158,9 +151,8 @@ where
     fn clone_unchecked(&mut self) -> Result<Self, ViewError> {
         Ok(ByteMapView {
             context: self.context.clone(),
-            delete_storage_first: self.delete_storage_first,
             updates: self.updates.clone(),
-            deleted_prefixes: self.deleted_prefixes.clone(),
+            deletion_set: self.deletion_set.clone(),
         })
     }
 }
@@ -199,7 +191,7 @@ where
     /// # })
     /// ```
     pub fn remove(&mut self, short_key: Vec<u8>) {
-        if self.delete_storage_first {
+        if self.deletion_set.contains_key(&short_key) {
             // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
             self.updates.remove(&short_key);
         } else {
@@ -230,9 +222,7 @@ where
         for key in key_list {
             self.updates.remove(&key);
         }
-        if !self.delete_storage_first {
-            insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
-        }
+        self.deletion_set.insert_key_prefix(key_prefix);
     }
 
     /// Obtains the extra data.
@@ -261,10 +251,7 @@ where
             };
             return Ok(test);
         }
-        if self.delete_storage_first {
-            return Ok(false);
-        }
-        if contains_key(&self.deleted_prefixes, short_key) {
+        if self.deletion_set.contains_key(short_key) {
             return Ok(false);
         }
         let key = self.context.base_index(short_key);
@@ -298,10 +285,7 @@ where
             };
             return Ok(value);
         }
-        if self.delete_storage_first {
-            return Ok(None);
-        }
-        if contains_key(&self.deleted_prefixes, short_key) {
+        if self.deletion_set.contains_key(short_key) {
             return Ok(None);
         }
         let key = self.context.base_index(short_key);
@@ -326,7 +310,7 @@ where
     pub async fn get_mut(&mut self, short_key: &[u8]) -> Result<Option<&mut V>, ViewError> {
         let update = match self.updates.entry(short_key.to_vec()) {
             Entry::Vacant(e) => {
-                if self.delete_storage_first || contains_key(&self.deleted_prefixes, short_key) {
+                if self.deletion_set.contains_key(short_key) {
                     None
                 } else {
                     let key = self.context.base_index(short_key);
@@ -376,11 +360,11 @@ where
         F: FnMut(&[u8]) -> Result<bool, ViewError> + Send,
     {
         let prefix_len = prefix.len();
-        let iter = self.deleted_prefixes.range(get_interval(prefix.clone()));
-        let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
-        if !self.delete_storage_first && !contains_key(&self.deleted_prefixes, &prefix) {
+        if !self.deletion_set.contains_key(&prefix) {
+            let iter = self.deletion_set.deleted_prefixes.range(get_interval(prefix.clone()));
+            let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
             let base = self.context.base_index(&prefix);
             for index in self.context.find_keys_by_prefix(&base).await?.iterator() {
                 let index = index?;
@@ -571,11 +555,11 @@ where
         F: FnMut(&[u8], &[u8]) -> Result<bool, ViewError> + Send,
     {
         let prefix_len = prefix.len();
-        let iter = self.deleted_prefixes.range(get_interval(prefix.clone()));
-        let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
-        if !self.delete_storage_first && !contains_key(&self.deleted_prefixes, &prefix) {
+        if !self.deletion_set.contains_key(&prefix) {
+            let iter = self.deletion_set.deleted_prefixes.range(get_interval(prefix.clone()));
+            let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
             let base = self.context.base_index(&prefix);
             for entry in self
                 .context
@@ -737,9 +721,7 @@ where
     /// ```
     pub async fn get_mut_or_default(&mut self, short_key: &[u8]) -> Result<&mut V, ViewError> {
         let update = match self.updates.entry(short_key.to_vec()) {
-            Entry::Vacant(e)
-                if self.delete_storage_first || contains_key(&self.deleted_prefixes, short_key) =>
-            {
+            Entry::Vacant(e) if self.deletion_set.contains_key(short_key) => {
                 e.insert(Update::Set(V::default()))
             }
             Entry::Vacant(e) => {

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -363,7 +363,10 @@ where
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
         if !self.deletion_set.contains_key(&prefix) {
-            let iter = self.deletion_set.deleted_prefixes.range(get_interval(prefix.clone()));
+            let iter = self
+                .deletion_set
+                .deleted_prefixes
+                .range(get_interval(prefix.clone()));
             let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
             let base = self.context.base_index(&prefix);
             for index in self.context.find_keys_by_prefix(&base).await?.iterator() {
@@ -558,7 +561,10 @@ where
         let mut updates = self.updates.range(get_interval(prefix.clone()));
         let mut update = updates.next();
         if !self.deletion_set.contains_key(&prefix) {
-            let iter = self.deletion_set.deleted_prefixes.range(get_interval(prefix.clone()));
+            let iter = self
+                .deletion_set
+                .deleted_prefixes
+                .range(get_interval(prefix.clone()));
             let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
             let base = self.context.base_index(&prefix);
             for entry in self


### PR DESCRIPTION
## Motivation

The `delete_storage_first` / `deleted_prefixes` entries in `MapView` and `KeyValueStoreView` can be refactored. This simplifies those complex data types.

## Proposal

The `DeletionSet` is introduced in the `common.rs` file.

## Test Plan

CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
