### PR TITLE
Message Policy accepts messages from specific chains.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -121,7 +121,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
-* `--message-policy <MESSAGE_POLICY>` — The policy for handling incoming messages
+* `--blanket-message-policy <BLANKET_MESSAGE_POLICY>` — The policy for handling incoming messages
 
   Default value: `accept`
 
@@ -133,6 +133,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
   - `ignore`:
     Don't include any messages in blocks, and don't make any decision whether to accept or reject
 
+* `--restrict-chain-ids-to <RESTRICT_CHAIN_IDS_TO>` — A set of chains to restrict incoming messages from. By default, messages from all chains are accepted. To reject messages from all chains, specify an empty string
 
 
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -17,7 +17,7 @@ use linera_base::{
 };
 use linera_chain::data_types::Certificate;
 use linera_core::{
-    client::{ChainClient, Client},
+    client::{ChainClient, Client, MessagePolicy},
     data_types::ClientOutcome,
     node::CrossChainMessageDelivery,
     JoinSetExt as _,
@@ -195,7 +195,10 @@ where
             chain.pending_block.clone(),
             chain.pending_blobs.clone(),
         );
-        chain_client.options_mut().message_policy = self.options.message_policy;
+        chain_client.options_mut().message_policy = MessagePolicy::new(
+            self.options.blanket_message_policy,
+            self.options.restrict_chain_ids_to.clone(),
+        );
         chain_client
     }
 

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, iter, num::NonZeroU16, path::PathBuf, time::Duration};
+use std::{collections::HashSet, env, iter, num::NonZeroU16, path::PathBuf, time::Duration};
 
 use chrono::{DateTime, Utc};
 use linera_base::{
@@ -10,7 +10,7 @@ use linera_base::{
     identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
-use linera_core::client::MessagePolicy;
+use linera_core::client::BlanketMessagePolicy;
 use linera_execution::{
     committee::ValidatorName, system::SystemChannel, ResourceControlPolicy, UserApplicationId,
     WasmRuntime, WithWasmDefault as _,
@@ -131,7 +131,13 @@ pub struct ClientOptions {
 
     /// The policy for handling incoming messages.
     #[arg(long, default_value = "accept")]
-    pub message_policy: MessagePolicy,
+    pub blanket_message_policy: BlanketMessagePolicy,
+
+    /// A set of chains to restrict incoming messages from. By default, messages
+    /// from all chains are accepted. To reject messages from all chains, specify
+    /// an empty string.
+    #[arg(long, value_parser = util::parse_chain_set)]
+    pub restrict_chain_ids_to: Option<HashSet<ChainId>>,
 }
 
 impl ClientOptions {

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -1,10 +1,14 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{num::ParseIntError, time::Duration};
+use std::{collections::HashSet, num::ParseIntError, str::FromStr, time::Duration};
 
 use futures::future;
-use linera_base::data_types::{TimeDelta, Timestamp};
+use linera_base::{
+    crypto::CryptoError,
+    data_types::{TimeDelta, Timestamp},
+    identifiers::ChainId,
+};
 use linera_core::{data_types::RoundTimeout, node::NotificationStream, worker::Reason};
 use tokio_stream::StreamExt as _;
 
@@ -14,6 +18,13 @@ pub fn parse_millis(s: &str) -> Result<Duration, ParseIntError> {
 
 pub fn parse_millis_delta(s: &str) -> Result<TimeDelta, ParseIntError> {
     Ok(TimeDelta::from_millis(s.parse()?))
+}
+
+pub fn parse_chain_set(s: &str) -> Result<HashSet<ChainId>, CryptoError> {
+    match s.trim() {
+        "" => Ok(HashSet::new()),
+        s => s.split(",").map(ChainId::from_str).collect(),
+    }
 }
 
 /// Returns after the specified time or if we receive a notification that a new round has started.

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{hash_map, BTreeMap, HashMap},
+    collections::{hash_map, BTreeMap, HashMap, HashSet},
     convert::Infallible,
     iter,
     ops::{Deref, DerefMut},
@@ -119,7 +119,7 @@ where
             local_node,
             chains: DashMap::new(),
             max_pending_messages,
-            message_policy: MessagePolicy::Accept,
+            message_policy: MessagePolicy::new(BlanketMessagePolicy::Accept, None),
             cross_chain_message_delivery,
             notifier: Arc::new(Notifier::default()),
             storage,
@@ -180,7 +180,7 @@ where
             chain_id,
             options: ChainClientOptions {
                 max_pending_messages: self.max_pending_messages,
-                message_policy: self.message_policy,
+                message_policy: self.message_policy.clone(),
                 cross_chain_message_delivery: self.cross_chain_message_delivery,
             },
         }
@@ -188,10 +188,18 @@ where
 }
 
 /// Policies for automatically handling incoming messages.
-///
-/// These apply to all messages except for the initial `OpenChain`, which is always accepted.
+#[derive(Clone, Debug)]
+pub struct MessagePolicy {
+    /// The blanket policy applied to all messages.
+    blanket: BlanketMessagePolicy,
+    /// A collection of chains which restrict the origin of messages to be
+    /// accepted. `Option::None` means that messages from all chains are accepted. An empty
+    /// `HashSet` denotes that messages from no chains are accepted.
+    restrict_chain_ids_to: Option<HashSet<ChainId>>,
+}
+
 #[derive(Copy, Clone, Debug, clap::ValueEnum)]
-pub enum MessagePolicy {
+pub enum BlanketMessagePolicy {
     /// Automatically accept all incoming messages. Reject them only if execution fails.
     Accept,
     /// Automatically reject tracked messages, ignore or skip untracked messages, but accept
@@ -203,14 +211,40 @@ pub enum MessagePolicy {
 }
 
 impl MessagePolicy {
+    pub fn new(
+        blanket: BlanketMessagePolicy,
+        restrict_chain_ids_to: Option<HashSet<ChainId>>,
+    ) -> Self {
+        Self {
+            blanket,
+            restrict_chain_ids_to,
+        }
+    }
+
+    #[tracing::instrument(level = "trace", skip(self))]
+    fn handle(&self, bundle: &mut IncomingBundle) -> bool {
+        if self.is_reject() {
+            if bundle.bundle.is_skippable() {
+                return false;
+            } else if bundle.bundle.is_tracked() {
+                bundle.action = MessageAction::Reject;
+            }
+        }
+        let sender = bundle.origin.sender;
+        match &self.restrict_chain_ids_to {
+            None => true,
+            Some(chains) => chains.contains(&sender),
+        }
+    }
+
     #[tracing::instrument(level = "trace", skip(self))]
     fn is_ignore(&self) -> bool {
-        matches!(self, Self::Ignore)
+        matches!(self.blanket, BlanketMessagePolicy::Ignore)
     }
 
     #[tracing::instrument(level = "trace", skip(self))]
     fn is_reject(&self) -> bool {
-        matches!(self, Self::Reject)
+        matches!(self.blanket, BlanketMessagePolicy::Reject)
     }
 }
 
@@ -593,12 +627,8 @@ where
                 );
                 break;
             }
-            if self.options.message_policy.is_reject() {
-                if message.bundle.is_skippable() {
-                    continue;
-                } else if message.bundle.is_tracked() {
-                    message.action = MessageAction::Reject;
-                }
+            if !self.options.message_policy.handle(&mut message) {
+                continue;
             }
             pending_messages.push(message);
         }

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -39,7 +39,10 @@ use crate::test_utils::ScyllaDbStorageBuilder;
 #[cfg(feature = "storage-service")]
 use crate::test_utils::ServiceStorageBuilder;
 use crate::{
-    client::{ChainClient, ChainClientError, ClientOutcome, MessageAction, MessagePolicy},
+    client::{
+        BlanketMessagePolicy, ChainClient, ChainClientError, ClientOutcome, MessageAction,
+        MessagePolicy,
+    },
     local_node::LocalNodeError,
     node::{
         CrossChainMessageDelivery,
@@ -2490,7 +2493,7 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.options_mut().message_policy = MessagePolicy::Ignore;
+    receiver.options_mut().message_policy = MessagePolicy::new(BlanketMessagePolicy::Ignore, None);
     receiver
         .receive_certificate_and_update_validators(cert)
         .await?;
@@ -2503,7 +2506,7 @@ where
         Amount::from_tokens(3)
     );
 
-    receiver.options_mut().message_policy = MessagePolicy::Reject;
+    receiver.options_mut().message_policy = MessagePolicy::new(BlanketMessagePolicy::Reject, None);
     let certs = receiver.process_inbox().await?.0;
     assert_eq!(certs.len(), 1);
     sender


### PR DESCRIPTION
## Motivation

Some clients (for example the faucet) should only process incoming messages from pre-specified chains (for example the admin chain for epoch changes).

## Proposal

Modify `MessagePolicy` to have a notion of a restricted chain.