### PR TITLE
Make the variables of `DeletionSet` private.

### DIFF
--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -14,6 +14,7 @@ use std::{
     collections::BTreeSet,
     fmt::{Debug, Display},
     future::Future,
+    mem,
     ops::{
         Bound,
         Bound::{Excluded, Included, Unbounded},
@@ -43,8 +44,8 @@ pub(crate) enum Update<T> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct DeletionSet {
-    pub delete_storage_first: bool,
-    pub deleted_prefixes: BTreeSet<Vec<u8>>,
+    delete_storage_first: bool,
+    deleted_prefixes: BTreeSet<Vec<u8>>,
 }
 
 impl DeletionSet {
@@ -77,6 +78,22 @@ impl DeletionSet {
         if !self.delete_storage_first {
             insert_key_prefix(&mut self.deleted_prefixes, key_prefix);
         }
+    }
+
+    pub fn delete_storage_first(&self) -> bool {
+        self.delete_storage_first
+    }
+
+    pub fn delete_storage_first_mut(&mut self) -> &mut bool {
+        &mut self.delete_storage_first
+    }
+
+    pub fn deleted_prefixes_mut(&mut self) -> BTreeSet<Vec<u8>> {
+        mem::take(&mut self.deleted_prefixes)
+    }
+
+    pub fn deleted_prefixes(&self) -> &BTreeSet<Vec<u8>> {
+        &self.deleted_prefixes
     }
 }
 

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -223,7 +223,7 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError> {
         let mut delete_view = false;
-        if self.deletion_set.delete_storage_first {
+        if self.deletion_set.delete_storage_first() {
             delete_view = true;
             self.stored_total_size = SizeData::default();
             batch.delete_key_prefix(self.context.base_key());
@@ -236,7 +236,7 @@ where
             }
             self.stored_hash = None
         } else {
-            for index in mem::take(&mut self.deletion_set.deleted_prefixes) {
+            for index in self.deletion_set.deleted_prefixes_mut() {
                 let key = self.context.base_tag_index(KeyTag::Index as u8, &index);
                 batch.delete_key_prefix(key);
             }
@@ -263,7 +263,7 @@ where
             batch.put_key_value(key, &self.total_size)?;
             self.stored_total_size = self.total_size;
         }
-        self.deletion_set.delete_storage_first = false;
+        *self.deletion_set.delete_storage_first_mut() = false;
         Ok(delete_view)
     }
 
@@ -348,9 +348,9 @@ where
         let key_prefix = self.context.base_tag(KeyTag::Index as u8);
         let mut updates = self.updates.iter();
         let mut update = updates.next();
-        if !self.deletion_set.delete_storage_first {
+        if !self.deletion_set.delete_storage_first() {
             let mut suffix_closed_set =
-                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes().iter());
             for index in self
                 .context
                 .find_keys_by_prefix(&key_prefix)
@@ -448,9 +448,9 @@ where
         let key_prefix = self.context.base_tag(KeyTag::Index as u8);
         let mut updates = self.updates.iter();
         let mut update = updates.next();
-        if !self.deletion_set.delete_storage_first {
+        if !self.deletion_set.delete_storage_first() {
             let mut suffix_closed_set =
-                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes().iter());
             for entry in self
                 .context
                 .find_key_values_by_prefix(&key_prefix)
@@ -903,9 +903,9 @@ where
             .updates
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
-        if !self.deletion_set.delete_storage_first {
+        if !self.deletion_set.delete_storage_first() {
             let mut suffix_closed_set =
-                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes().iter());
             for key in self
                 .context
                 .find_keys_by_prefix(&key_prefix_full)
@@ -977,9 +977,9 @@ where
             .updates
             .range((Included(key_prefix.to_vec()), key_prefix_upper));
         let mut update = updates.next();
-        if !self.deletion_set.delete_storage_first {
+        if !self.deletion_set.delete_storage_first() {
             let mut suffix_closed_set =
-                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes.iter());
+                SuffixClosedSetIterator::new(0, self.deletion_set.deleted_prefixes().iter());
             for entry in self
                 .context
                 .find_key_values_by_prefix(&key_prefix_full)

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -106,7 +106,7 @@ where
 
     fn flush(&mut self, batch: &mut Batch) -> Result<bool, ViewError> {
         let mut delete_view = false;
-        if self.deletion_set.delete_storage_first {
+        if self.deletion_set.delete_storage_first() {
             delete_view = true;
             batch.delete_key_prefix(self.context.base_key());
             for (index, update) in mem::take(&mut self.updates) {
@@ -117,7 +117,7 @@ where
                 }
             }
         } else {
-            for index in mem::take(&mut self.deletion_set.deleted_prefixes) {
+            for index in self.deletion_set.deleted_prefixes_mut() {
                 let key = self.context.base_index(&index);
                 batch.delete_key_prefix(key);
             }
@@ -129,7 +129,7 @@ where
                 }
             }
         }
-        self.deletion_set.delete_storage_first = false;
+        *self.deletion_set.delete_storage_first_mut() = false;
         Ok(delete_view)
     }
 
@@ -362,7 +362,7 @@ where
         if !self.deletion_set.contains_prefix_of(&prefix) {
             let iter = self
                 .deletion_set
-                .deleted_prefixes
+                .deleted_prefixes()
                 .range(get_interval(prefix.clone()));
             let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
             let base = self.context.base_index(&prefix);
@@ -560,7 +560,7 @@ where
         if !self.deletion_set.contains_prefix_of(&prefix) {
             let iter = self
                 .deletion_set
-                .deleted_prefixes
+                .deleted_prefixes()
                 .range(get_interval(prefix.clone()));
             let mut suffix_closed_set = SuffixClosedSetIterator::new(prefix_len, iter);
             let base = self.context.base_index(&prefix);


### PR DESCRIPTION
## Motivation

The `delete_storage_first` and `deleted_prefixes` of `DeletionSet` were not private which is viewed as a weakness.

## Proposal

The `getter` are introduced for the variables in mutable versions and not.

## Test Plan

The CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
