### PR TITLE
Fixed typo on MessageKind

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -654,7 +654,7 @@ pub enum MessageKind {
     /// The message cannot be skipped but can be rejected. A receipt must be sent
     /// when the message is rejected in a block of the receiver.
     Tracked,
-    /// This event is a receipt automatically created when the original event was rejected.
+    /// This message is a receipt automatically created when the original message was rejected.
     Bouncing,
 }
 


### PR DESCRIPTION
## Motivation

Events were renamed to messages but a comment wasn't updated.

## Proposal

Update comment.
