### PR TITLE
Rdme

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -188,8 +188,13 @@ jobs:
     - name: Check for outdated README.md
       run: |
         (set -e; for I in linera-*; do if [ -d "$I" ]; then echo $I; cargo rdme --check --no-fail-on-warnings -w $I; fi; done)
-        cd examples
-        (set -e; for I in fungible native-fungible non-fungible social crowd-funding amm hex-game counter meta-counter matching-engine; do echo $I; cargo rdme --check --no-fail-on-warnings -w $I; done)
+        (set -e; cd examples; for dir in */; do
+            if [ -f "${dir}README.md" ] && grep -q "<!-- cargo-rdme start -->" "${dir}README.md"; then
+                dir_name="${dir%/}"
+                echo "${dir_name}"
+                cargo rdme --check --no-fail-on-warnings -w "${dir_name}"
+            fi
+        done)
     - name: Run Wasm application lints
       run: |
         cd examples

--- a/examples/gen-nft/README.md
+++ b/examples/gen-nft/README.md
@@ -91,7 +91,7 @@ linera service --port $PORT &
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         mint(
-            minter: "User:289c661d6da9b5d1a54c50642b9129f0115f762e60c6568f9db5c3ac71996d32",
+            minter: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
             prompt: "Hello!"
         )
     }
@@ -99,7 +99,7 @@ linera service --port $PORT &
 - To check that it's there, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
-        nft(tokenId: "kSIB3o59Ut8wioJdISqZwWedPGUlHK2HapnkOLqLSRA") {
+        nft(tokenId: "9NMD4q5nf2rNy2JQQ9MpUR0c55M8cqeE+Yjngi7t8i0") {
             tokenId,
             owner,
             prompt,
@@ -110,7 +110,7 @@ linera service --port $PORT &
 - To check that it's assigned to the owner, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
-        ownedNfts(owner: "User:289c661d6da9b5d1a54c50642b9129f0115f762e60c6568f9db5c3ac71996d32")
+        ownedNfts(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
     }
 ```
 - To check everything that it's there, run the query:
@@ -123,8 +123,8 @@ linera service --port $PORT &
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         transfer(
-            sourceOwner: "User:289c661d6da9b5d1a54c50642b9129f0115f762e60c6568f9db5c3ac71996d32",
-            tokenId: "kSIB3o59Ut8wioJdISqZwWedPGUlHK2HapnkOLqLSRA",
+            sourceOwner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+            tokenId: "9NMD4q5nf2rNy2JQQ9MpUR0c55M8cqeE+Yjngi7t8i0",
             targetAccount: {
                 chainId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65",
                 owner: "User:598d18f67709fe76ed6a36b75a7c9889012d30b896800dfd027ee10e1afd49a3"

--- a/examples/gen-nft/src/lib.rs
+++ b/examples/gen-nft/src/lib.rs
@@ -93,7 +93,7 @@ linera service --port $PORT &
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         mint(
-            minter: "User:289c661d6da9b5d1a54c50642b9129f0115f762e60c6568f9db5c3ac71996d32",
+            minter: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
             prompt: "Hello!"
         )
     }
@@ -101,7 +101,7 @@ linera service --port $PORT &
 - To check that it's there, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
-        nft(tokenId: "kSIB3o59Ut8wioJdISqZwWedPGUlHK2HapnkOLqLSRA") {
+        nft(tokenId: "9NMD4q5nf2rNy2JQQ9MpUR0c55M8cqeE+Yjngi7t8i0") {
             tokenId,
             owner,
             prompt,
@@ -112,7 +112,7 @@ linera service --port $PORT &
 - To check that it's assigned to the owner, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
-        ownedNfts(owner: "User:289c661d6da9b5d1a54c50642b9129f0115f762e60c6568f9db5c3ac71996d32")
+        ownedNfts(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
     }
 ```
 - To check everything that it's there, run the query:
@@ -125,8 +125,8 @@ linera service --port $PORT &
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         transfer(
-            sourceOwner: "User:289c661d6da9b5d1a54c50642b9129f0115f762e60c6568f9db5c3ac71996d32",
-            tokenId: "kSIB3o59Ut8wioJdISqZwWedPGUlHK2HapnkOLqLSRA",
+            sourceOwner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
+            tokenId: "9NMD4q5nf2rNy2JQQ9MpUR0c55M8cqeE+Yjngi7t8i0",
             targetAccount: {
                 chainId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65",
                 owner: "User:598d18f67709fe76ed6a36b75a7c9889012d30b896800dfd027ee10e1afd49a3"


### PR DESCRIPTION
## Motivation

`rust.yml` currently contains a line to check that `cargo-rdme` has been applied to each example, and the `README.md` matches the documentation in `lib.rs`. That line lists each example explicitly, and whenever we add one we have to remember including it here.

In fact, we already forgot to do this for `gen-nft`, and its `README.md` is outdated!

## Proposal

Change the line so it automatically finds all subdirectories with a `README.md` containing the line `<!-- cargo-rdme start -->`.

Update the `gen-nft` README file.

## Test Plan

I ran it locally and it found the outdated `gen-nft` README!

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
