### PR TITLE
CI: lock dependencies in cargo install

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -66,8 +66,8 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install cargo tools
       run: |
-        cargo install cargo-index
-        cargo install cargo-local-registry
+        cargo install --locked cargo-index
+        cargo install --locked cargo-local-registry
     - name: Setup git committer information
       run: |
         git config --global user.email "ci@linera.io"


### PR DESCRIPTION
## Motivation

I'm seeing a suspicious failure on main

## Proposal

Use `cargo install --locked` for this test

## Test Plan

CI
