### PR TITLE
`linera_base::tracing`: don't try to guess when the caller wants JSON

### DIFF
--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -41,10 +41,7 @@ pub fn init() {
                 .from_env_lossy(),
         );
 
-    if std::env::var("NO_COLOR")
-        .ok()
-        .filter(|x| !x.is_empty())
-        .is_some()
+    if std::env::var("NO_COLOR").is_ok_and(|x| !x.is_empty())
         || cfg!(feature = "web")
         || !std::io::stderr().is_terminal()
     {


### PR DESCRIPTION
## Motivation

We have several places in our code where we effectively nuke the environment, so can't override this behaviour with `RUST_LOG_FORMAT=plain`, but nevertheless still want non-JSON output. 

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Don't output JSON when `stderr` is not a terminal, just disable ANSI colouring.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

Check CI.

<!-- How to test that the changes are correct. -->

## Release Plan

Mostly a cosmetic change; no version bump required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
