### PR TITLE
`linera_core::worker`: don't hold mutexes over `await` points

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -754,19 +754,19 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<ChainActorEndpoint<StorageClient>, WorkerError> {
-        let mut receiver = None;
+        let mut new_receiver = None;
         let sender = self
             .chain_workers
             .lock()
             .unwrap()
             .get_or_insert(chain_id, || {
-                let (sender, receiver_) = mpsc::unbounded_channel();
-                receiver = Some(receiver_);
+                let (sender, receiver) = mpsc::unbounded_channel();
+                new_receiver = Some(receiver);
                 sender
             })
             .clone();
 
-        if let Some(receiver) = receiver {
+        if let Some(receiver) = new_receiver {
             let actor = ChainWorkerActor::load(
                 self.chain_worker_config.clone(),
                 self.storage.clone(),

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -6,7 +6,7 @@ use std::{
     borrow::Cow,
     collections::{hash_map, BTreeMap, HashMap, VecDeque},
     num::NonZeroUsize,
-    sync::{Arc, LazyLock},
+    sync::{Arc, LazyLock, Mutex},
     time::Duration,
 };
 
@@ -33,10 +33,10 @@ use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
-    sync::{mpsc, oneshot, Mutex, OwnedRwLockReadGuard},
+    sync::{mpsc, oneshot, OwnedRwLockReadGuard},
     task::JoinSet,
 };
-use tracing::{error, instrument, trace, warn};
+use tracing::{error, instrument, trace, warn, Instrument as _};
 #[cfg(with_metrics)]
 use {
     linera_base::prometheus_util,
@@ -54,6 +54,7 @@ use {
 use crate::{
     chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
+    join_set_ext::JoinSetExt,
     value_cache::ValueCache,
 };
 
@@ -333,7 +334,7 @@ where
     #[cfg(test)]
     pub(crate) async fn with_key_pair(mut self, key_pair: Option<Arc<KeyPair>>) -> Self {
         self.chain_worker_config.key_pair = key_pair;
-        self.chain_workers.lock().await.clear();
+        self.chain_workers.lock().unwrap().clear();
         self
     }
 
@@ -454,7 +455,7 @@ where
             {
                 self.delivery_notifiers
                     .lock()
-                    .await
+                    .unwrap()
                     .entry(chain_id)
                     .or_default()
                     .entry(height)
@@ -753,29 +754,34 @@ where
         &self,
         chain_id: ChainId,
     ) -> Result<ChainActorEndpoint<StorageClient>, WorkerError> {
-        let mut chain_workers = self.chain_workers.lock().await;
+        let mut receiver = None;
+        let sender = self
+            .chain_workers
+            .lock()
+            .unwrap()
+            .get_or_insert(chain_id, || {
+                let (sender, receiver_) = mpsc::unbounded_channel();
+                receiver = Some(receiver_);
+                sender
+            })
+            .clone();
 
-        if !chain_workers.contains(&chain_id) {
-            chain_workers.push(
+        if let Some(receiver) = receiver {
+            let actor = ChainWorkerActor::load(
+                self.chain_worker_config.clone(),
+                self.storage.clone(),
+                self.recent_hashed_certificate_values.clone(),
+                self.recent_hashed_blobs.clone(),
                 chain_id,
-                ChainWorkerActor::spawn(
-                    self.chain_worker_config.clone(),
-                    self.storage.clone(),
-                    self.recent_hashed_certificate_values.clone(),
-                    self.recent_hashed_blobs.clone(),
-                    chain_id,
-                    &mut *self.chain_worker_tasks.lock().await,
-                )
-                .await?,
-            );
+            )
+            .await?;
+            self.chain_worker_tasks
+                .lock()
+                .unwrap()
+                .spawn_task(actor.run(receiver).in_current_span());
         }
 
-        Ok(chain_workers
-            .get(&chain_id)
-            .expect(
-                "Chain worker should have been inserted in the cache if it wasn't there already",
-            )
-            .clone())
+        Ok(sender)
     }
 
     #[instrument(skip_all, fields(
@@ -984,7 +990,7 @@ where
                     .await?;
                 // Handle delivery notifiers for this chain, if any.
                 if let hash_map::Entry::Occupied(mut map) =
-                    self.delivery_notifiers.lock().await.entry(sender)
+                    self.delivery_notifiers.lock().unwrap().entry(sender)
                 {
                     while let Some(entry) = map.get_mut().first_entry() {
                         if entry.key() > &height_with_fully_delivered_messages {


### PR DESCRIPTION
## Motivation

Currently the `linera_core::worker` has a pattern in which it takes an async mutex (`futures::lock::Mutex`) and holds it while doing other async work.  This results in deadlocks if the future that holds the mutex is not known and being polled at the same time.  

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Restructure `linera_core::worker` so that mutexes are not held over `await` points.  Once this is done, there is no need to use the heavyweight `futures::lock::Mutex`, and we can replace it with the much lighter `std::sync::Mutex`, whose guards also conveniently don't implement `Send` and so will error if accidentally held over an `await` point.

Also, add a (static) test to ensure that the future returned from `ChainClient::listen` (with memory storage and the test provider) is `Send`, ensuring that even if we remove `tokio::spawn` calls later on, we will still catch this failure case. 

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

Internal refactor: no particular care required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [the `tokio` project's advice on this code structure](https://tokio.rs/tokio/tutorial/shared-state)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
