### PR TITLE
Make the memory stores persistent within a run.

### DIFF
--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -8,7 +8,7 @@ use linera_base::{
     identifiers::ChainId,
 };
 #[cfg(with_testing)]
-use linera_views::memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES};
+use linera_views::memory::{create_test_memory_context, MemoryContext};
 use linera_views::{
     common::Context,
     queue_view::QueueView,
@@ -269,7 +269,7 @@ where
     ViewError: From<<MemoryContext<()> as linera_views::common::Context>::Error>,
 {
     pub async fn new() -> Self {
-        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, ());
+        let context = create_test_memory_context();
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -3,7 +3,7 @@
 
 use linera_base::data_types::{ArithmeticError, BlockHeight};
 #[cfg(with_testing)]
-use linera_views::memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES};
+use linera_views::memory::{create_test_memory_context, MemoryContext};
 use linera_views::{
     common::Context,
     queue_view::QueueView,
@@ -79,7 +79,7 @@ where
     ViewError: From<<MemoryContext<()> as linera_views::common::Context>::Error>,
 {
     pub async fn new() -> Self {
-        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, ());
+        let context = create_test_memory_context();
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -42,7 +42,7 @@ where
         let exec_runtime_context =
             TestExecutionRuntimeContext::new(chain_id, ExecutionRuntimeConfig::default());
         let namespace = generate_test_namespace();
-        let context = MemoryContext::new(
+        let context = MemoryContext::new_for_testing(
             TEST_MEMORY_MAX_STREAM_QUERIES,
             &namespace,
             exec_runtime_context,

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -21,6 +21,7 @@ use linera_execution::{
 };
 use linera_views::{
     memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    test_utils::generate_test_namespace,
     views::{View, ViewError},
 };
 
@@ -40,7 +41,12 @@ where
     pub async fn new(chain_id: ChainId) -> Self {
         let exec_runtime_context =
             TestExecutionRuntimeContext::new(chain_id, ExecutionRuntimeConfig::default());
-        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, exec_runtime_context);
+        let namespace = generate_test_namespace();
+        let context = MemoryContext::new(
+            TEST_MEMORY_MAX_STREAM_QUERIES,
+            &namespace,
+            exec_runtime_context,
+        );
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -25,7 +25,7 @@ use linera_execution::{
 };
 use linera_storage::{MemoryStorage, Storage, TestClock};
 use linera_version::VersionInfo;
-use linera_views::{memory::TEST_MEMORY_MAX_STREAM_QUERIES, views::ViewError};
+use linera_views::{memory::create_memory_store_test_config, views::ViewError};
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 #[cfg(feature = "dynamodb")]
@@ -907,9 +907,12 @@ impl StorageBuilder for MemoryStorageBuilder {
     type Storage = MemoryStorage<TestClock>;
 
     async fn build(&mut self) -> Result<Self::Storage, anyhow::Error> {
+        let store_config = create_memory_store_test_config();
+        let namespace = generate_test_namespace();
         Ok(MemoryStorage::new_for_testing(
+            store_config,
+            &namespace,
             self.wasm_runtime,
-            TEST_MEMORY_MAX_STREAM_QUERIES,
             self.clock.clone(),
         )
         .await?)

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -43,7 +43,8 @@ use linera_execution::{
 };
 use linera_storage::{MemoryStorage, Storage, TestClock};
 use linera_views::{
-    memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    memory::{create_memory_store_test_config, MemoryContext},
+    test_utils::generate_test_namespace,
     views::{CryptoHashView, RootView, ViewError},
 };
 use test_case::test_case;
@@ -3028,9 +3029,10 @@ where
 #[test(tokio::test)]
 async fn test_cross_chain_helper() -> anyhow::Result<()> {
     // Make a committee and worker (only used for signing certificates)
+    let store_config = create_memory_store_test_config();
+    let namespace = generate_test_namespace();
     let store =
-        MemoryStorage::new_for_testing(None, TEST_MEMORY_MAX_STREAM_QUERIES, TestClock::new())
-            .await?;
+        MemoryStorage::new_for_testing(store_config, &namespace, None, TestClock::new()).await?;
     let (committee, worker) = init_worker(store, true);
     let committees = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
 

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -17,7 +17,7 @@ use linera_views::{
 use serde::{Deserialize, Serialize};
 #[cfg(with_testing)]
 use {
-    linera_views::memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    linera_views::memory::{create_test_memory_context, MemoryContext},
     linera_views::views::View,
     std::collections::BTreeMap,
 };
@@ -263,7 +263,7 @@ where
     ViewError: From<<MemoryContext<()> as linera_views::common::Context>::Error>,
 {
     pub async fn new() -> Self {
-        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, ());
+        let context = create_test_memory_context();
         Self::load(context)
             .await
             .expect("Loading from memory should work")

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -15,6 +15,7 @@ use linera_base::{
 use linera_views::{
     common::Context,
     memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    test_utils::generate_test_namespace,
     views::{CryptoHashView, View, ViewError},
 };
 
@@ -102,7 +103,8 @@ impl SystemExecutionState {
             application_permissions,
         } = self;
         let extra = TestExecutionRuntimeContext::new(chain_id, execution_runtime_config);
-        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, extra);
+        let namespace = generate_test_namespace();
+        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace, extra);
         let mut view = ExecutionStateView::load(context)
             .await
             .expect("Loading from memory should work");

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -104,7 +104,8 @@ impl SystemExecutionState {
         } = self;
         let extra = TestExecutionRuntimeContext::new(chain_id, execution_runtime_config);
         let namespace = generate_test_namespace();
-        let context = MemoryContext::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace, extra);
+        let context =
+            MemoryContext::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace, extra);
         let mut view = ExecutionStateView::load(context)
             .await
             .expect("Loading from memory should work");

--- a/linera-execution/src/test_utils/system_execution_state.rs
+++ b/linera-execution/src/test_utils/system_execution_state.rs
@@ -104,7 +104,7 @@ impl SystemExecutionState {
         } = self;
         let extra = TestExecutionRuntimeContext::new(chain_id, execution_runtime_config);
         let namespace = generate_test_namespace();
-        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace, extra);
+        let context = MemoryContext::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace, extra);
         let mut view = ExecutionStateView::load(context)
             .await
             .expect("Loading from memory should work");

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -10,7 +10,7 @@ use linera_storage_service::common::{KeyTag, MAX_PAYLOAD_SIZE};
 use linera_views::{
     batch::Batch,
     common::{CommonStoreConfig, ReadableKeyValueStore, WritableKeyValueStore},
-    memory::{create_memory_store_stream_queries, MemoryStore},
+    memory::MemoryStore,
 };
 #[cfg(feature = "rocksdb")]
 use linera_views::{
@@ -574,7 +574,8 @@ async fn main() {
     let common_config = CommonStoreConfig::default();
     let (store, endpoint) = match options {
         ServiceStoreServerOptions::Memory { endpoint } => {
-            let store = create_memory_store_stream_queries(common_config.max_stream_queries);
+            let namespace = "linera_storage_service";
+            let store = MemoryStore::new(common_config.max_stream_queries, namespace).unwrap();
             let store = ServiceStoreServerInternal::Memory(store);
             (store, endpoint)
         }

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -45,7 +45,7 @@ use {
     crate::common::{
         ContextFromStore, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
-    crate::memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
+    crate::memory::{create_test_memory_context, MemoryContext},
     async_lock::RwLock,
     std::sync::Arc,
 };
@@ -1184,7 +1184,7 @@ pub type KeyValueStoreMemoryContext<E> = ContextFromStore<E, ViewContainer<Memor
 impl<E> KeyValueStoreMemoryContext<E> {
     /// Creates a [`KeyValueStoreMemoryContext`].
     pub async fn new(base_key: Vec<u8>, extra: E) -> Result<Self, ViewError> {
-        let context = MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, ());
+        let context = create_test_memory_context();
         let store = ViewContainer::new(context).await?;
         Ok(Self {
             store,

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -242,7 +242,7 @@ impl MemoryStore {
     }
 
     /// Create a memory store if one is missing and otherwise connect with the existing one
-    pub fn sync_maybe_create_and_connect(
+    fn sync_maybe_create_and_connect(
         config: &MemoryStoreConfig,
         namespace: &str,
         kill_on_drop: bool,
@@ -396,8 +396,8 @@ pub enum MemoryStoreError {
     #[error("The value is too large for the MemoryStore")]
     TooLargeValue,
 
-    /// The namespace is not existent
-    #[error("The namespace is not existent")]
+    /// The namespace does not exist
+    #[error("The namespace does not exist")]
     NotExistentNamespace,
 
     /// The database is not consistent

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -78,7 +78,6 @@ impl Drop for MemoryStore {
     }
 }
 
-
 impl ReadableKeyValueStore<MemoryStoreError> for MemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
@@ -221,34 +220,23 @@ impl MemoryStore {
         })
     }
 
-    fn sync_list_all(
-        namespace_memory_store: &NamespaceMemoryStore,
-    ) -> Vec<String> {
+    fn sync_list_all(namespace_memory_store: &NamespaceMemoryStore) -> Vec<String> {
         namespace_memory_store.keys().cloned().collect::<Vec<_>>()
     }
 
-    fn sync_exists(
-        namespace_memory_store: &NamespaceMemoryStore,
-        namespace: &str,
-    ) -> bool {
+    fn sync_exists(namespace_memory_store: &NamespaceMemoryStore, namespace: &str) -> bool {
         let namespace = namespace.to_string();
         namespace_memory_store.contains_key(&namespace)
     }
 
-    fn sync_create(
-        namespace_memory_store: &mut NamespaceMemoryStore,
-        namespace: &str,
-    ) {
+    fn sync_create(namespace_memory_store: &mut NamespaceMemoryStore, namespace: &str) {
         let namespace = namespace.to_string();
         let map = MemoryStoreMap::new();
         let map = Arc::new(RwLock::new(map));
         namespace_memory_store.insert(namespace, map);
     }
 
-    fn sync_delete(
-        namespace_memory_store: &mut NamespaceMemoryStore,
-        namespace: &str,
-    ) {
+    fn sync_delete(namespace_memory_store: &mut NamespaceMemoryStore, namespace: &str) {
         let namespace = namespace.to_string();
         namespace_memory_store.remove(&namespace);
     }
@@ -280,7 +268,10 @@ impl MemoryStore {
 
     /// Creates a `MemoryStore` from a number of queries and a namespace for testing.
     #[cfg(with_testing)]
-    pub fn new_for_testing(max_stream_queries: usize, namespace: &str) -> Result<Self, MemoryStoreError> {
+    pub fn new_for_testing(
+        max_stream_queries: usize,
+        namespace: &str,
+    ) -> Result<Self, MemoryStoreError> {
         let common_config = CommonStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries,

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -47,7 +47,7 @@ pub const TEST_MEMORY_MAX_STREAM_QUERIES: usize = 10;
 /// The analog of the database is the BTreeMap
 type MemoryStoreMap = BTreeMap<Vec<u8>, Vec<u8>>;
 
-/// The container for the MemoryStopMap according to the Namespace.
+/// The container for the `MemoryStopMap` according to the Namespace.
 type NamespaceMemoryStore = BTreeMap<String, Arc<RwLock<MemoryStoreMap>>>;
 
 /// The global variables of the Namespace memory stores

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -702,6 +702,16 @@ where
             .expect("creation of a namespace");
         assert!(S::exists(config, namespace).await.expect("test"));
     }
+    // Connecting to all of them at once
+    {
+        let mut connections = Vec::new();
+        for namespace in &working_namespaces {
+            let connection = S::connect(config, namespace)
+                .await
+                .expect("a connection to the namespace");
+            connections.push(connection);
+        }
+    }
     // Listing all of them
     let namespaces = namespaces_with_prefix::<S>(config, &prefix).await;
     assert_eq!(namespaces, working_namespaces);

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -426,7 +426,8 @@ impl LimitedTestMemoryStore {
     /// Creates a `LimitedTestMemoryStore`
     pub fn new() -> Self {
         let namespace = generate_test_namespace();
-        let store = MemoryStore::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace).unwrap();
+        let store =
+            MemoryStore::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace).unwrap();
         LimitedTestMemoryStore { store }
     }
 }

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -432,6 +432,7 @@ impl LimitedTestMemoryStore {
 }
 
 /// Provides a `LimitedTestMemoryStore<()>` that can be used for tests.
+#[cfg(with_testing)]
 pub fn create_value_splitting_memory_store() -> ValueSplittingStore<LimitedTestMemoryStore> {
     ValueSplittingStore::new(LimitedTestMemoryStore::new())
 }

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -426,7 +426,7 @@ impl LimitedTestMemoryStore {
     /// Creates a `LimitedTestMemoryStore`
     pub fn new() -> Self {
         let namespace = generate_test_namespace();
-        let store = MemoryStore::new(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace).unwrap();
+        let store = MemoryStore::new_for_testing(TEST_MEMORY_MAX_STREAM_QUERIES, &namespace).unwrap();
         LimitedTestMemoryStore { store }
     }
 }

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -1,15 +1,22 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#![cfg(any(feature = "rocksdb", feature = "dynamodb", feature = "scylladb"))]
-
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::{create_dynamo_db_test_config, DynamoDbStore};
 #[cfg(feature = "rocksdb")]
 use linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStore};
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::{create_scylla_db_test_config, ScyllaDbStore};
-use linera_views::test_utils::admin_test;
+use linera_views::{
+    memory::{create_memory_store_test_config, MemoryStore},
+    test_utils::admin_test,
+};
+
+#[tokio::test]
+async fn admin_test_memory() {
+    let config = create_memory_store_test_config();
+    admin_test::<MemoryStore>(&config).await;
+}
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -38,8 +38,8 @@ async fn test_reads_memory() {
 #[tokio::test]
 async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let (store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
-        run_reads(store, scenario).await;
+        let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+        run_reads(key_value_store, scenario).await;
     }
 }
 
@@ -47,8 +47,8 @@ async fn test_reads_rocks_db() {
 #[tokio::test]
 async fn test_reads_dynamo_db() {
     for scenario in get_random_test_scenarios() {
-        let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-        run_reads(store, scenario).await;
+        let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+        run_reads(key_value_store, scenario).await;
     }
 }
 
@@ -65,8 +65,8 @@ async fn test_reads_scylla_db() {
 #[wasm_bindgen_test]
 async fn test_reads_indexed_db() {
     for scenario in get_random_test_scenarios() {
-        let store = linera_views::indexed_db::create_indexed_db_test_store().await;
-        run_reads(store, scenario).await;
+        let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
+        run_reads(key_value_store, scenario).await;
     }
 }
 
@@ -120,22 +120,22 @@ async fn test_rocks_db_writes_from_blank() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_blank() {
-    let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-    run_writes_from_blank(&store).await;
+    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_blank() {
-    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    run_writes_from_blank(&store).await;
+    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[cfg(with_indexeddb)]
 #[wasm_bindgen_test]
 async fn test_indexed_db_writes_from_blank() {
-    let store = linera_views::indexed_db::create_indexed_db_test_store().await;
-    run_writes_from_blank(&store).await;
+    let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
+    run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
@@ -166,17 +166,17 @@ async fn test_big_value_read_write() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn scylla_db_tombstone_triggering_test() {
-    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    linera_views::test_utils::tombstone_triggering_test(store).await;
+    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    linera_views::test_utils::tombstone_triggering_test(key_value_store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {
-    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(store, target_size, value_sizes).await;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 
 #[tokio::test]
@@ -190,28 +190,28 @@ async fn test_memory_big_write_read() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_big_write_read() {
-    let (store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+    let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(store, target_size, value_sizes).await;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 
 #[cfg(with_indexeddb)]
 #[wasm_bindgen_test]
 async fn test_indexed_db_big_write_read() {
-    let store = linera_views::indexed_db::create_indexed_db_test_store().await;
+    let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(store, target_size, value_sizes).await;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_big_write_read() {
-    let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(store, target_size, value_sizes).await;
+    run_big_write_read(key_value_store, target_size, value_sizes).await;
 }
 
 #[tokio::test]
@@ -223,27 +223,27 @@ async fn test_memory_writes_from_state() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_state() {
-    let (store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
-    run_writes_from_state(&store).await;
+    let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+    run_writes_from_state(&key_value_store).await;
 }
 
 #[cfg(with_indexeddb)]
 #[wasm_bindgen_test]
 async fn test_indexed_db_writes_from_state() {
-    let store = linera_views::indexed_db::create_indexed_db_test_store().await;
-    run_writes_from_state(&store).await;
+    let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
+    run_writes_from_state(&key_value_store).await;
 }
 
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_state() {
-    let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-    run_writes_from_state(&store).await;
+    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+    run_writes_from_state(&key_value_store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_state() {
-    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    run_writes_from_state(&store).await;
+    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    run_writes_from_state(&key_value_store).await;
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -38,8 +38,8 @@ async fn test_reads_memory() {
 #[tokio::test]
 async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
-        run_reads(key_value_store, scenario).await;
+        let (store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+        run_reads(store, scenario).await;
     }
 }
 
@@ -47,8 +47,8 @@ async fn test_reads_rocks_db() {
 #[tokio::test]
 async fn test_reads_dynamo_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-        run_reads(key_value_store, scenario).await;
+        let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+        run_reads(store, scenario).await;
     }
 }
 
@@ -56,8 +56,8 @@ async fn test_reads_dynamo_db() {
 #[tokio::test]
 async fn test_reads_scylla_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-        run_reads(key_value_store, scenario).await;
+        let store = linera_views::scylla_db::create_scylla_db_test_store().await;
+        run_reads(store, scenario).await;
     }
 }
 
@@ -65,8 +65,8 @@ async fn test_reads_scylla_db() {
 #[wasm_bindgen_test]
 async fn test_reads_indexed_db() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
-        run_reads(key_value_store, scenario).await;
+        let store = linera_views::indexed_db::create_indexed_db_test_store().await;
+        run_reads(store, scenario).await;
     }
 }
 
@@ -120,22 +120,22 @@ async fn test_rocks_db_writes_from_blank() {
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_blank() {
-    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-    run_writes_from_blank(&key_value_store).await;
+    let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+    run_writes_from_blank(&store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_blank() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    run_writes_from_blank(&key_value_store).await;
+    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    run_writes_from_blank(&store).await;
 }
 
 #[cfg(with_indexeddb)]
 #[wasm_bindgen_test]
 async fn test_indexed_db_writes_from_blank() {
-    let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
-    run_writes_from_blank(&key_value_store).await;
+    let store = linera_views::indexed_db::create_indexed_db_test_store().await;
+    run_writes_from_blank(&store).await;
 }
 
 #[tokio::test]
@@ -166,17 +166,17 @@ async fn test_big_value_read_write() {
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn scylla_db_tombstone_triggering_test() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    linera_views::test_utils::tombstone_triggering_test(key_value_store).await;
+    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    linera_views::test_utils::tombstone_triggering_test(store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_big_write_read() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(key_value_store, target_size, value_sizes).await;
+    run_big_write_read(store, target_size, value_sizes).await;
 }
 
 #[tokio::test]
@@ -190,28 +190,28 @@ async fn test_memory_big_write_read() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_big_write_read() {
-    let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+    let (store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(key_value_store, target_size, value_sizes).await;
+    run_big_write_read(store, target_size, value_sizes).await;
 }
 
 #[cfg(with_indexeddb)]
 #[wasm_bindgen_test]
 async fn test_indexed_db_big_write_read() {
-    let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
+    let store = linera_views::indexed_db::create_indexed_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(key_value_store, target_size, value_sizes).await;
+    run_big_write_read(store, target_size, value_sizes).await;
 }
 
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_big_write_read() {
-    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+    let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
-    run_big_write_read(key_value_store, target_size, value_sizes).await;
+    run_big_write_read(store, target_size, value_sizes).await;
 }
 
 #[tokio::test]
@@ -223,27 +223,27 @@ async fn test_memory_writes_from_state() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_state() {
-    let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
-    run_writes_from_state(&key_value_store).await;
+    let (store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+    run_writes_from_state(&store).await;
 }
 
 #[cfg(with_indexeddb)]
 #[wasm_bindgen_test]
 async fn test_indexed_db_writes_from_state() {
-    let key_value_store = linera_views::indexed_db::create_indexed_db_test_store().await;
-    run_writes_from_state(&key_value_store).await;
+    let store = linera_views::indexed_db::create_indexed_db_test_store().await;
+    run_writes_from_state(&store).await;
 }
 
 #[cfg(with_dynamodb)]
 #[tokio::test]
 async fn test_dynamo_db_writes_from_state() {
-    let key_value_store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
-    run_writes_from_state(&key_value_store).await;
+    let store = linera_views::dynamo_db::create_dynamo_db_test_store().await;
+    run_writes_from_state(&store).await;
 }
 
 #[cfg(with_scylladb)]
 #[tokio::test]
 async fn test_scylla_db_writes_from_state() {
-    let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
-    run_writes_from_state(&key_value_store).await;
+    let store = linera_views::scylla_db::create_scylla_db_test_store().await;
+    run_writes_from_state(&store).await;
 }

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -56,8 +56,8 @@ async fn test_reads_dynamo_db() {
 #[tokio::test]
 async fn test_reads_scylla_db() {
     for scenario in get_random_test_scenarios() {
-        let store = linera_views::scylla_db::create_scylla_db_test_store().await;
-        run_reads(store, scenario).await;
+        let key_value_store = linera_views::scylla_db::create_scylla_db_test_store().await;
+        run_reads(key_value_store, scenario).await;
     }
 }
 


### PR DESCRIPTION
## Motivation

The memory store has the weakness that it does not implement the namespace. Each instance is a specific one.

## Proposal

The following was done:
* A global variable `MEMORY_STORES` for storing the existing memory stores is introduced.
* The implementation uses `std::sync::Mutex` to avoid being async.
* The switch from `read().await` to `read()?` leads to some `PoisonError` being emitted which are converted with relevant `From` operators.
* The `now_or_never` calls are eliminated when the stores are created, which is cleaner. The `async` features of the stores are blanks.
* The `MemoryStore` is now using a `Arc<RwLock<MemoryStoreMap>>` and the `MutexGuard` is eliminated.
* The `admin_test` has been added for the `memory` and the `admin_test` has been strengthened by adding multiple connections to the test.
* The `views_test.rs` code has been streamlined for the `MemoryStore`, `KeyValueStoreView` and `LruMemoryStore` which simplifies the test code.
* The `MemoryStorage` code is changed accordingly.
* The `MemoryStore` if not limited by `[cfg(with_testing)]`. However, the generation of random namespace remains restricted to the testing frameworks.

## Test Plan

The CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
