### PR TITLE
Add the `multi_get` to the MapView type.

### DIFF
--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -370,10 +370,14 @@ async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) -> Result<()> 
                 let part_key_values = view.map.key_values_by_prefix(vec![u]).await?;
                 assert_eq!(part_state_vec, part_key_values);
             }
-            for key in &all_keys {
+            let keys_vec = all_keys.clone().into_iter().collect::<Vec<_>>();
+            let values = view.map.multi_get(keys_vec.clone()).await?;
+            for i in 0..keys_vec.len() {
+                let key = &keys_vec[i];
                 let test_map = new_state_map.contains_key(key);
                 let test_view = view.map.get(key).await?.is_some();
                 assert_eq!(test_map, test_view);
+                assert_eq!(test_map, values[i].is_some());
             }
         }
         if save {


### PR DESCRIPTION
## Motivation

The `MapView` has a natural usage for the `multi_get` operation. This PR implements it.

## Proposal

The following is done:
* The `multi_get`is introduced
* The `from_bytes_option` is used in order to avoid adding a trait requirement to `V`.

## Test Plan

The test is added to the random test

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
