### PR TITLE
Fix subscription race condition in social pub-sub test

### DIFF
--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -648,6 +648,8 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
         .mutate(format!("subscribe(chainId: \"{chain1}\")"))
         .await?;
 
+    node_service1.process_inbox(&chain1).await?;
+
     // The returned hash should now be the latest one.
     let query = format!("query {{ chain(chainId: \"{chain2}\") {{ tipState {{ blockHash }} }} }}");
     let response = node_service2.query_node(&query).await?;

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -652,8 +652,11 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
 
     // The returned hash should now be the latest one.
     let query = format!("query {{ chain(chainId: \"{chain2}\") {{ tipState {{ blockHash }} }} }}");
-    let response = node_service2.query_node(&query).await?;
-    assert_eq!(hash, response["chain"]["tipState"]["blockHash"]);
+    for node_service in [&node_service2, &node_service1] {
+        let response = node_service.query_node(&query).await?;
+        assert_eq!(hash, response["chain"]["tipState"]["blockHash"]);
+    }
+
     let mut notifications = Box::pin(node_service2.notifications(chain2).await?);
 
     let app1 = node_service1


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
CI was having intermittent failures when running the `test_wasm_end_to_end_social_user_pub_sub` test ([e.g.](https://github.com/linera-io/linera-protocol/actions/runs/10160563243/job/28097195712#step:8:8087)). This was caused by a race condition between the poster and the subscriber, where sometimes the poster would post a message before handling the subscriber's subscription request.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Process the inbox of the poster before posting the message. An assertion was also added to check that the poster's node service contains the subscriber's block requesting for the subscription. This increases the chance that it has already produced a block to accept the subscription.

## Test Plan

<!-- How to test that the changes are correct. -->
Nothing needed, because this only fixes a bug in an existing test.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this only affects tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
