### PR TITLE
Remove id/blob getters from HashedBlob

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -817,11 +817,6 @@ impl HashedBlob {
         Ok(blob.into_hashed())
     }
 
-    /// A content-addressed blob ID i.e. the hash of the `Blob`.
-    pub fn id(&self) -> BlobId {
-        self.id
-    }
-
     /// Creates a [`HashedBlob`] from a string for testing purposes.
     #[cfg(with_testing)]
     pub fn test_blob(content: &str) -> Self {
@@ -829,11 +824,6 @@ impl HashedBlob {
             bytes: content.as_bytes().to_vec(),
         };
         blob.into_hashed()
-    }
-
-    /// Returns a reference to the inner `Blob`, without the hash.
-    pub fn blob(&self) -> &Blob {
-        &self.blob
     }
 
     /// Moves ownership of the blob of binary data

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -399,7 +399,7 @@ impl ChainManager {
         }
 
         for hashed_blob in proposal.hashed_blobs {
-            self.pending_blobs.insert(hashed_blob.id(), hashed_blob);
+            self.pending_blobs.insert(hashed_blob.id, hashed_blob);
         }
 
         if let Some(key_pair) = key_pair {

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -331,7 +331,7 @@ where
         let blob = HashedBlob::load_from_file(&blob_path)
             .await
             .context(format!("failed to load blob from {:?}", &blob_path))?;
-        let blob_id = blob.id();
+        let blob_id = blob.id;
 
         info!("Publishing blob");
         self.apply_client_command(chain_client, |chain_client| {

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -355,7 +355,7 @@ where
     ) -> Result<Vec<BlobId>, WorkerError> {
         // Find all certificates containing blobs used when executing this block.
         for hashed_blob in hashed_blobs {
-            let blob_id = hashed_blob.id();
+            let blob_id = hashed_blob.id;
             ensure!(
                 required_blob_ids.remove(&blob_id),
                 WorkerError::UnneededBlob { blob_id }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2561,9 +2561,9 @@ where
         self.client.local_node.cache_recent_blob(&hashed_blob).await;
         self.state_mut()
             .pending_blobs
-            .insert(hashed_blob.id(), hashed_blob.clone());
+            .insert(hashed_blob.id, hashed_blob.clone());
         self.execute_operation(Operation::System(SystemOperation::PublishBlob {
-            blob_id: hashed_blob.id(),
+            blob_id: hashed_blob.id,
         }))
         .await
     }
@@ -2574,7 +2574,7 @@ where
             self.client.local_node.cache_recent_blob(hashed_blob).await;
             self.state_mut()
                 .pending_blobs
-                .insert(hashed_blob.id(), hashed_blob.clone());
+                .insert(hashed_blob.id, hashed_blob.clone());
         }
     }
 

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -730,7 +730,7 @@ where
         blob_id: BlobId,
     ) -> Option<HashedBlob> {
         match node.download_blob(blob_id).await.map(Blob::into_hashed) {
-            Ok(hashed_blob) if hashed_blob.id() == blob_id => Some(hashed_blob),
+            Ok(hashed_blob) if hashed_blob.id == blob_id => Some(hashed_blob),
             Ok(_) => {
                 tracing::info!("Validator {name} sent an invalid blob {blob_id}.");
                 None

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1492,7 +1492,7 @@ where
         .await?;
 
     let blob0 = HashedBlob::test_blob("blob0");
-    let blob0_id = blob0.id();
+    let blob0_id = blob0.id;
 
     // Try to read a blob without publishing it first, should fail
     let result = client1_a
@@ -1539,7 +1539,7 @@ where
 
     client2_a.synchronize_from_validators().await.unwrap();
     let blob1 = HashedBlob::test_blob("blob1");
-    let blob1_id = blob1.id();
+    let blob1_id = blob1.id;
 
     client2_a.add_pending_blobs(&[blob1]).await;
     let blob_0_1_operations = vec![
@@ -1660,7 +1660,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let blob0 = HashedBlob::test_blob("blob0");
-    let blob0_id = blob0.id();
+    let blob0_id = blob0.id;
 
     // Publish blob on chain 1
     let publish_certificate = client1.publish_blob(blob0).await.unwrap().unwrap();
@@ -1807,7 +1807,7 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     let blob0 = HashedBlob::test_blob("blob0");
-    let blob0_id = blob0.id();
+    let blob0_id = blob0.id;
 
     client1.synchronize_from_validators().await.unwrap();
     // Publish blob0 on chain 1
@@ -1819,7 +1819,7 @@ where
         .requires_blob(&blob0_id));
 
     let blob2 = HashedBlob::test_blob("blob2");
-    let blob2_id = blob2.id();
+    let blob2_id = blob2.id;
 
     client2.synchronize_from_validators().await.unwrap();
     // Publish blob2 on chain 2
@@ -1839,7 +1839,7 @@ where
 
     client3_a.synchronize_from_validators().await.unwrap();
     let blob1 = HashedBlob::test_blob("blob1");
-    let blob1_id = blob1.id();
+    let blob1_id = blob1.id;
 
     client3_a.add_pending_blobs(&[blob1]).await;
     let blob_0_1_operations = vec![
@@ -1913,7 +1913,7 @@ where
 
     client3_b.synchronize_from_validators().await.unwrap();
     let blob3 = HashedBlob::test_blob("blob3");
-    let blob3_id = blob3.id();
+    let blob3_id = blob3.id;
 
     client3_b.add_pending_blobs(&[blob3]).await;
     let blob_2_3_operations = vec![

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -464,7 +464,7 @@ where
             .read_hashed_blob(blob_id)
             .await
             .map_err(Into::into);
-        sender.send(hashed_blob.map(|hashed_blob| hashed_blob.blob().clone()))
+        sender.send(hashed_blob.map(|hashed_blob| hashed_blob.blob.clone()))
     }
 
     async fn do_download_certificate_value(

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -43,7 +43,7 @@ async fn test_insert_single_certificate_value() {
 async fn test_insert_single_hashed_blob() {
     let cache = ValueCache::<BlobId, HashedBlob>::default();
     let value = create_dummy_hashed_blob(0);
-    let blob_id = value.id();
+    let blob_id = value.id;
 
     assert!(cache.insert(Cow::Borrowed(&value)).await);
     assert!(cache.contains(&blob_id).await);
@@ -84,13 +84,13 @@ async fn test_insert_many_hashed_blobs_individually() {
     }
 
     for blob in &blobs {
-        assert!(cache.contains(&blob.id()).await);
-        assert_eq!(cache.get(&blob.id()).await.as_ref(), Some(blob));
+        assert!(cache.contains(&blob.id).await);
+        assert_eq!(cache.get(&blob.id).await.as_ref(), Some(blob));
     }
 
     assert_eq!(
         cache.keys::<BTreeSet<_>>().await,
-        BTreeSet::from_iter(blobs.iter().map(HashedBlob::id))
+        BTreeSet::from_iter(blobs.iter().map(|blob| blob.id))
     );
 }
 

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -119,7 +119,7 @@ where
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
 
     let contract_blob = HashedBlob::load_from_file(contract_path.clone()).await?;
-    let expected_contract_blob_id = contract_blob.id();
+    let expected_contract_blob_id = contract_blob.id;
     let certificate = publisher
         .publish_blob(contract_blob.clone())
         .await
@@ -135,7 +135,7 @@ where
         .any(|responses| responses.contains(&OracleResponse::Blob(expected_contract_blob_id))));
 
     let service_blob = HashedBlob::load_from_file(service_path.clone()).await?;
-    let expected_service_blob_id = service_blob.id();
+    let expected_service_blob_id = service_blob.id;
     let certificate = publisher.publish_blob(service_blob).await.unwrap().unwrap();
     assert!(certificate
         .value()

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -244,7 +244,7 @@ impl ValueCache<BlobId, HashedBlob> {
     ///
     /// Returns [`true`] if the value was not already present in the cache.
     pub async fn insert<'a>(&self, value: Cow<'a, HashedBlob>) -> bool {
-        let blob_id = (*value).id();
+        let blob_id = value.id;
         let mut cache = self.cache.lock().await;
         if cache.contains(&blob_id) {
             // Promote the re-inserted value in the cache, as if it was accessed again.

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -602,7 +602,7 @@ where
 
     async fn write_hashed_blob(&self, blob: &HashedBlob) -> Result<(), ViewError> {
         let mut batch = Batch::new();
-        Self::add_blob_to_batch(&blob.id(), blob, &mut batch)?;
+        Self::add_blob_to_batch(&blob.id, blob, &mut batch)?;
         self.write_batch(batch).await?;
         Ok(())
     }
@@ -654,7 +654,7 @@ where
     async fn write_hashed_blobs(&self, blobs: &[HashedBlob]) -> Result<(), ViewError> {
         let mut batch = Batch::new();
         for blob in blobs {
-            Self::add_blob_to_batch(&blob.id(), blob, &mut batch)?;
+            Self::add_blob_to_batch(&blob.id, blob, &mut batch)?;
         }
         self.write_batch(batch).await
     }
@@ -670,7 +670,7 @@ where
             Self::add_hashed_cert_value_to_batch(value, &mut batch)?;
         }
         for blob in blobs {
-            Self::add_blob_to_batch(&blob.id(), blob, &mut batch)?;
+            Self::add_blob_to_batch(&blob.id, blob, &mut batch)?;
         }
         Self::add_certificate_to_batch(certificate, &mut batch)?;
         self.write_batch(batch).await


### PR DESCRIPTION
## Motivation

We're keeping the fields public to make it easier to write different parts of the code that use this

## Proposal

So we don't need the getters anymore, since the fields are public.

## Test Plan

CI

