### PR TITLE
Make HashedBlob's fields private

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -803,9 +803,9 @@ impl From<HashedBlob> for Blob {
 #[derive(Eq, PartialEq, Debug, Hash, Clone, WitType, WitStore)]
 pub struct HashedBlob {
     /// ID of the blob.
-    pub id: BlobId,
+    id: BlobId,
     /// A blob of binary data.
-    pub blob: Blob,
+    blob: Blob,
 }
 
 impl HashedBlob {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1551,7 +1551,7 @@ where
             let new_found_blobs = missing_blobs
                 .iter()
                 .filter_map(|blob_id| info.manager.pending_blobs.get(blob_id))
-                .map(|blob| (blob.id, blob.clone()))
+                .map(|blob| (blob.id(), blob.clone()))
                 .collect::<HashMap<_, _>>();
             missing_blobs.retain(|blob_id| !new_found_blobs.contains_key(blob_id));
             new_found_blobs.into_values().collect()

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -448,7 +448,7 @@ where
         self.node.state.recent_hashed_blobs()
     }
 
-    #[tracing::instrument(level = "trace", skip(self, hashed_blob), fields(blob_id = ?hashed_blob.id))]
+    #[tracing::instrument(level = "trace", skip(self, hashed_blob), fields(blob_id = ?hashed_blob.id()))]
     pub async fn cache_recent_blob(&self, hashed_blob: &HashedBlob) -> bool {
         self.node
             .state

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1698,7 +1698,7 @@ where
 
     client2_a.synchronize_from_validators().await.unwrap();
     let blob1 = HashedBlob::test_blob("blob1");
-    let blob1_id = blob1.id;
+    let blob1_id = blob1.id();
 
     client2_a.add_pending_blobs(&[blob1]).await;
     let blob_0_1_operations = vec![

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -11,7 +11,7 @@ use futures::channel::mpsc;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::{self, MeasureLatency as _};
 use linera_base::{
-    data_types::{Amount, ApplicationPermissions, HashedBlob, Timestamp},
+    data_types::{Amount, ApplicationPermissions, Blob, Timestamp},
     identifiers::{Account, BlobId, MessageId, Owner},
     ownership::ChainOwnership,
 };
@@ -443,7 +443,7 @@ pub enum ExecutionRequest {
 
     ReadBlob {
         blob_id: BlobId,
-        callback: Sender<HashedBlob>,
+        callback: Sender<Blob>,
     },
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -31,7 +31,7 @@ use linera_base::{
     abi::Abi,
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, BlockHeight, HashedBlob, Resources,
+        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Resources,
         SendMessageRequest, Timestamp,
     },
     doc_scalar, hex_debug,
@@ -257,7 +257,7 @@ pub trait ExecutionRuntimeContext {
         description: &UserApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError>;
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ExecutionError>;
+    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ExecutionError>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -491,7 +491,7 @@ pub trait BaseRuntime {
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError>;
 
     /// Reads a blob specified by a given `BlobId`.
-    fn read_blob(&mut self, blob_id: &BlobId) -> Result<HashedBlob, ExecutionError>;
+    fn read_blob(&mut self, blob_id: &BlobId) -> Result<Blob, ExecutionError>;
 }
 
 pub trait ServiceRuntime: BaseRuntime {
@@ -850,7 +850,7 @@ pub struct TestExecutionRuntimeContext {
     execution_runtime_config: ExecutionRuntimeConfig,
     user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
     user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
-    blobs: Arc<DashMap<BlobId, HashedBlob>>,
+    blobs: Arc<DashMap<BlobId, Blob>>,
 }
 
 #[cfg(with_testing)]
@@ -913,7 +913,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
             .clone())
     }
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ExecutionError> {
+    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ExecutionError> {
         Ok(self
             .blobs
             .get(&blob_id)

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -12,7 +12,7 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, BlockHeight, HashedBlob, OracleResponse,
+        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, OracleResponse,
         Resources, SendMessageRequest, Timestamp,
     },
     ensure,
@@ -712,7 +712,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().assert_before(timestamp)
     }
 
-    fn read_blob(&mut self, blob_id: &BlobId) -> Result<HashedBlob, ExecutionError> {
+    fn read_blob(&mut self, blob_id: &BlobId) -> Result<Blob, ExecutionError> {
         self.inner().read_blob(blob_id)
     }
 }
@@ -1013,7 +1013,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(())
     }
 
-    fn read_blob(&mut self, blob_id: &BlobId) -> Result<HashedBlob, ExecutionError> {
+    fn read_blob(&mut self, blob_id: &BlobId) -> Result<Blob, ExecutionError> {
         if let Some(responses) = &mut self.replaying_oracle_responses {
             match responses.next() {
                 Some(OracleResponse::Blob(oracle_blob_id)) if oracle_blob_id == *blob_id => {}

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -15,7 +15,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, HashedBlob, OracleResponse, Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, Blob, OracleResponse, Timestamp,
     },
     ensure, hex_debug,
     identifiers::{Account, BlobId, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
@@ -1050,7 +1050,7 @@ where
         Ok(messages)
     }
 
-    pub async fn read_blob(&mut self, blob_id: BlobId) -> Result<HashedBlob, SystemExecutionError> {
+    pub async fn read_blob(&mut self, blob_id: BlobId) -> Result<Blob, SystemExecutionError> {
         self.context()
             .extra()
             .get_blob(blob_id)

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -5,7 +5,7 @@ use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, HashedBlob, SendMessageRequest, Timestamp,
+        Amount, ApplicationPermissions, Blob, BlockHeight, SendMessageRequest, Timestamp,
     },
     identifiers::{
         Account, ApplicationId, BlobId, ChainId, ChannelName, MessageId, Owner, StreamName,
@@ -357,7 +357,7 @@ where
     }
 
     /// Reads a blob from storage.
-    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<HashedBlob, RuntimeError> {
+    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<Blob, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
@@ -531,7 +531,7 @@ where
     }
 
     /// Reads a blob from storage.
-    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<HashedBlob, RuntimeError> {
+    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<Blob, RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, Blob, BlockHeight, HashedBlob, TimeDelta, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
 };
@@ -46,15 +46,6 @@ impl From<wit_system_api::BlobId> for BlobId {
 impl From<wit_system_api::Blob> for Blob {
     fn from(blob: wit_system_api::Blob) -> Self {
         Blob { bytes: blob.bytes }
-    }
-}
-
-impl From<wit_system_api::HashedBlob> for HashedBlob {
-    fn from(hashed_blob: wit_system_api::HashedBlob) -> Self {
-        HashedBlob {
-            id: hashed_blob.id.into(),
-            blob: hashed_blob.blob.into(),
-        }
     }
 }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -6,8 +6,8 @@
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, HashedBlob, Resources, SendMessageRequest,
-        Timestamp,
+        Amount, ApplicationPermissions, Blob, BlockHeight, HashedBlob, Resources,
+        SendMessageRequest, Timestamp,
     },
     identifiers::{
         Account, ApplicationId, BlobId, ChainId, ChannelName, Destination, MessageId, Owner,
@@ -273,7 +273,7 @@ where
 
     /// Reads a blob with the given `BlobId` from storage.
     pub fn read_blob(&mut self, blob_id: BlobId) -> HashedBlob {
-        wit::read_blob(blob_id.into()).into()
+        Blob::from(wit::read_blob(blob_id.into())).with_hash_unchecked(blob_id)
     }
 }
 

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, Blob, BlockHeight, HashedBlob, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, Timestamp},
     identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
 };
 
@@ -20,15 +20,6 @@ impl From<wit_system_api::CryptoHash> for ChainId {
 impl From<wit_system_api::Owner> for Owner {
     fn from(owner: wit_system_api::Owner) -> Self {
         Owner(owner.inner0.into())
-    }
-}
-
-impl From<wit_system_api::HashedBlob> for HashedBlob {
-    fn from(hashed_blob: wit_system_api::HashedBlob) -> Self {
-        HashedBlob {
-            id: hashed_blob.id.into(),
-            blob: hashed_blob.blob.into(),
-        }
     }
 }
 

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 
 use linera_base::{
     abi::ServiceAbi,
-    data_types::{Amount, BlockHeight, HashedBlob, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, HashedBlob, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, Owner},
 };
 
@@ -147,6 +147,6 @@ where
 
     /// Reads a blob with the given `BlobId` from storage.
     pub fn read_blob(&mut self, blob_id: BlobId) -> HashedBlob {
-        wit::read_blob(blob_id.into()).into()
+        Blob::from(wit::read_blob(blob_id.into())).with_hash_unchecked(blob_id)
     }
 }

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -25,7 +25,7 @@ interface contract-system-api {
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
-    read-blob: func(blob-id: blob-id) -> hashed-blob;
+    read-blob: func(blob-id: blob-id) -> blob;
     log: func(message: string, level: log-level);
     consume-fuel: func(fuel: u64);
 
@@ -94,11 +94,6 @@ interface contract-system-api {
     variant destination {
         recipient(chain-id),
         subscribers(channel-name),
-    }
-
-    record hashed-blob {
-        id: blob-id,
-        blob: blob,
     }
 
     enum log-level {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,7 @@ interface service-system-api {
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
-    read-blob: func(blob-id: blob-id) -> hashed-blob;
+    read-blob: func(blob-id: blob-id) -> blob;
     assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
 
@@ -52,11 +52,6 @@ interface service-system-api {
         part2: u64,
         part3: u64,
         part4: u64,
-    }
-
-    record hashed-blob {
-        id: blob-id,
-        blob: blob,
     }
 
     enum log-level {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -601,7 +601,7 @@ where
         self.apply_client_command(&chain_id, move |client| {
             let hashed_blob = hashed_blob.clone();
             async move {
-                let blob_id = hashed_blob.id;
+                let blob_id = hashed_blob.id();
                 let result = client
                     .publish_blob(hashed_blob)
                     .await

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -23,7 +23,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlockHeight, HashedBlob, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, HashedBlob, Timestamp},
     identifiers::{BlobId, ChainDescription, ChainId, GenericApplicationId},
     ownership::ChainOwnership,
 };
@@ -123,7 +123,7 @@ pub trait Storage: Sized {
         hash: CryptoHash,
     ) -> Result<HashedCertificateValue, ViewError>;
 
-    /// Reads the blob with the given blob ID.
+    /// Reads the hashed blob with the given blob ID.
     async fn read_hashed_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ViewError>;
 
     /// Reads the blobs with the given blob IDs.
@@ -473,7 +473,7 @@ where
         }
     }
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ExecutionError> {
-        Ok(self.storage.read_hashed_blob(blob_id).await?)
+    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ExecutionError> {
+        Ok(self.storage.read_hashed_blob(blob_id).await?.into_inner())
     }
 }


### PR DESCRIPTION
## Motivation

The `HashedBlob` type should guarantee that, unless you use a function containing `unchecked`, the hash in the ID always matches the content.

## Proposal

Make `HashedBlob` fields private

## Test Plan

CI

