### PR TITLE
Introduce micro-benchmarks for the stores.

### DIFF
--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -79,3 +79,7 @@ cfg_aliases.workspace = true
 [[bench]]
 name = "reentrant_collection_view"
 harness = false
+
+[[bench]]
+name = "stores"
+harness = false

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -1,26 +1,25 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, Instant};
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    time::{Duration, Instant},
+};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use linera_views::{
-    batch::Batch,
-    test_utils::{prefix_expansion, get_random_key_values2},
-    memory::{create_memory_store, MemoryStore},
-    common::{LocalKeyValueStore},
-};
-use tokio::runtime::Runtime;
-
-#[cfg(with_rocksdb)]
-use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbStore};
-
 #[cfg(with_dynamodb)]
 use linera_views::dynamo_db::{create_dynamo_db_test_store, DynamoDbStore};
-
+#[cfg(with_rocksdb)]
+use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbStore};
 #[cfg(with_scylladb)]
 use linera_views::scylla_db::{create_scylla_db_test_store, ScyllaDbStore};
+use linera_views::{
+    batch::Batch,
+    common::LocalKeyValueStore,
+    memory::{create_memory_store, MemoryStore},
+    test_utils::{get_random_key_values2, prefix_expansion},
+};
+use tokio::runtime::Runtime;
 
 pub async fn performance_contains_key<S: LocalKeyValueStore>(store: S, iterations: u64) -> Duration
 where
@@ -37,6 +36,7 @@ where
         for key_value in &key_values {
             batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
         }
+        store.write_batch(batch, &[]).await.unwrap();
 
         let measurement = Instant::now();
         for key_value in &key_values {
@@ -53,60 +53,495 @@ where
 }
 
 fn bench_contain_key(criterion: &mut Criterion) {
-    criterion.bench_function(
-        "memory_contain_key",
-        |bencher| {
-            bencher
-                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
-		.iter_custom(|iterations| async move {
-                    let store = create_memory_store();
-                    performance_contains_key::<MemoryStore>(store, iterations).await
-                })
-        }
-    );
+    criterion.bench_function("memory_contain_key", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_memory_store();
+                performance_contains_key::<MemoryStore>(store, iterations).await
+            })
+    });
 
     #[cfg(with_rocksdb)]
-    criterion.bench_function(
-        "rocksdb_contain_key",
-        |bencher| {
-            bencher
-                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
-		.iter_custom(|iterations| async move {
-                    let (store, _dir) = create_rocks_db_test_store().await;
-                    performance_contains_key::<RocksDbStore>(store, iterations).await
-                })
-        }
-    );
+    criterion.bench_function("rocksdb_contain_key", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let (store, _dir) = create_rocks_db_test_store().await;
+                performance_contains_key::<RocksDbStore>(store, iterations).await
+            })
+    });
 
     #[cfg(with_dynamodb)]
-    criterion.bench_function(
-        "dynamodb_contain_key",
-        |bencher| {
-            bencher
-                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
-		.iter_custom(|iterations| async move {
-                    let store = create_dynamo_db_test_store().await;
-                    performance_contains_key::<DynamoDbStore>(store, iterations).await
-                })
-        }
-    );
+    criterion.bench_function("dynamodb_contain_key", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_contains_key::<DynamoDbStore>(store, iterations).await
+            })
+    });
 
     #[cfg(with_scylladb)]
-    criterion.bench_function(
-        "scylladb_contain_key",
-        |bencher| {
-            bencher
-                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
-		.iter_custom(|iterations| async move {
-                    let store = create_scylla_db_test_store().await;
-                    performance_contains_key::<ScyllaDbStore>(store, iterations).await
-                })
+    criterion.bench_function("scylladb_contain_key", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_contains_key::<ScyllaDbStore>(store, iterations).await
+            })
+    });
+}
+
+pub async fn performance_contains_keys<S: LocalKeyValueStore>(store: S, iterations: u64) -> Duration
+where
+    S::Error: Debug,
+{
+    let prefix = vec![0];
+    let num_entries = 100;
+    let len_value = 10000;
+
+    let mut total_time = Duration::ZERO;
+    for _ in 0..iterations {
+        let key_values = prefix_expansion(&prefix, get_random_key_values2(num_entries, len_value));
+        let mut batch = Batch::new();
+        for key_value in &key_values {
+            batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
         }
-    );
+        store.write_batch(batch, &[]).await.unwrap();
+        let keys = key_values
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect::<Vec<_>>();
+
+        let measurement = Instant::now();
+        black_box(store.contains_keys(keys).await.unwrap());
+        total_time += measurement.elapsed();
+
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(prefix.clone());
+        store.write_batch(batch, &[]).await.unwrap();
+    }
+
+    total_time
+}
+
+fn bench_contain_keys(criterion: &mut Criterion) {
+    criterion.bench_function("memory_contain_keys", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_memory_store();
+                performance_contains_keys::<MemoryStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_contain_keys", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let (store, _dir) = create_rocks_db_test_store().await;
+                performance_contains_keys::<RocksDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_contain_keys", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_contains_keys::<DynamoDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_contain_keys", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_contains_keys::<ScyllaDbStore>(store, iterations).await
+            })
+    });
+}
+
+pub async fn performance_find_keys_by_prefix<S: LocalKeyValueStore>(
+    store: S,
+    iterations: u64,
+) -> Duration
+where
+    S::Error: Debug,
+{
+    let prefix = vec![0];
+    let num_entries = 100;
+    let len_value = 10000;
+
+    let mut total_time = Duration::ZERO;
+    for _ in 0..iterations {
+        let key_values = prefix_expansion(&prefix, get_random_key_values2(num_entries, len_value));
+        let mut batch = Batch::new();
+        for key_value in &key_values {
+            batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        }
+        store.write_batch(batch, &[]).await.unwrap();
+
+        let measurement = Instant::now();
+        black_box(store.find_keys_by_prefix(&prefix).await.unwrap());
+        total_time += measurement.elapsed();
+
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(prefix.clone());
+        store.write_batch(batch, &[]).await.unwrap();
+    }
+
+    total_time
+}
+
+fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
+    criterion.bench_function("memory_find_keys_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_memory_store();
+                performance_find_keys_by_prefix::<MemoryStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_find_keys_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let (store, _dir) = create_rocks_db_test_store().await;
+                performance_find_keys_by_prefix::<RocksDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_find_keys_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_find_keys_by_prefix::<DynamoDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_find_keys_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_find_keys_by_prefix::<ScyllaDbStore>(store, iterations).await
+            })
+    });
+}
+
+pub async fn performance_find_key_values_by_prefix<S: LocalKeyValueStore>(
+    store: S,
+    iterations: u64,
+) -> Duration
+where
+    S::Error: Debug,
+{
+    let prefix = vec![0];
+    let num_entries = 100;
+    let len_value = 10000;
+
+    let mut total_time = Duration::ZERO;
+    for _ in 0..iterations {
+        let key_values = prefix_expansion(&prefix, get_random_key_values2(num_entries, len_value));
+        let mut batch = Batch::new();
+        for key_value in &key_values {
+            batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        }
+        store.write_batch(batch, &[]).await.unwrap();
+
+        let measurement = Instant::now();
+        black_box(store.find_key_values_by_prefix(&prefix).await.unwrap());
+        total_time += measurement.elapsed();
+
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(prefix.clone());
+        store.write_batch(batch, &[]).await.unwrap();
+    }
+
+    total_time
+}
+
+fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
+    criterion.bench_function("memory_find_key_values_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_memory_store();
+                performance_find_key_values_by_prefix::<MemoryStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_find_key_values_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let (store, _dir) = create_rocks_db_test_store().await;
+                performance_find_key_values_by_prefix::<RocksDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_find_key_values_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_find_key_values_by_prefix::<DynamoDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_find_key_values_by_prefix", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_find_key_values_by_prefix::<ScyllaDbStore>(store, iterations).await
+            })
+    });
+}
+
+pub async fn performance_read_value_bytes<S: LocalKeyValueStore>(
+    store: S,
+    iterations: u64,
+) -> Duration
+where
+    S::Error: Debug,
+{
+    let prefix = vec![0];
+    let num_entries = 100;
+    let len_value = 10000;
+
+    let mut total_time = Duration::ZERO;
+    for _ in 0..iterations {
+        let key_values = prefix_expansion(&prefix, get_random_key_values2(num_entries, len_value));
+        let mut batch = Batch::new();
+        for key_value in &key_values {
+            batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        }
+        store.write_batch(batch, &[]).await.unwrap();
+
+        let measurement = Instant::now();
+        for (key, _) in &key_values {
+            black_box(store.read_value_bytes(key).await.unwrap());
+        }
+        total_time += measurement.elapsed();
+
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(prefix.clone());
+        store.write_batch(batch, &[]).await.unwrap();
+    }
+
+    total_time
+}
+
+fn bench_read_value_bytes(criterion: &mut Criterion) {
+    criterion.bench_function("memory_read_value_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_memory_store();
+                performance_read_value_bytes::<MemoryStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_read_value_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let (store, _dir) = create_rocks_db_test_store().await;
+                performance_read_value_bytes::<RocksDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_read_value_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_read_value_bytes::<DynamoDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_read_value_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_read_value_bytes::<ScyllaDbStore>(store, iterations).await
+            })
+    });
+}
+
+pub async fn performance_read_multi_values_bytes<S: LocalKeyValueStore>(
+    store: S,
+    iterations: u64,
+) -> Duration
+where
+    S::Error: Debug,
+{
+    let prefix = vec![0];
+    let num_entries = 100;
+    let len_value = 10000;
+
+    let mut total_time = Duration::ZERO;
+    for _ in 0..iterations {
+        let key_values = prefix_expansion(&prefix, get_random_key_values2(num_entries, len_value));
+        let mut batch = Batch::new();
+        for key_value in &key_values {
+            batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        }
+        store.write_batch(batch, &[]).await.unwrap();
+        let keys = key_values
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect::<Vec<_>>();
+
+        let measurement = Instant::now();
+        black_box(store.read_multi_values_bytes(keys).await.unwrap());
+        total_time += measurement.elapsed();
+
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(prefix.clone());
+        store.write_batch(batch, &[]).await.unwrap();
+    }
+
+    total_time
+}
+
+fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
+    criterion.bench_function("memory_read_multi_values_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_memory_store();
+                performance_read_multi_values_bytes::<MemoryStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_read_multi_values_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let (store, _dir) = create_rocks_db_test_store().await;
+                performance_read_multi_values_bytes::<RocksDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_read_multi_values_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_read_multi_values_bytes::<DynamoDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_read_multi_values_bytes", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_read_multi_values_bytes::<ScyllaDbStore>(store, iterations).await
+            })
+    });
+}
+
+pub async fn performance_write_batch<S: LocalKeyValueStore>(store: S, iterations: u64) -> Duration
+where
+    S::Error: Debug,
+{
+    let prefix = vec![0];
+    let num_entries = 100;
+    let len_value = 10000;
+
+    let mut total_time = Duration::ZERO;
+    for _ in 0..iterations {
+        let key_values = prefix_expansion(&prefix, get_random_key_values2(num_entries, len_value));
+        let mut batch = Batch::new();
+        for key_value in &key_values {
+            batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        }
+
+        let measurement = Instant::now();
+        store.write_batch(batch, &[]).await.unwrap();
+        total_time += measurement.elapsed();
+
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(prefix.clone());
+        store.write_batch(batch, &[]).await.unwrap();
+    }
+
+    total_time
+}
+
+fn bench_write_batch(criterion: &mut Criterion) {
+    criterion.bench_function("memory_write_batch", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_memory_store();
+                performance_write_batch::<MemoryStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_write_batch", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let (store, _dir) = create_rocks_db_test_store().await;
+                performance_write_batch::<RocksDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_write_batch", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_write_batch::<DynamoDbStore>(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_write_batch", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_write_batch::<ScyllaDbStore>(store, iterations).await
+            })
+    });
 }
 
 criterion_group!(
     benches,
-    bench_contain_key
+    bench_contain_key,
+    bench_contain_keys,
+    bench_find_keys_by_prefix,
+    bench_find_key_values_by_prefix,
+    bench_read_value_bytes,
+    bench_read_multi_values_bytes,
+    bench_write_batch
 );
 criterion_main!(benches);

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -8,11 +8,19 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use linera_views::{
     batch::Batch,
     test_utils::{prefix_expansion, get_random_key_values2},
-    memory::MemoryStore,
-    memory::create_memory_store,
+    memory::{create_memory_store, MemoryStore},
     common::{LocalKeyValueStore},
 };
 use tokio::runtime::Runtime;
+
+#[cfg(with_rocksdb)]
+use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbStore};
+
+#[cfg(with_dynamodb)]
+use linera_views::dynamo_db::{create_dynamo_db_test_store, DynamoDbStore};
+
+#[cfg(with_scylladb)]
+use linera_views::scylla_db::{create_scylla_db_test_store, ScyllaDbStore};
 
 pub async fn performance_contains_key<S: LocalKeyValueStore>(store: S, iterations: u64) -> Duration
 where
@@ -77,7 +85,7 @@ fn bench_contain_key(criterion: &mut Criterion) {
             bencher
                 .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
 		.iter_custom(|iterations| async move {
-                    let store = create_dynamo_db_test_config().await;
+                    let store = create_dynamo_db_test_store().await;
                     performance_contains_key::<DynamoDbStore>(store, iterations).await
                 })
         }

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{Duration, Instant};
+use std::fmt::Debug;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use linera_views::{
+    batch::Batch,
+    test_utils::{prefix_expansion, get_random_key_values2},
+    memory::MemoryStore,
+    memory::create_memory_store,
+    common::{LocalKeyValueStore},
+};
+use tokio::runtime::Runtime;
+
+pub async fn performance_contains_key<S: LocalKeyValueStore>(store: S, iterations: u64) -> Duration
+where
+    S::Error: Debug,
+{
+    let prefix = vec![0];
+    let num_entries = 100;
+    let len_value = 10000;
+
+    let mut total_time = Duration::ZERO;
+    for _ in 0..iterations {
+        let key_values = prefix_expansion(&prefix, get_random_key_values2(num_entries, len_value));
+        let mut batch = Batch::new();
+        for key_value in &key_values {
+            batch.put_key_value_bytes(key_value.0.clone(), key_value.1.clone());
+        }
+
+        let measurement = Instant::now();
+        for key_value in &key_values {
+            black_box(store.contains_key(&key_value.0).await.unwrap());
+        }
+        total_time += measurement.elapsed();
+
+        let mut batch = Batch::new();
+        batch.delete_key_prefix(prefix.clone());
+        store.write_batch(batch, &[]).await.unwrap();
+    }
+
+    total_time
+}
+
+fn bench_contain_key(criterion: &mut Criterion) {
+    criterion.bench_function(
+        "memory_contain_key",
+        |bencher| {
+            bencher
+                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+		.iter_custom(|iterations| async move {
+                    let store = create_memory_store();
+                    performance_contains_key::<MemoryStore>(store, iterations).await
+                })
+        }
+    );
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function(
+        "rocksdb_contain_key",
+        |bencher| {
+            bencher
+                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+		.iter_custom(|iterations| async move {
+                    let (store, _dir) = create_rocks_db_test_store().await;
+                    performance_contains_key::<RocksDbStore>(store, iterations).await
+                })
+        }
+    );
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function(
+        "dynamodb_contain_key",
+        |bencher| {
+            bencher
+                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+		.iter_custom(|iterations| async move {
+                    let store = create_dynamo_db_test_config().await;
+                    performance_contains_key::<DynamoDbStore>(store, iterations).await
+                })
+        }
+    );
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function(
+        "scylladb_contain_key",
+        |bencher| {
+            bencher
+                .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+		.iter_custom(|iterations| async move {
+                    let store = create_scylla_db_test_store().await;
+                    performance_contains_key::<ScyllaDbStore>(store, iterations).await
+                })
+        }
+    );
+}
+
+criterion_group!(
+    benches,
+    bench_contain_key
+);
+criterion_main!(benches);

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -331,7 +331,8 @@ fn get_random_key_values1(num_entries: usize, len_value: usize) -> Vec<(Vec<u8>,
     get_random_key_values_prefix(&mut rng, key_prefix, 8, len_value, num_entries)
 }
 
-fn get_random_key_values2(num_entries: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
+/// Generates a list of random key-values with no duplicates
+pub fn get_random_key_values2(num_entries: usize, len_value: usize) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut rng = make_deterministic_rng();
     let key_prefix = vec![0];
     let mut key_values = Vec::new();
@@ -346,6 +347,17 @@ fn get_random_key_values2(num_entries: usize, len_value: usize) -> Vec<(Vec<u8>,
     }
     key_values
 }
+
+/// Add a prefix to a list of key-values
+pub fn prefix_expansion(prefix: &[u8], key_values: Vec<(Vec<u8>,Vec<u8>)>) -> Vec<(Vec<u8>,Vec<u8>)> {
+    key_values.into_iter().map(|(key,value)| {
+        let mut big_key = prefix.to_vec();
+        big_key.extend(key);
+        (big_key,value)
+    }).collect()
+}
+
+
 
 /// We build a number of scenarios for testing the reads.
 pub fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -349,15 +349,19 @@ pub fn get_random_key_values2(num_entries: usize, len_value: usize) -> Vec<(Vec<
 }
 
 /// Add a prefix to a list of key-values
-pub fn prefix_expansion(prefix: &[u8], key_values: Vec<(Vec<u8>,Vec<u8>)>) -> Vec<(Vec<u8>,Vec<u8>)> {
-    key_values.into_iter().map(|(key,value)| {
-        let mut big_key = prefix.to_vec();
-        big_key.extend(key);
-        (big_key,value)
-    }).collect()
+pub fn prefix_expansion(
+    prefix: &[u8],
+    key_values: Vec<(Vec<u8>, Vec<u8>)>,
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    key_values
+        .into_iter()
+        .map(|(key, value)| {
+            let mut big_key = prefix.to_vec();
+            big_key.extend(key);
+            (big_key, value)
+        })
+        .collect()
 }
-
-
 
 /// We build a number of scenarios for testing the reads.
 pub fn get_random_test_scenarios() -> Vec<Vec<(Vec<u8>, Vec<u8>)>> {


### PR DESCRIPTION
## Motivation

The microbenchmarks allow measurements of simple operations of the stores.


## Proposal

The code was implemented by using the `KeyValueStore` template function.
It reveals the following:
* The `join` operation for RocksDb is less efficient than simple iterating, which is expected.
* The grouping of operations (e.g. `read_value_bytes` -> `read_multi_values_bytes`) gets worse performance for the `memory`store.

## Test Plan

Not relevant.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
