### PR TITLE
Allow open-chain messages to be rejected

### DIFF
--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -867,7 +867,7 @@ where
         // Finally, charge for the block fee, except if the chain is closed and the block
         // was used to reject some incoming messages (and only that).
         if !self.is_closed()
-            || !block.incoming_bundles.is_empty()
+            || block.incoming_bundles.is_empty()
             || !block.has_only_rejected_messages()
         {
             resource_controller

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -729,10 +729,6 @@ where
                 self.execution_state.system.closed.set(true);
             }
         }
-        ensure!(
-            !self.is_closed() || !block.incoming_bundles.is_empty(),
-            ChainError::ClosedChain
-        );
         let app_permissions = self.execution_state.system.application_permissions.get();
         let mut mandatory = HashSet::<UserApplicationId>::from_iter(
             app_permissions.mandatory_applications.iter().cloned(),

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -121,6 +121,22 @@ impl Block {
             .map(|im| im.bundle.messages.len())
             .sum()
     }
+
+    /// Returns an iterator over all transactions, by index.
+    pub fn transactions(&self) -> impl Iterator<Item = (u32, Transaction<'_>)> {
+        let bundles = self.incoming_bundles.iter().map(Transaction::Messages);
+        let operations = self.operations.iter().map(Transaction::Operation);
+        (0u32..).zip(bundles.chain(operations))
+    }
+}
+
+/// A transaction in a block: incoming messages or an operation.
+#[derive(Debug, Clone)]
+pub enum Transaction<'a> {
+    /// A bundle of incoming messages.
+    Messages(&'a IncomingBundle),
+    /// An operation.
+    Operation(&'a Operation),
 }
 
 /// A chain ID with a block height.

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -807,7 +807,7 @@ impl ExecutedBlock {
         message_index: u32,
     ) -> Option<MessageId> {
         let block = &self.block;
-        let transaction_index = block.message_count().checked_add(operation_index)?;
+        let transaction_index = block.incoming_bundles.len().checked_add(operation_index)?;
         if message_index
             >= u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()?
         {

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -1283,7 +1283,7 @@ doc_scalar!(
 );
 doc_scalar!(
     MessageBundle,
-    "A message together with non replayable information to ensure uniqueness in a particular inbox"
+    "A set of messages from a single block, for a single destination."
 );
 doc_scalar!(
     Medium,

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -14,7 +14,7 @@ mod outbox;
 pub mod test;
 
 pub use chain::ChainStateView;
-use data_types::{Event, Origin};
+use data_types::{MessageBundle, Origin, PostedMessage};
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, BlockHeight, Round, Timestamp},
@@ -49,48 +49,51 @@ pub enum ChainError {
     },
     #[error(
         "Message in block proposed to {chain_id:?} does not match the previously received messages from \
-        origin {origin:?}: was {event:?} instead of {previous_event:?}"
+        origin {origin:?}: was {bundle:?} instead of {previous_bundle:?}"
     )]
     UnexpectedMessage {
         chain_id: ChainId,
         origin: Box<Origin>,
-        event: Event,
-        previous_event: Event,
+        bundle: MessageBundle,
+        previous_bundle: MessageBundle,
     },
     #[error(
         "Message in block proposed to {chain_id:?} is out of order compared to previous messages \
-         from origin {origin:?}: {event:?}. Block and height should be at least: \
+         from origin {origin:?}: {bundle:?}. Block and height should be at least: \
          {next_height}, {next_index}"
     )]
     IncorrectMessageOrder {
         chain_id: ChainId,
         origin: Box<Origin>,
-        event: Event,
+        bundle: MessageBundle,
         next_height: BlockHeight,
         next_index: u32,
     },
-    #[error("Block proposed to {chain_id:?} is attempting to reject protected message {event:?}")]
+    #[error(
+        "Block proposed to {chain_id:?} is attempting to reject protected message \
+        {posted_message:?}"
+    )]
     CannotRejectMessage {
         chain_id: ChainId,
         origin: Box<Origin>,
-        event: Event,
+        posted_message: PostedMessage,
     },
     #[error(
-        "Block proposed to {chain_id:?} is attempting to skip a message \
-         that cannot be skipped: {event:?}"
+        "Block proposed to {chain_id:?} is attempting to skip a message bundle \
+         that cannot be skipped: {bundle:?}"
     )]
     CannotSkipMessage {
         chain_id: ChainId,
         origin: Box<Origin>,
-        event: Event,
+        bundle: MessageBundle,
     },
     #[error(
-        "Incoming message in block proposed to {chain_id:?} has timestamp {message_timestamp:}, \
-         which is later than the block timestamp {block_timestamp:}."
+        "Incoming message bundle in block proposed to {chain_id:?} has timestamp \
+        {bundle_timestamp:}, which is later than the block timestamp {block_timestamp:}."
     )]
-    IncorrectEventTimestamp {
+    IncorrectBundleTimestamp {
         chain_id: ChainId,
-        message_timestamp: Timestamp,
+        bundle_timestamp: Timestamp,
         block_timestamp: Timestamp,
     },
     #[error("The signature was not created by a valid entity")]

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -143,7 +143,7 @@ pub enum ChainError {
     MissingMandatoryApplications(Vec<ApplicationId>),
     #[error("Can't use grant across different broadcast messages")]
     GrantUseOnBroadcast,
-    #[error("ExecutedBlock contains fewer oracle records than transactions")]
+    #[error("ExecutedBlock contains fewer oracle response lists than transactions")]
     MissingOracleResponseList,
     #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
     CertificateValueHashMismatch {

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -143,7 +143,7 @@ pub enum ChainError {
     MissingMandatoryApplications(Vec<ApplicationId>),
     #[error("Can't use grant across different broadcast messages")]
     GrantUseOnBroadcast,
-    #[error("ExecutedBlock contains fewer oracle responses than requests")]
+    #[error("ExecutedBlock contains fewer oracle records than transactions")]
     MissingOracleResponseList,
     #[error("Unexpected hash for CertificateValue! Expected: {expected:?}, Actual: {actual:?}")]
     CertificateValueHashMismatch {

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -142,6 +142,8 @@ impl VoteTestExt for Vote {
 /// Helper trait to simplify constructing messages for tests.
 pub trait MessageTestExt: Sized {
     fn to_simple_incoming(self, sender: ChainId, height: BlockHeight) -> IncomingBundle;
+
+    fn to_posted(self, index: u32, kind: MessageKind) -> PostedMessage;
 }
 
 impl<T: Into<Message>> MessageTestExt for T {
@@ -154,16 +156,28 @@ impl<T: Into<Message>> MessageTestExt for T {
             index: 0,
             message: self.into(),
         };
+        let bundle = MessageBundle {
+            certificate_hash: CryptoHash::test_hash("certificate"),
+            height,
+            transaction_index: 0,
+            timestamp: Timestamp::from(0),
+            messages: vec![posted_message],
+        };
         IncomingBundle {
             origin: Origin::chain(sender),
-            bundle: MessageBundle {
-                certificate_hash: CryptoHash::test_hash("certificate"),
-                height,
-                transaction_index: 0,
-                timestamp: Timestamp::from(0),
-                messages: vec![posted_message],
-            },
+            bundle,
             action: MessageAction::Accept,
+        }
+    }
+
+    fn to_posted(self, index: u32, kind: MessageKind) -> PostedMessage {
+        PostedMessage {
+            authenticated_signer: None,
+            grant: Amount::ZERO,
+            refund_grant_to: None,
+            kind,
+            index,
+            message: self.into(),
         }
     }
 }

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -15,8 +15,8 @@ use linera_execution::{
 };
 
 use crate::data_types::{
-    Block, BlockProposal, Certificate, Event, HashedCertificateValue, IncomingBundle,
-    MessageAction, Origin, SignatureAggregator, Vote,
+    Block, BlockProposal, Certificate, HashedCertificateValue, IncomingBundle, MessageAction,
+    MessageBundle, Origin, PostedMessage, SignatureAggregator, Vote,
 };
 
 /// Creates a new child of the given block, with the same timestamp.
@@ -146,18 +146,22 @@ pub trait MessageTestExt: Sized {
 
 impl<T: Into<Message>> MessageTestExt for T {
     fn to_simple_incoming(self, sender: ChainId, height: BlockHeight) -> IncomingBundle {
+        let posted_message = PostedMessage {
+            authenticated_signer: None,
+            grant: Amount::ZERO,
+            refund_grant_to: None,
+            kind: MessageKind::Protected,
+            index: 0,
+            message: self.into(),
+        };
         IncomingBundle {
             origin: Origin::chain(sender),
-            event: Event {
+            bundle: MessageBundle {
                 certificate_hash: CryptoHash::test_hash("certificate"),
                 height,
-                index: 0,
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Protected,
+                transaction_index: 0,
                 timestamp: Timestamp::from(0),
-                message: self.into(),
+                messages: vec![posted_message],
             },
             action: MessageAction::Accept,
         }

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -58,7 +58,7 @@ fn make_app_description() -> UserApplicationDescription {
         bytecode_id: BytecodeId::new(make_admin_message_id(BlockHeight(1))),
         bytecode_location: BytecodeLocation {
             certificate_hash: CryptoHash::test_hash("bytecode certificate"),
-            operation_index: 0,
+            transaction_index: 0,
         },
         creation: make_admin_message_id(BlockHeight(2)),
         required_application_ids: vec![],

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -85,7 +85,6 @@ fn make_open_chain_config() -> OpenChainConfig {
         admin_id: admin_id(),
         epoch: Epoch::ZERO,
         committees: iter::once((Epoch::ZERO, committee)).collect(),
-        balance: Amount::from_tokens(10),
         application_permissions: Default::default(),
     }
 }

--- a/linera-chain/src/unit_tests/inbox_tests.rs
+++ b/linera-chain/src/unit_tests/inbox_tests.rs
@@ -3,14 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use assert_matches::assert_matches;
-use linera_base::{
-    crypto::CryptoHash,
-    data_types::{Amount, Timestamp},
-};
+use linera_base::{crypto::CryptoHash, data_types::Timestamp};
 use linera_execution::{Message, MessageKind, UserApplicationId};
 
 use super::*;
-use crate::data_types::PostedMessage;
+use crate::test::MessageTestExt as _;
 
 fn make_bundle(
     certificate_hash: CryptoHash,
@@ -18,23 +15,16 @@ fn make_bundle(
     index: u32,
     message: impl Into<Vec<u8>>,
 ) -> MessageBundle {
-    let posted_message = PostedMessage {
-        authenticated_signer: None,
-        grant: Amount::ZERO,
-        refund_grant_to: None,
-        kind: MessageKind::Simple,
-        index,
-        message: Message::User {
-            application_id: UserApplicationId::default(),
-            bytes: message.into(),
-        },
+    let message = Message::User {
+        application_id: UserApplicationId::default(),
+        bytes: message.into(),
     };
     MessageBundle {
         certificate_hash,
         height: BlockHeight::from(height),
         timestamp: Timestamp::default(),
         transaction_index: index,
-        messages: vec![posted_message],
+        messages: vec![message.to_posted(index, MessageKind::Simple)],
     }
 }
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -491,12 +491,14 @@ where
                 committees,
                 admin_id: self.wallet.genesis_admin_chain(),
                 epoch,
-                balance,
                 application_permissions: Default::default(),
             };
-            let operations = iter::repeat(Operation::System(SystemOperation::OpenChain(config)))
-                .take(num_new_chains)
-                .collect();
+            let operations = iter::repeat(Operation::System(SystemOperation::OpenChain {
+                config,
+                balance,
+            }))
+            .take(num_new_chains)
+            .collect();
             let certificate = chain_client
                 .execute_without_prepare(operations)
                 .await?

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -9,7 +9,7 @@ use futures::future::try_join_all;
 use linera_base::{
     data_types::{Blob, BlockHeight, Timestamp},
     ensure,
-    identifiers::ChainId,
+    identifiers::{ChainId, MessageId},
 };
 use linera_chain::{
     data_types::{
@@ -259,20 +259,23 @@ where
             return Ok((info, actions));
         }
         if tip.is_first_block() && !self.state.chain.is_active() {
-            let local_time = self.state.storage.clock().current_time();
-            for message in &block.incoming_bundles {
-                if self
-                    .state
-                    .chain
-                    .execute_init_message(
-                        message.id(),
-                        &message.event.message,
-                        message.event.timestamp,
-                        local_time,
-                    )
-                    .await?
-                {
-                    break;
+            if let Some(incoming_bundle) = block.incoming_bundles.first() {
+                if let Some(posted_message) = incoming_bundle.bundle.messages.first() {
+                    let message_id = MessageId {
+                        chain_id: incoming_bundle.origin.sender,
+                        height: incoming_bundle.bundle.height,
+                        index: posted_message.index,
+                    };
+                    let local_time = self.state.storage.clock().current_time();
+                    self.state
+                        .chain
+                        .execute_init_message(
+                            message_id,
+                            &posted_message.message,
+                            incoming_bundle.bundle.timestamp,
+                            local_time,
+                        )
+                        .await?;
                 }
             }
         }
@@ -338,7 +341,7 @@ where
         .await?;
 
         // Execute the block and update inboxes.
-        self.state.chain.remove_events_from_inboxes(block).await?;
+        self.state.chain.remove_bundles_from_inboxes(block).await?;
         let local_time = self.state.storage.clock().current_time();
         let verified_outcome = Box::pin(self.state.chain.execute_block(
             block,
@@ -385,7 +388,7 @@ where
     pub(super) async fn process_cross_chain_update(
         &mut self,
         origin: Origin,
-        bundles: Vec<MessageBundle>,
+        bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
         // Only process certificates with relevant heights and epochs.
         let next_height_to_receive = self
@@ -572,12 +575,12 @@ impl<'a> CrossChainUpdateHelper<'a> {
         recipient: ChainId,
         next_height_to_receive: BlockHeight,
         last_anticipated_block_height: Option<BlockHeight>,
-        mut bundles: Vec<MessageBundle>,
+        mut bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Vec<MessageBundle>, WorkerError> {
         let mut latest_height = None;
         let mut skipped_len = 0;
         let mut trusted_len = 0;
-        for (i, bundle) in bundles.iter().enumerate() {
+        for (i, (epoch, bundle)) in bundles.iter().enumerate() {
             // Make sure that heights are not decreasing.
             ensure!(
                 latest_height <= Some(bundle.height),
@@ -591,32 +594,35 @@ impl<'a> CrossChainUpdateHelper<'a> {
             // Check if the height is trusted or the epoch is trusted.
             if self.allow_messages_from_deprecated_epochs
                 || Some(bundle.height) <= last_anticipated_block_height
-                || Some(bundle.epoch) >= self.current_epoch
-                || self.committees.contains_key(&bundle.epoch)
+                || Some(*epoch) >= self.current_epoch
+                || self.committees.contains_key(epoch)
             {
                 trusted_len = i + 1;
             }
         }
         if skipped_len > 0 {
-            let sample_bundle = &bundles[skipped_len - 1];
+            let (_, sample_bundle) = &bundles[skipped_len - 1];
             debug!(
                 "Ignoring repeated messages to {recipient:?} from {origin:?} at height {}",
                 sample_bundle.height,
             );
         }
         if skipped_len < bundles.len() && trusted_len < bundles.len() {
-            let sample_bundle = &bundles[trusted_len];
+            let (sample_epoch, sample_bundle) = &bundles[trusted_len];
             warn!(
                 "Refusing messages to {recipient:?} from {origin:?} at height {} \
                  because the epoch {:?} is not trusted any more",
-                sample_bundle.height, sample_bundle.epoch,
+                sample_bundle.height, sample_epoch,
             );
         }
-        let certificates = if skipped_len < trusted_len {
-            bundles.drain(skipped_len..trusted_len).collect()
+        let bundles = if skipped_len < trusted_len {
+            bundles
+                .drain(skipped_len..trusted_len)
+                .map(|(_, bundle)| bundle)
+                .collect()
         } else {
             vec![]
         };
-        Ok(certificates)
+        Ok(bundles)
     }
 }

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -12,6 +12,8 @@ use std::{
     sync::Arc,
 };
 
+#[cfg(with_testing)]
+use linera_base::identifiers::BytecodeId;
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Blob, BlockHeight},
@@ -32,8 +34,6 @@ use linera_execution::{
 use linera_storage::Storage;
 use linera_views::views::{ClonableView, ViewError};
 use tokio::sync::{OwnedRwLockReadGuard, RwLock};
-#[cfg(with_testing)]
-use {linera_base::identifiers::BytecodeId, linera_chain::data_types::Event};
 
 #[cfg(test)]
 pub(crate) use self::attempted_changes::CrossChainUpdateHelper;
@@ -141,18 +141,18 @@ where
             .await
     }
 
-    /// Searches for an event in one of the chain's inboxes.
+    /// Searches for a bundle in one of the chain's inboxes.
     #[cfg(with_testing)]
-    pub(super) async fn find_event_in_inbox(
+    pub(super) async fn find_bundle_in_inbox(
         &mut self,
         inbox_id: Origin,
         certificate_hash: CryptoHash,
         height: BlockHeight,
         index: u32,
-    ) -> Result<Option<Event>, WorkerError> {
+    ) -> Result<Option<MessageBundle>, WorkerError> {
         ChainWorkerStateWithTemporaryChanges::new(self)
             .await
-            .find_event_in_inbox(inbox_id, certificate_hash, height, index)
+            .find_bundle_in_inbox(inbox_id, certificate_hash, height, index)
             .await
     }
 
@@ -269,7 +269,7 @@ where
     pub(super) async fn process_cross_chain_update(
         &mut self,
         origin: Origin,
-        bundles: Vec<MessageBundle>,
+        bundles: Vec<(Epoch, MessageBundle)>,
     ) -> Result<Option<BlockHeight>, WorkerError> {
         ChainWorkerStateWithAttemptedChanges::new(self)
             .await

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2478,10 +2478,9 @@ where
                 committees,
                 admin_id: self.admin_id(),
                 epoch,
-                balance,
                 application_permissions: application_permissions.clone(),
             };
-            let operation = Operation::System(SystemOperation::OpenChain(config));
+            let operation = Operation::System(SystemOperation::OpenChain { config, balance });
             let certificate = match self.execute_block(vec![operation]).await? {
                 ExecuteBlockOutcome::Executed(certificate) => certificate,
                 ExecuteBlockOutcome::Conflict(_) => continue,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -182,7 +182,7 @@ pub enum CrossChainRequest {
     UpdateRecipient {
         sender: ChainId,
         recipient: ChainId,
-        bundle_vecs: Vec<(Medium, Vec<MessageBundle>)>,
+        bundle_vecs: Vec<(Medium, Vec<(Epoch, MessageBundle)>)>,
     },
     /// Acknowledge the height of the highest confirmed blocks communicated with `UpdateRecipient`.
     ConfirmUpdatedRecipient {
@@ -207,8 +207,8 @@ impl CrossChainRequest {
         match self {
             CrossChainRequest::UpdateRecipient { bundle_vecs, .. } => {
                 bundle_vecs.iter().any(|(_, bundles)| {
-                    debug_assert!(bundles.windows(2).all(|w| w[0].height <= w[1].height));
-                    matches!(bundles.first(), Some(h) if h.height <= height)
+                    debug_assert!(bundles.windows(2).all(|w| w[0].1.height <= w[1].1.height));
+                    matches!(bundles.first(), Some((_, h)) if h.height <= height)
                 })
             }
             _ => false,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -14,7 +14,10 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
-    data_types::{CertificateValue, Event, ExecutedBlock, IncomingBundle, Medium, Origin},
+    data_types::{
+        CertificateValue, ExecutedBlock, IncomingBundle, Medium, MessageBundle, Origin,
+        PostedMessage,
+    },
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
@@ -243,10 +246,10 @@ where
         // Both `Claim` messages were included in the block.
         assert_eq!(messages.len(), 2);
         // The first one was rejected.
-        assert_eq!(messages[0].event.height, BlockHeight::from(2));
+        assert_eq!(messages[0].bundle.height, BlockHeight::from(2));
         assert_eq!(messages[0].action, MessageAction::Reject);
         // The second was accepted.
-        assert_eq!(messages[1].event.height, BlockHeight::from(3));
+        assert_eq!(messages[1].bundle.height, BlockHeight::from(3));
         assert_eq!(messages[1].action, MessageAction::Accept);
     }
 
@@ -759,9 +762,11 @@ where
         result,
         Err(ChainClientError::LocalNodeError(
             LocalNodeError::WorkerError(WorkerError::ChainError(error))
-        )) if matches!(*error, ChainError::CannotSkipMessage {
-            event: Event { message: Message::System(SystemMessage::Credit { .. }), .. }, ..
-        })
+        )) if matches!(&*error, ChainError::CannotSkipMessage {
+            bundle: MessageBundle { messages, .. }, ..
+        } if matches!(messages[..], [PostedMessage {
+            message: Message::System(SystemMessage::Credit { .. }), ..
+        }]))
     );
     Ok(())
 }
@@ -922,28 +927,38 @@ where
     assert!(block.operations.is_empty());
     assert_eq!(block.incoming_bundles.len(), 2);
     assert_matches!(
-        block.incoming_bundles[0],
+        &block.incoming_bundles[0],
         IncomingBundle {
             origin: Origin { sender, medium: Medium::Direct },
             action: MessageAction::Reject,
-            event: Event {
-                kind: MessageKind::Tracked,
-                message: Message::System(SystemMessage::Credit { .. }),
+            bundle: MessageBundle {
+                messages,
                 ..
             },
-        } if sender == ChainId::root(2)
+        } if *sender == ChainId::root(2) && matches!(messages[..],
+            [PostedMessage {
+                message: Message::System(SystemMessage::Credit { .. }),
+                kind: MessageKind::Tracked,
+                ..
+            }]
+        )
     );
     assert_matches!(
-        block.incoming_bundles[1],
+        &block.incoming_bundles[1],
         IncomingBundle {
             origin: Origin { sender, medium: Medium::Direct },
             action: MessageAction::Reject,
-            event: Event {
-                kind: MessageKind::Protected,
-                message: Message::System(SystemMessage::Subscribe { .. }),
+            bundle: MessageBundle {
+                messages,
                 ..
             },
-        } if sender == ChainId::root(2)
+        } if *sender == ChainId::root(2) && matches!(messages[..],
+            [PostedMessage {
+                message: Message::System(SystemMessage::Subscribe { .. }),
+                kind: MessageKind::Protected,
+                ..
+            }]
+        )
     );
 
     // Since blocks are free of charge on closed chains, empty blocks are not allowed.

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -632,7 +632,7 @@ where
         certificate.value(),
         CertificateValue::ConfirmedBlock { executed_block, .. } if matches!(
             executed_block.block.operations[open_chain_message_id.index as usize],
-            Operation::System(SystemOperation::OpenChain(_)),
+            Operation::System(SystemOperation::OpenChain {..}),
         ),
         "Unexpected certificate value",
     );
@@ -738,7 +738,7 @@ where
         &certificate.value(),
         CertificateValue::ConfirmedBlock { executed_block: ExecutedBlock { block, .. }, .. } if matches!(
             block.operations[open_chain_message_id.index as usize],
-            Operation::System(SystemOperation::OpenChain(_)),
+            Operation::System(SystemOperation::OpenChain { .. }),
         ),
         "Unexpected certificate value",
     );

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -961,13 +961,12 @@ where
         )
     );
 
-    // Since blocks are free of charge on closed chains, empty blocks are not allowed.
-    assert_matches!(
-        client1.execute_operations(vec![]).await,
-        Err(ChainClientError::LocalNodeError(
-            LocalNodeError::WorkerError(WorkerError::ChainError(error))
-        )) if matches!(*error, ChainError::ClosedChain)
-    );
+    // Empty blocks are allowed on closed chains but they must pay the block fee.
+    {
+        let balance = client1.local_balance().await.unwrap();
+        client1.execute_operations(vec![]).await.unwrap();
+        assert!(client1.local_balance().await.unwrap() < balance);
+    }
     Ok(())
 }
 

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -521,11 +521,11 @@ where
     // Second message is the bounced message.
     assert_eq!(incoming_bundles[1].action, MessageAction::Accept);
     assert_eq!(
-        incoming_bundles[1].bundle.messages[0].kind,
+        incoming_bundles[1].bundle.messages[1].kind,
         MessageKind::Bouncing
     );
     assert_matches!(
-        incoming_bundles[1].bundle.messages[0].message,
+        incoming_bundles[1].bundle.messages[1].message,
         Message::User { .. }
     );
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -494,7 +494,6 @@ where
         authenticated_caller_id: None,
         height: run_block.height,
         index: Some(0),
-        next_message_index: 0,
     };
     let mut controller = ResourceController::default();
     creator_state
@@ -505,7 +504,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await?;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -125,7 +125,9 @@ where
         contract: contract_bytecode,
         service: service_bytecode,
     };
-    let publish_message = SystemMessage::BytecodePublished { operation_index: 0 };
+    let publish_message = SystemMessage::BytecodePublished {
+        transaction_index: 0,
+    };
     let publish_block = make_first_block(publisher_chain.into())
         .with_timestamp(1)
         .with_operation(publish_operation);
@@ -196,7 +198,7 @@ where
     });
     let bytecode_location = BytecodeLocation {
         certificate_hash: publish_certificate.hash(),
-        operation_index: 0,
+        transaction_index: 0,
     };
     let broadcast_message = SystemMessage::BytecodeLocations {
         locations: vec![(bytecode_id, bytecode_location)],

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -23,7 +23,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         BlockExecutionOutcome, ChannelFullName, HashedCertificateValue, IncomingBundle,
-        MessageAction, MessageBundle, Origin, OutgoingMessage, PostedMessage,
+        MessageAction, MessageBundle, Origin, OutgoingMessage,
     },
     test::{make_child_block, make_first_block, BlockTestExt},
 };
@@ -139,16 +139,18 @@ where
         ..SystemExecutionState::new(Epoch::ZERO, publisher_chain, admin_id)
     };
     let publisher_state_hash = publisher_system_state.clone().into_hash().await;
+    let publish_out_msg = OutgoingMessage {
+        destination: Destination::Recipient(publisher_chain.into()),
+        authenticated_signer: None,
+        grant: Amount::ZERO,
+        refund_grant_to: None,
+        kind: MessageKind::Protected,
+        message: Message::System(publish_message.clone()),
+    };
+    let publish_posted_msg = publish_out_msg.clone().into_posted(0);
     let publish_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![vec![OutgoingMessage {
-                destination: Destination::Recipient(publisher_chain.into()),
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Protected,
-                message: Message::System(publish_message.clone()),
-            }]],
+            messages: vec![vec![publish_out_msg]],
             events: vec![Vec::new()],
             state_hash: publisher_state_hash,
             oracle_responses: vec![Vec::new()],
@@ -177,14 +179,7 @@ where
             height: publish_block_height,
             timestamp: Timestamp::from(1),
             transaction_index: 0,
-            messages: vec![PostedMessage {
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Protected,
-                index: 0,
-                message: Message::System(publish_message),
-            }],
+            messages: vec![publish_posted_msg],
         },
         action: MessageAction::Accept,
     };
@@ -244,6 +239,7 @@ where
         kind: MessageKind::Simple,
         message: Message::System(broadcast_message.clone()),
     };
+    let broadcast_posted_message = broadcast_outgoing_message.clone().into_posted(0);
     let broadcast_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
             messages: vec![vec![broadcast_outgoing_message]],
@@ -292,16 +288,18 @@ where
     };
     creator_system_state.subscriptions.insert(publisher_channel);
     let creator_state = creator_system_state.clone().into_view().await;
+    let subscribe_out_msg = OutgoingMessage {
+        destination: Destination::Recipient(publisher_chain.into()),
+        authenticated_signer: None,
+        grant: Amount::ZERO,
+        refund_grant_to: None,
+        kind: MessageKind::Protected,
+        message: Message::System(subscribe_message.clone()),
+    };
+    let subscribe_posted_msg = subscribe_out_msg.clone().into_posted(0);
     let subscribe_block_proposal = HashedCertificateValue::new_confirmed(
         BlockExecutionOutcome {
-            messages: vec![vec![OutgoingMessage {
-                destination: Destination::Recipient(publisher_chain.into()),
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Protected,
-                message: Message::System(subscribe_message.clone()),
-            }]],
+            messages: vec![vec![subscribe_out_msg]],
             events: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
             oracle_responses: vec![Vec::new()],
@@ -330,14 +328,7 @@ where
             height: subscribe_block_height,
             timestamp: Timestamp::from(2),
             transaction_index: 0,
-            messages: vec![PostedMessage {
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Protected,
-                index: 0,
-                message: subscribe_message.into(),
-            }],
+            messages: vec![subscribe_posted_msg],
         },
         action: MessageAction::Accept,
     };
@@ -417,14 +408,7 @@ where
                 height: broadcast_block_height,
                 timestamp: Timestamp::from(1),
                 transaction_index: 0,
-                messages: vec![PostedMessage {
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Simple,
-                    index: 0,
-                    message: Message::System(broadcast_message),
-                }],
+                messages: vec![broadcast_posted_message],
             },
             action: MessageAction::Accept,
         });

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -22,8 +22,8 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        BlockExecutionOutcome, ChannelFullName, Event, HashedCertificateValue, IncomingBundle,
-        MessageAction, Origin, OutgoingMessage,
+        BlockExecutionOutcome, ChannelFullName, HashedCertificateValue, IncomingBundle,
+        MessageAction, MessageBundle, Origin, OutgoingMessage, PostedMessage,
     },
     test::{make_child_block, make_first_block, BlockTestExt},
 };
@@ -170,16 +170,19 @@ where
     // Produce one more block to broadcast the bytecode ID.
     let broadcast_message = IncomingBundle {
         origin: Origin::chain(publisher_chain.into()),
-        event: Event {
+        bundle: MessageBundle {
             certificate_hash: publish_certificate.hash(),
             height: publish_block_height,
-            index: 0,
-            authenticated_signer: None,
-            grant: Amount::ZERO,
-            refund_grant_to: None,
-            kind: MessageKind::Protected,
             timestamp: Timestamp::from(1),
-            message: Message::System(publish_message),
+            transaction_index: 0,
+            messages: vec![PostedMessage {
+                authenticated_signer: None,
+                grant: Amount::ZERO,
+                refund_grant_to: None,
+                kind: MessageKind::Protected,
+                index: 0,
+                message: Message::System(publish_message),
+            }],
         },
         action: MessageAction::Accept,
     };
@@ -320,16 +323,19 @@ where
     // Accept subscription
     let accept_message = IncomingBundle {
         origin: Origin::chain(creator_chain.into()),
-        event: Event {
+        bundle: MessageBundle {
             certificate_hash: subscribe_certificate.hash(),
             height: subscribe_block_height,
-            index: 0,
-            authenticated_signer: None,
-            grant: Amount::ZERO,
-            refund_grant_to: None,
-            kind: MessageKind::Protected,
             timestamp: Timestamp::from(2),
-            message: subscribe_message.into(),
+            transaction_index: 0,
+            messages: vec![PostedMessage {
+                authenticated_signer: None,
+                grant: Amount::ZERO,
+                refund_grant_to: None,
+                kind: MessageKind::Protected,
+                index: 0,
+                message: subscribe_message.into(),
+            }],
         },
         action: MessageAction::Accept,
     };
@@ -404,16 +410,19 @@ where
         .with_operation(create_operation)
         .with_incoming_bundle(IncomingBundle {
             origin: Origin::channel(publisher_chain.into(), publish_admin_channel),
-            event: Event {
+            bundle: MessageBundle {
                 certificate_hash: broadcast_certificate.hash(),
                 height: broadcast_block_height,
-                index: 0,
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Simple,
                 timestamp: Timestamp::from(1),
-                message: Message::System(broadcast_message),
+                transaction_index: 0,
+                messages: vec![PostedMessage {
+                    authenticated_signer: None,
+                    grant: Amount::ZERO,
+                    refund_grant_to: None,
+                    kind: MessageKind::Simple,
+                    index: 0,
+                    message: Message::System(broadcast_message),
+                }],
             },
             action: MessageAction::Accept,
         });

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -32,8 +32,8 @@ use linera_execution::{
     system::{SystemChannel, SystemMessage, SystemOperation},
     test_utils::SystemExecutionState,
     Bytecode, BytecodeLocation, ChannelSubscription, Message, MessageKind, Operation,
-    OperationContext, ResourceController, UserApplicationDescription, UserApplicationId,
-    WasmContractModule, WasmRuntime,
+    OperationContext, ResourceController, TransactionTracker, UserApplicationDescription,
+    UserApplicationId, WasmContractModule, WasmRuntime,
 };
 #[cfg(feature = "dynamodb")]
 use linera_storage::DynamoDbStorage;
@@ -503,7 +503,7 @@ where
                 application_id,
                 bytes: user_operation,
             },
-            Some(Vec::new()),
+            &mut TransactionTracker::with_oracle_responses(Vec::new()),
             &mut controller,
         )
         .await?;

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -26,8 +26,8 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         Block, BlockExecutionOutcome, BlockProposal, Certificate, ChainAndHeight, ChannelFullName,
-        Event, HashedCertificateValue, IncomingBundle, LiteVote, Medium, MessageAction, Origin,
-        OutgoingMessage, SignatureAggregator,
+        HashedCertificateValue, IncomingBundle, LiteVote, Medium, MessageAction, MessageBundle,
+        Origin, OutgoingMessage, PostedMessage, SignatureAggregator,
     },
     test::{make_child_block, make_first_block, BlockTestExt, VoteTestExt},
     ChainError, ChainExecutionContext,
@@ -261,21 +261,27 @@ where
 
     let mut messages = incoming_bundles
         .iter()
-        .map(|incoming_bundle| {
-            if matches!(incoming_bundle.action, MessageAction::Reject)
-                && matches!(incoming_bundle.event.kind, MessageKind::Tracked)
-            {
-                vec![OutgoingMessage {
-                    authenticated_signer: incoming_bundle.event.authenticated_signer,
-                    destination: Destination::Recipient(incoming_bundle.origin.sender),
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Bouncing,
-                    message: incoming_bundle.event.message.clone(),
-                }]
-            } else {
-                Vec::new()
-            }
+        .flat_map(|incoming_bundle| {
+            incoming_bundle
+                .bundle
+                .messages
+                .iter()
+                .map(|posted_message| {
+                    if matches!(incoming_bundle.action, MessageAction::Reject)
+                        && matches!(posted_message.kind, MessageKind::Tracked)
+                    {
+                        vec![OutgoingMessage {
+                            authenticated_signer: posted_message.authenticated_signer,
+                            destination: Destination::Recipient(incoming_bundle.origin.sender),
+                            grant: Amount::ZERO,
+                            refund_grant_to: None,
+                            kind: MessageKind::Bouncing,
+                            message: posted_message.message.clone(),
+                        }]
+                    } else {
+                        Vec::new()
+                    }
+                })
         })
         .collect::<Vec<_>>();
 
@@ -841,46 +847,55 @@ where
             .with_simple_transfer(ChainId::root(3), Amount::from_tokens(5))
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate0.value.hash(),
                     height: BlockHeight::ZERO,
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::ONE),
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 0,
+                        message: system_credit_message(Amount::ONE),
+                    }],
                 },
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate0.value.hash(),
                     height: BlockHeight::ZERO,
-                    index: 1,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::from_tokens(2)),
+                    transaction_index: 1,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 0,
+                        message: system_credit_message(Amount::from_tokens(2)),
+                    }],
                 },
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate1.value.hash(),
                     height: BlockHeight::from(1),
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::from_tokens(2)), // wrong amount
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 0,
+                        message: system_credit_message(Amount::from_tokens(2)), // wrong amount
+                    }],
                 },
                 action: MessageAction::Accept,
             })
@@ -897,16 +912,19 @@ where
             .with_simple_transfer(ChainId::root(3), Amount::from_tokens(6))
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate0.value.hash(),
                     height: BlockHeight::ZERO,
-                    index: 1,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::from_tokens(2)),
+                    transaction_index: 1,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 1,
+                        message: system_credit_message(Amount::from_tokens(2)),
+                    }],
                 },
                 action: MessageAction::Accept,
             })
@@ -923,46 +941,55 @@ where
             .with_simple_transfer(ChainId::root(3), Amount::from_tokens(6))
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate1.value.hash(),
                     height: BlockHeight::from(1),
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::from_tokens(3)),
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 0,
+                        message: system_credit_message(Amount::from_tokens(3)),
+                    }],
                 },
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate0.value.hash(),
                     height: BlockHeight::ZERO,
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::ONE),
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 0,
+                        message: system_credit_message(Amount::ONE),
+                    }],
                 },
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate0.value.hash(),
                     height: BlockHeight::ZERO,
-                    index: 1,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::from_tokens(2)),
+                    transaction_index: 1,
+                    messages: vec![PostedMessage {
+                        message: system_credit_message(Amount::from_tokens(2)),
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        index: 1,
+                        kind: MessageKind::Tracked,
+                    }],
                 },
                 action: MessageAction::Accept,
             })
@@ -979,16 +1006,19 @@ where
             .with_simple_transfer(ChainId::root(3), Amount::ONE)
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate0.value.hash(),
                     height: BlockHeight::ZERO,
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::ONE),
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        message: system_credit_message(Amount::ONE),
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        index: 0,
+                        kind: MessageKind::Tracked,
+                    }],
                 },
                 action: MessageAction::Accept,
             })
@@ -1026,31 +1056,37 @@ where
             .with_simple_transfer(ChainId::root(3), Amount::from_tokens(3))
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate0.value.hash(),
                     height: BlockHeight::from(0),
-                    index: 1,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::from_tokens(2)),
+                    transaction_index: 1,
+                    messages: vec![PostedMessage {
+                        message: system_credit_message(Amount::from_tokens(2)),
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        index: 1,
+                        kind: MessageKind::Tracked,
+                    }],
                 },
                 action: MessageAction::Accept,
             })
             .with_incoming_bundle(IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate1.value.hash(),
                     height: BlockHeight::from(1),
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: system_credit_message(Amount::from_tokens(3)),
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        message: system_credit_message(Amount::from_tokens(3)),
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        index: 0,
+                        kind: MessageKind::Tracked,
+                    }],
                 },
                 action: MessageAction::Accept,
             })
@@ -1271,23 +1307,26 @@ where
     };
     let open_chain_message = IncomingBundle {
         origin: Origin::chain(ChainId::root(3)),
-        event: Event {
+        bundle: MessageBundle {
             certificate_hash: CryptoHash::test_hash("certificate"),
             height: BlockHeight::ZERO,
-            index: 0,
-            authenticated_signer: None,
-            grant: Amount::ZERO,
-            refund_grant_to: None,
-            kind: MessageKind::Protected,
             timestamp: Timestamp::from(0),
-            message: Message::System(SystemMessage::OpenChain(OpenChainConfig {
-                ownership,
-                admin_id,
-                epoch,
-                committees,
-                balance,
-                application_permissions: Default::default(),
-            })),
+            transaction_index: 0,
+            messages: vec![PostedMessage {
+                authenticated_signer: None,
+                grant: Amount::ZERO,
+                refund_grant_to: None,
+                kind: MessageKind::Protected,
+                index: 0,
+                message: Message::System(SystemMessage::OpenChain(OpenChainConfig {
+                    ownership,
+                    admin_id,
+                    epoch,
+                    committees,
+                    balance,
+                    application_permissions: Default::default(),
+                })),
+            }],
         },
         action: MessageAction::Accept,
     };
@@ -1438,16 +1477,19 @@ where
         Amount::from_tokens(1000),
         vec![IncomingBundle {
             origin: Origin::chain(ChainId::root(3)),
-            event: Event {
+            bundle: MessageBundle {
                 certificate_hash: CryptoHash::test_hash("certificate"),
                 height: BlockHeight::ZERO,
-                index: 0,
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Tracked,
                 timestamp: Timestamp::from(0),
-                message: system_credit_message(Amount::from_tokens(995)),
+                transaction_index: 0,
+                messages: vec![PostedMessage {
+                    authenticated_signer: None,
+                    grant: Amount::ZERO,
+                    refund_grant_to: None,
+                    kind: MessageKind::Tracked,
+                    index: 0,
+                    message: system_credit_message(Amount::from_tokens(995)),
+                }],
             },
             action: MessageAction::Accept,
         }],
@@ -1473,27 +1515,30 @@ where
         .await?
         .expect("Missing inbox for `ChainId::root(3)` in `ChainId::root(1)`");
     assert_eq!(BlockHeight::ZERO, inbox.next_block_height_to_receive()?);
-    assert_eq!(inbox.added_events.count(), 0);
+    assert_eq!(inbox.added_bundles.count(), 0);
     assert_matches!(
         inbox
-            .removed_events
+            .removed_bundles
             .front()
             .await?
             .unwrap(),
-        Event {
+        MessageBundle {
             certificate_hash,
             height,
-            index: 0,
-            authenticated_signer: None,
-            grant: Amount::ZERO,
-            refund_grant_to: None,
-            kind: MessageKind::Tracked,
             timestamp,
-            message: Message::System(SystemMessage::Credit { amount, .. }),
+            transaction_index: 0,
+            messages,
         } if certificate_hash == CryptoHash::test_hash("certificate")
             && height == BlockHeight::ZERO
             && timestamp == Timestamp::from(0)
-            && amount == Amount::from_tokens(995),
+            && matches!(messages[..], [PostedMessage {
+                authenticated_signer: None,
+                grant: Amount::ZERO,
+                refund_grant_to: None,
+                kind: MessageKind::Tracked,
+                index: 0,
+                message: Message::System(SystemMessage::Credit { amount, .. }),
+            }] if amount == Amount::from_tokens(995)),
         "Unexpected event",
     );
     assert_eq!(chain.confirmed_log.count(), 1);
@@ -1615,21 +1660,24 @@ where
         .expect("Missing inbox for `ChainId::root(1)` in `ChainId::root(1)`");
     assert_eq!(BlockHeight::from(1), inbox.next_block_height_to_receive()?);
     assert_matches!(
-        inbox.added_events.front().await?.unwrap(),
-        Event {
+        inbox.added_bundles.front().await?.unwrap(),
+        MessageBundle {
             certificate_hash,
             height,
-            index: 0,
+            timestamp,
+            transaction_index: 0,
+            messages,
+        } if certificate_hash == certificate.hash()
+        && height == BlockHeight::ZERO
+        && timestamp == Timestamp::from(0)
+        && matches!(messages[..], [PostedMessage {
             authenticated_signer: None,
             grant: Amount::ZERO,
             refund_grant_to: None,
             kind: MessageKind::Tracked,
-            timestamp,
+            index: 0,
             message: Message::System(SystemMessage::Credit { amount, .. })
-        } if certificate_hash == certificate.hash()
-            && height == BlockHeight::ZERO
-            && timestamp == Timestamp::from(0)
-            && amount == Amount::ONE,
+        }] if amount == Amount::ONE),
         "Unexpected event",
     );
     assert_eq!(
@@ -1688,24 +1736,27 @@ where
     assert_eq!(BlockHeight::from(1), inbox.next_block_height_to_receive()?);
     assert_matches!(
         inbox
-            .added_events
+            .added_bundles
             .front()
             .await?
             .unwrap(),
-        Event {
+        MessageBundle {
             certificate_hash,
             height,
-            index: 0,
+            timestamp,
+            transaction_index: 0,
+            messages,
+        } if certificate_hash == certificate.hash()
+        && height == BlockHeight::ZERO
+        && timestamp == Timestamp::from(0)
+        && matches!(messages[..], [PostedMessage {
             authenticated_signer: None,
             grant: Amount::ZERO,
             refund_grant_to: None,
             kind: MessageKind::Tracked,
-            timestamp,
+            index: 0,
             message: Message::System(SystemMessage::Credit { amount, .. })
-        } if certificate_hash == certificate.hash()
-            && height == BlockHeight::ZERO
-            && timestamp == Timestamp::from(0)
-            && amount == Amount::from_tokens(10),
+        }] if amount == Amount::from_tokens(10)),
         "Unexpected event",
     );
     assert_eq!(chain.confirmed_log.count(), 0);
@@ -1891,16 +1942,19 @@ where
         Amount::ONE,
         vec![IncomingBundle {
             origin: Origin::chain(ChainId::root(1)),
-            event: Event {
+            bundle: MessageBundle {
                 certificate_hash: certificate.hash(),
                 height: BlockHeight::ZERO,
-                index: 0,
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Tracked,
                 timestamp: Timestamp::from(0),
-                message: system_credit_message(Amount::from_tokens(5)),
+                transaction_index: 0,
+                messages: vec![PostedMessage {
+                    authenticated_signer: None,
+                    grant: Amount::ZERO,
+                    refund_grant_to: None,
+                    kind: MessageKind::Tracked,
+                    index: 0,
+                    message: system_credit_message(Amount::from_tokens(5)),
+                }],
             },
             action: MessageAction::Accept,
         }],
@@ -2078,20 +2132,23 @@ where
         Amount::ONE,
         vec![IncomingBundle {
             origin: Origin::chain(ChainId::root(1)),
-            event: Event {
+            bundle: MessageBundle {
                 certificate_hash: certificate00.hash(),
                 height: BlockHeight::from(0),
-                index: 0,
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Tracked,
                 timestamp: Timestamp::from(0),
-                message: Message::System(SystemMessage::Credit {
-                    source: None,
-                    target: Some(sender),
-                    amount: Amount::from_tokens(5),
-                }),
+                transaction_index: 0,
+                messages: vec![PostedMessage {
+                    authenticated_signer: None,
+                    grant: Amount::ZERO,
+                    refund_grant_to: None,
+                    kind: MessageKind::Tracked,
+                    index: 0,
+                    message: Message::System(SystemMessage::Credit {
+                        source: None,
+                        target: Some(sender),
+                        amount: Amount::from_tokens(5),
+                    }),
+                }],
             },
             action: MessageAction::Accept,
         }],
@@ -2162,39 +2219,45 @@ where
         vec![
             IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate1.hash(),
                     height: BlockHeight::from(2),
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: Message::System(SystemMessage::Credit {
-                        source: Some(sender),
-                        target: Some(recipient),
-                        amount: Amount::from_tokens(3),
-                    }),
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 0,
+                        message: Message::System(SystemMessage::Credit {
+                            source: Some(sender),
+                            target: Some(recipient),
+                            amount: Amount::from_tokens(3),
+                        }),
+                    }],
                 },
                 action: MessageAction::Reject,
             },
             IncomingBundle {
                 origin: Origin::chain(ChainId::root(1)),
-                event: Event {
+                bundle: MessageBundle {
                     certificate_hash: certificate2.hash(),
                     height: BlockHeight::from(3),
-                    index: 0,
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
                     timestamp: Timestamp::from(0),
-                    message: Message::System(SystemMessage::Credit {
-                        source: Some(sender),
-                        target: Some(recipient),
-                        amount: Amount::from_tokens(2),
-                    }),
+                    transaction_index: 0,
+                    messages: vec![PostedMessage {
+                        authenticated_signer: None,
+                        grant: Amount::ZERO,
+                        refund_grant_to: None,
+                        kind: MessageKind::Tracked,
+                        index: 0,
+                        message: Message::System(SystemMessage::Credit {
+                            source: Some(sender),
+                            target: Some(recipient),
+                            amount: Amount::from_tokens(2),
+                        }),
+                    }],
                 },
                 action: MessageAction::Accept,
             },
@@ -2226,20 +2289,23 @@ where
         Amount::from_tokens(3),
         vec![IncomingBundle {
             origin: Origin::chain(ChainId::root(2)),
-            event: Event {
+            bundle: MessageBundle {
                 certificate_hash: certificate.hash(),
                 height: BlockHeight::from(0),
-                index: 0,
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Bouncing,
                 timestamp: Timestamp::from(0),
-                message: Message::System(SystemMessage::Credit {
-                    source: Some(sender),
-                    target: Some(recipient),
-                    amount: Amount::from_tokens(3),
-                }),
+                transaction_index: 0,
+                messages: vec![PostedMessage {
+                    authenticated_signer: None,
+                    grant: Amount::ZERO,
+                    refund_grant_to: None,
+                    kind: MessageKind::Bouncing,
+                    index: 0,
+                    message: Message::System(SystemMessage::Credit {
+                        source: Some(sender),
+                        target: Some(recipient),
+                        amount: Amount::from_tokens(3),
+                    }),
+                }],
             },
             action: MessageAction::Accept,
         }],
@@ -2451,19 +2517,22 @@ where
                     .with_epoch(1)
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(admin_id),
-                        event: Event {
+                        bundle: MessageBundle {
                             certificate_hash: certificate0.value.hash(),
                             height: BlockHeight::ZERO,
-                            index: 1,
-                            authenticated_signer: None,
-                            grant: Amount::ZERO,
-                            refund_grant_to: None,
-                            kind: MessageKind::Protected,
                             timestamp: Timestamp::from(0),
-                            message: Message::System(SystemMessage::Subscribe {
-                                id: user_id,
-                                subscription: admin_channel_subscription.clone(),
-                            }),
+                            transaction_index: 0,
+                            messages: vec![PostedMessage {
+                                authenticated_signer: None,
+                                grant: Amount::ZERO,
+                                refund_grant_to: None,
+                                kind: MessageKind::Protected,
+                                index: 1,
+                                message: Message::System(SystemMessage::Subscribe {
+                                    id: user_id,
+                                    subscription: admin_channel_subscription.clone(),
+                                }),
+                            }],
                         },
                         action: MessageAction::Accept,
                     }),
@@ -2515,42 +2584,34 @@ where
         );
         user_chain.validate_incoming_bundles().await?;
         matches!(
-            user_chain
+            &user_chain
                 .inboxes
                 .try_load_entry(&Origin::chain(admin_id))
                 .await?
                 .expect("Missing inbox for admin chain in user chain")
-                .added_events
+                .added_bundles
                 .read_front(10)
                 .await?[..],
-            [
-                Event {
-                    message: Message::System(SystemMessage::OpenChain(_)),
-                    ..
-                },
-                Event {
-                    message: Message::System(SystemMessage::Credit { .. }),
-                    ..
-                },
-                Event {
-                    message: Message::System(SystemMessage::Notify { .. }),
-                    ..
-                }
-            ]
+            [event1, event2, event3]
+            if matches!(event1.messages[..], [PostedMessage {
+                 message: Message::System(SystemMessage::OpenChain(_)), ..
+            }]) && matches!(event2.messages[..], [PostedMessage {
+                message: Message::System(SystemMessage::Credit { .. }), ..
+            }]) && matches!(event3.messages[..], [PostedMessage {
+                message: Message::System(SystemMessage::Notify { .. }), ..
+            }])
         );
         let channel_inbox = user_chain
             .inboxes
             .try_load_entry(&admin_channel_origin)
             .await?
             .expect("Missing inbox for admin channel in user chain");
-        matches!(
-            channel_inbox.added_events.read_front(10).await?[..],
-            [Event {
-                message: Message::System(SystemMessage::SetCommittees { .. }),
-                ..
-            }]
+        matches!(&channel_inbox.added_bundles.read_front(10).await?[..], [event]
+            if matches!(event.messages[..], [PostedMessage {
+                message: Message::System(SystemMessage::SetCommittees { .. }), ..
+            }])
         );
-        assert_eq!(channel_inbox.removed_events.count(), 0);
+        assert_eq!(channel_inbox.removed_bundles.count(), 0);
         assert_eq!(user_chain.execution_state.system.committees.get().len(), 1);
     }
     // Make the child receive the pending messages.
@@ -2582,71 +2643,85 @@ where
                 make_first_block(user_id)
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(admin_id),
-                        event: Event {
+                        bundle: MessageBundle {
                             certificate_hash: certificate0.value.hash(),
                             height: BlockHeight::from(0),
-                            index: 0,
-                            authenticated_signer: None,
-                            grant: Amount::ZERO,
-                            refund_grant_to: None,
-                            kind: MessageKind::Protected,
                             timestamp: Timestamp::from(0),
-                            message: Message::System(SystemMessage::OpenChain(OpenChainConfig {
-                                ownership: ChainOwnership::single(key_pair.public()),
-                                epoch: Epoch::from(0),
-                                committees: committees.clone(),
-                                admin_id,
-                                balance: Amount::ZERO,
-                                application_permissions: Default::default(),
-                            })),
+                            transaction_index: 0,
+                            messages: vec![PostedMessage {
+                                authenticated_signer: None,
+                                grant: Amount::ZERO,
+                                refund_grant_to: None,
+                                kind: MessageKind::Protected,
+                                index: 0,
+                                message: Message::System(SystemMessage::OpenChain(
+                                    OpenChainConfig {
+                                        ownership: ChainOwnership::single(key_pair.public()),
+                                        epoch: Epoch::from(0),
+                                        committees: committees.clone(),
+                                        admin_id,
+                                        balance: Amount::ZERO,
+                                        application_permissions: Default::default(),
+                                    },
+                                )),
+                            }],
                         },
                         action: MessageAction::Accept,
                     })
                     .with_incoming_bundle(IncomingBundle {
                         origin: admin_channel_origin.clone(),
-                        event: Event {
+                        bundle: MessageBundle {
                             certificate_hash: certificate1.value.hash(),
                             height: BlockHeight::from(1),
-                            index: 0,
-                            authenticated_signer: None,
-                            grant: Amount::ZERO,
-                            refund_grant_to: None,
-                            kind: MessageKind::Protected,
                             timestamp: Timestamp::from(0),
-                            message: Message::System(SystemMessage::SetCommittees {
-                                epoch: Epoch::from(1),
-                                committees: committees2.clone(),
-                            }),
+                            transaction_index: 0,
+                            messages: vec![PostedMessage {
+                                authenticated_signer: None,
+                                grant: Amount::ZERO,
+                                refund_grant_to: None,
+                                kind: MessageKind::Protected,
+                                index: 0,
+                                message: Message::System(SystemMessage::SetCommittees {
+                                    epoch: Epoch::from(1),
+                                    committees: committees2.clone(),
+                                }),
+                            }],
                         },
                         action: MessageAction::Accept,
                     })
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(admin_id),
-                        event: Event {
+                        bundle: MessageBundle {
                             certificate_hash: certificate1.value.hash(),
                             height: BlockHeight::from(1),
-                            index: 1,
-                            authenticated_signer: None,
-                            grant: Amount::ZERO,
-                            refund_grant_to: None,
-                            kind: MessageKind::Tracked,
                             timestamp: Timestamp::from(0),
-                            message: system_credit_message(Amount::from_tokens(2)),
+                            transaction_index: 1,
+                            messages: vec![PostedMessage {
+                                authenticated_signer: None,
+                                grant: Amount::ZERO,
+                                refund_grant_to: None,
+                                kind: MessageKind::Tracked,
+                                index: 1,
+                                message: system_credit_message(Amount::from_tokens(2)),
+                            }],
                         },
                         action: MessageAction::Accept,
                     })
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(admin_id),
-                        event: Event {
+                        bundle: MessageBundle {
                             certificate_hash: certificate2.value.hash(),
                             height: BlockHeight::from(2),
-                            index: 0,
-                            authenticated_signer: None,
-                            grant: Amount::ZERO,
-                            refund_grant_to: None,
-                            kind: MessageKind::Protected,
                             timestamp: Timestamp::from(0),
-                            message: Message::System(SystemMessage::Notify { id: user_id }),
+                            transaction_index: 0,
+                            messages: vec![PostedMessage {
+                                authenticated_signer: None,
+                                grant: Amount::ZERO,
+                                refund_grant_to: None,
+                                kind: MessageKind::Protected,
+                                index: 0,
+                                message: Message::System(SystemMessage::Notify { id: user_id }),
+                            }],
                         },
                         action: MessageAction::Accept,
                     }),
@@ -2686,8 +2761,8 @@ where
                 .await?
                 .expect("Missing inbox for admin chain in user chain");
             assert_eq!(inbox.next_block_height_to_receive()?, BlockHeight(3));
-            assert_eq!(inbox.added_events.count(), 0);
-            assert_eq!(inbox.removed_events.count(), 0);
+            assert_eq!(inbox.added_bundles.count(), 0);
+            assert_eq!(inbox.removed_bundles.count(), 0);
         }
         {
             let inbox = user_chain
@@ -2696,8 +2771,8 @@ where
                 .await?
                 .expect("Missing inbox for admin channel in user chain");
             assert_eq!(inbox.next_block_height_to_receive()?, BlockHeight(2));
-            assert_eq!(inbox.added_events.count(), 0);
-            assert_eq!(inbox.removed_events.count(), 0);
+            assert_eq!(inbox.added_bundles.count(), 0);
+            assert_eq!(inbox.removed_bundles.count(), 0);
         }
         Ok(())
     }
@@ -2817,18 +2892,18 @@ where
     assert!(admin_chain.is_active());
     assert_eq!(admin_chain.inboxes.indices().await?.len(), 1);
     matches!(
-        admin_chain
+        &admin_chain
             .inboxes
             .try_load_entry(&Origin::chain(user_id))
             .await?
             .expect("Missing inbox for user chain in admin chain")
-            .added_events
+            .added_bundles
             .read_front(10)
             .await?[..],
-        [Event {
+        [event] if matches!(event.messages[..], [PostedMessage {
             message: Message::System(SystemMessage::Credit { .. }),
             ..
-        }]
+        }])
     );
     Ok(())
 }
@@ -2981,16 +3056,19 @@ where
                     .with_epoch(1)
                     .with_incoming_bundle(IncomingBundle {
                         origin: Origin::chain(user_id),
-                        event: Event {
+                        bundle: MessageBundle {
                             certificate_hash: certificate0.value.hash(),
                             height: BlockHeight::ZERO,
-                            index: 0,
-                            authenticated_signer: None,
-                            grant: Amount::ZERO,
-                            refund_grant_to: None,
-                            kind: MessageKind::Tracked,
                             timestamp: Timestamp::from(0),
-                            message: system_credit_message(Amount::ONE),
+                            transaction_index: 0,
+                            messages: vec![PostedMessage {
+                                authenticated_signer: None,
+                                grant: Amount::ZERO,
+                                refund_grant_to: None,
+                                kind: MessageKind::Tracked,
+                                index: 0,
+                                message: system_credit_message(Amount::ONE),
+                            }],
                         },
                         action: MessageAction::Accept,
                     }),
@@ -3109,6 +3187,10 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let bundles012 = Vec::from_iter(bundles01.iter().cloned().chain(bundles2.iter().cloned()));
     let bundles0123 = Vec::from_iter(bundles012.iter().cloned().chain(bundles3.iter().cloned()));
 
+    fn without_epochs(bundles: &[(Epoch, MessageBundle)]) -> Vec<MessageBundle> {
+        bundles.iter().map(|(_, bundle)| bundle.clone()).collect()
+    }
+
     let helper = CrossChainUpdateHelper {
         allow_messages_from_deprecated_epochs: true,
         current_epoch: Some(Epoch::from(1)),
@@ -3123,7 +3205,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             None,
             bundles01.clone()
         )?,
-        bundles01.clone()
+        without_epochs(&bundles01)
     );
     // Received heights is removing prefixes.
     assert_eq!(
@@ -3134,7 +3216,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             None,
             bundles01.clone()
         )?,
-        bundles1.clone()
+        without_epochs(&bundles1)
     );
     assert_eq!(
         helper.select_message_bundles(
@@ -3183,7 +3265,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             None,
             bundles0123.clone()
         )?,
-        bundles012.clone()
+        without_epochs(&bundles012)
     );
     // Received heights is still removing prefixes.
     assert_eq!(
@@ -3194,7 +3276,12 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             None,
             bundles012.clone()
         )?,
-        Vec::from_iter(bundles1.iter().cloned().chain(bundles2.iter().cloned()))
+        bundles1
+            .iter()
+            .cloned()
+            .chain(bundles2.iter().cloned())
+            .map(|(_, bundle)| bundle.clone())
+            .collect::<Vec<_>>()
     );
     // Anticipated messages re-certify blocks up to the given height.
     assert_eq!(
@@ -3205,7 +3292,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             Some(BlockHeight::from(1)),
             bundles01.clone()
         )?,
-        bundles1.clone()
+        without_epochs(&bundles1)
     );
     assert_eq!(
         helper.select_message_bundles(
@@ -3215,7 +3302,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
             Some(BlockHeight::from(1)),
             bundles01.clone()
         )?,
-        bundles01.clone()
+        without_epochs(&bundles01)
     );
     Ok(())
 }

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -29,7 +29,7 @@ use linera_chain::{
         HashedCertificateValue, IncomingBundle, LiteVote, Medium, MessageAction, MessageBundle,
         Origin, OutgoingMessage, PostedMessage, SignatureAggregator,
     },
-    test::{make_child_block, make_first_block, BlockTestExt, VoteTestExt},
+    test::{make_child_block, make_first_block, BlockTestExt, MessageTestExt, VoteTestExt},
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
@@ -852,14 +852,9 @@ where
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 0,
-                        message: system_credit_message(Amount::ONE),
-                    }],
+                    messages: vec![
+                        system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
+                    ],
                 },
                 action: MessageAction::Accept,
             })
@@ -870,14 +865,8 @@ where
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 0,
-                        message: system_credit_message(Amount::from_tokens(2)),
-                    }],
+                    messages: vec![system_credit_message(Amount::from_tokens(2))
+                        .to_posted(0, MessageKind::Tracked)],
                 },
                 action: MessageAction::Accept,
             })
@@ -888,14 +877,10 @@ where
                     height: BlockHeight::from(1),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 0,
-                        message: system_credit_message(Amount::from_tokens(2)), // wrong amount
-                    }],
+                    messages: vec![
+                        system_credit_message(Amount::from_tokens(2))
+                            .to_posted(0, MessageKind::Tracked), // wrong amount
+                    ],
                 },
                 action: MessageAction::Accept,
             })
@@ -917,14 +902,8 @@ where
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 1,
-                        message: system_credit_message(Amount::from_tokens(2)),
-                    }],
+                    messages: vec![system_credit_message(Amount::from_tokens(2))
+                        .to_posted(1, MessageKind::Tracked)],
                 },
                 action: MessageAction::Accept,
             })
@@ -946,14 +925,8 @@ where
                     height: BlockHeight::from(1),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 0,
-                        message: system_credit_message(Amount::from_tokens(3)),
-                    }],
+                    messages: vec![system_credit_message(Amount::from_tokens(3))
+                        .to_posted(0, MessageKind::Tracked)],
                 },
                 action: MessageAction::Accept,
             })
@@ -964,14 +937,9 @@ where
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 0,
-                        message: system_credit_message(Amount::ONE),
-                    }],
+                    messages: vec![
+                        system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
+                    ],
                 },
                 action: MessageAction::Accept,
             })
@@ -982,14 +950,8 @@ where
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
-                    messages: vec![PostedMessage {
-                        message: system_credit_message(Amount::from_tokens(2)),
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        index: 1,
-                        kind: MessageKind::Tracked,
-                    }],
+                    messages: vec![system_credit_message(Amount::from_tokens(2))
+                        .to_posted(1, MessageKind::Tracked)],
                 },
                 action: MessageAction::Accept,
             })
@@ -1011,14 +973,9 @@ where
                     height: BlockHeight::ZERO,
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        message: system_credit_message(Amount::ONE),
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        index: 0,
-                        kind: MessageKind::Tracked,
-                    }],
+                    messages: vec![
+                        system_credit_message(Amount::ONE).to_posted(0, MessageKind::Tracked)
+                    ],
                 },
                 action: MessageAction::Accept,
             })
@@ -1061,14 +1018,8 @@ where
                     height: BlockHeight::from(0),
                     timestamp: Timestamp::from(0),
                     transaction_index: 1,
-                    messages: vec![PostedMessage {
-                        message: system_credit_message(Amount::from_tokens(2)),
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        index: 1,
-                        kind: MessageKind::Tracked,
-                    }],
+                    messages: vec![system_credit_message(Amount::from_tokens(2))
+                        .to_posted(1, MessageKind::Tracked)],
                 },
                 action: MessageAction::Accept,
             })
@@ -1079,14 +1030,8 @@ where
                     height: BlockHeight::from(1),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        message: system_credit_message(Amount::from_tokens(3)),
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        index: 0,
-                        kind: MessageKind::Tracked,
-                    }],
+                    messages: vec![system_credit_message(Amount::from_tokens(3))
+                        .to_posted(0, MessageKind::Tracked)],
                 },
                 action: MessageAction::Accept,
             })
@@ -1312,21 +1257,15 @@ where
             height: BlockHeight::ZERO,
             timestamp: Timestamp::from(0),
             transaction_index: 0,
-            messages: vec![PostedMessage {
-                authenticated_signer: None,
-                grant: Amount::ZERO,
-                refund_grant_to: None,
-                kind: MessageKind::Protected,
-                index: 0,
-                message: Message::System(SystemMessage::OpenChain(OpenChainConfig {
-                    ownership,
-                    admin_id,
-                    epoch,
-                    committees,
-                    balance,
-                    application_permissions: Default::default(),
-                })),
-            }],
+            messages: vec![Message::System(SystemMessage::OpenChain(OpenChainConfig {
+                ownership,
+                admin_id,
+                epoch,
+                committees,
+                balance,
+                application_permissions: Default::default(),
+            }))
+            .to_posted(0, MessageKind::Protected)],
         },
         action: MessageAction::Accept,
     };
@@ -1482,14 +1421,8 @@ where
                 height: BlockHeight::ZERO,
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
-                messages: vec![PostedMessage {
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
-                    index: 0,
-                    message: system_credit_message(Amount::from_tokens(995)),
-                }],
+                messages: vec![system_credit_message(Amount::from_tokens(995))
+                    .to_posted(0, MessageKind::Tracked)],
             },
             action: MessageAction::Accept,
         }],
@@ -1947,14 +1880,8 @@ where
                 height: BlockHeight::ZERO,
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
-                messages: vec![PostedMessage {
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
-                    index: 0,
-                    message: system_credit_message(Amount::from_tokens(5)),
-                }],
+                messages: vec![system_credit_message(Amount::from_tokens(5))
+                    .to_posted(0, MessageKind::Tracked)],
             },
             action: MessageAction::Accept,
         }],
@@ -2137,18 +2064,12 @@ where
                 height: BlockHeight::from(0),
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
-                messages: vec![PostedMessage {
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Tracked,
-                    index: 0,
-                    message: Message::System(SystemMessage::Credit {
-                        source: None,
-                        target: Some(sender),
-                        amount: Amount::from_tokens(5),
-                    }),
-                }],
+                messages: vec![Message::System(SystemMessage::Credit {
+                    source: None,
+                    target: Some(sender),
+                    amount: Amount::from_tokens(5),
+                })
+                .to_posted(0, MessageKind::Tracked)],
             },
             action: MessageAction::Accept,
         }],
@@ -2224,18 +2145,12 @@ where
                     height: BlockHeight::from(2),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 0,
-                        message: Message::System(SystemMessage::Credit {
-                            source: Some(sender),
-                            target: Some(recipient),
-                            amount: Amount::from_tokens(3),
-                        }),
-                    }],
+                    messages: vec![Message::System(SystemMessage::Credit {
+                        source: Some(sender),
+                        target: Some(recipient),
+                        amount: Amount::from_tokens(3),
+                    })
+                    .to_posted(0, MessageKind::Tracked)],
                 },
                 action: MessageAction::Reject,
             },
@@ -2246,18 +2161,12 @@ where
                     height: BlockHeight::from(3),
                     timestamp: Timestamp::from(0),
                     transaction_index: 0,
-                    messages: vec![PostedMessage {
-                        authenticated_signer: None,
-                        grant: Amount::ZERO,
-                        refund_grant_to: None,
-                        kind: MessageKind::Tracked,
-                        index: 0,
-                        message: Message::System(SystemMessage::Credit {
-                            source: Some(sender),
-                            target: Some(recipient),
-                            amount: Amount::from_tokens(2),
-                        }),
-                    }],
+                    messages: vec![Message::System(SystemMessage::Credit {
+                        source: Some(sender),
+                        target: Some(recipient),
+                        amount: Amount::from_tokens(2),
+                    })
+                    .to_posted(0, MessageKind::Tracked)],
                 },
                 action: MessageAction::Accept,
             },
@@ -2294,18 +2203,12 @@ where
                 height: BlockHeight::from(0),
                 timestamp: Timestamp::from(0),
                 transaction_index: 0,
-                messages: vec![PostedMessage {
-                    authenticated_signer: None,
-                    grant: Amount::ZERO,
-                    refund_grant_to: None,
-                    kind: MessageKind::Bouncing,
-                    index: 0,
-                    message: Message::System(SystemMessage::Credit {
-                        source: Some(sender),
-                        target: Some(recipient),
-                        amount: Amount::from_tokens(3),
-                    }),
-                }],
+                messages: vec![Message::System(SystemMessage::Credit {
+                    source: Some(sender),
+                    target: Some(recipient),
+                    amount: Amount::from_tokens(3),
+                })
+                .to_posted(0, MessageKind::Bouncing)],
             },
             action: MessageAction::Accept,
         }],
@@ -2522,17 +2425,11 @@ where
                             height: BlockHeight::ZERO,
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
-                            messages: vec![PostedMessage {
-                                authenticated_signer: None,
-                                grant: Amount::ZERO,
-                                refund_grant_to: None,
-                                kind: MessageKind::Protected,
-                                index: 1,
-                                message: Message::System(SystemMessage::Subscribe {
-                                    id: user_id,
-                                    subscription: admin_channel_subscription.clone(),
-                                }),
-                            }],
+                            messages: vec![Message::System(SystemMessage::Subscribe {
+                                id: user_id,
+                                subscription: admin_channel_subscription.clone(),
+                            })
+                            .to_posted(1, MessageKind::Protected)],
                         },
                         action: MessageAction::Accept,
                     }),
@@ -2648,23 +2545,17 @@ where
                             height: BlockHeight::from(0),
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
-                            messages: vec![PostedMessage {
-                                authenticated_signer: None,
-                                grant: Amount::ZERO,
-                                refund_grant_to: None,
-                                kind: MessageKind::Protected,
-                                index: 0,
-                                message: Message::System(SystemMessage::OpenChain(
-                                    OpenChainConfig {
-                                        ownership: ChainOwnership::single(key_pair.public()),
-                                        epoch: Epoch::from(0),
-                                        committees: committees.clone(),
-                                        admin_id,
-                                        balance: Amount::ZERO,
-                                        application_permissions: Default::default(),
-                                    },
-                                )),
-                            }],
+                            messages: vec![Message::System(SystemMessage::OpenChain(
+                                OpenChainConfig {
+                                    ownership: ChainOwnership::single(key_pair.public()),
+                                    epoch: Epoch::from(0),
+                                    committees: committees.clone(),
+                                    admin_id,
+                                    balance: Amount::ZERO,
+                                    application_permissions: Default::default(),
+                                },
+                            ))
+                            .to_posted(0, MessageKind::Protected)],
                         },
                         action: MessageAction::Accept,
                     })
@@ -2675,17 +2566,11 @@ where
                             height: BlockHeight::from(1),
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
-                            messages: vec![PostedMessage {
-                                authenticated_signer: None,
-                                grant: Amount::ZERO,
-                                refund_grant_to: None,
-                                kind: MessageKind::Protected,
-                                index: 0,
-                                message: Message::System(SystemMessage::SetCommittees {
-                                    epoch: Epoch::from(1),
-                                    committees: committees2.clone(),
-                                }),
-                            }],
+                            messages: vec![Message::System(SystemMessage::SetCommittees {
+                                epoch: Epoch::from(1),
+                                committees: committees2.clone(),
+                            })
+                            .to_posted(0, MessageKind::Protected)],
                         },
                         action: MessageAction::Accept,
                     })
@@ -2696,14 +2581,8 @@ where
                             height: BlockHeight::from(1),
                             timestamp: Timestamp::from(0),
                             transaction_index: 1,
-                            messages: vec![PostedMessage {
-                                authenticated_signer: None,
-                                grant: Amount::ZERO,
-                                refund_grant_to: None,
-                                kind: MessageKind::Tracked,
-                                index: 1,
-                                message: system_credit_message(Amount::from_tokens(2)),
-                            }],
+                            messages: vec![system_credit_message(Amount::from_tokens(2))
+                                .to_posted(1, MessageKind::Tracked)],
                         },
                         action: MessageAction::Accept,
                     })
@@ -2714,14 +2593,8 @@ where
                             height: BlockHeight::from(2),
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
-                            messages: vec![PostedMessage {
-                                authenticated_signer: None,
-                                grant: Amount::ZERO,
-                                refund_grant_to: None,
-                                kind: MessageKind::Protected,
-                                index: 0,
-                                message: Message::System(SystemMessage::Notify { id: user_id }),
-                            }],
+                            messages: vec![Message::System(SystemMessage::Notify { id: user_id })
+                                .to_posted(0, MessageKind::Protected)],
                         },
                         action: MessageAction::Accept,
                     }),
@@ -3061,14 +2934,8 @@ where
                             height: BlockHeight::ZERO,
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
-                            messages: vec![PostedMessage {
-                                authenticated_signer: None,
-                                grant: Amount::ZERO,
-                                refund_grant_to: None,
-                                kind: MessageKind::Tracked,
-                                index: 0,
-                                message: system_credit_message(Amount::ONE),
-                            }],
+                            messages: vec![system_credit_message(Amount::ONE)
+                                .to_posted(0, MessageKind::Tracked)],
                         },
                         action: MessageAction::Accept,
                     }),

--- a/linera-execution/README.md
+++ b/linera-execution/README.md
@@ -1,6 +1,7 @@
 <!-- cargo-rdme start -->
 
-This module manages the execution of the system application and the user applications in a Linera chain.
+This module manages the execution of the system application and the user applications in a
+Linera chain.
 
 <!-- cargo-rdme end -->
 

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -65,7 +65,7 @@ pub struct BytecodeLocation {
     /// The certificate that published the bytecode.
     pub certificate_hash: CryptoHash,
     /// The index in the certificate of the operation that published the bytecode (not the message!).
-    pub operation_index: u32,
+    pub transaction_index: u32,
 }
 
 #[derive(Debug, ClonableView, HashableView)]

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -66,8 +66,8 @@ where
             authenticated_signer: None,
             authenticated_caller_id: None,
             height: application_description.creation.height,
-            index: Some(application_description.creation.index),
-            next_message_index: 0,
+            index: Some(0),
+            next_message_index: application_description.creation.index + 1,
         };
 
         let action = UserAction::Instantiate(context, instantiation_argument);

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    sync::Mutex,
+    vec,
+};
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
 use linera_base::{
@@ -151,7 +155,7 @@ where
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
-        oracle_responses: Option<Vec<OracleResponse>>,
+        oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
         resource_controller: &mut ResourceController<Option<Owner>>,
     ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
@@ -182,7 +186,7 @@ where
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
-        oracle_responses: Option<Vec<OracleResponse>>,
+        oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
         resource_controller: &mut ResourceController<Option<Owner>>,
     ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         let mut cloned_grant = grant.as_ref().map(|x| **x);
@@ -197,6 +201,7 @@ where
         };
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
+        let oracle_responses = oracle_responses.as_ref().map(Arc::clone);
         let execution_outcomes_future = tokio::task::spawn_blocking(move || {
             ContractSyncRuntime::run_action(
                 execution_state_sender,
@@ -293,6 +298,8 @@ where
         resource_controller: &mut ResourceController<Option<Owner>>,
     ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
+        let oracle_responses =
+            oracle_responses.map(|responses| Arc::new(Mutex::new(responses.into_iter())));
         match operation {
             Operation::System(op) => {
                 let (mut result, new_application, mut returned_oracle_responses) =
@@ -346,7 +353,7 @@ where
         local_time: Timestamp,
         message: Message,
         grant: Option<&mut Amount>,
-        oracle_responses: Option<Vec<OracleResponse>>,
+        oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
         resource_controller: &mut ResourceController<Option<Owner>>,
     ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -3,13 +3,12 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
-    sync::Mutex,
-    vec,
+    mem, vec,
 };
 
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
 use linera_base::{
-    data_types::{Amount, BlockHeight, OracleResponse, Timestamp},
+    data_types::{Amount, BlockHeight, Timestamp},
     identifiers::{Account, ChainId, Destination, Owner},
 };
 use linera_views::{
@@ -33,8 +32,8 @@ use crate::{
     resources::ResourceController, system::SystemExecutionStateView, ContractSyncRuntime,
     ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
     MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, Response, SystemMessage, UserApplicationDescription,
-    UserApplicationId,
+    RawExecutionOutcome, RawOutgoingMessage, Response, SystemMessage, TransactionTracker,
+    UserApplicationDescription, UserApplicationId,
 };
 
 /// A view accessing the execution state of a chain.
@@ -91,6 +90,7 @@ where
             tracker,
             account: None,
         };
+        let mut txn_tracker = TransactionTracker::default();
         self.run_user_action(
             application_id,
             chain_id,
@@ -98,11 +98,12 @@ where
             action,
             context.refund_grant_to(),
             None,
-            None,
+            &mut txn_tracker,
             &mut resource_controller,
         )
         .await?;
-
+        self.update_execution_outcomes_with_app_registrations(&mut txn_tracker)
+            .await?;
         Ok(())
     }
 }
@@ -155,26 +156,22 @@ where
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
-        oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
+        txn_tracker: &mut TransactionTracker,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
+    ) -> Result<(), ExecutionError> {
         let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
-        let (execution_outcomes, oracle_responses) = self
-            .run_user_action_with_runtime(
-                application_id,
-                chain_id,
-                local_time,
-                action,
-                refund_grant_to,
-                grant,
-                oracle_responses,
-                resource_controller,
-            )
-            .await?;
-        let execution_outcomes = self
-            .update_execution_outcomes_with_app_registrations(execution_outcomes)
-            .await?;
-        Ok((execution_outcomes, oracle_responses))
+        self.run_user_action_with_runtime(
+            application_id,
+            chain_id,
+            local_time,
+            action,
+            refund_grant_to,
+            grant,
+            txn_tracker,
+            resource_controller,
+        )
+        .await?;
+        Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -186,9 +183,9 @@ where
         action: UserAction,
         refund_grant_to: Option<Account>,
         grant: Option<&mut Amount>,
-        oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
+        txn_tracker: &mut TransactionTracker,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
+    ) -> Result<(), ExecutionError> {
         let mut cloned_grant = grant.as_ref().map(|x| **x);
         let initial_balance = resource_controller
             .with_state_and_grant(self, cloned_grant.as_mut())
@@ -201,7 +198,7 @@ where
         };
         let (execution_state_sender, mut execution_state_receiver) =
             futures::channel::mpsc::unbounded();
-        let oracle_responses = oracle_responses.as_ref().map(Arc::clone);
+        let txn_tracker_moved = mem::take(txn_tracker);
         let execution_outcomes_future = tokio::task::spawn_blocking(move || {
             ContractSyncRuntime::run_action(
                 execution_state_sender,
@@ -211,30 +208,32 @@ where
                 refund_grant_to,
                 controller,
                 action,
-                oracle_responses,
+                txn_tracker_moved,
             )
         });
         while let Some(request) = execution_state_receiver.next().await {
             self.handle_request(request).await?;
         }
-        let (execution_outcomes, oracle_responses, controller) =
-            execution_outcomes_future.await??;
+
+        let (controller, txn_tracker_moved) = execution_outcomes_future.await??;
+        *txn_tracker = txn_tracker_moved;
         resource_controller
             .with_state_and_grant(self, grant)
             .await?
             .merge_balance(initial_balance, controller.balance()?)?;
         resource_controller.tracker = controller.tracker;
-        Ok((execution_outcomes, oracle_responses))
+        Ok(())
     }
 
     /// Schedules application registration messages when needed.
     ///
     /// Ensures that the outgoing messages in `results` are preceded by a system message that
     /// registers the application that will handle the messages.
-    async fn update_execution_outcomes_with_app_registrations(
+    pub async fn update_execution_outcomes_with_app_registrations(
         &self,
-        mut results: Vec<ExecutionOutcome>,
-    ) -> Result<Vec<ExecutionOutcome>, ExecutionError> {
+        txn_tracker: &mut TransactionTracker,
+    ) -> Result<(), ExecutionError> {
+        let results = txn_tracker.outcomes_mut();
         let user_application_outcomes = results.iter().filter_map(|outcome| match outcome {
             ExecutionOutcome::User(application_id, result) => Some((application_id, result)),
             _ => None,
@@ -252,7 +251,7 @@ where
         }
 
         if applications_to_register_per_destination.is_empty() {
-            return Ok(results);
+            return Ok(());
         }
 
         let messages = applications_to_register_per_destination
@@ -286,7 +285,7 @@ where
 
         results.insert(0, ExecutionOutcome::System(system_outcome));
 
-        Ok(results)
+        Ok(())
     }
 
     pub async fn execute_operation(
@@ -294,57 +293,49 @@ where
         context: OperationContext,
         local_time: Timestamp,
         operation: Operation,
-        oracle_responses: Option<Vec<OracleResponse>>,
+        txn_tracker: &mut TransactionTracker,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
+    ) -> Result<(), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
-        let oracle_responses =
-            oracle_responses.map(|responses| Arc::new(Mutex::new(responses.into_iter())));
         match operation {
             Operation::System(op) => {
-                let (mut result, new_application, mut returned_oracle_responses) =
-                    self.system.execute_operation(context, op).await?;
-                result.authenticated_signer = context.authenticated_signer;
-                result.refund_grant_to = context.refund_grant_to();
-                let mut outcomes = vec![ExecutionOutcome::System(result)];
+                let new_application = self
+                    .system
+                    .execute_operation(context, op, txn_tracker)
+                    .await?;
                 if let Some((application_id, argument)) = new_application {
                     let user_action = UserAction::Instantiate(context, argument);
-                    let (user_outcomes, oracle_responses) = self
-                        .run_user_action(
-                            application_id,
-                            context.chain_id,
-                            local_time,
-                            user_action,
-                            context.refund_grant_to(),
-                            None,
-                            oracle_responses,
-                            resource_controller,
-                        )
-                        .await?;
-                    outcomes.extend(user_outcomes);
-                    returned_oracle_responses.extend(oracle_responses);
+                    self.run_user_action(
+                        application_id,
+                        context.chain_id,
+                        local_time,
+                        user_action,
+                        context.refund_grant_to(),
+                        None,
+                        txn_tracker,
+                        resource_controller,
+                    )
+                    .await?;
                 }
-                Ok((outcomes, returned_oracle_responses))
             }
             Operation::User {
                 application_id,
                 bytes,
             } => {
-                let (outcomes, oracle_responses) = self
-                    .run_user_action(
-                        application_id,
-                        context.chain_id,
-                        local_time,
-                        UserAction::Operation(context, bytes),
-                        context.refund_grant_to(),
-                        None,
-                        oracle_responses,
-                        resource_controller,
-                    )
-                    .await?;
-                Ok((outcomes, oracle_responses))
+                self.run_user_action(
+                    application_id,
+                    context.chain_id,
+                    local_time,
+                    UserAction::Operation(context, bytes),
+                    context.refund_grant_to(),
+                    None,
+                    txn_tracker,
+                    resource_controller,
+                )
+                .await?;
             }
         }
+        Ok(())
     }
 
     pub async fn execute_message(
@@ -353,34 +344,33 @@ where
         local_time: Timestamp,
         message: Message,
         grant: Option<&mut Amount>,
-        oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
+        txn_tracker: &mut TransactionTracker,
         resource_controller: &mut ResourceController<Option<Owner>>,
-    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
+    ) -> Result<(), ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match message {
             Message::System(message) => {
                 let outcome = self.system.execute_message(context, message).await?;
-                Ok((vec![ExecutionOutcome::System(outcome)], Vec::new()))
+                txn_tracker.add_outcome(ExecutionOutcome::System(outcome));
             }
             Message::User {
                 application_id,
                 bytes,
             } => {
-                let (outcomes, oracle_responses) = self
-                    .run_user_action(
-                        application_id,
-                        context.chain_id,
-                        local_time,
-                        UserAction::Message(context, bytes),
-                        context.refund_grant_to,
-                        grant,
-                        oracle_responses,
-                        resource_controller,
-                    )
-                    .await?;
-                Ok((outcomes, oracle_responses))
+                self.run_user_action(
+                    application_id,
+                    context.chain_id,
+                    local_time,
+                    UserAction::Message(context, bytes),
+                    context.refund_grant_to,
+                    grant,
+                    txn_tracker,
+                    resource_controller,
+                )
+                .await?;
             }
         }
+        Ok(())
     }
 
     pub async fn bounce_message(

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -67,10 +67,10 @@ where
             authenticated_caller_id: None,
             height: application_description.creation.height,
             index: Some(0),
-            next_message_index: application_description.creation.index + 1,
         };
 
         let action = UserAction::Instantiate(context, instantiation_argument);
+        let next_message_index = application_description.creation.index + 1;
 
         let application_id = self
             .system
@@ -90,7 +90,7 @@ where
             tracker,
             account: None,
         };
-        let mut txn_tracker = TransactionTracker::default();
+        let mut txn_tracker = TransactionTracker::new(next_message_index, None);
         self.run_user_action(
             application_id,
             chain_id,
@@ -129,14 +129,6 @@ impl UserAction {
             UserAction::Instantiate(context, _) => context.height,
             UserAction::Operation(context, _) => context.height,
             UserAction::Message(context, _) => context.height,
-        }
-    }
-
-    pub(crate) fn next_message_index(&self) -> u32 {
-        match self {
-            UserAction::Instantiate(context, _) => context.next_message_index,
-            UserAction::Operation(context, _) => context.next_message_index,
-            UserAction::Message(context, _) => context.next_message_index,
         }
     }
 }
@@ -351,7 +343,7 @@ where
         match message {
             Message::System(message) => {
                 let outcome = self.system.execute_message(context, message).await?;
-                txn_tracker.add_system_outcome(outcome);
+                txn_tracker.add_system_outcome(outcome)?;
             }
             Message::User {
                 application_id,
@@ -395,7 +387,7 @@ where
                     kind: MessageKind::Bouncing,
                     message,
                 });
-                txn_tracker.add_system_outcome(outcome);
+                txn_tracker.add_system_outcome(outcome)?;
             }
             Message::User {
                 application_id,
@@ -413,7 +405,7 @@ where
                     kind: MessageKind::Bouncing,
                     message: bytes,
                 });
-                txn_tracker.add_user_outcome(application_id, outcome);
+                txn_tracker.add_user_outcome(application_id, outcome)?;
             }
         }
         Ok(())
@@ -440,7 +432,7 @@ where
             },
         };
         outcome.messages.push(message);
-        txn_tracker.add_system_outcome(outcome);
+        txn_tracker.add_system_outcome(outcome)?;
         Ok(())
     }
 

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -268,10 +268,9 @@ where
                     admin_id: self.system.admin_id.get().ok_or_else(inactive_err)?,
                     epoch: self.system.epoch.get().ok_or_else(inactive_err)?,
                     committees: self.system.committees.get().clone(),
-                    balance,
                     application_permissions,
                 };
-                let messages = self.system.open_chain(config, next_message_id)?;
+                let messages = self.system.open_chain(config, balance, next_message_id)?;
                 callback.respond(messages)
             }
 
@@ -421,7 +420,7 @@ pub enum ExecutionRequest {
         balance: Amount,
         next_message_id: MessageId,
         application_permissions: ApplicationPermissions,
-        callback: Sender<[RawOutgoingMessage<SystemMessage, Amount>; 2]>,
+        callback: Sender<Vec<RawOutgoingMessage<SystemMessage, Amount>>>,
     },
 
     CloseChain {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module manages the execution of the system application and the user applications in a Linera chain.
+//! This module manages the execution of the system application and the user applications in a
+//! Linera chain.
 
 #![deny(clippy::large_futures)]
 
@@ -16,6 +17,7 @@ mod runtime;
 pub mod system;
 #[cfg(with_testing)]
 pub mod test_utils;
+mod transaction_tracker;
 mod util;
 mod wasm;
 
@@ -71,6 +73,7 @@ pub use crate::{
         SystemExecutionError, SystemExecutionStateView, SystemMessage, SystemOperation,
         SystemQuery, SystemResponse,
     },
+    transaction_tracker::TransactionTracker,
 };
 
 /// The maximum length of an event key in bytes.
@@ -156,8 +159,8 @@ pub enum ExecutionError {
     ReqwestError(#[from] reqwest::Error),
     #[error("Encountered IO error")]
     IoError(#[from] std::io::Error),
-    #[error("No recorded response for oracle query")]
-    MissingOracleResponse,
+    #[error("More recorded oracle responses than expected")]
+    UnexpectedOracleResponse,
     #[error("Invalid JSON: {}", .0)]
     Json(#[from] serde_json::Error),
     #[error("Recorded response for oracle query has the wrong type")]
@@ -743,6 +746,13 @@ impl ExecutionOutcome {
             ExecutionOutcome::User(app_id, _) => GenericApplicationId::User(*app_id),
         }
     }
+
+    pub fn message_count(&self) -> usize {
+        match self {
+            ExecutionOutcome::System(outcome) => outcome.messages.len(),
+            ExecutionOutcome::User(_, outcome) => outcome.messages.len(),
+        }
+    }
 }
 
 impl<Message, Grant> RawExecutionOutcome<Message, Grant> {
@@ -834,11 +844,11 @@ impl OperationContext {
         })
     }
 
-    fn next_message_id(&self) -> MessageId {
+    fn next_message_id(&self, message_count: u32) -> MessageId {
         MessageId {
             chain_id: self.chain_id,
             height: self.height,
-            index: self.next_message_index,
+            index: self.next_message_index + message_count,
         }
     }
 }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -276,8 +276,6 @@ pub struct OperationContext {
     pub height: BlockHeight,
     /// The current index of the operation.
     pub index: Option<u32>,
-    /// The index of the next message to be created.
-    pub next_message_index: u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -297,8 +295,6 @@ pub struct MessageContext {
     /// The ID of the message (based on the operation height and index in the remote
     /// certificate).
     pub message_id: MessageId,
-    /// The index of the next message to be created.
-    pub next_message_index: u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -309,8 +305,6 @@ pub struct FinalizeContext {
     pub authenticated_signer: Option<Owner>,
     /// The current block height.
     pub height: BlockHeight,
-    /// The index of the next message to be created.
-    pub next_message_index: u32,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -844,11 +838,11 @@ impl OperationContext {
         })
     }
 
-    fn next_message_id(&self, message_count: u32) -> MessageId {
+    fn next_message_id(&self, next_message_index: u32) -> MessageId {
         MessageId {
             chain_id: self.chain_id,
             height: self.height,
-            index: self.next_message_index + message_count,
+            index: next_message_index,
         }
     }
 }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -6,7 +6,6 @@ use std::{
     mem,
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex},
-    vec,
 };
 
 use custom_debug_derive::Debug;
@@ -31,8 +30,8 @@ use crate::{
     util::{ReceiverExt, UnboundedSenderExt},
     BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, FinalizeContext,
     MessageContext, OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime,
-    UserApplicationDescription, UserApplicationId, UserContractInstance, UserServiceInstance,
-    MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
+    TransactionTracker, UserApplicationDescription, UserApplicationId, UserContractInstance,
+    UserServiceInstance, MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]
@@ -88,14 +87,8 @@ pub struct SyncRuntimeInternal<UserInstance> {
     call_stack: Vec<ApplicationStatus>,
     /// The set of the IDs of the applications that are in the `call_stack`.
     active_applications: HashSet<UserApplicationId>,
-    /// Accumulate the externally visible results (e.g. cross-chain messages) of applications.
-    execution_outcomes: Vec<ExecutionOutcome>,
-    /// Accumulated events emitted by applications.
-    events: Vec<()>,
-    /// Recorded responses to oracle queries.
-    recorded_oracle_responses: Vec<OracleResponse>,
-    /// Oracle responses that are being replayed.
-    replaying_oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
+    /// The tracking information for this transaction.
+    transaction_tracker: TransactionTracker,
 
     /// Track application states based on views.
     view_user_states: BTreeMap<UserApplicationId, ViewUserState>,
@@ -109,16 +102,10 @@ pub struct SyncRuntimeInternal<UserInstance> {
 impl<UserInstance> SyncRuntimeInternal<UserInstance> {
     /// Returns the index of the next outcome's first message.
     fn next_message_index(&self) -> Result<u32, ArithmeticError> {
-        let mut index = self.next_message_index;
-        for outcome in &self.execution_outcomes {
-            let len = match outcome {
-                ExecutionOutcome::System(outcome) => outcome.messages.len(),
-                ExecutionOutcome::User(_, outcome) => outcome.messages.len(),
-            };
-            let len = u32::try_from(len).map_err(|_| ArithmeticError::Overflow)?;
-            index = index.checked_add(len).ok_or(ArithmeticError::Overflow)?;
-        }
-        Ok(index)
+        let len = self.transaction_tracker.message_count()?;
+        self.next_message_index
+            .checked_add(len)
+            .ok_or(ArithmeticError::Overflow)
     }
 }
 
@@ -309,7 +296,7 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
         execution_state_sender: ExecutionStateSender,
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
-        replaying_oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
+        transaction_tracker: TransactionTracker,
     ) -> Self {
         Self {
             chain_id,
@@ -324,13 +311,10 @@ impl<UserInstance> SyncRuntimeInternal<UserInstance> {
             loaded_applications: HashMap::new(),
             call_stack: Vec::new(),
             active_applications: HashSet::new(),
-            execution_outcomes: Vec::new(),
-            events: Vec::new(),
             view_user_states: BTreeMap::new(),
             refund_grant_to,
             resource_controller,
-            replaying_oracle_responses,
-            recorded_oracle_responses: Vec::new(),
+            transaction_tracker,
         }
     }
 
@@ -506,8 +490,8 @@ impl SyncRuntimeInternal<UserContractInstance> {
             self.resource_controller.track_grant(message.grant)?;
         }
 
-        self.execution_outcomes
-            .push(ExecutionOutcome::User(application_id, outcome));
+        self.transaction_tracker
+            .add_outcome(ExecutionOutcome::User(application_id, outcome));
         Ok(())
     }
 }
@@ -945,23 +929,23 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         application_id: ApplicationId,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        let response = if let Some(responses) = &mut self.replaying_oracle_responses {
-            match responses.lock().expect("Mutex is poisoned").next() {
-                Some(OracleResponse::Service(bytes)) => bytes,
-                Some(_) => return Err(ExecutionError::OracleResponseMismatch),
-                None => return Err(ExecutionError::MissingOracleResponse),
-            }
-        } else {
-            let context = QueryContext {
-                chain_id: self.chain_id,
-                next_block_height: self.height,
-                local_time: self.local_time,
+        let response =
+            if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
+                match response {
+                    OracleResponse::Service(bytes) => bytes,
+                    _ => return Err(ExecutionError::OracleResponseMismatch),
+                }
+            } else {
+                let context = QueryContext {
+                    chain_id: self.chain_id,
+                    next_block_height: self.height,
+                    local_time: self.local_time,
+                };
+                let sender = self.execution_state_sender.clone();
+                ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?
             };
-            let sender = self.execution_state_sender.clone();
-            ServiceSyncRuntime::new(sender, context).run_query(application_id, query)?
-        };
-        self.recorded_oracle_responses
-            .push(OracleResponse::Service(response.clone()));
+        self.transaction_tracker
+            .add_oracle_response(OracleResponse::Service(response.clone()));
         Ok(response)
     }
 
@@ -971,34 +955,33 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         content_type: String,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
-        let bytes = if let Some(responses) = &mut self.replaying_oracle_responses {
-            match responses.lock().expect("Mutex is poisoned").next() {
-                Some(OracleResponse::Post(bytes)) => bytes,
-                Some(_) => return Err(ExecutionError::OracleResponseMismatch),
-                None => return Err(ExecutionError::MissingOracleResponse),
-            }
-        } else {
-            let url = url.to_string();
-            self.execution_state_sender
-                .send_request(|callback| ExecutionRequest::HttpPost {
-                    url,
-                    content_type,
-                    payload,
-                    callback,
-                })?
-                .recv_response()?
-        };
-        self.recorded_oracle_responses
-            .push(OracleResponse::Post(bytes.clone()));
+        let bytes =
+            if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
+                match response {
+                    OracleResponse::Post(bytes) => bytes,
+                    _ => return Err(ExecutionError::OracleResponseMismatch),
+                }
+            } else {
+                let url = url.to_string();
+                self.execution_state_sender
+                    .send_request(|callback| ExecutionRequest::HttpPost {
+                        url,
+                        content_type,
+                        payload,
+                        callback,
+                    })?
+                    .recv_response()?
+            };
+        self.transaction_tracker
+            .add_oracle_response(OracleResponse::Post(bytes.clone()));
         Ok(bytes)
     }
 
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError> {
-        if let Some(responses) = &mut self.replaying_oracle_responses {
-            match responses.lock().expect("Mutex is poisoned").next() {
-                Some(OracleResponse::Assert) => {}
-                Some(_) => return Err(ExecutionError::OracleResponseMismatch),
-                None => return Err(ExecutionError::MissingOracleResponse),
+        if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
+            match response {
+                OracleResponse::Assert => {}
+                _ => return Err(ExecutionError::OracleResponseMismatch),
             }
         } else {
             ensure!(
@@ -1009,16 +992,16 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 }
             );
         }
-        self.recorded_oracle_responses.push(OracleResponse::Assert);
+        self.transaction_tracker
+            .add_oracle_response(OracleResponse::Assert);
         Ok(())
     }
 
     fn read_blob_content(&mut self, blob_id: &BlobId) -> Result<BlobContent, ExecutionError> {
-        if let Some(responses) = &mut self.replaying_oracle_responses {
-            match responses.lock().expect("Mutex is poisoned").next() {
-                Some(OracleResponse::Blob(oracle_blob_id)) if oracle_blob_id == *blob_id => {}
-                Some(_) => return Err(ExecutionError::OracleResponseMismatch),
-                None => return Err(ExecutionError::MissingOracleResponse),
+        if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
+            match response {
+                OracleResponse::Blob(oracle_blob_id) if oracle_blob_id == *blob_id => {}
+                _ => return Err(ExecutionError::OracleResponseMismatch),
             }
         }
         let blob_content = self
@@ -1028,8 +1011,8 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
                 callback,
             })?
             .recv_response()?;
-        self.recorded_oracle_responses
-            .push(OracleResponse::Blob(*blob_id));
+        self.transaction_tracker
+            .add_oracle_response(OracleResponse::Blob(*blob_id));
         Ok(blob_content)
     }
 }
@@ -1051,15 +1034,8 @@ impl ContractSyncRuntime {
         refund_grant_to: Option<Account>,
         resource_controller: ResourceController,
         action: UserAction,
-        replaying_oracle_responses: Option<Arc<Mutex<vec::IntoIter<OracleResponse>>>>,
-    ) -> Result<
-        (
-            Vec<ExecutionOutcome>,
-            Vec<OracleResponse>,
-            ResourceController,
-        ),
-        ExecutionError,
-    > {
+        txn_tracker: TransactionTracker,
+    ) -> Result<(ResourceController, TransactionTracker), ExecutionError> {
         let executing_message = match &action {
             UserAction::Message(context, _) => Some(context.into()),
             _ => None,
@@ -1078,7 +1054,7 @@ impl ContractSyncRuntime {
                 execution_state_sender,
                 refund_grant_to,
                 resource_controller,
-                replaying_oracle_responses,
+                txn_tracker,
             ),
         )));
         let finalize_context = FinalizeContext {
@@ -1098,11 +1074,7 @@ impl ContractSyncRuntime {
         let runtime = runtime
             .into_inner()
             .expect("Runtime clones should have been freed by now");
-        Ok((
-            runtime.execution_outcomes,
-            runtime.recorded_oracle_responses,
-            runtime.resource_controller,
-        ))
+        Ok((runtime.resource_controller, runtime.transaction_tracker))
     }
 
     /// Notifies all loaded applications that execution is finalizing.
@@ -1250,8 +1222,8 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             })?
             .recv_response()?;
         self.inner()
-            .execution_outcomes
-            .push(ExecutionOutcome::System(execution_outcome));
+            .transaction_tracker
+            .add_outcome(ExecutionOutcome::System(execution_outcome));
         Ok(())
     }
 
@@ -1275,8 +1247,8 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .recv_response()?
             .with_authenticated_signer(signer);
         self.inner()
-            .execution_outcomes
-            .push(ExecutionOutcome::System(execution_outcome));
+            .transaction_tracker
+            .add_outcome(ExecutionOutcome::System(execution_outcome));
         Ok(())
     }
 
@@ -1347,8 +1319,8 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let outcome = RawExecutionOutcome::default()
             .with_message(open_chain_message)
             .with_message(subscribe_message);
-        this.execution_outcomes
-            .push(ExecutionOutcome::System(outcome));
+        this.transaction_tracker
+            .add_outcome(ExecutionOutcome::System(outcome));
         Ok(chain_id)
     }
 
@@ -1401,7 +1373,7 @@ impl ServiceSyncRuntime {
                 execution_state_sender,
                 None,
                 ResourceController::default(),
-                None,
+                TransactionTracker::default(),
             )
             .into(),
         ));

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -1288,7 +1288,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             index: this.transaction_tracker.next_message_index(),
         };
         let chain_id = ChainId::child(next_message_id);
-        let [open_chain_message, subscribe_message] = this
+        let messages = this
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::OpenChain {
                 ownership,
@@ -1298,9 +1298,10 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
                 callback,
             })?
             .recv_response()?;
-        let outcome = RawExecutionOutcome::default()
-            .with_message(open_chain_message)
-            .with_message(subscribe_message);
+        let outcome = RawExecutionOutcome {
+            messages,
+            ..RawExecutionOutcome::default()
+        };
         this.transaction_tracker.add_system_outcome(outcome)?;
         Ok(chain_id)
     }

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -28,10 +28,10 @@ use crate::{
     execution_state_actor::{ExecutionRequest, ExecutionStateSender},
     resources::ResourceController,
     util::{ReceiverExt, UnboundedSenderExt},
-    BaseRuntime, ContractRuntime, ExecutionError, ExecutionOutcome, FinalizeContext,
-    MessageContext, OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime,
-    TransactionTracker, UserApplicationDescription, UserApplicationId, UserContractInstance,
-    UserServiceInstance, MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
+    BaseRuntime, ContractRuntime, ExecutionError, FinalizeContext, MessageContext,
+    OperationContext, QueryContext, RawExecutionOutcome, ServiceRuntime, TransactionTracker,
+    UserApplicationDescription, UserApplicationId, UserContractInstance, UserServiceInstance,
+    MAX_EVENT_KEY_LEN, MAX_STREAM_NAME_LEN,
 };
 
 #[cfg(test)]
@@ -491,7 +491,7 @@ impl SyncRuntimeInternal<UserContractInstance> {
         }
 
         self.transaction_tracker
-            .add_outcome(ExecutionOutcome::User(application_id, outcome));
+            .add_user_outcome(application_id, outcome);
         Ok(())
     }
 }
@@ -1223,7 +1223,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .recv_response()?;
         self.inner()
             .transaction_tracker
-            .add_outcome(ExecutionOutcome::System(execution_outcome));
+            .add_system_outcome(execution_outcome);
         Ok(())
     }
 
@@ -1248,7 +1248,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
             .with_authenticated_signer(signer);
         self.inner()
             .transaction_tracker
-            .add_outcome(ExecutionOutcome::System(execution_outcome));
+            .add_system_outcome(execution_outcome);
         Ok(())
     }
 
@@ -1319,8 +1319,7 @@ impl ContractRuntime for ContractSyncRuntimeHandle {
         let outcome = RawExecutionOutcome::default()
             .with_message(open_chain_message)
             .with_message(subscribe_message);
-        this.transaction_tracker
-            .add_outcome(ExecutionOutcome::System(outcome));
+        this.transaction_tracker.add_system_outcome(outcome);
         Ok(chain_id)
     }
 

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -38,9 +38,9 @@ use crate::test_utils::SystemExecutionState;
 use crate::{
     committee::{Committee, Epoch},
     ApplicationRegistryView, Bytecode, BytecodeLocation, ChannelName, ChannelSubscription,
-    Destination, ExecutionRuntimeContext, MessageContext, MessageKind, OperationContext,
-    QueryContext, RawExecutionOutcome, RawOutgoingMessage, UserApplicationDescription,
-    UserApplicationId,
+    Destination, ExecutionOutcome, ExecutionRuntimeContext, MessageContext, MessageKind,
+    OperationContext, QueryContext, RawExecutionOutcome, RawOutgoingMessage, TransactionTracker,
+    UserApplicationDescription, UserApplicationId,
 };
 
 /// The relative index of the `OpenChain` message created by the `OpenChain` operation.
@@ -419,6 +419,10 @@ pub enum SystemExecutionError {
 
     #[error("Blob not found on storage read: {0}")]
     BlobNotFoundOnRead(BlobId),
+    #[error("Oracle response mismatch")]
+    OracleResponseMismatch,
+    #[error("No recorded response for oracle query")]
+    MissingOracleResponse,
 }
 
 impl<C> SystemExecutionStateView<C>
@@ -448,21 +452,18 @@ where
         &mut self,
         context: OperationContext,
         operation: SystemOperation,
-    ) -> Result<
-        (
-            RawExecutionOutcome<SystemMessage, Amount>,
-            Option<(UserApplicationId, Vec<u8>)>,
-            Vec<OracleResponse>,
-        ),
-        SystemExecutionError,
-    > {
+        txn_tracker: &mut TransactionTracker,
+    ) -> Result<Option<(UserApplicationId, Vec<u8>)>, SystemExecutionError> {
         use SystemOperation::*;
-        let mut outcome = RawExecutionOutcome::default();
+        let mut outcome = RawExecutionOutcome {
+            authenticated_signer: context.authenticated_signer,
+            refund_grant_to: context.refund_grant_to(),
+            ..RawExecutionOutcome::default()
+        };
         let mut new_application = None;
-        let mut oracle_responses = Vec::new();
         match operation {
             OpenChain(config) => {
-                let next_message_id = context.next_message_id();
+                let next_message_id = context.next_message_id(txn_tracker.message_count()?);
                 let messages = self.open_chain(config, next_message_id)?;
                 outcome.messages.extend(messages);
                 #[cfg(with_metrics)]
@@ -650,7 +651,7 @@ where
             } => {
                 let id = UserApplicationId {
                     bytecode_id,
-                    creation: context.next_message_id(),
+                    creation: context.next_message_id(txn_tracker.message_count()?),
                 };
                 self.registry
                     .register_new_application(
@@ -684,16 +685,31 @@ where
                 outcome.messages.push(message);
             }
             PublishBlob { blob_id } => {
-                oracle_responses.push(OracleResponse::Blob(blob_id));
+                let response = OracleResponse::Blob(blob_id);
+                if let Some(recorded_response) = txn_tracker.next_replayed_oracle_response()? {
+                    ensure!(
+                        recorded_response == response,
+                        SystemExecutionError::OracleResponseMismatch
+                    );
+                }
+                txn_tracker.add_oracle_response(response);
             }
             #[cfg(with_testing)]
             ReadBlob { blob_id } => {
+                let response = OracleResponse::Blob(blob_id);
+                if let Some(recorded_response) = txn_tracker.next_replayed_oracle_response()? {
+                    ensure!(
+                        recorded_response == response,
+                        SystemExecutionError::OracleResponseMismatch
+                    );
+                }
                 self.read_blob_content(blob_id).await?;
-                oracle_responses.push(OracleResponse::Blob(blob_id));
+                txn_tracker.add_oracle_response(response);
             }
         }
 
-        Ok((outcome, new_application, oracle_responses))
+        txn_tracker.add_outcome(ExecutionOutcome::System(outcome));
+        Ok(new_application)
     }
 
     pub async fn transfer(
@@ -1104,15 +1120,19 @@ mod tests {
             contract: Bytecode::new(vec![]),
             service: Bytecode::new(vec![]),
         };
-        let (result, new_application, _) = view
+        let mut txn_tracker = TransactionTracker::default();
+        let new_application = view
             .system
-            .execute_operation(context, operation)
+            .execute_operation(context, operation, &mut txn_tracker)
             .await
             .unwrap();
         assert_eq!(new_application, None);
         let operation_index = context
             .index
             .expect("Missing operation index in dummy context");
+        let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
+            panic!("Unexpected outcome");
+        };
         assert_eq!(
             result.messages[PUBLISH_BYTECODE_MESSAGE_INDEX as usize].message,
             SystemMessage::BytecodePublished { operation_index }
@@ -1142,11 +1162,15 @@ mod tests {
             instantiation_argument: vec![],
             required_application_ids: vec![],
         };
-        let (result, new_application, _) = view
+        let mut txn_tracker = TransactionTracker::default();
+        let new_application = view
             .system
-            .execute_operation(context, operation)
+            .execute_operation(context, operation, &mut txn_tracker)
             .await
             .unwrap();
+        let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
+            panic!("Unexpected outcome");
+        };
         assert_eq!(
             result.messages[CREATE_APPLICATION_MESSAGE_INDEX as usize].message,
             SystemMessage::ApplicationCreated
@@ -1178,13 +1202,17 @@ mod tests {
             balance: Amount::ZERO,
             application_permissions: Default::default(),
         };
+        let mut txn_tracker = TransactionTracker::default();
         let operation = SystemOperation::OpenChain(config.clone());
-        let (result, new_application, _) = view
+        let new_application = view
             .system
-            .execute_operation(context, operation)
+            .execute_operation(context, operation, &mut txn_tracker)
             .await
             .unwrap();
         assert_eq!(new_application, None);
+        let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
+            panic!("Unexpected outcome");
+        };
         assert_eq!(
             result.messages[OPEN_CHAIN_MESSAGE_INDEX as usize].message,
             SystemMessage::OpenChain(config)

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -463,7 +463,7 @@ where
         let mut new_application = None;
         match operation {
             OpenChain(config) => {
-                let next_message_id = context.next_message_id(txn_tracker.message_count()?);
+                let next_message_id = context.next_message_id(txn_tracker.next_message_index());
                 let messages = self.open_chain(config, next_message_id)?;
                 outcome.messages.extend(messages);
                 #[cfg(with_metrics)]
@@ -651,7 +651,7 @@ where
             } => {
                 let id = UserApplicationId {
                     bytecode_id,
-                    creation: context.next_message_id(txn_tracker.message_count()?),
+                    creation: context.next_message_id(txn_tracker.next_message_index()),
                 };
                 self.registry
                     .register_new_application(
@@ -708,7 +708,7 @@ where
             }
         }
 
-        txn_tracker.add_system_outcome(outcome);
+        txn_tracker.add_system_outcome(outcome)?;
         Ok(new_application)
     }
 
@@ -1100,7 +1100,6 @@ mod tests {
             authenticated_caller_id: None,
             height: BlockHeight::from(7),
             index: Some(2),
-            next_message_index: 3,
         };
         let state = SystemExecutionState {
             description: Some(description),
@@ -1178,7 +1177,7 @@ mod tests {
         let creation = MessageId {
             chain_id: context.chain_id,
             height: context.height,
-            index: context.next_message_index + CREATE_APPLICATION_MESSAGE_INDEX,
+            index: CREATE_APPLICATION_MESSAGE_INDEX,
         };
         let id = ApplicationId {
             bytecode_id,

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -38,8 +38,8 @@ use crate::test_utils::SystemExecutionState;
 use crate::{
     committee::{Committee, Epoch},
     ApplicationRegistryView, Bytecode, BytecodeLocation, ChannelName, ChannelSubscription,
-    Destination, ExecutionOutcome, ExecutionRuntimeContext, MessageContext, MessageKind,
-    OperationContext, QueryContext, RawExecutionOutcome, RawOutgoingMessage, TransactionTracker,
+    Destination, ExecutionRuntimeContext, MessageContext, MessageKind, OperationContext,
+    QueryContext, RawExecutionOutcome, RawOutgoingMessage, TransactionTracker,
     UserApplicationDescription, UserApplicationId,
 };
 
@@ -708,7 +708,7 @@ where
             }
         }
 
-        txn_tracker.add_outcome(ExecutionOutcome::System(outcome));
+        txn_tracker.add_system_outcome(outcome);
         Ok(new_application)
     }
 
@@ -1085,7 +1085,7 @@ mod tests {
     use linera_views::memory::MemoryContext;
 
     use super::*;
-    use crate::{ExecutionStateView, TestExecutionRuntimeContext};
+    use crate::{ExecutionOutcome, ExecutionStateView, TestExecutionRuntimeContext};
 
     /// Returns an execution state view and a matching operation context, for epoch 1, with root
     /// chain 0 as the admin ID and one empty committee.

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -235,7 +235,7 @@ pub enum SystemMessage {
         subscription: ChannelSubscription,
     },
     /// Notifies that a new application bytecode was published.
-    BytecodePublished { operation_index: u32 },
+    BytecodePublished { transaction_index: u32 },
     /// Notifies that a new application was created.
     ApplicationCreated,
     /// Shares the locations of published bytecodes.
@@ -262,10 +262,10 @@ impl SystemMessage {
         certificate_hash: CryptoHash,
     ) -> Box<dyn Iterator<Item = BytecodeLocation> + '_> {
         match self {
-            SystemMessage::BytecodePublished { operation_index } => {
+            SystemMessage::BytecodePublished { transaction_index } => {
                 Box::new(iter::once(BytecodeLocation {
                     certificate_hash,
-                    operation_index: *operation_index,
+                    transaction_index: *transaction_index,
                 }))
             }
             SystemMessage::BytecodeLocations {
@@ -636,7 +636,7 @@ where
                     grant: Amount::ZERO,
                     kind: MessageKind::Protected,
                     message: SystemMessage::BytecodePublished {
-                        operation_index: context
+                        transaction_index: context
                             .index
                             .expect("System application can not be called by other applications"),
                     },
@@ -887,11 +887,11 @@ where
                 outcome.messages.push(message);
                 outcome.unsubscribe.push((subscription.name.clone(), id));
             }
-            BytecodePublished { operation_index } => {
+            BytecodePublished { transaction_index } => {
                 let bytecode_id = BytecodeId::new(context.message_id);
                 let bytecode_location = BytecodeLocation {
                     certificate_hash: context.certificate_hash,
-                    operation_index,
+                    transaction_index,
                 };
                 self.registry
                     .register_published_bytecode(bytecode_id, bytecode_location)?;
@@ -1127,7 +1127,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(new_application, None);
-        let operation_index = context
+        let transaction_index = context
             .index
             .expect("Missing operation index in dummy context");
         let [ExecutionOutcome::System(result)] = &txn_tracker.destructure().unwrap().0[..] else {
@@ -1135,7 +1135,7 @@ mod tests {
         };
         assert_eq!(
             result.messages[PUBLISH_BYTECODE_MESSAGE_INDEX as usize].message,
-            SystemMessage::BytecodePublished { operation_index }
+            SystemMessage::BytecodePublished { transaction_index }
         );
     }
 
@@ -1149,7 +1149,7 @@ mod tests {
         });
         let location = BytecodeLocation {
             certificate_hash: CryptoHash::test_hash("certificate"),
-            operation_index: 1,
+            transaction_index: 1,
         };
         view.system
             .registry

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -42,7 +42,7 @@ pub fn create_dummy_user_application_description(index: u64) -> UserApplicationD
         }),
         bytecode_location: BytecodeLocation {
             certificate_hash,
-            operation_index: 0,
+            transaction_index: 0,
         },
         creation: MessageId {
             chain_id,

--- a/linera-execution/src/transaction_tracker.rs
+++ b/linera-execution/src/transaction_tracker.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::vec;
+
+use linera_base::{
+    data_types::{ArithmeticError, OracleResponse},
+    ensure,
+};
+
+use crate::{ExecutionError, ExecutionOutcome, SystemExecutionError};
+
+#[derive(Debug, Default)]
+pub struct TransactionTracker {
+    replaying_oracle_responses: Option<vec::IntoIter<OracleResponse>>,
+    oracle_responses: Vec<OracleResponse>,
+    outcomes: Vec<ExecutionOutcome>,
+}
+
+impl TransactionTracker {
+    pub fn with_oracle_responses(oracle_responses: Vec<OracleResponse>) -> Self {
+        TransactionTracker {
+            replaying_oracle_responses: Some(oracle_responses.into_iter()),
+            ..TransactionTracker::default()
+        }
+    }
+
+    pub fn add_outcome(&mut self, outcome: ExecutionOutcome) {
+        self.outcomes.push(outcome);
+    }
+
+    pub fn add_outcomes(&mut self, outcomes: impl IntoIterator<Item = ExecutionOutcome>) {
+        self.outcomes.extend(outcomes);
+    }
+
+    pub fn add_oracle_response(&mut self, oracle_response: OracleResponse) {
+        self.oracle_responses.push(oracle_response);
+    }
+
+    pub fn next_replayed_oracle_response(
+        &mut self,
+    ) -> Result<Option<OracleResponse>, SystemExecutionError> {
+        let Some(responses) = &mut self.replaying_oracle_responses else {
+            return Ok(None); // Not in replay mode.
+        };
+        let response = responses
+            .next()
+            .ok_or_else(|| SystemExecutionError::MissingOracleResponse)?;
+        Ok(Some(response))
+    }
+
+    pub fn message_count(&self) -> Result<u32, ArithmeticError> {
+        let mut count = 0usize;
+        for outcome in &self.outcomes {
+            count = count
+                .checked_add(outcome.message_count())
+                .ok_or(ArithmeticError::Overflow)?;
+        }
+        u32::try_from(count).map_err(|_| ArithmeticError::Overflow)
+    }
+
+    pub fn destructure(
+        self,
+    ) -> Result<(Vec<ExecutionOutcome>, Vec<OracleResponse>), ExecutionError> {
+        let TransactionTracker {
+            replaying_oracle_responses,
+            oracle_responses,
+            outcomes,
+        } = self;
+        if let Some(mut responses) = replaying_oracle_responses {
+            ensure!(
+                responses.next().is_none(),
+                ExecutionError::UnexpectedOracleResponse
+            );
+        }
+        Ok((outcomes, oracle_responses))
+    }
+
+    pub(crate) fn outcomes_mut(&mut self) -> &mut Vec<ExecutionOutcome> {
+        &mut self.outcomes
+    }
+}

--- a/linera-execution/src/unit_tests/applications_tests.rs
+++ b/linera-execution/src/unit_tests/applications_tests.rs
@@ -44,7 +44,7 @@ fn app_description(index: u32, deps: Vec<u32>) -> UserApplicationDescription {
 fn location(operation_index: u32) -> BytecodeLocation {
     BytecodeLocation {
         certificate_hash: CryptoHash::test_hash("certificate"),
-        operation_index,
+        transaction_index: operation_index,
     }
 }
 

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -21,7 +21,7 @@ use super::{ApplicationStatus, SyncRuntimeHandle, SyncRuntimeInternal};
 use crate::{
     execution_state_actor::ExecutionRequest,
     runtime::{LoadedApplication, ResourceController, SyncRuntime},
-    ContractRuntime, RawExecutionOutcome, UserContractInstance,
+    ContractRuntime, RawExecutionOutcome, TransactionTracker, UserContractInstance,
 };
 
 /// Test if dropping [`SyncRuntime`] does not leak memory.
@@ -184,7 +184,7 @@ fn create_runtime<Application>() -> (
         execution_state_sender,
         None,
         resource_controller,
-        None,
+        TransactionTracker::default(),
     );
 
     (runtime, execution_state_receiver)

--- a/linera-execution/src/unit_tests/runtime_tests.rs
+++ b/linera-execution/src/unit_tests/runtime_tests.rs
@@ -179,12 +179,11 @@ fn create_runtime<Application>() -> (
         BlockHeight(0),
         Timestamp::from(0),
         None,
-        0,
         None,
         execution_state_sender,
         None,
         resource_controller,
-        TransactionTracker::default(),
+        TransactionTracker::new(0, Some(Vec::new())),
     );
 
     (runtime, execution_state_receiver)

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -190,10 +190,9 @@ async fn test_fee_consumption(
         height: BlockHeight(0),
         certificate_hash: CryptoHash::default(),
         message_id: MessageId::default(),
-        next_message_index: 0,
     };
     let mut grant = initial_grant.unwrap_or_default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_message(
         context,
         Timestamp::from(0),
@@ -212,7 +211,7 @@ async fn test_fee_consumption(
     .await
     .unwrap();
 
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         vec![

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -5,7 +5,10 @@
 
 #![allow(clippy::items_after_test_module)]
 
-use std::{sync::Arc, vec};
+use std::{
+    sync::{Arc, Mutex},
+    vec,
+};
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
@@ -206,7 +209,7 @@ async fn test_fee_consumption(
             } else {
                 None
             },
-            Some(Vec::new()),
+            Some(Arc::new(Mutex::new(Vec::new().into_iter()))),
             &mut controller,
         )
         .await

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -35,7 +35,6 @@ fn make_operation_context() -> OperationContext {
         index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
-        next_message_index: 0,
     }
 }
 
@@ -58,7 +57,7 @@ async fn test_missing_bytecode_for_user_application() -> anyhow::Result<()> {
                 application_id: *app_id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await;
@@ -146,7 +145,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         ..make_operation_context()
     };
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -163,7 +162,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: Some(owner),
     };
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         vec![
@@ -305,7 +304,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
 
     let context = make_operation_context();
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -321,7 +320,7 @@ async fn test_simulated_session() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: None,
     };
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         vec![
@@ -415,7 +414,7 @@ async fn test_simulated_session_leak() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await;
@@ -456,7 +455,7 @@ async fn test_rejecting_block_from_finalize() -> anyhow::Result<()> {
                 application_id: id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await;
@@ -527,7 +526,7 @@ async fn test_rejecting_block_from_called_applications_finalize() -> anyhow::Res
                 application_id: first_id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await;
@@ -636,7 +635,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
 
     let context = make_operation_context();
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -667,7 +666,7 @@ async fn test_sending_message_from_finalize() -> anyhow::Result<()> {
         owner: None,
     };
 
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         vec![
@@ -754,7 +753,7 @@ async fn test_cross_application_call_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await;
@@ -814,7 +813,7 @@ async fn test_cross_application_call_from_finalize_of_called_application() -> an
                 application_id: caller_id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await;
@@ -873,7 +872,7 @@ async fn test_calling_application_again_from_finalize() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await;
@@ -930,7 +929,7 @@ async fn test_cross_application_error() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![],
             },
-            &mut TransactionTracker::with_oracle_responses(Vec::new()),
+            &mut TransactionTracker::new(0, Some(Vec::new())),
             &mut controller,
         )
         .await,
@@ -976,7 +975,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
 
     let context = make_operation_context();
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -1010,7 +1009,7 @@ async fn test_simple_message() -> anyhow::Result<()> {
         owner: None,
     };
 
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         &[
@@ -1081,7 +1080,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
 
     let context = make_operation_context();
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -1111,7 +1110,7 @@ async fn test_message_from_cross_application_call() -> anyhow::Result<()> {
         owner: None,
     };
 
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         &[
@@ -1200,7 +1199,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
 
     let context = make_operation_context();
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -1229,7 +1228,7 @@ async fn test_message_from_deeper_call() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: None,
     };
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         &[
@@ -1364,7 +1363,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
     // Execute the operation, starting the test scenario
     let context = make_operation_context();
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -1415,7 +1414,7 @@ async fn test_multiple_messages_from_different_applications() -> anyhow::Result<
     };
 
     // Return to checking the user application outcomes
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         &[
@@ -1478,11 +1477,11 @@ async fn test_open_chain() {
 
     let context = OperationContext {
         height: BlockHeight(1),
-        next_message_index: 5,
         ..make_operation_context()
     };
+    let first_message_index = 5;
     // We will send one additional message before calling open_chain.
-    let index = context.next_message_index + 1;
+    let index = first_message_index + 1;
     let message_id = MessageId {
         chain_id: context.chain_id,
         height: context.height,
@@ -1511,7 +1510,7 @@ async fn test_open_chain() {
         application_id,
         bytes: vec![],
     };
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(5, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -1523,14 +1522,14 @@ async fn test_open_chain() {
     .unwrap();
 
     assert_eq!(*view.system.balance.get(), Amount::from_tokens(3));
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     let message = outcomes
         .iter()
         .flat_map(|outcome| match outcome {
             ExecutionOutcome::System(outcome) => &outcome.messages,
             ExecutionOutcome::User(_, _) => panic!("Unexpected message"),
         })
-        .nth((index - context.next_message_index) as usize)
+        .nth((index - first_message_index) as usize)
         .unwrap();
     let RawOutgoingMessage {
         message: SystemMessage::OpenChain(config),
@@ -1599,7 +1598,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        &mut TransactionTracker::with_oracle_responses(Vec::new()),
+        &mut TransactionTracker::new(0, Some(Vec::new())),
         &mut controller,
     )
     .await
@@ -1613,7 +1612,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation.into(),
-        &mut TransactionTracker::with_oracle_responses(Vec::new()),
+        &mut TransactionTracker::new(0, Some(Vec::new())),
         &mut controller,
     )
     .await
@@ -1635,7 +1634,7 @@ async fn test_close_chain() {
         context,
         Timestamp::from(0),
         operation,
-        &mut TransactionTracker::with_oracle_responses(Vec::new()),
+        &mut TransactionTracker::new(0, Some(Vec::new())),
         &mut controller,
     )
     .await

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -34,10 +34,9 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
-        next_message_index: 0,
     };
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_operation(
         context,
         Timestamp::from(0),
@@ -52,7 +51,7 @@ async fn test_simple_system_operation() -> anyhow::Result<()> {
         chain_id: ChainId::root(0),
         owner: None,
     };
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         vec![ExecutionOutcome::System(
@@ -84,10 +83,9 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
         },
         authenticated_signer: None,
         refund_grant_to: None,
-        next_message_index: 0,
     };
     let mut controller = ResourceController::default();
-    let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+    let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
     view.execute_message(
         context,
         Timestamp::from(0),
@@ -99,7 +97,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
     .await
     .unwrap();
     assert_eq!(view.system.balance.get(), &Amount::from_tokens(4));
-    let (outcomes, _) = txn_tracker.destructure().unwrap();
+    let (outcomes, _, _) = txn_tracker.destructure().unwrap();
     assert_eq!(
         outcomes,
         vec![ExecutionOutcome::System(RawExecutionOutcome::default())]

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -3,6 +3,8 @@
 
 #![allow(clippy::field_reassign_with_default)]
 
+use std::sync::{Arc, Mutex};
+
 use linera_base::{
     crypto::CryptoHash,
     data_types::{Amount, BlockHeight, Timestamp},
@@ -92,7 +94,7 @@ async fn test_simple_system_message() -> anyhow::Result<()> {
             Timestamp::from(0),
             Message::System(message),
             None,
-            Some(Vec::new()),
+            Some(Arc::new(Mutex::new(Vec::new().into_iter()))),
             &mut controller,
         )
         .await

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -70,7 +70,6 @@ async fn test_fuel_for_counter_wasm_application(
         index: Some(0),
         authenticated_signer: None,
         authenticated_caller_id: None,
-        next_message_index: 0,
     };
     let increments = [2_u64, 9, 7, 1000];
     let policy = ResourceControlPolicy {
@@ -89,7 +88,7 @@ async fn test_fuel_for_counter_wasm_application(
             chain_id: ChainId::root(0),
             owner: None,
         };
-        let mut txn_tracker = TransactionTracker::with_oracle_responses(Vec::new());
+        let mut txn_tracker = TransactionTracker::new(0, Some(Vec::new()));
         view.execute_operation(
             context,
             Timestamp::from(0),
@@ -98,7 +97,7 @@ async fn test_fuel_for_counter_wasm_application(
             &mut controller,
         )
         .await?;
-        let (outcomes, _) = txn_tracker.destructure().unwrap();
+        let (outcomes, _, _) = txn_tracker.destructure().unwrap();
         assert_eq!(
             outcomes,
             vec![

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -25,12 +25,10 @@ test('Block mounting', () => {
                 bundle: {
                   certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
                   height: 5,
-                  messages: [
-                    [0, {
-                      authenticated_signer: null,
-                      message: { System: { BytecodePublished: { operation_index: 0 } } }
-                    }]
-                  ],
+                  messages: [{
+                    authenticated_signer: null,
+                    message: { System: { BytecodePublished: { operation_index: 0 } } }
+                  }],
                   timestamp: 1694097510206912
                 },
                 action: "Accept",

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -22,14 +22,15 @@ test('Block mounting', () => {
                   medium: "Direct",
                   sender: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
                 },
-                event: {
-                  authenticated_signer: null,
+                bundle: {
                   certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
                   height: 5,
-                  index: 0,
-                  message: {
-                    System: { BytecodePublished: { operation_index: 0 } }
-                  },
+                  messages: [
+                    [0, {
+                      authenticated_signer: null,
+                      message: { System: { BytecodePublished: { operation_index: 0 } } }
+                    }]
+                  ],
                   timestamp: 1694097510206912
                 },
                 action: "Accept",

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -27,12 +27,10 @@ test('Blocks mounting', () => {
                     bundle: {
                       certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
                       height: 5,
-                      messages: [
-                        [0, {
-                          authenticated_signer: null,
-                          message: { System: { BytecodePublished: { operation_index: 0 } } }
-                        }]
-                      ],
+                      messages: [{
+                        authenticated_signer: null,
+                        message: { System: { BytecodePublished: { operation_index: 0 } } }
+                      }],
                       timestamp: 1694097510206912
                     },
                     action: "Accept",

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -24,14 +24,15 @@ test('Blocks mounting', () => {
                       medium: "Direct",
                       sender: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"
                     },
-                    event: {
-                      authenticated_signer: null,
+                    bundle: {
                       certificate_hash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
                       height: 5,
-                      index: 0,
-                      message: {
-                        System: { BytecodePublished: { operation_index: 0 } }
-                      },
+                      messages: [
+                        [0, {
+                          authenticated_signer: null,
+                          message: { System: { BytecodePublished: { operation_index: 0 } } }
+                        }]
+                      ],
                       timestamp: 1694097510206912
                     },
                     action: "Accept",

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -136,7 +136,7 @@ BytecodeLocation:
   STRUCT:
     - certificate_hash:
         TYPENAME: CryptoHash
-    - operation_index: U32
+    - transaction_index: U32
 Certificate:
   STRUCT:
     - value:
@@ -905,7 +905,7 @@ SystemMessage:
     6:
       BytecodePublished:
         STRUCT:
-          - operation_index: U32
+          - transaction_index: U32
     7:
       ApplicationCreated: UNIT
     8:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -359,7 +359,9 @@ CrossChainRequest:
                 TUPLE:
                   - TYPENAME: Medium
                   - SEQ:
-                      TYPENAME: MessageBundle
+                      TUPLE:
+                        - TYPENAME: Epoch
+                        - TYPENAME: MessageBundle
     1:
       ConfirmUpdatedRecipient:
         STRUCT:
@@ -389,27 +391,6 @@ Destination:
           TYPENAME: ChannelName
 Epoch:
   NEWTYPESTRUCT: U32
-Event:
-  STRUCT:
-    - certificate_hash:
-        TYPENAME: CryptoHash
-    - height:
-        TYPENAME: BlockHeight
-    - index: U32
-    - authenticated_signer:
-        OPTION:
-          TYPENAME: Owner
-    - grant:
-        TYPENAME: Amount
-    - refund_grant_to:
-        OPTION:
-          TYPENAME: Account
-    - kind:
-        TYPENAME: MessageKind
-    - timestamp:
-        TYPENAME: Timestamp
-    - message:
-        TYPENAME: Message
 EventRecord:
   STRUCT:
     - stream_id:
@@ -452,8 +433,8 @@ IncomingBundle:
   STRUCT:
     - origin:
         TYPENAME: Origin
-    - event:
-        TYPENAME: Event
+    - bundle:
+        TYPENAME: MessageBundle
     - action:
         TYPENAME: MessageAction
 LiteCertificate:
@@ -513,17 +494,14 @@ MessageBundle:
   STRUCT:
     - height:
         TYPENAME: BlockHeight
-    - epoch:
-        TYPENAME: Epoch
     - timestamp:
         TYPENAME: Timestamp
-    - hash:
+    - certificate_hash:
         TYPENAME: CryptoHash
+    - transaction_index: U32
     - messages:
         SEQ:
-          TUPLE:
-            - U32
-            - TYPENAME: OutgoingMessage
+          TYPENAME: PostedMessage
 MessageId:
   STRUCT:
     - chain_id:
@@ -696,6 +674,21 @@ OutgoingMessage:
 Owner:
   NEWTYPESTRUCT:
     TYPENAME: CryptoHash
+PostedMessage:
+  STRUCT:
+    - authenticated_signer:
+        OPTION:
+          TYPENAME: Owner
+    - grant:
+        TYPENAME: Amount
+    - refund_grant_to:
+        OPTION:
+          TYPENAME: Account
+    - kind:
+        TYPENAME: MessageKind
+    - index: U32
+    - message:
+        TYPENAME: Message
 ProposalContent:
   STRUCT:
     - block:

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -617,8 +617,6 @@ OpenChainConfig:
             TYPENAME: Epoch
           VALUE:
             TYPENAME: Committee
-    - balance:
-        TYPENAME: Amount
     - application_permissions:
         TYPENAME: ApplicationPermissions
 Operation:
@@ -960,8 +958,11 @@ SystemOperation:
               TYPENAME: UserData
     2:
       OpenChain:
-        NEWTYPE:
-          TYPENAME: OpenChainConfig
+        STRUCT:
+          - config:
+              TYPENAME: OpenChainConfig
+          - balance:
+              TYPENAME: Amount
     3:
       CloseChain: UNIT
     4:

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -12,8 +12,8 @@ use linera_base::{
     ownership::TimeoutConfig,
 };
 use linera_chain::data_types::{
-    Block, Certificate, ChannelFullName, Event, HashedCertificateValue, IncomingBundle, LiteVote,
-    Medium, MessageAction, Origin, SignatureAggregator,
+    Block, Certificate, ChannelFullName, HashedCertificateValue, IncomingBundle, LiteVote, Medium,
+    MessageAction, Origin, SignatureAggregator,
 };
 use linera_execution::{
     system::{Recipient, SystemChannel, SystemOperation, UserData},
@@ -195,32 +195,13 @@ impl BlockBuilder {
             sender: certificate.value().chain_id(),
             medium: medium.clone(),
         };
-        let executed_block = certificate
-            .value()
-            .executed_block()
-            .expect("Failed to obtain executed block from certificate");
         let bundles = certificate
             .message_bundles_for(medium, self.block.chain_id)
             .into_iter()
-            .flat_map(|bundle| {
-                bundle
-                    .messages
-                    .into_iter()
-                    .map(|(index, message)| IncomingBundle {
-                        origin: origin.clone(),
-                        event: Event {
-                            certificate_hash: certificate.hash(),
-                            height: certificate.value().height(),
-                            index,
-                            authenticated_signer: message.authenticated_signer,
-                            grant: message.grant,
-                            refund_grant_to: message.refund_grant_to,
-                            kind: message.kind,
-                            timestamp: executed_block.block.timestamp,
-                            message: message.message,
-                        },
-                        action,
-                    })
+            .map(|(_epoch, bundle)| IncomingBundle {
+                origin: origin.clone(),
+                bundle,
+                action,
             });
         self.with_incoming_bundles(bundles)
     }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -299,7 +299,10 @@ impl ActiveChain {
     }
 
     /// Subscribes this microchain to the bytecodes published on the `publisher_id` microchain.
-    pub async fn subscribe_to_published_bytecodes_from(&mut self, publisher_id: ChainId) {
+    pub async fn subscribe_to_published_bytecodes_from(
+        &mut self,
+        publisher_id: ChainId,
+    ) -> Certificate {
         let publisher = self.validator.get_chain(&publisher_id);
 
         let subscribe_certificate = self
@@ -324,7 +327,7 @@ impl ActiveChain {
         self.add_block(|block| {
             block.with_system_messages_from(&accept_certificate, SystemChannel::PublishedBytecodes);
         })
-        .await;
+        .await
     }
 
     /// Creates an application on this microchain, using the bytecode referenced by `bytecode_id`.

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -186,13 +186,15 @@ impl TestValidator {
                 .collect(),
             admin_id,
             epoch: Epoch::ZERO,
-            balance: Amount::ZERO,
             application_permissions: ApplicationPermissions::default(),
         };
 
         let certificate = admin_chain
             .add_block(|block| {
-                block.with_system_operation(SystemOperation::OpenChain(new_chain_config));
+                block.with_system_operation(SystemOperation::OpenChain {
+                    config: new_chain_config,
+                    balance: 0.into(),
+                });
             })
             .await;
         let executed_block = certificate

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -49,10 +49,10 @@ query ChainInbox($chainId: ChainId!, $origin: Origin!) {
             height
             index
           }
-          addedEvents {
+          addedBundles {
             entries
           }
-          removedEvents {
+          removedBundles {
             entries
           }
         }
@@ -111,8 +111,8 @@ query Chain(
             height
             index
           }
-          addedEvents { entries }
-          removedEvents { entries }
+          addedBundles { entries }
+          removedBundles { entries }
         }
       }
     }
@@ -166,7 +166,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           previousBlockHash
           incomingBundles {
             origin
-            event
+            bundle
             action
           }
           operations
@@ -211,7 +211,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
           previousBlockHash
           incomingBundles {
             origin
-            event
+            bundle
             action
           }
           operations

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -203,11 +203,11 @@ type ChainStateExtendedView {
 	"""
 	inboxes: ReentrantCollectionView_Origin_InboxStateView_2059505700!
 	"""
-	A queue of unskippable events, with the timestamp when we added them to the inbox.
+	A queue of unskippable bundles, with the timestamp when we added them to the inbox.
 	"""
 	unskippable: QueueView_TimestampedInboxEntry_ce4d8b86!
 	"""
-	Non-skippable events that have been removed but are still in the queue.
+	Non-skippable bundles that have been removed but are still in the queue.
 	"""
 	removedUnskippable: [InboxEntry!]!
 	"""
@@ -378,11 +378,6 @@ A number identifying the configuration of the chain (aka the committee)
 scalar Epoch
 
 """
-A message together with non replayable information to ensure uniqueness in a particular inbox
-"""
-scalar Event
-
-"""
 An event recorded in an executed block.
 """
 type EventRecord {
@@ -439,17 +434,18 @@ type InboxEntry {
 }
 
 """
-The state of a inbox.
-* An inbox is used to track events received and executed locally.
-* An `Event` consists of a logical cursor `(height, index)` and some message content `message`.
-* On the surface, an inbox looks like a FIFO queue: the main APIs are `add_event` and
-`remove_event`.
-* However, events can also be removed before they are added. When this happens,
-the events removed by anticipation are tracked in a separate queue. Any event added
-later will be required to match the first removed event and so on.
-* The cursors of added events (resp. removed events) must be increasing over time.
-* Reconciliation of added and removed events is allowed to skip some added events.
-However, the opposite is not true: every removed event must be eventually added.
+The state of an inbox.
+* An inbox is used to track bundles received and executed locally.
+* A `MessageBundle` consists of a logical cursor `(height, index)` and some message
+content `messages`.
+* On the surface, an inbox looks like a FIFO queue: the main APIs are `add_bundle` and
+`remove_bundle`.
+* However, bundles can also be removed before they are added. When this happens,
+the bundles removed by anticipation are tracked in a separate queue. Any bundle added
+later will be required to match the first removed bundle and so on.
+* The cursors of added bundles (resp. removed bundles) must be increasing over time.
+* Reconciliation of added and removed bundles is allowed to skip some added bundles.
+However, the opposite is not true: every removed bundle must be eventually added.
 """
 type InboxStateView {
 	"""
@@ -461,14 +457,14 @@ type InboxStateView {
 	"""
 	nextCursorToRemove: Cursor!
 	"""
-	These events have been added and are waiting to be removed.
+	These bundles have been added and are waiting to be removed.
 	"""
-	addedEvents: QueueView_Event_fd202526!
+	addedBundles: QueueView_MessageBundle_f33fd73d!
 	"""
-	These events have been removed by anticipation and are waiting to be added.
-	At least one of `added_events` and `removed_events` should be empty.
+	These bundles have been removed by anticipation and are waiting to be added.
+	At least one of `added_bundles` and `removed_bundles` should be empty.
 	"""
-	removedEvents: QueueView_Event_fd202526!
+	removedBundles: QueueView_MessageBundle_f33fd73d!
 }
 
 """
@@ -483,7 +479,7 @@ type IncomingBundle {
 	The content of the message to be delivered to the inbox identified by
 	`origin`.
 	"""
-	event: Event!
+	bundle: MessageBundle!
 	"""
 	What to do with the message.
 	"""
@@ -551,6 +547,11 @@ scalar Message
 Whether an incoming message is accepted or rejected
 """
 scalar MessageAction
+
+"""
+A message together with non replayable information to ensure uniqueness in a particular inbox
+"""
+scalar MessageBundle
 
 """
 The kind of outgoing message being sent
@@ -718,7 +719,7 @@ type OutboxStateView {
 }
 
 """
-A message together with routing information.
+A posted message together with routing information.
 """
 type OutgoingMessage {
 	"""
@@ -738,7 +739,7 @@ type OutgoingMessage {
 	"""
 	refundGrantTo: Account
 	"""
-	The kind of event being sent.
+	The kind of message being sent.
 	"""
 	kind: MessageKind!
 	"""
@@ -773,8 +774,8 @@ type QueueView_BlockHeight_f5d50b5f {
 	entries(count: Int): [BlockHeight!]!
 }
 
-type QueueView_Event_fd202526 {
-	entries(count: Int): [Event!]!
+type QueueView_MessageBundle_f33fd73d {
+	entries(count: Int): [MessageBundle!]!
 }
 
 type QueueView_TimestampedInboxEntry_ce4d8b86 {

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -549,7 +549,7 @@ Whether an incoming message is accepted or rejected
 scalar MessageAction
 
 """
-A message together with non replayable information to ensure uniqueness in a particular inbox
+A set of messages from a single block, for a single destination.
 """
 scalar MessageBundle
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -25,7 +25,7 @@ mod types {
     pub type ChainOwnership = Value;
     pub type ChannelFullName = Value;
     pub type Epoch = Value;
-    pub type Event = Value;
+    pub type MessageBundle = Value;
     pub type MessageKind = Value;
     pub type Message = Value;
     pub type MessageAction = Value;
@@ -62,7 +62,7 @@ mod types {
 mod types {
     pub use linera_base::ownership::ChainOwnership;
     pub use linera_chain::{
-        data_types::{ChannelFullName, Event, MessageAction, Origin, Target},
+        data_types::{ChannelFullName, MessageAction, MessageBundle, Origin, Target},
         manager::ChainManager,
     };
     pub use linera_core::worker::{Notification, Reason};
@@ -144,12 +144,12 @@ mod from {
         fn from(val: block::BlockBlockValueExecutedBlockBlockIncomingBundles) -> Self {
             let block::BlockBlockValueExecutedBlockBlockIncomingBundles {
                 origin,
-                event,
+                bundle,
                 action,
             } = val;
             IncomingBundle {
                 origin,
-                event,
+                bundle,
                 action,
             }
         }

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -3021,12 +3021,12 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
 
     let account2 = Account::chain(chain2);
     assert_eq!(
-        client1.local_balance(account2).await?,
-        Amount::from_tokens(6),
+        client1.query_balance(account2).await?,
+        Amount::from_millis(5999),
     );
     assert_eq!(
-        client2.local_balance(account2).await?,
-        Amount::from_tokens(6),
+        client2.query_balance(account2).await?,
+        Amount::from_millis(5999),
     );
 
     // Transfer 2 + 1 units from Chain 2 to Chain 1 using both clients, leaving 3 (minus fees).
@@ -3190,17 +3190,22 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 
     // Clients 2 and 3 should have the tokens, and own the chain.
     client2.sync(chain2).await?;
+    // We haven't process incoming messages yet.
     assert_eq!(
         client2.local_balance(Account::chain(chain2)).await?,
-        Amount::from_tokens(2),
+        Amount::from_tokens(0),
+    );
+    assert_eq!(
+        client2.query_balance(Account::chain(chain2)).await?,
+        Amount::from_millis(1999),
     );
     client2.transfer(Amount::ONE, chain2, chain1).await?;
     assert!(client2.local_balance(Account::chain(chain2)).await? <= Amount::ONE);
 
     client3.sync(chain3).await?;
     assert_eq!(
-        client3.local_balance(Account::chain(chain3)).await?,
-        Amount::from_tokens(2),
+        client3.query_balance(Account::chain(chain3)).await?,
+        Amount::from_millis(1999),
     );
     client3.transfer(Amount::ONE, chain3, chain1).await?;
     assert!(client3.query_balance(Account::chain(chain3)).await? <= Amount::ONE);

--- a/linera-service/tests/end_to_end_tests.rs
+++ b/linera-service/tests/end_to_end_tests.rs
@@ -3193,7 +3193,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
     // We haven't process incoming messages yet.
     assert_eq!(
         client2.local_balance(Account::chain(chain2)).await?,
-        Amount::from_tokens(0),
+        Amount::ZERO,
     );
     assert_eq!(
         client2.query_balance(Account::chain(chain2)).await?,


### PR DESCRIPTION
## Motivation

`OpenChain` messages can be created by user operations. After #1475, they could be grouped with user messages in a fallible transaction. Therefore, `OpenChain` messages have to be rejectable.

## Proposal

* Make `OpenChain` messages "simple" instead of "protected".
* Rejecting an `OpenChain` message is allowed and close the chain immediately.
* When closing a chain in the middle of a block, operations or accepted messages are now disallowed right after the chain is closed (not at the next block).
* Empty blocks on closed chains are allowed but they have to pay a block fee.

I didn't change the `open_chain` syscall or the `OpenChain`operation but after #1475, we should probably remove the initial transfer entirely. (This transfer is redundant and restricted to chain-to-chain accounts)

## Test Plan

CI

## Release Plan

- Contains breaking changes.
- Next devnet ok

## Links

- Based on https://github.com/linera-io/linera-protocol/pull/2177.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
