### PR TITLE
Several memory store refactorings.

### DIFF
--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 version.workspace = true
 
 [features]
-test = ["tokio/macros"]
+test = ["tokio/macros", "linera-views/test"]
 fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
 wasmer = [

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -32,7 +32,7 @@ wasmtime = [
     "linera-storage/wasmtime",
     "linera-witty/wasmtime",
 ]
-test = ["linera-base/test"]
+test = ["linera-base/test", "linera-views/test"]
 
 [dependencies]
 async-graphql.workspace = true

--- a/linera-sdk/src/views/mock_key_value_store.rs
+++ b/linera-sdk/src/views/mock_key_value_store.rs
@@ -15,7 +15,7 @@ use futures::FutureExt as _;
 use linera_views::{
     batch::Batch,
     common::{ReadableKeyValueStore, WritableKeyValueStore},
-    memory::{create_memory_store, MemoryStore},
+    memory::{create_test_memory_store, MemoryStore},
 };
 
 /// A mock [`KeyValueStore`] implementation using a [`MemoryStore`].
@@ -32,7 +32,7 @@ pub(super) struct MockKeyValueStore {
 impl Default for MockKeyValueStore {
     fn default() -> Self {
         MockKeyValueStore {
-            store: create_memory_store(),
+            store: create_test_memory_store(),
             contains_key_promises: PromiseRegistry::default(),
             contains_keys_promises: PromiseRegistry::default(),
             read_multi_promises: PromiseRegistry::default(),

--- a/linera-views/benches/reentrant_collection_view.rs
+++ b/linera-views/benches/reentrant_collection_view.rs
@@ -7,7 +7,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use linera_views::{
     batch::Batch,
     common::Context,
-    memory::{create_memory_context, MemoryContext},
+    memory::{create_test_memory_context, MemoryContext},
     reentrant_collection_view::ReentrantCollectionView,
     register_view::RegisterView,
     views::View,
@@ -151,7 +151,7 @@ enum ComplexIndex {
 async fn create_populated_reentrant_collection_view(
 ) -> ReentrantCollectionView<MemoryContext<()>, ComplexIndex, RegisterView<MemoryContext<()>, String>>
 {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut view: ReentrantCollectionView<_, ComplexIndex, RegisterView<_, String>> =
         ReentrantCollectionView::load(context)
             .await

--- a/linera-views/src/batch.rs
+++ b/linera-views/src/batch.rs
@@ -625,7 +625,7 @@ mod tests {
     use linera_views::{
         batch::{Batch, SimpleUnorderedBatch, UnorderedBatch},
         common::Context,
-        memory::create_memory_context,
+        memory::create_test_memory_context,
     };
 
     #[test]
@@ -682,7 +682,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simplify_batch5() {
-        let context = create_memory_context();
+        let context = create_test_memory_context();
         let mut batch = Batch::new();
         batch.put_key_value_bytes(vec![1, 2, 3], vec![]);
         batch.put_key_value_bytes(vec![1, 2, 4], vec![]);
@@ -705,7 +705,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simplify_batch6() {
-        let context = create_memory_context();
+        let context = create_test_memory_context();
         let insertions = vec![(vec![1, 2, 3], vec![])];
         let simple_unordered_batch = SimpleUnorderedBatch {
             insertions: insertions.clone(),

--- a/linera-views/src/collection_view.rs
+++ b/linera-views/src/collection_view.rs
@@ -215,11 +215,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&[0, 1]).await.unwrap();
     ///   let value = subview.get();
@@ -235,11 +235,11 @@ where
     /// is read-only.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&[0, 1]).await.unwrap();
     ///   let subview = view.load_entry_or_insert(&[0, 1]).await.unwrap();
@@ -256,11 +256,11 @@ where
     /// May fail if one subview is already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.load_entry_or_insert(&[0, 1]).await.unwrap();
@@ -319,11 +319,11 @@ where
     /// Resets an entry to the default value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&[0, 1]).await.unwrap();
     ///   let value = subview.get_mut();
@@ -349,11 +349,11 @@ where
     /// Tests if the collection contains a specified key and returns a boolean.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.load_entry_mut(&[0, 1]).await.unwrap();
@@ -379,11 +379,11 @@ where
     /// Marks the entry as removed. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&[0, 1]).await.unwrap();
     ///   let value = subview.get_mut();
@@ -458,11 +458,11 @@ where
     /// ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&[0, 1]).await.unwrap();
     ///   view.load_entry_mut(&[0, 2]).await.unwrap();
@@ -523,11 +523,11 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&[0, 1]).await.unwrap();
     ///   view.load_entry_mut(&[0, 2]).await.unwrap();
@@ -553,11 +553,11 @@ where
     /// Returns the list of keys in the collection. The order is lexicographic.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::ByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ByteCollectionView<_, RegisterView<_,String>> = ByteCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&[0, 1]).await.unwrap();
     ///   view.load_entry_mut(&[0, 2]).await.unwrap();
@@ -724,11 +724,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -749,11 +749,11 @@ where
     /// is read-only.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   let subview = view.load_entry_or_insert(&23).await.unwrap();
@@ -775,11 +775,11 @@ where
     /// May fail if one subview is already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.load_entry_or_insert(&23).await.unwrap();
@@ -807,11 +807,11 @@ where
     /// Resets an entry to the default value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -834,11 +834,11 @@ where
     /// Removes an entry from the CollectionView. If absent nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -875,11 +875,11 @@ where
     /// the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&25).await.unwrap();
@@ -910,11 +910,11 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&24).await.unwrap();
@@ -943,11 +943,11 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CollectionView<_, u64, RegisterView<_,String>> = CollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&28).await.unwrap();
@@ -1073,11 +1073,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -1098,11 +1098,11 @@ where
     /// is read-only.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   let subview = view.load_entry_or_insert(&23).await.unwrap();
@@ -1124,11 +1124,11 @@ where
     /// May fail if one subview is already being visited.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.load_entry_or_insert(&23).await.unwrap();
@@ -1156,11 +1156,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -1183,11 +1183,11 @@ where
     /// Removes an entry from the CollectionView. If absent nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -1223,11 +1223,11 @@ where
     /// Returns the list of indices in the collection in the order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&23).await.unwrap();
     ///   view.load_entry_mut(&25).await.unwrap();
@@ -1258,11 +1258,11 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&28).await.unwrap();
     ///   view.load_entry_mut(&24).await.unwrap();
@@ -1292,11 +1292,11 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::collection_view::CustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : CustomCollectionView<_, u128, RegisterView<_,String>> = CustomCollectionView::load(context).await.unwrap();
     ///   view.load_entry_mut(&28).await.unwrap();
     ///   view.load_entry_mut(&24).await.unwrap();

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -309,10 +309,10 @@ where
     /// Getting the total sizes that will be used for keys and values when stored
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::{KeyValueStoreView, SizeData};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   let total_size = view.total_size();
     ///   assert_eq!(total_size, SizeData::default());
@@ -326,10 +326,10 @@ where
     /// false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]).await.unwrap();
     ///   view.insert(vec![0,2], vec![0]).await.unwrap();
@@ -396,10 +396,10 @@ where
     /// Applies the function f over all indices.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]).await.unwrap();
     ///   view.insert(vec![0,2], vec![0]).await.unwrap();
@@ -427,10 +427,10 @@ where
     /// If the function f returns false then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]).await.unwrap();
     ///   view.insert(vec![0,2], vec![0]).await.unwrap();
@@ -496,10 +496,10 @@ where
     /// Applies the function f over all index/value pairs.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]).await.unwrap();
     ///   view.insert(vec![0,2], vec![0]).await.unwrap();
@@ -525,10 +525,10 @@ where
     /// Returns the list of indices in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]).await.unwrap();
     ///   view.insert(vec![0,2], vec![0]).await.unwrap();
@@ -549,10 +549,10 @@ where
     /// Returns the list of indices and values in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]).await.unwrap();
     ///   view.insert(vec![0,2], vec![0]).await.unwrap();
@@ -573,10 +573,10 @@ where
     /// Returns the number of entries.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![0]).await.unwrap();
     ///   view.insert(vec![0,2], vec![0]).await.unwrap();
@@ -597,10 +597,10 @@ where
     /// Obtains the value at the given index, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]).await.unwrap();
     ///   assert_eq!(view.get(&[0,1]).await.unwrap(), Some(vec![42]));
@@ -626,10 +626,10 @@ where
     /// Tests whether the store contains a specific index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]).await.unwrap();
     ///   assert!(view.contains_key(&[0,1]).await.unwrap());
@@ -655,10 +655,10 @@ where
     /// Tests whether the view contains a range of indices
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]).await.unwrap();
     ///   let keys = vec![vec![0,1], vec![0,2]];
@@ -697,10 +697,10 @@ where
     /// Obtains the values of a range of indices
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![42]).await.unwrap();
     ///   assert_eq!(view.multi_get(vec![vec![0,1], vec![0,2]]).await.unwrap(), vec![Some(vec![42]), None]);
@@ -740,11 +740,11 @@ where
     /// Applies the given batch of `crate::common::WriteOperation`.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use linera_views::batch::Batch;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]).await.unwrap();
     ///   view.insert(vec![3,4], vec![42]).await.unwrap();
@@ -824,10 +824,10 @@ where
     /// Sets or inserts a value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]).await.unwrap();
     ///   assert_eq!(view.get(&[0,1]).await.unwrap(), Some(vec![34]));
@@ -842,10 +842,10 @@ where
     /// Removes a value. If absent then the action has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]).await.unwrap();
     ///   view.remove(vec![0,1]).await.unwrap();
@@ -861,10 +861,10 @@ where
     /// Deletes a key_prefix.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]).await.unwrap();
     ///   view.remove_by_prefix(vec![0]).await.unwrap();
@@ -880,10 +880,10 @@ where
     /// Iterates over all the keys matching the given prefix. The prefix is not included in the returned keys.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]).await.unwrap();
     ///   view.insert(vec![3,4], vec![42]).await.unwrap();
@@ -951,10 +951,10 @@ where
     /// prefix is not included in the returned keys.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::key_value_store_view::KeyValueStoreView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view = KeyValueStoreView::load(context).await.unwrap();
     ///   view.insert(vec![0,1], vec![34]).await.unwrap();
     ///   view.insert(vec![3,4], vec![42]).await.unwrap();

--- a/linera-views/src/log_view.rs
+++ b/linera-views/src/log_view.rs
@@ -154,10 +154,10 @@ where
     /// Pushes a value to the end of the log.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     /// # })
@@ -169,10 +169,10 @@ where
     /// Reads the size of the log.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   log.push(42);
@@ -202,10 +202,10 @@ where
     /// Reads the logged value with the given index (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   assert_eq!(log.get(0).await.unwrap(), Some(34));
@@ -226,10 +226,10 @@ where
     /// Reads several logged keys (including staged ones)
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   log.push(42);
@@ -285,10 +285,10 @@ where
     /// Reads the logged values in the given range (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::log_view::LogView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut log = LogView::load(context).await.unwrap();
     ///   log.push(34);
     ///   log.push(42);

--- a/linera-views/src/map_view.rs
+++ b/linera-views/src/map_view.rs
@@ -164,10 +164,10 @@ where
     /// Inserts or resets the value of a key of the map.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   assert_eq!(map.keys().await.unwrap(), vec![vec![0,1]]);
@@ -180,10 +180,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], "Hello");
     ///   map.remove(vec![0,1]);
@@ -201,10 +201,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![0,2], String::from("Bonjour"));
@@ -232,10 +232,10 @@ where
     /// Returns `true` if the map contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0, 1], String::from("Hello"));
     ///   assert!(map.contains_key(&[0,1]).await.unwrap());
@@ -267,10 +267,10 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   assert_eq!(map.get(&[0,1]).await.unwrap(), Some(String::from("Hello")));
@@ -294,10 +294,10 @@ where
     /// Reads the values at the given positions, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   let values = map.multi_get(vec![vec![0,1],vec![0,2]]).await.unwrap();
@@ -330,10 +330,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   let value = map.get_mut(&[0,1]).await.unwrap().unwrap();
@@ -373,10 +373,10 @@ where
     /// function and if it returns false, then the loop exits
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -445,10 +445,10 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   let mut count = 0;
@@ -477,10 +477,10 @@ where
     /// Returns the list of keys of the map in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -506,10 +506,10 @@ where
     /// in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -536,10 +536,10 @@ where
     /// Returns the number of keys of the map
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -567,10 +567,10 @@ where
     /// prematurely
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   map.insert(vec![1,2], String::from("Bonjour"));
@@ -650,10 +650,10 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   let mut count = 0;
@@ -690,10 +690,10 @@ where
     /// in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![1,2], String::from("Hello"));
     ///   let prefix = vec![1];
@@ -723,10 +723,10 @@ where
     /// Returns the list of keys and values of the map in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![1,2], String::from("Hello"));
     ///   assert_eq!(map.key_values().await.unwrap(), vec![(vec![1,2], String::from("Hello"))]);
@@ -747,10 +747,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::ByteMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = ByteMapView::load(context).await.unwrap();
     ///   map.insert(vec![0,1], String::from("Hello"));
     ///   assert_eq!(map.get_mut_or_default(&[7]).await.unwrap(), "");
@@ -901,10 +901,10 @@ where
     /// Inserts or resets a value at an index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_,u32,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&(24 as u32), String::from("Hello"));
     ///   assert_eq!(map.get(&(24 as u32)).await.unwrap(), Some(String::from("Hello")));
@@ -923,10 +923,10 @@ where
     /// Removes a value. If absent then the operation does nothing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = MapView::<_,u32,String>::load(context).await.unwrap();
     ///   map.remove(&(37 as u32));
     ///   assert_eq!(map.get(&(37 as u32)).await.unwrap(), None);
@@ -950,10 +950,10 @@ where
     /// Returns `true` if the map contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = MapView::<_,u32,String>::load(context).await.unwrap();
     ///   map.insert(&(37 as u32), String::from("Hello"));
     ///   assert!(map.contains_key(&(37 as u32)).await.unwrap());
@@ -980,10 +980,10 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_, u32,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&(37 as u32), String::from("Hello"));
     ///   assert_eq!(map.get(&(37 as u32)).await.unwrap(), Some(String::from("Hello")));
@@ -1002,10 +1002,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView::<_,u32,String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(37 as u32), String::from("Hello"));
     ///   assert_eq!(map.get_mut(&(34 as u32)).await.unwrap(), None);
@@ -1034,10 +1034,10 @@ where
     /// Returns the list of indices in the map. The order is determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView::<_,u32,String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(37 as u32), String::from("Hello"));
     ///   assert_eq!(map.indices().await.unwrap(), vec![37 as u32]);
@@ -1058,10 +1058,10 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_, u128, String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Thanks"));
     ///   map.insert(&(37 as u128), String::from("Spasiba"));
@@ -1095,10 +1095,10 @@ where
     /// determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_, u128, String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   let mut count = 0;
@@ -1131,10 +1131,10 @@ where
     /// If the function returns false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_, u128, String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Thanks"));
     ///   map.insert(&(37 as u128), String::from("Spasiba"));
@@ -1169,10 +1169,10 @@ where
     /// visited in an order determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_,Vec<u8>,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&vec![0,1], String::from("Hello"));
     ///   let mut count = 0;
@@ -1213,10 +1213,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_,u32,u128> = MapView::load(context).await.unwrap();
     ///   let value = map.get_mut_or_default(&(34 as u32)).await.unwrap();
     ///   assert_eq!(*value, 0 as u128);
@@ -1329,10 +1329,10 @@ where
     /// Insert or resets a value.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView<_,u128,_> = MapView::load(context).await.unwrap();
     ///   map.insert(&(24 as u128), String::from("Hello"));
     ///   assert_eq!(map.get(&(24 as u128)).await.unwrap(), Some(String::from("Hello")));
@@ -1351,10 +1351,10 @@ where
     /// Removes a value. If absent then this does not do anything.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = MapView::<_,u128,String>::load(context).await.unwrap();
     ///   map.remove(&(37 as u128));
     ///   assert_eq!(map.get(&(37 as u128)).await.unwrap(), None);
@@ -1378,10 +1378,10 @@ where
     /// Returns `true` if the map contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = MapView::<_,u128,String>::load(context).await.unwrap();
     ///   map.insert(&(37 as u128), String::from("Hello"));
     ///   assert!(map.contains_key(&(37 as u128)).await.unwrap());
@@ -1408,11 +1408,11 @@ where
     /// Reads the value at the given position, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use linera_views::memory::MemoryContext;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : CustomMapView<MemoryContext<()>, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   assert_eq!(map.get(&(34 as u128)).await.unwrap(), Some(String::from("Hello")));
@@ -1430,10 +1430,10 @@ where
     /// Obtains a mutable reference to a value at a given position if available
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   let value = map.get_mut(&(34 as u128)).await.unwrap().unwrap();
@@ -1462,10 +1462,10 @@ where
     /// by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::MapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : MapView::<_,u128,String> = MapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Bonjour"));
@@ -1487,10 +1487,10 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1523,10 +1523,10 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1560,10 +1560,10 @@ where
     /// If the function returns false, then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map = CustomMapView::<_,u128,String>::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1597,10 +1597,10 @@ where
     /// visited in an order determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   map.insert(&(34 as u128), String::from("Hello"));
     ///   map.insert(&(37 as u128), String::from("Hola"));
@@ -1642,10 +1642,10 @@ where
     /// Default value if the index is missing.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::map_view::CustomMapView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut map : CustomMapView<_, u128, String> = CustomMapView::load(context).await.unwrap();
     ///   assert_eq!(*map.get_mut_or_default(&(34 as u128)).await.unwrap(), String::new());
     /// # })

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -218,7 +218,7 @@ impl<E> MemoryContext<E> {
 /// Provides a `MemoryContext<()>` that can be used for tests.
 /// It is not named create_memory_test_context because it is massively
 /// used and so we want to have a short name.
-pub fn create_memory_context() -> MemoryContext<()> {
+pub fn create_test_memory_context() -> MemoryContext<()> {
     MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, ())
 }
 
@@ -238,7 +238,7 @@ pub fn create_memory_store_stream_queries(max_stream_queries: usize) -> MemorySt
 }
 
 /// Creates a test memory store for working.
-pub fn create_memory_store() -> MemoryStore {
+pub fn create_test_memory_store() -> MemoryStore {
     create_memory_store_stream_queries(TEST_MEMORY_MAX_STREAM_QUERIES)
 }
 

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -218,6 +218,7 @@ impl<E> MemoryContext<E> {
 /// Provides a `MemoryContext<()>` that can be used for tests.
 /// It is not named create_memory_test_context because it is massively
 /// used and so we want to have a short name.
+#[cfg(with_testing)]
 pub fn create_test_memory_context() -> MemoryContext<()> {
     MemoryContext::new(TEST_MEMORY_MAX_STREAM_QUERIES, ())
 }
@@ -238,6 +239,7 @@ pub fn create_memory_store_stream_queries(max_stream_queries: usize) -> MemorySt
 }
 
 /// Creates a test memory store for working.
+#[cfg(with_testing)]
 pub fn create_test_memory_store() -> MemoryStore {
     create_memory_store_stream_queries(TEST_MEMORY_MAX_STREAM_QUERIES)
 }

--- a/linera-views/src/queue_view.rs
+++ b/linera-views/src/queue_view.rs
@@ -193,10 +193,10 @@ where
     /// Reads the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -216,10 +216,10 @@ where
     /// Reads the back value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -237,10 +237,10 @@ where
     /// Deletes the front value, if any.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34 as u128);
     ///   queue.delete_front();
@@ -258,10 +258,10 @@ where
     /// Pushes a value to the end of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(37);
@@ -275,10 +275,10 @@ where
     /// Reads the size of the queue.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   assert_eq!(queue.count(), 1);
@@ -315,10 +315,10 @@ where
     /// Reads the `count` next values in the queue (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -355,10 +355,10 @@ where
     /// Reads the `count` last values in the queue (including staged ones).
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(42);
@@ -391,10 +391,10 @@ where
     /// Reads all the elements
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   queue.push_back(37);
@@ -428,10 +428,10 @@ where
     /// Gets a mutable iterator on the entries of the queue
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::queue_view::QueueView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut queue = QueueView::load(context).await.unwrap();
     ///   queue.push_back(34);
     ///   let mut iter = queue.iter_mut().await.unwrap();

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -321,11 +321,11 @@ where
     /// can be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
     ///   let value = subview.get();
@@ -348,11 +348,11 @@ where
     /// If an entry is absent then `None` is returned.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -378,11 +378,11 @@ where
     /// Returns `true` if the collection contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   let _subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
     ///   assert!(view.contains_key(&[0, 1]).await.unwrap());
@@ -408,11 +408,11 @@ where
     /// Removes an entry. If absent then nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   let mut subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
     ///   let value = subview.get_mut();
@@ -435,11 +435,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -481,11 +481,11 @@ where
     /// The entries in `short_keys` have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(&[0, 1]).await.unwrap();
@@ -569,11 +569,11 @@ where
     /// The entries in short_keys have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&[0,1]).await.unwrap();
@@ -653,11 +653,11 @@ where
     /// Loads all the entries for reading at once.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&[0,1]).await.unwrap();
@@ -721,11 +721,11 @@ where
     /// Loads all the entries for writing at once.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&[0,1]).await.unwrap();
@@ -797,11 +797,11 @@ where
     /// Returns the list of indices in the collection in lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&[0, 1]).await.unwrap();
     ///   view.try_load_entry_mut(&[0, 2]).await.unwrap();
@@ -824,11 +824,11 @@ where
     /// ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&[0, 1]).await.unwrap();
     ///   view.try_load_entry_mut(&[0, 2]).await.unwrap();
@@ -888,11 +888,11 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantByteCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantByteCollectionView<_, RegisterView<_,String>> = ReentrantByteCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&[0, 1]).await.unwrap();
     ///   view.try_load_entry_mut(&[0, 2]).await.unwrap();
@@ -1074,11 +1074,11 @@ where
     /// then be modified.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -1101,11 +1101,11 @@ where
     /// If an entry is absent then `None` is returned.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1130,11 +1130,11 @@ where
     /// Returns `true` if the collection contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   assert!(view.contains_key(&23).await.unwrap());
@@ -1153,11 +1153,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let mut subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -1180,11 +1180,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1223,11 +1223,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries_mut(&indices).await.unwrap();
@@ -1256,11 +1256,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1291,11 +1291,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1325,11 +1325,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1367,11 +1367,11 @@ where
     /// by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&25).await.unwrap();
@@ -1394,11 +1394,11 @@ where
     /// the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&24).await.unwrap();
@@ -1427,11 +1427,11 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCollectionView<_, u64, RegisterView<_,String>> = ReentrantCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&28).await.unwrap();
@@ -1557,11 +1557,11 @@ where
     /// is absent then a default entry is put in the collection on this index.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get();
@@ -1584,11 +1584,11 @@ where
     /// If an entry is absent then `None` is returned.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1613,11 +1613,11 @@ where
     /// Returns `true` if the collection contains a value for the specified key.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let _subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   assert!(view.contains_key(&23).await.unwrap());
@@ -1636,11 +1636,11 @@ where
     /// Removes an entry. If absent then nothing happens.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let mut subview = view.try_load_entry_mut(&23).await.unwrap();
     ///   let value = subview.get_mut();
@@ -1663,11 +1663,11 @@ where
     /// Marks the entry so that it is removed in the next flush.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let mut subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1708,11 +1708,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   let indices = vec![23, 42];
     ///   let subviews = view.try_load_entries_mut(indices).await.unwrap();
@@ -1741,11 +1741,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1776,11 +1776,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1810,11 +1810,11 @@ where
     /// The entries in indices have to be all distinct.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   {
     ///     let _subview = view.try_load_entry_mut(&23).await.unwrap();
@@ -1850,11 +1850,11 @@ where
     /// the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&23).await.unwrap();
     ///   view.try_load_entry_mut(&25).await.unwrap();
@@ -1877,11 +1877,11 @@ where
     /// then the loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&28).await.unwrap();
     ///   view.try_load_entry_mut(&24).await.unwrap();
@@ -1911,11 +1911,11 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::{create_memory_context, MemoryContext};
+    /// # use linera_views::memory::{create_test_memory_context, MemoryContext};
     /// # use linera_views::reentrant_collection_view::ReentrantCustomCollectionView;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut view : ReentrantCustomCollectionView<_, u128, RegisterView<_,String>> = ReentrantCustomCollectionView::load(context).await.unwrap();
     ///   view.try_load_entry_mut(&28).await.unwrap();
     ///   view.try_load_entry_mut(&24).await.unwrap();

--- a/linera-views/src/register_view.rs
+++ b/linera-views/src/register_view.rs
@@ -134,10 +134,10 @@ where
     /// Access the current value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut register = RegisterView::<_,u32>::load(context).await.unwrap();
     ///   let value = register.get();
     ///   assert_eq!(*value, 0);
@@ -153,10 +153,10 @@ where
     /// Sets the value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut register = RegisterView::load(context).await.unwrap();
     ///   register.set(5);
     ///   let value = register.get();
@@ -182,10 +182,10 @@ where
     /// Obtains a mutable reference to the value in the register.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::register_view::RegisterView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut register : RegisterView<_,u32> = RegisterView::load(context).await.unwrap();
     ///   let value = register.get_mut();
     ///   assert_eq!(*value, 0);

--- a/linera-views/src/set_view.rs
+++ b/linera-views/src/set_view.rs
@@ -135,9 +135,9 @@ where
     /// Insert a value. If already present then it has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   assert_eq!(set.contains(&[0,1]).await.unwrap(), true);
@@ -150,9 +150,9 @@ where
     /// Removes a value from the set. If absent then no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.remove(vec![0,1]);
     ///   assert_eq!(set.contains(&[0,1]).await.unwrap(), false);
@@ -181,9 +181,9 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   assert_eq!(set.contains(&[34]).await.unwrap(), false);
@@ -214,9 +214,9 @@ where
     /// Returns the list of keys in the set. The order is lexicographic.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   set.insert(vec![0,2]);
@@ -238,9 +238,9 @@ where
     /// prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   set.insert(vec![0,2]);
@@ -301,9 +301,9 @@ where
     /// lexicographic order.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::ByteSetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::ByteSetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = ByteSetView::load(context).await.unwrap();
     ///   set.insert(vec![0,1]);
     ///   set.insert(vec![0,2]);
@@ -432,10 +432,10 @@ where
     /// Inserts a value. If already present then no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::SetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   assert_eq!(set.indices().await.unwrap().len(), 1);
@@ -454,9 +454,9 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::SetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::SetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.remove(&(34 as u32));
     ///   assert_eq!(set.indices().await.unwrap().len(), 0);
@@ -487,9 +487,9 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::SetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::SetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set : SetView<_,u32> = SetView::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   assert_eq!(set.contains(&(34 as u32)).await.unwrap(), true);
@@ -515,9 +515,9 @@ where
     /// Returns the list of indices in the set. The order is determined by serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::{memory::create_memory_context, set_view::SetView};
+    /// # use linera_views::{memory::create_test_memory_context, set_view::SetView};
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set : SetView<_,u32> = SetView::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   assert_eq!(set.indices().await.unwrap(), vec![34 as u32]);
@@ -538,10 +538,10 @@ where
     /// loop ends prematurely.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::SetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   set.insert(&(37 as u32));
@@ -571,10 +571,10 @@ where
     /// determined by the serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::SetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = SetView::<_,u32>::load(context).await.unwrap();
     ///   set.insert(&(34 as u32));
     ///   set.insert(&(37 as u32));
@@ -695,10 +695,10 @@ where
     /// Inserts a value. If present then it has no effect.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   assert_eq!(set.indices().await.unwrap().len(), 1);
@@ -717,10 +717,10 @@ where
     /// Removes a value. If absent then nothing is done.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.remove(&(34 as u128));
     ///   assert_eq!(set.indices().await.unwrap().len(), 0);
@@ -751,10 +751,10 @@ where
     /// Returns true if the given index exists in the set.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   assert_eq!(set.contains(&(34 as u128)).await.unwrap(), true);
@@ -781,10 +781,10 @@ where
     /// serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   set.insert(&(37 as u128));
@@ -806,10 +806,10 @@ where
     /// false, then the loop prematurely ends.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   set.insert(&(37 as u128));
@@ -839,10 +839,10 @@ where
     /// determined by the custom serialization.
     /// ```rust
     /// # tokio_test::block_on(async {
-    /// # use linera_views::memory::create_memory_context;
+    /// # use linera_views::memory::create_test_memory_context;
     /// # use linera_views::set_view::CustomSetView;
     /// # use crate::linera_views::views::View;
-    /// # let context = create_memory_context();
+    /// # let context = create_test_memory_context();
     ///   let mut set = CustomSetView::<_,u128>::load(context).await.unwrap();
     ///   set.insert(&(34 as u128));
     ///   set.insert(&(37 as u128));

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -22,7 +22,7 @@ use crate::scylla_db::{create_scylla_db_test_config, ScyllaDbContext, ScyllaDbSt
 use crate::{
     batch::Batch,
     common::Context,
-    memory::{create_memory_context, MemoryContext},
+    memory::{create_test_memory_context, MemoryContext},
     queue_view::QueueView,
     reentrant_collection_view::ReentrantCollectionView,
     register_view::{HashedRegisterView, RegisterView},
@@ -205,7 +205,7 @@ impl TestContextFactory for MemoryContextFactory {
     type Context = MemoryContext<()>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        Ok(create_memory_context())
+        Ok(create_test_memory_context())
     }
 }
 
@@ -295,7 +295,7 @@ async fn test_clone_includes_staged_changes<V>(
 where
     V: TestView,
 {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut original = V::load(context).await?;
     let original_state = original.stage_initial_changes().await?;
 
@@ -319,7 +319,7 @@ async fn test_original_and_clone_stage_changes_separately<V>(
 where
     V: TestView,
 {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut original = V::load(context).await?;
     original.stage_initial_changes().await?;
 
@@ -343,7 +343,7 @@ where
 /// Otherwise `rollback` may set the cached staged hash value to an incorrect value.
 #[tokio::test]
 async fn test_clearing_of_cached_stored_hash() -> anyhow::Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut view = HashedRegisterView::<_, String>::load(context.clone()).await?;
 
     let empty_hash = view.hash().await?;
@@ -383,7 +383,7 @@ async fn test_clearing_of_cached_stored_hash() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_reentrant_collection_view_has_no_pending_changes_after_try_load_entries(
 ) -> anyhow::Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let values = [(1, "first".to_owned()), (2, "second".to_owned())];
     let mut view =
         ReentrantCollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
@@ -410,7 +410,7 @@ async fn test_reentrant_collection_view_has_no_pending_changes_after_try_load_en
 #[tokio::test]
 async fn test_reentrant_collection_view_has_pending_changes_after_new_entry() -> anyhow::Result<()>
 {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let values = [(1, "first".to_owned()), (2, "second".to_owned())];
     let mut view =
         ReentrantCollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
@@ -434,7 +434,7 @@ async fn test_reentrant_collection_view_has_pending_changes_after_new_entry() ->
 #[tokio::test]
 async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entry_mut(
 ) -> anyhow::Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let values = [(1, "first".to_owned()), (2, "second".to_owned())];
     let mut view =
         ReentrantCollectionView::<_, u8, RegisterView<_, String>>::load(context.clone()).await?;
@@ -467,7 +467,7 @@ async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entry
 #[tokio::test]
 async fn test_reentrant_collection_view_has_pending_changes_after_try_load_entries_mut(
 ) -> anyhow::Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let values = [
         (1, "first".to_owned()),
         (2, "second".to_owned()),

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -341,17 +341,17 @@ where
 
 /// A virtual DB store where data are persisted in memory.
 #[derive(Clone)]
-pub struct LimitedMemoryStore {
+pub struct LimitedTestMemoryStore {
     store: MemoryStore,
 }
 
-impl Default for LimitedMemoryStore {
+impl Default for LimitedTestMemoryStore {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ReadableKeyValueStore<MemoryStoreError> for LimitedMemoryStore {
+impl ReadableKeyValueStore<MemoryStoreError> for LimitedTestMemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -391,7 +391,7 @@ impl ReadableKeyValueStore<MemoryStoreError> for LimitedMemoryStore {
     }
 }
 
-impl WritableKeyValueStore<MemoryStoreError> for LimitedMemoryStore {
+impl WritableKeyValueStore<MemoryStoreError> for LimitedTestMemoryStore {
     // We set up the MAX_VALUE_SIZE to the artificially low value of 100
     // purely for testing purposes.
     const MAX_VALUE_SIZE: usize = 100;
@@ -409,12 +409,12 @@ impl WritableKeyValueStore<MemoryStoreError> for LimitedMemoryStore {
     }
 }
 
-impl KeyValueStore for LimitedMemoryStore {
+impl KeyValueStore for LimitedTestMemoryStore {
     type Error = MemoryStoreError;
 }
 
-impl LimitedMemoryStore {
-    /// Creates a `LimitedMemoryStore`
+impl LimitedTestMemoryStore {
+    /// Creates a `LimitedTestMemoryStore`
     pub fn new() -> Self {
         let common_config = CommonStoreConfig {
             max_concurrent_queries: None,
@@ -427,13 +427,13 @@ impl LimitedMemoryStore {
             .now_or_never()
             .unwrap()
             .unwrap();
-        LimitedMemoryStore { store }
+        LimitedTestMemoryStore { store }
     }
 }
 
-/// Provides a `LimitedMemoryStore<()>` that can be used for tests.
-pub fn create_value_splitting_memory_store() -> ValueSplittingStore<LimitedMemoryStore> {
-    ValueSplittingStore::new(LimitedMemoryStore::new())
+/// Provides a `LimitedTestMemoryStore<()>` that can be used for tests.
+pub fn create_value_splitting_memory_store() -> ValueSplittingStore<LimitedTestMemoryStore> {
+    ValueSplittingStore::new(LimitedTestMemoryStore::new())
 }
 
 #[cfg(test)]
@@ -441,7 +441,7 @@ mod tests {
     use linera_views::{
         batch::Batch,
         common::{ReadableKeyValueStore, WritableKeyValueStore},
-        value_splitting::{LimitedMemoryStore, ValueSplittingStore},
+        value_splitting::{LimitedTestMemoryStore, ValueSplittingStore},
     };
     use rand::Rng;
 
@@ -450,8 +450,8 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::assertions_on_constants)]
     async fn test_value_splitting1_testing_leftovers() {
-        let store = LimitedMemoryStore::new();
-        const MAX_LEN: usize = LimitedMemoryStore::MAX_VALUE_SIZE;
+        let store = LimitedTestMemoryStore::new();
+        const MAX_LEN: usize = LimitedTestMemoryStore::MAX_VALUE_SIZE;
         assert!(MAX_LEN > 10);
         let big_store = ValueSplittingStore::new(store.clone());
         let key = vec![0, 0];
@@ -476,8 +476,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_value_splitting2_testing_splitting() {
-        let store = LimitedMemoryStore::new();
-        const MAX_LEN: usize = LimitedMemoryStore::MAX_VALUE_SIZE;
+        let store = LimitedTestMemoryStore::new();
+        const MAX_LEN: usize = LimitedTestMemoryStore::MAX_VALUE_SIZE;
         let big_store = ValueSplittingStore::new(store.clone());
         let key = vec![0, 0];
         // Writing a big value
@@ -513,8 +513,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_value_splitting3_write_and_delete() {
-        let store = LimitedMemoryStore::new();
-        const MAX_LEN: usize = LimitedMemoryStore::MAX_VALUE_SIZE;
+        let store = LimitedTestMemoryStore::new();
+        const MAX_LEN: usize = LimitedTestMemoryStore::MAX_VALUE_SIZE;
         let big_store = ValueSplittingStore::new(store.clone());
         let key = vec![0, 0];
         // writing a big key

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyIterable, KeyValueIterable,
+        AdminKeyValueStore, CommonStoreConfig, KeyIterable, KeyValueIterable,
         KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
     memory::{MemoryStore, MemoryStoreConfig, MemoryStoreError, TEST_MEMORY_MAX_STREAM_QUERIES},
@@ -341,17 +341,17 @@ where
 
 /// A virtual DB store where data are persisted in memory.
 #[derive(Clone)]
-pub struct TestMemoryStoreInternal {
+pub struct LimitedMemoryStore {
     store: MemoryStore,
 }
 
-impl Default for TestMemoryStoreInternal {
+impl Default for LimitedMemoryStore {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ReadableKeyValueStore<MemoryStoreError> for TestMemoryStoreInternal {
+impl ReadableKeyValueStore<MemoryStoreError> for LimitedMemoryStore {
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -391,7 +391,7 @@ impl ReadableKeyValueStore<MemoryStoreError> for TestMemoryStoreInternal {
     }
 }
 
-impl WritableKeyValueStore<MemoryStoreError> for TestMemoryStoreInternal {
+impl WritableKeyValueStore<MemoryStoreError> for LimitedMemoryStore {
     // We set up the MAX_VALUE_SIZE to the artificially low value of 100
     // purely for testing purposes.
     const MAX_VALUE_SIZE: usize = 100;
@@ -409,12 +409,12 @@ impl WritableKeyValueStore<MemoryStoreError> for TestMemoryStoreInternal {
     }
 }
 
-impl KeyValueStore for TestMemoryStoreInternal {
+impl KeyValueStore for LimitedMemoryStore {
     type Error = MemoryStoreError;
 }
 
-impl TestMemoryStoreInternal {
-    /// Creates a `TestMemoryStoreInternal`
+impl LimitedMemoryStore {
+    /// Creates a `LimitedMemoryStore`
     pub fn new() -> Self {
         let common_config = CommonStoreConfig {
             max_concurrent_queries: None,
@@ -427,139 +427,13 @@ impl TestMemoryStoreInternal {
             .now_or_never()
             .unwrap()
             .unwrap();
-        TestMemoryStoreInternal { store }
+        LimitedMemoryStore { store }
     }
 }
 
-/// Supposed to be removed later
-#[derive(Clone)]
-pub struct TestMemoryStore {
-    store: ValueSplittingStore<TestMemoryStoreInternal>,
-}
-
-impl ReadableKeyValueStore<MemoryStoreError> for TestMemoryStore {
-    const MAX_KEY_SIZE: usize = usize::MAX;
-    type Keys = Vec<Vec<u8>>;
-    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
-
-    fn max_stream_queries(&self) -> usize {
-        self.store.max_stream_queries()
-    }
-
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, MemoryStoreError> {
-        self.store.read_value_bytes(key).await
-    }
-
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, MemoryStoreError> {
-        self.store.contains_key(key).await
-    }
-
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, MemoryStoreError> {
-        self.store.contains_keys(keys).await
-    }
-
-    async fn read_multi_values_bytes(
-        &self,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, MemoryStoreError> {
-        self.store.read_multi_values_bytes(keys).await
-    }
-
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, MemoryStoreError> {
-        self.store.find_keys_by_prefix(key_prefix).await
-    }
-
-    async fn find_key_values_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, MemoryStoreError> {
-        self.store.find_key_values_by_prefix(key_prefix).await
-    }
-}
-
-impl WritableKeyValueStore<MemoryStoreError> for TestMemoryStore {
-    const MAX_VALUE_SIZE: usize = usize::MAX;
-
-    async fn write_batch(&self, batch: Batch, base_key: &[u8]) -> Result<(), MemoryStoreError> {
-        self.store.write_batch(batch, base_key).await
-    }
-
-    async fn clear_journal(&self, base_key: &[u8]) -> Result<(), MemoryStoreError> {
-        self.store.clear_journal(base_key).await
-    }
-}
-
-impl KeyValueStore for TestMemoryStore {
-    type Error = MemoryStoreError;
-}
-
-impl TestMemoryStore {
-    /// Creates a `TestMemoryStore` from the guard
-    pub fn new() -> Self {
-        let store = TestMemoryStoreInternal::new();
-        let store = ValueSplittingStore::new(store);
-        TestMemoryStore { store }
-    }
-}
-
-impl Default for TestMemoryStore {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type TestMemoryContext<E> = ContextFromStore<E, TestMemoryStore>;
-
-impl<E> TestMemoryContext<E> {
-    /// Creates a [`TestMemoryContext`].
-    pub fn new(extra: E) -> Self {
-        let store = TestMemoryStore::new();
-        let base_key = Vec::new();
-        Self {
-            store,
-            base_key,
-            extra,
-        }
-    }
-}
-
-/// Provides a `TestMemoryContext<()>` that can be used for tests.
-/// It is not named create_memory_test_context because it is massively
-/// used and so we want to have a short name.
-pub fn create_test_memory_context() -> TestMemoryContext<()> {
-    TestMemoryContext::new(())
-}
-
-/// Creates a `TestMemoryStore` for working.
-pub fn create_test_memory_store() -> TestMemoryStore {
-    TestMemoryStore::new()
-}
-
-/// An implementation of [`crate::common::Context`] that stores all values in memory.
-pub type TestMemoryContextInternal<E> = ContextFromStore<E, TestMemoryStoreInternal>;
-
-impl<E> TestMemoryContextInternal<E> {
-    /// Creates a [`TestMemoryContextInternal`].
-    pub fn new(extra: E) -> Self {
-        let store = TestMemoryStoreInternal::new();
-        let base_key = Vec::new();
-        Self {
-            store,
-            base_key,
-            extra,
-        }
-    }
-}
-
-/// Provides a `TestMemoryStoreInternal<()>` that can be used for tests.
-pub fn create_test_memory_store_internal() -> TestMemoryStoreInternal {
-    TestMemoryStoreInternal::new()
-}
-
-/// Provides a `TestMemoryContextInternal<()>` that can be used for tests.
-pub fn create_test_memory_context_internal() -> TestMemoryContextInternal<()> {
-    TestMemoryContextInternal::new(())
+/// Provides a `LimitedMemoryStore<()>` that can be used for tests.
+pub fn create_value_splitting_memory_store() -> ValueSplittingStore<LimitedMemoryStore> {
+    ValueSplittingStore::new(LimitedMemoryStore::new())
 }
 
 #[cfg(test)]
@@ -568,7 +442,7 @@ mod tests {
         batch::Batch,
         common::{ReadableKeyValueStore, WritableKeyValueStore},
         value_splitting::{
-            create_test_memory_store_internal, TestMemoryStoreInternal, ValueSplittingStore,
+            LimitedMemoryStore, ValueSplittingStore,
         },
     };
     use rand::Rng;
@@ -578,8 +452,8 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::assertions_on_constants)]
     async fn test_value_splitting1_testing_leftovers() {
-        let store = create_test_memory_store_internal();
-        const MAX_LEN: usize = TestMemoryStoreInternal::MAX_VALUE_SIZE;
+        let store = LimitedMemoryStore::new();
+        const MAX_LEN: usize = LimitedMemoryStore::MAX_VALUE_SIZE;
         assert!(MAX_LEN > 10);
         let big_store = ValueSplittingStore::new(store.clone());
         let key = vec![0, 0];
@@ -604,8 +478,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_value_splitting2_testing_splitting() {
-        let store = create_test_memory_store_internal();
-        const MAX_LEN: usize = TestMemoryStoreInternal::MAX_VALUE_SIZE;
+        let store = LimitedMemoryStore::new();
+        const MAX_LEN: usize = LimitedMemoryStore::MAX_VALUE_SIZE;
         let big_store = ValueSplittingStore::new(store.clone());
         let key = vec![0, 0];
         // Writing a big value
@@ -641,8 +515,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_value_splitting3_write_and_delete() {
-        let store = create_test_memory_store_internal();
-        const MAX_LEN: usize = TestMemoryStoreInternal::MAX_VALUE_SIZE;
+        let store = LimitedMemoryStore::new();
+        const MAX_LEN: usize = LimitedMemoryStore::MAX_VALUE_SIZE;
         let big_store = ValueSplittingStore::new(store.clone());
         let key = vec![0, 0];
         // writing a big key

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        AdminKeyValueStore, CommonStoreConfig, KeyIterable, KeyValueIterable,
-        KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+        AdminKeyValueStore, CommonStoreConfig, KeyIterable, KeyValueIterable, KeyValueStore,
+        ReadableKeyValueStore, WritableKeyValueStore,
     },
     memory::{MemoryStore, MemoryStoreConfig, MemoryStoreError, TEST_MEMORY_MAX_STREAM_QUERIES},
 };
@@ -441,9 +441,7 @@ mod tests {
     use linera_views::{
         batch::Batch,
         common::{ReadableKeyValueStore, WritableKeyValueStore},
-        value_splitting::{
-            LimitedMemoryStore, ValueSplittingStore,
-        },
+        value_splitting::{LimitedMemoryStore, ValueSplittingStore},
     };
     use rand::Rng;
 

--- a/linera-views/tests/hashable_tests.rs
+++ b/linera-views/tests/hashable_tests.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use linera_views::{
     common::HasherOutput,
     hashable_wrapper::WrappedHashableContainerView,
-    memory::create_memory_context,
+    memory::create_test_memory_context,
     register_view::{HashedRegisterView, RegisterView},
     views::{HashableView, View},
 };
@@ -20,7 +20,7 @@ struct TestType<C> {
 // TODO(#560): Implement the same for CryptoHash
 #[tokio::test]
 async fn check_hashable_container_hash() -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let test = TestType::load(context).await?;
     let hash1 = test.inner.hash().await?;
     let hash2 = test.wrap.hash().await?;
@@ -30,7 +30,7 @@ async fn check_hashable_container_hash() -> Result<()> {
 
 #[tokio::test]
 async fn check_hashable_hash() -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut view = HashedRegisterView::<_, u32>::load(context).await?;
     let hash0 = view.hash().await?;
     let val = view.get_mut();

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -9,7 +9,7 @@ use linera_views::{
     common::Context,
     key_value_store_view::{KeyValueStoreView, SizeData},
     map_view::HashedByteMapView,
-    memory::create_memory_context,
+    memory::create_test_memory_context,
     queue_view::HashedQueueView,
     reentrant_collection_view::HashedReentrantCollectionView,
     register_view::RegisterView,
@@ -42,7 +42,7 @@ where
 
 #[tokio::test]
 async fn classic_collection_view_check() -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut rng = test_utils::make_deterministic_rng();
     let mut map = BTreeMap::<u8, u32>::new();
     let n = 20;
@@ -156,7 +156,7 @@ fn total_size(vec: &Vec<(Vec<u8>, Vec<u8>)>) -> SizeData {
 
 #[tokio::test]
 async fn key_value_store_view_mutability() -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut rng = test_utils::make_deterministic_rng();
     let mut state_map = BTreeMap::new();
     let n = 40;
@@ -255,7 +255,7 @@ pub struct ByteMapStateView<C> {
 }
 
 async fn run_map_view_mutability<R: RngCore + Clone>(rng: &mut R) -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut state_map = BTreeMap::new();
     let mut all_keys = BTreeSet::new();
     let n = 10;
@@ -410,7 +410,7 @@ pub struct QueueStateView<C> {
 
 #[tokio::test]
 async fn queue_view_mutability_check() -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut rng = test_utils::make_deterministic_rng();
     let mut vector = Vec::new();
     let n = 20;
@@ -516,7 +516,7 @@ where
 
 #[tokio::test]
 async fn reentrant_collection_view_check() -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let mut rng = test_utils::make_deterministic_rng();
     let mut map = BTreeMap::<u8, u32>::new();
     let n = 20;

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -5,7 +5,7 @@ use linera_views::{
     batch::Batch,
     common::{ReadableKeyValueStore, WritableKeyValueStore},
     key_value_store_view::ViewContainer,
-    memory::{create_memory_context, create_memory_store},
+    memory::{create_test_memory_context, create_test_memory_store},
     test_utils::{
         self, get_random_test_scenarios, run_big_write_read, run_reads, run_writes_from_blank,
         run_writes_from_state,
@@ -29,7 +29,7 @@ async fn test_reads_test_memory() {
 #[tokio::test]
 async fn test_reads_memory() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_memory_store();
+        let key_value_store = create_test_memory_store();
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -73,7 +73,7 @@ async fn test_reads_indexed_db() {
 #[tokio::test]
 async fn test_reads_key_value_store_view_memory() {
     for scenario in get_random_test_scenarios() {
-        let context = create_memory_context();
+        let context = create_test_memory_context();
         let key_value_store = ViewContainer::new(context).await.unwrap();
         run_reads(key_value_store, scenario).await;
     }
@@ -81,7 +81,7 @@ async fn test_reads_key_value_store_view_memory() {
 
 #[tokio::test]
 async fn test_specific_reads_memory() {
-    let key_value_store = create_memory_store();
+    let key_value_store = create_test_memory_store();
     let key_values = vec![
         (vec![0, 1, 255], Vec::new()),
         (vec![0, 1, 255, 37], Vec::new()),
@@ -99,13 +99,13 @@ async fn test_test_memory_writes_from_blank() {
 
 #[tokio::test]
 async fn test_memory_writes_from_blank() {
-    let key_value_store = create_memory_store();
+    let key_value_store = create_test_memory_store();
     run_writes_from_blank(&key_value_store).await;
 }
 
 #[tokio::test]
 async fn test_key_value_store_view_memory_writes_from_blank() {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     let key_value_store = ViewContainer::new(context).await.unwrap();
     run_writes_from_blank(&key_value_store).await;
 }
@@ -141,7 +141,7 @@ async fn test_indexed_db_writes_from_blank() {
 #[tokio::test]
 async fn test_big_value_read_write() {
     use rand::{distributions::Alphanumeric, Rng};
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     for count in [50, 1024] {
         let rng = test_utils::make_deterministic_rng();
         let test_string = rng
@@ -181,7 +181,7 @@ async fn test_scylla_db_big_write_read() {
 
 #[tokio::test]
 async fn test_memory_big_write_read() {
-    let key_value_store = linera_views::memory::create_memory_store();
+    let key_value_store = linera_views::memory::create_test_memory_store();
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
@@ -216,7 +216,7 @@ async fn test_dynamo_db_big_write_read() {
 
 #[tokio::test]
 async fn test_memory_writes_from_state() {
-    let key_value_store = create_memory_store();
+    let key_value_store = create_test_memory_store();
     run_writes_from_state(&key_value_store).await;
 }
 

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -10,7 +10,7 @@ use linera_views::{
         self, get_random_test_scenarios, run_big_write_read, run_reads, run_writes_from_blank,
         run_writes_from_state,
     },
-    value_splitting::create_test_memory_store,
+    value_splitting::create_value_splitting_memory_store,
 };
 #[cfg(web)]
 use wasm_bindgen_test::wasm_bindgen_test;
@@ -21,7 +21,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[tokio::test]
 async fn test_reads_test_memory() {
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_test_memory_store();
+        let key_value_store = create_value_splitting_memory_store();
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -93,7 +93,7 @@ async fn test_specific_reads_memory() {
 
 #[tokio::test]
 async fn test_test_memory_writes_from_blank() {
-    let key_value_store = create_test_memory_store();
+    let key_value_store = create_value_splitting_memory_store();
     run_writes_from_blank(&key_value_store).await;
 }
 

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -25,7 +25,7 @@ use linera_views::{
     lru_caching::{LruCachingMemoryContext, LruCachingStore},
     map_view::{ByteMapView, HashedMapView},
     memory::{
-        create_memory_context, MemoryContext, MemoryStore, MemoryStoreMap,
+        create_test_memory_context, MemoryContext, MemoryStore, MemoryStoreMap,
         TEST_MEMORY_MAX_STREAM_QUERIES,
     },
     queue_view::HashedQueueView,
@@ -708,7 +708,7 @@ pub struct ByteMapStateView<C> {
 
 #[tokio::test]
 async fn test_byte_map_view() -> Result<()> {
-    let context = create_memory_context();
+    let context = create_test_memory_context();
     {
         let mut view = ByteMapStateView::load(context.clone()).await?;
         view.map.insert(vec![0, 1], 5);
@@ -909,7 +909,7 @@ async fn test_collection_removal() -> Result<()> {
     type EntryType = HashedRegisterView<MemoryContext<()>, u8>;
     type CollectionViewType = HashedCollectionView<MemoryContext<()>, u8, EntryType>;
 
-    let context = create_memory_context();
+    let context = create_test_memory_context();
 
     // Write a dummy entry into the collection.
     let mut collection = CollectionViewType::load(context.clone()).await?;
@@ -940,7 +940,7 @@ async fn test_removal_api_first_second_condition(
     type EntryType = HashedRegisterView<MemoryContext<()>, u8>;
     type CollectionViewType = HashedCollectionView<MemoryContext<()>, u8, EntryType>;
 
-    let context = create_memory_context();
+    let context = create_test_memory_context();
 
     // First add an entry `1` with value `100` and commit
     let mut collection: CollectionViewType = HashedCollectionView::load(context.clone()).await?;


### PR DESCRIPTION
## Motivation

The work on the global memory store revealed some issues with the memory context/store. They are here addressed separately.

## Proposal

The following was done:
* Renaming `TestMemoryStoreInternal` as `LimitedMemoryStore`.
* Eliminate `TestMemoryStore`.
* Rename `create_memory_store` as `create_test_memory_store` and same for `context`.
* Put `create_test_memory_context/store` under a `#[cfg(with_testing)]` which forces some changes in two `Cargo.toml` files.

## Test Plan

CI.

## Release Plan
Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
