### PR TITLE
Blob->BlobContent HashedBlob->Blob

### DIFF
--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     bcs_scalar,
     crypto::{BcsHashable, CryptoError, CryptoHash, PublicKey},
-    data_types::{Blob, BlockHeight},
+    data_types::{BlobContent, BlockHeight},
     doc_scalar,
 };
 
@@ -188,7 +188,7 @@ impl FromStr for BlobType {
     }
 }
 
-/// A content-addressed blob ID i.e. the hash of the Blob.
+/// A content-addressed blob ID i.e. the hash of the `BlobContent`.
 #[derive(
     Eq,
     PartialEq,
@@ -213,10 +213,10 @@ pub struct BlobId {
 }
 
 impl BlobId {
-    /// Creates a new `BlobId` from a `Blob`
-    pub fn new_data(blob: &Blob) -> Self {
+    /// Creates a new `BlobId` from a `BlobContent`
+    pub fn new_data(blob_payload: &BlobContent) -> Self {
         BlobId {
-            hash: CryptoHash::new(blob),
+            hash: CryptoHash::new(blob_payload),
             blob_type: BlobType::Data,
         }
     }
@@ -956,7 +956,7 @@ doc_scalar!(AccountOwner, "An owner of an account.");
 doc_scalar!(Account, "An account");
 doc_scalar!(
     BlobId,
-    "A content-addressed blob ID i.e. the hash of the Blob"
+    "A content-addressed blob ID i.e. the hash of the `BlobContent`"
 );
 
 #[cfg(test)]

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, collections::HashSet};
 use async_graphql::SimpleObject;
 use linera_base::{
     crypto::{BcsHashable, BcsSignable, CryptoError, CryptoHash, KeyPair, PublicKey, Signature},
-    data_types::{Amount, BlockHeight, HashedBlob, OracleResponse, Round, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
     doc_scalar, ensure,
     identifiers::{
         Account, BlobId, ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner,
@@ -219,7 +219,7 @@ pub struct BlockProposal {
     pub owner: Owner,
     pub signature: Signature,
     pub hashed_certificate_values: Vec<HashedCertificateValue>,
-    pub hashed_blobs: Vec<HashedBlob>,
+    pub blobs: Vec<Blob>,
     pub validated_block_certificate: Option<LiteCertificate<'static>>,
 }
 
@@ -867,7 +867,7 @@ impl BlockProposal {
         block: Block,
         secret: &KeyPair,
         hashed_certificate_values: Vec<HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
     ) -> Self {
         let content = ProposalContent {
             round,
@@ -880,7 +880,7 @@ impl BlockProposal {
             owner: secret.public().into(),
             signature,
             hashed_certificate_values,
-            hashed_blobs,
+            blobs,
             validated_block_certificate: None,
         }
     }
@@ -890,7 +890,7 @@ impl BlockProposal {
         validated_block_certificate: Certificate,
         secret: &KeyPair,
         hashed_certificate_values: Vec<HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
     ) -> Self {
         let lite_cert = validated_block_certificate.lite_certificate().cloned();
         let CertificateValue::ValidatedBlock { executed_block } =
@@ -909,7 +909,7 @@ impl BlockProposal {
             owner: secret.public().into(),
             signature,
             hashed_certificate_values,
-            hashed_blobs,
+            blobs,
             validated_block_certificate: Some(lite_cert),
         }
     }

--- a/linera-chain/src/manager.rs
+++ b/linera-chain/src/manager.rs
@@ -72,7 +72,7 @@ use std::collections::BTreeMap;
 
 use linera_base::{
     crypto::{KeyPair, PublicKey},
-    data_types::{ArithmeticError, BlockHeight, HashedBlob, Round, Timestamp},
+    data_types::{ArithmeticError, Blob, BlockHeight, Round, Timestamp},
     doc_scalar, ensure,
     identifiers::{BlobId, ChainId, Owner},
     ownership::ChainOwnership,
@@ -135,7 +135,7 @@ pub struct ChainManager {
     /// The owners that take over in fallback mode.
     pub fallback_owners: BTreeMap<Owner, (PublicKey, u64)>,
     /// These are blobs belonging to proposed or validated blocks that have not been confirmed yet.
-    pub pending_blobs: BTreeMap<BlobId, HashedBlob>,
+    pub pending_blobs: BTreeMap<BlobId, Blob>,
 }
 
 doc_scalar!(
@@ -398,8 +398,8 @@ impl ChainManager {
             }
         }
 
-        for hashed_blob in proposal.hashed_blobs {
-            self.pending_blobs.insert(hashed_blob.id(), hashed_blob);
+        for blob in proposal.blobs {
+            self.pending_blobs.insert(blob.id(), blob);
         }
 
         if let Some(key_pair) = key_pair {
@@ -580,7 +580,7 @@ pub struct ChainManagerInfo {
     /// The timestamp when the current round times out.
     pub round_timeout: Option<Timestamp>,
     /// These are blobs belonging to proposed or validated blocks that have not been confirmed yet.
-    pub pending_blobs: BTreeMap<BlobId, HashedBlob>,
+    pub pending_blobs: BTreeMap<BlobId, Blob>,
 }
 
 impl From<&ChainManager> for ChainManagerInfo {

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -14,7 +14,7 @@ use colored::Colorize;
 use futures::Future;
 use linera_base::{
     crypto::KeyPair,
-    data_types::{BlockHeight, HashedBlob, Timestamp},
+    data_types::{Blob, BlockHeight, Timestamp},
     identifiers::{Account, BlobId, BytecodeId, ChainId},
     ownership::ChainOwnership,
 };
@@ -328,7 +328,7 @@ where
         blob_path: PathBuf,
     ) -> anyhow::Result<BlobId> {
         info!("Loading data blob file");
-        let blob = HashedBlob::load_data_blob_from_file(&blob_path)
+        let blob = Blob::load_data_blob_from_file(&blob_path)
             .await
             .context(format!("failed to load data blob from {:?}", &blob_path))?;
         let blob_id = blob.id();

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Context as _;
 use linera_base::{
     crypto::{CryptoHash, CryptoRng, KeyPair, PublicKey},
-    data_types::{BlockHeight, HashedBlob, Timestamp},
+    data_types::{Blob, BlockHeight, Timestamp},
     identifiers::{BlobId, ChainDescription, ChainId},
 };
 use linera_chain::data_types::Block;
@@ -211,7 +211,7 @@ pub struct UserChain {
     pub timestamp: Timestamp,
     pub next_block_height: BlockHeight,
     pub pending_block: Option<Block>,
-    pub pending_blobs: BTreeMap<BlobId, HashedBlob>,
+    pub pending_blobs: BTreeMap<BlobId, Blob>,
 }
 
 impl UserChain {

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -10,7 +10,7 @@ use std::{
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, HashedBlob, Timestamp},
+    data_types::{Blob, BlockHeight, Timestamp},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -114,7 +114,7 @@ where
     ProcessValidatedBlock {
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions, bool), WorkerError>>,
     },
 
@@ -122,7 +122,7 @@ where
     ProcessConfirmedBlock {
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
         callback: oneshot::Sender<Result<(ChainInfoResponse, NetworkActions), WorkerError>>,
     },
 
@@ -167,7 +167,7 @@ where
         config: ChainWorkerConfig,
         storage: StorageClient,
         certificate_value_cache: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
-        blob_cache: Arc<ValueCache<BlobId, HashedBlob>>,
+        blob_cache: Arc<ValueCache<BlobId, Blob>>,
         chain_id: ChainId,
     ) -> Result<Self, WorkerError> {
         let (service_runtime_thread, execution_state_receiver, runtime_request_sender) =
@@ -290,7 +290,7 @@ where
                 ChainWorkerRequest::ProcessValidatedBlock {
                     certificate,
                     hashed_certificate_values,
-                    hashed_blobs,
+                    blobs,
                     callback,
                 } => callback
                     .send(
@@ -298,7 +298,7 @@ where
                             .process_validated_block(
                                 certificate,
                                 &hashed_certificate_values,
-                                &hashed_blobs,
+                                &blobs,
                             )
                             .await,
                     )
@@ -306,7 +306,7 @@ where
                 ChainWorkerRequest::ProcessConfirmedBlock {
                     certificate,
                     hashed_certificate_values,
-                    hashed_blobs,
+                    blobs,
                     callback,
                 } => callback
                     .send(
@@ -314,7 +314,7 @@ where
                             .process_confirmed_block(
                                 certificate,
                                 &hashed_certificate_values,
-                                &hashed_blobs,
+                                &blobs,
                             )
                             .await,
                     )
@@ -435,24 +435,24 @@ where
             ChainWorkerRequest::ProcessValidatedBlock {
                 certificate,
                 hashed_certificate_values,
-                hashed_blobs,
+                blobs,
                 callback: _callback,
             } => formatter
                 .debug_struct("ChainWorkerRequest::ProcessValidatedBlock")
                 .field("certificate", &certificate)
                 .field("hashed_certificate_values", &hashed_certificate_values)
-                .field("hashed_blobs", &hashed_blobs)
+                .field("blobs", &blobs)
                 .finish_non_exhaustive(),
             ChainWorkerRequest::ProcessConfirmedBlock {
                 certificate,
                 hashed_certificate_values,
-                hashed_blobs,
+                blobs,
                 callback: _callback,
             } => formatter
                 .debug_struct("ChainWorkerRequest::ProcessConfirmedBlock")
                 .field("certificate", &certificate)
                 .field("hashed_certificate_values", &hashed_certificate_values)
-                .field("hashed_blobs", &hashed_blobs)
+                .field("blobs", &blobs)
                 .finish_non_exhaustive(),
             ChainWorkerRequest::ProcessCrossChainUpdate {
                 origin,

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -177,7 +177,7 @@ where
                 },
             owner,
             hashed_certificate_values,
-            hashed_blobs,
+            blobs,
             validated_block_certificate,
             signature: _,
         } = proposal;
@@ -232,7 +232,7 @@ where
                 block,
                 block.published_blob_ids(),
                 hashed_certificate_values,
-                hashed_blobs,
+                blobs,
             )
             .await?;
         // Write the values so that the bytecode is available during execution.

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -5,7 +5,7 @@
 use futures::stream::{BoxStream, LocalBoxStream, Stream};
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
-    data_types::{ArithmeticError, Blob, BlockHeight, HashedBlob},
+    data_types::{ArithmeticError, Blob, BlobContent, BlockHeight},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::{
@@ -62,7 +62,7 @@ pub trait LocalValidatorNode {
         &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError>;
 
@@ -81,7 +81,7 @@ pub trait LocalValidatorNode {
     /// Subscribes to receiving notifications for a collection of chains.
     async fn subscribe(&self, chains: Vec<ChainId>) -> Result<Self::NotificationStream, NodeError>;
 
-    async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError>;
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError>;
 
     async fn download_certificate_value(
         &self,

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1513,7 +1513,7 @@ where
         )
         .await?;
 
-    let blob0 = HashedBlob::test_data_blob("blob0");
+    let blob0 = Blob::test_data_blob("blob0");
     let blob0_id = blob0.id();
 
     // Try to read a blob without publishing it first, should fail
@@ -1560,7 +1560,7 @@ where
         .await;
 
     client2_a.synchronize_from_validators().await.unwrap();
-    let blob1 = HashedBlob::test_data_blob("blob1");
+    let blob1 = Blob::test_data_blob("blob1");
     let blob1_id = blob1.id();
 
     client2_a.add_pending_blobs(&[blob1]).await;
@@ -1681,7 +1681,7 @@ where
     // Take one validator down
     builder.set_fault_type([3], FaultType::Offline).await;
 
-    let blob0 = HashedBlob::test_data_blob("blob0");
+    let blob0 = Blob::test_data_blob("blob0");
     let blob0_id = blob0.id();
 
     // Publish blob on chain 1
@@ -1697,7 +1697,7 @@ where
         .await;
 
     client2_a.synchronize_from_validators().await.unwrap();
-    let blob1 = HashedBlob::test_data_blob("blob1");
+    let blob1 = Blob::test_data_blob("blob1");
     let blob1_id = blob1.id();
 
     client2_a.add_pending_blobs(&[blob1]).await;
@@ -1828,7 +1828,7 @@ where
     // Take one validator down
     builder.set_fault_type([3], FaultType::Offline).await;
 
-    let blob0 = HashedBlob::test_data_blob("blob0");
+    let blob0 = Blob::test_data_blob("blob0");
     let blob0_id = blob0.id();
 
     client1.synchronize_from_validators().await.unwrap();
@@ -1840,7 +1840,7 @@ where
         .unwrap()
         .requires_blob(&blob0_id));
 
-    let blob2 = HashedBlob::test_data_blob("blob2");
+    let blob2 = Blob::test_data_blob("blob2");
     let blob2_id = blob2.id();
 
     client2.synchronize_from_validators().await.unwrap();
@@ -1860,7 +1860,7 @@ where
         .await;
 
     client3_a.synchronize_from_validators().await.unwrap();
-    let blob1 = HashedBlob::test_data_blob("blob1");
+    let blob1 = Blob::test_data_blob("blob1");
     let blob1_id = blob1.id();
 
     client3_a.add_pending_blobs(&[blob1]).await;
@@ -1934,7 +1934,7 @@ where
         .await;
 
     client3_b.synchronize_from_validators().await.unwrap();
-    let blob3 = HashedBlob::test_data_blob("blob3");
+    let blob3 = Blob::test_data_blob("blob3");
     let blob3_id = blob3.id();
 
     client3_b.add_pending_blobs(&[blob3]).await;
@@ -2231,9 +2231,7 @@ where
         .manager;
     assert!(manager.requested_proposed.is_some());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
-    let result = client1
-        .publish_blob(HashedBlob::test_data_blob("blob1"))
-        .await;
+    let result = client1.publish_blob(Blob::test_data_blob("blob1")).await;
     assert!(result.is_err());
     assert!(client1.pending_block().is_some());
     assert!(!client1.pending_blobs().is_empty());

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, collections::BTreeSet};
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{BlockHeight, HashedBlob, Timestamp},
+    data_types::{Blob, BlockHeight, Timestamp},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{
@@ -38,11 +38,11 @@ async fn test_insert_single_certificate_value() {
     assert_eq!(cache.keys::<BTreeSet<_>>().await, BTreeSet::from([hash]));
 }
 
-/// Tests inserting a hashed blob in the cache.
+/// Tests inserting a blob in the cache.
 #[tokio::test]
-async fn test_insert_single_hashed_blob() {
-    let cache = ValueCache::<BlobId, HashedBlob>::default();
-    let value = create_dummy_hashed_blob(0);
+async fn test_insert_single_blob() {
+    let cache = ValueCache::<BlobId, Blob>::default();
+    let value = create_dummy_blob(0);
     let blob_id = value.id();
 
     assert!(cache.insert(Cow::Borrowed(&value)).await);
@@ -73,11 +73,11 @@ async fn test_insert_many_certificate_values_individually() {
     );
 }
 
-/// Tests inserting many hashed blobs in the cache, one-by-one.
+/// Tests inserting many blobs in the cache, one-by-one.
 #[tokio::test]
-async fn test_insert_many_hashed_blobs_individually() {
-    let cache = ValueCache::<BlobId, HashedBlob>::default();
-    let blobs = create_dummy_hashed_blobs();
+async fn test_insert_many_blobs_individually() {
+    let cache = ValueCache::<BlobId, Blob>::default();
+    let blobs = create_dummy_blobs();
 
     for blob in &blobs {
         assert!(cache.insert(Cow::Borrowed(blob)).await);
@@ -90,7 +90,7 @@ async fn test_insert_many_hashed_blobs_individually() {
 
     assert_eq!(
         cache.keys::<BTreeSet<_>>().await,
-        BTreeSet::from_iter(blobs.iter().map(HashedBlob::id))
+        BTreeSet::from_iter(blobs.iter().map(Blob::id))
     );
 }
 
@@ -507,11 +507,11 @@ where
     heights.into_iter().map(create_dummy_certificate_value)
 }
 
-/// Creates multiple dummy [`HashedBlob`]s to use in the tests.
-fn create_dummy_hashed_blobs() -> Vec<HashedBlob> {
+/// Creates multiple dummy [`Blob`]s to use in the tests.
+fn create_dummy_blobs() -> Vec<Blob> {
     let mut blobs = Vec::new();
     for i in 0..DEFAULT_VALUE_CACHE_SIZE {
-        blobs.push(create_dummy_hashed_blob(i));
+        blobs.push(create_dummy_blob(i));
     }
     blobs
 }
@@ -526,9 +526,9 @@ fn create_dummy_certificate_value(height: impl Into<BlockHeight>) -> HashedCerti
     .into()
 }
 
-/// Creates a new dummy [`HashedBlob`] to use in the tests.
-fn create_dummy_hashed_blob(id: usize) -> HashedBlob {
-    HashedBlob::test_data_blob(&format!("test{}", id))
+/// Creates a new dummy [`Blob`] to use in the tests.
+fn create_dummy_blob(id: usize) -> Blob {
+    Blob::test_data_blob(&format!("test{}", id))
 }
 
 /// Creates a dummy [`HashedCertificateValue::ValidatedBlock`] to use in the tests.

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -19,7 +19,7 @@ use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, HashedBlob, OracleResponse},
+    data_types::{Amount, Blob, OracleResponse},
     identifiers::{
         AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner, StreamId,
         StreamName,
@@ -118,7 +118,7 @@ where
     let (contract_path, service_path) =
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
 
-    let contract_blob = HashedBlob::load_data_blob_from_file(contract_path.clone()).await?;
+    let contract_blob = Blob::load_data_blob_from_file(contract_path.clone()).await?;
     let expected_contract_blob_id = contract_blob.id();
     let certificate = publisher
         .publish_blob(contract_blob.clone())
@@ -134,7 +134,7 @@ where
         .iter()
         .any(|responses| responses.contains(&OracleResponse::Blob(expected_contract_blob_id))));
 
-    let service_blob = HashedBlob::load_data_blob_from_file(service_path.clone()).await?;
+    let service_blob = Blob::load_data_blob_from_file(service_path.clone()).await?;
     let expected_service_blob_id = service_blob.id();
     let certificate = publisher.publish_blob(service_blob).await.unwrap().unwrap();
     assert!(certificate

--- a/linera-core/src/value_cache.rs
+++ b/linera-core/src/value_cache.rs
@@ -11,7 +11,7 @@ mod unit_tests;
 use std::{any::type_name, sync::LazyLock};
 use std::{borrow::Cow, hash::Hash, num::NonZeroUsize};
 
-use linera_base::{crypto::CryptoHash, data_types::HashedBlob, identifiers::BlobId};
+use linera_base::{crypto::CryptoHash, data_types::Blob, identifiers::BlobId};
 use linera_chain::data_types::{Certificate, HashedCertificateValue, LiteCertificate};
 use lru::LruCache;
 use tokio::sync::Mutex;
@@ -236,14 +236,14 @@ impl ValueCache<CryptoHash, HashedCertificateValue> {
     }
 }
 
-impl ValueCache<BlobId, HashedBlob> {
-    /// Inserts a [`HashedBlob`] into the cache, if it's not already present.
+impl ValueCache<BlobId, Blob> {
+    /// Inserts a [`Blob`] into the cache, if it's not already present.
     ///
     /// The `value` is wrapped in a [`Cow`] so that it is only cloned if it needs to be
     /// inserted in the cache.
     ///
     /// Returns [`true`] if the value was not already present in the cache.
-    pub async fn insert<'a>(&self, value: Cow<'a, HashedBlob>) -> bool {
+    pub async fn insert<'a>(&self, value: Cow<'a, Blob>) -> bool {
         let blob_id = (*value).id();
         let mut cache = self.cache.lock().await;
         if cache.contains(&blob_id) {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -11,7 +11,7 @@ use futures::channel::mpsc;
 #[cfg(with_metrics)]
 use linera_base::prometheus_util::{self, MeasureLatency as _};
 use linera_base::{
-    data_types::{Amount, ApplicationPermissions, Blob, Timestamp},
+    data_types::{Amount, ApplicationPermissions, BlobContent, Timestamp},
     identifiers::{Account, BlobId, MessageId, Owner},
     ownership::ChainOwnership,
 };
@@ -443,7 +443,7 @@ pub enum ExecutionRequest {
 
     ReadBlob {
         blob_id: BlobId,
-        callback: Sender<Blob>,
+        callback: Sender<BlobContent>,
     },
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -31,7 +31,7 @@ use linera_base::{
     abi::Abi,
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Resources,
+        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, Resources,
         SendMessageRequest, Timestamp,
     },
     doc_scalar, hex_debug,
@@ -257,7 +257,7 @@ pub trait ExecutionRuntimeContext {
         description: &UserApplicationDescription,
     ) -> Result<UserServiceCode, ExecutionError>;
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ExecutionError>;
+    async fn get_blob(&self, blob_id: BlobId) -> Result<BlobContent, ExecutionError>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -491,7 +491,7 @@ pub trait BaseRuntime {
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError>;
 
     /// Reads a blob specified by a given `BlobId`.
-    fn read_blob(&mut self, blob_id: &BlobId) -> Result<Blob, ExecutionError>;
+    fn read_blob(&mut self, blob_id: &BlobId) -> Result<BlobContent, ExecutionError>;
 }
 
 pub trait ServiceRuntime: BaseRuntime {
@@ -850,7 +850,7 @@ pub struct TestExecutionRuntimeContext {
     execution_runtime_config: ExecutionRuntimeConfig,
     user_contracts: Arc<DashMap<UserApplicationId, UserContractCode>>,
     user_services: Arc<DashMap<UserApplicationId, UserServiceCode>>,
-    blobs: Arc<DashMap<BlobId, Blob>>,
+    blobs: Arc<DashMap<BlobId, BlobContent>>,
 }
 
 #[cfg(with_testing)]
@@ -913,7 +913,7 @@ impl ExecutionRuntimeContext for TestExecutionRuntimeContext {
             .clone())
     }
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ExecutionError> {
+    async fn get_blob(&self, blob_id: BlobId) -> Result<BlobContent, ExecutionError> {
         Ok(self
             .blobs
             .get(&blob_id)

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -12,7 +12,7 @@ use std::{
 use custom_debug_derive::Debug;
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, OracleResponse,
+        Amount, ApplicationPermissions, ArithmeticError, BlobContent, BlockHeight, OracleResponse,
         Resources, SendMessageRequest, Timestamp,
     },
     ensure,
@@ -712,7 +712,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().assert_before(timestamp)
     }
 
-    fn read_blob(&mut self, blob_id: &BlobId) -> Result<Blob, ExecutionError> {
+    fn read_blob(&mut self, blob_id: &BlobId) -> Result<BlobContent, ExecutionError> {
         self.inner().read_blob(blob_id)
     }
 }
@@ -1013,7 +1013,7 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         Ok(())
     }
 
-    fn read_blob(&mut self, blob_id: &BlobId) -> Result<Blob, ExecutionError> {
+    fn read_blob(&mut self, blob_id: &BlobId) -> Result<BlobContent, ExecutionError> {
         if let Some(responses) = &mut self.replaying_oracle_responses {
             match responses.next() {
                 Some(OracleResponse::Blob(oracle_blob_id)) if oracle_blob_id == *blob_id => {}

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -15,7 +15,7 @@ use custom_debug_derive::Debug;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, OracleResponse, Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, BlobContent, OracleResponse, Timestamp,
     },
     ensure, hex_debug,
     identifiers::{Account, BlobId, BytecodeId, ChainDescription, ChainId, MessageId, Owner},
@@ -1050,7 +1050,10 @@ where
         Ok(messages)
     }
 
-    pub async fn read_blob(&mut self, blob_id: BlobId) -> Result<Blob, SystemExecutionError> {
+    pub async fn read_blob(
+        &mut self,
+        blob_id: BlobId,
+    ) -> Result<BlobContent, SystemExecutionError> {
         self.context()
             .extra()
             .get_blob(blob_id)

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -5,7 +5,7 @@ use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlockHeight, SendMessageRequest, Timestamp,
+        Amount, ApplicationPermissions, BlobContent, BlockHeight, SendMessageRequest, Timestamp,
     },
     identifiers::{
         Account, ApplicationId, BlobId, ChainId, ChannelName, MessageId, Owner, StreamName,
@@ -357,7 +357,7 @@ where
     }
 
     /// Reads a blob from storage.
-    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<Blob, RuntimeError> {
+    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<BlobContent, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
@@ -531,7 +531,7 @@ where
     }
 
     /// Reads a blob from storage.
-    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<Blob, RuntimeError> {
+    fn read_blob(caller: &mut Caller, blob_id: BlobId) -> Result<BlobContent, RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -56,7 +56,7 @@ service ValidatorNode {
   rpc GetGenesisConfigHash(google.protobuf.Empty) returns (CryptoHash);
 
   // Downloads a blob.
-  rpc DownloadBlob(BlobId) returns (Blob);
+  rpc DownloadBlob(BlobId) returns (BlobContent);
 
   // Downloads a certificate value.
   rpc DownloadCertificateValue(CryptoHash) returns (CertificateValue);
@@ -260,13 +260,13 @@ message Signature {
   bytes bytes = 1;
 }
 
-// A content-addressed blob ID i.e. the hash of the Blob.
+// A content-addressed blob ID i.e. the hash of the `BlobContent`.
 message BlobId {
   bytes bytes = 1;
 }
 
 // A blob of binary data.
-message Blob {
+message BlobContent {
   bytes bytes = 1;
 }
 

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -3,7 +3,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, HashedBlob},
+    data_types::{Blob, BlobContent},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{
@@ -84,30 +84,20 @@ impl ValidatorNode for Client {
         &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         match self {
             Client::Grpc(grpc_client) => {
                 grpc_client
-                    .handle_certificate(
-                        certificate,
-                        hashed_certificate_values,
-                        hashed_blobs,
-                        delivery,
-                    )
+                    .handle_certificate(certificate, hashed_certificate_values, blobs, delivery)
                     .await
             }
 
             #[cfg(with_simple_network)]
             Client::Simple(simple_client) => {
                 simple_client
-                    .handle_certificate(
-                        certificate,
-                        hashed_certificate_values,
-                        hashed_blobs,
-                        delivery,
-                    )
+                    .handle_certificate(certificate, hashed_certificate_values, blobs, delivery)
                     .await
             }
         }
@@ -152,7 +142,7 @@ impl ValidatorNode for Client {
         })
     }
 
-    async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         Ok(match self {
             Client::Grpc(grpc_client) => grpc_client.download_blob(blob_id).await?,
 

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -6,7 +6,7 @@ use std::{iter, time::Duration};
 use futures::{future, stream, StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, HashedBlob},
+    data_types::{Blob, BlobContent},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{self, Certificate, CertificateValue, HashedCertificateValue};
@@ -168,14 +168,14 @@ impl ValidatorNode for GrpcClient {
         &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<data_types::HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<linera_core::data_types::ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
             hashed_certificate_values,
-            hashed_blobs,
+            blobs,
             wait_for_outgoing_messages,
         };
         client_delegate!(self, handle_certificate, request)
@@ -282,7 +282,7 @@ impl ValidatorNode for GrpcClient {
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]
-    async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         Ok(self
             .client
             .clone()

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -3,7 +3,7 @@
 
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey, Signature},
-    data_types::{Blob, BlockHeight},
+    data_types::{BlobContent, BlockHeight},
     ensure,
     identifiers::{BlobId, ChainId, Owner},
 };
@@ -182,7 +182,7 @@ impl TryFrom<BlockProposal> for api::BlockProposal {
             hashed_certificate_values: bincode::serialize(
                 &block_proposal.hashed_certificate_values,
             )?,
-            blobs: bincode::serialize(&block_proposal.hashed_blobs)?,
+            blobs: bincode::serialize(&block_proposal.blobs)?,
             validated_block_certificate: block_proposal
                 .validated_block_certificate
                 .map(|cert| bincode::serialize(&cert))
@@ -207,7 +207,7 @@ impl TryFrom<api::BlockProposal> for BlockProposal {
             hashed_certificate_values: bincode::deserialize(
                 &block_proposal.hashed_certificate_values,
             )?,
-            hashed_blobs: bincode::deserialize(&block_proposal.blobs)?,
+            blobs: bincode::deserialize(&block_proposal.blobs)?,
             validated_block_certificate: block_proposal
                 .validated_block_certificate
                 .map(|bytes| bincode::deserialize(&bytes))
@@ -328,7 +328,7 @@ impl TryFrom<api::HandleCertificateRequest> for HandleCertificateRequest {
             certificate: certificate.try_into()?,
             wait_for_outgoing_messages: cert_request.wait_for_outgoing_messages,
             hashed_certificate_values: values,
-            hashed_blobs: blobs,
+            blobs,
         })
     }
 }
@@ -341,7 +341,7 @@ impl TryFrom<HandleCertificateRequest> for api::HandleCertificateRequest {
             chain_id: Some(request.certificate.value().chain_id().into()),
             certificate: Some(request.certificate.try_into()?),
             hashed_certificate_values: bincode::serialize(&request.hashed_certificate_values)?,
-            blobs: bincode::serialize(&request.hashed_blobs)?,
+            blobs: bincode::serialize(&request.blobs)?,
             wait_for_outgoing_messages: request.wait_for_outgoing_messages,
         })
     }
@@ -568,14 +568,14 @@ impl TryFrom<api::CryptoHash> for CryptoHash {
     }
 }
 
-impl From<Blob> for api::Blob {
-    fn from(blob: Blob) -> Self {
+impl From<BlobContent> for api::BlobContent {
+    fn from(blob: BlobContent) -> Self {
         Self { bytes: blob.bytes }
     }
 }
 
-impl From<api::Blob> for Blob {
-    fn from(blob: api::Blob) -> Self {
+impl From<api::BlobContent> for BlobContent {
+    fn from(blob: api::BlobContent) -> Self {
         Self { bytes: blob.bytes }
     }
 }
@@ -802,7 +802,7 @@ pub mod tests {
         let request = HandleCertificateRequest {
             certificate,
             hashed_certificate_values: values,
-            hashed_blobs: vec![],
+            blobs: vec![],
             wait_for_outgoing_messages: false,
         };
 
@@ -866,7 +866,7 @@ pub mod tests {
                 }
                 .with(get_block()),
             )],
-            hashed_blobs: vec![],
+            blobs: vec![],
             validated_block_certificate: Some(cert),
         };
 

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -523,14 +523,14 @@ where
         let HandleCertificateRequest {
             certificate,
             hashed_certificate_values,
-            hashed_blobs,
+            blobs,
             wait_for_outgoing_messages,
         } = request.into_inner().try_into()?;
         let (sender, receiver) = wait_for_outgoing_messages.then(oneshot::channel).unzip();
         match self
             .state
             .clone()
-            .handle_certificate(certificate, hashed_certificate_values, hashed_blobs, sender)
+            .handle_certificate(certificate, hashed_certificate_values, blobs, sender)
             .await
         {
             Ok((info, actions)) => {

--- a/linera-rpc/src/lib.rs
+++ b/linera-rpc/src/lib.rs
@@ -37,7 +37,7 @@ pub struct HandleCertificateRequest {
     pub certificate: linera_chain::data_types::Certificate,
     pub wait_for_outgoing_messages: bool,
     pub hashed_certificate_values: Vec<linera_chain::data_types::HashedCertificateValue>,
-    pub hashed_blobs: Vec<linera_base::data_types::HashedBlob>,
+    pub blobs: Vec<linera_base::data_types::Blob>,
 }
 
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("file_descriptor_set");

--- a/linera-rpc/src/message.rs
+++ b/linera-rpc/src/message.rs
@@ -4,7 +4,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::Blob,
+    data_types::BlobContent,
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{BlockProposal, Certificate, CertificateValue, LiteVote};
@@ -38,7 +38,7 @@ pub enum RpcMessage {
     Error(Box<NodeError>),
     VersionInfoResponse(Box<VersionInfo>),
     GenesisConfigHashResponse(Box<CryptoHash>),
-    DownloadBlobResponse(Box<Blob>),
+    DownloadBlobResponse(Box<BlobContent>),
     DownloadCertificateValueResponse(Box<CertificateValue>),
     DownloadCertificateResponse(Box<Certificate>),
     BlobLastUsedByResponse(Box<CryptoHash>),
@@ -136,7 +136,7 @@ impl TryFrom<RpcMessage> for VersionInfo {
     }
 }
 
-impl TryFrom<RpcMessage> for Blob {
+impl TryFrom<RpcMessage> for BlobContent {
     type Error = NodeError;
     fn try_from(message: RpcMessage) -> Result<Self, Self::Error> {
         use RpcMessage::*;
@@ -239,8 +239,8 @@ impl From<VersionInfo> for RpcMessage {
     }
 }
 
-impl From<Blob> for RpcMessage {
-    fn from(blob: Blob) -> Self {
+impl From<BlobContent> for RpcMessage {
+    fn from(blob: BlobContent) -> Self {
         RpcMessage::DownloadBlobResponse(Box::new(blob))
     }
 }

--- a/linera-rpc/src/simple/client.rs
+++ b/linera-rpc/src/simple/client.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use futures::{sink::SinkExt, stream::StreamExt};
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Blob, HashedBlob},
+    data_types::{Blob, BlobContent},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{
@@ -101,14 +101,14 @@ impl ValidatorNode for SimpleClient {
         &self,
         certificate: Certificate,
         hashed_certificate_values: Vec<HashedCertificateValue>,
-        hashed_blobs: Vec<HashedBlob>,
+        blobs: Vec<Blob>,
         delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         let wait_for_outgoing_messages = delivery.wait_for_outgoing_messages();
         let request = HandleCertificateRequest {
             certificate,
             hashed_certificate_values,
-            hashed_blobs,
+            blobs,
             wait_for_outgoing_messages,
         };
         self.query(request.into()).await
@@ -138,7 +138,7 @@ impl ValidatorNode for SimpleClient {
         self.query(RpcMessage::GenesisConfigHashQuery).await
     }
 
-    async fn download_blob(&self, blob_id: BlobId) -> Result<Blob, NodeError> {
+    async fn download_blob(&self, blob_id: BlobId) -> Result<BlobContent, NodeError> {
         self.query(RpcMessage::DownloadBlob(Box::new(blob_id)))
             .await
     }

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -255,7 +255,7 @@ where
                     .handle_certificate(
                         request.certificate,
                         request.hashed_certificate_values,
-                        request.hashed_blobs,
+                        request.blobs,
                         sender,
                     )
                     .await

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -45,6 +45,12 @@ ApplicationPermissions:
           TYPENAME: ApplicationId
 Blob:
   STRUCT:
+    - blob_type:
+        TYPENAME: BlobType
+    - blob:
+        TYPENAME: BlobContent
+BlobContent:
+  STRUCT:
     - bytes: BYTES
 BlobId:
   STRUCT:
@@ -113,9 +119,9 @@ BlockProposal:
     - hashed_certificate_values:
         SEQ:
           TYPENAME: CertificateValue
-    - hashed_blobs:
+    - blobs:
         SEQ:
-          TYPENAME: HashedBlob
+          TYPENAME: Blob
     - validated_block_certificate:
         OPTION:
           TYPENAME: LiteCertificate
@@ -290,7 +296,7 @@ ChainManagerInfo:
           KEY:
             TYPENAME: BlobId
           VALUE:
-            TYPENAME: HashedBlob
+            TYPENAME: Blob
 ChainOwnership:
   STRUCT:
     - super_owners:
@@ -434,20 +440,14 @@ HandleCertificateRequest:
     - hashed_certificate_values:
         SEQ:
           TYPENAME: CertificateValue
-    - hashed_blobs:
+    - blobs:
         SEQ:
-          TYPENAME: HashedBlob
+          TYPENAME: Blob
 HandleLiteCertRequest:
   STRUCT:
     - certificate:
         TYPENAME: LiteCertificate
     - wait_for_outgoing_messages: BOOL
-HashedBlob:
-  STRUCT:
-    - blob_type:
-        TYPENAME: BlobType
-    - blob:
-        TYPENAME: Blob
 IncomingMessage:
   STRUCT:
     - origin:
@@ -820,7 +820,7 @@ RpcMessage:
     15:
       DownloadBlobResponse:
         NEWTYPE:
-          TYPENAME: Blob
+          TYPENAME: BlobContent
     16:
       DownloadCertificateValueResponse:
         NEWTYPE:

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, Blob, BlockHeight, TimeDelta, Timestamp},
+    data_types::{Amount, BlobContent, BlockHeight, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
 };
@@ -54,9 +54,9 @@ impl From<wit_system_api::BlobType> for BlobType {
     }
 }
 
-impl From<wit_system_api::Blob> for Blob {
-    fn from(blob: wit_system_api::Blob) -> Self {
-        Blob { bytes: blob.bytes }
+impl From<wit_system_api::BlobContent> for BlobContent {
+    fn from(blob: wit_system_api::BlobContent) -> Self {
+        BlobContent { bytes: blob.bytes }
     }
 }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlockHeight, HashedBlob, Resources,
+        Amount, ApplicationPermissions, Blob, BlobContent, BlockHeight, Resources,
         SendMessageRequest, Timestamp,
     },
     identifiers::{
@@ -272,8 +272,8 @@ where
     }
 
     /// Reads a blob with the given `BlobId` from storage.
-    pub fn read_blob(&mut self, blob_id: BlobId) -> HashedBlob {
-        Blob::from(wit::read_blob(blob_id.into())).with_blob_id_unchecked(blob_id)
+    pub fn read_blob(&mut self, blob_id: BlobId) -> Blob {
+        BlobContent::from(wit::read_blob(blob_id.into())).with_blob_id_unchecked(blob_id)
     }
 }
 

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -10,7 +10,7 @@ use std::{
 
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
-    data_types::{Amount, BlockHeight, HashedBlob, Resources, SendMessageRequest, Timestamp},
+    data_types::{Amount, Blob, BlockHeight, Resources, SendMessageRequest, Timestamp},
     identifiers::{
         Account, ApplicationId, BlobId, ChainId, ChannelName, Destination, MessageId, Owner,
         StreamName,
@@ -48,7 +48,7 @@ where
     claim_requests: Vec<ClaimRequest>,
     expected_service_queries: VecDeque<(ApplicationId, String, String)>,
     expected_post_requests: VecDeque<(String, Vec<u8>, Vec<u8>)>,
-    expected_read_blob_requests: VecDeque<(BlobId, HashedBlob)>,
+    expected_read_blob_requests: VecDeque<(BlobId, Blob)>,
     key_value_store: KeyValueStore,
 }
 
@@ -614,7 +614,7 @@ where
     }
 
     /// Adds an expected `read_blob` call, and the response it should return in the test.
-    pub fn add_expected_read_blob_requests(&mut self, blob_id: BlobId, response: HashedBlob) {
+    pub fn add_expected_read_blob_requests(&mut self, blob_id: BlobId, response: Blob) {
         self.expected_read_blob_requests
             .push_back((blob_id, response));
     }
@@ -666,7 +666,7 @@ where
     }
 
     /// Reads a blob with the given `BlobId` from storage.
-    pub fn read_blob(&mut self, blob_id: &BlobId) -> HashedBlob {
+    pub fn read_blob(&mut self, blob_id: &BlobId) -> Blob {
         let maybe_request = self.expected_read_blob_requests.pop_front();
         let (expected_blob_id, response) = maybe_request.expect("Unexpected read_blob request");
         assert_eq!(*blob_id, expected_blob_id);

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -5,7 +5,7 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, Blob, BlockHeight, Timestamp},
+    data_types::{Amount, BlobContent, BlockHeight, Timestamp},
     identifiers::{ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner},
 };
 
@@ -40,9 +40,9 @@ impl From<wit_system_api::BlobType> for BlobType {
     }
 }
 
-impl From<wit_system_api::Blob> for Blob {
-    fn from(blob: wit_system_api::Blob) -> Self {
-        Blob { bytes: blob.bytes }
+impl From<wit_system_api::BlobContent> for BlobContent {
+    fn from(blob: wit_system_api::BlobContent) -> Self {
+        BlobContent { bytes: blob.bytes }
     }
 }
 

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 
 use linera_base::{
     abi::ServiceAbi,
-    data_types::{Amount, Blob, BlockHeight, HashedBlob, Timestamp},
+    data_types::{Amount, Blob, BlobContent, BlockHeight, Timestamp},
     identifiers::{ApplicationId, BlobId, ChainId, Owner},
 };
 
@@ -146,7 +146,7 @@ where
     }
 
     /// Reads a blob with the given `BlobId` from storage.
-    pub fn read_blob(&mut self, blob_id: BlobId) -> HashedBlob {
-        Blob::from(wit::read_blob(blob_id.into())).with_blob_id_unchecked(blob_id)
+    pub fn read_blob(&mut self, blob_id: BlobId) -> Blob {
+        BlobContent::from(wit::read_blob(blob_id.into())).with_blob_id_unchecked(blob_id)
     }
 }

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -25,7 +25,7 @@ interface contract-system-api {
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
-    read-blob: func(blob-id: blob-id) -> blob;
+    read-blob: func(blob-id: blob-id) -> blob-content;
     log: func(message: string, level: log-level);
     consume-fuel: func(fuel: u64);
 
@@ -49,7 +49,7 @@ interface contract-system-api {
         close-chain: list<application-id>,
     }
 
-    record blob {
+    record blob-content {
         bytes: list<u8>,
     }
 

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,7 +14,7 @@ interface service-system-api {
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
-    read-blob: func(blob-id: blob-id) -> blob;
+    read-blob: func(blob-id: blob-id) -> blob-content;
     assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
 
@@ -27,7 +27,7 @@ interface service-system-api {
         creation: message-id,
     }
 
-    record blob {
+    record blob-content {
         bytes: list<u8>,
     }
 

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -43,10 +43,10 @@ input ApplicationPermissions {
 """
 A blob of binary data.
 """
-scalar Blob
+scalar BlobContent
 
 """
-A content-addressed blob ID i.e. the hash of the Blob
+A content-addressed blob ID i.e. the hash of the `BlobContent`
 """
 scalar BlobId
 
@@ -664,7 +664,7 @@ type MutationRoot {
 	"""
 	Publishes a new data blob.
 	"""
-	publishDataBlob(chainId: ChainId!, blob: Blob!): BlobId!
+	publishDataBlob(chainId: ChainId!, blob: BlobContent!): BlobId!
 	"""
 	Creates a new application.
 	"""

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -30,7 +30,7 @@ use linera_rpc::{
             notifier_service_server::{NotifierService, NotifierServiceServer},
             validator_node_server::{ValidatorNode, ValidatorNodeServer},
             validator_worker_client::ValidatorWorkerClient,
-            Blob, BlobId, BlockProposal, Certificate, CertificateValue, ChainInfoQuery,
+            BlobContent, BlobId, BlockProposal, Certificate, CertificateValue, ChainInfoQuery,
             ChainInfoResult, CryptoHash, HandleCertificateRequest, LiteCertificate, Notification,
             SubscriptionRequest, VersionInfo,
         },
@@ -415,15 +415,18 @@ where
     }
 
     #[instrument(skip_all, err(Display))]
-    async fn download_blob(&self, request: Request<BlobId>) -> Result<Response<Blob>, Status> {
+    async fn download_blob(
+        &self,
+        request: Request<BlobId>,
+    ) -> Result<Response<BlobContent>, Status> {
         let blob_id = request.into_inner().try_into()?;
-        let hashed_blob = self
+        let blob = self
             .0
             .storage
-            .read_hashed_blob(blob_id)
+            .read_blob(blob_id)
             .await
             .map_err(|err| Status::from_error(Box::new(err)))?;
-        Ok(Response::new(hashed_blob.into_inner().into()))
+        Ok(Response::new(blob.into_inner().into()))
     }
 
     #[instrument(skip_all, err(Display))]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -790,7 +790,7 @@ impl Runnable for Job {
                         HandleCertificateRequest {
                             certificate: certificate.clone(),
                             hashed_certificate_values: vec![],
-                            hashed_blobs: vec![],
+                            blobs: vec![],
                             wait_for_outgoing_messages: true,
                         }
                         .into()

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -19,7 +19,7 @@ use futures::{
 };
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
-    data_types::{Amount, ApplicationPermissions, Blob, TimeDelta, Timestamp},
+    data_types::{Amount, ApplicationPermissions, BlobContent, TimeDelta, Timestamp},
     identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
     BcsHexParseError,
@@ -596,14 +596,18 @@ where
     }
 
     /// Publishes a new data blob.
-    async fn publish_data_blob(&self, chain_id: ChainId, blob: Blob) -> Result<BlobId, Error> {
-        let hashed_blob = blob.with_data_blob_id();
+    async fn publish_data_blob(
+        &self,
+        chain_id: ChainId,
+        blob: BlobContent,
+    ) -> Result<BlobId, Error> {
+        let blob = blob.with_data_blob_id();
         self.apply_client_command(&chain_id, move |client| {
-            let hashed_blob = hashed_blob.clone();
+            let blob = blob.clone();
             async move {
-                let blob_id = hashed_blob.id();
+                let blob_id = blob.id();
                 let result = client
-                    .publish_blob(hashed_blob)
+                    .publish_blob(blob)
                     .await
                     .map_err(Error::from)
                     .map(|outcome| outcome.map(|_| blob_id));

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -298,11 +298,7 @@ where
                 self.genesis_config.hash().into(),
             ))),
             DownloadBlob(blob_id) => Ok(Some(
-                self.storage
-                    .read_hashed_blob(*blob_id)
-                    .await?
-                    .into_inner()
-                    .into(),
+                self.storage.read_blob(*blob_id).await?.into_inner().into(),
             )),
             DownloadCertificateValue(hash) => Ok(Some(
                 self.storage

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use linera_base::{
     crypto::{CryptoHash, KeyPair},
-    data_types::{Blob, HashedBlob, Timestamp},
+    data_types::{Blob, BlobContent, Timestamp},
     identifiers::{BlobId, ChainId},
 };
 use linera_chain::data_types::{
@@ -56,7 +56,7 @@ impl ValidatorNode for DummyValidatorNode {
         &self,
         _: Certificate,
         _: Vec<HashedCertificateValue>,
-        _: Vec<HashedBlob>,
+        _: Vec<Blob>,
         _delivery: CrossChainMessageDelivery,
     ) -> Result<ChainInfoResponse, NodeError> {
         Err(NodeError::UnexpectedMessage)
@@ -81,7 +81,7 @@ impl ValidatorNode for DummyValidatorNode {
         Err(NodeError::UnexpectedMessage)
     }
 
-    async fn download_blob(&self, _: BlobId) -> Result<Blob, NodeError> {
+    async fn download_blob(&self, _: BlobId) -> Result<BlobContent, NodeError> {
         Err(NodeError::UnexpectedMessage)
     }
 

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -23,7 +23,7 @@ use dashmap::{mapref::entry::Entry, DashMap};
 use futures::future;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, Blob, BlockHeight, HashedBlob, Timestamp},
+    data_types::{Amount, Blob, BlobContent, BlockHeight, Timestamp},
     identifiers::{BlobId, ChainDescription, ChainId, GenericApplicationId},
     ownership::ChainOwnership,
 };
@@ -123,14 +123,11 @@ pub trait Storage: Sized {
         hash: CryptoHash,
     ) -> Result<HashedCertificateValue, ViewError>;
 
-    /// Reads the hashed blob with the given blob ID.
-    async fn read_hashed_blob(&self, blob_id: BlobId) -> Result<HashedBlob, ViewError>;
+    /// Reads the blob with the given blob ID.
+    async fn read_blob(&self, blob_id: BlobId) -> Result<Blob, ViewError>;
 
     /// Reads the blobs with the given blob IDs.
-    async fn read_hashed_blobs(
-        &self,
-        blob_ids: &[BlobId],
-    ) -> Result<Vec<Option<HashedBlob>>, ViewError>;
+    async fn read_blobs(&self, blob_ids: &[BlobId]) -> Result<Vec<Option<Blob>>, ViewError>;
 
     /// Reads the blob state with the given blob ID.
     async fn read_blob_state(&self, blob_id: BlobId) -> Result<BlobState, ViewError>;
@@ -149,13 +146,13 @@ pub trait Storage: Sized {
     ) -> Result<(), ViewError>;
 
     /// Writes the given blob.
-    async fn write_hashed_blob(&self, blob: &HashedBlob) -> Result<(), ViewError>;
+    async fn write_blob(&self, blob: &Blob) -> Result<(), ViewError>;
 
-    /// Writes hashed certificates, hashed blobs and certificate
-    async fn write_hashed_certificate_values_hashed_blobs_certificate(
+    /// Writes hashed certificates, blobs and certificate
+    async fn write_hashed_certificate_values_blobs_certificate(
         &self,
         values: &[HashedCertificateValue],
-        blobs: &[HashedBlob],
+        blobs: &[Blob],
         certificate: &Certificate,
     ) -> Result<(), ViewError>;
 
@@ -180,7 +177,7 @@ pub trait Storage: Sized {
     ) -> Result<(), ViewError>;
 
     /// Writes several blobs.
-    async fn write_hashed_blobs(&self, blobs: &[HashedBlob]) -> Result<(), ViewError>;
+    async fn write_blobs(&self, blobs: &[Blob]) -> Result<(), ViewError>;
 
     /// Tests existence of the certificate with the given hash.
     async fn contains_certificate(&self, hash: CryptoHash) -> Result<bool, ViewError>;
@@ -473,7 +470,7 @@ where
         }
     }
 
-    async fn get_blob(&self, blob_id: BlobId) -> Result<Blob, ExecutionError> {
-        Ok(self.storage.read_hashed_blob(blob_id).await?.into_inner())
+    async fn get_blob(&self, blob_id: BlobId) -> Result<BlobContent, ExecutionError> {
+        Ok(self.storage.read_blob(blob_id).await?.into_inner())
     }
 }


### PR DESCRIPTION
## Motivation

`HashedBlob` isn't really a hashed blob anymore, as the `BlobId` now has more than just the hash.

## Proposal

Change `Blob` to be `BlobContent`, and change `HashedBlob` to `Blob`. Hopefully this makes the code a bit less confusing.

## Test Plan

CI

