### PR TITLE
Remove python HTTP server from LLM example README

### DIFF
--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -47,29 +47,15 @@ CHAIN=e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65
 See the file `linera-protocol/examples/fungible/README.md` or the [online developer
 manual](https://linera.dev) for instructions.
 
-## Setting Up
+## Using the LLM Application
 
-First, ensure you have the model and tokenizer locally by running:
-
-```bash
-wget -O model.bin -c https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.bin
-wget -c https://huggingface.co/spaces/lmz/candle-llama2/resolve/main/tokenizer.json
-```
-
-Then, in a separate terminal window, run the Python server to serve models locally:
-```bash
-python3 -m http.server 10001
-```
-
-Finally, deploy the application:
+First, deploy the application:
 ```bash
 cd ..
 APP_ID=$(linera project publish-and-create llm)
 ```
 
-## Using the LLM Application
-
-First, a node service for the current wallet has to be started:
+Then, a node service for the current wallet has to be started:
 
 ```bash
 PORT=8080

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -51,7 +51,7 @@ manual](https://linera.dev) for instructions.
 
 First, deploy the application:
 ```bash
-cd ..
+cd examples
 APP_ID=$(linera project publish-and-create llm)
 ```
 

--- a/examples/llm/src/lib.rs
+++ b/examples/llm/src/lib.rs
@@ -53,7 +53,7 @@ manual](https://linera.dev) for instructions.
 
 First, deploy the application:
 ```bash
-cd ..
+cd examples
 APP_ID=$(linera project publish-and-create llm)
 ```
 

--- a/examples/llm/src/lib.rs
+++ b/examples/llm/src/lib.rs
@@ -49,29 +49,15 @@ CHAIN=e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65
 See the file `linera-protocol/examples/fungible/README.md` or the [online developer
 manual](https://linera.dev) for instructions.
 
-## Setting Up
+## Using the LLM Application
 
-First, ensure you have the model and tokenizer locally by running:
-
-```bash
-wget -O model.bin -c https://huggingface.co/karpathy/tinyllamas/resolve/main/stories42M.bin
-wget -c https://huggingface.co/spaces/lmz/candle-llama2/resolve/main/tokenizer.json
-```
-
-Then, in a separate terminal window, run the Python server to serve models locally:
-```bash
-python3 -m http.server 10001
-```
-
-Finally, deploy the application:
+First, deploy the application:
 ```bash
 cd ..
 APP_ID=$(linera project publish-and-create llm)
 ```
 
-## Using the LLM Application
-
-First, a node service for the current wallet has to be started:
+Then, a node service for the current wallet has to be started:
 
 ```bash
 PORT=8080


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Since #2258, the model is no longer downloaded from a local server. Unfortunately the README was not updated to reflect that.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Update the README file to remove the mention of setting up a local HTTP server with the models.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should catch any issues with the README file.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this only changes the README file.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
