### PR TITLE
`linera-version`: use a committed cache of the API hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4683,6 +4683,7 @@ dependencies = [
  "async-graphql-derive",
  "base64 0.22.0",
  "cargo_metadata",
+ "fs-err",
  "glob",
  "quote",
  "semver 1.0.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4678,6 +4678,7 @@ dependencies = [
 name = "linera-version"
 version = "0.12.0"
 dependencies = [
+ "anyhow",
  "async-graphql",
  "async-graphql-derive",
  "base64 0.22.0",
@@ -4686,6 +4687,7 @@ dependencies = [
  "quote",
  "semver 1.0.22",
  "serde",
+ "serde_json",
  "sha3",
  "thiserror",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
 either = "1.10.0"
 ethers = { version = "2.0.14", features = ["solc"] }
 frunk = "0.4.2"
-fs-err = { version = "2.11.0", features = ["tokio"] }
+fs-err = "2.11.0"
 fs4 = "0.8.2"
 fs_extra = "1.3.0"
 futures = "0.3.30"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1981,7 +1981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
- "tokio",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3519,6 +3519,7 @@ dependencies = [
 name = "linera-version"
 version = "0.12.0"
 dependencies = [
+ "anyhow",
  "async-graphql",
  "async-graphql-derive",
  "base64 0.22.0",
@@ -3527,6 +3528,7 @@ dependencies = [
  "quote",
  "semver 1.0.22",
  "serde",
+ "serde_json",
  "sha3",
  "thiserror",
  "tracing",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1975,6 +1975,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fungible"
 version = "0.1.0"
 dependencies = [
@@ -3524,6 +3534,7 @@ dependencies = [
  "async-graphql-derive",
  "base64 0.22.0",
  "cargo_metadata",
+ "fs-err",
  "glob",
  "quote",
  "semver 1.0.22",

--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -68,7 +68,7 @@ clap-markdown.workspace = true
 colored.workspace = true
 comfy-table.workspace = true
 current_platform = "0.2.0"
-fs-err.workspace = true
+fs-err = { workspace = true, features = ["tokio"] }
 fs_extra = { workspace = true, optional = true }
 futures.workspace = true
 hex.workspace = true

--- a/linera-version/Cargo.toml
+++ b/linera-version/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 async-graphql.workspace = true
 async-graphql-derive.workspace = true
 base64.workspace = true
@@ -19,6 +20,7 @@ cargo_metadata.workspace = true
 glob.workspace = true
 semver.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 sha3.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
@@ -29,6 +31,8 @@ cargo_metadata.workspace = true
 glob.workspace = true
 quote.workspace = true
 semver.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 sha3.workspace = true
 thiserror.workspace = true
 

--- a/linera-version/Cargo.toml
+++ b/linera-version/Cargo.toml
@@ -17,6 +17,7 @@ async-graphql.workspace = true
 async-graphql-derive.workspace = true
 base64.workspace = true
 cargo_metadata.workspace = true
+fs-err.workspace = true
 glob.workspace = true
 semver.workspace = true
 serde.workspace = true
@@ -28,6 +29,7 @@ tracing.workspace = true
 [build-dependencies]
 base64.workspace = true
 cargo_metadata.workspace = true
+fs-err.workspace = true
 glob.workspace = true
 quote.workspace = true
 semver.workspace = true

--- a/linera-version/api-hashes.json
+++ b/linera-version/api-hashes.json
@@ -1,0 +1,5 @@
+{
+    "rpc": "K9p3m/MsIPZL32CYddAqlG6PHKprJvMjei5cIiqFgDY",
+    "graphql": "RmwcE5swpH/HkjbetY/YyD6ebNQFS9oeU6ayEAvDjEQ",
+    "wit": "0X+I4jeHCdpD2M0R+OVodI4pH+dF9rt0K/iHENVcnug"
+}

--- a/linera-version/build.rs
+++ b/linera-version/build.rs
@@ -51,7 +51,7 @@ fn main() {
 
     let out_path = std::path::Path::new(&std::env::var_os("OUT_DIR").unwrap()).join("static.rs");
 
-    std::fs::write(&out_path, static_code.to_string().as_bytes()).unwrap_or_else(|e| {
+    fs_err::write(&out_path, static_code.to_string().as_bytes()).unwrap_or_else(|e| {
         panic!(
             "failed to write output file `{}`: {}",
             out_path.display(),

--- a/linera-version/src/main.rs
+++ b/linera-version/src/main.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_version::VersionInfo;
+
+fn main() -> anyhow::Result<()> {
+    serde_json::to_writer_pretty(std::io::stdout(), &VersionInfo::get()?.api_hashes())?;
+
+    Ok(())
+}

--- a/linera-version/src/version_info/mod.rs
+++ b/linera-version/src/version_info/mod.rs
@@ -74,10 +74,6 @@ impl VersionInfo {
         STRING.as_str()
     }
 
-    fn api_hashes(&self) -> (&Hash, &Hash, &Hash) {
-        (&self.rpc_hash, &self.graphql_hash, &self.wit_hash)
-    }
-
     /// Whether this version is known to be (remote!) API-compatible with `other`.
     /// Note that this relation _is not_ symmetric.
     /// It also may give false negatives.

--- a/linera-version/src/version_info/type.rs
+++ b/linera-version/src/version_info/type.rs
@@ -106,7 +106,7 @@ fn get_hash(
     let mut n_file = 0;
     for path in glob::glob(&package_glob)? {
         let path = path?;
-        let mut file = std::fs::File::open(&path)?;
+        let mut file = fs_err::File::open(&path)?;
         relevant_paths.push(path);
         n_file += 1;
         while file.read(&mut buffer)? != 0 {
@@ -179,7 +179,10 @@ pub struct ApiHashes {
 
 impl VersionInfo {
     pub fn get() -> Result<Self, Error> {
-        Self::trace_get(&std::env::current_dir()?, &mut vec![])
+        Self::trace_get(
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")),
+            &mut vec![],
+        )
     }
 
     fn trace_get(crate_dir: &std::path::Path, paths: &mut Vec<PathBuf>) -> Result<Self, Error> {
@@ -218,7 +221,7 @@ impl VersionInfo {
         }
         .into();
 
-        let api_hashes: ApiHashes = serde_json::from_reader(std::fs::File::open(api_hashes_path)?)?;
+        let api_hashes: ApiHashes = serde_json::from_reader(fs_err::File::open(api_hashes_path)?)?;
 
         let rpc_hash = get_hash(
             paths,

--- a/linera-version/tests/up_to_date.rs
+++ b/linera-version/tests/up_to_date.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use linera_version::VersionInfo;
+
+#[test]
+fn up_to_date() {
+    assert_eq!(VersionInfo::get().unwrap(), VersionInfo::default(),);
+}

--- a/linera-version/tests/up_to_date.rs
+++ b/linera-version/tests/up_to_date.rs
@@ -10,6 +10,6 @@ fn up_to_date() {
         VersionInfo::default().api_hashes(),
         "`linera-version` API hash cache out of date.\n\
          Please update `linera-version/api-hashes.json` by running:\n\
-         $ cargo run linera-version > linera-version/api-hashes.json"
+         $ cargo run -p linera-version > linera-version/api-hashes.json"
     );
 }

--- a/linera-version/tests/up_to_date.rs
+++ b/linera-version/tests/up_to_date.rs
@@ -5,5 +5,11 @@ use linera_version::VersionInfo;
 
 #[test]
 fn up_to_date() {
-    assert_eq!(VersionInfo::get().unwrap(), VersionInfo::default(),);
+    assert_eq!(
+        VersionInfo::get().unwrap().api_hashes(),
+        VersionInfo::default().api_hashes(),
+        "`linera-version` API hash cache out of date.\n\
+         Please update `linera-version/api-hashes.json` by running:\n\
+         $ cargo run linera-version > linera-version/api-hashes.json"
+    );
 }

--- a/scripts/test_publish.sh
+++ b/scripts/test_publish.sh
@@ -34,7 +34,7 @@ trap 'cd "$LINERA_DIR"; git checkout -f HEAD .cargo/config.toml' EXIT
 # Initialize the git repository for the index if needed. Ideally, we'd like to use `cargo
 # index init` first but the tool refuses to update an existing directory.
 git init "$REGISTRY"/index || true
-(cd "$REGISTRY"/index; git add .; git commit -m 'update registry')
+(cd "$REGISTRY"/index; git add .; git commit -m 'update registry' --allow-empty)
 
 # Build the packages in order and add them to the local registry.
 grep -v '^#' "$1" | while read LINE; do


### PR DESCRIPTION
## Motivation

Currently `linera-service --version` is broken on installations resulting from `cargo install linera-service`.  This is because the information we need to generate the API hashes (from `linera-rpc`, `linera-sdk`, and `linera-service-graphql-client`) isn't necessarily available at build time, these crates not being dependencies of `linera-service`.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Instead, compute the hashes at commit-time, except for the git commit hash, which would be computationally difficult to commit to git.  The git commit hash can instead be read from a special-purpose file `.cargo_vcs_info.json` added to the packaged crate by `cargo publish` at publish time.

Also, add a test to CI that ensures that file is up-to-date.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

I have tested locally by modifying my Cargo cache, and by using the `scripts/test_publish.sh` script.  However, it is hard to test conclusively without performing a real release.

<!-- How to test that the changes are correct. -->

## Release Plan

Bugfix.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Fixes https://github.com/linera-io/linera-protocol/issues/2147.
- Fixes https://github.com/linera-io/linera-protocol/issues/2002.