### PR TITLE
Fix schema_export: create namespace before using it.

### DIFF
--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -163,7 +163,7 @@ async fn main() -> std::io::Result<()> {
 
     let store_config = MemoryStoreConfig::new(TEST_MEMORY_MAX_STREAM_QUERIES);
     let namespace = "schema_export";
-    let storage = MemoryStorage::new(store_config, namespace, None)
+    let storage = MemoryStorage::initialize(store_config, namespace, None)
         .await
         .expect("storage");
     let config = ChainListenerConfig::default();


### PR DESCRIPTION
## Motivation

`cargo run --locked --bin linera-schema-export` fails with:

```
thread 'main' panicked at linera-service/src/schema_export.rs:168:10:
storage: NotExistentNamespace
```

## Proposal

Call `MemoryStorage::initialize` instead of `MemoryStorage::new`, to create the namespace.

## Test Plan

With this change, `linera-schema-export` works for me locally.

## Links

- Possibly related: https://github.com/linera-io/linera-protocol/pull/2316
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
