### PR TITLE
Don't use individual message IDs in linera-sdk testing.

### DIFF
--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -66,7 +66,7 @@ async fn collect_pledges() {
     for (backer_chain, backer_account, _balance) in &backers {
         backer_chain.register_application(campaign_id).await;
 
-        let pledge_messages = backer_chain
+        let pledge_certificate = backer_chain
             .add_block(|block| {
                 block.with_operation(
                     campaign_id,
@@ -78,13 +78,15 @@ async fn collect_pledges() {
             })
             .await;
 
-        assert_eq!(pledge_messages.len(), 3);
-        pledges_and_transfers.extend(pledge_messages);
+        assert_eq!(pledge_certificate.outgoing_message_count(), 3);
+        pledges_and_transfers.push(pledge_certificate);
     }
 
     campaign_chain
         .add_block(|block| {
-            block.with_incoming_bundles(pledges_and_transfers);
+            for certificate in &pledges_and_transfers {
+                block.with_messages_from(certificate);
+            }
         })
         .await;
 
@@ -168,7 +170,7 @@ async fn cancel_successful_campaign() {
     for (backer_chain, backer_account, _balance) in &backers {
         backer_chain.register_application(campaign_id).await;
 
-        let pledge_messages = backer_chain
+        let pledge_certificate = backer_chain
             .add_block(|block| {
                 block.with_operation(
                     campaign_id,
@@ -180,13 +182,15 @@ async fn cancel_successful_campaign() {
             })
             .await;
 
-        assert_eq!(pledge_messages.len(), 3);
-        pledges_and_transfers.extend(pledge_messages);
+        assert_eq!(pledge_certificate.outgoing_message_count(), 3);
+        pledges_and_transfers.push(pledge_certificate);
     }
 
     campaign_chain
         .add_block(|block| {
-            block.with_incoming_bundles(pledges_and_transfers);
+            for certificate in &pledges_and_transfers {
+                block.with_messages_from(certificate);
+            }
         })
         .await;
 

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -299,7 +299,7 @@ pub async fn create_with_accounts(
     for (chain, account, initial_amount) in &accounts {
         chain.register_application(application_id).await;
 
-        let claim_messages = chain
+        let claim_certificate = chain
             .add_block(|block| {
                 block.with_operation(
                     application_id,
@@ -318,19 +318,19 @@ pub async fn create_with_accounts(
             })
             .await;
 
-        assert_eq!(claim_messages.len(), 2);
+        assert_eq!(claim_certificate.outgoing_message_count(), 2);
 
-        let transfer_messages = token_chain
+        let transfer_certificate = token_chain
             .add_block(|block| {
-                block.with_incoming_bundle(claim_messages[1]);
+                block.with_messages_from(&claim_certificate);
             })
             .await;
 
-        assert_eq!(transfer_messages.len(), 2);
+        assert_eq!(transfer_certificate.outgoing_message_count(), 2);
 
         chain
             .add_block(|block| {
-                block.with_incoming_bundle(transfer_messages[1]);
+                block.with_messages_from(&transfer_certificate);
             })
             .await;
     }

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -10,7 +10,7 @@ use fungible::{
 };
 use linera_sdk::{
     base::{AccountOwner, Amount},
-    test::TestValidator,
+    test::{Medium, MessageAction, TestValidator},
 };
 
 /// Test transferring tokens across microchains.
@@ -122,7 +122,11 @@ async fn test_bouncing_tokens() {
 
     receiver_chain
         .add_block(move |block| {
-            block.with_messages_from(&certificate).with_rejection();
+            block.with_messages_from_by_medium(
+                &certificate,
+                &Medium::Direct,
+                MessageAction::Reject,
+            );
         })
         .await;
 

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -143,7 +143,7 @@ async fn single_transaction() {
     user_chain_b.register_application(matching_id).await;
 
     // Creating the bid orders
-    let mut order_certificates = Vec::new();
+    let mut bid_certificates = Vec::new();
     for price in [1, 2] {
         let price = Price { price };
         let order = Order::Insert {
@@ -153,19 +153,19 @@ async fn single_transaction() {
             price,
         };
         let operation = Operation::ExecuteOrder { order };
-        let order_certificate = user_chain_a
+        let bid_certificate = user_chain_a
             .add_block(|block| {
                 block.with_operation(matching_id, operation);
             })
             .await;
 
-        assert_eq!(order_certificate.outgoing_message_count(), 3);
-        order_certificates.push(order_certificate);
+        assert_eq!(bid_certificate.outgoing_message_count(), 3);
+        bid_certificates.push(bid_certificate);
     }
 
     matching_chain
         .add_block(|block| {
-            for certificate in &order_certificates {
+            for certificate in &bid_certificates {
                 block.with_messages_from(certificate);
             }
         })

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -143,7 +143,7 @@ async fn single_transaction() {
     user_chain_b.register_application(matching_id).await;
 
     // Creating the bid orders
-    let mut orders_bids = Vec::new();
+    let mut order_certificates = Vec::new();
     for price in [1, 2] {
         let price = Price { price };
         let order = Order::Insert {
@@ -153,18 +153,21 @@ async fn single_transaction() {
             price,
         };
         let operation = Operation::ExecuteOrder { order };
-        let order_messages = user_chain_a
+        let order_certificate = user_chain_a
             .add_block(|block| {
                 block.with_operation(matching_id, operation);
             })
             .await;
-        assert_eq!(order_messages.len(), 3);
-        orders_bids.extend(order_messages);
+
+        assert_eq!(order_certificate.outgoing_message_count(), 3);
+        order_certificates.push(order_certificate);
     }
 
     matching_chain
         .add_block(|block| {
-            block.with_incoming_bundles(orders_bids);
+            for certificate in &order_certificates {
+                block.with_messages_from(certificate);
+            }
         })
         .await;
 
@@ -192,7 +195,7 @@ async fn single_transaction() {
         );
     }
 
-    let mut orders_asks = Vec::new();
+    let mut ask_certificates = Vec::new();
     for price in [4, 2] {
         let price = Price { price };
         let order = Order::Insert {
@@ -202,19 +205,21 @@ async fn single_transaction() {
             price,
         };
         let operation = Operation::ExecuteOrder { order };
-        let order_messages = user_chain_b
+        let ask_certificate = user_chain_b
             .add_block(|block| {
                 block.with_operation(matching_id, operation);
             })
             .await;
 
-        assert_eq!(order_messages.len(), 3);
-        orders_asks.extend(order_messages);
+        assert_eq!(ask_certificate.outgoing_message_count(), 3);
+        ask_certificates.push(ask_certificate);
     }
 
     matching_chain
         .add_block(|block| {
-            block.with_incoming_bundles(orders_asks);
+            for certificate in &ask_certificates {
+                block.with_messages_from(certificate);
+            }
         })
         .await;
 
@@ -253,15 +258,15 @@ async fn single_transaction() {
         order_id: order_ids_a[0],
     };
     let operation = Operation::ExecuteOrder { order };
-    let order_messages = user_chain_a
+    let order_certificate = user_chain_a
         .add_block(|block| {
             block.with_operation(matching_id, operation);
         })
         .await;
-    assert_eq!(order_messages.len(), 2);
+    assert_eq!(order_certificate.outgoing_message_count(), 2);
     matching_chain
         .add_block(|block| {
-            block.with_incoming_bundles(order_messages);
+            block.with_messages_from(&order_certificate);
         })
         .await;
     user_chain_a.handle_received_messages().await;

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -1138,9 +1138,15 @@ impl Certificate {
     pub fn requires_blob(&self, blob_id: &BlobId) -> bool {
         self.value()
             .executed_block()
-            .map_or(false, |executed_block| {
-                executed_block.requires_blob(blob_id)
-            })
+            .is_some_and(|executed_block| executed_block.requires_blob(blob_id))
+    }
+
+    #[cfg(with_testing)]
+    pub fn outgoing_message_count(&self) -> usize {
+        let Some(executed_block) = self.value().executed_block() else {
+            return 0;
+        };
+        executed_block.messages().iter().map(Vec::len).sum()
     }
 }
 

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -160,13 +160,13 @@ impl BlockBuilder {
     /// present in the inboxes of the microchain that owns this block.
     pub(crate) fn with_incoming_bundles(
         &mut self,
-        messages: impl IntoIterator<Item = IncomingBundle>,
+        bundles: impl IntoIterator<Item = IncomingBundle>,
     ) -> &mut Self {
-        self.block.incoming_bundles.extend(messages);
+        self.block.incoming_bundles.extend(bundles);
         self
     }
 
-    /// Receives all admin messages  that were sent to this chain by the given certificate.
+    /// Receives all admin messages that were sent to this chain by the given certificate.
     pub fn with_system_messages_from(
         &mut self,
         certificate: &Certificate,

--- a/linera-sdk/src/test/block.rs
+++ b/linera-sdk/src/test/block.rs
@@ -5,20 +5,18 @@
 //!
 //! Helps with the construction of blocks, adding operations and
 
-use std::mem;
-
 use linera_base::{
     crypto::PublicKey,
     data_types::{Amount, ApplicationPermissions, Round, Timestamp},
-    identifiers::{ApplicationId, ChainId, MessageId, Owner},
+    identifiers::{ApplicationId, ChainId, GenericApplicationId, Owner},
     ownership::TimeoutConfig,
 };
 use linera_chain::data_types::{
-    Block, Certificate, HashedCertificateValue, IncomingBundle, LiteVote, MessageAction,
-    SignatureAggregator,
+    Block, Certificate, ChannelFullName, Event, HashedCertificateValue, IncomingBundle, LiteVote,
+    Medium, MessageAction, Origin, SignatureAggregator,
 };
 use linera_execution::{
-    system::{Recipient, SystemOperation, UserData},
+    system::{Recipient, SystemChannel, SystemOperation, UserData},
     Operation,
 };
 
@@ -29,7 +27,6 @@ use crate::ToBcsBytes;
 /// [`Certificate`]s using a [`TestValidator`].
 pub struct BlockBuilder {
     block: Block,
-    incoming_bundles: Vec<(MessageId, MessageAction)>,
     validator: TestValidator,
 }
 
@@ -73,7 +70,6 @@ impl BlockBuilder {
                 authenticated_signer: Some(owner),
                 timestamp: Timestamp::from(0),
             },
-            incoming_bundles: Vec::new(),
             validator,
         }
     }
@@ -158,47 +154,11 @@ impl BlockBuilder {
         self
     }
 
-    /// Receives an incoming message referenced by the [`MessageId`].
-    ///
-    /// The block that produces the message must have already been executed by the test validator,
-    /// so that the message is already in the inbox of the microchain this block belongs to.
-    pub fn with_incoming_bundle(&mut self, message_id: MessageId) -> &mut Self {
-        self.incoming_bundles
-            .push((message_id, MessageAction::Accept));
-        self
-    }
-
-    /// Rejects an incoming message referenced by the [`MessageId`].
-    ///
-    /// The block that produces the message must have already been executed by the test validator,
-    /// so that the message is already in the inbox of the microchain this block belongs to.
-    pub fn with_message_rejection(&mut self, message_id: MessageId) -> &mut Self {
-        self.incoming_bundles
-            .push((message_id, MessageAction::Reject));
-        self
-    }
-
-    /// Receives multiple incoming messages referenced by the [`MessageId`]s.
-    ///
-    /// The blocks that produce the messages must have already been executed by the test validator,
-    /// so that the messages are already in the inbox of the microchain this block belongs to.
-    pub fn with_incoming_bundles(
-        &mut self,
-        message_ids: impl IntoIterator<Item = MessageId>,
-    ) -> &mut Self {
-        self.incoming_bundles.extend(
-            message_ids
-                .into_iter()
-                .map(|message_id| (message_id, MessageAction::Accept)),
-        );
-        self
-    }
-
-    /// Receives incoming messages by specifying them directly.
+    /// Receives incoming message bundles by specifying them directly.
     ///
     /// This is an internal method that bypasses the check to see if the messages are already
     /// present in the inboxes of the microchain that owns this block.
-    pub(crate) fn with_raw_messages(
+    pub(crate) fn with_incoming_bundles(
         &mut self,
         messages: impl IntoIterator<Item = IncomingBundle>,
     ) -> &mut Self {
@@ -206,24 +166,81 @@ impl BlockBuilder {
         self
     }
 
+    /// Receives all admin messages  that were sent to this chain by the given certificate.
+    pub fn with_system_messages_from(
+        &mut self,
+        certificate: &Certificate,
+        channel: SystemChannel,
+    ) -> &mut Self {
+        self.with_messages_from_by_medium(
+            certificate,
+            &Medium::Channel(ChannelFullName {
+                application_id: GenericApplicationId::System,
+                name: channel.name(),
+            }),
+        )
+    }
+
+    /// Receives all direct messages  that were sent to this chain by the given certificate.
+    pub fn with_messages_from(&mut self, certificate: &Certificate) -> &mut Self {
+        self.with_messages_from_by_medium(certificate, &Medium::Direct)
+    }
+
+    /// Receives all messages that were sent to this chain by the given certificate.
+    pub fn with_messages_from_by_medium(
+        &mut self,
+        certificate: &Certificate,
+        medium: &Medium,
+    ) -> &mut Self {
+        let origin = Origin {
+            sender: certificate.value().chain_id(),
+            medium: medium.clone(),
+        };
+        let bundles = certificate
+            .message_bundles_for(medium, self.block.chain_id)
+            .into_iter()
+            .flat_map(|bundle| {
+                bundle
+                    .messages
+                    .into_iter()
+                    .map(|(index, message)| IncomingBundle {
+                        origin: origin.clone(),
+                        event: Event {
+                            certificate_hash: certificate.hash(),
+                            height: certificate.value().height(),
+                            index,
+                            authenticated_signer: message.authenticated_signer,
+                            grant: message.grant,
+                            refund_grant_to: message.refund_grant_to,
+                            kind: message.kind,
+                            timestamp: certificate
+                                .value()
+                                .executed_block()
+                                .unwrap()
+                                .block
+                                .timestamp,
+                            message: message.message,
+                        },
+                        action: MessageAction::Accept,
+                    })
+            });
+        self.with_incoming_bundles(bundles)
+    }
+
+    /// Rejects the most recently added message bundle.
+    pub fn with_rejection(&mut self) -> &mut Self {
+        self.block.incoming_bundles.last_mut().unwrap().action = MessageAction::Reject;
+        self
+    }
+
     /// Tries to sign the prepared [`Block`] with the [`TestValidator`]'s keys and return the
     /// resulting [`Certificate`]. Returns an error if block execution fails.
-    pub(crate) async fn try_sign(mut self) -> anyhow::Result<(Certificate, Vec<MessageId>)> {
-        self.collect_incoming_bundles().await;
-
+    pub(crate) async fn try_sign(self) -> anyhow::Result<Certificate> {
         let (executed_block, _) = self
             .validator
             .worker()
             .stage_block_execution(self.block)
             .await?;
-
-        let message_ids = (0..executed_block
-            .messages()
-            .iter()
-            .map(Vec::len)
-            .sum::<usize>() as u32)
-            .map(|index| executed_block.message_id(index))
-            .collect();
 
         let value = HashedCertificateValue::new_confirmed(executed_block);
         let vote = LiteVote::new(value.lite(), Round::Fast, self.validator.key_pair());
@@ -233,28 +250,6 @@ impl BlockBuilder {
             .expect("Failed to sign block")
             .expect("Committee has more than one test validator");
 
-        Ok((certificate, message_ids))
-    }
-
-    /// Collects and adds the previously requested messages to this block.
-    ///
-    /// The requested messages must already all be in the inboxes of the microchain that owns this
-    /// block.
-    async fn collect_incoming_bundles(&mut self) {
-        let chain_id = self.block.chain_id;
-
-        for (message_id, action) in mem::take(&mut self.incoming_bundles) {
-            let mut message = self
-                .validator
-                .worker()
-                .find_incoming_bundle(chain_id, message_id)
-                .await
-                .expect("Failed to find message to receive in block")
-                .expect("Message that block should consume has not been emitted");
-
-            message.action = action;
-
-            self.block.incoming_bundles.push(message);
-        }
+        Ok(certificate)
     }
 }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -195,6 +195,7 @@ impl ActiveChain {
             block.with_messages_from(&certificate);
         })
         .await;
+
         BytecodeId::new(message_id).with_abi()
     }
 

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -180,7 +180,10 @@ impl ActiveChain {
             })
             .await;
 
-        let executed_block = certificate.value().executed_block().unwrap();
+        let executed_block = certificate
+            .value()
+            .executed_block()
+            .expect("Failed to obtain executed block from certificate");
         assert_eq!(executed_block.messages().len(), 1);
         let message_id = MessageId {
             chain_id: executed_block.block.chain_id,
@@ -373,7 +376,10 @@ impl ActiveChain {
             })
             .await;
 
-        let executed_block = creation_certificate.value().executed_block().unwrap();
+        let executed_block = creation_certificate
+            .value()
+            .executed_block()
+            .expect("Failed to obtain executed block from certificate");
         assert_eq!(executed_block.messages().len(), 1);
         let creation = MessageId {
             chain_id: executed_block.block.chain_id,

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -20,7 +20,10 @@ use linera_base::{
 use linera_chain::{data_types::Certificate, ChainError, ChainExecutionContext};
 use linera_core::{data_types::ChainInfoQuery, worker::WorkerError};
 use linera_execution::{
-    system::{SystemChannel, SystemExecutionError, SystemMessage, SystemOperation},
+    system::{
+        SystemChannel, SystemExecutionError, SystemMessage, SystemOperation,
+        CREATE_APPLICATION_MESSAGE_INDEX, PUBLISH_BYTECODE_MESSAGE_INDEX,
+    },
     Bytecode, ExecutionError, Message, Query, Response,
 };
 use serde::Serialize;
@@ -87,7 +90,7 @@ impl ActiveChain {
     ///
     /// The `block_builder` parameter is a closure that should use the [`BlockBuilder`] parameter
     /// to provide the block's contents.
-    pub async fn add_block(&self, block_builder: impl FnOnce(&mut BlockBuilder)) -> Vec<MessageId> {
+    pub async fn add_block(&self, block_builder: impl FnOnce(&mut BlockBuilder)) -> Certificate {
         self.try_add_block(block_builder)
             .await
             .expect("Failed to execute block.")
@@ -100,7 +103,7 @@ impl ActiveChain {
     pub async fn try_add_block(
         &self,
         block_builder: impl FnOnce(&mut BlockBuilder),
-    ) -> anyhow::Result<Vec<MessageId>> {
+    ) -> anyhow::Result<Certificate> {
         let mut tip = self.tip.lock().await;
         let mut block = BlockBuilder::new(
             self.description.into(),
@@ -112,7 +115,7 @@ impl ActiveChain {
         block_builder(&mut block);
 
         // TODO(#2066): Remove boxing once call-stack is shallower
-        let (certificate, message_ids) = Box::pin(block.try_sign()).await?;
+        let certificate = Box::pin(block.try_sign()).await?;
 
         self.validator
             .worker()
@@ -120,9 +123,9 @@ impl ActiveChain {
             .await
             .expect("Rejected certificate");
 
-        *tip = Some(certificate);
+        *tip = Some(certificate.clone());
 
-        Ok(message_ids)
+        Ok(certificate)
     }
 
     /// Receives all queued messages in all inboxes of this microchain.
@@ -140,7 +143,7 @@ impl ActiveChain {
         let messages = information.info.requested_pending_messages;
 
         self.add_block(|block| {
-            block.with_raw_messages(messages);
+            block.with_incoming_bundles(messages);
         })
         .await;
     }
@@ -171,20 +174,25 @@ impl ActiveChain {
         Self::build_bytecodes_in(&repository_path).await;
         let (contract, service) = self.find_bytecodes_in(&repository_path).await;
 
-        let publish_messages = self
+        let certificate = self
             .add_block(|block| {
                 block.with_system_operation(SystemOperation::PublishBytecode { contract, service });
             })
             .await;
 
-        assert_eq!(publish_messages.len(), 1);
+        let executed_block = certificate.value().executed_block().unwrap();
+        assert_eq!(executed_block.messages().len(), 1);
+        let message_id = MessageId {
+            chain_id: executed_block.block.chain_id,
+            height: executed_block.block.height,
+            index: PUBLISH_BYTECODE_MESSAGE_INDEX,
+        };
 
         self.add_block(|block| {
-            block.with_incoming_bundle(publish_messages[0]);
+            block.with_messages_from(&certificate);
         })
         .await;
-
-        BytecodeId::new(publish_messages[0]).with_abi()
+        BytecodeId::new(message_id).with_abi()
     }
 
     /// Compiles the crate in the `repository` path.
@@ -290,7 +298,7 @@ impl ActiveChain {
     pub async fn subscribe_to_published_bytecodes_from(&mut self, publisher_id: ChainId) {
         let publisher = self.validator.get_chain(&publisher_id);
 
-        let request_messages = self
+        let subscribe_certificate = self
             .add_block(|block| {
                 block.with_system_operation(SystemOperation::Subscribe {
                     chain_id: publisher.id(),
@@ -299,18 +307,18 @@ impl ActiveChain {
             })
             .await;
 
-        assert_eq!(request_messages.len(), 1);
+        assert_eq!(subscribe_certificate.outgoing_message_count(), 1);
 
-        let accept_messages = publisher
+        let accept_certificate = publisher
             .add_block(|block| {
-                block.with_incoming_bundle(request_messages[0]);
+                block.with_messages_from(&subscribe_certificate);
             })
             .await;
 
-        assert_eq!(accept_messages.len(), 1);
+        assert_eq!(accept_certificate.outgoing_message_count(), 1);
 
         self.add_block(|block| {
-            block.with_incoming_bundle(accept_messages[0]);
+            block.with_system_messages_from(&accept_certificate, SystemChannel::PublishedBytecodes);
         })
         .await;
     }
@@ -337,13 +345,15 @@ impl ActiveChain {
         Parameters: Serialize,
         InstantiationArgument: Serialize,
     {
-        let bytecode_location_message = if self.needs_bytecode_location(bytecode_id).await {
+        if self.needs_bytecode_location(bytecode_id).await {
             self.subscribe_to_published_bytecodes_from(bytecode_id.message_id.chain_id)
                 .await;
-            Some(self.find_bytecode_location(bytecode_id).await)
-        } else {
-            None
-        };
+            let certificate = self.find_bytecode_location(bytecode_id).await;
+            self.add_block(|block| {
+                block.with_system_messages_from(&certificate, SystemChannel::PublishedBytecodes);
+            })
+            .await;
+        }
 
         let parameters = serde_json::to_vec(&parameters).unwrap();
         let instantiation_argument = serde_json::to_vec(&instantiation_argument).unwrap();
@@ -352,12 +362,8 @@ impl ActiveChain {
             self.register_application(dependency).await;
         }
 
-        let creation_messages = self
+        let creation_certificate = self
             .add_block(|block| {
-                if let Some(message_id) = bytecode_location_message {
-                    block.with_incoming_bundle(message_id);
-                }
-
                 block.with_system_operation(SystemOperation::CreateApplication {
                     bytecode_id: bytecode_id.forget_abi(),
                     parameters,
@@ -367,11 +373,17 @@ impl ActiveChain {
             })
             .await;
 
-        assert_eq!(creation_messages.len(), 1);
+        let executed_block = creation_certificate.value().executed_block().unwrap();
+        assert_eq!(executed_block.messages().len(), 1);
+        let creation = MessageId {
+            chain_id: executed_block.block.chain_id,
+            height: executed_block.block.height,
+            index: CREATE_APPLICATION_MESSAGE_INDEX,
+        };
 
         ApplicationId {
             bytecode_id: bytecode_id.just_abi(),
-            creation: creation_messages[0],
+            creation,
         }
     }
 
@@ -388,11 +400,11 @@ impl ActiveChain {
             .is_none()
     }
 
-    /// Finds the message that sends the message with the bytecode location of `bytecode_id`.
+    /// Finds the certificate that sends the message with the bytecode location of `bytecode_id`.
     async fn find_bytecode_location<Abi, Parameters, InstantiationArgument>(
         &self,
         bytecode_id: BytecodeId<Abi, Parameters, InstantiationArgument>,
-    ) -> MessageId {
+    ) -> Certificate {
         for height in bytecode_id.message_id.height.0.. {
             let certificate = self
                 .validator
@@ -406,23 +418,14 @@ impl ActiveChain {
                 .value()
                 .messages()
                 .expect("Unexpected certificate value");
-            let message_index = messages.iter().flatten().position(|message| {
+            if messages.iter().flatten().any(|message| {
                 matches!(
                     &message.message,
                     Message::System(SystemMessage::BytecodeLocations { locations })
                         if locations.iter().any(|(id, _)| id == &bytecode_id.forget_abi())
                 )
-            });
-
-            if let Some(index) = message_index {
-                return MessageId {
-                    chain_id: bytecode_id.message_id.chain_id,
-                    height: BlockHeight(height),
-                    index: index.try_into().expect(
-                        "Incompatible `MessageId` index types in \
-                        `linera-sdk` and `linera-execution`",
-                    ),
-                };
+            }) {
+                return certificate;
             }
         }
 
@@ -434,29 +437,25 @@ impl ActiveChain {
         if self.needs_application_description(application_id).await {
             let source_chain = self.validator.get_chain(&application_id.creation.chain_id);
 
-            let request_messages = self
+            let request_certificate = self
                 .add_block(|block| {
                     block.with_request_for_application(application_id);
                 })
                 .await;
 
-            assert_eq!(request_messages.len(), 1);
-
-            let register_messages = source_chain
+            let register_certificate = source_chain
                 .add_block(|block| {
-                    block.with_incoming_bundle(request_messages[0]);
+                    block.with_messages_from(&request_certificate);
                 })
                 .await;
 
-            assert_eq!(register_messages.len(), 1);
-
-            let final_messages = self
+            let final_certificate = self
                 .add_block(|block| {
-                    block.with_incoming_bundle(register_messages[0]);
+                    block.with_messages_from(&register_certificate);
                 })
                 .await;
 
-            assert_eq!(final_messages.len(), 0);
+            assert_eq!(final_certificate.outgoing_message_count(), 0);
         }
     }
 

--- a/linera-sdk/src/test/mod.rs
+++ b/linera-sdk/src/test/mod.rs
@@ -18,6 +18,9 @@ mod mock_stubs;
 #[cfg(with_integration_testing)]
 mod validator;
 
+#[cfg(with_integration_testing)]
+pub use linera_chain::data_types::{Medium, MessageAction};
+
 #[cfg(with_testing)]
 pub use self::mock_stubs::*;
 #[cfg(with_integration_testing)]

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -195,7 +195,10 @@ impl TestValidator {
                 block.with_system_operation(SystemOperation::OpenChain(new_chain_config));
             })
             .await;
-        let executed_block = certificate.value().executed_block().unwrap();
+        let executed_block = certificate
+            .value()
+            .executed_block()
+            .expect("Failed to obtain executed block from certificate");
 
         ChainDescription::Child(MessageId {
             chain_id: executed_block.block.chain_id,

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -13,7 +13,7 @@ use futures::FutureExt as _;
 use linera_base::{
     crypto::{KeyPair, PublicKey},
     data_types::{Amount, ApplicationPermissions, Timestamp},
-    identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId},
+    identifiers::{ApplicationId, BytecodeId, ChainDescription, ChainId, MessageId},
     ownership::ChainOwnership,
 };
 use linera_core::worker::WorkerState;
@@ -190,13 +190,18 @@ impl TestValidator {
             application_permissions: ApplicationPermissions::default(),
         };
 
-        let messages = admin_chain
+        let certificate = admin_chain
             .add_block(|block| {
                 block.with_system_operation(SystemOperation::OpenChain(new_chain_config));
             })
             .await;
+        let executed_block = certificate.value().executed_block().unwrap();
 
-        ChainDescription::Child(messages[OPEN_CHAIN_MESSAGE_INDEX as usize])
+        ChainDescription::Child(MessageId {
+            chain_id: executed_block.block.chain_id,
+            height: executed_block.block.height,
+            index: OPEN_CHAIN_MESSAGE_INDEX,
+        })
     }
 
     /// Returns the [`ActiveChain`] reference to the microchain identified by `chain_id`.


### PR DESCRIPTION
## Motivation

After https://github.com/linera-io/linera-protocol/issues/1475, we won't be able to accept or reject messages individually anymore, only whole message _bundles_. The linera-sdk tests currently handle messages individually, by ID.

## Proposal

Use messages from a whole certificate instead. Return the certificate from `try_sign`.

## Test Plan

The existing tests should catch regressions.

## Links

- Preparation for https://github.com/linera-io/linera-protocol/issues/1475
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
