### PR TITLE
Rename IncomingMessage to IncomingBundle.

### DIFF
--- a/examples/crowd-funding/tests/campaign_lifecycle.rs
+++ b/examples/crowd-funding/tests/campaign_lifecycle.rs
@@ -84,7 +84,7 @@ async fn collect_pledges() {
 
     campaign_chain
         .add_block(|block| {
-            block.with_incoming_messages(pledges_and_transfers);
+            block.with_incoming_bundles(pledges_and_transfers);
         })
         .await;
 
@@ -186,7 +186,7 @@ async fn cancel_successful_campaign() {
 
     campaign_chain
         .add_block(|block| {
-            block.with_incoming_messages(pledges_and_transfers);
+            block.with_incoming_bundles(pledges_and_transfers);
         })
         .await;
 

--- a/examples/fungible/src/lib.rs
+++ b/examples/fungible/src/lib.rs
@@ -322,7 +322,7 @@ pub async fn create_with_accounts(
 
         let transfer_messages = token_chain
             .add_block(|block| {
-                block.with_incoming_message(claim_messages[1]);
+                block.with_incoming_bundle(claim_messages[1]);
             })
             .await;
 
@@ -330,7 +330,7 @@ pub async fn create_with_accounts(
 
         chain
             .add_block(|block| {
-                block.with_incoming_message(transfer_messages[1]);
+                block.with_incoming_bundle(transfer_messages[1]);
             })
             .await;
     }

--- a/examples/fungible/tests/cross_chain.rs
+++ b/examples/fungible/tests/cross_chain.rs
@@ -121,7 +121,7 @@ async fn test_bouncing_tokens() {
     receiver_chain
         .add_block(move |block| {
             block
-                .with_incoming_message(messages[0])
+                .with_incoming_bundle(messages[0])
                 .with_message_rejection(messages[1]);
         })
         .await;

--- a/examples/matching-engine/tests/transaction.rs
+++ b/examples/matching-engine/tests/transaction.rs
@@ -164,7 +164,7 @@ async fn single_transaction() {
 
     matching_chain
         .add_block(|block| {
-            block.with_incoming_messages(orders_bids);
+            block.with_incoming_bundles(orders_bids);
         })
         .await;
 
@@ -214,7 +214,7 @@ async fn single_transaction() {
 
     matching_chain
         .add_block(|block| {
-            block.with_incoming_messages(orders_asks);
+            block.with_incoming_bundles(orders_asks);
         })
         .await;
 
@@ -261,7 +261,7 @@ async fn single_transaction() {
     assert_eq!(order_messages.len(), 2);
     matching_chain
         .add_block(|block| {
-            block.with_incoming_messages(order_messages);
+            block.with_incoming_bundles(order_messages);
         })
         .await;
     user_chain_a.handle_received_messages().await;

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -41,7 +41,7 @@ pub struct Block {
     pub epoch: Epoch,
     /// A selection of incoming messages to be executed first. Successive messages of same
     /// sender and height are grouped together for conciseness.
-    pub incoming_messages: Vec<IncomingMessage>,
+    pub incoming_bundles: Vec<IncomingBundle>,
     /// The operations to execute.
     pub operations: Vec<Operation>,
     /// The block height.
@@ -63,7 +63,7 @@ impl Block {
     /// Returns all bytecode locations referred to in this block's incoming messages.
     pub fn bytecode_locations(&self) -> HashSet<BytecodeLocation> {
         let mut locations = HashSet::new();
-        for message in &self.incoming_messages {
+        for message in &self.incoming_bundles {
             if let Message::System(sys_message) = &message.event.message {
                 locations.extend(sys_message.bytecode_locations(message.event.certificate_hash));
             }
@@ -88,7 +88,7 @@ impl Block {
     pub fn has_only_rejected_messages(&self) -> bool {
         self.operations.is_empty()
             && self
-                .incoming_messages
+                .incoming_bundles
                 .iter()
                 .all(|message| message.action == MessageAction::Reject)
     }
@@ -103,7 +103,7 @@ pub struct ChainAndHeight {
 
 /// A message received from a block of another chain.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, SimpleObject)]
-pub struct IncomingMessage {
+pub struct IncomingBundle {
     /// The origin of the message (chain and channel if any).
     pub origin: Origin,
     /// The content of the message to be delivered to the inbox identified by
@@ -122,7 +122,7 @@ pub enum MessageAction {
     Reject,
 }
 
-impl IncomingMessage {
+impl IncomingBundle {
     /// Returns the ID identifying this message.
     pub fn id(&self) -> MessageId {
         MessageId {
@@ -713,7 +713,7 @@ impl ExecutedBlock {
         message_index: u32,
     ) -> Option<MessageId> {
         let block = &self.block;
-        let transaction_index = block.incoming_messages.len().checked_add(operation_index)?;
+        let transaction_index = block.incoming_bundles.len().checked_add(operation_index)?;
         if message_index
             >= u32::try_from(self.outcome.messages.get(transaction_index)?.len()).ok()?
         {

--- a/linera-chain/src/lib.rs
+++ b/linera-chain/src/lib.rs
@@ -153,7 +153,7 @@ pub enum ChainError {
 pub enum ChainExecutionContext {
     Query,
     DescribeApplication,
-    IncomingMessage(u32),
+    IncomingBundle(u32),
     Operation(u32),
     Block,
     #[cfg(with_testing)]

--- a/linera-chain/src/test.rs
+++ b/linera-chain/src/test.rs
@@ -15,7 +15,7 @@ use linera_execution::{
 };
 
 use crate::data_types::{
-    Block, BlockProposal, Certificate, Event, HashedCertificateValue, IncomingMessage,
+    Block, BlockProposal, Certificate, Event, HashedCertificateValue, IncomingBundle,
     MessageAction, Origin, SignatureAggregator, Vote,
 };
 
@@ -26,7 +26,7 @@ pub fn make_child_block(parent: &HashedCertificateValue) -> Block {
     Block {
         epoch: parent_value.epoch(),
         chain_id: parent_value.chain_id(),
-        incoming_messages: vec![],
+        incoming_bundles: vec![],
         operations: vec![],
         previous_block_hash: Some(parent.hash()),
         height: parent_value.height().try_add_one().unwrap(),
@@ -40,7 +40,7 @@ pub fn make_first_block(chain_id: ChainId) -> Block {
     Block {
         epoch: Epoch::ZERO,
         chain_id,
-        incoming_messages: vec![],
+        incoming_bundles: vec![],
         operations: vec![],
         previous_block_hash: None,
         height: BlockHeight::ZERO,
@@ -61,7 +61,7 @@ pub trait BlockTestExt: Sized {
     fn with_simple_transfer(self, chain_id: ChainId, amount: Amount) -> Self;
 
     /// Returns the block with the given message appended at the end.
-    fn with_incoming_message(self, incoming_message: IncomingMessage) -> Self;
+    fn with_incoming_bundle(self, incoming_bundle: IncomingBundle) -> Self;
 
     /// Returns the block with the specified timestamp.
     fn with_timestamp(self, timestamp: impl Into<Timestamp>) -> Self;
@@ -97,8 +97,8 @@ impl BlockTestExt for Block {
         self.with_transfer(None, Recipient::chain(chain_id), amount)
     }
 
-    fn with_incoming_message(mut self, incoming_message: IncomingMessage) -> Self {
-        self.incoming_messages.push(incoming_message);
+    fn with_incoming_bundle(mut self, incoming_bundle: IncomingBundle) -> Self {
+        self.incoming_bundles.push(incoming_bundle);
         self
     }
 
@@ -141,12 +141,12 @@ impl VoteTestExt for Vote {
 
 /// Helper trait to simplify constructing messages for tests.
 pub trait MessageTestExt: Sized {
-    fn to_simple_incoming(self, sender: ChainId, height: BlockHeight) -> IncomingMessage;
+    fn to_simple_incoming(self, sender: ChainId, height: BlockHeight) -> IncomingBundle;
 }
 
 impl<T: Into<Message>> MessageTestExt for T {
-    fn to_simple_incoming(self, sender: ChainId, height: BlockHeight) -> IncomingMessage {
-        IncomingMessage {
+    fn to_simple_incoming(self, sender: ChainId, height: BlockHeight) -> IncomingBundle {
+        IncomingBundle {
             origin: Origin::chain(sender),
             event: Event {
                 certificate_hash: CryptoHash::test_hash("certificate"),

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -126,8 +126,8 @@ async fn test_application_permissions() {
 
     // An operation that doesn't belong to the app isn't allowed.
     let invalid_block = make_first_block(chain_id)
-        .with_incoming_message(open_chain_message.clone())
-        .with_incoming_message(register_app_message.clone())
+        .with_incoming_bundle(open_chain_message.clone())
+        .with_incoming_bundle(register_app_message.clone())
         .with_simple_transfer(chain_id, Amount::ONE);
     let result = chain.execute_block(&invalid_block, time, None).await;
     assert_matches!(result, Err(ChainError::AuthorizedApplications(app_ids))
@@ -142,8 +142,8 @@ async fn test_application_permissions() {
         bytes: b"foo".to_vec(),
     };
     let valid_block = make_first_block(chain_id)
-        .with_incoming_message(open_chain_message)
-        .with_incoming_message(register_app_message.clone())
+        .with_incoming_bundle(open_chain_message)
+        .with_incoming_bundle(register_app_message.clone())
         .with_operation(app_operation.clone());
     let outcome = chain.execute_block(&valid_block, time, None).await.unwrap();
     let value = HashedCertificateValue::new_confirmed(outcome.with(valid_block));

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -210,7 +210,7 @@ where
             info!("Received new notification: {:?}", notification);
             Self::maybe_sleep(config.delay_before_ms).await;
             match &notification.reason {
-                Reason::NewIncomingMessage { .. } => timeout = storage.clock().current_time(),
+                Reason::NewIncomingBundle { .. } => timeout = storage.clock().current_time(),
                 Reason::NewBlock { .. } | Reason::NewRound { .. } => {
                     if let Err(error) = client.update_validators().await {
                         warn!(

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -624,7 +624,7 @@ where
             let block = Block {
                 epoch: Epoch::ZERO,
                 chain_id,
-                incoming_messages: Vec::new(),
+                incoming_bundles: Vec::new(),
                 operations,
                 previous_block_hash: chain.block_hash,
                 height: chain.next_block_height,

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -22,7 +22,7 @@ pub async fn wait_for_next_round(stream: &mut NotificationStream, timeout: Round
     let mut stream = stream.filter(|notification| match &notification.reason {
         Reason::NewBlock { height, .. } => *height >= timeout.next_block_height,
         Reason::NewRound { round, .. } => *round > timeout.current_round,
-        Reason::NewIncomingMessage { .. } => false,
+        Reason::NewIncomingBundle { .. } => false,
     });
     future::select(
         Box::pin(stream.next()),

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -260,7 +260,7 @@ where
         }
         if tip.is_first_block() && !self.state.chain.is_active() {
             let local_time = self.state.storage.clock().current_time();
-            for message in &block.incoming_messages {
+            for message in &block.incoming_bundles {
                 if self
                     .state
                     .chain
@@ -358,7 +358,7 @@ where
         let tip = self.state.chain.tip_state.get_mut();
         tip.block_hash = Some(certificate.hash());
         tip.next_block_height.try_add_assign_one()?;
-        tip.num_incoming_messages += block.incoming_messages.len() as u32;
+        tip.num_incoming_bundles += block.incoming_bundles.len() as u32;
         tip.num_operations += block.operations.len() as u32;
         tip.num_outgoing_messages += executed_block.outcome.messages.len() as u32;
         self.state.chain.confirmed_log.push(certificate.hash());

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -10,7 +10,7 @@ use linera_base::{
 use linera_chain::{
     data_types::{
         Block, BlockExecutionOutcome, BlockProposal, ExecutedBlock, HashedCertificateValue,
-        IncomingMessage, MessageAction, ProposalContent,
+        IncomingBundle, MessageAction, ProposalContent,
     },
     manager,
 };
@@ -278,7 +278,7 @@ where
             .get()
             .verify_counters(block, &outcome)?;
         // Verify that the resulting chain would have no unconfirmed incoming messages.
-        self.0.chain.validate_incoming_messages().await?;
+        self.0.chain.validate_incoming_bundles().await?;
         Ok(Some((outcome, local_time)))
     }
 
@@ -315,7 +315,7 @@ where
             };
             for (origin, inbox) in pairs {
                 for event in inbox.added_events.elements().await? {
-                    messages.push(IncomingMessage {
+                    messages.push(IncomingBundle {
                         origin: origin.clone(),
                         event: event.clone(),
                         action,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -10,7 +10,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, Owner},
 };
 use linera_chain::{
-    data_types::{ChainAndHeight, IncomingMessage, Medium, MessageBundle},
+    data_types::{ChainAndHeight, IncomingBundle, Medium, MessageBundle},
     manager::ChainManagerInfo,
     ChainStateView,
 };
@@ -156,7 +156,7 @@ pub struct ChainInfo {
     /// The current committees.
     pub requested_committees: Option<BTreeMap<Epoch, Committee>>,
     /// The received messages that are waiting be picked in the next block (if requested).
-    pub requested_pending_messages: Vec<IncomingMessage>,
+    pub requested_pending_messages: Vec<IncomingBundle>,
     /// The response to `request_sent_certificate_hashes_in_range`
     pub requested_sent_certificate_hashes: Vec<CryptoHash>,
     /// The current number of received certificates (useful for `request_received_log_excluding_first_nth`)

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -14,7 +14,7 @@ use linera_base::{
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
-    data_types::{CertificateValue, Event, ExecutedBlock, IncomingMessage, Medium, Origin},
+    data_types::{CertificateValue, Event, ExecutedBlock, IncomingBundle, Medium, Origin},
     ChainError, ChainExecutionContext,
 };
 use linera_execution::{
@@ -239,7 +239,7 @@ where
         .await?;
     let cert = receiver.process_inbox().await?.0.pop().unwrap();
     {
-        let messages = &cert.value().block().unwrap().incoming_messages;
+        let messages = &cert.value().block().unwrap().incoming_bundles;
         // Both `Claim` messages were included in the block.
         assert_eq!(messages.len(), 2);
         // The first one was rejected.
@@ -920,10 +920,10 @@ where
     let (certificates, _) = client1.process_inbox().await.unwrap();
     let block = certificates[0].value().block().unwrap();
     assert!(block.operations.is_empty());
-    assert_eq!(block.incoming_messages.len(), 2);
+    assert_eq!(block.incoming_bundles.len(), 2);
     assert_matches!(
-        block.incoming_messages[0],
-        IncomingMessage {
+        block.incoming_bundles[0],
+        IncomingBundle {
             origin: Origin { sender, medium: Medium::Direct },
             action: MessageAction::Reject,
             event: Event {
@@ -934,8 +934,8 @@ where
         } if sender == ChainId::root(2)
     );
     assert_matches!(
-        block.incoming_messages[1],
-        IncomingMessage {
+        block.incoming_bundles[1],
+        IncomingBundle {
             origin: Origin { sender, medium: Medium::Direct },
             action: MessageAction::Reject,
             event: Event {

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -538,7 +538,7 @@ fn create_dummy_validated_block_value() -> HashedCertificateValue {
             block: Block {
                 chain_id: ChainId(CryptoHash::test_hash("Fake chain ID")),
                 epoch: Epoch::ZERO,
-                incoming_messages: vec![],
+                incoming_bundles: vec![],
                 operations: vec![],
                 height: BlockHeight::ZERO,
                 timestamp: Timestamp::from(0),

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -457,10 +457,10 @@ where
     let mut certs = receiver.process_inbox().await.unwrap().0;
     assert_eq!(certs.len(), 1);
     let cert = certs.pop().unwrap();
-    let incoming_messages = &cert.value().block().unwrap().incoming_messages;
-    assert_eq!(incoming_messages.len(), 1);
-    assert_eq!(incoming_messages[0].action, MessageAction::Reject);
-    assert_eq!(incoming_messages[0].event.kind, MessageKind::Simple);
+    let incoming_bundles = &cert.value().block().unwrap().incoming_bundles;
+    assert_eq!(incoming_bundles.len(), 1);
+    assert_eq!(incoming_bundles[0].action, MessageAction::Reject);
+    assert_eq!(incoming_bundles[0].event.kind, MessageKind::Simple);
     let messages = cert.value().messages().unwrap();
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0].len(), 0);
@@ -481,10 +481,10 @@ where
     let mut certs = receiver.process_inbox().await.unwrap().0;
     assert_eq!(certs.len(), 1);
     let cert = certs.pop().unwrap();
-    let incoming_messages = &cert.value().block().unwrap().incoming_messages;
-    assert_eq!(incoming_messages.len(), 1);
-    assert_eq!(incoming_messages[0].action, MessageAction::Reject);
-    assert_eq!(incoming_messages[0].event.kind, MessageKind::Tracked);
+    let incoming_bundles = &cert.value().block().unwrap().incoming_bundles;
+    assert_eq!(incoming_bundles.len(), 1);
+    assert_eq!(incoming_bundles[0].action, MessageAction::Reject);
+    assert_eq!(incoming_bundles[0].event.kind, MessageKind::Tracked);
     let messages = cert.value().messages().unwrap();
     assert_eq!(messages.len(), 1);
 
@@ -496,19 +496,19 @@ where
     let mut certs = creator.process_inbox().await.unwrap().0;
     assert_eq!(certs.len(), 1);
     let cert = certs.pop().unwrap();
-    let incoming_messages = &cert.value().block().unwrap().incoming_messages;
-    assert_eq!(incoming_messages.len(), 2);
+    let incoming_bundles = &cert.value().block().unwrap().incoming_bundles;
+    assert_eq!(incoming_bundles.len(), 2);
     // First message is the grant refund for the successful message sent before.
-    assert_eq!(incoming_messages[0].action, MessageAction::Accept);
-    assert_eq!(incoming_messages[0].event.kind, MessageKind::Tracked);
+    assert_eq!(incoming_bundles[0].action, MessageAction::Accept);
+    assert_eq!(incoming_bundles[0].event.kind, MessageKind::Tracked);
     assert_matches!(
-        incoming_messages[0].event.message,
+        incoming_bundles[0].event.message,
         Message::System(SystemMessage::Credit { .. })
     );
     // Second message is the bounced message.
-    assert_eq!(incoming_messages[1].action, MessageAction::Accept);
-    assert_eq!(incoming_messages[1].event.kind, MessageKind::Bouncing);
-    assert_matches!(incoming_messages[1].event.message, Message::User { .. });
+    assert_eq!(incoming_bundles[1].action, MessageAction::Accept);
+    assert_eq!(incoming_bundles[1].event.kind, MessageKind::Bouncing);
+    assert_matches!(incoming_bundles[1].event.message, Message::User { .. });
 
     Ok(())
 }
@@ -647,7 +647,7 @@ where
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
         CertificateValue::ConfirmedBlock { executed_block, .. } => {
-            &executed_block.block.incoming_messages
+            &executed_block.block.incoming_bundles
         }
         _ => panic!("Unexpected value"),
     };
@@ -683,7 +683,7 @@ where
     assert_eq!(certs.len(), 1);
     let messages = match certs[0].value() {
         CertificateValue::ConfirmedBlock { executed_block, .. } => {
-            &executed_block.block.incoming_messages
+            &executed_block.block.incoming_bundles
         }
         _ => panic!("Unexpected value"),
     };
@@ -857,7 +857,7 @@ where
     // There should be a message receiving the new post.
     let messages = match certs[0].value() {
         CertificateValue::ConfirmedBlock { executed_block, .. } => {
-            &executed_block.block.incoming_messages
+            &executed_block.block.incoming_bundles
         }
         _ => panic!("Unexpected value"),
     };

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -22,7 +22,7 @@ use linera_base::{
 };
 use linera_chain::{
     data_types::{
-        BlockExecutionOutcome, ChannelFullName, Event, HashedCertificateValue, IncomingMessage,
+        BlockExecutionOutcome, ChannelFullName, Event, HashedCertificateValue, IncomingBundle,
         MessageAction, Origin, OutgoingMessage,
     },
     test::{make_child_block, make_first_block, BlockTestExt},
@@ -168,7 +168,7 @@ where
     assert!(info.manager.pending.is_none());
 
     // Produce one more block to broadcast the bytecode ID.
-    let broadcast_message = IncomingMessage {
+    let broadcast_message = IncomingBundle {
         origin: Origin::chain(publisher_chain.into()),
         event: Event {
             certificate_hash: publish_certificate.hash(),
@@ -185,7 +185,7 @@ where
     };
     let broadcast_block = make_child_block(&publish_certificate.value)
         .with_timestamp(1)
-        .with_incoming_message(broadcast_message);
+        .with_incoming_bundle(broadcast_message);
     let bytecode_id = BytecodeId::new(MessageId {
         chain_id: publisher_chain.into(),
         height: publish_block_height,
@@ -318,7 +318,7 @@ where
     assert!(info.manager.pending.is_none());
 
     // Accept subscription
-    let accept_message = IncomingMessage {
+    let accept_message = IncomingBundle {
         origin: Origin::chain(creator_chain.into()),
         event: Event {
             certificate_hash: subscribe_certificate.hash(),
@@ -335,7 +335,7 @@ where
     };
     let accept_block = make_child_block(&broadcast_certificate.value)
         .with_timestamp(3)
-        .with_incoming_message(accept_message);
+        .with_incoming_bundle(accept_message);
     publisher_system_state.timestamp = Timestamp::from(3);
     let publisher_state_hash = publisher_system_state.into_hash().await;
     let accept_block_proposal = HashedCertificateValue::new_confirmed(
@@ -402,7 +402,7 @@ where
     let create_block = make_child_block(&subscribe_certificate.value)
         .with_timestamp(4)
         .with_operation(create_operation)
-        .with_incoming_message(IncomingMessage {
+        .with_incoming_bundle(IncomingBundle {
             origin: Origin::channel(publisher_chain.into(), publish_admin_channel),
             event: Event {
                 certificate_hash: broadcast_certificate.hash(),

--- a/linera-explorer/src/components/Block.test.ts
+++ b/linera-explorer/src/components/Block.test.ts
@@ -17,7 +17,7 @@ test('Block mounting', () => {
               timestamp: 1694097511817833,
               authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
               previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-              incomingMessages: [{
+              incomingBundles: [{
                 origin: {
                   medium: "Direct",
                   sender: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"

--- a/linera-explorer/src/components/Block.vue
+++ b/linera-explorer/src/components/Block.vue
@@ -62,17 +62,17 @@ defineProps<{block: HashedCertificateValue, title: string}>()
           <span><strong>Status</strong></span>
           <span>{{ block.value.status }}</span>
         </li>
-        <li v-if="block.value.executedBlock?.block.incomingMessages.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#in-messages-collapse-'+block.hash">
-          <span><strong>Incoming Messages</strong> ({{ block.value.executedBlock?.block.incomingMessages.length }})</span>
+        <li v-if="block.value.executedBlock?.block.incomingBundles.length!==0" class="list-group-item d-flex justify-content-between" data-bs-toggle="collapse" :data-bs-target="'#in-messages-collapse-'+block.hash">
+          <span><strong>Incoming Messages</strong> ({{ block.value.executedBlock?.block.incomingBundles.length }})</span>
           <i class="bi bi-caret-down-fill"></i>
         </li>
         <li v-else class="list-group-item d-flex justify-content-between">
           <span><strong>Incoming Messages</strong> (0)</span>
           <span></span>
         </li>
-        <div v-if="block.value.executedBlock?.block.incomingMessages.length!==0" class="collapse" :id="'in-messages-collapse-'+block.hash">
+        <div v-if="block.value.executedBlock?.block.incomingBundles.length!==0" class="collapse" :id="'in-messages-collapse-'+block.hash">
           <ul class="list-group">
-            <li v-for="(m, i) in block.value.executedBlock?.block.incomingMessages" class="list-group-item p-0" key="block.hash+'-inmessage-'+i">
+            <li v-for="(m, i) in block.value.executedBlock?.block.incomingBundles" class="list-group-item p-0" key="block.hash+'-inmessage-'+i">
               <div class="card">
                 <div class="card-header">Message {{ i+1 }}</div>
                 <div class="card-body">

--- a/linera-explorer/src/components/Blocks.test.ts
+++ b/linera-explorer/src/components/Blocks.test.ts
@@ -19,7 +19,7 @@ test('Blocks mounting', () => {
                   timestamp: 1694097511817833,
                   authenticatedSigner: "a36c72207a7c3cef20eb254978c0947d7cf28c9c7d7c62de42a0ed9db901cf3f",
                   previousBlockHash: "f1c748c5e39591125250e85d57fdeac0b7ba44a32c12c616eb4537f93b6e5d0a",
-                  incomingMessages: [{
+                  incomingBundles: [{
                     origin: {
                       medium: "Direct",
                       sender: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65"

--- a/linera-explorer/src/components/Blocks.vue
+++ b/linera-explorer/src/components/Blocks.vue
@@ -30,7 +30,7 @@ defineProps<{blocks: HashedCertificateValue[]}>()
           <td>{{ (new Date(b.value.executedBlock?.block.timestamp/1000)).toLocaleString() }}</td>
           <td :title="b.value.executedBlock?.block.authenticatedSigner">{{ short_hash(b.value.executedBlock?.block.authenticatedSigner) }}</td>
           <td>{{ b.value.status }}</td>
-          <td>{{ b.value.executedBlock?.block.incomingMessages.length }}</td>
+          <td>{{ b.value.executedBlock?.block.incomingBundles.length }}</td>
           <td>{{ b.value.executedBlock?.outcome.messages.length }}</td>
           <td>{{ b.value.executedBlock?.block.operations.length }}</td>
           <td>

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -68,9 +68,9 @@ Block:
         TYPENAME: ChainId
     - epoch:
         TYPENAME: Epoch
-    - incoming_messages:
+    - incoming_bundles:
         SEQ:
-          TYPENAME: IncomingMessage
+          TYPENAME: IncomingBundle
     - operations:
         SEQ:
           TYPENAME: Operation
@@ -223,7 +223,7 @@ ChainInfo:
               TYPENAME: Committee
     - requested_pending_messages:
         SEQ:
-          TYPENAME: IncomingMessage
+          TYPENAME: IncomingBundle
     - requested_sent_certificate_hashes:
         SEQ:
           TYPENAME: CryptoHash
@@ -448,7 +448,7 @@ HandleLiteCertRequest:
     - certificate:
         TYPENAME: LiteCertificate
     - wait_for_outgoing_messages: BOOL
-IncomingMessage:
+IncomingBundle:
   STRUCT:
     - origin:
         TYPENAME: Origin

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -180,7 +180,7 @@ impl ActiveChain {
         assert_eq!(publish_messages.len(), 1);
 
         self.add_block(|block| {
-            block.with_incoming_message(publish_messages[0]);
+            block.with_incoming_bundle(publish_messages[0]);
         })
         .await;
 
@@ -303,14 +303,14 @@ impl ActiveChain {
 
         let accept_messages = publisher
             .add_block(|block| {
-                block.with_incoming_message(request_messages[0]);
+                block.with_incoming_bundle(request_messages[0]);
             })
             .await;
 
         assert_eq!(accept_messages.len(), 1);
 
         self.add_block(|block| {
-            block.with_incoming_message(accept_messages[0]);
+            block.with_incoming_bundle(accept_messages[0]);
         })
         .await;
     }
@@ -355,7 +355,7 @@ impl ActiveChain {
         let creation_messages = self
             .add_block(|block| {
                 if let Some(message_id) = bytecode_location_message {
-                    block.with_incoming_message(message_id);
+                    block.with_incoming_bundle(message_id);
                 }
 
                 block.with_system_operation(SystemOperation::CreateApplication {
@@ -444,7 +444,7 @@ impl ActiveChain {
 
             let register_messages = source_chain
                 .add_block(|block| {
-                    block.with_incoming_message(request_messages[0]);
+                    block.with_incoming_bundle(request_messages[0]);
                 })
                 .await;
 
@@ -452,7 +452,7 @@ impl ActiveChain {
 
             let final_messages = self
                 .add_block(|block| {
-                    block.with_incoming_message(register_messages[0]);
+                    block.with_incoming_bundle(register_messages[0]);
                 })
                 .await;
 

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -164,7 +164,7 @@ query Block($hash: CryptoHash, $chainId: ChainId!) {
           timestamp
           authenticatedSigner
           previousBlockHash
-          incomingMessages {
+          incomingBundles {
             origin
             event
             action
@@ -209,7 +209,7 @@ query Blocks($from: CryptoHash, $chainId: ChainId!, $limit: Int) {
           timestamp
           authenticatedSigner
           previousBlockHash
-          incomingMessages {
+          incomingBundles {
             origin
             event
             action

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -72,7 +72,7 @@ type Block {
 	A selection of incoming messages to be executed first. Successive messages of same
 	sender and height are grouped together for conciseness.
 	"""
-	incomingMessages: [IncomingMessage!]!
+	incomingBundles: [IncomingBundle!]!
 	"""
 	The operations to execute.
 	"""
@@ -240,7 +240,7 @@ type ChainTipState {
 	"""
 	Number of incoming messages.
 	"""
-	numIncomingMessages: Int!
+	numIncomingBundles: Int!
 	"""
 	Number of operations.
 	"""
@@ -474,7 +474,7 @@ type InboxStateView {
 """
 A message received from a block of another chain.
 """
-type IncomingMessage {
+type IncomingBundle {
 	"""
 	The origin of the message (chain and channel if any).
 	"""

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -47,7 +47,7 @@ mod types {
             height: BlockHeight,
             hash: CryptoHash,
         },
-        NewIncomingMessage {
+        NewIncomingBundle {
             origin: Origin,
             height: BlockHeight,
         },
@@ -134,20 +134,20 @@ pub struct Transfer;
 mod from {
     use linera_base::identifiers::StreamId;
     use linera_chain::data_types::{
-        BlockExecutionOutcome, EventRecord, ExecutedBlock, HashedCertificateValue, IncomingMessage,
+        BlockExecutionOutcome, EventRecord, ExecutedBlock, HashedCertificateValue, IncomingBundle,
         OutgoingMessage,
     };
 
     use super::*;
 
-    impl From<block::BlockBlockValueExecutedBlockBlockIncomingMessages> for IncomingMessage {
-        fn from(val: block::BlockBlockValueExecutedBlockBlockIncomingMessages) -> Self {
-            let block::BlockBlockValueExecutedBlockBlockIncomingMessages {
+    impl From<block::BlockBlockValueExecutedBlockBlockIncomingBundles> for IncomingBundle {
+        fn from(val: block::BlockBlockValueExecutedBlockBlockIncomingBundles) -> Self {
+            let block::BlockBlockValueExecutedBlockBlockIncomingBundles {
                 origin,
                 event,
                 action,
             } = val;
-            IncomingMessage {
+            IncomingBundle {
                 origin,
                 event,
                 action,
@@ -160,21 +160,21 @@ mod from {
             let block::BlockBlockValueExecutedBlockBlock {
                 chain_id,
                 epoch,
-                incoming_messages,
+                incoming_bundles,
                 operations,
                 height,
                 timestamp,
                 authenticated_signer,
                 previous_block_hash,
             } = val;
-            let incoming_messages = incoming_messages
+            let incoming_bundles = incoming_bundles
                 .into_iter()
-                .map(IncomingMessage::from)
+                .map(IncomingBundle::from)
                 .collect();
             linera_chain::data_types::Block {
                 chain_id,
                 epoch,
-                incoming_messages,
+                incoming_bundles,
                 operations,
                 height,
                 timestamp,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -1151,7 +1151,7 @@ pub async fn wait_for_next_round(stream: &mut NotificationStream, timeout: Round
     let mut stream = stream.filter(|notification| match &notification.reason {
         Reason::NewBlock { height, .. } => *height >= timeout.next_block_height,
         Reason::NewRound { round, .. } => *round > timeout.current_round,
-        Reason::NewIncomingMessage { .. } => false,
+        Reason::NewIncomingBundle { .. } => false,
     });
     future::select(
         Box::pin(stream.next()),


### PR DESCRIPTION
## Motivation

After https://github.com/linera-io/linera-protocol/issues/1475, what is currently the `IncomingMessage` type will contain a whole _bundle_ of messages, that have to be either all accepted or rejected.

## Proposal

To reduce the diff when implementing https://github.com/linera-io/linera-protocol/issues/1475, already rename `IncomingMessage` to `IncomingBundle`, even though it's currently still only one message.

## Test Plan

Only renaming.

## Links

- Preparation for https://github.com/linera-io/linera-protocol/issues/1475
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
