### PR TITLE
Add blobs to NFT example

### DIFF
--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -84,21 +84,38 @@ linera service --port $PORT &
 
 ### Using GraphiQL
 
+- Navigate to `http://localhost:8080/`.
+- To publish a blob, run the mutation:
+```gql,uri=http://localhost:8080/
+    mutation {
+        publishDataBlob(
+          chainId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65",
+          blobContent: {
+            bytes: [1, 2, 3, 4]
+          }
+        )
+    }
+```
+
 - Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
-- To mint an NFT, run the query:
+- To mint an NFT, run the mutation:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         mint(
             minter: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
             name: "nft1",
-            payload: [1, 2, 3, 4]
+            blobId: {
+              hash: "34a20da0fdd7e24ddbff60cb7f952b053b3f0e196e622d47c3a368f690f01326",
+              blob_type: "Data"
+            }
         )
     }
 ```
+
 - To check that it's there, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
-        nft(tokenId: "kSIB3o59Ut8wioJdISqZwWedPGUlHK2HapnkOLqLSRA") {
+        nft(tokenId: "o66hIR1qQ8oUoTZTKHK35Cg1ObRgYSpBJnnS2gyvGBQ") {
             tokenId,
             owner,
             name,
@@ -107,24 +124,27 @@ linera service --port $PORT &
         }
     }
 ```
+
 - To check that it's assigned to the owner, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
         ownedNfts(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
     }
 ```
+
 - To check everything that it's there, run the query:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
         nfts
     }
 ```
-- To transfer the NFT to user `$OWNER_2`, still on chain `$CHAIN_1`, run the query:
+
+- To transfer the NFT to user `$OWNER_2`, still on chain `$CHAIN_1`, run the mutation:
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         transfer(
             sourceOwner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
-            tokenId: "kSIB3o59Ut8wioJdISqZwWedPGUlHK2HapnkOLqLSRA",
+            tokenId: "o66hIR1qQ8oUoTZTKHK35Cg1ObRgYSpBJnnS2gyvGBQ",
             targetAccount: {
                 chainId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65",
                 owner: "User:598d18f67709fe76ed6a36b75a7c9889012d30b896800dfd027ee10e1afd49a3"

--- a/examples/non-fungible/src/contract.rs
+++ b/examples/non-fungible/src/contract.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeSet;
 
 use fungible::Account;
 use linera_sdk::{
-    base::{AccountOwner, WithContractAbi},
+    base::{AccountOwner, BlobId, WithContractAbi},
     views::{RootView, View, ViewStorageContext},
     Contract, ContractRuntime,
 };
@@ -51,10 +51,10 @@ impl Contract for NonFungibleTokenContract {
             Operation::Mint {
                 minter,
                 name,
-                payload,
+                blob_id,
             } => {
                 self.check_account_authentication(minter);
-                self.mint(minter, name, payload).await;
+                self.mint(minter, name, blob_id).await;
             }
 
             Operation::Transfer {
@@ -176,13 +176,13 @@ impl NonFungibleTokenContract {
             .expect("NFT {token_id} not found")
     }
 
-    async fn mint(&mut self, owner: AccountOwner, name: String, payload: Vec<u8>) {
+    async fn mint(&mut self, owner: AccountOwner, name: String, blob_id: BlobId) {
         let token_id = Nft::create_token_id(
             &self.runtime.chain_id(),
             &self.runtime.application_id().forget_abi(),
             &name,
             &owner,
-            &payload,
+            &blob_id,
             *self.state.num_minted_nfts.get(),
         )
         .expect("Failed to serialize NFT metadata");
@@ -192,7 +192,7 @@ impl NonFungibleTokenContract {
             owner,
             name,
             minter: owner,
-            payload,
+            blob_id,
         })
         .await;
 

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -7,14 +7,14 @@ mod state;
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use fungible::Account;
 use linera_sdk::{
-    base::{AccountOwner, WithServiceAbi},
+    base::{AccountOwner, BlobId, WithServiceAbi},
     views::{View, ViewStorageContext},
     Service, ServiceRuntime,
 };
@@ -24,6 +24,7 @@ use self::state::NonFungibleToken;
 
 pub struct NonFungibleTokenService {
     state: Arc<NonFungibleToken>,
+    runtime: Arc<Mutex<ServiceRuntime<Self>>>,
 }
 
 linera_sdk::service!(NonFungibleTokenService);
@@ -41,6 +42,7 @@ impl Service for NonFungibleTokenService {
             .expect("Failed to load state");
         NonFungibleTokenService {
             state: Arc::new(state),
+            runtime: Arc::new(Mutex::new(runtime)),
         }
     }
 
@@ -48,6 +50,7 @@ impl Service for NonFungibleTokenService {
         let schema = Schema::build(
             QueryRoot {
                 non_fungible_token: self.state.clone(),
+                runtime: self.runtime.clone(),
             },
             MutationRoot,
             EmptySubscription,
@@ -59,6 +62,7 @@ impl Service for NonFungibleTokenService {
 
 struct QueryRoot {
     non_fungible_token: Arc<NonFungibleToken>,
+    runtime: Arc<Mutex<ServiceRuntime<NonFungibleTokenService>>>,
 }
 
 #[Object]
@@ -73,7 +77,14 @@ impl QueryRoot {
             .unwrap();
 
         if let Some(nft) = nft {
-            let nft_output = NftOutput::new_with_token_id(token_id, nft);
+            let payload = {
+                let mut runtime = self
+                    .runtime
+                    .try_lock()
+                    .expect("Services only run in a single thread");
+                runtime.read_blob(nft.blob_id).into_inner().bytes
+            };
+            let nft_output = NftOutput::new_with_token_id(token_id, nft, payload);
             Some(nft_output)
         } else {
             None
@@ -85,7 +96,14 @@ impl QueryRoot {
         self.non_fungible_token
             .nfts
             .for_each_index_value(|_token_id, nft| {
-                let nft_output = NftOutput::new(nft);
+                let payload = {
+                    let mut runtime = self
+                        .runtime
+                        .try_lock()
+                        .expect("Services only run in a single thread");
+                    runtime.read_blob(nft.blob_id).into_inner().bytes
+                };
+                let nft_output = NftOutput::new(nft, payload);
                 nfts.insert(nft_output.token_id.clone(), nft_output);
                 Ok(())
             })
@@ -143,7 +161,14 @@ impl QueryRoot {
                 .await
                 .unwrap()
                 .unwrap();
-            let nft_output = NftOutput::new(nft);
+            let payload = {
+                let mut runtime = self
+                    .runtime
+                    .try_lock()
+                    .expect("Services only run in a single thread");
+                runtime.read_blob(nft.blob_id).into_inner().bytes
+            };
+            let nft_output = NftOutput::new(nft, payload);
             result.insert(nft_output.token_id.clone(), nft_output);
         }
 
@@ -155,11 +180,11 @@ struct MutationRoot;
 
 #[Object]
 impl MutationRoot {
-    async fn mint(&self, minter: AccountOwner, name: String, payload: Vec<u8>) -> Vec<u8> {
+    async fn mint(&self, minter: AccountOwner, name: String, blob_id: BlobId) -> Vec<u8> {
         bcs::to_bytes(&Operation::Mint {
             minter,
             name,
-            payload,
+            blob_id,
         })
         .unwrap()
     }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -780,6 +780,14 @@ pub struct BlobContent {
 }
 
 impl BlobContent {
+    /// Creates a [`BlobContent`] from a string for testing purposes.
+    #[cfg(with_testing)]
+    pub fn test_blob_content(content: &str) -> Self {
+        BlobContent {
+            bytes: content.as_bytes().to_vec(),
+        }
+    }
+
     /// Creates a `Blob` without checking that this is the correct `BlobId`.
     pub fn with_blob_id_unchecked(self, blob_id: BlobId) -> Blob {
         Blob {
@@ -842,10 +850,7 @@ impl Blob {
     /// Creates a [`Blob`] from a string for testing purposes.
     #[cfg(with_testing)]
     pub fn test_data_blob(content: &str) -> Self {
-        let blob_content = BlobContent {
-            bytes: content.as_bytes().to_vec(),
-        };
-        blob_content.with_data_blob_id()
+        BlobContent::test_blob_content(content).with_data_blob_id()
     }
 
     /// Returns a reference to the inner `BlobContent`, without the hash.

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -19,8 +19,8 @@ use linera_base::{
     abi::ContractAbi,
     command::{resolve_binary, CommandExt},
     crypto::{CryptoHash, PublicKey},
-    data_types::Amount,
-    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
+    data_types::{Amount, BlobContent},
+    identifiers::{Account, ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
 };
 use linera_client::{config::GenesisConfig, wallet::Wallet};
 use linera_core::worker::Notification;
@@ -908,6 +908,21 @@ impl NodeService {
                 Ok((id, link))
             })
             .collect()
+    }
+
+    pub async fn publish_data_blob(
+        &self,
+        chain_id: &ChainId,
+        blob_content: &BlobContent,
+    ) -> Result<BlobId> {
+        let query = format!(
+            "mutation {{ publishDataBlob(chainId: {}, blobContent: {}) }}",
+            chain_id.to_value(),
+            blob_content.to_value(),
+        );
+        let data = self.query_node(query).await?;
+        serde_json::from_value(data["publishDataBlob"].clone())
+            .context("missing publishDataBlob field in response")
     }
 
     pub async fn publish_bytecode<Abi, Parameters, InstantiationArgument>(


### PR DESCRIPTION
## Motivation

Right now we just have the NFT's image "payload" (the bytes of the image) loaded in the example app's state.

## Proposal

Let's use blobs instead for that

## Test Plan

e2e test was modified to work with blobs

