### PR TITLE
Correct an issue for the memory-storage-service.

### DIFF
--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -244,7 +244,7 @@ enum ServiceStoreServerOptions {
     #[cfg(feature = "rocksdb")]
     #[command(name = "rocksdb")]
     RocksDb {
-        #[arg(long = "endpoint")]
+        #[arg(long = "path")]
         path: String,
         #[arg(long = "endpoint")]
         endpoint: String,


### PR DESCRIPTION
## Motivation

A typo in the input prevents the use of RocksDb for the linera-storage-service.

## Proposal

The problem is addressed directly.

## Test Plan

It has been tested locally that after the correction, the storage-service works with RocksDb.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
