### PR TITLE
Replace async locks by sync locks for `KeyValueStoreView` and `ReentrantCollectionView`.

### DIFF
--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -680,7 +680,8 @@ where
             {
                 let cached_entries = self.cached_entries.lock().unwrap();
                 for short_key in &short_keys {
-                    if !self.updates.contains_key(short_key) && !cached_entries.contains_key(short_key)
+                    if !self.updates.contains_key(short_key)
+                        && !cached_entries.contains_key(short_key)
                     {
                         let key = self
                             .context
@@ -983,7 +984,7 @@ where
                 cached_entries_result.push(cached_entries.get(key).cloned());
             }
         }
-        for (key,cached_entry) in keys.into_iter().zip(cached_entries_result) {
+        for (key, cached_entry) in keys.into_iter().zip(cached_entries_result) {
             hasher.update_with_bytes(&key)?;
             let hash = if let Some(entry) = self.updates.get(&key) {
                 let Update::Set(view) = entry else {

--- a/linera-views/src/reentrant_collection_view.rs
+++ b/linera-views/src/reentrant_collection_view.rs
@@ -10,10 +10,10 @@ use std::{
     io::Write,
     marker::PhantomData,
     mem,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
-use async_lock::{Mutex, RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
+use async_lock::{RwLock, RwLockReadGuardArc, RwLockWriteGuardArc};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 #[cfg(with_metrics)]
@@ -184,7 +184,7 @@ where
     fn clear(&mut self) {
         self.delete_storage_first = true;
         self.updates.clear();
-        self.cached_entries.get_mut().clear();
+        self.cached_entries.get_mut().unwrap().clear();
     }
 }
 
@@ -274,7 +274,7 @@ where
                 }
             },
             Vacant(entry) => {
-                let wrapped_view = match self.cached_entries.get_mut().remove(short_key) {
+                let wrapped_view = match self.cached_entries.get_mut().unwrap().remove(short_key) {
                     Some(view) => view,
                     None => {
                         Self::wrapped_view(&self.context, self.delete_storage_first, short_key)
@@ -299,14 +299,18 @@ where
         } else if self.delete_storage_first {
             None
         } else {
-            let mut cached_entries = self.cached_entries.lock().await;
-
-            if let Some(view) = cached_entries.get(short_key) {
+            let view = {
+                let cached_entries = self.cached_entries.lock().unwrap();
+                let view = cached_entries.get(short_key);
+                view.cloned()
+            };
+            if let Some(view) = view {
                 Some(view.clone())
             } else {
                 let key_index = self.context.base_tag_index(KeyTag::Index as u8, short_key);
                 if self.context.contains_key(&key_index).await? {
                     let view = Self::wrapped_view(&self.context, false, short_key).await?;
+                    let mut cached_entries = self.cached_entries.lock().unwrap();
                     cached_entries.insert(short_key.to_owned(), view.clone());
                     Some(view)
                 } else {
@@ -397,7 +401,7 @@ where
             }
         } else if self.delete_storage_first {
             false
-        } else if self.cached_entries.lock().await.contains_key(short_key) {
+        } else if self.cached_entries.lock().unwrap().contains_key(short_key) {
             true
         } else {
             let key_index = self.context.base_tag_index(KeyTag::Index as u8, short_key);
@@ -423,7 +427,7 @@ where
     /// # })
     /// ```
     pub fn remove_entry(&mut self, short_key: Vec<u8>) {
-        self.cached_entries.get_mut().remove(&short_key);
+        self.cached_entries.get_mut().unwrap().remove(&short_key);
         if self.delete_storage_first {
             // Optimization: No need to mark `short_key` for deletion as we are going to remove all the keys at once.
             self.updates.remove(&short_key);
@@ -461,7 +465,7 @@ where
         let view = Arc::new(RwLock::new(view));
         let view = Update::Set(view);
         self.updates.insert(short_key.to_vec(), view);
-        self.cached_entries.get_mut().remove(short_key);
+        self.cached_entries.get_mut().unwrap().remove(short_key);
         Ok(())
     }
 
@@ -503,7 +507,7 @@ where
         &mut self,
         short_keys: Vec<Vec<u8>>,
     ) -> Result<Vec<WriteGuardedView<W>>, ViewError> {
-        let cached_entries = self.cached_entries.get_mut();
+        let cached_entries = self.cached_entries.get_mut().unwrap();
         let mut short_keys_to_load = Vec::new();
         let mut keys = Vec::new();
         for short_key in &short_keys {
@@ -593,7 +597,7 @@ where
         let mut keys_to_check = Vec::new();
         let mut keys_to_check_metadata = Vec::new();
 
-        let mut cached_entries = self.cached_entries.lock().await;
+        let mut cached_entries = self.cached_entries.lock().unwrap();
 
         for (position, short_key) in short_keys.into_iter().enumerate() {
             if let Some(update) = self.updates.get(&short_key) {
@@ -670,35 +674,41 @@ where
         &self,
     ) -> Result<Vec<(Vec<u8>, ReadGuardedView<W>)>, ViewError> {
         let short_keys = self.keys().await?;
-        let mut cached_entries = self.cached_entries.lock().await;
         if !self.delete_storage_first {
             let mut keys = Vec::new();
             let mut short_keys_to_load = Vec::new();
-            for short_key in &short_keys {
-                if !self.updates.contains_key(short_key) && !cached_entries.contains_key(short_key)
-                {
-                    let key = self
-                        .context
-                        .base_tag_index(KeyTag::Subview as u8, short_key);
-                    let context = self.context.clone_with_base_key(key);
-                    keys.extend(W::pre_load(&context)?);
-                    short_keys_to_load.push(short_key.to_vec());
+            {
+                let cached_entries = self.cached_entries.lock().unwrap();
+                for short_key in &short_keys {
+                    if !self.updates.contains_key(short_key) && !cached_entries.contains_key(short_key)
+                    {
+                        let key = self
+                            .context
+                            .base_tag_index(KeyTag::Subview as u8, short_key);
+                        let context = self.context.clone_with_base_key(key);
+                        keys.extend(W::pre_load(&context)?);
+                        short_keys_to_load.push(short_key.to_vec());
+                    }
                 }
             }
             let values = self.context.read_multi_values_bytes(keys).await?;
-            for (loaded_values, short_key) in values
-                .chunks_exact(W::NUM_INIT_KEYS)
-                .zip(short_keys_to_load)
             {
-                let key = self
-                    .context
-                    .base_tag_index(KeyTag::Subview as u8, &short_key);
-                let context = self.context.clone_with_base_key(key);
-                let view = W::post_load(context, loaded_values)?;
-                let wrapped_view = Arc::new(RwLock::new(view));
-                cached_entries.insert(short_key.to_vec(), wrapped_view);
+                let mut cached_entries = self.cached_entries.lock().unwrap();
+                for (loaded_values, short_key) in values
+                    .chunks_exact(W::NUM_INIT_KEYS)
+                    .zip(short_keys_to_load)
+                {
+                    let key = self
+                        .context
+                        .base_tag_index(KeyTag::Subview as u8, &short_key);
+                    let context = self.context.clone_with_base_key(key);
+                    let view = W::post_load(context, loaded_values)?;
+                    let wrapped_view = Arc::new(RwLock::new(view));
+                    cached_entries.insert(short_key.to_vec(), wrapped_view);
+                }
             }
         }
+        let cached_entries = self.cached_entries.lock().unwrap();
         short_keys
             .into_iter()
             .map(|short_key| {
@@ -738,21 +748,23 @@ where
         &mut self,
     ) -> Result<Vec<(Vec<u8>, WriteGuardedView<W>)>, ViewError> {
         let short_keys = self.keys().await?;
-        let cached_entries = self.cached_entries.get_mut();
         if !self.delete_storage_first {
             let mut keys = Vec::new();
             let mut short_keys_to_load = Vec::new();
-            for short_key in &short_keys {
-                if !self.updates.contains_key(short_key) {
-                    if let Some(view) = cached_entries.remove(short_key) {
-                        self.updates.insert(short_key.to_vec(), Update::Set(view));
-                    } else {
-                        let key = self
-                            .context
-                            .base_tag_index(KeyTag::Subview as u8, short_key);
-                        let context = self.context.clone_with_base_key(key);
-                        keys.extend(W::pre_load(&context)?);
-                        short_keys_to_load.push(short_key.to_vec());
+            {
+                let cached_entries = self.cached_entries.get_mut().unwrap();
+                for short_key in &short_keys {
+                    if !self.updates.contains_key(short_key) {
+                        if let Some(view) = cached_entries.remove(short_key) {
+                            self.updates.insert(short_key.to_vec(), Update::Set(view));
+                        } else {
+                            let key = self
+                                .context
+                                .base_tag_index(KeyTag::Subview as u8, short_key);
+                            let context = self.context.clone_with_base_key(key);
+                            keys.extend(W::pre_load(&context)?);
+                            short_keys_to_load.push(short_key.to_vec());
+                        }
                     }
                 }
             }
@@ -931,7 +943,7 @@ where
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
         hasher.update_with_bcs_bytes(&keys.len())?;
-        let cached_entries = self.cached_entries.get_mut();
+        let cached_entries = self.cached_entries.get_mut().unwrap();
         for key in keys {
             hasher.update_with_bytes(&key)?;
             let hash = if let Some(entry) = self.updates.get_mut(&key) {
@@ -964,8 +976,14 @@ where
         let mut hasher = sha3::Sha3_256::default();
         let keys = self.keys().await?;
         hasher.update_with_bcs_bytes(&keys.len())?;
-        let cached_entries = self.cached_entries.lock().await;
-        for key in keys {
+        let mut cached_entries_result = Vec::new();
+        {
+            let cached_entries = self.cached_entries.lock().unwrap();
+            for key in &keys {
+                cached_entries_result.push(cached_entries.get(key).cloned());
+            }
+        }
+        for (key,cached_entry) in keys.into_iter().zip(cached_entries_result) {
             hasher.update_with_bytes(&key)?;
             let hash = if let Some(entry) = self.updates.get(&key) {
                 let Update::Set(view) = entry else {
@@ -975,7 +993,7 @@ where
                     .try_read_arc()
                     .ok_or_else(|| ViewError::TryLockError(key))?;
                 view.hash().await?
-            } else if let Some(view) = cached_entries.get(&key) {
+            } else if let Some(view) = cached_entry {
                 let view = view
                     .try_read_arc()
                     .ok_or_else(|| ViewError::TryLockError(key))?;


### PR DESCRIPTION
## Motivation

It is preferable to use sync locks for memory access when possible.

## Proposal

For the `KeyValueStoreView` the work is very similar to the for `HashableWrapper`.

For the `ReentrantCollectionView` the mutex is eliminated. However, a way to remove the inner async `RwLock` could not be found.

## Test Plan

The compilation and the CI.

## Release Plan

Nit relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
