### PR TITLE
Ensure only data blobs are present in SDK/System API calls

### DIFF
--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -86,6 +86,7 @@ linera service --port $PORT &
 
 - Navigate to `http://localhost:8080/`.
 - To publish a blob, run the mutation:
+
 ```gql,uri=http://localhost:8080/
     mutation {
         publishDataBlob(
@@ -99,23 +100,22 @@ linera service --port $PORT &
 
 - Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
 - To mint an NFT, run the mutation:
+
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         mint(
             minter: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
             name: "nft1",
-            blobId: {
-              hash: "34a20da0fdd7e24ddbff60cb7f952b053b3f0e196e622d47c3a368f690f01326",
-              blob_type: "Data"
-            }
+            blobHash: "34a20da0fdd7e24ddbff60cb7f952b053b3f0e196e622d47c3a368f690f01326",
         )
     }
 ```
 
 - To check that it's there, run the query:
+
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
-        nft(tokenId: "o66hIR1qQ8oUoTZTKHK35Cg1ObRgYSpBJnnS2gyvGBQ") {
+        nft(tokenId: "iQe01ZJeKo8E7HPr+MfwFedBZMdZ2v3UDI0F0kHMY+A") {
             tokenId,
             owner,
             name,
@@ -126,6 +126,7 @@ linera service --port $PORT &
 ```
 
 - To check that it's assigned to the owner, run the query:
+
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
         ownedNfts(owner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f")
@@ -133,6 +134,7 @@ linera service --port $PORT &
 ```
 
 - To check everything that it's there, run the query:
+
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     query {
         nfts
@@ -140,11 +142,12 @@ linera service --port $PORT &
 ```
 
 - To transfer the NFT to user `$OWNER_2`, still on chain `$CHAIN_1`, run the mutation:
+
 ```gql,uri=http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID
     mutation {
         transfer(
             sourceOwner: "User:7136460f0c87ae46f966f898d494c4b40c4ae8c527f4d1c0b1fa0f7cff91d20f",
-            tokenId: "o66hIR1qQ8oUoTZTKHK35Cg1ObRgYSpBJnnS2gyvGBQ",
+            tokenId: "iQe01ZJeKo8E7HPr+MfwFedBZMdZ2v3UDI0F0kHMY+A",
             targetAccount: {
                 chainId: "e476187f6ddfeb9d588c7b45d3df334d5501d6499b3f9ad5595cae86cce16a65",
                 owner: "User:598d18f67709fe76ed6a36b75a7c9889012d30b896800dfd027ee10e1afd49a3"

--- a/examples/non-fungible/src/service.rs
+++ b/examples/non-fungible/src/service.rs
@@ -14,9 +14,9 @@ use async_graphql::{EmptySubscription, Object, Request, Response, Schema};
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use fungible::Account;
 use linera_sdk::{
-    base::{AccountOwner, BlobId, WithServiceAbi},
+    base::{AccountOwner, WithServiceAbi},
     views::{View, ViewStorageContext},
-    Service, ServiceRuntime,
+    DataBlobHash, Service, ServiceRuntime,
 };
 use non_fungible::{NftOutput, Operation, TokenId};
 
@@ -82,7 +82,7 @@ impl QueryRoot {
                     .runtime
                     .try_lock()
                     .expect("Services only run in a single thread");
-                runtime.read_blob(nft.blob_id).into_inner().bytes
+                runtime.read_data_blob(nft.blob_hash)
             };
             let nft_output = NftOutput::new_with_token_id(token_id, nft, payload);
             Some(nft_output)
@@ -101,7 +101,7 @@ impl QueryRoot {
                         .runtime
                         .try_lock()
                         .expect("Services only run in a single thread");
-                    runtime.read_blob(nft.blob_id).into_inner().bytes
+                    runtime.read_data_blob(nft.blob_hash)
                 };
                 let nft_output = NftOutput::new(nft, payload);
                 nfts.insert(nft_output.token_id.clone(), nft_output);
@@ -166,7 +166,7 @@ impl QueryRoot {
                     .runtime
                     .try_lock()
                     .expect("Services only run in a single thread");
-                runtime.read_blob(nft.blob_id).into_inner().bytes
+                runtime.read_data_blob(nft.blob_hash)
             };
             let nft_output = NftOutput::new(nft, payload);
             result.insert(nft_output.token_id.clone(), nft_output);
@@ -180,11 +180,11 @@ struct MutationRoot;
 
 #[Object]
 impl MutationRoot {
-    async fn mint(&self, minter: AccountOwner, name: String, blob_id: BlobId) -> Vec<u8> {
+    async fn mint(&self, minter: AccountOwner, name: String, blob_hash: DataBlobHash) -> Vec<u8> {
         bcs::to_bytes(&Operation::Mint {
             minter,
             name,
-            blob_id,
+            blob_hash,
         })
         .unwrap()
     }

--- a/examples/non-fungible/web-frontend/src/App.js
+++ b/examples/non-fungible/web-frontend/src/App.js
@@ -33,8 +33,12 @@ const GET_OWNED_NFTS = gql`
 `;
 
 const MINT_NFT = gql`
-  mutation Mint($minter: AccountOwner!, $name: String!, $blobId: BlobId!) {
-    mint(minter: $minter, name: $name, blobId: $blobId)
+  mutation Mint(
+    $minter: AccountOwner!
+    $name: String!
+    $blobHash: CryptoHash!
+  ) {
+    mint(minter: $minter, name: $name, blobHash: $blobHash)
   }
 `;
 
@@ -183,24 +187,28 @@ function App({ chainId, owner }) {
       variables: {
         chainId: chainId,
         blobContent: {
-          bytes: Array.from(byteArrayFile)
+          bytes: Array.from(byteArrayFile),
         },
       },
     }).then((r) => {
       if ('errors' in r) {
-        console.log('Got error while publishing Data Blob: ' + JSON.stringify(r, null, 2));
+        console.log(
+          'Got error while publishing Data Blob: ' + JSON.stringify(r, null, 2)
+        );
       } else {
         console.log('Data Blob published: ' + JSON.stringify(r, null, 2));
-        const blobId = r['data']['publishDataBlob'];
+        const blobHash = r['data']['publishDataBlob']['hash'];
         mintNft({
           variables: {
             minter: `User:${owner}`,
             name: name,
-            blobId: blobId,
+            blobHash: blobHash,
           },
         }).then((r) => {
           if ('errors' in r) {
-            console.log('Got error while minting NFT: ' + JSON.stringify(r, null, 2));
+            console.log(
+              'Got error while minting NFT: ' + JSON.stringify(r, null, 2)
+            );
           } else {
             console.log('NFT minted: ' + JSON.stringify(r, null, 2));
           }
@@ -229,7 +237,9 @@ function App({ chainId, owner }) {
       },
     }).then((r) => {
       if ('errors' in r) {
-        console.log('Error while transferring NFT: ' + JSON.stringify(r, null, 2));
+        console.log(
+          'Error while transferring NFT: ' + JSON.stringify(r, null, 2)
+        );
       } else {
         console.log('NFT transferred: ' + JSON.stringify(r, null, 2));
       }

--- a/linera-base/src/identifiers.rs
+++ b/linera-base/src/identifiers.rs
@@ -211,8 +211,13 @@ pub struct BlobId {
 impl BlobId {
     /// Creates a new `BlobId` from a `BlobContent`
     pub fn new_data(blob_content: &BlobContent) -> Self {
+        Self::new_data_from_hash(CryptoHash::new(blob_content))
+    }
+
+    /// Creates a new `BlobId` from a hash
+    pub fn new_data_from_hash(hash: CryptoHash) -> Self {
         BlobId {
-            hash: CryptoHash::new(blob_content),
+            hash,
             blob_type: BlobType::Data,
         }
     }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -31,7 +31,7 @@ use linera_base::{
     abi::Abi,
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Resources,
+        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Resources,
         SendMessageRequest, Timestamp,
     },
     doc_scalar, hex_debug,
@@ -492,11 +492,11 @@ pub trait BaseRuntime {
     /// owner, not a super owner.
     fn assert_before(&mut self, timestamp: Timestamp) -> Result<(), ExecutionError>;
 
-    /// Reads a blob content specified by a given `BlobId`.
-    fn read_blob_content(&mut self, blob_id: &BlobId) -> Result<BlobContent, ExecutionError>;
+    /// Reads a data blob content specified by a given hash.
+    fn read_data_blob(&mut self, hash: &CryptoHash) -> Result<Vec<u8>, ExecutionError>;
 
-    /// Asserts the existence of a blob with the given `BlobId`.
-    fn assert_blob_exists(&mut self, blob_id: &BlobId) -> Result<(), ExecutionError>;
+    /// Asserts the existence of a data blob with the given hash.
+    fn assert_data_blob_exists(&mut self, hash: &CryptoHash) -> Result<(), ExecutionError>;
 }
 
 pub trait ServiceRuntime: BaseRuntime {

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -4,12 +4,9 @@
 use std::{any::Any, collections::HashMap, marker::PhantomData};
 
 use linera_base::{
-    data_types::{
-        Amount, ApplicationPermissions, BlobContent, BlockHeight, SendMessageRequest, Timestamp,
-    },
-    identifiers::{
-        Account, ApplicationId, BlobId, ChainId, ChannelName, MessageId, Owner, StreamName,
-    },
+    crypto::CryptoHash,
+    data_types::{Amount, ApplicationPermissions, BlockHeight, SendMessageRequest, Timestamp},
+    identifiers::{Account, ApplicationId, ChainId, ChannelName, MessageId, Owner, StreamName},
     ownership::{ChainOwnership, CloseChainError},
 };
 use linera_views::batch::{Batch, WriteOperation};
@@ -356,24 +353,21 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Reads a blob content from storage.
-    fn read_blob_content(
-        caller: &mut Caller,
-        blob_id: BlobId,
-    ) -> Result<BlobContent, RuntimeError> {
+    /// Reads a data blob from storage.
+    fn read_data_blob(caller: &mut Caller, hash: CryptoHash) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .read_blob_content(&blob_id)
+            .read_data_blob(&hash)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Asserts the existence of a blob with the given `BlobId`.
-    fn assert_blob_exists(caller: &mut Caller, blob_id: BlobId) -> Result<(), RuntimeError> {
+    /// Asserts the existence of a data blob with the given hash.
+    fn assert_data_blob_exists(caller: &mut Caller, hash: CryptoHash) -> Result<(), RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .assert_blob_exists(&blob_id)
+            .assert_data_blob_exists(&hash)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
@@ -542,24 +536,21 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Reads a blob content from storage.
-    fn read_blob_content(
-        caller: &mut Caller,
-        blob_id: BlobId,
-    ) -> Result<BlobContent, RuntimeError> {
+    /// Reads a data blob from storage.
+    fn read_data_blob(caller: &mut Caller, hash: CryptoHash) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .read_blob_content(&blob_id)
+            .read_data_blob(&hash)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
-    /// Asserts the existence of a blob with the given `BlobId`.
-    fn assert_blob_exists(caller: &mut Caller, blob_id: BlobId) -> Result<(), RuntimeError> {
+    /// Asserts the existence of a data blob with the given hash.
+    fn assert_data_blob_exists(caller: &mut Caller, hash: CryptoHash) -> Result<(), RuntimeError> {
         caller
             .user_data_mut()
             .runtime
-            .assert_blob_exists(&blob_id)
+            .assert_data_blob_exists(&hash)
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-sdk/src/contract/conversions_from_wit.rs
+++ b/linera-sdk/src/contract/conversions_from_wit.rs
@@ -5,8 +5,8 @@
 
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlobContent, BlockHeight, TimeDelta, Timestamp},
-    identifiers::{ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner},
+    data_types::{Amount, BlockHeight, TimeDelta, Timestamp},
+    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, CloseChainError, TimeoutConfig},
 };
 
@@ -34,29 +34,6 @@ impl From<wit_system_api::ApplicationId> for ApplicationId {
             bytecode_id: application_id.bytecode_id.into(),
             creation: application_id.creation.into(),
         }
-    }
-}
-
-impl From<wit_system_api::BlobId> for BlobId {
-    fn from(blob_id: wit_system_api::BlobId) -> Self {
-        Self {
-            hash: blob_id.hash.into(),
-            blob_type: blob_id.blob_type.into(),
-        }
-    }
-}
-
-impl From<wit_system_api::BlobType> for BlobType {
-    fn from(blob_type: wit_system_api::BlobType) -> Self {
-        match blob_type {
-            wit_system_api::BlobType::Data => BlobType::Data,
-        }
-    }
-}
-
-impl From<wit_system_api::BlobContent> for BlobContent {
-    fn from(blob: wit_system_api::BlobContent) -> Self {
-        BlobContent { bytes: blob.bytes }
     }
 }
 

--- a/linera-sdk/src/contract/conversions_to_wit.rs
+++ b/linera-sdk/src/contract/conversions_to_wit.rs
@@ -10,8 +10,8 @@ use linera_base::{
         Timestamp,
     },
     identifiers::{
-        Account, ApplicationId, BlobId, BlobType, BytecodeId, ChainId, ChannelName, Destination,
-        MessageId, Owner, StreamName,
+        Account, ApplicationId, BytecodeId, ChainId, ChannelName, Destination, MessageId, Owner,
+        StreamName,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -41,23 +41,6 @@ impl From<Owner> for wit_system_api::Owner {
     fn from(owner: Owner) -> Self {
         wit_system_api::Owner {
             inner0: owner.0.into(),
-        }
-    }
-}
-
-impl From<BlobId> for wit_system_api::BlobId {
-    fn from(blob_id: BlobId) -> Self {
-        wit_system_api::BlobId {
-            hash: blob_id.hash.into(),
-            blob_type: blob_id.blob_type.into(),
-        }
-    }
-}
-
-impl From<BlobType> for wit_system_api::BlobType {
-    fn from(blob_id: BlobType) -> Self {
-        match blob_id {
-            BlobType::Data => wit_system_api::BlobType::Data,
         }
     }
 }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -6,19 +6,17 @@
 use linera_base::{
     abi::{ContractAbi, ServiceAbi},
     data_types::{
-        Amount, ApplicationPermissions, Blob, BlobContent, BlockHeight, Resources,
-        SendMessageRequest, Timestamp,
+        Amount, ApplicationPermissions, BlockHeight, Resources, SendMessageRequest, Timestamp,
     },
     identifiers::{
-        Account, ApplicationId, BlobId, ChainId, ChannelName, Destination, MessageId, Owner,
-        StreamName,
+        Account, ApplicationId, ChainId, ChannelName, Destination, MessageId, Owner, StreamName,
     },
     ownership::{ChainOwnership, CloseChainError},
 };
 use serde::Serialize;
 
 use super::wit::contract_system_api as wit;
-use crate::{Contract, KeyValueStore};
+use crate::{Contract, DataBlobHash, KeyValueStore};
 
 /// The common runtime to interface with the host executing the contract.
 ///
@@ -271,14 +269,14 @@ where
         wit::assert_before(timestamp.into());
     }
 
-    /// Reads a blob with the given `BlobId` from storage.
-    pub fn read_blob(&mut self, blob_id: BlobId) -> Blob {
-        BlobContent::from(wit::read_blob_content(blob_id.into())).with_blob_id_unchecked(blob_id)
+    /// Reads a data blob with the given hash from storage.
+    pub fn read_data_blob(&mut self, hash: DataBlobHash) -> Vec<u8> {
+        wit::read_data_blob(hash.0.into())
     }
 
-    /// Asserts that a blob with the given `BlobId` exists in storage.
-    pub fn assert_blob_exists(&mut self, blob_id: BlobId) {
-        wit::assert_blob_exists(blob_id.into())
+    /// Asserts that a data blob with the given hash exists in storage.
+    pub fn assert_data_blob_exists(&mut self, hash: DataBlobHash) {
+        wit::assert_data_blob_exists(hash.0.into())
     }
 }
 

--- a/linera-sdk/src/lib.rs
+++ b/linera-sdk/src/lib.rs
@@ -45,13 +45,17 @@ pub mod views;
 use std::fmt::Debug;
 
 pub use bcs;
-use linera_base::abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi};
 pub use linera_base::{
     abi,
     data_types::{Resources, SendMessageRequest},
     ensure,
 };
-use serde::{de::DeserializeOwned, Serialize};
+use linera_base::{
+    abi::{ContractAbi, ServiceAbi, WithContractAbi, WithServiceAbi},
+    crypto::CryptoHash,
+    doc_scalar,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use serde_json;
 
 #[doc(hidden)]
@@ -63,6 +67,12 @@ pub use self::{
     service::ServiceRuntime,
     views::KeyValueStore,
 };
+
+/// Hash of a data blob.
+#[derive(Eq, Hash, PartialEq, Debug, Serialize, Deserialize, Clone, Copy)]
+pub struct DataBlobHash(pub CryptoHash);
+
+doc_scalar!(DataBlobHash, "Hash of a Data Blob");
 
 /// The contract interface of a Linera application.
 ///

--- a/linera-sdk/src/service/conversions_from_wit.rs
+++ b/linera-sdk/src/service/conversions_from_wit.rs
@@ -5,8 +5,8 @@
 
 use linera_base::{
     crypto::CryptoHash,
-    data_types::{Amount, BlobContent, BlockHeight, Timestamp},
-    identifiers::{ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner},
+    data_types::{Amount, BlockHeight, Timestamp},
+    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
 
 use super::wit::service_system_api as wit_system_api;
@@ -20,29 +20,6 @@ impl From<wit_system_api::CryptoHash> for ChainId {
 impl From<wit_system_api::Owner> for Owner {
     fn from(owner: wit_system_api::Owner) -> Self {
         Owner(owner.inner0.into())
-    }
-}
-
-impl From<wit_system_api::BlobId> for BlobId {
-    fn from(blob_id: wit_system_api::BlobId) -> Self {
-        Self {
-            hash: blob_id.hash.into(),
-            blob_type: blob_id.blob_type.into(),
-        }
-    }
-}
-
-impl From<wit_system_api::BlobType> for BlobType {
-    fn from(blob_type: wit_system_api::BlobType) -> Self {
-        match blob_type {
-            wit_system_api::BlobType::Data => BlobType::Data,
-        }
-    }
-}
-
-impl From<wit_system_api::BlobContent> for BlobContent {
-    fn from(blob: wit_system_api::BlobContent) -> Self {
-        BlobContent { bytes: blob.bytes }
     }
 }
 

--- a/linera-sdk/src/service/conversions_to_wit.rs
+++ b/linera-sdk/src/service/conversions_to_wit.rs
@@ -6,7 +6,7 @@
 use linera_base::{
     crypto::CryptoHash,
     data_types::BlockHeight,
-    identifiers::{ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
 
 use super::wit::service_system_api as wit_system_api;
@@ -40,23 +40,6 @@ impl From<Owner> for wit_system_api::Owner {
     fn from(owner: Owner) -> Self {
         wit_system_api::Owner {
             inner0: owner.0.into(),
-        }
-    }
-}
-
-impl From<BlobId> for wit_system_api::BlobId {
-    fn from(blob_id: BlobId) -> Self {
-        wit_system_api::BlobId {
-            hash: blob_id.hash.into(),
-            blob_type: blob_id.blob_type.into(),
-        }
-    }
-}
-
-impl From<BlobType> for wit_system_api::BlobType {
-    fn from(blob_type: BlobType) -> Self {
-        match blob_type {
-            BlobType::Data => wit_system_api::BlobType::Data,
         }
     }
 }

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -7,12 +7,12 @@ use std::cell::Cell;
 
 use linera_base::{
     abi::ServiceAbi,
-    data_types::{Amount, Blob, BlobContent, BlockHeight, Timestamp},
-    identifiers::{ApplicationId, BlobId, ChainId, Owner},
+    data_types::{Amount, BlockHeight, Timestamp},
+    identifiers::{ApplicationId, ChainId, Owner},
 };
 
 use super::wit::service_system_api as wit;
-use crate::{KeyValueStore, Service};
+use crate::{DataBlobHash, KeyValueStore, Service};
 
 /// The runtime available during execution of a query.
 pub struct ServiceRuntime<Application>
@@ -145,13 +145,13 @@ where
         value
     }
 
-    /// Reads a blob with the given `BlobId` from storage.
-    pub fn read_blob(&mut self, blob_id: BlobId) -> Blob {
-        BlobContent::from(wit::read_blob_content(blob_id.into())).with_blob_id_unchecked(blob_id)
+    /// Reads a data blob with the given hash from storage.
+    pub fn read_data_blob(&mut self, hash: DataBlobHash) -> Vec<u8> {
+        wit::read_data_blob(hash.0.into())
     }
 
-    /// Asserts that a blob with the given `BlobId` exists in storage.
-    pub fn assert_blob_exists(&mut self, blob_id: BlobId) {
-        wit::assert_blob_exists(blob_id.into())
+    /// Asserts that a data blob with the given hash exists in storage.
+    pub fn assert_data_blob_exists(&mut self, hash: DataBlobHash) {
+        wit::assert_data_blob_exists(hash.0.into())
     }
 }

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -25,8 +25,8 @@ interface contract-system-api {
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
-    read-blob-content: func(blob-id: blob-id) -> blob-content;
-    assert-blob-exists: func(blob-id: blob-id);
+    read-data-blob: func(hash: crypto-hash) -> list<u8>;
+    assert-data-blob-exists: func(hash: crypto-hash);
     log: func(message: string, level: log-level);
     consume-fuel: func(fuel: u64);
 
@@ -48,19 +48,6 @@ interface contract-system-api {
         execute-operations: option<list<application-id>>,
         mandatory-applications: list<application-id>,
         close-chain: list<application-id>,
-    }
-
-    record blob-content {
-        bytes: list<u8>,
-    }
-
-    record blob-id {
-        hash: crypto-hash,
-        blob-type: blob-type,
-    }
-
-    enum blob-type {
-        data,
     }
 
     record block-height {

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -14,8 +14,8 @@ interface service-system-api {
     fetch-url: func(url: string) -> list<u8>;
     query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
-    read-blob-content: func(blob-id: blob-id) -> blob-content;
-    assert-blob-exists: func(blob-id: blob-id);
+    read-data-blob: func(hash: crypto-hash) -> list<u8>;
+    assert-data-blob-exists: func(hash: crypto-hash);
     assert-before: func(timestamp: timestamp);
     log: func(message: string, level: log-level);
 
@@ -26,19 +26,6 @@ interface service-system-api {
     record application-id {
         bytecode-id: bytecode-id,
         creation: message-id,
-    }
-
-    record blob-content {
-        bytes: list<u8>,
-    }
-
-    record blob-id {
-        hash: crypto-hash,
-        blob-type: blob-type,
-    }
-
-    enum blob-type {
-        data,
     }
 
     record block-height {


### PR DESCRIPTION
## Motivation

We don't want `BlobId` exposed to the SDK. Users will only be aware of `Data` blobs, the other types will be only internally used.

## Proposal

Only expose `Data` blobs to the SDK, and assume when dealing with blobs that it's a `Data` blob. Because of that we don't need to use `BlobId` everywhere, and can just use the hash of the `Data` blob in most places.

## Test Plan

CI + also retested the NFT UI