### PR TITLE
Script to sync lib.rs to modified README in examples

### DIFF
--- a/scripts/sync_readme.sh
+++ b/scripts/sync_readme.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Must run this from the root directory of the example that the README is being modified
+
+README_FILE="README.md"
+LIB_FILE="src/lib.rs"
+
+# Extract the relevant portion from the README, excluding the cargo-rdme markers
+README_CONTENT=$(sed -n '/<!-- cargo-rdme start -->/,/<!-- cargo-rdme end -->/p' $README_FILE | sed '1d;$d')
+
+# Remove leading and trailing empty lines while preserving internal empty lines
+ESCAPED_CONTENT=$(echo "$README_CONTENT" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba')
+
+# Escape dollar signs and backticks to prevent issues in the lib.rs output
+ESCAPED_CONTENT=$(echo "$ESCAPED_CONTENT" | sed 's/\\/\\\\/g; s/\$/\\\$/g; s/\`/\\\`/g')
+
+# Replace the corresponding doc comment in lib.rs
+perl -0777 -i -pe "s|/\*!.*?\*/|/\*!\n$ESCAPED_CONTENT\n*/|s" $LIB_FILE


### PR DESCRIPTION
## Motivation

This might be a bit of excessive laziness, but I think it's tedious every time you do any changes to any of the example `README`'s, that you have to copy over the changes to the respective `lib.rs` file.

## Proposal

Created a script that you can run from the example's root directory and it'll sync whatever changes you made to the `README` file to the respective `lib.rs` file. Depending on how well this works, this could be used as a pre-commit hook, and then CI will check if the files are properly synched.

## Test Plan

Did some random changes to `README` files and made sure only those changes got synched over to the respective `lib.rs` file.

