### PR TITLE
Remove `anyhow` from `linera-client`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4273,6 +4273,8 @@ dependencies = [
  "test-case",
  "test-log",
  "test-strategy",
+ "thiserror",
+ "thiserror-context",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -7498,6 +7500,12 @@ checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
+
+[[package]]
+name = "thiserror-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c47055a4888725c27962ef13f6de5b8ab42662b88fd5488184a6bd353dbeffab"
 
 [[package]]
 name = "thiserror-impl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4230,7 +4230,6 @@ version = "0.12.0"
 dependencies = [
  "amm",
  "anyhow",
- "async-graphql",
  "async-trait",
  "base64 0.22.1",
  "bcs",

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -57,7 +57,6 @@ local-storage = ["web"]
 web-default = ["web", "wasmer", "local-storage"]
 
 [dependencies]
-async-graphql.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
 cfg-if.workspace = true

--- a/linera-client/Cargo.toml
+++ b/linera-client/Cargo.toml
@@ -57,7 +57,6 @@ local-storage = ["web"]
 web-default = ["web", "wasmer", "local-storage"]
 
 [dependencies]
-anyhow.workspace = true
 async-graphql.workspace = true
 async-trait.workspace = true
 bcs.workspace = true
@@ -80,6 +79,8 @@ linera-views.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
+thiserror-context = "0.1.1"
 tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
@@ -100,6 +101,7 @@ cfg_aliases.workspace = true
 
 [dev-dependencies]
 amm.workspace = true
+anyhow.workspace = true
 base64.workspace = true
 counter.workspace = true
 crowd-funding.workspace = true

--- a/linera-client/src/chain_clients.rs
+++ b/linera-client/src/chain_clients.rs
@@ -3,12 +3,17 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use async_graphql::Error;
 use futures::lock::{Mutex, MutexGuard};
 use linera_base::identifiers::ChainId;
 use linera_core::client::ChainClient;
 use linera_storage::Storage;
 use linera_views::views::ViewError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("unknown chain ID {0}")]
+    MissingChain(ChainId),
+}
 
 pub type ClientMapInner<P, S> = BTreeMap<ChainId, ChainClient<P, S>>;
 pub struct ChainClients<P, S>(pub Arc<Mutex<ClientMapInner<P, S>>>)
@@ -52,7 +57,7 @@ where
     pub async fn try_client_lock(&self, chain_id: &ChainId) -> Result<ChainClient<P, S>, Error> {
         self.client_lock(chain_id)
             .await
-            .ok_or_else(|| Error::new(format!("Unknown chain ID: {}", chain_id)))
+            .ok_or(Error::MissingChain(*chain_id))
     }
 
     pub async fn map_lock(&self) -> MutexGuard<ClientMapInner<P, S>> {

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -25,7 +25,7 @@ use linera_storage::Storage;
 use linera_views::views::ViewError;
 use tracing::{debug, error, info, warn, Instrument as _};
 
-use crate::{chain_clients::ChainClients, wallet::Wallet};
+use crate::{Error, chain_clients::ChainClients, wallet::Wallet};
 
 #[cfg(test)]
 #[path = "unit_tests/chain_listener.rs"]
@@ -155,7 +155,7 @@ where
         context: Arc<Mutex<C>>,
         storage: S,
         config: ChainListenerConfig,
-    ) -> anyhow::Result<()>
+    ) -> Result<(), Error>
     where
         C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     {

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -25,7 +25,7 @@ use linera_storage::Storage;
 use linera_views::views::ViewError;
 use tracing::{debug, error, info, warn, Instrument as _};
 
-use crate::{Error, chain_clients::ChainClients, wallet::Wallet};
+use crate::{chain_clients::ChainClients, wallet::Wallet, Error};
 
 #[cfg(test)]
 #[path = "unit_tests/chain_listener.rs"]

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -65,13 +65,13 @@ use {
 };
 
 use crate::{
-    Error,
     chain_listener,
     client_options::{ChainOwnershipConfig, ClientOptions},
     config::WalletState,
     persistent::Persist,
     util,
     wallet::{UserChain, Wallet},
+    Error,
 };
 
 pub struct ClientContext<Storage, W>
@@ -285,7 +285,9 @@ where
                     self.save_wallet();
                     return Ok(certificates);
                 }
-                Some(timestamp) => util::wait_for_next_round(&mut notification_stream, timestamp).await,
+                Some(timestamp) => {
+                    util::wait_for_next_round(&mut notification_stream, timestamp).await
+                }
             }
         }
     }

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -7,7 +7,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use anyhow::Context;
 use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
@@ -26,6 +25,7 @@ use linera_core::{
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_storage::Storage;
 use linera_views::views::ViewError;
+use thiserror_context::Context;
 use tokio::task::JoinSet;
 use tracing::{debug, info};
 #[cfg(feature = "benchmark")]
@@ -65,11 +65,12 @@ use {
 };
 
 use crate::{
+    Error,
     chain_listener,
     client_options::{ChainOwnershipConfig, ClientOptions},
     config::WalletState,
     persistent::Persist,
-    util::wait_for_next_round,
+    util,
     wallet::{UserChain, Wallet},
 };
 
@@ -247,7 +248,7 @@ where
     pub async fn process_inbox(
         &mut self,
         chain_client: &ChainClient<NodeProvider, S>,
-    ) -> anyhow::Result<Vec<Certificate>> {
+    ) -> Result<Vec<Certificate>, Error> {
         let mut certificates = Vec::new();
         // Try processing the inbox optimistically without waiting for validator notifications.
         let (new_certificates, maybe_timeout) = {
@@ -284,7 +285,7 @@ where
                     self.save_wallet();
                     return Ok(certificates);
                 }
-                Some(timestamp) => wait_for_next_round(&mut notification_stream, timestamp).await,
+                Some(timestamp) => util::wait_for_next_round(&mut notification_stream, timestamp).await,
             }
         }
     }
@@ -297,11 +298,11 @@ where
         &mut self,
         client: &ChainClient<NodeProvider, S>,
         mut f: F,
-    ) -> anyhow::Result<T>
+    ) -> Result<T, Error>
     where
         F: FnMut(&ChainClient<NodeProvider, S>) -> Fut,
         Fut: Future<Output = Result<ClientOutcome<T>, E>>,
-        anyhow::Error: From<E>,
+        Error: From<E>,
     {
         // Try applying f optimistically without validator notifications. Return if committed.
         let result = f(client).await;
@@ -323,7 +324,7 @@ where
                 ClientOutcome::WaitForTimeout(timeout) => timeout,
             };
             // Otherwise wait and try again in the next round.
-            wait_for_next_round(&mut notification_stream, timeout).await;
+            util::wait_for_next_round(&mut notification_stream, timeout).await;
         }
     }
 
@@ -331,7 +332,7 @@ where
         &mut self,
         chain_id: Option<ChainId>,
         ownership_config: ChainOwnershipConfig,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Error> {
         let chain_id = chain_id.unwrap_or_else(|| self.default_chain());
         let chain_client = self.make_chain_client(chain_id);
         info!("Changing ownership for chain {}", chain_id);
@@ -369,7 +370,7 @@ where
         chain_client: &ChainClient<NodeProvider, S>,
         contract: PathBuf,
         service: PathBuf,
-    ) -> anyhow::Result<BytecodeId> {
+    ) -> Result<BytecodeId, Error> {
         info!("Loading bytecode files");
         let contract_bytecode = Bytecode::load_from_file(&contract).await.context(format!(
             "failed to load contract bytecode from {:?}",
@@ -407,7 +408,7 @@ where
         &mut self,
         chain_client: &ChainClient<NodeProvider, S>,
         blob_path: PathBuf,
-    ) -> anyhow::Result<BlobId> {
+    ) -> Result<BlobId, Error> {
         info!("Loading data blob file");
         let blob = Blob::load_data_blob_from_file(&blob_path)
             .await
@@ -453,7 +454,7 @@ where
         &mut self,
         num_chains: usize,
         balance: Amount,
-    ) -> anyhow::Result<HashMap<ChainId, KeyPair>> {
+    ) -> Result<HashMap<ChainId, KeyPair>, Error> {
         let mut key_pairs = HashMap::new();
         for chain_id in self.wallet.own_chain_ids() {
             if key_pairs.len() == num_chains {
@@ -477,13 +478,13 @@ where
         let default_chain_id = self
             .wallet
             .default_chain()
-            .context("should have default chain")?;
+            .expect("should have default chain");
         let chain_client = self.make_chain_client(default_chain_id);
         while key_pairs.len() < num_chains {
             let key_pair = self.wallet.generate_key_pair();
             let public_key = key_pair.public();
             let (epoch, committees) = chain_client.epoch_and_committees(default_chain_id).await?;
-            let epoch = epoch.context("missing epoch on the default chain")?;
+            let epoch = epoch.expect("default chain should be active");
             // Put at most 1000 OpenChain operations in each block.
             let num_new_chains = (num_chains - key_pairs.len()).min(1000);
             let config = OpenChainConfig {
@@ -504,12 +505,12 @@ where
             let executed_block = certificate
                 .value()
                 .executed_block()
-                .context("certificate should be confirmed block")?;
+                .expect("certificate should be confirmed block");
             let timestamp = executed_block.block.timestamp;
             for i in 0..num_new_chains {
                 let message_id = executed_block
                     .message_id_for_operation(i, OPEN_CHAIN_MESSAGE_INDEX)
-                    .context("failed to create new chain")?;
+                    .expect("failed to create new chain");
                 let chain_id = ChainId::child(message_id);
                 key_pairs.insert(chain_id, key_pair.copy());
                 self.update_wallet_for_new_chain(chain_id, Some(key_pair.copy()), timestamp);
@@ -531,11 +532,11 @@ where
         key_pairs: &HashMap<ChainId, KeyPair>,
         application_id: ApplicationId,
         max_in_flight: usize,
-    ) -> anyhow::Result<()> {
+    ) -> Result<(), Error> {
         let default_chain_id = self
             .wallet
             .default_chain()
-            .context("should have default chain")?;
+            .expect("should have default chain");
         let default_key = self
             .wallet
             .get(default_chain_id)
@@ -587,18 +588,18 @@ where
                             return Ok(chain_client);
                         }
                     }
-                    anyhow::bail!("Could not instantiate application on chain {:?}", chain_id);
+                    panic!("Could not instantiate application on chain {chain_id:?}");
                 }
             })
             .collect::<Vec<_>>();
         // We have to collect the futures to avoid a higher-ranked lifetime error:
         // https://github.com/rust-lang/rust/issues/102211#issuecomment-1673201352
-        let results = stream::iter(futures)
+        let clients = stream::iter(futures)
             .buffer_unordered(max_in_flight)
-            .collect::<Vec<_>>()
+            .collect::<Vec<Result<_, Error>>>()
             .await;
-        for result in results {
-            let client = result?;
+        for client in clients {
+            let client = client?;
             self.update_wallet_from_client(&client).await;
         }
         Ok(())
@@ -810,7 +811,7 @@ where
     }
 
     /// Stages the execution of a block proposal.
-    pub async fn stage_block_execution(&self, block: Block) -> anyhow::Result<ExecutedBlock> {
+    pub async fn stage_block_execution(&self, block: Block) -> Result<ExecutedBlock, Error> {
         Ok(self
             .client
             .local_node()

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -39,10 +39,7 @@ pub enum Error {
     #[error("default configuration directory not supported: please specify a path")]
     NoDefaultConfigurationDirectory,
     #[error("there are {public_keys} public keys but {weights} weights")]
-    MisalignedWeights {
-        public_keys: usize,
-        weights: usize,
-    },
+    MisalignedWeights { public_keys: usize, weights: usize },
     #[error("storage error: {0}")]
     Storage(#[from] crate::storage::Error),
     #[error("persistence error: {0}")]
@@ -140,7 +137,10 @@ pub struct ClientOptions {
 impl ClientOptions {
     pub fn init() -> Result<Self, Error> {
         let mut options = <ClientOptions as clap::Parser>::parse();
-        let suffix = options.with_wallet.map(|n| format!("_{}", n)).unwrap_or_default();
+        let suffix = options
+            .with_wallet
+            .map(|n| format!("_{}", n))
+            .unwrap_or_default();
         let wallet_env_var = env::var(format!("LINERA_WALLET{suffix}")).ok();
         let storage_env_var = env::var(format!("LINERA_STORAGE{suffix}")).ok();
         if let (None, Some(wallet_path)) = (&options.wallet_state_path, wallet_env_var) {
@@ -242,7 +242,10 @@ impl ClientOptions {
         if wallet_path.exists() {
             return Err(Error::WalletAlreadyExists(wallet_path));
         }
-        Ok(WalletState::create_from_file(&wallet_path, Wallet::new(genesis_config, testing_prng_seed))?)
+        Ok(WalletState::create_from_file(
+            &wallet_path,
+            Wallet::new(genesis_config, testing_prng_seed),
+        )?)
     }
 }
 

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -42,7 +42,6 @@ util::impl_from_dynamic!(Error:Persistence, persistent::local_storage::Error);
 #[cfg(feature = "fs")]
 util::impl_from_dynamic!(Error:Persistence, persistent::file::Error);
 
-
 /// The public configuration of a validator.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidatorConfig {

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{util, persistent};
+use thiserror_context::Context;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Inner {
+    #[error("chain client error: {0}")]
+    ChainClient(#[from] linera_core::client::ChainClientError),
+    #[error("options error: {0}")]
+    Options(#[from] crate::client_options::Error),
+    #[error("persistence error: {0}")]
+    Persistence(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("view error: {0}")]
+    View(#[from] linera_views::views::ViewError),
+    #[error("non-existent chain: {0:?}")]
+    NonexistentChain(linera_base::identifiers::ChainId),
+    #[error("no keypair found for chain: {0:?}")]
+    NonexistentKeypair(linera_base::identifiers::ChainId),
+    #[error("error on the local node: {0}")]
+    LocalNode(#[from] linera_core::local_node::LocalNodeError),
+}
+
+thiserror_context::impl_context!(Error(Inner));
+
+util::impl_from_dynamic!(Inner:Persistence, persistent::memory::Error);
+#[cfg(feature = "fs")]
+util::impl_from_dynamic!(Inner:Persistence, persistent::file::Error);
+#[cfg(with_local_storage)]
+util::impl_from_dynamic!(Inner:Persistence, persistent::local_storage::Error);

--- a/linera-client/src/error.rs
+++ b/linera-client/src/error.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{util, persistent};
 use thiserror_context::Context;
+
+use crate::{persistent, util};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Inner {

--- a/linera-client/src/lib.rs
+++ b/linera-client/src/lib.rs
@@ -10,7 +10,10 @@ pub mod chain_listener;
 pub mod client_context;
 pub mod client_options;
 pub mod config;
+mod error;
 pub mod persistent;
 pub mod storage;
 pub mod util;
 pub mod wallet;
+
+pub use error::Error;

--- a/linera-client/src/persistent/file.rs
+++ b/linera-client/src/persistent/file.rs
@@ -6,26 +6,61 @@ use std::{
     path::Path,
 };
 
-use anyhow::Context as _;
 use fs4::FileExt as _;
+use thiserror_context::Context;
 
 use super::Persist;
 
 /// A guard that keeps an exclusive lock on a file.
 struct Lock(fs_err::File);
 
+#[derive(Debug, thiserror::Error)]
+enum ErrorInner {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Serde(#[from] serde_json::Error),
+}
+
+thiserror_context::impl_context!(Error(ErrorInner));
+
+/// Utility: run a fallible cleanup function if an operation failed, attaching the
+/// original operation as context to its error.
+trait CleanupExt {
+    type Ok;
+    type Error;
+
+    fn or_cleanup<E>(self, f: impl FnOnce() -> Result<(), E>) -> Result<Self::Ok, Self::Error>
+    where
+        E: Into<Self::Error>,
+        Result<(), E>: Context<Self::Error, Self::Ok, E>;
+}
+
+impl<T, W> CleanupExt for Result<T, W>
+where
+    W: std::fmt::Display + Send + Sync + 'static,
+{
+    type Ok = T;
+    type Error = W;
+
+    fn or_cleanup<E>(self, cleanup: impl FnOnce() -> Result<(), E>) -> Self
+    where
+        E: Into<W>,
+        Result<(), E>: Context<W, T, E>,
+    {
+        self.or_else(|error| if let Err(cleanup_error) = cleanup() {
+            Err(cleanup_error).context(error)
+        } else {
+            Err(error.into())
+        })
+    }
+}
+
 impl Lock {
     /// Acquires an exclusive lock on a provided `file`, returning a [`Lock`] which will
     /// release the lock when dropped.
-    pub fn new(file: fs_err::File, path: &Path) -> anyhow::Result<Self> {
-        file.file().try_lock_exclusive().with_context(|| {
-            format!(
-                "Error getting write lock \"{}\". Please make sure the file exists \
-                 and that it is not in use by another process already.",
-                path.display()
-            )
-        })?;
-
+    pub fn new(file: fs_err::File) -> std::io::Result<Self> {
+        file.file().try_lock_exclusive()?;
         Ok(Lock(file))
     }
 }
@@ -69,7 +104,7 @@ fn open_options() -> fs_err::OpenOptions {
 
 impl<T: serde::de::DeserializeOwned> File<T> {
     /// Creates a new persistent file at `path` containing `value`.
-    pub fn new(path: &Path, value: T) -> anyhow::Result<Self> {
+    pub fn new(path: &Path, value: T) -> Result<Self, Error> {
         Ok(Self {
             _lock: Lock::new(
                 fs_err::OpenOptions::new()
@@ -77,17 +112,16 @@ impl<T: serde::de::DeserializeOwned> File<T> {
                     .write(true)
                     .create(true)
                     .open(path)?,
-                path,
-            )?,
+            ).with_context(|| format!("locking path {}", path.display()))?,
             path: path.into(),
             value,
         })
     }
 
     /// Reads the value from a file at `path`, returning an error if it does not exist.
-    pub fn read(path: &Path) -> anyhow::Result<Self> {
+    pub fn read(path: &Path) -> Result<Self, Error> {
         Self::read_or_create(path, || {
-            Err(anyhow::anyhow!("Path does not exist: {}", path.display()))
+            Err(std::io::Error::new(std::io::ErrorKind::NotFound, format!("path does not exist: {}", path.display())).into())
         })
     }
 
@@ -95,9 +129,9 @@ impl<T: serde::de::DeserializeOwned> File<T> {
     /// if it does not exist. If it does exist, `value` will not be called.
     pub fn read_or_create(
         path: &Path,
-        value: impl FnOnce() -> anyhow::Result<T>,
-    ) -> anyhow::Result<Self> {
-        let lock = Lock::new(open_options().read(true).open(path)?, path)?;
+        value: impl FnOnce() -> Result<T, Error>,
+    ) -> Result<Self, Error> {
+        let lock = Lock::new(open_options().read(true).open(path)?)?;
         let mut reader = io::BufReader::new(&lock.0);
 
         Ok(Self {
@@ -113,7 +147,7 @@ impl<T: serde::de::DeserializeOwned> File<T> {
 }
 
 impl<T: serde::Serialize + serde::de::DeserializeOwned> Persist for File<T> {
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn as_mut(this: &mut Self) -> &mut T {
         &mut this.value
@@ -128,20 +162,16 @@ impl<T: serde::Serialize + serde::de::DeserializeOwned> Persist for File<T> {
     /// The temporary file is then renamed to the original filename. If
     /// serialization or writing to disk fails, the temporary file is
     /// deleted.
-    fn persist(this: &mut Self) -> anyhow::Result<()> {
+    fn persist(this: &mut Self) -> Result<(), Error> {
         let mut temp_file_path = this.path.clone();
         temp_file_path.set_extension("json.new");
         let temp_file = open_options().open(&temp_file_path)?;
         let mut temp_file_writer = std::io::BufWriter::new(temp_file);
 
-        if let Err(e) = serde_json::to_writer_pretty(&mut temp_file_writer, &this.value) {
-            fs_err::remove_file(&temp_file_path).context("handling writing error {e}")?;
-            anyhow::bail!("failed to serialize the wallet state: {e}")
-        }
-        if let Err(e) = temp_file_writer.flush() {
-            fs_err::remove_file(&temp_file_path).context("handling flushing error {e}")?;
-            anyhow::bail!("failed to write the wallet state: {e}");
-        }
+        let remove_temp_file = || fs_err::remove_file(&temp_file_path);
+
+        serde_json::to_writer_pretty(&mut temp_file_writer, &this.value).map_err(Error::from).or_cleanup(remove_temp_file)?;
+        temp_file_writer.flush().map_err(Error::from).or_cleanup(remove_temp_file)?;
         fs_err::rename(&temp_file_path, &this.path)?;
         Ok(())
     }

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -528,7 +528,7 @@ impl StoreConfig {
 pub trait Runnable {
     type Output;
 
-    async fn run<S>(self, storage: S) -> Result<Self::Output, Error>
+    async fn run<S>(self, storage: S) -> Self::Output
     where
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::StoreError>;
@@ -553,27 +553,27 @@ where
             let store_config = MemoryStoreConfig::new(config.common_config.max_stream_queries);
             let mut storage = MemoryStorage::new(store_config, &namespace, wasm_runtime).await?;
             genesis_config.initialize_storage(&mut storage).await?;
-            job.run(storage).await
+            Ok(job.run(storage).await)
         }
         #[cfg(feature = "storage-service")]
         StoreConfig::Service(config, namespace) => {
             let storage = ServiceStorage::new(config, &namespace, wasm_runtime).await?;
-            job.run(storage).await
+            Ok(job.run(storage).await)
         }
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config, namespace) => {
             let storage = RocksDbStorage::new(config, &namespace, wasm_runtime).await?;
-            job.run(storage).await
+            Ok(job.run(storage).await)
         }
         #[cfg(feature = "dynamodb")]
         StoreConfig::DynamoDb(config, namespace) => {
             let storage = DynamoDbStorage::new(config, &namespace, wasm_runtime).await?;
-            job.run(storage).await
+            Ok(job.run(storage).await)
         }
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config, namespace) => {
             let storage = ScyllaDbStorage::new(config, &namespace, wasm_runtime).await?;
-            job.run(storage).await
+            Ok(job.run(storage).await)
         }
     }
 }

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -46,13 +46,11 @@ macro_rules! impl_from_infallible {
     ($target:path) => {
         impl From<::std::convert::Infallible> for $target {
             fn from(infallible: ::std::convert::Infallible) -> Self {
-                match infallible { }
+                match infallible {}
             }
         }
-    }
+    };
 }
 
-pub(crate) use {
-    impl_from_dynamic,
-    impl_from_infallible,
-};
+pub(crate) use impl_from_dynamic;
+pub(crate) use impl_from_infallible;

--- a/linera-client/src/util.rs
+++ b/linera-client/src/util.rs
@@ -3,7 +3,6 @@
 
 use std::{num::ParseIntError, time::Duration};
 
-use anyhow::Result;
 use futures::future;
 use linera_base::data_types::{TimeDelta, Timestamp};
 use linera_core::{data_types::RoundTimeout, node::NotificationStream, worker::Reason};
@@ -32,3 +31,28 @@ pub async fn wait_for_next_round(stream: &mut NotificationStream, timeout: Round
     )
     .await;
 }
+
+macro_rules! impl_from_dynamic {
+    ($target:ty : $variant:ident, $source:ty) => {
+        impl From<$source> for $target {
+            fn from(error: $source) -> Self {
+                <$target>::$variant(Box::new(error))
+            }
+        }
+    };
+}
+
+macro_rules! impl_from_infallible {
+    ($target:path) => {
+        impl From<::std::convert::Infallible> for $target {
+            fn from(infallible: ::std::convert::Infallible) -> Self {
+                match infallible { }
+            }
+        }
+    }
+}
+
+pub(crate) use {
+    impl_from_dynamic,
+    impl_from_infallible,
+};

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -19,7 +19,7 @@ use linera_views::views::ViewError;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, error, config::GenesisConfig};
+use crate::{config::GenesisConfig, error, Error};
 
 #[derive(Serialize, Deserialize)]
 pub struct Wallet {
@@ -72,7 +72,10 @@ impl Wallet {
             .chains
             .get_mut(chain_id)
             .ok_or(error::Inner::NonexistentChain(*chain_id))?;
-        chain.key_pair.take().ok_or(error::Inner::NonexistentKeypair(*chain_id).into())
+        chain
+            .key_pair
+            .take()
+            .ok_or(error::Inner::NonexistentKeypair(*chain_id).into())
     }
 
     pub fn forget_chain(&mut self, chain_id: &ChainId) -> Result<UserChain, Error> {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -97,7 +97,7 @@ fn read_json(string: Option<String>, path: Option<PathBuf>) -> anyhow::Result<Ve
 
 #[async_trait]
 impl Runnable for Job {
-    type Output = ();
+    type Output = anyhow::Result<()>;
 
     async fn run<S>(self, storage: S) -> anyhow::Result<()>
     where
@@ -1421,7 +1421,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                 Ok(project.test().await?)
             }
             ProjectCommand::PublishAndCreate { .. } => {
-                options.run_with_storage(Job(options.clone())).await
+                options.run_with_storage(Job(options.clone())).await?
             }
         },
 
@@ -1568,12 +1568,12 @@ Make sure to use a Linera client compatible with this network.
                         faucet.is_some(),
                         "Using --with-new-chain requires --faucet to be set"
                     );
-                    options.run_with_storage(Job(options.clone())).await?;
+                    options.run_with_storage(Job(options.clone())).await??;
                 }
                 Ok(())
             }
         },
 
-        _ => options.run_with_storage(Job(options.clone())).await,
+        _ => options.run_with_storage(Job(options.clone())).await?,
     }
 }

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -107,7 +107,7 @@ impl ProxyContext {
 
 #[async_trait]
 impl Runnable for ProxyContext {
-    type Output = ();
+    type Output = Result<(), anyhow::Error>;
 
     async fn run<S>(self, storage: S) -> Result<(), anyhow::Error>
     where
@@ -369,6 +369,6 @@ impl ProxyOptions {
             ProxyContext::from_options(self)?,
         )
         .boxed()
-        .await
+        .await?
     }
 }


### PR DESCRIPTION
## Motivation

Now that `linera-client` is a library, it shouldn't be using `anyhow` for its errors, since we'd like to give the caller more control over error-handling.  In particular, [`anyhow::Error`](https://docs.rs/anyhow/latest/anyhow/struct.Error.html) can't be represented as a [`JsError`](https://docs.rs/wasm-bindgen/latest/wasm_bindgen/struct.JsError.html) (since it doesn't implement [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html), [for coherence reasons](https://github.com/dtolnay/anyhow/issues/25)), so we can't raise `anyhow::Error` to JavaScript.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Replace `anyhow` with concrete [`thiserror`](https://crates.io/crates/thiserror) error types in `linera-client`.  Where we want to track error context, e.g. where errors occur in the process of handling other errors, introduce [`thiserror-context`](https://crates.io/crates/thiserror-context).

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
This is a backwards-incompatible API change for `linera-client`, so should cause a major version bump.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
