### PR TITLE
open_chain returns the message ID.

### DIFF
--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -577,7 +577,7 @@ pub trait ContractRuntime: BaseRuntime {
         ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> Result<ChainId, ExecutionError>;
+    ) -> Result<(MessageId, ChainId), ExecutionError>;
 
     /// Closes the current chain.
     fn close_chain(&mut self) -> Result<(), ExecutionError>;

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -267,7 +267,7 @@ where
         chain_ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> Result<ChainId, RuntimeError> {
+    ) -> Result<(MessageId, ChainId), RuntimeError> {
         caller
             .user_data_mut()
             .runtime

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -1496,9 +1496,10 @@ async fn test_open_chain() {
             runtime.transfer(None, destination, Amount::ONE).unwrap();
             let id = runtime.application_id().unwrap();
             let application_permissions = ApplicationPermissions::new_single(id);
-            let chain_id = runtime
+            let (actual_message_id, chain_id) = runtime
                 .open_chain(child_ownership, application_permissions, Amount::ONE)
                 .unwrap();
+            assert_eq!(message_id, actual_message_id);
             assert_eq!(chain_id, ChainId::child(message_id));
             Ok(vec![])
         }

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -201,13 +201,13 @@ where
         chain_ownership: ChainOwnership,
         application_permissions: ApplicationPermissions,
         balance: Amount,
-    ) -> ChainId {
-        wit::open_chain(
+    ) -> (MessageId, ChainId) {
+        let (message_id, chain_id) = wit::open_chain(
             &chain_ownership.into(),
             &application_permissions.into(),
             balance.into(),
-        )
-        .into()
+        );
+        (message_id.into(), chain_id.into())
     }
 
     /// Calls another application.

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -18,7 +18,7 @@ interface contract-system-api {
     transfer: func(source: option<owner>, destination: account, amount: amount);
     claim: func(source: account, destination: account, amount: amount);
     get-chain-ownership: func() -> chain-ownership;
-    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> chain-id;
+    open-chain: func(chain-ownership: chain-ownership, application-permissions: application-permissions, balance: amount) -> tuple<message-id, chain-id>;
     close-chain: func() -> result<tuple<>, close-chain-error>;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);


### PR DESCRIPTION
## Motivation

The `open_chain` method allows contracts to create new chains. It returns the new chain ID. To assign a key to the new chain and add it to their wallet, users need the _message ID_, however.

## Proposal

Return both the message ID and the chain ID.

## Test Plan

The test was extended.
This will also be used in the hex-game example soon.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- #2326 
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
