### PR TITLE
Insert RegisterApplications before the first user outcome.

### DIFF
--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -275,8 +275,13 @@ where
             ..RawExecutionOutcome::default()
         };
 
+        // Insert the message before the first user outcome.
+        let index = results
+            .iter()
+            .position(|outcome| matches!(outcome, ExecutionOutcome::User(_, _)))
+            .unwrap_or(results.len());
         // TODO(#2362): This inserts messages in front of existing ones, invalidating their IDs.
-        results.insert(0, ExecutionOutcome::System(system_outcome));
+        results.insert(index, ExecutionOutcome::System(system_outcome));
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

For any bundle with user applications, `RegisterApplications` is retroactively inserted at the beginning to make sure those applications are registered in the recipient chain. This is a problem if the first message is `OpenChain`, which is required to be the first message in the bundle.

## Proposal

Insert `RegisterApplications` before the first _user_ application instead of at the beginning. This makes sure that `OpenChain` is never replaced as the bundles first message, and keeps its message ID correct in more (but not all) cases.

## Test Plan

Tests should catch any regressions. The workaround itself will be used and tested in an upcoming PR, where hex-game will create its own temporary chains.


## Links

- This is a partial workaround for https://github.com/linera-io/linera-protocol/issues/2362
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
