### PR TITLE
ChainStateView::execute_block can now activate a chain.

### DIFF
--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -16,7 +16,7 @@ use linera_base::{
 };
 use linera_execution::{
     committee::{Committee, Epoch, ValidatorName},
-    BytecodeLocation, Message, MessageKind, Operation, SystemMessage, SystemOperation,
+    BytecodeLocation, Message, MessageKind, Operation, SystemOperation,
 };
 use serde::{de::Deserializer, Deserialize, Serialize};
 
@@ -94,17 +94,6 @@ impl Block {
                 .incoming_bundles
                 .iter()
                 .all(|message| message.action == MessageAction::Reject)
-    }
-
-    /// Returns whether `OpenChain` is the first message in this block.
-    pub fn starts_with_open_chain(&self) -> bool {
-        let Some(posted_message) = self.incoming_messages().next() else {
-            return false;
-        };
-        matches!(
-            posted_message.message,
-            Message::System(SystemMessage::OpenChain(_))
-        )
     }
 
     /// Returns an iterator over all incoming [`PostedMessage`]s in this block.

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -139,8 +139,6 @@ where
         &mut self,
         block: Block,
     ) -> Result<(ExecutedBlock, ChainInfoResponse), WorkerError> {
-        self.0.ensure_is_active()?;
-
         let local_time = self.0.storage.clock().current_time();
         let signer = block.authenticated_signer;
 


### PR DESCRIPTION
## Motivation

The linera-sdk `TestValidator` directly calls `execute_block`, without first handling the immediate message. That currently fails if it's the first block of a new child chain, because it has not been initialized yet.

## Proposal

In `execute_block`, if it's block 0 of a child chain and the first message is `OpenChain`, execute that message before doing anything that requires the chain to be active.

## Test Plan

CI should catch any regressions.
The feature itself was tested locally and will be used soon when the hex-game is extended to automatically create temporary chains.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
