### PR TITLE
feat: split-off `MockApplication::assert_no_more_expected_calls` into two

### DIFF
--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -3718,10 +3718,10 @@ where
         );
     }
 
-    // TODO(#2249): Split the assertion in two
     drop(worker);
     tokio::time::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();
+    application.assert_no_active_instances();
 
     Ok(())
 }
@@ -3881,10 +3881,10 @@ where
         );
     }
 
-    // TODO(#2249): Split the assertion in two
     drop(worker);
     tokio::time::sleep(Duration::from_millis(10)).await;
     application.assert_no_more_expected_calls();
+    application.assert_no_active_instances();
 
     Ok(())
 }

--- a/linera-execution/src/test_utils/mock_application.rs
+++ b/linera-execution/src/test_utils/mock_application.rs
@@ -63,17 +63,21 @@ impl MockApplication {
         }
     }
 
-    /// Panics if there are still expected calls in one of the [`MockApplicationInstance`]s created
-    /// from this [`MockApplication`].
+    /// Panics if there are still expected calls left in this [`MockApplication`].
     pub fn assert_no_more_expected_calls(&self) {
         assert!(
             self.expected_calls.lock().unwrap().is_empty(),
             "Missing call to instantiate a `MockApplicationInstance`"
         );
+    }
+
+    /// Panics if there are still expected calls in one of the [`MockApplicationInstance`]s created
+    /// from this [`MockApplication`].
+    pub fn assert_no_active_instances(&self) {
         assert_eq!(
             self.active_instances.load(Ordering::Acquire),
             0,
-            "`MockApplicationInstance` is still waiting for expected calls"
+            "At least one of `MockApplicationInstance` is still waiting for expected calls"
         );
     }
 }


### PR DESCRIPTION
## Motivation
- Resolve #2249

## Proposal
- split the `assert_no_more_expected_calls` into two - itself & `assert_no_active_instances`

## Test Plan
CI
