### PR TITLE
Compress Wasm bytecodes when publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4389,6 +4389,7 @@ dependencies = [
  "wasm-instrument",
  "wasmparser 0.101.1",
  "wasmtime",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -8633,7 +8634,7 @@ dependencies = [
  "sha2 0.9.9",
  "toml 0.5.11",
  "windows-sys 0.36.1",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -9523,7 +9524,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -9533,6 +9543,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ webassembly-test = "0.1.0"
 web-sys = "0.3.69"
 web-time = "1.1.0"
 wit-bindgen = "0.24.0"
+zstd = "0.13.2"
 
 linera-base = { version = "0.12.0", path = "./linera-base" }
 linera-chain = { version = "0.12.0", path = "./linera-chain" }

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "wasm-encoder 0.24.1",
  "wasm-instrument",
  "wasmparser 0.101.1",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -6690,7 +6691,7 @@ dependencies = [
  "sha2 0.9.9",
  "toml 0.5.11",
  "windows-sys 0.36.1",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -7469,7 +7470,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe 7.2.1",
 ]
 
 [[package]]
@@ -7479,6 +7489,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2516,8 +2516,8 @@ where
         service: Bytecode,
     ) -> Result<ClientOutcome<(BytecodeId, Certificate)>, ChainClientError> {
         self.execute_operation(Operation::System(SystemOperation::PublishBytecode {
-            contract: contract.clone(),
-            service: service.clone(),
+            contract: contract.into(),
+            service: service.into(),
         }))
         .await?
         .try_map(|certificate| {

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -122,8 +122,8 @@ where
 
     // Publish some bytecode.
     let publish_operation = SystemOperation::PublishBytecode {
-        contract: contract_bytecode,
-        service: service_bytecode,
+        contract: contract_bytecode.into(),
+        service: service_bytecode.into(),
     };
     let publish_message = SystemMessage::BytecodePublished {
         transaction_index: 0,

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -60,6 +60,7 @@ wasm-encoder = { workspace = true, optional = true }
 wasm-instrument = { workspace = true, optional = true, features = ["sign_ext"] }
 wasmparser = { workspace = true, optional = true }
 wasmtime = { workspace = true, optional = true }
+zstd.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1070,7 +1070,7 @@ impl AsRef<[u8]> for Bytecode {
 
 impl fmt::Debug for Bytecode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Bytecode").finish()
+        f.debug_struct("Bytecode").finish_non_exhaustive()
     }
 }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1068,8 +1068,8 @@ impl AsRef<[u8]> for Bytecode {
     }
 }
 
-impl std::fmt::Debug for Bytecode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+impl fmt::Debug for Bytecode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Bytecode").finish()
     }
 }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -37,9 +37,9 @@ use {linera_base::prometheus_util, prometheus::IntCounterVec};
 use crate::test_utils::SystemExecutionState;
 use crate::{
     committee::{Committee, Epoch},
-    ApplicationRegistryView, Bytecode, BytecodeLocation, ChannelName, ChannelSubscription,
-    Destination, ExecutionRuntimeContext, MessageContext, MessageKind, OperationContext,
-    QueryContext, RawExecutionOutcome, RawOutgoingMessage, TransactionTracker,
+    ApplicationRegistryView, BytecodeLocation, ChannelName, ChannelSubscription,
+    CompressedBytecode, Destination, ExecutionRuntimeContext, MessageContext, MessageKind,
+    OperationContext, QueryContext, RawExecutionOutcome, RawOutgoingMessage, TransactionTracker,
     UserApplicationDescription, UserApplicationId,
 };
 
@@ -157,8 +157,8 @@ pub enum SystemOperation {
     },
     /// Publishes a new application bytecode.
     PublishBytecode {
-        contract: Bytecode,
-        service: Bytecode,
+        contract: CompressedBytecode,
+        service: CompressedBytecode,
     },
     /// Publishes a new blob.
     PublishBlob { blob_id: BlobId },
@@ -1110,7 +1110,7 @@ mod tests {
     use linera_views::memory::MemoryContext;
 
     use super::*;
-    use crate::{ExecutionOutcome, ExecutionStateView, TestExecutionRuntimeContext};
+    use crate::{Bytecode, ExecutionOutcome, ExecutionStateView, TestExecutionRuntimeContext};
 
     /// Returns an execution state view and a matching operation context, for epoch 1, with root
     /// chain 0 as the admin ID and one empty committee.
@@ -1141,8 +1141,8 @@ mod tests {
     async fn bytecode_message_index() {
         let (mut view, context) = new_view_and_context().await;
         let operation = SystemOperation::PublishBytecode {
-            contract: Bytecode::new(vec![]),
-            service: Bytecode::new(vec![]),
+            contract: Bytecode::new(vec![]).into(),
+            service: Bytecode::new(vec![]).into(),
         };
         let mut txn_tracker = TransactionTracker::default();
         let new_application = view

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -125,9 +125,6 @@ BlockProposal:
     - validated_block_certificate:
         OPTION:
           TYPENAME: LiteCertificate
-Bytecode:
-  STRUCT:
-    - bytes: BYTES
 BytecodeId:
   STRUCT:
     - message_id:
@@ -340,6 +337,9 @@ Committee:
             TYPENAME: ValidatorState
     - policy:
         TYPENAME: ResourceControlPolicy
+CompressedBytecode:
+  STRUCT:
+    - compressed_bytes: BYTES
 CrateVersion:
   STRUCT:
     - major: U32
@@ -1000,9 +1000,9 @@ SystemOperation:
       PublishBytecode:
         STRUCT:
           - contract:
-              TYPENAME: Bytecode
+              TYPENAME: CompressedBytecode
           - service:
-              TYPENAME: Bytecode
+              TYPENAME: CompressedBytecode
     9:
       PublishBlob:
         STRUCT:

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -327,7 +327,7 @@ pub trait Storage: Sized {
             unreachable!("unexpected bytecode operation");
         };
         Ok(Arc::new(
-            WasmContractModule::new(contract, wasm_runtime).await?,
+            WasmContractModule::new(contract.try_into()?, wasm_runtime).await?,
         ))
     }
 
@@ -360,7 +360,7 @@ pub trait Storage: Sized {
             unreachable!("unexpected bytecode operation");
         };
         Ok(Arc::new(
-            WasmServiceModule::new(service, wasm_runtime).await?,
+            WasmServiceModule::new(service.try_into()?, wasm_runtime).await?,
         ))
     }
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Sometimes publishing application fails because the bytecodes are too large, and hit gRPC message size limits when sending the block proposal.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Compress the bytecodes using Zstandard when including them in the `SystemOperation::PublishBytecode`. Use a new `CompressedBytecode` type to represent the compressed bytecode, and make it simple to convert to and from an uncompressed `Bytecode`.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should catch any regressions, since end-to-end tests cover publishing bytecodes and using them in applications.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
A new major version must be released, because this breaks backward compatibility with bytecode publishing.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
