### PR TITLE
Change of the `KeyValueStore`trait.

### DIFF
--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -58,11 +58,7 @@ enum LatestBlock {
 
 impl<S> Indexer<S>
 where
-    S: KeyValueStore
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    S: KeyValueStore + Clone + Send + Sync + 'static,
     S::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -11,7 +11,7 @@ use axum::{extract::Extension, routing::get, Router};
 use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::ChainId};
 use linera_chain::data_types::HashedCertificateValue;
 use linera_views::{
-    common::{AdminKeyValueStore, Context, ContextFromStore, KeyValueStore},
+    common::{Context, ContextFromStore, KeyValueStore},
     map_view::MapView,
     register_view::RegisterView,
     set_view::SetView,
@@ -58,19 +58,18 @@ enum LatestBlock {
 
 impl<S> Indexer<S>
 where
-    S: AdminKeyValueStore<Error = <S as KeyValueStore>::Error>
-        + KeyValueStore
+    S: KeyValueStore
         + Clone
         + Send
         + Sync
         + 'static,
-    <S as KeyValueStore>::Error: From<bcs::Error>
+    S::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send
         + Sync
         + std::error::Error
         + 'static,
-    ViewError: From<<S as KeyValueStore>::Error>,
+    ViewError: From<S::Error>,
 {
     /// Loads the indexer using a database backend with an `indexer` prefix.
     pub async fn load(store: S) -> Result<Self, IndexerError> {

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -72,11 +72,7 @@ pub async fn load<S, V: View<ContextFromStore<(), S>>>(
     name: &str,
 ) -> Result<Arc<Mutex<V>>, IndexerError>
 where
-    S: KeyValueStore
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    S: KeyValueStore + Clone + Send + Sync + 'static,
     S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<S::Error>,
 {

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -9,7 +9,7 @@ use async_graphql::{EmptyMutation, EmptySubscription, ObjectType, Schema};
 use axum::Router;
 use linera_chain::data_types::HashedCertificateValue;
 use linera_views::{
-    common::{AdminKeyValueStore, ContextFromStore, KeyValueStore},
+    common::{ContextFromStore, KeyValueStore},
     views::{View, ViewError},
 };
 use tokio::sync::Mutex;
@@ -72,14 +72,13 @@ pub async fn load<S, V: View<ContextFromStore<(), S>>>(
     name: &str,
 ) -> Result<Arc<Mutex<V>>, IndexerError>
 where
-    S: AdminKeyValueStore<Error = <S as KeyValueStore>::Error>
-        + KeyValueStore
+    S: KeyValueStore
         + Clone
         + Send
         + Sync
         + 'static,
-    <S as KeyValueStore>::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<<S as KeyValueStore>::Error>,
+    S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
+    ViewError: From<S::Error>,
 {
     let root_key = name.as_bytes().to_vec();
     let store = store

--- a/linera-indexer/lib/src/runner.rs
+++ b/linera-indexer/lib/src/runner.rs
@@ -5,7 +5,7 @@
 
 use linera_base::identifiers::ChainId;
 use linera_views::{
-    common::{AdminKeyValueStore, KeyValueStore},
+    common::KeyValueStore,
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
 };
@@ -49,13 +49,12 @@ impl<DB, Config> Runner<DB, Config>
 where
     Self: Send,
     Config: Clone + std::fmt::Debug + Send + Sync + clap::Parser + clap::Args,
-    DB: AdminKeyValueStore<Error = <DB as KeyValueStore>::Error>
-        + KeyValueStore
+    DB: KeyValueStore
         + Clone
         + Send
         + Sync
         + 'static,
-    <DB as KeyValueStore>::Error: From<bcs::Error>
+    DB::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send
         + Sync

--- a/linera-indexer/lib/src/runner.rs
+++ b/linera-indexer/lib/src/runner.rs
@@ -37,27 +37,27 @@ pub struct IndexerConfig<Config: clap::Args> {
     pub command: IndexerCommand,
 }
 
-pub struct Runner<DB, Config: clap::Args> {
-    pub store: DB,
+pub struct Runner<S, Config: clap::Args> {
+    pub store: S,
     pub config: IndexerConfig<Config>,
-    pub indexer: Indexer<DB>,
+    pub indexer: Indexer<S>,
 }
 
-impl<DB, Config> Runner<DB, Config>
+impl<S, Config> Runner<S, Config>
 where
     Self: Send,
     Config: Clone + std::fmt::Debug + Send + Sync + clap::Parser + clap::Args,
-    DB: KeyValueStore + Clone + Send + Sync + 'static,
-    DB::Error: From<bcs::Error>
+    S: KeyValueStore + Clone + Send + Sync + 'static,
+    S::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send
         + Sync
         + std::error::Error
         + 'static,
-    ViewError: From<<DB as KeyValueStore>::Error>,
+    ViewError: From<S::Error>,
 {
     /// Loads a new runner
-    pub async fn new(config: IndexerConfig<Config>, store: DB) -> Result<Self, IndexerError>
+    pub async fn new(config: IndexerConfig<Config>, store: S) -> Result<Self, IndexerError>
     where
         Self: Sized,
     {
@@ -72,13 +72,13 @@ where
     /// Registers a new plugin to the indexer
     pub async fn add_plugin(
         &mut self,
-        plugin: impl Plugin<DB> + 'static,
+        plugin: impl Plugin<S> + 'static,
     ) -> Result<(), IndexerError> {
         self.indexer.add_plugin(plugin).await
     }
 
     /// Runs a server from the indexer and the plugins
-    async fn server(port: u16, indexer: &Indexer<DB>) -> Result<(), IndexerError> {
+    async fn server(port: u16, indexer: &Indexer<S>) -> Result<(), IndexerError> {
         let mut app = indexer.route(None);
         for plugin in indexer.plugins.values() {
             app = plugin.route(app);

--- a/linera-indexer/lib/src/runner.rs
+++ b/linera-indexer/lib/src/runner.rs
@@ -5,9 +5,7 @@
 
 use linera_base::identifiers::ChainId;
 use linera_views::{
-    common::KeyValueStore,
-    value_splitting::DatabaseConsistencyError,
-    views::ViewError,
+    common::KeyValueStore, value_splitting::DatabaseConsistencyError, views::ViewError,
 };
 use tokio::select;
 use tracing::{info, warn};
@@ -49,11 +47,7 @@ impl<DB, Config> Runner<DB, Config>
 where
     Self: Send,
     Config: Clone + std::fmt::Debug + Send + Sync + clap::Parser + clap::Args,
-    DB: KeyValueStore
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    DB: KeyValueStore + Clone + Send + Sync + 'static,
     DB::Error: From<bcs::Error>
         + From<DatabaseConsistencyError>
         + Send

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -20,9 +20,7 @@ use linera_chain::data_types::HashedCertificateValue;
 use linera_core::worker::Reason;
 use linera_service_graphql_client::{block, chains, notifications, Block, Chains, Notifications};
 use linera_views::{
-    common::KeyValueStore,
-    value_splitting::DatabaseConsistencyError,
-    views::ViewError,
+    common::KeyValueStore, value_splitting::DatabaseConsistencyError, views::ViewError,
 };
 use tokio::runtime::Handle;
 use tracing::error;
@@ -133,11 +131,7 @@ impl Listener {
         chain_id: ChainId,
     ) -> Result<ChainId, IndexerError>
     where
-        DB: KeyValueStore
-            + Clone
-            + Send
-            + Sync
-            + 'static,
+        DB: KeyValueStore + Clone + Send + Sync + 'static,
         DB::Error: From<bcs::Error>
             + From<DatabaseConsistencyError>
             + Send

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -125,20 +125,20 @@ pub struct Listener {
 
 impl Listener {
     /// Connects to the websocket of the service node for a particular chain
-    pub async fn listen<DB>(
+    pub async fn listen<S>(
         &self,
-        indexer: &Indexer<DB>,
+        indexer: &Indexer<S>,
         chain_id: ChainId,
     ) -> Result<ChainId, IndexerError>
     where
-        DB: KeyValueStore + Clone + Send + Sync + 'static,
-        DB::Error: From<bcs::Error>
+        S: KeyValueStore + Clone + Send + Sync + 'static,
+        S::Error: From<bcs::Error>
             + From<DatabaseConsistencyError>
             + Send
             + Sync
             + std::error::Error
             + 'static,
-        ViewError: From<DB::Error>,
+        ViewError: From<S::Error>,
     {
         let mut request = self.service.websocket().into_client_request()?;
         request.headers_mut().insert(

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -20,7 +20,7 @@ use linera_chain::data_types::HashedCertificateValue;
 use linera_core::worker::Reason;
 use linera_service_graphql_client::{block, chains, notifications, Block, Chains, Notifications};
 use linera_views::{
-    common::{AdminKeyValueStore, KeyValueStore},
+    common::KeyValueStore,
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
 };
@@ -133,19 +133,18 @@ impl Listener {
         chain_id: ChainId,
     ) -> Result<ChainId, IndexerError>
     where
-        DB: AdminKeyValueStore<Error = <DB as KeyValueStore>::Error>
-            + KeyValueStore
+        DB: KeyValueStore
             + Clone
             + Send
             + Sync
             + 'static,
-        <DB as KeyValueStore>::Error: From<bcs::Error>
+        DB::Error: From<bcs::Error>
             + From<DatabaseConsistencyError>
             + Send
             + Sync
             + std::error::Error
             + 'static,
-        ViewError: From<<DB as KeyValueStore>::Error>,
+        ViewError: From<DB::Error>,
     {
         let mut request = self.service.websocket().into_client_request()?;
         request.headers_mut().insert(

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -16,7 +16,7 @@ use linera_indexer::{
     plugin::{load, route, sdl, Plugin},
 };
 use linera_views::{
-    common::{AdminKeyValueStore, Context, ContextFromStore, KeyValueStore},
+    common::{Context, ContextFromStore, KeyValueStore},
     map_view::MapView,
     views::{RootView, ViewError},
 };
@@ -112,14 +112,13 @@ static NAME: &str = "operations";
 #[async_trait::async_trait]
 impl<S> Plugin<S> for OperationsPlugin<ContextFromStore<(), S>>
 where
-    S: AdminKeyValueStore<Error = <S as KeyValueStore>::Error>
-        + KeyValueStore
+    S: KeyValueStore
         + Clone
         + Send
         + Sync
         + 'static,
-    <S as KeyValueStore>::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<<S as KeyValueStore>::Error>,
+    S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
+    ViewError: From<S::Error>,
 {
     fn name(&self) -> String {
         NAME.to_string()

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -112,11 +112,7 @@ static NAME: &str = "operations";
 #[async_trait::async_trait]
 impl<S> Plugin<S> for OperationsPlugin<ContextFromStore<(), S>>
 where
-    S: KeyValueStore
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    S: KeyValueStore + Clone + Send + Sync + 'static,
     S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
     ViewError: From<S::Error>,
 {

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -333,8 +333,7 @@ impl WitInterface {
     }
 }
 
-impl linera_views::common::RestrictedKeyValueStore for KeyValueStore {
-}
+impl linera_views::common::RestrictedKeyValueStore for KeyValueStore {}
 
 /// Implementation of [`linera_views::common::Context`] to be used for data storage
 /// by Linera applications.

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -329,7 +329,7 @@ impl WitInterface {
     }
 }
 
-impl linera_views::common::KeyValueStore for KeyValueStore {
+impl linera_views::common::RestrictedKeyValueStore for KeyValueStore {
     type Error = ViewError;
 }
 

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -333,8 +333,6 @@ impl WitInterface {
     }
 }
 
-impl linera_views::common::RestrictedKeyValueStore for KeyValueStore {}
-
 /// Implementation of [`linera_views::common::Context`] to be used for data storage
 /// by Linera applications.
 pub type ViewStorageContext = ContextFromStore<(), KeyValueStore>;

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -79,7 +79,8 @@ impl KeyValueStore {
     }
 }
 
-impl ReadableKeyValueStore<ViewError> for KeyValueStore {
+impl ReadableKeyValueStore for KeyValueStore {
+    type ReadError = ViewError;
     // The KeyValueStore of the system_api does not have limits
     // on the size of its values.
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
@@ -149,7 +150,8 @@ impl ReadableKeyValueStore<ViewError> for KeyValueStore {
     }
 }
 
-impl WritableKeyValueStore<ViewError> for KeyValueStore {
+impl WritableKeyValueStore for KeyValueStore {
+    type WriteError = ViewError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use linera_base::ensure;
 use linera_views::{
     batch::Batch,
-    common::{ContextFromStore, ReadableKeyValueStore, WritableKeyValueStore},
+    common::{ContextFromStore, ReadableKeyValueStore, WithError, WritableKeyValueStore},
     views::ViewError,
 };
 
@@ -79,8 +79,11 @@ impl KeyValueStore {
     }
 }
 
+impl WithError for KeyValueStore {
+    type Error = ViewError;
+}
+
 impl ReadableKeyValueStore for KeyValueStore {
-    type ReadError = ViewError;
     // The KeyValueStore of the system_api does not have limits
     // on the size of its values.
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
@@ -151,7 +154,6 @@ impl ReadableKeyValueStore for KeyValueStore {
 }
 
 impl WritableKeyValueStore for KeyValueStore {
-    type WriteError = ViewError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {
@@ -332,7 +334,6 @@ impl WitInterface {
 }
 
 impl linera_views::common::RestrictedKeyValueStore for KeyValueStore {
-    type Error = ViewError;
 }
 
 /// Implementation of [`linera_views::common::Context`] to be used for data storage

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -63,7 +63,8 @@ pub struct ServiceStoreClientInternal {
     root_key: Vec<u8>,
 }
 
-impl ReadableKeyValueStore<ServiceStoreError> for ServiceStoreClientInternal {
+impl ReadableKeyValueStore for ServiceStoreClientInternal {
+    type ReadError = ServiceStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -227,7 +228,8 @@ impl ReadableKeyValueStore<ServiceStoreError> for ServiceStoreClientInternal {
     }
 }
 
-impl WritableKeyValueStore<ServiceStoreError> for ServiceStoreClientInternal {
+impl WritableKeyValueStore for ServiceStoreClientInternal {
+    type WriteError = ServiceStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ServiceStoreError> {
@@ -373,7 +375,8 @@ impl ServiceStoreClientInternal {
     }
 }
 
-impl AdminKeyValueStore<ServiceStoreError> for ServiceStoreClientInternal {
+impl AdminKeyValueStore for ServiceStoreClientInternal {
+    type AdminError = ServiceStoreError;
     type Config = ServiceStoreConfig;
 
     async fn connect(
@@ -537,7 +540,8 @@ pub struct ServiceStoreClient {
     store: ServiceStoreClientInternal,
 }
 
-impl ReadableKeyValueStore<ServiceStoreError> for ServiceStoreClient {
+impl ReadableKeyValueStore for ServiceStoreClient {
+    type ReadError = ServiceStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -580,7 +584,8 @@ impl ReadableKeyValueStore<ServiceStoreError> for ServiceStoreClient {
     }
 }
 
-impl WritableKeyValueStore<ServiceStoreError> for ServiceStoreClient {
+impl WritableKeyValueStore for ServiceStoreClient {
+    type WriteError = ServiceStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ServiceStoreError> {
@@ -596,7 +601,8 @@ impl KeyValueStore for ServiceStoreClient {
     type Error = ServiceStoreError;
 }
 
-impl AdminKeyValueStore<ServiceStoreError> for ServiceStoreClient {
+impl AdminKeyValueStore for ServiceStoreClient {
+    type AdminError = ServiceStoreError;
     type Config = ServiceStoreConfig;
 
     async fn connect(

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -12,7 +12,7 @@ use linera_views::test_utils::generate_test_namespace;
 use linera_views::{
     batch::{Batch, WriteOperation},
     common::{
-        AdminKeyValueStore, CommonStoreConfig, KeyValueStore, ReadableKeyValueStore, WithError,
+        AdminKeyValueStore, CommonStoreConfig, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
 };
@@ -296,8 +296,6 @@ impl WritableKeyValueStore for ServiceStoreClientInternal {
         Ok(())
     }
 }
-
-impl KeyValueStore for ServiceStoreClientInternal {}
 
 impl ServiceStoreClientInternal {
     /// Obtains the semaphore lock on the database if needed.
@@ -597,8 +595,6 @@ impl WritableKeyValueStore for ServiceStoreClient {
         self.store.clear_journal().await
     }
 }
-
-impl KeyValueStore for ServiceStoreClient {}
 
 impl AdminKeyValueStore for ServiceStoreClient {
     type Config = ServiceStoreConfig;

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -12,8 +12,8 @@ use linera_views::test_utils::generate_test_namespace;
 use linera_views::{
     batch::{Batch, WriteOperation},
     common::{
-        AdminKeyValueStore, CommonStoreConfig, KeyValueStore, ReadableKeyValueStore,
-        WithError, WritableKeyValueStore,
+        AdminKeyValueStore, CommonStoreConfig, KeyValueStore, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore,
     },
 };
 use serde::de::DeserializeOwned;
@@ -297,8 +297,7 @@ impl WritableKeyValueStore for ServiceStoreClientInternal {
     }
 }
 
-impl KeyValueStore for ServiceStoreClientInternal {
-}
+impl KeyValueStore for ServiceStoreClientInternal {}
 
 impl ServiceStoreClientInternal {
     /// Obtains the semaphore lock on the database if needed.
@@ -599,8 +598,7 @@ impl WritableKeyValueStore for ServiceStoreClient {
     }
 }
 
-impl KeyValueStore for ServiceStoreClient {
-}
+impl KeyValueStore for ServiceStoreClient {}
 
 impl AdminKeyValueStore for ServiceStoreClient {
     type Config = ServiceStoreConfig;

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -373,8 +373,7 @@ impl ServiceStoreClientInternal {
     }
 }
 
-impl AdminKeyValueStore for ServiceStoreClientInternal {
-    type Error = ServiceStoreError;
+impl AdminKeyValueStore<ServiceStoreError> for ServiceStoreClientInternal {
     type Config = ServiceStoreConfig;
 
     async fn connect(
@@ -597,8 +596,7 @@ impl KeyValueStore for ServiceStoreClient {
     type Error = ServiceStoreError;
 }
 
-impl AdminKeyValueStore for ServiceStoreClient {
-    type Error = ServiceStoreError;
+impl AdminKeyValueStore<ServiceStoreError> for ServiceStoreClient {
     type Config = ServiceStoreConfig;
 
     async fn connect(

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -13,7 +13,7 @@ use linera_views::{
     batch::{Batch, WriteOperation},
     common::{
         AdminKeyValueStore, CommonStoreConfig, KeyValueStore, ReadableKeyValueStore,
-        WritableKeyValueStore,
+        WithError, WritableKeyValueStore,
     },
 };
 use serde::de::DeserializeOwned;
@@ -63,8 +63,11 @@ pub struct ServiceStoreClientInternal {
     root_key: Vec<u8>,
 }
 
+impl WithError for ServiceStoreClientInternal {
+    type Error = ServiceStoreError;
+}
+
 impl ReadableKeyValueStore for ServiceStoreClientInternal {
-    type ReadError = ServiceStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -229,7 +232,6 @@ impl ReadableKeyValueStore for ServiceStoreClientInternal {
 }
 
 impl WritableKeyValueStore for ServiceStoreClientInternal {
-    type WriteError = ServiceStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ServiceStoreError> {
@@ -296,7 +298,6 @@ impl WritableKeyValueStore for ServiceStoreClientInternal {
 }
 
 impl KeyValueStore for ServiceStoreClientInternal {
-    type Error = ServiceStoreError;
 }
 
 impl ServiceStoreClientInternal {
@@ -376,7 +377,6 @@ impl ServiceStoreClientInternal {
 }
 
 impl AdminKeyValueStore for ServiceStoreClientInternal {
-    type AdminError = ServiceStoreError;
     type Config = ServiceStoreConfig;
 
     async fn connect(
@@ -540,8 +540,11 @@ pub struct ServiceStoreClient {
     store: ServiceStoreClientInternal,
 }
 
+impl WithError for ServiceStoreClient {
+    type Error = ServiceStoreError;
+}
+
 impl ReadableKeyValueStore for ServiceStoreClient {
-    type ReadError = ServiceStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -585,7 +588,6 @@ impl ReadableKeyValueStore for ServiceStoreClient {
 }
 
 impl WritableKeyValueStore for ServiceStoreClient {
-    type WriteError = ServiceStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ServiceStoreError> {
@@ -598,11 +600,9 @@ impl WritableKeyValueStore for ServiceStoreClient {
 }
 
 impl KeyValueStore for ServiceStoreClient {
-    type Error = ServiceStoreError;
 }
 
 impl AdminKeyValueStore for ServiceStoreClient {
-    type AdminError = ServiceStoreError;
     type Config = ServiceStoreConfig;
 
     async fn connect(

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -9,7 +9,7 @@ use linera_base::command::resolve_binary;
 #[cfg(with_metrics)]
 use linera_views::metering::KeyValueStoreMetrics;
 use linera_views::{
-    common::{CacheSize, CommonStoreConfig, MIN_VIEW_TAG},
+    common::{CommonStoreConfig, MIN_VIEW_TAG},
     value_splitting::DatabaseConsistencyError,
 };
 use thiserror::Error;
@@ -102,12 +102,6 @@ pub struct ServiceStoreConfig {
     pub endpoint: String,
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,
-}
-
-impl CacheSize for ServiceStoreConfig {
-    fn cache_size(&self) -> usize {
-        self.common_config.cache_size
-    }
 }
 
 /// Obtains the binary of the executable.

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -22,7 +22,7 @@ use linera_execution::{
 };
 use linera_views::{
     batch::Batch,
-    common::{from_bytes_option, AdminKeyValueStore, ContextFromStore, KeyValueStore},
+    common::{from_bytes_option, ContextFromStore, KeyValueStore},
     value_splitting::DatabaseConsistencyError,
     views::{View, ViewError},
 };
@@ -216,7 +216,6 @@ pub struct DbStorageInner<Client> {
 impl<Client> DbStorageInner<Client>
 where
     Client: KeyValueStore
-        + AdminKeyValueStore<Error = <Client as KeyValueStore>::Error>
         + Clone
         + Send
         + Sync
@@ -409,8 +408,7 @@ impl TestClock {
 #[async_trait]
 impl<Client, C> Storage for DbStorage<Client, C>
 where
-    Client: AdminKeyValueStore<Error = <Client as KeyValueStore>::Error>
-        + KeyValueStore
+    Client: KeyValueStore
         + Clone
         + Send
         + Sync
@@ -800,7 +798,6 @@ where
 impl<Client> DbStorage<Client, WallClock>
 where
     Client: KeyValueStore
-        + AdminKeyValueStore<Error = <Client as KeyValueStore>::Error>
         + Clone
         + Send
         + Sync

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -215,11 +215,7 @@ pub struct DbStorageInner<Client> {
 
 impl<Client> DbStorageInner<Client>
 where
-    Client: KeyValueStore
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    Client: KeyValueStore + Clone + Send + Sync + 'static,
     ViewError: From<<Client as KeyValueStore>::Error>,
     <Client as KeyValueStore>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
@@ -408,11 +404,7 @@ impl TestClock {
 #[async_trait]
 impl<Client, C> Storage for DbStorage<Client, C>
 where
-    Client: KeyValueStore
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    Client: KeyValueStore + Clone + Send + Sync + 'static,
     C: Clock + Clone + Send + Sync + 'static,
     ViewError: From<<Client as KeyValueStore>::Error>,
     <Client as KeyValueStore>::Error:
@@ -797,11 +789,7 @@ where
 
 impl<Client> DbStorage<Client, WallClock>
 where
-    Client: KeyValueStore
-        + Clone
-        + Send
-        + Sync
-        + 'static,
+    Client: KeyValueStore + Clone + Send + Sync + 'static,
     ViewError: From<<Client as KeyValueStore>::Error>,
     <Client as KeyValueStore>::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -22,7 +22,7 @@ use linera_execution::{
 };
 use linera_views::{
     batch::Batch,
-    common::{from_bytes_option, ContextFromStore, KeyValueStore, WithError},
+    common::{from_bytes_option, ContextFromStore, KeyValueStore},
     value_splitting::DatabaseConsistencyError,
     views::{View, ViewError},
 };
@@ -216,8 +216,8 @@ pub struct DbStorageInner<Client> {
 impl<Client> DbStorageInner<Client>
 where
     Client: KeyValueStore + Clone + Send + Sync + 'static,
-    ViewError: From<<Client as WithError>::Error>,
-    <Client as WithError>::Error:
+    ViewError: From<Client::Error>,
+    Client::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     pub(crate) fn new(client: Client, wasm_runtime: Option<WasmRuntime>) -> Self {
@@ -235,7 +235,7 @@ where
         namespace: &str,
         root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
-    ) -> Result<Self, <Client as WithError>::Error> {
+    ) -> Result<Self, Client::Error> {
         let client = Client::recreate_and_connect(&store_config, namespace, root_key).await?;
         let storage = Self::new(client, wasm_runtime);
         Ok(storage)
@@ -246,7 +246,7 @@ where
         namespace: &str,
         root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
-    ) -> Result<Self, <Client as WithError>::Error> {
+    ) -> Result<Self, Client::Error> {
         let store = Client::maybe_create_and_connect(&store_config, namespace, root_key).await?;
         let storage = Self::new(store, wasm_runtime);
         Ok(storage)
@@ -257,7 +257,7 @@ where
         namespace: &str,
         root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
-    ) -> Result<Self, <Client as WithError>::Error> {
+    ) -> Result<Self, Client::Error> {
         let client = Client::connect(&store_config, namespace, root_key).await?;
         let storage = Self::new(client, wasm_runtime);
         Ok(storage)
@@ -406,12 +406,12 @@ impl<Client, C> Storage for DbStorage<Client, C>
 where
     Client: KeyValueStore + Clone + Send + Sync + 'static,
     C: Clock + Clone + Send + Sync + 'static,
-    ViewError: From<<Client as WithError>::Error>,
-    <Client as WithError>::Error:
+    ViewError: From<Client::Error>,
+    Client::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     type Context = ContextFromStore<ChainRuntimeContext<Self>, Client>;
-    type StoreError = <Client as WithError>::Error;
+    type StoreError = Client::Error;
 
     fn clock(&self) -> &dyn Clock {
         &self.clock
@@ -725,8 +725,8 @@ impl<Client, C> DbStorage<Client, C>
 where
     Client: KeyValueStore + Clone + Send + Sync + 'static,
     C: Clock,
-    ViewError: From<<Client as WithError>::Error>,
-    <Client as WithError>::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
+    ViewError: From<Client::Error>,
+    Client::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
 {
     fn add_hashed_cert_value_to_batch(
         value: &HashedCertificateValue,
@@ -790,8 +790,8 @@ where
 impl<Client> DbStorage<Client, WallClock>
 where
     Client: KeyValueStore + Clone + Send + Sync + 'static,
-    ViewError: From<<Client as WithError>::Error>,
-    <Client as WithError>::Error:
+    ViewError: From<Client::Error>,
+    Client::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     pub async fn initialize(
@@ -799,7 +799,7 @@ where
         namespace: &str,
         root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
-    ) -> Result<Self, <Client as WithError>::Error> {
+    ) -> Result<Self, Client::Error> {
         let storage =
             DbStorageInner::<Client>::initialize(store_config, namespace, root_key, wasm_runtime)
                 .await?;
@@ -811,7 +811,7 @@ where
         namespace: &str,
         root_key: &[u8],
         wasm_runtime: Option<WasmRuntime>,
-    ) -> Result<Self, <Client as WithError>::Error> {
+    ) -> Result<Self, Client::Error> {
         let storage =
             DbStorageInner::<Client>::make(store_config, namespace, root_key, wasm_runtime).await?;
         Ok(Self::create(storage, WallClock))

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -372,13 +372,19 @@ pub trait LocalReadableKeyValueStore {
     async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::ReadError>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
-    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError>;
+    async fn read_multi_values_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError>;
 
     /// Finds the `key` matching the prefix. The prefix is not included in the returned keys.
     async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::ReadError>;
 
     /// Finds the `(key,value)` pairs matching the prefix. The prefix is not included in the returned keys.
-    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, Self::ReadError>;
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, Self::ReadError>;
 
     // We can't use `async fn` here in the below implementations due to
     // https://github.com/rust-lang/impl-trait-utils/issues/17, but once that bug is fixed
@@ -440,7 +446,11 @@ pub trait LocalAdminKeyValueStore: Sized {
     type Config: Send + Sync;
 
     /// Connects to an existing namespace using the given configuration.
-    async fn connect(config: &Self::Config, namespace: &str, root_key: &[u8]) -> Result<Self, Self::AdminError>;
+    async fn connect(
+        config: &Self::Config,
+        namespace: &str,
+        root_key: &[u8],
+    ) -> Result<Self, Self::AdminError>;
 
     /// Takes a connection and creates a new one with a different `root_key`.
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, Self::AdminError>;
@@ -508,7 +518,8 @@ pub trait RestrictedKeyValueStore:
 
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
 pub trait LocalRestrictedKeyValueStore:
-    LocalReadableKeyValueStore<ReadError = Self::Error> + LocalWritableKeyValueStore<WriteError = Self::Error>
+    LocalReadableKeyValueStore<ReadError = Self::Error>
+    + LocalWritableKeyValueStore<WriteError = Self::Error>
 {
     /// The error type.
     type Error: Debug;
@@ -545,7 +556,6 @@ pub trait LocalKeyValueStore:
 impl<S: KeyValueStore> LocalKeyValueStore for S {
     type Error = <Self as KeyValueStore>::Error;
 }
-
 
 #[doc(hidden)]
 /// Iterates keys by reference in a vector of keys.

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -344,47 +344,50 @@ pub trait KeyValueIterable<Error> {
     fn into_iterator_owned(self) -> Self::IteratorOwned;
 }
 
+/// The error type for the Key Value Stores
+pub trait WithError {
+    /// The error type.
+    type Error: Debug + From<bcs::Error>;
+}
+
 /// Low-level, asynchronous read key-value operations. Useful for storage APIs not based on views.
 #[trait_variant::make(ReadableKeyValueStore: Send)]
-pub trait LocalReadableKeyValueStore {
-    /// The error type.
-    type ReadError: Debug + From<bcs::Error>;
-
+pub trait LocalReadableKeyValueStore: WithError {
     /// The maximal size of keys that can be stored.
     const MAX_KEY_SIZE: usize;
 
     /// Returns type for key search operations.
-    type Keys: KeyIterable<Self::ReadError>;
+    type Keys: KeyIterable<Self::Error>;
 
     /// Returns type for key-value search operations.
-    type KeyValues: KeyValueIterable<Self::ReadError>;
+    type KeyValues: KeyValueIterable<Self::Error>;
 
     /// Retrieve the number of stream queries.
     fn max_stream_queries(&self) -> usize;
 
     /// Retrieves a `Vec<u8>` from the database using the provided `key`.
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::ReadError>;
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error>;
 
     /// Tests whether a key exists in the database
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::ReadError>;
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error>;
 
     /// Tests whether a list of keys exist in the database
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::ReadError>;
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error>;
 
     /// Retrieves multiple `Vec<u8>` from the database using the provided `keys`.
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError>;
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
 
     /// Finds the `key` matching the prefix. The prefix is not included in the returned keys.
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::ReadError>;
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error>;
 
     /// Finds the `(key,value)` pairs matching the prefix. The prefix is not included in the returned keys.
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::ReadError>;
+    ) -> Result<Self::KeyValues, Self::Error>;
 
     // We can't use `async fn` here in the below implementations due to
     // https://github.com/rust-lang/impl-trait-utils/issues/17, but once that bug is fixed
@@ -394,7 +397,7 @@ pub trait LocalReadableKeyValueStore {
     fn read_value<V: DeserializeOwned>(
         &self,
         key: &[u8],
-    ) -> impl Future<Output = Result<Option<V>, Self::ReadError>>
+    ) -> impl Future<Output = Result<Option<V>, Self::Error>>
     where
         Self: Sync,
     {
@@ -405,7 +408,7 @@ pub trait LocalReadableKeyValueStore {
     fn read_multi_values<V: DeserializeOwned + Send>(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> impl Future<Output = Result<Vec<Option<V>>, Self::ReadError>>
+    ) -> impl Future<Output = Result<Vec<Option<V>>, Self::Error>>
     where
         Self: Sync,
     {
@@ -421,27 +424,21 @@ pub trait LocalReadableKeyValueStore {
 
 /// Low-level, asynchronous write key-value operations. Useful for storage APIs not based on views.
 #[trait_variant::make(WritableKeyValueStore: Send)]
-pub trait LocalWritableKeyValueStore {
-    /// The error type.
-    type WriteError: Debug;
-
+pub trait LocalWritableKeyValueStore: WithError {
     /// The maximal size of values that can be stored.
     const MAX_VALUE_SIZE: usize;
 
     /// Writes the `batch` in the database.
-    async fn write_batch(&self, batch: Batch) -> Result<(), Self::WriteError>;
+    async fn write_batch(&self, batch: Batch) -> Result<(), Self::Error>;
 
     /// Clears any journal entry that may remain.
     /// The journal is located at the `root_key`.
-    async fn clear_journal(&self) -> Result<(), Self::WriteError>;
+    async fn clear_journal(&self) -> Result<(), Self::Error>;
 }
 
 /// Low-level trait for the administration of stores and their namespaces.
 #[trait_variant::make(AdminKeyValueStore: Send)]
-pub trait LocalAdminKeyValueStore: Sized {
-    /// The error type.
-    type AdminError: Debug;
-
+pub trait LocalAdminKeyValueStore: WithError + Sized {
     /// The configuration needed to interact with a new store.
     type Config: Send + Sync;
 
@@ -450,16 +447,16 @@ pub trait LocalAdminKeyValueStore: Sized {
         config: &Self::Config,
         namespace: &str,
         root_key: &[u8],
-    ) -> Result<Self, Self::AdminError>;
+    ) -> Result<Self, Self::Error>;
 
     /// Takes a connection and creates a new one with a different `root_key`.
-    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, Self::AdminError>;
+    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, Self::Error>;
 
     /// Obtains the list of existing namespaces.
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, Self::AdminError>;
+    async fn list_all(config: &Self::Config) -> Result<Vec<String>, Self::Error>;
 
     /// Deletes all the existing namespaces.
-    fn delete_all(config: &Self::Config) -> impl Future<Output = Result<(), Self::AdminError>> {
+    fn delete_all(config: &Self::Config) -> impl Future<Output = Result<(), Self::Error>> {
         async {
             let namespaces = Self::list_all(config).await?;
             for namespace in namespaces {
@@ -470,20 +467,20 @@ pub trait LocalAdminKeyValueStore: Sized {
     }
 
     /// Tests if a given namespace exists.
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, Self::AdminError>;
+    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, Self::Error>;
 
     /// Creates a namespace. Returns an error if the namespace exists.
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), Self::AdminError>;
+    async fn create(config: &Self::Config, namespace: &str) -> Result<(), Self::Error>;
 
     /// Deletes the given namespace.
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), Self::AdminError>;
+    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), Self::Error>;
 
     /// Initializes a storage if missing and provides it.
     fn maybe_create_and_connect(
         config: &Self::Config,
         namespace: &str,
         root_key: &[u8],
-    ) -> impl Future<Output = Result<Self, Self::AdminError>> {
+    ) -> impl Future<Output = Result<Self, Self::Error>> {
         async {
             if !Self::exists(config, namespace).await? {
                 Self::create(config, namespace).await?;
@@ -497,7 +494,7 @@ pub trait LocalAdminKeyValueStore: Sized {
         config: &Self::Config,
         namespace: &str,
         root_key: &[u8],
-    ) -> impl Future<Output = Result<Self, Self::AdminError>> {
+    ) -> impl Future<Output = Result<Self, Self::Error>> {
         async {
             if Self::exists(config, namespace).await? {
                 Self::delete(config, namespace).await?;
@@ -509,53 +506,22 @@ pub trait LocalAdminKeyValueStore: Sized {
 }
 
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
-pub trait RestrictedKeyValueStore:
-    ReadableKeyValueStore<ReadError = Self::Error> + WritableKeyValueStore<WriteError = Self::Error>
-{
-    /// The error type.
-    type Error: Debug;
-}
+pub trait RestrictedKeyValueStore: ReadableKeyValueStore + WritableKeyValueStore {}
 
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
-pub trait LocalRestrictedKeyValueStore:
-    LocalReadableKeyValueStore<ReadError = Self::Error>
-    + LocalWritableKeyValueStore<WriteError = Self::Error>
-{
-    /// The error type.
-    type Error: Debug;
-}
+pub trait LocalRestrictedKeyValueStore: LocalReadableKeyValueStore + LocalWritableKeyValueStore {}
 
-impl<S: RestrictedKeyValueStore> LocalRestrictedKeyValueStore for S {
-    type Error = <Self as RestrictedKeyValueStore>::Error;
-}
+impl<S: RestrictedKeyValueStore> LocalRestrictedKeyValueStore for S {}
 
-impl<S: KeyValueStore> RestrictedKeyValueStore for S {
-    type Error = <Self as KeyValueStore>::Error;
-}
+impl<S: KeyValueStore> RestrictedKeyValueStore for S {}
 
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
-pub trait KeyValueStore:
-    ReadableKeyValueStore<ReadError = Self::Error>
-    + WritableKeyValueStore<WriteError = Self::Error>
-    + AdminKeyValueStore<AdminError = Self::Error>
-{
-    /// The error type.
-    type Error: Debug;
-}
+pub trait KeyValueStore: ReadableKeyValueStore + WritableKeyValueStore + AdminKeyValueStore {}
 
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
-pub trait LocalKeyValueStore:
-    LocalReadableKeyValueStore<ReadError = Self::Error>
-    + LocalWritableKeyValueStore<WriteError = Self::Error>
-    + LocalAdminKeyValueStore<AdminError = Self::Error>
-{
-    /// The error type.
-    type Error: Debug;
-}
+pub trait LocalKeyValueStore: LocalReadableKeyValueStore + LocalWritableKeyValueStore + LocalAdminKeyValueStore {}
 
-impl<S: KeyValueStore> LocalKeyValueStore for S {
-    type Error = <Self as KeyValueStore>::Error;
-}
+impl<S: KeyValueStore> LocalKeyValueStore for S {}
 
 #[doc(hidden)]
 /// Iterates keys by reference in a vector of keys.

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -439,11 +439,7 @@ pub trait LocalAdminKeyValueStore<E>: Sized {
     type Config: Send + Sync + CacheSize;
 
     /// Connects to an existing namespace using the given configuration.
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, E>;
+    async fn connect(config: &Self::Config, namespace: &str, root_key: &[u8]) -> Result<Self, E>;
 
     /// Takes a connection and creates a new one with a different `root_key`.
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, E>;
@@ -533,7 +529,9 @@ impl<S: LocalKeyValueStore> LocalRestrictedKeyValueStore for S {
 
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
 pub trait KeyValueStore:
-    ReadableKeyValueStore<Self::Error> + WritableKeyValueStore<Self::Error> + AdminKeyValueStore<Self::Error>
+    ReadableKeyValueStore<Self::Error>
+    + WritableKeyValueStore<Self::Error>
+    + AdminKeyValueStore<Self::Error>
 {
     /// The error type.
     type Error: Debug;
@@ -541,7 +539,9 @@ pub trait KeyValueStore:
 
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
 pub trait LocalKeyValueStore:
-    LocalReadableKeyValueStore<Self::Error> + LocalWritableKeyValueStore<Self::Error> + LocalAdminKeyValueStore<Self::Error>
+    LocalReadableKeyValueStore<Self::Error>
+    + LocalWritableKeyValueStore<Self::Error>
+    + LocalAdminKeyValueStore<Self::Error>
 {
     /// The error type.
     type Error: Debug;

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -426,17 +426,11 @@ pub trait LocalWritableKeyValueStore<E> {
     async fn clear_journal(&self) -> Result<(), E>;
 }
 
-/// Config types need to be able to return their cache size
-pub trait CacheSize {
-    /// Get the cache size of the `Config` entry.
-    fn cache_size(&self) -> usize;
-}
-
 /// Low-level trait for the administration of stores and their namespaces.
 #[trait_variant::make(AdminKeyValueStore: Send)]
 pub trait LocalAdminKeyValueStore<E>: Sized {
     /// The configuration needed to interact with a new store.
-    type Config: Send + Sync + CacheSize;
+    type Config: Send + Sync;
 
     /// Connects to an existing namespace using the given configuration.
     async fn connect(config: &Self::Config, namespace: &str, root_key: &[u8]) -> Result<Self, E>;

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -509,17 +509,26 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
 pub trait RestrictedKeyValueStore: ReadableKeyValueStore + WritableKeyValueStore {}
 
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
-pub trait LocalRestrictedKeyValueStore: LocalReadableKeyValueStore + LocalWritableKeyValueStore {}
+pub trait LocalRestrictedKeyValueStore:
+    LocalReadableKeyValueStore + LocalWritableKeyValueStore
+{
+}
 
 impl<S: RestrictedKeyValueStore> LocalRestrictedKeyValueStore for S {}
 
 impl<S: KeyValueStore> RestrictedKeyValueStore for S {}
 
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
-pub trait KeyValueStore: ReadableKeyValueStore + WritableKeyValueStore + AdminKeyValueStore {}
+pub trait KeyValueStore:
+    ReadableKeyValueStore + WritableKeyValueStore + AdminKeyValueStore
+{
+}
 
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
-pub trait LocalKeyValueStore: LocalReadableKeyValueStore + LocalWritableKeyValueStore + LocalAdminKeyValueStore {}
+pub trait LocalKeyValueStore:
+    LocalReadableKeyValueStore + LocalWritableKeyValueStore + LocalAdminKeyValueStore
+{
+}
 
 impl<S: KeyValueStore> LocalKeyValueStore for S {}
 

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -515,12 +515,6 @@ impl<S: KeyValueStore> RestrictedKeyValueStore for S {
     type Error = <Self as KeyValueStore>::Error;
 }
 
-/*
-impl<S: LocalKeyValueStore> LocalRestrictedKeyValueStore for S {
-    type Error = <Self as LocalKeyValueStore>::Error;
-}
-*/
-
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
 pub trait KeyValueStore:
     ReadableKeyValueStore<Self::Error>

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -508,15 +508,15 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
 pub trait RestrictedKeyValueStore: ReadableKeyValueStore + WritableKeyValueStore {}
 
+impl<T> RestrictedKeyValueStore for T where T: ReadableKeyValueStore + WritableKeyValueStore {}
+
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
 pub trait LocalRestrictedKeyValueStore:
     LocalReadableKeyValueStore + LocalWritableKeyValueStore
 {
 }
 
-impl<S: RestrictedKeyValueStore> LocalRestrictedKeyValueStore for S {}
-
-impl<S: KeyValueStore> RestrictedKeyValueStore for S {}
+impl<T> LocalRestrictedKeyValueStore for T where T: LocalReadableKeyValueStore + LocalWritableKeyValueStore {}
 
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
 pub trait KeyValueStore:
@@ -524,13 +524,15 @@ pub trait KeyValueStore:
 {
 }
 
+impl<T> KeyValueStore for T where T: ReadableKeyValueStore + WritableKeyValueStore + AdminKeyValueStore {}
+
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
 pub trait LocalKeyValueStore:
     LocalReadableKeyValueStore + LocalWritableKeyValueStore + LocalAdminKeyValueStore
 {
 }
 
-impl<S: KeyValueStore> LocalKeyValueStore for S {}
+impl<T> LocalKeyValueStore for T where T: LocalReadableKeyValueStore + LocalWritableKeyValueStore + LocalAdminKeyValueStore {}
 
 #[doc(hidden)]
 /// Iterates keys by reference in a vector of keys.

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -516,7 +516,10 @@ pub trait LocalRestrictedKeyValueStore:
 {
 }
 
-impl<T> LocalRestrictedKeyValueStore for T where T: LocalReadableKeyValueStore + LocalWritableKeyValueStore {}
+impl<T> LocalRestrictedKeyValueStore for T where
+    T: LocalReadableKeyValueStore + LocalWritableKeyValueStore
+{
+}
 
 /// Low-level, asynchronous write and read key-value operations. Useful for storage APIs not based on views.
 pub trait KeyValueStore:
@@ -524,7 +527,10 @@ pub trait KeyValueStore:
 {
 }
 
-impl<T> KeyValueStore for T where T: ReadableKeyValueStore + WritableKeyValueStore + AdminKeyValueStore {}
+impl<T> KeyValueStore for T where
+    T: ReadableKeyValueStore + WritableKeyValueStore + AdminKeyValueStore
+{
+}
 
 /// Low-level, asynchronous write and read key-value operations, without a `Send` bound. Useful for storage APIs not based on views.
 pub trait LocalKeyValueStore:
@@ -532,7 +538,10 @@ pub trait LocalKeyValueStore:
 {
 }
 
-impl<T> LocalKeyValueStore for T where T: LocalReadableKeyValueStore + LocalWritableKeyValueStore + LocalAdminKeyValueStore {}
+impl<T> LocalKeyValueStore for T where
+    T: LocalReadableKeyValueStore + LocalWritableKeyValueStore + LocalAdminKeyValueStore
+{
+}
 
 #[doc(hidden)]
 /// Iterates keys by reference in a vector of keys.

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -43,10 +43,10 @@ use crate::{
     batch::{Batch, SimpleUnorderedBatch},
     common::{
         AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyIterable, KeyValueIterable,
-        KeyValueStore, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     journaling::{
-        DirectKeyValueStore, DirectWritableKeyValueStore, JournalConsistencyError,
+        DirectWritableKeyValueStore, JournalConsistencyError,
         JournalingKeyValueStore,
     },
     lru_caching::LruCachingStore,
@@ -958,8 +958,6 @@ impl DirectWritableKeyValueStore for DynamoDbStoreInternal {
     }
 }
 
-impl DirectKeyValueStore for DynamoDbStoreInternal {}
-
 /// A shared DB client for DynamoDb implementing LruCaching
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
@@ -1034,8 +1032,6 @@ impl WritableKeyValueStore for DynamoDbStore {
         self.store.clear_journal().await
     }
 }
-
-impl KeyValueStore for DynamoDbStore {}
 
 impl AdminKeyValueStore for DynamoDbStore {
     type Config = DynamoDbStoreConfig;

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -958,8 +958,7 @@ impl DirectWritableKeyValueStore for DynamoDbStoreInternal {
     }
 }
 
-impl DirectKeyValueStore for DynamoDbStoreInternal {
-}
+impl DirectKeyValueStore for DynamoDbStoreInternal {}
 
 /// A shared DB client for DynamoDb implementing LruCaching
 #[derive(Clone)]
@@ -1036,8 +1035,7 @@ impl WritableKeyValueStore for DynamoDbStore {
     }
 }
 
-impl KeyValueStore for DynamoDbStore {
-}
+impl KeyValueStore for DynamoDbStore {}
 
 impl AdminKeyValueStore for DynamoDbStore {
     type Config = DynamoDbStoreConfig;

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -42,8 +42,8 @@ use crate::metering::{
 use crate::{
     batch::{Batch, SimpleUnorderedBatch},
     common::{
-        AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyIterable,
-        KeyValueIterable, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+        AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyIterable, KeyValueIterable,
+        KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
     journaling::{
         DirectKeyValueStore, DirectWritableKeyValueStore, JournalConsistencyError,

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -352,7 +352,8 @@ pub struct DynamoDbStoreConfig {
     pub common_config: CommonStoreConfig,
 }
 
-impl AdminKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
+impl AdminKeyValueStore for DynamoDbStoreInternal {
+    type AdminError = DynamoDbStoreError;
     type Config = DynamoDbStoreConfig;
 
     async fn connect(
@@ -851,7 +852,8 @@ impl KeyValueIterable<DynamoDbStoreError> for DynamoDbKeyValues {
     }
 }
 
-impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
+impl ReadableKeyValueStore for DynamoDbStoreInternal {
+    type ReadError = DynamoDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = DynamoDbKeys;
     type KeyValues = DynamoDbKeyValues;
@@ -925,7 +927,8 @@ impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
 }
 
 #[async_trait]
-impl DirectWritableKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
+impl DirectWritableKeyValueStore for DynamoDbStoreInternal {
+    type WriteError = DynamoDbStoreError;
     const MAX_BATCH_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_SIZE;
     const MAX_BATCH_TOTAL_SIZE: usize = MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE;
     const MAX_VALUE_SIZE: usize = VISIBLE_MAX_VALUE_SIZE;
@@ -974,7 +977,8 @@ pub struct DynamoDbStore {
     store: LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<DynamoDbStoreInternal>>>,
 }
 
-impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStore {
+impl ReadableKeyValueStore for DynamoDbStore {
+    type ReadError = DynamoDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE - 4;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -1017,7 +1021,8 @@ impl ReadableKeyValueStore<DynamoDbStoreError> for DynamoDbStore {
     }
 }
 
-impl WritableKeyValueStore<DynamoDbStoreError> for DynamoDbStore {
+impl WritableKeyValueStore for DynamoDbStore {
+    type WriteError = DynamoDbStoreError;
     const MAX_VALUE_SIZE: usize = DynamoDbStoreInternal::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), DynamoDbStoreError> {
@@ -1033,7 +1038,8 @@ impl KeyValueStore for DynamoDbStore {
     type Error = DynamoDbStoreError;
 }
 
-impl AdminKeyValueStore<DynamoDbStoreError> for DynamoDbStore {
+impl AdminKeyValueStore for DynamoDbStore {
+    type AdminError = DynamoDbStoreError;
     type Config = DynamoDbStoreConfig;
 
     async fn connect(

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -42,7 +42,7 @@ use crate::metering::{
 use crate::{
     batch::{Batch, SimpleUnorderedBatch},
     common::{
-        AdminKeyValueStore, CacheSize, CommonStoreConfig, ContextFromStore, KeyIterable,
+        AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyIterable,
         KeyValueIterable, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
     journaling::{
@@ -350,12 +350,6 @@ pub struct DynamoDbStoreConfig {
     pub config: Config,
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,
-}
-
-impl CacheSize for DynamoDbStoreConfig {
-    fn cache_size(&self) -> usize {
-        self.common_config.cache_size
-    }
 }
 
 impl AdminKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -45,10 +45,7 @@ use crate::{
         AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyIterable, KeyValueIterable,
         ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
-    journaling::{
-        DirectWritableKeyValueStore, JournalConsistencyError,
-        JournalingKeyValueStore,
-    },
+    journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
     lru_caching::LruCachingStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
 };

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -358,8 +358,7 @@ impl CacheSize for DynamoDbStoreConfig {
     }
 }
 
-impl AdminKeyValueStore for DynamoDbStoreInternal {
-    type Error = DynamoDbStoreError;
+impl AdminKeyValueStore<DynamoDbStoreError> for DynamoDbStoreInternal {
     type Config = DynamoDbStoreConfig;
 
     async fn connect(
@@ -1040,8 +1039,7 @@ impl KeyValueStore for DynamoDbStore {
     type Error = DynamoDbStoreError;
 }
 
-impl AdminKeyValueStore for DynamoDbStore {
-    type Error = DynamoDbStoreError;
+impl AdminKeyValueStore<DynamoDbStoreError> for DynamoDbStore {
     type Config = DynamoDbStoreConfig;
 
     async fn connect(

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_upper_bound_option, CacheSize, CommonStoreConfig, ContextFromStore,
+        get_upper_bound_option, CommonStoreConfig, ContextFromStore,
         LocalAdminKeyValueStore, LocalKeyValueStore, LocalReadableKeyValueStore,
         LocalWritableKeyValueStore,
     },
@@ -23,12 +23,6 @@ use crate::{
 pub struct IndexedDbStoreConfig {
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,
-}
-
-impl CacheSize for IndexedDbStoreConfig {
-    fn cache_size(&self) -> usize {
-        self.common_config.cache_size
-    }
 }
 
 impl IndexedDbStoreConfig {

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -11,7 +11,7 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::{
         get_upper_bound_option, CommonStoreConfig, ContextFromStore, LocalAdminKeyValueStore,
-        LocalKeyValueStore, LocalReadableKeyValueStore, LocalRestrictedKeyValueStore,
+        LocalReadableKeyValueStore,
         LocalWritableKeyValueStore, WithError,
     },
     value_splitting::DatabaseConsistencyError,
@@ -306,10 +306,6 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
             .delete_object_store(namespace)?)
     }
 }
-
-impl LocalKeyValueStore for IndexedDbStore {}
-
-impl LocalRestrictedKeyValueStore for IndexedDbStore {}
 
 /// An implementation of [`crate::common::Context`] that stores all values in an IndexedDB
 /// database.

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -88,7 +88,8 @@ fn prefix_to_range(prefix: &[u8]) -> Result<web_sys::IdbKeyRange, wasm_bindgen::
     }
 }
 
-impl LocalReadableKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
+impl LocalReadableKeyValueStore for IndexedDbStore {
+    type ReadError = IndexedDbStoreError;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -179,7 +180,8 @@ impl LocalReadableKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
     }
 }
 
-impl LocalWritableKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
+impl LocalWritableKeyValueStore for IndexedDbStore {
+    type WriteError = IndexedDbStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), IndexedDbStoreError> {
@@ -222,7 +224,8 @@ impl LocalWritableKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
     }
 }
 
-impl LocalAdminKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
+impl LocalAdminKeyValueStore for IndexedDbStore {
+    type AdminError = IndexedDbStoreError;
     type Config = IndexedDbStoreConfig;
 
     async fn connect(

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -12,7 +12,7 @@ use crate::{
     common::{
         get_upper_bound_option, CommonStoreConfig, ContextFromStore, LocalAdminKeyValueStore,
         LocalKeyValueStore, LocalReadableKeyValueStore, LocalRestrictedKeyValueStore,
-        LocalWritableKeyValueStore,
+        LocalWritableKeyValueStore, WithError,
     },
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
@@ -88,8 +88,11 @@ fn prefix_to_range(prefix: &[u8]) -> Result<web_sys::IdbKeyRange, wasm_bindgen::
     }
 }
 
+impl WithError for IndexedDbStore {
+    type Error = IndexedDbStoreError;
+}
+
 impl LocalReadableKeyValueStore for IndexedDbStore {
-    type ReadError = IndexedDbStoreError;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -181,7 +184,6 @@ impl LocalReadableKeyValueStore for IndexedDbStore {
 }
 
 impl LocalWritableKeyValueStore for IndexedDbStore {
-    type WriteError = IndexedDbStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), IndexedDbStoreError> {
@@ -225,7 +227,6 @@ impl LocalWritableKeyValueStore for IndexedDbStore {
 }
 
 impl LocalAdminKeyValueStore for IndexedDbStore {
-    type AdminError = IndexedDbStoreError;
     type Config = IndexedDbStoreConfig;
 
     async fn connect(
@@ -306,13 +307,9 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
     }
 }
 
-impl LocalKeyValueStore for IndexedDbStore {
-    type Error = IndexedDbStoreError;
-}
+impl LocalKeyValueStore for IndexedDbStore {}
 
-impl LocalRestrictedKeyValueStore for IndexedDbStore {
-    type Error = IndexedDbStoreError;
-}
+impl LocalRestrictedKeyValueStore for IndexedDbStore {}
 
 /// An implementation of [`crate::common::Context`] that stores all values in an IndexedDB
 /// database.

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_upper_bound_option, CommonStoreConfig, ContextFromStore,
-        LocalAdminKeyValueStore, LocalKeyValueStore, LocalReadableKeyValueStore,
+        get_upper_bound_option, CommonStoreConfig, ContextFromStore, LocalAdminKeyValueStore,
+        LocalKeyValueStore, LocalReadableKeyValueStore, LocalRestrictedKeyValueStore,
         LocalWritableKeyValueStore,
     },
     value_splitting::DatabaseConsistencyError,
@@ -222,8 +222,7 @@ impl LocalWritableKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
     }
 }
 
-impl LocalAdminKeyValueStore for IndexedDbStore {
-    type Error = IndexedDbStoreError;
+impl LocalAdminKeyValueStore<IndexedDbStoreError> for IndexedDbStore {
     type Config = IndexedDbStoreConfig;
 
     async fn connect(
@@ -305,6 +304,10 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
 }
 
 impl LocalKeyValueStore for IndexedDbStore {
+    type Error = IndexedDbStoreError;
+}
+
+impl LocalRestrictedKeyValueStore for IndexedDbStore {
     type Error = IndexedDbStoreError;
 }
 

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -11,8 +11,7 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::{
         get_upper_bound_option, CommonStoreConfig, ContextFromStore, LocalAdminKeyValueStore,
-        LocalReadableKeyValueStore,
-        LocalWritableKeyValueStore, WithError,
+        LocalReadableKeyValueStore, LocalWritableKeyValueStore, WithError,
     },
     value_splitting::DatabaseConsistencyError,
     views::ViewError,

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -97,7 +97,7 @@ struct JournalHeader {
     block_count: u32,
 }
 
-/// A journaling [`KeyValueStore`] built from an inner [`DirectKeyValueStore`].
+/// A journaling Key Value Store built from an inner [`DirectKeyValueStore`].
 #[derive(Clone)]
 pub struct JournalingKeyValueStore<K> {
     /// The inner store.

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -27,8 +27,8 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, BatchValueWriter, DeletePrefixExpander, SimplifiedBatch},
     common::{
-        AdminKeyValueStore, KeyIterable, KeyValueStore, ReadableKeyValueStore,
-        WithError, WritableKeyValueStore, MIN_VIEW_TAG,
+        AdminKeyValueStore, KeyIterable, KeyValueStore, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore, MIN_VIEW_TAG,
     },
 };
 
@@ -81,7 +81,10 @@ pub trait DirectWritableKeyValueStore: WithError {
 }
 
 /// Low-level, asynchronous direct read/write key-value operations with simplified batch
-pub trait DirectKeyValueStore: ReadableKeyValueStore + DirectWritableKeyValueStore + AdminKeyValueStore {}
+pub trait DirectKeyValueStore:
+    ReadableKeyValueStore + DirectWritableKeyValueStore + AdminKeyValueStore
+{
+}
 
 /// The header that contains the current state of the journal.
 #[derive(Serialize, Deserialize, Default, Debug)]

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -82,7 +82,9 @@ pub trait DirectWritableKeyValueStore<E> {
 
 /// Low-level, asynchronous direct read/write key-value operations with simplified batch
 pub trait DirectKeyValueStore:
-    ReadableKeyValueStore<Self::Error> + DirectWritableKeyValueStore<Self::Error> + AdminKeyValueStore<Self::Error>
+    ReadableKeyValueStore<Self::Error>
+    + DirectWritableKeyValueStore<Self::Error>
+    + AdminKeyValueStore<Self::Error>
 {
     /// The error type.
     type Error: Debug + From<bcs::Error>;
@@ -162,17 +164,13 @@ where
     }
 }
 
-impl<K,E> AdminKeyValueStore<E> for JournalingKeyValueStore<K>
+impl<K, E> AdminKeyValueStore<E> for JournalingKeyValueStore<K>
 where
     K: AdminKeyValueStore<E> + Send + Sync,
 {
     type Config = K::Config;
 
-    async fn connect(
-        config: &Self::Config,
-        namespace: &str,
-        root_key: &[u8],
-    ) -> Result<Self, E> {
+    async fn connect(config: &Self::Config, namespace: &str, root_key: &[u8]) -> Result<Self, E> {
         let store = K::connect(config, namespace, root_key).await?;
         Ok(Self { store })
     }

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -117,10 +117,10 @@ where
     }
 }
 
-impl<K> ReadableKeyValueStore<K::Error> for JournalingKeyValueStore<K>
+impl<K, E> ReadableKeyValueStore<E> for JournalingKeyValueStore<K>
 where
-    K: DirectKeyValueStore + Send + Sync,
-    K::Error: From<JournalConsistencyError>,
+    K: ReadableKeyValueStore<E> + Send + Sync,
+    E: From<JournalConsistencyError>,
 {
     /// The size constant do not change
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
@@ -133,33 +133,27 @@ where
         self.store.max_stream_queries()
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, K::Error> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, E> {
         self.store.read_value_bytes(key).await
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, K::Error> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, E> {
         self.store.contains_key(key).await
     }
 
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, K::Error> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E> {
         self.store.contains_keys(keys).await
     }
 
-    async fn read_multi_values_bytes(
-        &self,
-        keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, K::Error> {
+    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, E> {
         self.store.read_multi_values_bytes(keys).await
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, K::Error> {
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, E> {
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
-    async fn find_key_values_by_prefix(
-        &self,
-        key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, K::Error> {
+    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, E> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
 }

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -27,8 +27,8 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, BatchValueWriter, DeletePrefixExpander, SimplifiedBatch},
     common::{
-        AdminKeyValueStore, KeyIterable, ReadableKeyValueStore, WithError,
-        WritableKeyValueStore, MIN_VIEW_TAG,
+        AdminKeyValueStore, KeyIterable, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        MIN_VIEW_TAG,
     },
 };
 
@@ -86,7 +86,10 @@ pub trait DirectKeyValueStore:
 {
 }
 
-impl<T> DirectKeyValueStore for T where T: ReadableKeyValueStore + DirectWritableKeyValueStore + AdminKeyValueStore {}
+impl<T> DirectKeyValueStore for T where
+    T: ReadableKeyValueStore + DirectWritableKeyValueStore + AdminKeyValueStore
+{
+}
 
 /// The header that contains the current state of the journal.
 #[derive(Serialize, Deserialize, Default, Debug)]

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -150,7 +150,10 @@ where
         self.store.contains_keys(keys).await
     }
 
-    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
+    async fn read_multi_values_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
         self.store.read_multi_values_bytes(keys).await
     }
 
@@ -158,7 +161,10 @@ where
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
-    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, Self::ReadError> {
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, Self::ReadError> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
 }
@@ -171,7 +177,11 @@ where
 
     type Config = K::Config;
 
-    async fn connect(config: &Self::Config, namespace: &str, root_key: &[u8]) -> Result<Self, Self::AdminError> {
+    async fn connect(
+        config: &Self::Config,
+        namespace: &str,
+        root_key: &[u8],
+    ) -> Result<Self, Self::AdminError> {
         let store = K::connect(config, namespace, root_key).await?;
         Ok(Self { store })
     }

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, BatchValueWriter, DeletePrefixExpander, SimplifiedBatch},
     common::{
-        AdminKeyValueStore, KeyIterable, ReadableKeyValueStore,
+        AdminKeyValueStore, KeyIterable, KeyValueStore, ReadableKeyValueStore,
         WithError, WritableKeyValueStore, MIN_VIEW_TAG,
     },
 };
@@ -114,7 +114,7 @@ impl<K> WithError for JournalingKeyValueStore<K>
 where
     K: WithError,
 {
-    type Error = <K as WithError>::Error;
+    type Error = K::Error;
 }
 
 impl<K> ReadableKeyValueStore for JournalingKeyValueStore<K>
@@ -231,6 +231,13 @@ where
         }
         Ok(())
     }
+}
+
+impl<K> KeyValueStore for JournalingKeyValueStore<K>
+where
+    K: DirectKeyValueStore + Send + Sync,
+    K::Error: From<JournalConsistencyError>,
+{
 }
 
 impl<K> JournalingKeyValueStore<K>

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, BatchValueWriter, DeletePrefixExpander, SimplifiedBatch},
     common::{
-        AdminKeyValueStore, KeyIterable, KeyValueStore, ReadableKeyValueStore, WithError,
+        AdminKeyValueStore, KeyIterable, ReadableKeyValueStore, WithError,
         WritableKeyValueStore, MIN_VIEW_TAG,
     },
 };
@@ -85,6 +85,8 @@ pub trait DirectKeyValueStore:
     ReadableKeyValueStore + DirectWritableKeyValueStore + AdminKeyValueStore
 {
 }
+
+impl<T> DirectKeyValueStore for T where T: ReadableKeyValueStore + DirectWritableKeyValueStore + AdminKeyValueStore {}
 
 /// The header that contains the current state of the journal.
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -234,13 +236,6 @@ where
         }
         Ok(())
     }
-}
-
-impl<K> KeyValueStore for JournalingKeyValueStore<K>
-where
-    K: DirectKeyValueStore + Send + Sync,
-    K::Error: From<JournalConsistencyError>,
-{
 }
 
 impl<K> JournalingKeyValueStore<K>

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -1081,11 +1081,12 @@ pub struct ViewContainer<C> {
 }
 
 #[cfg(with_testing)]
-impl<C> ReadableKeyValueStore<ViewError> for ViewContainer<C>
+impl<C> ReadableKeyValueStore for ViewContainer<C>
 where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,
 {
+    type ReadError = ViewError;
     const MAX_KEY_SIZE: usize = C::MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -1132,11 +1133,12 @@ where
 }
 
 #[cfg(with_testing)]
-impl<C> WritableKeyValueStore<ViewError> for ViewContainer<C>
+impl<C> WritableKeyValueStore for ViewContainer<C>
 where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,
 {
+    type WriteError = ViewError;
     const MAX_VALUE_SIZE: usize = C::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -41,10 +41,7 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
 
 #[cfg(with_testing)]
 use {
-    crate::common::{
-        ContextFromStore, ReadableKeyValueStore, WithError,
-        WritableKeyValueStore,
-    },
+    crate::common::{ContextFromStore, ReadableKeyValueStore, WithError, WritableKeyValueStore},
     crate::memory::{create_test_memory_context, MemoryContext},
     async_lock::RwLock,
     std::sync::Arc,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -42,7 +42,7 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
 #[cfg(with_testing)]
 use {
     crate::common::{
-        ContextFromStore, ReadableKeyValueStore, RestrictedKeyValueStore, WithError,
+        ContextFromStore, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
     crate::memory::{create_test_memory_context, MemoryContext},
@@ -1157,14 +1157,6 @@ where
     async fn clear_journal(&self) -> Result<(), ViewError> {
         Ok(())
     }
-}
-
-#[cfg(with_testing)]
-impl<C> RestrictedKeyValueStore for ViewContainer<C>
-where
-    C: Context + Sync + Send + Clone,
-    ViewError: From<C::Error>,
-{
 }
 
 #[cfg(with_testing)]

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -42,7 +42,7 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
 #[cfg(with_testing)]
 use {
     crate::common::{
-        ContextFromStore, ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore,
+        ContextFromStore, WithError, ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore,
     },
     crate::memory::{create_test_memory_context, MemoryContext},
     async_lock::RwLock,
@@ -1081,12 +1081,18 @@ pub struct ViewContainer<C> {
 }
 
 #[cfg(with_testing)]
+impl<C> WithError for ViewContainer<C>
+where
+{
+    type Error = ViewError;
+}
+
+#[cfg(with_testing)]
 impl<C> ReadableKeyValueStore for ViewContainer<C>
 where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,
 {
-    type ReadError = ViewError;
     const MAX_KEY_SIZE: usize = C::MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -1138,7 +1144,6 @@ where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,
 {
-    type WriteError = ViewError;
     const MAX_VALUE_SIZE: usize = C::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {
@@ -1161,7 +1166,6 @@ where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,
 {
-    type Error = ViewError;
 }
 
 #[cfg(with_testing)]

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -42,7 +42,7 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
 #[cfg(with_testing)]
 use {
     crate::common::{
-        ContextFromStore, RestrictedKeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+        ContextFromStore, ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore,
     },
     crate::memory::{create_test_memory_context, MemoryContext},
     async_lock::RwLock,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -42,7 +42,7 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
 #[cfg(with_testing)]
 use {
     crate::common::{
-        ContextFromStore, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+        ContextFromStore, RestrictedKeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
     crate::memory::{create_test_memory_context, MemoryContext},
     async_lock::RwLock,
@@ -1154,7 +1154,7 @@ where
 }
 
 #[cfg(with_testing)]
-impl<C> KeyValueStore for ViewContainer<C>
+impl<C> RestrictedKeyValueStore for ViewContainer<C>
 where
     C: Context + Sync + Send + Clone,
     ViewError: From<C::Error>,

--- a/linera-views/src/key_value_store_view.rs
+++ b/linera-views/src/key_value_store_view.rs
@@ -42,7 +42,8 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
 #[cfg(with_testing)]
 use {
     crate::common::{
-        ContextFromStore, WithError, ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore,
+        ContextFromStore, ReadableKeyValueStore, RestrictedKeyValueStore, WithError,
+        WritableKeyValueStore,
     },
     crate::memory::{create_test_memory_context, MemoryContext},
     async_lock::RwLock,
@@ -1081,9 +1082,7 @@ pub struct ViewContainer<C> {
 }
 
 #[cfg(with_testing)]
-impl<C> WithError for ViewContainer<C>
-where
-{
+impl<C> WithError for ViewContainer<C> {
     type Error = ViewError;
 }
 

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -23,7 +23,10 @@ use {
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{get_interval, WithError, ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore},
+    common::{
+        get_interval, ReadableKeyValueStore, RestrictedKeyValueStore, WithError,
+        WritableKeyValueStore,
+    },
 };
 
 #[cfg(with_metrics)]
@@ -275,11 +278,8 @@ where
     }
 }
 
-impl<K> RestrictedKeyValueStore for LruCachingStore<K>
-where
-    K: RestrictedKeyValueStore + Send + Sync,
-{
-}
+impl<K> RestrictedKeyValueStore for LruCachingStore<K> where K: RestrictedKeyValueStore + Send + Sync
+{}
 
 fn new_lru_prefix_cache(cache_size: usize) -> Option<Arc<Mutex<LruPrefixCache>>> {
     if cache_size == 0 {

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -112,7 +112,7 @@ impl<K> WithError for LruCachingStore<K>
 where
     K: WithError,
 {
-    type Error = <K as WithError>::Error;
+    type Error = K::Error;
 }
 
 impl<K> ReadableKeyValueStore for LruCachingStore<K>

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -179,7 +179,10 @@ where
         Ok(results)
     }
 
-    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
+    async fn read_multi_values_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
         let Some(lru_read_values) = &self.lru_read_values else {
             return self.store.read_multi_values_bytes(keys).await;
         };
@@ -222,7 +225,10 @@ where
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
-    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, Self::ReadError> {
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, Self::ReadError> {
         self.store.find_key_values_by_prefix(key_prefix).await
     }
 }

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -16,7 +16,7 @@ use linked_hash_map::LinkedHashMap;
 use prometheus::{register_int_counter_vec, IntCounterVec};
 #[cfg(with_testing)]
 use {
-    crate::common::{CommonStoreConfig, ContextFromStore},
+    crate::common::{AdminKeyValueStore as _, CommonStoreConfig, ContextFromStore},
     crate::memory::{MemoryStore, MemoryStoreConfig, TEST_MEMORY_MAX_STREAM_QUERIES},
     crate::views::ViewError,
 };
@@ -316,10 +316,10 @@ impl<E> LruCachingMemoryContext<E> {
         let config = MemoryStoreConfig { common_config };
         let namespace = "linera";
         let root_key = &[];
-        let store =
-            LruCachingStore::<MemoryStore>::maybe_create_and_connect(&config, namespace, root_key)
-                .await
-                .expect("store");
+        let store = MemoryStore::maybe_create_and_connect(&config, namespace, root_key)
+            .await
+            .expect("store");
+        let store = LruCachingStore::new(store, cache_size);
         let base_key = Vec::new();
         Ok(Self {
             store,

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -23,10 +23,7 @@ use {
 
 use crate::{
     batch::{Batch, WriteOperation},
-    common::{
-        get_interval, RestrictedKeyValueStore, ReadableKeyValueStore,
-        WritableKeyValueStore,
-    },
+    common::{get_interval, ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore},
 };
 
 #[cfg(with_metrics)]

--- a/linera-views/src/lru_caching.rs
+++ b/linera-views/src/lru_caching.rs
@@ -278,9 +278,6 @@ where
     }
 }
 
-impl<K> RestrictedKeyValueStore for LruCachingStore<K> where K: RestrictedKeyValueStore + Send + Sync
-{}
-
 fn new_lru_prefix_cache(cache_size: usize) -> Option<Arc<Mutex<LruPrefixCache>>> {
     if cache_size == 0 {
         None

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -15,7 +15,7 @@ use crate::{
     batch::{Batch, DeletePrefixExpander, WriteOperation},
     common::{
         get_interval, AdminKeyValueStore, CommonStoreConfig, Context, ContextFromStore,
-        KeyIterable, KeyValueStore, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        KeyIterable, ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
@@ -363,8 +363,6 @@ impl AdminKeyValueStore for MemoryStore {
         Ok(())
     }
 }
-
-impl KeyValueStore for MemoryStore {}
 
 /// An implementation of [`crate::common::Context`] that stores all values in memory.
 pub type MemoryContext<E> = ContextFromStore<E, MemoryStore>;

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -304,8 +304,7 @@ impl CacheSize for MemoryStoreConfig {
     }
 }
 
-impl AdminKeyValueStore for MemoryStore {
-    type Error = MemoryStoreError;
+impl AdminKeyValueStore<MemoryStoreError> for MemoryStore {
     type Config = MemoryStoreConfig;
 
     async fn connect(

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -14,7 +14,7 @@ use crate::test_utils::generate_test_namespace;
 use crate::{
     batch::{Batch, DeletePrefixExpander, WriteOperation},
     common::{
-        get_interval, AdminKeyValueStore, CacheSize, CommonStoreConfig, Context, ContextFromStore,
+        get_interval, AdminKeyValueStore, CommonStoreConfig, Context, ContextFromStore,
         KeyIterable, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
     value_splitting::DatabaseConsistencyError,
@@ -295,12 +295,6 @@ impl MemoryStore {
         let config = MemoryStoreConfig { common_config };
         let kill_on_drop = true;
         MemoryStore::sync_maybe_create_and_connect(&config, namespace, root_key, kill_on_drop)
-    }
-}
-
-impl CacheSize for MemoryStoreConfig {
-    fn cache_size(&self) -> usize {
-        self.common_config.cache_size
     }
 }
 

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -15,7 +15,7 @@ use crate::{
     batch::{Batch, DeletePrefixExpander, WriteOperation},
     common::{
         get_interval, AdminKeyValueStore, CommonStoreConfig, Context, ContextFromStore,
-        KeyIterable, KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+        KeyIterable, KeyValueStore, ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     value_splitting::DatabaseConsistencyError,
     views::ViewError,
@@ -129,8 +129,11 @@ impl Drop for MemoryStore {
     }
 }
 
+impl WithError for MemoryStore {
+    type Error = MemoryStoreError;
+}
+
 impl ReadableKeyValueStore for MemoryStore {
-    type ReadError = MemoryStoreError;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -216,8 +219,6 @@ impl ReadableKeyValueStore for MemoryStore {
 }
 
 impl WritableKeyValueStore for MemoryStore {
-    type WriteError = MemoryStoreError;
-
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), MemoryStoreError> {
@@ -302,8 +303,6 @@ impl MemoryStore {
 }
 
 impl AdminKeyValueStore for MemoryStore {
-    type AdminError = MemoryStoreError;
-
     type Config = MemoryStoreConfig;
 
     async fn connect(
@@ -365,9 +364,7 @@ impl AdminKeyValueStore for MemoryStore {
     }
 }
 
-impl KeyValueStore for MemoryStore {
-    type Error = MemoryStoreError;
-}
+impl KeyValueStore for MemoryStore {}
 
 /// An implementation of [`crate::common::Context`] that stores all values in memory.
 pub type MemoryContext<E> = ContextFromStore<E, MemoryStore>;

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -129,7 +129,8 @@ impl Drop for MemoryStore {
     }
 }
 
-impl ReadableKeyValueStore<MemoryStoreError> for MemoryStore {
+impl ReadableKeyValueStore for MemoryStore {
+    type ReadError = MemoryStoreError;
     const MAX_KEY_SIZE: usize = usize::MAX;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -214,7 +215,9 @@ impl ReadableKeyValueStore<MemoryStoreError> for MemoryStore {
     }
 }
 
-impl WritableKeyValueStore<MemoryStoreError> for MemoryStore {
+impl WritableKeyValueStore for MemoryStore {
+    type WriteError = MemoryStoreError;
+
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), MemoryStoreError> {
@@ -298,7 +301,9 @@ impl MemoryStore {
     }
 }
 
-impl AdminKeyValueStore<MemoryStoreError> for MemoryStore {
+impl AdminKeyValueStore for MemoryStore {
+    type AdminError = MemoryStoreError;
+
     type Config = MemoryStoreConfig;
 
     async fn connect(

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -121,10 +121,11 @@ pub struct MeteredStore<K> {
     pub store: K,
 }
 
-impl<K, E> ReadableKeyValueStore<E> for MeteredStore<K>
+impl<K> ReadableKeyValueStore for MeteredStore<K>
 where
-    K: ReadableKeyValueStore<E> + Send + Sync,
+    K: ReadableKeyValueStore + Send + Sync,
 {
+    type ReadError = K::ReadError;
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
     type Keys = K::Keys;
     type KeyValues = K::KeyValues;
@@ -133,49 +134,50 @@ where
         self.store.max_stream_queries()
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, E> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::ReadError> {
         let _metric = self.counter.read_value_bytes.measure_latency();
         self.store.read_value_bytes(key).await
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, E> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::ReadError> {
         let _metric = self.counter.contains_key.measure_latency();
         self.store.contains_key(key).await
     }
 
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, E> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::ReadError> {
         let _metric = self.counter.contains_keys.measure_latency();
         self.store.contains_keys(keys).await
     }
 
-    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, E> {
+    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
         let _metric = self.counter.read_multi_values_bytes.measure_latency();
         self.store.read_multi_values_bytes(keys).await
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, E> {
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::ReadError> {
         let _metric = self.counter.find_keys_by_prefix.measure_latency();
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
-    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, E> {
+    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, Self::ReadError> {
         let _metric = self.counter.find_key_values_by_prefix.measure_latency();
         self.store.find_key_values_by_prefix(key_prefix).await
     }
 }
 
-impl<K, E> WritableKeyValueStore<E> for MeteredStore<K>
+impl<K> WritableKeyValueStore for MeteredStore<K>
 where
-    K: WritableKeyValueStore<E> + Send + Sync,
+    K: WritableKeyValueStore + Send + Sync,
 {
+    type WriteError = K::WriteError;
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
-    async fn write_batch(&self, batch: Batch) -> Result<(), E> {
+    async fn write_batch(&self, batch: Batch) -> Result<(), Self::WriteError> {
         let _metric = self.counter.write_batch.measure_latency();
         self.store.write_batch(batch).await
     }
 
-    async fn clear_journal(&self) -> Result<(), E> {
+    async fn clear_journal(&self) -> Result<(), Self::WriteError> {
         let _metric = self.counter.clear_journal.measure_latency();
         self.store.clear_journal().await
     }

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -9,7 +9,7 @@ use prometheus::HistogramVec;
 
 use crate::{
     batch::Batch,
-    common::{ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore},
+    common::{ReadableKeyValueStore, RestrictedKeyValueStore, WithError, WritableKeyValueStore},
 };
 
 #[derive(Clone)]
@@ -121,11 +121,17 @@ pub struct MeteredStore<K> {
     pub store: K,
 }
 
+impl<K> WithError for MeteredStore<K>
+where
+    K: WithError
+{
+    type Error = K::Error;
+}
+
 impl<K> ReadableKeyValueStore for MeteredStore<K>
 where
     K: ReadableKeyValueStore + Send + Sync,
 {
-    type ReadError = K::ReadError;
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
     type Keys = K::Keys;
     type KeyValues = K::KeyValues;
@@ -134,17 +140,17 @@ where
         self.store.max_stream_queries()
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::ReadError> {
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         let _metric = self.counter.read_value_bytes.measure_latency();
         self.store.read_value_bytes(key).await
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::ReadError> {
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
         let _metric = self.counter.contains_key.measure_latency();
         self.store.contains_key(key).await
     }
 
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::ReadError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error> {
         let _metric = self.counter.contains_keys.measure_latency();
         self.store.contains_keys(keys).await
     }
@@ -152,12 +158,12 @@ where
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
         let _metric = self.counter.read_multi_values_bytes.measure_latency();
         self.store.read_multi_values_bytes(keys).await
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::ReadError> {
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
         let _metric = self.counter.find_keys_by_prefix.measure_latency();
         self.store.find_keys_by_prefix(key_prefix).await
     }
@@ -165,7 +171,7 @@ where
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, Self::ReadError> {
+    ) -> Result<Self::KeyValues, Self::Error> {
         let _metric = self.counter.find_key_values_by_prefix.measure_latency();
         self.store.find_key_values_by_prefix(key_prefix).await
     }
@@ -175,15 +181,14 @@ impl<K> WritableKeyValueStore for MeteredStore<K>
 where
     K: WritableKeyValueStore + Send + Sync,
 {
-    type WriteError = K::WriteError;
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
-    async fn write_batch(&self, batch: Batch) -> Result<(), Self::WriteError> {
+    async fn write_batch(&self, batch: Batch) -> Result<(), Self::Error> {
         let _metric = self.counter.write_batch.measure_latency();
         self.store.write_batch(batch).await
     }
 
-    async fn clear_journal(&self) -> Result<(), Self::WriteError> {
+    async fn clear_journal(&self) -> Result<(), Self::Error> {
         let _metric = self.counter.clear_journal.measure_latency();
         self.store.clear_journal().await
     }
@@ -193,7 +198,6 @@ impl<K> RestrictedKeyValueStore for MeteredStore<K>
 where
     K: RestrictedKeyValueStore + Send + Sync,
 {
-    type Error = K::Error;
 }
 
 impl<K> MeteredStore<K> {

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -123,7 +123,7 @@ pub struct MeteredStore<K> {
 
 impl<K> WithError for MeteredStore<K>
 where
-    K: WithError
+    K: WithError,
 {
     type Error = K::Error;
 }
@@ -194,11 +194,7 @@ where
     }
 }
 
-impl<K> RestrictedKeyValueStore for MeteredStore<K>
-where
-    K: RestrictedKeyValueStore + Send + Sync,
-{
-}
+impl<K> RestrictedKeyValueStore for MeteredStore<K> where K: RestrictedKeyValueStore + Send + Sync {}
 
 impl<K> MeteredStore<K> {
     /// Creates a new Metered store

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -9,7 +9,7 @@ use prometheus::HistogramVec;
 
 use crate::{
     batch::Batch,
-    common::{ReadableKeyValueStore, RestrictedKeyValueStore, WithError, WritableKeyValueStore},
+    common::{ReadableKeyValueStore, WithError, WritableKeyValueStore},
 };
 
 #[derive(Clone)]
@@ -193,8 +193,6 @@ where
         self.store.clear_journal().await
     }
 }
-
-impl<K> RestrictedKeyValueStore for MeteredStore<K> where K: RestrictedKeyValueStore + Send + Sync {}
 
 impl<K> MeteredStore<K> {
     /// Creates a new Metered store

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -9,7 +9,7 @@ use prometheus::HistogramVec;
 
 use crate::{
     batch::Batch,
-    common::{RestrictedKeyValueStore, ReadableKeyValueStore, WritableKeyValueStore},
+    common::{ReadableKeyValueStore, RestrictedKeyValueStore, WritableKeyValueStore},
 };
 
 #[derive(Clone)]

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -9,7 +9,7 @@ use prometheus::HistogramVec;
 
 use crate::{
     batch::Batch,
-    common::{KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore},
+    common::{RestrictedKeyValueStore, ReadableKeyValueStore, WritableKeyValueStore},
 };
 
 #[derive(Clone)]
@@ -181,9 +181,9 @@ where
     }
 }
 
-impl<K> KeyValueStore for MeteredStore<K>
+impl<K> RestrictedKeyValueStore for MeteredStore<K>
 where
-    K: KeyValueStore + Send + Sync,
+    K: RestrictedKeyValueStore + Send + Sync,
 {
     type Error = K::Error;
 }

--- a/linera-views/src/metering.rs
+++ b/linera-views/src/metering.rs
@@ -149,7 +149,10 @@ where
         self.store.contains_keys(keys).await
     }
 
-    async fn read_multi_values_bytes(&self, keys: Vec<Vec<u8>>) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
+    async fn read_multi_values_bytes(
+        &self,
+        keys: Vec<Vec<u8>>,
+    ) -> Result<Vec<Option<Vec<u8>>>, Self::ReadError> {
         let _metric = self.counter.read_multi_values_bytes.measure_latency();
         self.store.read_multi_values_bytes(keys).await
     }
@@ -159,7 +162,10 @@ where
         self.store.find_keys_by_prefix(key_prefix).await
     }
 
-    async fn find_key_values_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::KeyValues, Self::ReadError> {
+    async fn find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Self::KeyValues, Self::ReadError> {
         let _metric = self.counter.find_key_values_by_prefix.measure_latency();
         self.store.find_key_values_by_prefix(key_prefix).await
     }

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -25,7 +25,7 @@ use crate::metering::{
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_upper_bound, AdminKeyValueStore, CacheSize, CommonStoreConfig, ContextFromStore,
+        get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
         KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
     lru_caching::LruCachingStore,
@@ -64,12 +64,6 @@ pub struct RocksDbStoreConfig {
     pub path_buf: PathBuf,
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,
-}
-
-impl CacheSize for RocksDbStoreConfig {
-    fn cache_size(&self) -> usize {
-        self.common_config.cache_size
-    }
 }
 
 #[derive(Default)]

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -432,8 +432,7 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
     }
 }
 
-impl KeyValueStore for RocksDbStoreInternal {
-}
+impl KeyValueStore for RocksDbStoreInternal {}
 
 /// A shared DB client for RocksDB implementing LruCaching
 #[derive(Clone)]
@@ -616,8 +615,7 @@ impl AdminKeyValueStore for RocksDbStore {
     }
 }
 
-impl KeyValueStore for RocksDbStore {
-}
+impl KeyValueStore for RocksDbStore {}
 
 impl<E: Clone + Send + Sync> RocksDbContext<E> {
     /// Creates a [`RocksDbContext`].

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -26,7 +26,7 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::{
         get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyValueStore,
-        ReadableKeyValueStore, WritableKeyValueStore,
+        ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     lru_caching::LruCachingStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
@@ -140,8 +140,11 @@ impl RocksDbStoreInternal {
     }
 }
 
+impl WithError for RocksDbStoreInternal {
+    type Error = RocksDbStoreError;
+}
+
 impl ReadableKeyValueStore for RocksDbStoreInternal {
-    type ReadError = RocksDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -276,7 +279,6 @@ impl ReadableKeyValueStore for RocksDbStoreInternal {
 }
 
 impl WritableKeyValueStore for RocksDbStoreInternal {
-    type WriteError = RocksDbStoreError;
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
 
     async fn write_batch(&self, mut batch: Batch) -> Result<(), RocksDbStoreError> {
@@ -341,7 +343,6 @@ fn root_key_as_string(root_key: &[u8]) -> String {
 }
 
 impl AdminKeyValueStore for RocksDbStoreInternal {
-    type AdminError = RocksDbStoreError;
     type Config = RocksDbStoreConfig;
 
     async fn connect(
@@ -432,7 +433,6 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
 }
 
 impl KeyValueStore for RocksDbStoreInternal {
-    type Error = RocksDbStoreError;
 }
 
 /// A shared DB client for RocksDB implementing LruCaching
@@ -517,8 +517,11 @@ impl RocksDbStore {
     }
 }
 
+impl WithError for RocksDbStore {
+    type Error = RocksDbStoreError;
+}
+
 impl ReadableKeyValueStore for RocksDbStore {
-    type ReadError = RocksDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -562,7 +565,6 @@ impl ReadableKeyValueStore for RocksDbStore {
 }
 
 impl WritableKeyValueStore for RocksDbStore {
-    type WriteError = RocksDbStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), RocksDbStoreError> {
@@ -575,7 +577,6 @@ impl WritableKeyValueStore for RocksDbStore {
 }
 
 impl AdminKeyValueStore for RocksDbStore {
-    type AdminError = RocksDbStoreError;
     type Config = RocksDbStoreConfig;
 
     async fn connect(
@@ -616,7 +617,6 @@ impl AdminKeyValueStore for RocksDbStore {
 }
 
 impl KeyValueStore for RocksDbStore {
-    type Error = RocksDbStoreError;
 }
 
 impl<E: Clone + Send + Sync> RocksDbContext<E> {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -344,8 +344,7 @@ fn root_key_as_string(root_key: &[u8]) -> String {
     format!("ROOT_KEY_{}", hex::encode(root_key))
 }
 
-impl AdminKeyValueStore for RocksDbStoreInternal {
-    type Error = RocksDbStoreError;
+impl AdminKeyValueStore<RocksDbStoreError> for RocksDbStoreInternal {
     type Config = RocksDbStoreConfig;
 
     async fn connect(
@@ -576,8 +575,7 @@ impl WritableKeyValueStore<RocksDbStoreError> for RocksDbStore {
     }
 }
 
-impl AdminKeyValueStore for RocksDbStore {
-    type Error = RocksDbStoreError;
+impl AdminKeyValueStore<RocksDbStoreError> for RocksDbStore {
     type Config = RocksDbStoreConfig;
 
     async fn connect(

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -140,7 +140,8 @@ impl RocksDbStoreInternal {
     }
 }
 
-impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStoreInternal {
+impl ReadableKeyValueStore for RocksDbStoreInternal {
+    type ReadError = RocksDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -274,7 +275,8 @@ impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStoreInternal {
     }
 }
 
-impl WritableKeyValueStore<RocksDbStoreError> for RocksDbStoreInternal {
+impl WritableKeyValueStore for RocksDbStoreInternal {
+    type WriteError = RocksDbStoreError;
     const MAX_VALUE_SIZE: usize = MAX_VALUE_SIZE;
 
     async fn write_batch(&self, mut batch: Batch) -> Result<(), RocksDbStoreError> {
@@ -338,7 +340,8 @@ fn root_key_as_string(root_key: &[u8]) -> String {
     format!("ROOT_KEY_{}", hex::encode(root_key))
 }
 
-impl AdminKeyValueStore<RocksDbStoreError> for RocksDbStoreInternal {
+impl AdminKeyValueStore for RocksDbStoreInternal {
+    type AdminError = RocksDbStoreError;
     type Config = RocksDbStoreConfig;
 
     async fn connect(
@@ -514,7 +517,8 @@ impl RocksDbStore {
     }
 }
 
-impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStore {
+impl ReadableKeyValueStore for RocksDbStore {
+    type ReadError = RocksDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -557,7 +561,8 @@ impl ReadableKeyValueStore<RocksDbStoreError> for RocksDbStore {
     }
 }
 
-impl WritableKeyValueStore<RocksDbStoreError> for RocksDbStore {
+impl WritableKeyValueStore for RocksDbStore {
+    type WriteError = RocksDbStoreError;
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), RocksDbStoreError> {
@@ -569,7 +574,8 @@ impl WritableKeyValueStore<RocksDbStoreError> for RocksDbStore {
     }
 }
 
-impl AdminKeyValueStore<RocksDbStoreError> for RocksDbStore {
+impl AdminKeyValueStore for RocksDbStore {
+    type AdminError = RocksDbStoreError;
     type Config = RocksDbStoreConfig;
 
     async fn connect(

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -25,8 +25,8 @@ use crate::metering::{
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
-        KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+        get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyValueStore,
+        ReadableKeyValueStore, WritableKeyValueStore,
     },
     lru_caching::LruCachingStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -25,7 +25,7 @@ use crate::metering::{
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyValueStore,
+        get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
         ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     lru_caching::LruCachingStore,
@@ -432,8 +432,6 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
     }
 }
 
-impl KeyValueStore for RocksDbStoreInternal {}
-
 /// A shared DB client for RocksDB implementing LruCaching
 #[derive(Clone)]
 pub struct RocksDbStore {
@@ -614,8 +612,6 @@ impl AdminKeyValueStore for RocksDbStore {
         RocksDbStoreInternal::delete(config, namespace).await
     }
 }
-
-impl KeyValueStore for RocksDbStore {}
 
 impl<E: Clone + Send + Sync> RocksDbContext<E> {
     /// Creates a [`RocksDbContext`].

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -42,7 +42,7 @@ use crate::metering::{MeteredStore, LRU_CACHING_METRICS, SCYLLA_DB_METRICS};
 use crate::{
     batch::{Batch, UnorderedBatch},
     common::{
-        get_upper_bound_option, AdminKeyValueStore, CacheSize, CommonStoreConfig, ContextFromStore,
+        get_upper_bound_option, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
         KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
     },
     journaling::{
@@ -802,12 +802,6 @@ pub struct ScyllaDbStoreConfig {
     pub uri: String,
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,
-}
-
-impl CacheSize for ScyllaDbStoreConfig {
-    fn cache_size(&self) -> usize {
-        self.common_config.cache_size
-    }
 }
 
 impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -43,7 +43,7 @@ use crate::{
     batch::{Batch, UnorderedBatch},
     common::{
         get_upper_bound_option, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
-        KeyValueStore, ReadableKeyValueStore, WritableKeyValueStore,
+        KeyValueStore, ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     journaling::{
         DirectKeyValueStore, DirectWritableKeyValueStore, JournalConsistencyError,
@@ -454,8 +454,11 @@ impl From<ScyllaDbStoreError> for crate::views::ViewError {
     }
 }
 
+impl WithError for ScyllaDbStoreInternal {
+    type Error = ScyllaDbStoreError;
+}
+
 impl ReadableKeyValueStore for ScyllaDbStoreInternal {
-    type ReadError = ScyllaDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -540,7 +543,6 @@ impl ReadableKeyValueStore for ScyllaDbStoreInternal {
 
 #[async_trait]
 impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
-    type WriteError = ScyllaDbStoreError;
     // The constant 14000 is an empirical constant that was found to be necessary
     // to make the ScyllaDb system work. We have not been able to find this or
     // a similar constant in the source code or the documentation.
@@ -573,7 +575,6 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
 }
 
 impl AdminKeyValueStore for ScyllaDbStoreInternal {
-    type AdminError = ScyllaDbStoreError;
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(
@@ -763,7 +764,6 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
 }
 
 impl DirectKeyValueStore for ScyllaDbStoreInternal {
-    type Error = ScyllaDbStoreError;
 }
 
 impl ScyllaDbStoreInternal {
@@ -807,8 +807,11 @@ pub struct ScyllaDbStoreConfig {
     pub common_config: CommonStoreConfig,
 }
 
+impl WithError for ScyllaDbStore {
+    type Error = ScyllaDbStoreError;
+}
+
 impl ReadableKeyValueStore for ScyllaDbStore {
-    type ReadError = ScyllaDbStoreError;
     const MAX_KEY_SIZE: usize = ScyllaDbStoreInternal::MAX_KEY_SIZE;
 
     type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore>::Keys;
@@ -857,7 +860,6 @@ impl ReadableKeyValueStore for ScyllaDbStore {
 }
 
 impl WritableKeyValueStore for ScyllaDbStore {
-    type WriteError = ScyllaDbStoreError;
     const MAX_VALUE_SIZE: usize = ScyllaDbStoreInternal::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ScyllaDbStoreError> {
@@ -870,7 +872,6 @@ impl WritableKeyValueStore for ScyllaDbStore {
 }
 
 impl AdminKeyValueStore for ScyllaDbStore {
-    type AdminError = ScyllaDbStoreError;
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(
@@ -911,7 +912,6 @@ impl AdminKeyValueStore for ScyllaDbStore {
 }
 
 impl KeyValueStore for ScyllaDbStore {
-    type Error = ScyllaDbStoreError;
 }
 
 impl ScyllaDbStore {

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -454,7 +454,8 @@ impl From<ScyllaDbStoreError> for crate::views::ViewError {
     }
 }
 
-impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStoreInternal {
+impl ReadableKeyValueStore for ScyllaDbStoreInternal {
+    type ReadError = ScyllaDbStoreError;
     const MAX_KEY_SIZE: usize = MAX_KEY_SIZE;
     type Keys = Vec<Vec<u8>>;
     type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
@@ -538,7 +539,8 @@ impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStoreInternal {
 }
 
 #[async_trait]
-impl DirectWritableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStoreInternal {
+impl DirectWritableKeyValueStore for ScyllaDbStoreInternal {
+    type WriteError = ScyllaDbStoreError;
     // The constant 14000 is an empirical constant that was found to be necessary
     // to make the ScyllaDb system work. We have not been able to find this or
     // a similar constant in the source code or the documentation.
@@ -570,7 +572,8 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
     big_key
 }
 
-impl AdminKeyValueStore<ScyllaDbStoreError> for ScyllaDbStoreInternal {
+impl AdminKeyValueStore for ScyllaDbStoreInternal {
+    type AdminError = ScyllaDbStoreError;
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(
@@ -804,13 +807,14 @@ pub struct ScyllaDbStoreConfig {
     pub common_config: CommonStoreConfig,
 }
 
-impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
+impl ReadableKeyValueStore for ScyllaDbStore {
+    type ReadError = ScyllaDbStoreError;
     const MAX_KEY_SIZE: usize = ScyllaDbStoreInternal::MAX_KEY_SIZE;
 
-    type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore<ScyllaDbStoreError>>::Keys;
+    type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore>::Keys;
 
     type KeyValues =
-        <ScyllaDbStoreInternal as ReadableKeyValueStore<ScyllaDbStoreError>>::KeyValues;
+        <ScyllaDbStoreInternal as ReadableKeyValueStore>::KeyValues;
 
     fn max_stream_queries(&self) -> usize {
         self.store.max_stream_queries()
@@ -853,7 +857,8 @@ impl ReadableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
     }
 }
 
-impl WritableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
+impl WritableKeyValueStore for ScyllaDbStore {
+    type WriteError = ScyllaDbStoreError;
     const MAX_VALUE_SIZE: usize = ScyllaDbStoreInternal::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), ScyllaDbStoreError> {
@@ -865,7 +870,8 @@ impl WritableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
     }
 }
 
-impl AdminKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
+impl AdminKeyValueStore for ScyllaDbStore {
+    type AdminError = ScyllaDbStoreError;
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -570,8 +570,7 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
     big_key
 }
 
-impl AdminKeyValueStore for ScyllaDbStoreInternal {
-    type Error = ScyllaDbStoreError;
+impl AdminKeyValueStore<ScyllaDbStoreError> for ScyllaDbStoreInternal {
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(
@@ -872,8 +871,7 @@ impl WritableKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
     }
 }
 
-impl AdminKeyValueStore for ScyllaDbStore {
-    type Error = ScyllaDbStoreError;
+impl AdminKeyValueStore<ScyllaDbStoreError> for ScyllaDbStore {
     type Config = ScyllaDbStoreConfig;
 
     async fn connect(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -43,10 +43,10 @@ use crate::{
     batch::{Batch, UnorderedBatch},
     common::{
         get_upper_bound_option, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
-        KeyValueStore, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     journaling::{
-        DirectKeyValueStore, DirectWritableKeyValueStore, JournalConsistencyError,
+        DirectWritableKeyValueStore, JournalConsistencyError,
         JournalingKeyValueStore,
     },
     lru_caching::LruCachingStore,
@@ -763,8 +763,6 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
     }
 }
 
-impl DirectKeyValueStore for ScyllaDbStoreInternal {}
-
 impl ScyllaDbStoreInternal {
     /// Obtains the semaphore lock on the database if needed.
     async fn acquire(&self) -> Option<SemaphoreGuard<'_>> {
@@ -909,8 +907,6 @@ impl AdminKeyValueStore for ScyllaDbStore {
         ScyllaDbStoreInternal::delete(config, namespace).await
     }
 }
-
-impl KeyValueStore for ScyllaDbStore {}
 
 impl ScyllaDbStore {
     #[cfg(with_metrics)]

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -45,10 +45,7 @@ use crate::{
         get_upper_bound_option, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
         ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
-    journaling::{
-        DirectWritableKeyValueStore, JournalConsistencyError,
-        JournalingKeyValueStore,
-    },
+    journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
     lru_caching::LruCachingStore,
     value_splitting::DatabaseConsistencyError,
 };

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -763,8 +763,7 @@ impl AdminKeyValueStore for ScyllaDbStoreInternal {
     }
 }
 
-impl DirectKeyValueStore for ScyllaDbStoreInternal {
-}
+impl DirectKeyValueStore for ScyllaDbStoreInternal {}
 
 impl ScyllaDbStoreInternal {
     /// Obtains the semaphore lock on the database if needed.
@@ -911,8 +910,7 @@ impl AdminKeyValueStore for ScyllaDbStore {
     }
 }
 
-impl KeyValueStore for ScyllaDbStore {
-}
+impl KeyValueStore for ScyllaDbStore {}
 
 impl ScyllaDbStore {
     #[cfg(with_metrics)]

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -813,8 +813,7 @@ impl ReadableKeyValueStore for ScyllaDbStore {
 
     type Keys = <ScyllaDbStoreInternal as ReadableKeyValueStore>::Keys;
 
-    type KeyValues =
-        <ScyllaDbStoreInternal as ReadableKeyValueStore>::KeyValues;
+    type KeyValues = <ScyllaDbStoreInternal as ReadableKeyValueStore>::KeyValues;
 
     fn max_stream_queries(&self) -> usize {
         self.store.max_stream_queries()

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -241,7 +241,10 @@ pub fn span_random_reordering_put_delete<R: Rng>(
 /// * `read_multi_values_bytes`
 /// * `find_keys_by_prefix` / `find_key_values_by_prefix`
 /// * The ordering of keys returned by `find_keys_by_prefix` and `find_key_values_by_prefix`
-pub async fn run_reads<S: LocalRestrictedKeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec<u8>)>) {
+pub async fn run_reads<S: LocalRestrictedKeyValueStore>(
+    store: S,
+    key_values: Vec<(Vec<u8>, Vec<u8>)>,
+) {
     // We need a nontrivial key_prefix because dynamo requires a non-trivial prefix
     let mut batch = Batch::new();
     let mut keys = Vec::new();

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -15,7 +15,7 @@ use crate::{
         Batch, WriteOperation,
         WriteOperation::{Delete, Put},
     },
-    common::{KeyIterable, KeyValueIterable, LocalAdminKeyValueStore, LocalKeyValueStore},
+    common::{KeyIterable, KeyValueIterable, LocalKeyValueStore, LocalRestrictedKeyValueStore},
 };
 
 // The following seed is chosen to have equal numbers of 1s and 0s, as advised by
@@ -241,7 +241,7 @@ pub fn span_random_reordering_put_delete<R: Rng>(
 /// * `read_multi_values_bytes`
 /// * `find_keys_by_prefix` / `find_key_values_by_prefix`
 /// * The ordering of keys returned by `find_keys_by_prefix` and `find_key_values_by_prefix`
-pub async fn run_reads<S: LocalKeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec<u8>)>) {
+pub async fn run_reads<S: LocalRestrictedKeyValueStore>(store: S, key_values: Vec<(Vec<u8>, Vec<u8>)>) {
     // We need a nontrivial key_prefix because dynamo requires a non-trivial prefix
     let mut batch = Batch::new();
     let mut keys = Vec::new();
@@ -434,7 +434,7 @@ fn realize_batch(batch: &Batch) -> BTreeMap<Vec<u8>, Vec<u8>> {
     kv_state
 }
 
-async fn read_key_values_prefix<C: LocalKeyValueStore>(
+async fn read_key_values_prefix<C: LocalRestrictedKeyValueStore>(
     key_value_store: &C,
     key_prefix: &[u8],
 ) -> BTreeMap<Vec<u8>, Vec<u8>> {
@@ -454,7 +454,7 @@ async fn read_key_values_prefix<C: LocalKeyValueStore>(
 }
 
 /// Writes and then reads data under a prefix, and verifies the result.
-pub async fn run_test_batch_from_blank<C: LocalKeyValueStore>(
+pub async fn run_test_batch_from_blank<C: LocalRestrictedKeyValueStore>(
     key_value_store: &C,
     key_prefix: Vec<u8>,
     batch: Batch,
@@ -467,7 +467,7 @@ pub async fn run_test_batch_from_blank<C: LocalKeyValueStore>(
 }
 
 /// Run many operations on batches always starting from a blank state.
-pub async fn run_writes_from_blank<C: LocalKeyValueStore>(key_value_store: &C) {
+pub async fn run_writes_from_blank<C: LocalRestrictedKeyValueStore>(key_value_store: &C) {
     let mut rng = make_deterministic_rng();
     let n_oper = 10;
     let batch_size = 500;
@@ -495,7 +495,7 @@ pub async fn run_writes_from_blank<C: LocalKeyValueStore>(key_value_store: &C) {
 /// Then we select half of them at random and delete them. By the random
 /// selection, Scylla is forced to introduce around 100000 tombstones
 /// which triggers the crash with the default settings.
-pub async fn tombstone_triggering_test<C: LocalKeyValueStore>(key_value_store: C) {
+pub async fn tombstone_triggering_test<C: LocalRestrictedKeyValueStore>(key_value_store: C) {
     let mut rng = make_deterministic_rng();
     let value_size = 100;
     let n_entry = 200000;
@@ -530,7 +530,7 @@ pub async fn tombstone_triggering_test<C: LocalKeyValueStore>(key_value_store: C
 /// must handle that.
 ///
 /// The size of the value vary as each size has its own issues.
-pub async fn run_big_write_read<C: LocalKeyValueStore>(
+pub async fn run_big_write_read<C: LocalRestrictedKeyValueStore>(
     key_value_store: C,
     target_size: usize,
     value_sizes: Vec<usize>,
@@ -552,7 +552,7 @@ pub async fn run_big_write_read<C: LocalKeyValueStore>(
 
 type StateBatch = (Vec<(Vec<u8>, Vec<u8>)>, Batch);
 
-async fn run_test_batch_from_state<C: LocalKeyValueStore>(
+async fn run_test_batch_from_state<C: LocalRestrictedKeyValueStore>(
     key_value_store: &C,
     key_prefix: Vec<u8>,
     state_and_batch: StateBatch,
@@ -644,7 +644,7 @@ fn generate_specific_state_batch(key_prefix: &[u8], option: usize) -> StateBatch
 
 /// Run some deterministic and random batches operation and check their
 /// correctness
-pub async fn run_writes_from_state<C: LocalKeyValueStore>(key_value_store: &C) {
+pub async fn run_writes_from_state<C: LocalRestrictedKeyValueStore>(key_value_store: &C) {
     for option in 0..7 {
         let key_prefix = if option == 6 {
             vec![255, 255, 255]
@@ -656,7 +656,7 @@ pub async fn run_writes_from_state<C: LocalKeyValueStore>(key_value_store: &C) {
     }
 }
 
-async fn namespaces_with_prefix<S: LocalAdminKeyValueStore>(
+async fn namespaces_with_prefix<S: LocalKeyValueStore>(
     config: &S::Config,
     prefix: &str,
 ) -> BTreeSet<String>
@@ -673,7 +673,7 @@ where
 /// Exercises the functionalities of the `AdminKeyValueStore`.
 /// This tests everything except the `delete_all` which would
 /// interact with other namespaces.
-pub async fn admin_test<S: LocalAdminKeyValueStore>(config: &S::Config)
+pub async fn admin_test<S: LocalKeyValueStore>(config: &S::Config)
 where
     S::Error: Debug,
 {

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 #[cfg(with_testing)]
 use crate::{
-    memory::{MemoryStore, MemoryStoreError, TEST_MEMORY_MAX_STREAM_QUERIES},
+    memory::{MemoryStore, MemoryStoreConfig, MemoryStoreError, TEST_MEMORY_MAX_STREAM_QUERIES},
     test_utils::generate_test_namespace,
 };
 
@@ -421,6 +421,41 @@ impl WritableKeyValueStore<MemoryStoreError> for LimitedTestMemoryStore {
 
     async fn clear_journal(&self) -> Result<(), MemoryStoreError> {
         self.store.clear_journal().await
+    }
+}
+
+#[cfg(with_testing)]
+impl AdminKeyValueStore<MemoryStoreError> for LimitedTestMemoryStore {
+    type Config = MemoryStoreConfig;
+
+    async fn connect(
+        config: &Self::Config,
+        namespace: &str,
+        root_key: &[u8],
+    ) -> Result<Self, MemoryStoreError> {
+        let store = MemoryStore::connect(config, namespace, root_key).await?;
+        Ok(Self { store })
+    }
+
+    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, MemoryStoreError> {
+        let store = self.store.clone_with_root_key(root_key)?;
+        Ok(Self { store })
+    }
+
+    async fn list_all(config: &Self::Config) -> Result<Vec<String>, MemoryStoreError> {
+        MemoryStore::list_all(config).await
+    }
+
+    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, MemoryStoreError> {
+        MemoryStore::exists(config, namespace).await
+    }
+
+    async fn create(config: &Self::Config, namespace: &str) -> Result<(), MemoryStoreError> {
+        MemoryStore::create(config, namespace).await
+    }
+
+    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), MemoryStoreError> {
+        MemoryStore::delete(config, namespace).await
     }
 }
 

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        KeyIterable, KeyValueIterable, WithError, ReadableKeyValueStore, RestrictedKeyValueStore,
+        KeyIterable, KeyValueIterable, ReadableKeyValueStore, RestrictedKeyValueStore, WithError,
         WritableKeyValueStore,
     },
 };
@@ -267,7 +267,6 @@ where
     K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
 {
 }
-
 
 impl<K> ValueSplittingStore<K>
 where

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -51,7 +51,7 @@ impl<K> WithError for ValueSplittingStore<K>
 where
     K: WithError,
 {
-    type Error = <K as WithError>::Error;
+    type Error = K::Error;
 }
 
 impl<K> ReadableKeyValueStore for ValueSplittingStore<K>

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        KeyIterable, KeyValueIterable, RestrictedKeyValueStore, ReadableKeyValueStore,
+        KeyIterable, KeyValueIterable, ReadableKeyValueStore, RestrictedKeyValueStore,
         WritableKeyValueStore,
     },
 };

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -254,44 +254,43 @@ where
     }
 }
 
-impl<K> AdminKeyValueStore for ValueSplittingStore<K>
+impl<K> AdminKeyValueStore<K::Error> for ValueSplittingStore<K>
 where
-    K: AdminKeyValueStore + Send + Sync,
+    K: KeyValueStore + Send + Sync,
 {
-    type Error = K::Error;
     type Config = K::Config;
 
     async fn connect(
         config: &Self::Config,
         namespace: &str,
         root_key: &[u8],
-    ) -> Result<Self, Self::Error> {
+    ) -> Result<Self, K::Error> {
         let store = K::connect(config, namespace, root_key).await?;
         Ok(Self { store })
     }
 
-    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, Self::Error> {
+    fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, K::Error> {
         let store = self.store.clone_with_root_key(root_key)?;
         Ok(Self { store })
     }
 
-    async fn list_all(config: &Self::Config) -> Result<Vec<String>, Self::Error> {
+    async fn list_all(config: &Self::Config) -> Result<Vec<String>, K::Error> {
         K::list_all(config).await
     }
 
-    async fn delete_all(config: &Self::Config) -> Result<(), Self::Error> {
+    async fn delete_all(config: &Self::Config) -> Result<(), K::Error> {
         K::delete_all(config).await
     }
 
-    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, Self::Error> {
+    async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, K::Error> {
         K::exists(config, namespace).await
     }
 
-    async fn create(config: &Self::Config, namespace: &str) -> Result<(), Self::Error> {
+    async fn create(config: &Self::Config, namespace: &str) -> Result<(), K::Error> {
         K::create(config, namespace).await
     }
 
-    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), Self::Error> {
+    async fn delete(config: &Self::Config, namespace: &str) -> Result<(), K::Error> {
         K::delete(config, namespace).await
     }
 }

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -261,13 +261,6 @@ where
     }
 }
 
-impl<K> RestrictedKeyValueStore for ValueSplittingStore<K>
-where
-    K: RestrictedKeyValueStore + Send + Sync,
-    K::Error: From<bcs::Error> + From<DatabaseConsistencyError>,
-{
-}
-
 impl<K> ValueSplittingStore<K>
 where
     K: RestrictedKeyValueStore + Send + Sync,
@@ -393,9 +386,6 @@ impl WritableKeyValueStore for LimitedTestMemoryStore {
         self.store.clear_journal().await
     }
 }
-
-#[cfg(with_testing)]
-impl RestrictedKeyValueStore for LimitedTestMemoryStore {}
 
 #[cfg(with_testing)]
 impl LimitedTestMemoryStore {

--- a/linera-views/src/value_splitting.rs
+++ b/linera-views/src/value_splitting.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 #[cfg(with_testing)]
 use crate::{
-    memory::{MemoryStore, MemoryStoreConfig, MemoryStoreError, TEST_MEMORY_MAX_STREAM_QUERIES},
+    memory::{MemoryStore, MemoryStoreError, TEST_MEMORY_MAX_STREAM_QUERIES},
     test_utils::generate_test_namespace,
 };
 


### PR DESCRIPTION
## Motivation

The use of the `AdminKeyValueStore` makes the code quite complicated in the `linera-storage`. A cleanup is needed in that respect.

## Proposal

Ideally, we would like to have `KeyValueStore = ReadableKeyValueStore + WritableKeyValueStore + AdminKeyValueStore`. However, this can not be done due to two obstacles:
* The `ViewContainer` is taking a `Context` to build a store. So, if it were to implement the `AdminKeyValueStore` then it would need to have the `Config` type and that is just the first problem that comes to mind.
* The `MeteredStore` cannot create its own store without knowing where to put the metrics and there is no simple way to do that since this is context-dependent.

Therefore, the solution was to have a `KeyValueStore` that implements all 3 traits and a `RestrictedKeyValueStore` that implements the first two.

This implies the following changes:
* The `LruCachingStore` implements just the Writable/Readable. The restriction is downgraded accordingly. So, the `AdminKeyValueStore` implementation is dropped.
* Correspondingly, the `CacheSize` trait is removed as well.
* The `ValueSplittingStore` is also using just the `RestrictedKeyValueStore`. So, the `AdminKeyValueStore` implementation is dropped as well.
* The `linera-storage` and the `linera-indexer` code are simplified as that was the objective of the PR.
* The `KeyValueStore` type used for the smart contracts is implementing just the `RestrictedKeyValueStore`.
* There are trait implications for the traits, but the implication `impl<S: LocalKeyValueStore> LocalRestrictedKeyValueStore for S` was not put as would give two different ways to make the trait implication and the compiler would complain. This complexifies the code for `IndexedDb`.

## Test Plan

The CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
