### PR TITLE
Fix schema_export

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -223,3 +223,6 @@ jobs:
       if: '!cancelled()'
       run: |
         ln -sf toolchains/build/rust-toolchain.toml
+    - name: Check linera-service GraphQL schema
+      run: |
+        diff <(cargo run --locked --bin linera-schema-export) linera-service-graphql-client/gql/service_schema.graphql

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -164,7 +164,7 @@ async fn main() -> std::io::Result<()> {
     let store_config = MemoryStoreConfig::new(TEST_MEMORY_MAX_STREAM_QUERIES);
     let namespace = "schema_export";
     let root_key = &[];
-    let storage = MemoryStorage::new(store_config, namespace, root_key, None)
+    let storage = MemoryStorage::initialize(store_config, namespace, root_key, None)
         .await
         .expect("storage");
     let config = ChainListenerConfig::default();


### PR DESCRIPTION
## Motivation

https://github.com/linera-io/linera-protocol/pull/2348 broke the `schema_export` by reverting https://github.com/linera-io/linera-protocol/pull/2350. 

## Proposal

Fix it again, and add it to CI to make sure it won't break again.

## Test Plan

Added a check to CI, not only that `schema_export` works, but also that the schema is up-to-date.


## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
