### PR TITLE
Feature-gate the http_post and query_service oracles.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,11 +69,11 @@ jobs:
       run: |
         cargo build --release -p linera-storage-service
         target/release/linera-storage-server memory --endpoint $LINERA_STORAGE_SERVICE &
-        cargo test --features storage-service -- storage_service --nocapture
+        cargo test --features storage-service,unstable-oracles -- storage_service --nocapture
     - name: Run Ethereum tests
       run: |
         cargo test -p linera-ethereum --features ethereum
-        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service
+        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
@@ -82,7 +82,7 @@ jobs:
         cargo run --bin wit-generator -- -c
     - name: Run all tests using the default features
       run: |
-        cargo test --locked
+        cargo test --features unstable-oracles --locked
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime

--- a/linera-execution/Cargo.toml
+++ b/linera-execution/Cargo.toml
@@ -15,6 +15,7 @@ version.workspace = true
 test = ["tokio/macros", "linera-views/test"]
 fs = ["tokio/fs"]
 metrics = ["prometheus", "linera-views/metrics"]
+unstable-oracles = []
 wasmer = [
     "bytes",
     "dep:wasmer",

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -180,6 +180,10 @@ pub enum ExecutionError {
     EventKeyTooLong,
     #[error("Stream names can be at most {MAX_STREAM_NAME_LEN} bytes.")]
     StreamNameTooLong,
+    // TODO(#2127): Remove this error and the unstable-oracles feature once there are fees
+    // and enforced limits for all oracles.
+    #[error("Unstable oracles are disabled on this network.")]
+    UnstableOracle,
 }
 
 /// The public entry points provided by the contract part of an application.

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -919,6 +919,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         application_id: ApplicationId,
         query: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
+        ensure!(
+            cfg!(feature = "unstable-oracles"),
+            ExecutionError::UnstableOracle
+        );
         let response =
             if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
                 match response {
@@ -945,6 +949,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
         content_type: String,
         payload: Vec<u8>,
     ) -> Result<Vec<u8>, ExecutionError> {
+        ensure!(
+            cfg!(feature = "unstable-oracles"),
+            ExecutionError::UnstableOracle
+        );
         let bytes =
             if let Some(response) = self.transaction_tracker.next_replayed_oracle_response()? {
                 match response {


### PR DESCRIPTION
## Motivation

The `http_post` oracle is only safe if all validators use an HTTP proxy (https://github.com/linera-io/linera-protocol/issues/2188). Both `http_post` and `query_service` will need fees and limits (https://github.com/linera-io/linera-protocol/issues/2127).

## Proposal

For now, feature-gate these oracles. With the default features, they are not enabled and contract calls that try to use them fail.

Users can continue to develop applications with them if they use the `unstable-oracles` feature for local development, but the public testnets will only support them once they are safe.

This does _not_ disable blobs, which also use the oracle mechanism, since they are essential to the system. Fees and limits for them will be added soon as part of https://github.com/linera-io/linera-protocol/issues/1981.

## Test Plan

The oracles continue to be tested in CI, since I added the feature there.
Locally, I verified that

```
cargo test --features=storage-service application_with_dependency
```

fails but

```
cargo test --features=storage-service,unstable-oracles application_with_dependency
```

passes.

## Release Plan

- Need to update the developer manual.
- This PR is adding or removing Cargo features.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2344.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
