### PR TITLE
Add a fee budget to temporary chains.

### DIFF
--- a/examples/hex-game/README.md
+++ b/examples/hex-game/README.md
@@ -81,7 +81,8 @@ mutation {
         "8a21aedaef74697db8b676c3e03ddf965bf4a808dc2bcabb6d70d6e6e3022ff7",
         "80265761fee067b68ba47cce7464cbc7f1da5b7044d8f68ffc898db5ccb563a5"
     ],
-    boardSize: 11
+    boardSize: 11,
+    feeBudget: "1"
   )
 }
 ```

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -55,8 +55,12 @@ impl Contract for HexContract {
             Operation::Start {
                 players,
                 board_size,
+                fee_budget,
                 timeouts,
-            } => self.execute_start(players, board_size, timeouts).await,
+            } => {
+                self.execute_start(players, board_size, fee_budget, timeouts)
+                    .await
+            }
         };
         self.handle_winner(outcome)
     }
@@ -141,6 +145,7 @@ impl HexContract {
         &mut self,
         players: [PublicKey; 2],
         board_size: u16,
+        fee_budget: Amount,
         timeouts: Option<Timeouts>,
     ) -> HexOutcome {
         assert_eq!(self.runtime.chain_id(), self.main_chain_id());
@@ -151,9 +156,7 @@ impl HexContract {
         );
         let app_id = self.runtime.application_id();
         let permissions = ApplicationPermissions::new_single(app_id.forget_abi());
-        let (message_id, chain_id) = self
-            .runtime
-            .open_chain(ownership, permissions, Amount::ZERO);
+        let (message_id, chain_id) = self.runtime.open_chain(ownership, permissions, fee_budget);
         for public_key in &players {
             self.state
                 .game_chains

--- a/examples/hex-game/src/lib.rs
+++ b/examples/hex-game/src/lib.rs
@@ -85,7 +85,8 @@ mutation {
         "8a21aedaef74697db8b676c3e03ddf965bf4a808dc2bcabb6d70d6e6e3022ff7",
         "80265761fee067b68ba47cce7464cbc7f1da5b7044d8f68ffc898db5ccb563a5"
     ],
-    boardSize: 11
+    boardSize: 11,
+    feeBudget: "1"
   )
 }
 ```
@@ -153,7 +154,7 @@ use std::iter;
 
 use async_graphql::{Enum, InputObject, Request, Response, SimpleObject};
 use linera_sdk::{
-    base::{ContractAbi, PublicKey, ServiceAbi, TimeDelta, Timestamp},
+    base::{Amount, ContractAbi, PublicKey, ServiceAbi, TimeDelta, Timestamp},
     graphql::GraphQLMutationRoot,
 };
 use serde::{Deserialize, Serialize};
@@ -172,6 +173,8 @@ pub enum Operation {
         players: [PublicKey; 2],
         /// The side length of the board. A typical size is 11.
         board_size: u16,
+        /// An amount transferred to the temporary chain to cover the fees.
+        fee_budget: Amount,
         /// Settings that determine how much time the players have to think about their turns.
         /// If this is `None`, the defaults are used.
         timeouts: Option<Timeouts>,

--- a/examples/hex-game/tests/hex_game.rs
+++ b/examples/hex-game/tests/hex_game.rs
@@ -7,7 +7,7 @@
 
 use hex_game::{HexAbi, Operation, Timeouts};
 use linera_sdk::{
-    base::{ChainDescription, KeyPair, TimeDelta},
+    base::{Amount, ChainDescription, KeyPair, TimeDelta},
     test::{ActiveChain, TestValidator},
 };
 
@@ -24,6 +24,7 @@ async fn hex_game() {
             let operation = Operation::Start {
                 board_size: 2,
                 players: [key_pair1.public(), key_pair2.public()],
+                fee_budget: Amount::ZERO,
                 timeouts: None,
             };
             block.with_operation(app_id, operation);
@@ -97,6 +98,7 @@ async fn hex_game_clock() {
             let operation = Operation::Start {
                 board_size: 2,
                 players: [key_pair1.public(), key_pair2.public()],
+                fee_budget: Amount::ZERO,
                 timeouts: None,
             };
             block.with_operation(app_id, operation).with_timestamp(time);


### PR DESCRIPTION
## Motivation

Temporary Hex game chains need a positive balance to pay the fees.

## Proposal

Add a fee budget to `Start`.

Once https://github.com/linera-io/linera-protocol/issues/1795 is implemented, this can be refunded when the temporary chain is closed.

## Test Plan

The parameter is used in the tests. More complete tests including refunds will be added later, when the lobby is implemented.

## Links

- Part of #2326.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
