### PR TITLE
Make cargo test work with and without the unstable-oracles feature.

### DIFF
--- a/examples/meta-counter/src/contract.rs
+++ b/examples/meta-counter/src/contract.rs
@@ -54,6 +54,7 @@ impl Contract for MetaCounterContract {
             recipient_id,
             authenticated,
             is_tracked,
+            query_service,
             fuel_grant,
             message,
         } = operation;
@@ -67,6 +68,13 @@ impl Contract for MetaCounterContract {
         }
         if is_tracked {
             message = message.with_tracking();
+        }
+        if query_service {
+            // Make a service query: The result will be logged in the executed block.
+            let counter_id = self.counter_id();
+            let _ = self
+                .runtime
+                .query_service(counter_id, "query { value }".into());
         }
         message.send_to(recipient_id);
     }
@@ -86,10 +94,6 @@ impl Contract for MetaCounterContract {
             }
             Message::Increment(value) => {
                 let counter_id = self.counter_id();
-                // Make a service query: The result will be logged in the executed block.
-                let _ = self
-                    .runtime
-                    .query_service(counter_id, "query { value }".into());
                 log::trace!("executing {} via {:?}", value, counter_id);
                 self.runtime.call_application(true, counter_id, &value);
             }

--- a/examples/meta-counter/src/lib.rs
+++ b/examples/meta-counter/src/lib.rs
@@ -23,16 +23,18 @@ pub struct Operation {
     pub recipient_id: ChainId,
     pub authenticated: bool,
     pub is_tracked: bool,
+    pub query_service: bool,
     pub fuel_grant: u64,
     pub message: Message,
 }
 
 impl Operation {
-    pub fn increment(recipient_id: ChainId, value: u64) -> Self {
+    pub fn increment(recipient_id: ChainId, value: u64, query_service: bool) -> Self {
         Operation {
             recipient_id,
             authenticated: false,
             is_tracked: false,
+            query_service,
             fuel_grant: 0,
             message: Message::Increment(value),
         }
@@ -43,6 +45,7 @@ impl Operation {
             recipient_id,
             authenticated: false,
             is_tracked: false,
+            query_service: false,
             fuel_grant: 0,
             message: Message::Fail,
         }

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -31,6 +31,7 @@ rocksdb = ["linera-views/rocksdb", "linera-storage/rocksdb"]
 dynamodb = ["linera-views/dynamodb", "linera-storage/dynamodb"]
 scylladb = ["linera-views/scylladb", "linera-storage/scylladb"]
 storage-service = []
+unstable-oracles = []
 metrics = [
     "prometheus",
     "linera-base/metrics",


### PR DESCRIPTION
## Motivation

As of https://github.com/linera-io/linera-protocol/pull/2396, `cargo test` fails because the `query_service` oracle call isn't allowed anymore.

## Proposal

Make the failing test only trigger the oracle call if the `unstable-oracles` feature is enabled.

## Test Plan

`cargo test` passes for me now, both with and without the flag.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
