### PR TITLE
Make the temporary directory of the RocksDb instances part of the store and the configuration.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,7 +4316,6 @@ dependencies = [
  "serde",
  "serde_json",
  "social",
- "tempfile",
  "test-case",
  "test-log",
  "test-strategy",
@@ -4713,7 +4712,6 @@ dependencies = [
  "linera-views",
  "prometheus",
  "serde",
- "tempfile",
  "tokio",
 ]
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3379,7 +3379,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "tempfile",
  "test-log",
  "test-strategy",
  "thiserror",
@@ -3502,7 +3501,6 @@ dependencies = [
  "linera-views",
  "prometheus",
  "serde",
- "tempfile",
  "tokio",
 ]
 

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -18,7 +18,7 @@ use {
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStorage,
-    linera_views::rocks_db::{RocksDbStore, RocksDbStoreConfig},
+    linera_views::rocks_db::{PathDir, RocksDbStore, RocksDbStoreConfig},
     std::path::PathBuf,
 };
 #[cfg(feature = "scylladb")]
@@ -339,8 +339,9 @@ impl StorageConfigNamespace {
             #[cfg(feature = "rocksdb")]
             StorageConfig::RocksDb { path } => {
                 let path_buf = path.to_path_buf();
+                let path_dir = PathDir { path_buf, _dir: None };
                 let config = RocksDbStoreConfig {
-                    path_buf,
+                    path_dir,
                     common_config,
                 };
                 Ok(StoreConfig::RocksDb(config, namespace))

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -18,7 +18,7 @@ use {
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStorage,
-    linera_views::rocks_db::{PathDir, RocksDbStore, RocksDbStoreConfig},
+    linera_views::rocks_db::{PathWithGuard, RocksDbStore, RocksDbStoreConfig},
     std::path::PathBuf,
 };
 #[cfg(feature = "scylladb")]
@@ -339,9 +339,9 @@ impl StorageConfigNamespace {
             #[cfg(feature = "rocksdb")]
             StorageConfig::RocksDb { path } => {
                 let path_buf = path.to_path_buf();
-                let path_dir = PathDir::new(path_buf);
+                let path_with_guard = PathWithGuard::new(path_buf);
                 let config = RocksDbStoreConfig {
-                    path_dir,
+                    path_with_guard,
                     common_config,
                 };
                 Ok(StoreConfig::RocksDb(config, namespace))

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -339,7 +339,7 @@ impl StorageConfigNamespace {
             #[cfg(feature = "rocksdb")]
             StorageConfig::RocksDb { path } => {
                 let path_buf = path.to_path_buf();
-                let path_dir = PathDir { path_buf, _dir: None };
+                let path_dir = PathDir::new(path_buf);
                 let config = RocksDbStoreConfig {
                     path_dir,
                     common_config,

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -22,7 +22,6 @@ test = [
     "linera-storage/test",
     "linera-views/test",
     "proptest",
-    "tempfile",
     "test-log",
     "test-strategy",
     "tokio/parking_lot",
@@ -69,7 +68,6 @@ proptest = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std_rng"] }
 serde.workspace = true
 serde_json.workspace = true
-tempfile = { workspace = true, optional = true }
 test-log = { workspace = true, optional = true }
 test-strategy = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -37,8 +37,8 @@ use {
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStorage,
-    linera_views::rocks_db::{create_rocks_db_test_path, create_rocks_db_common_config},
     linera_views::rocks_db::RocksDbStoreConfig,
+    linera_views::rocks_db::{create_rocks_db_common_config, create_rocks_db_test_path},
     tokio::sync::{Semaphore, SemaphorePermit},
 };
 #[cfg(feature = "scylladb")]

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -973,10 +973,10 @@ impl StorageBuilder for RocksDbStorageBuilder {
     type Storage = RocksDbStorage<TestClock>;
 
     async fn build(&mut self) -> Result<Self::Storage, anyhow::Error> {
-        let path_dir = create_rocks_db_test_path();
+        let path_with_guard = create_rocks_db_test_path();
         let common_config = create_rocks_db_common_config();
         let store_config = RocksDbStoreConfig {
-            path_dir,
+            path_with_guard,
             common_config,
         };
         let namespace = generate_test_namespace();

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -64,7 +64,7 @@ async fn test_memory_handle_certificates_to_create_application(
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> anyhow::Result<()> {
-    let (storage, _dir) = RocksDbStorage::make_test_storage(Some(wasm_runtime)).await;
+    let storage = RocksDbStorage::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
 

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use clap::Parser as _;
 use linera_views::{
     common::{AdminKeyValueStore, CommonStoreConfig},
-    rocks_db::{PathDir, RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{PathWithGuard, RocksDbStore, RocksDbStoreConfig},
 };
 
 use crate::{
@@ -44,9 +44,9 @@ impl RocksDbRunner {
             cache_size: config.client.cache_size,
         };
         let path_buf = config.client.storage.as_path().to_path_buf();
-        let path_dir = PathDir::new(path_buf);
+        let path_with_guard = PathWithGuard::new(path_buf);
         let store_config = RocksDbStoreConfig {
-            path_dir,
+            path_with_guard,
             common_config,
         };
         let namespace = config.client.table.clone();

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -44,7 +44,7 @@ impl RocksDbRunner {
             cache_size: config.client.cache_size,
         };
         let path_buf = config.client.storage.as_path().to_path_buf();
-        let path_dir = PathDir { path_buf, _dir: None };
+        let path_dir = PathDir::new(path_buf);
         let store_config = RocksDbStoreConfig {
             path_dir,
             common_config,

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use clap::Parser as _;
 use linera_views::{
     common::{AdminKeyValueStore, CommonStoreConfig},
-    rocks_db::{RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{PathDir, RocksDbStore, RocksDbStoreConfig},
 };
 
 use crate::{
@@ -43,8 +43,10 @@ impl RocksDbRunner {
             max_stream_queries: config.client.max_stream_queries,
             cache_size: config.client.cache_size,
         };
+        let path_buf = config.client.storage.as_path().to_path_buf();
+        let path_dir = PathDir { path_buf, _dir: None };
         let store_config = RocksDbStoreConfig {
-            path_buf: config.client.storage.as_path().to_path_buf(),
+            path_dir,
             common_config,
         };
         let namespace = config.client.table.clone();

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -32,7 +32,7 @@ use tonic_health::pb::{
 };
 use tracing::{info, warn};
 #[cfg(all(feature = "rocksdb", with_testing))]
-use {linera_views::rocks_db::create_rocks_db_test_path, std::ops::Deref};
+use {linera_views::rocks_db::{PathDir, create_rocks_db_test_path}, std::ops::Deref};
 
 use crate::{
     cli_wrappers::{ClientWrapper, LineraNet, LineraNetConfig, Network},
@@ -55,8 +55,7 @@ trait LocalServerInternal: Sized {
 
 #[cfg(all(feature = "rocksdb", with_testing))]
 struct LocalServerRocksDbInternal {
-    rocks_db_path: PathBuf,
-    _temp_dir: Option<TempDir>,
+    rocks_db_path_dir: PathDir,
 }
 
 #[cfg(all(feature = "rocksdb", with_testing))]
@@ -64,16 +63,12 @@ impl LocalServerInternal for LocalServerRocksDbInternal {
     type Config = PathBuf;
 
     async fn new_test() -> Result<Self> {
-        let (rocks_db_path, temp_dir) = create_rocks_db_test_path();
-        let _temp_dir = Some(temp_dir);
-        Ok(Self {
-            rocks_db_path,
-            _temp_dir,
-        })
+        let rocks_db_path_dir = create_rocks_db_test_path();
+        Ok(Self { rocks_db_path_dir })
     }
 
     fn get_config(&self) -> Self::Config {
-        self.rocks_db_path.clone()
+        self.rocks_db_path_dir.path_buf.clone()
     }
 }
 

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -32,7 +32,10 @@ use tonic_health::pb::{
 };
 use tracing::{info, warn};
 #[cfg(all(feature = "rocksdb", with_testing))]
-use {linera_views::rocks_db::{PathDir, create_rocks_db_test_path}, std::ops::Deref};
+use {
+    linera_views::rocks_db::{create_rocks_db_test_path, PathDir},
+    std::ops::Deref,
+};
 
 use crate::{
     cli_wrappers::{ClientWrapper, LineraNet, LineraNetConfig, Network},

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -33,7 +33,7 @@ use tonic_health::pb::{
 use tracing::{info, warn};
 #[cfg(all(feature = "rocksdb", with_testing))]
 use {
-    linera_views::rocks_db::{create_rocks_db_test_path, PathDir},
+    linera_views::rocks_db::{create_rocks_db_test_path, PathWithGuard},
     std::ops::Deref,
 };
 
@@ -58,7 +58,7 @@ trait LocalServerInternal: Sized {
 
 #[cfg(all(feature = "rocksdb", with_testing))]
 struct LocalServerRocksDbInternal {
-    rocks_db_path_dir: PathDir,
+    rocks_db_path: PathWithGuard,
 }
 
 #[cfg(all(feature = "rocksdb", with_testing))]
@@ -66,12 +66,12 @@ impl LocalServerInternal for LocalServerRocksDbInternal {
     type Config = PathBuf;
 
     async fn new_test() -> Result<Self> {
-        let rocks_db_path_dir = create_rocks_db_test_path();
-        Ok(Self { rocks_db_path_dir })
+        let rocks_db_path = create_rocks_db_test_path();
+        Ok(Self { rocks_db_path })
     }
 
     fn get_config(&self) -> Self::Config {
-        self.rocks_db_path_dir.path_buf.clone()
+        self.rocks_db_path.path_buf.clone()
     }
 }
 

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -15,7 +15,7 @@ use linera_views::{
 #[cfg(feature = "rocksdb")]
 use linera_views::{
     common::AdminKeyValueStore,
-    rocks_db::{PathDir, RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{PathWithGuard, RocksDbStore, RocksDbStoreConfig},
 };
 use serde::Serialize;
 use tonic::{transport::Server, Request, Response, Status};
@@ -584,9 +584,9 @@ async fn main() {
         #[cfg(feature = "rocksdb")]
         ServiceStoreServerOptions::RocksDb { path, endpoint } => {
             let path_buf = path.into();
-            let path_dir = PathDir::new(path_buf);
+            let path_with_guard = PathWithGuard::new(path_buf);
             let config = RocksDbStoreConfig {
-                path_dir,
+                path_with_guard,
                 common_config,
             };
             let store = RocksDbStore::maybe_create_and_connect(&config, namespace, root_key)

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -15,7 +15,7 @@ use linera_views::{
 #[cfg(feature = "rocksdb")]
 use linera_views::{
     common::AdminKeyValueStore,
-    rocks_db::{RocksDbStore, RocksDbStoreConfig},
+    rocks_db::{PathDir, RocksDbStore, RocksDbStoreConfig},
 };
 use serde::Serialize;
 use tonic::{transport::Server, Request, Response, Status};
@@ -584,8 +584,9 @@ async fn main() {
         #[cfg(feature = "rocksdb")]
         ServiceStoreServerOptions::RocksDb { path, endpoint } => {
             let path_buf = path.into();
+            let path_dir = PathDir::new(path_buf);
             let config = RocksDbStoreConfig {
-                path_buf,
+                path_dir,
                 common_config,
             };
             let store = RocksDbStore::maybe_create_and_connect(&config, namespace, root_key)

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -48,7 +48,6 @@ linera-execution.workspace = true
 linera-views.workspace = true
 prometheus.workspace = true
 serde.workspace = true
-tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -8,7 +8,6 @@ use {
     linera_execution::WasmRuntime,
     linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStoreConfig, RocksDbStoreError},
     linera_views::test_utils::generate_test_namespace,
-    tempfile::TempDir,
 };
 
 use crate::db_storage::DbStorage;
@@ -17,11 +16,11 @@ pub type RocksDbStorage<C> = DbStorage<RocksDbStore, C>;
 
 #[cfg(with_testing)]
 impl RocksDbStorage<TestClock> {
-    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> (Self, TempDir) {
-        let (store_config, dir) = create_rocks_db_test_config().await;
+    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
+        let store_config = create_rocks_db_test_config().await;
         let namespace = generate_test_namespace();
         let root_key = &[];
-        let storage = RocksDbStorage::new_for_testing(
+        RocksDbStorage::new_for_testing(
             store_config,
             &namespace,
             root_key,
@@ -29,8 +28,7 @@ impl RocksDbStorage<TestClock> {
             TestClock::new(),
         )
         .await
-        .expect("storage");
-        (storage, dir)
+        .expect("storage")
     }
 
     pub async fn new_for_testing(

--- a/linera-views/benches/stores.rs
+++ b/linera-views/benches/stores.rs
@@ -91,7 +91,7 @@ fn bench_contains_key(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let (store, _dir) = create_rocks_db_test_store().await;
+                let store = create_rocks_db_test_store().await;
                 performance_contains_key(store, iterations).await
             })
     });
@@ -162,7 +162,7 @@ fn bench_contains_keys(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let (store, _dir) = create_rocks_db_test_store().await;
+                let store = create_rocks_db_test_store().await;
                 performance_contains_keys(store, iterations).await
             })
     });
@@ -232,7 +232,7 @@ fn bench_find_keys_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let (store, _dir) = create_rocks_db_test_store().await;
+                let store = create_rocks_db_test_store().await;
                 performance_find_keys_by_prefix(store, iterations).await
             })
     });
@@ -307,7 +307,7 @@ fn bench_find_key_values_by_prefix(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let (store, _dir) = create_rocks_db_test_store().await;
+                let store = create_rocks_db_test_store().await;
                 performance_find_key_values_by_prefix(store, iterations).await
             })
     });
@@ -379,7 +379,7 @@ fn bench_read_value_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let (store, _dir) = create_rocks_db_test_store().await;
+                let store = create_rocks_db_test_store().await;
                 performance_read_value_bytes(store, iterations).await
             })
     });
@@ -453,7 +453,7 @@ fn bench_read_multi_values_bytes(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let (store, _dir) = create_rocks_db_test_store().await;
+                let store = create_rocks_db_test_store().await;
                 performance_read_multi_values_bytes(store, iterations).await
             })
     });
@@ -519,7 +519,7 @@ fn bench_write_batch(criterion: &mut Criterion) {
         bencher
             .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
             .iter_custom(|iterations| async move {
-                let (store, _dir) = create_rocks_db_test_store().await;
+                let store = create_rocks_db_test_store().await;
                 performance_write_batch(store, iterations).await
             })
     });

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -460,7 +460,14 @@ pub struct PathDir {
     /// The path to the data
     pub path_buf: PathBuf,
     /// The guard for the directory if one is needed
-    pub _dir: Option<Arc<TempDir>>,
+    _dir: Option<Arc<TempDir>>,
+}
+
+impl PathDir {
+    /// Create a PathDir from an existing path.
+    pub fn new(path_buf: PathBuf) -> Self {
+        Self { path_buf, _dir: None }
+    }
 }
 
 /// Returns the test path for RocksDB without common config.

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -350,8 +350,9 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
     ) -> Result<Self, RocksDbStoreError> {
         Self::check_namespace(namespace)?;
         let mut path_buf = config.path_dir.path_buf.clone();
-        let path_dir = config.path_dir.clone();
+        let mut path_dir = config.path_dir.clone();
         path_buf.push(namespace);
+        path_dir.path_buf = path_buf;
         let max_stream_queries = config.common_config.max_stream_queries;
         let cache_size = config.common_config.cache_size;
         RocksDbStoreInternal::connect_from_path(

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -11,12 +11,8 @@ use std::{
 
 use futures::future::join_all;
 use linera_base::{ensure, hex};
-use thiserror::Error;
 use tempfile::TempDir;
-#[cfg(with_testing)]
-use {
-    crate::{lru_caching::TEST_CACHE_SIZE, test_utils::generate_test_namespace},
-};
+use thiserror::Error;
 
 #[cfg(with_metrics)]
 use crate::metering::{
@@ -31,6 +27,8 @@ use crate::{
     lru_caching::LruCachingStore,
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
 };
+#[cfg(with_testing)]
+use crate::{lru_caching::TEST_CACHE_SIZE, test_utils::generate_test_namespace};
 
 /// The number of streams for the test
 #[cfg(with_testing)]
@@ -455,7 +453,7 @@ pub fn create_rocks_db_common_config() -> CommonStoreConfig {
 }
 
 /// A path and the guard for the temporary directory if needed
-#[derive(Clone,Debug)]
+#[derive(Clone, Debug)]
 pub struct PathDir {
     /// The path to the data
     pub path_buf: PathBuf,
@@ -466,7 +464,10 @@ pub struct PathDir {
 impl PathDir {
     /// Create a PathDir from an existing path.
     pub fn new(path_buf: PathBuf) -> Self {
-        Self { path_buf, _dir: None }
+        Self {
+            path_buf,
+            _dir: None,
+        }
     }
 }
 

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -12,10 +12,10 @@ use std::{
 use futures::future::join_all;
 use linera_base::{ensure, hex};
 use thiserror::Error;
+use tempfile::TempDir;
 #[cfg(with_testing)]
 use {
     crate::{lru_caching::TEST_CACHE_SIZE, test_utils::generate_test_namespace},
-    tempfile::TempDir,
 };
 
 #[cfg(with_metrics)]
@@ -51,7 +51,7 @@ pub type DB = rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>;
 #[derive(Clone)]
 struct RocksDbStoreInternal {
     db: Arc<DB>,
-    path_buf: PathBuf,
+    path_dir: PathDir,
     namespace: String,
     max_stream_queries: usize,
     cache_size: usize,
@@ -60,8 +60,8 @@ struct RocksDbStoreInternal {
 /// The initial configuration of the system
 #[derive(Clone, Debug)]
 pub struct RocksDbStoreConfig {
-    /// The path to the storage containing the namespaces.
-    pub path_buf: PathBuf,
+    /// The path to the storage containing the namespaces..
+    pub path_dir: PathDir,
     /// The common configuration of the key value store
     pub common_config: CommonStoreConfig,
 }
@@ -87,13 +87,13 @@ impl RocksDbStoreInternal {
     }
 
     fn build(
-        path_buf: PathBuf,
+        path_dir: PathDir,
         namespace: &str,
         max_stream_queries: usize,
         cache_size: usize,
         root_key: &[u8],
     ) -> Result<RocksDbStoreInternal, RocksDbStoreError> {
-        let mut full_path_buf = path_buf.clone();
+        let mut full_path_buf = path_dir.path_buf.clone();
         full_path_buf.push(root_key_as_string(root_key));
         if !std::path::Path::exists(&full_path_buf) {
             std::fs::create_dir(full_path_buf.clone())?;
@@ -104,7 +104,7 @@ impl RocksDbStoreInternal {
         let namespace = namespace.to_string();
         Ok(RocksDbStoreInternal {
             db: Arc::new(db),
-            path_buf,
+            path_dir,
             namespace,
             max_stream_queries,
             cache_size,
@@ -112,7 +112,7 @@ impl RocksDbStoreInternal {
     }
 
     fn connect_from_path(
-        path_buf: PathBuf,
+        path_dir: PathDir,
         namespace: &str,
         max_stream_queries: usize,
         cache_size: usize,
@@ -127,7 +127,7 @@ impl RocksDbStoreInternal {
             }
             Entry::Vacant(entry) => {
                 let store = Self::build(
-                    path_buf,
+                    path_dir,
                     namespace,
                     max_stream_queries,
                     cache_size,
@@ -351,12 +351,13 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
         root_key: &[u8],
     ) -> Result<Self, RocksDbStoreError> {
         Self::check_namespace(namespace)?;
-        let mut path_buf = config.path_buf.clone();
+        let mut path_buf = config.path_dir.path_buf.clone();
+        let path_dir = config.path_dir.clone();
         path_buf.push(namespace);
         let max_stream_queries = config.common_config.max_stream_queries;
         let cache_size = config.common_config.cache_size;
         RocksDbStoreInternal::connect_from_path(
-            path_buf,
+            path_dir,
             namespace,
             max_stream_queries,
             cache_size,
@@ -365,11 +366,11 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
     }
 
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, RocksDbStoreError> {
-        let path_buf = self.path_buf.clone();
+        let path_dir = self.path_dir.clone();
         let max_stream_queries = self.max_stream_queries;
         let cache_size = self.cache_size;
         RocksDbStoreInternal::connect_from_path(
-            path_buf,
+            path_dir,
             &self.namespace,
             max_stream_queries,
             cache_size,
@@ -378,7 +379,7 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
     }
 
     async fn list_all(config: &Self::Config) -> Result<Vec<String>, RocksDbStoreError> {
-        let entries = std::fs::read_dir(config.path_buf.clone())?;
+        let entries = std::fs::read_dir(config.path_dir.path_buf.clone())?;
         let mut namespaces = Vec::new();
         for entry in entries {
             let entry = entry?;
@@ -399,7 +400,7 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
     async fn delete_all(config: &Self::Config) -> Result<(), RocksDbStoreError> {
         let namespaces = RocksDbStoreInternal::list_all(config).await?;
         for namespace in namespaces {
-            let mut path_buf = config.path_buf.clone();
+            let mut path_buf = config.path_dir.path_buf.clone();
             path_buf.push(&namespace);
             std::fs::remove_dir_all(path_buf.as_path())?;
         }
@@ -408,7 +409,7 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
 
     async fn exists(config: &Self::Config, namespace: &str) -> Result<bool, RocksDbStoreError> {
         Self::check_namespace(namespace)?;
-        let mut path_buf = config.path_buf.clone();
+        let mut path_buf = config.path_dir.path_buf.clone();
         path_buf.push(namespace);
         let test = std::path::Path::exists(&path_buf);
         Ok(test)
@@ -416,7 +417,7 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
 
     async fn create(config: &Self::Config, namespace: &str) -> Result<(), RocksDbStoreError> {
         Self::check_namespace(namespace)?;
-        let mut path_buf = config.path_buf.clone();
+        let mut path_buf = config.path_dir.path_buf.clone();
         path_buf.push(namespace);
         std::fs::create_dir_all(path_buf)?;
         Ok(())
@@ -424,7 +425,7 @@ impl AdminKeyValueStore for RocksDbStoreInternal {
 
     async fn delete(config: &Self::Config, namespace: &str) -> Result<(), RocksDbStoreError> {
         Self::check_namespace(namespace)?;
-        let mut path_buf = config.path_buf.clone();
+        let mut path_buf = config.path_dir.path_buf.clone();
         path_buf.push(namespace);
         let path = path_buf.as_path();
         std::fs::remove_dir_all(path)?;
@@ -453,38 +454,46 @@ pub fn create_rocks_db_common_config() -> CommonStoreConfig {
     }
 }
 
+/// A path and the guard for the temporary directory if needed
+#[derive(Clone,Debug)]
+pub struct PathDir {
+    /// The path to the data
+    pub path_buf: PathBuf,
+    /// The guard for the directory if one is needed
+    pub _dir: Option<Arc<TempDir>>,
+}
+
 /// Returns the test path for RocksDB without common config.
 #[cfg(with_testing)]
-pub fn create_rocks_db_test_path() -> (PathBuf, TempDir) {
+pub fn create_rocks_db_test_path() -> PathDir {
     let dir = TempDir::new().unwrap();
     let path_buf = dir.path().to_path_buf();
-    (path_buf, dir)
+    let _dir = Some(Arc::new(dir));
+    PathDir { path_buf, _dir }
 }
 
 /// Returns the test config and a guard for the temporary directory
 #[cfg(with_testing)]
-pub async fn create_rocks_db_test_config() -> (RocksDbStoreConfig, TempDir) {
-    let (path_buf, tmp_dir) = create_rocks_db_test_path();
+pub async fn create_rocks_db_test_config() -> RocksDbStoreConfig {
+    let path_dir = create_rocks_db_test_path();
     let common_config = create_rocks_db_common_config();
-    let store_config = RocksDbStoreConfig {
-        path_buf,
+    RocksDbStoreConfig {
+        path_dir,
         common_config,
-    };
-    (store_config, tmp_dir)
+    }
 }
 
 /// Creates a RocksDB database client to be used for tests.
 /// The temporary directory has to be carried because if it goes
 /// out of scope then the RocksDB client can become unstable.
 #[cfg(with_testing)]
-pub async fn create_rocks_db_test_store() -> (RocksDbStore, TempDir) {
-    let (store_config, dir) = create_rocks_db_test_config().await;
+pub async fn create_rocks_db_test_store() -> RocksDbStore {
+    let store_config = create_rocks_db_test_config().await;
     let namespace = generate_test_namespace();
     let root_key = &[];
-    let store = RocksDbStore::recreate_and_connect(&store_config, &namespace, root_key)
+    RocksDbStore::recreate_and_connect(&store_config, &namespace, root_key)
         .await
-        .expect("client");
-    (store, dir)
+        .expect("store")
 }
 
 /// An implementation of [`crate::common::Context`] based on RocksDB

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -6,16 +6,14 @@ use std::{collections::VecDeque, fmt::Debug, marker::PhantomData};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use test_case::test_case;
-#[cfg(with_rocksdb)]
-use {
-    crate::rocks_db::{create_rocks_db_test_config, RocksDbContext, RocksDbStore},
-};
 
 #[cfg(with_dynamodb)]
 use crate::dynamo_db::{
     create_dynamo_db_common_config, DynamoDbContext, DynamoDbStore, DynamoDbStoreConfig,
     LocalStackTestContext,
 };
+#[cfg(with_rocksdb)]
+use crate::rocks_db::{create_rocks_db_test_config, RocksDbContext, RocksDbStore};
 #[cfg(with_scylladb)]
 use crate::scylla_db::{create_scylla_db_test_config, ScyllaDbContext, ScyllaDbStore};
 use crate::{
@@ -210,8 +208,7 @@ impl TestContextFactory for MemoryContextFactory {
 
 #[cfg(with_rocksdb)]
 #[derive(Default)]
-struct RocksDbContextFactory {
-}
+struct RocksDbContextFactory {}
 
 #[cfg(with_rocksdb)]
 #[async_trait]

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -9,7 +9,6 @@ use test_case::test_case;
 #[cfg(with_rocksdb)]
 use {
     crate::rocks_db::{create_rocks_db_test_config, RocksDbContext, RocksDbStore},
-    tempfile::TempDir,
 };
 
 #[cfg(with_dynamodb)]
@@ -212,7 +211,6 @@ impl TestContextFactory for MemoryContextFactory {
 #[cfg(with_rocksdb)]
 #[derive(Default)]
 struct RocksDbContextFactory {
-    temporary_directories: Vec<TempDir>,
 }
 
 #[cfg(with_rocksdb)]
@@ -221,15 +219,13 @@ impl TestContextFactory for RocksDbContextFactory {
     type Context = RocksDbContext<()>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        let (store_config, directory) = create_rocks_db_test_config().await;
+        let store_config = create_rocks_db_test_config().await;
         let namespace = generate_test_namespace();
         let root_key = &[];
         let store = RocksDbStore::recreate_and_connect(&store_config, &namespace, root_key)
             .await
             .expect("store");
         let context = RocksDbContext::new(store, ());
-
-        self.temporary_directories.push(directory);
 
         Ok(context)
     }

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -21,7 +21,7 @@ async fn admin_test_memory() {
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn admin_test_rocks_db() {
-    let (config, _dir) = create_rocks_db_test_config().await;
+    let config = create_rocks_db_test_config().await;
     admin_test::<RocksDbStore>(&config).await;
 }
 

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -38,7 +38,7 @@ async fn test_reads_memory() {
 #[tokio::test]
 async fn test_reads_rocks_db() {
     for scenario in get_random_test_scenarios() {
-        let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+        let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
         run_reads(key_value_store, scenario).await;
     }
 }
@@ -113,7 +113,7 @@ async fn test_key_value_store_view_memory_writes_from_blank() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_blank() {
-    let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+    let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
     run_writes_from_blank(&key_value_store).await;
 }
 
@@ -190,7 +190,7 @@ async fn test_memory_big_write_read() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_big_write_read() {
-    let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+    let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
     let value_sizes = vec![100, 1000, 200000, 5000000];
     let target_size = 20000000;
     run_big_write_read(key_value_store, target_size, value_sizes).await;
@@ -223,7 +223,7 @@ async fn test_memory_writes_from_state() {
 #[cfg(with_rocksdb)]
 #[tokio::test]
 async fn test_rocks_db_writes_from_state() {
-    let (key_value_store, _dir) = linera_views::rocks_db::create_rocks_db_test_store().await;
+    let key_value_store = linera_views::rocks_db::create_rocks_db_test_store().await;
     run_writes_from_state(&key_value_store).await;
 }
 

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -43,7 +43,6 @@ use rand::{Rng, RngCore};
 #[cfg(with_rocksdb)]
 use {
     linera_views::rocks_db::{create_rocks_db_test_store, RocksDbContext, RocksDbStore},
-    tempfile::TempDir,
 };
 
 #[allow(clippy::type_complexity)]
@@ -183,7 +182,6 @@ impl StateStore for LruMemoryStore {
 pub struct RocksDbTestStore {
     store: RocksDbStore,
     accessed_chains: BTreeSet<usize>,
-    _dir: TempDir,
 }
 
 #[cfg(with_rocksdb)]
@@ -192,12 +190,11 @@ impl StateStore for RocksDbTestStore {
     type Context = RocksDbContext<usize>;
 
     async fn new() -> Self {
-        let (store, dir) = create_rocks_db_test_store().await;
+        let store = create_rocks_db_test_store().await;
         let accessed_chains = BTreeSet::new();
         RocksDbTestStore {
             store,
             accessed_chains,
-            _dir: dir,
         }
     }
 

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -7,6 +7,8 @@ use anyhow::Result;
 use async_trait::async_trait;
 #[cfg(any(with_dynamodb, with_rocksdb, with_scylladb))]
 use linera_views::common::AdminKeyValueStore as _;
+#[cfg(with_rocksdb)]
+use linera_views::rocks_db::{create_rocks_db_test_store, RocksDbContext, RocksDbStore};
 #[cfg(with_scylladb)]
 use linera_views::scylla_db::{create_scylla_db_test_store, ScyllaDbContext, ScyllaDbStore};
 use linera_views::{
@@ -40,10 +42,6 @@ use linera_views::{
     test_utils::generate_test_namespace,
 };
 use rand::{Rng, RngCore};
-#[cfg(with_rocksdb)]
-use {
-    linera_views::rocks_db::{create_rocks_db_test_store, RocksDbContext, RocksDbStore},
-};
 
 #[allow(clippy::type_complexity)]
 #[derive(CryptoHashRootView)]


### PR DESCRIPTION
## Motivation

The RocksDb test stores require tracking of the temporary directory. This complicates working with that store and prevents further unification with other stores that do not require them.

## Proposal

The following is done:
* The `PathWithGuard`type is introduced for the RocksDb.
* This allows the removal of `_dir` entries all around.

The next step is to introduce the creation of a default test config in `AdminKeyValueStore`. But since that work is fairly independent from this one, this is for another PR.

## Test Plan

The CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
