### PR TITLE
Handle Subscribe and Unsubscribe offchain.

### DIFF
--- a/examples/social/src/lib.rs
+++ b/examples/social/src/lib.rs
@@ -245,9 +245,7 @@ pub enum Message {
     /// The origin chain wants to unsubscribe from the target chain.
     Unsubscribe,
     /// The origin chain made a post, and the target chain is subscribed.
-    /// This includes the most recent posts in reverse order, and the total count of posts by the
-    /// sender. I.e. the indices of the posts in the `Vec` are `count - 1, count - 2, ...`.
-    Posts { count: u64, posts: Vec<OwnPost> },
+    Post { index: u64, post: OwnPost },
     /// A Chain liked a post
     Like { key: Key },
     /// A Chain commented on a post

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -533,6 +533,7 @@ where
         origin: &Origin,
         bundle: MessageBundle,
         local_time: Timestamp,
+        add_to_received_log: bool,
     ) -> Result<(), ChainError> {
         assert!(!bundle.messages.is_empty());
         let chain_id = self.chain_id();
@@ -601,10 +602,7 @@ where
             }
         }
         // Remember the certificate for future validator/client synchronizations.
-        let log_count = self.received_log.count();
-        if log_count == 0
-            || self.received_log.get(log_count - 1).await?.as_ref() != Some(&chain_and_height)
-        {
+        if add_to_received_log {
             self.received_log.push(chain_and_height);
         }
         Ok(())

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -601,7 +601,12 @@ where
             }
         }
         // Remember the certificate for future validator/client synchronizations.
-        self.received_log.push(chain_and_height);
+        let log_count = self.received_log.count();
+        if log_count == 0
+            || self.received_log.get(log_count - 1).await?.as_ref() != Some(&chain_and_height)
+        {
+            self.received_log.push(chain_and_height);
+        }
         Ok(())
     }
 

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -1193,7 +1193,7 @@ where
                     return Ok(None); // No messages on this channel yet.
                 }
                 let full_name = ChannelFullName {
-                    application_id: GenericApplicationId::System,
+                    application_id,
                     name,
                 };
                 let target = Target::channel(id, full_name.clone());

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -114,7 +114,9 @@ impl Block {
         (0u32..).zip(bundles.chain(operations))
     }
 
-    pub fn open_chain_message(
+    /// If the block's first message is `OpenChain`, returns the bundle, the message and
+    /// the configuration for the new chain.
+    pub fn starts_with_open_chain_message(
         &self,
     ) -> Option<(&IncomingBundle, &PostedMessage, &OpenChainConfig)> {
         let in_bundle = self.incoming_bundles.first()?;

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -16,8 +16,8 @@ use linera_execution::{
     committee::{Committee, Epoch},
     system::OpenChainConfig,
     test_utils::{ExpectedCall, MockApplication},
-    ExecutionRuntimeConfig, ExecutionRuntimeContext, MessageKind, Operation, SystemMessage,
-    TestExecutionRuntimeContext, UserApplicationDescription,
+    ExecutionRuntimeConfig, ExecutionRuntimeContext, Message, MessageKind, Operation,
+    SystemMessage, TestExecutionRuntimeContext, UserApplicationDescription,
 };
 use linera_views::{
     memory::{MemoryContext, TEST_MEMORY_MAX_STREAM_QUERIES},
@@ -112,11 +112,11 @@ async fn test_application_permissions() {
         application_permissions: ApplicationPermissions::new_single(application_id),
         ..make_open_chain_config()
     };
-    let open_chain_message = SystemMessage::OpenChain(config).into();
     chain
-        .execute_init_message(message_id, &open_chain_message, time, time)
+        .execute_init_message(message_id, &config, time, time)
         .await
         .unwrap();
+    let open_chain_message = Message::System(SystemMessage::OpenChain(config));
 
     let register_app_message = SystemMessage::RegisterApplications {
         applications: vec![app_description],

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -464,7 +464,7 @@ where
         let chain = &mut self.state.chain;
         if let (Some(epoch), Some(entry)) = (
             chain.execution_state.system.epoch.get(),
-            chain.unskippable.front().await?,
+            chain.unskippable_entries.front().await?,
         ) {
             let ownership = chain.execution_state.system.ownership.get();
             let elapsed = self

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -253,7 +253,9 @@ where
         }
         // TODO(#2351): This sets the committee and then checks that committee's signatures.
         if tip.is_first_block() && !self.state.chain.is_active() {
-            if let Some((incoming_bundle, posted_message, config)) = block.open_chain_message() {
+            if let Some((incoming_bundle, posted_message, config)) =
+                block.starts_with_open_chain_message()
+            {
                 let message_id = MessageId {
                     chain_id: incoming_bundle.origin.sender,
                     height: incoming_bundle.bundle.height,
@@ -465,7 +467,7 @@ where
         let chain = &mut self.state.chain;
         if let (Some(epoch), Some(entry)) = (
             chain.execution_state.system.epoch.get(),
-            chain.unskippable_entries.front().await?,
+            chain.unskippable_bundles.front().await?,
         ) {
             let ownership = chain.execution_state.system.ownership.get();
             let elapsed = self

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -395,12 +395,15 @@ where
         };
         // Process the received messages in certificates.
         let local_time = self.state.storage.clock().current_time();
+        let mut previous_height = None;
         for bundle in bundles {
+            let add_to_received_log = previous_height != Some(bundle.height);
+            previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
             self.state
                 .chain
-                .receive_message_bundle(&origin, bundle, local_time)
-                .await?
+                .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
+                .await?;
         }
         if !self.state.config.allow_inactive_chains && !self.state.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -253,24 +253,22 @@ where
         }
         // TODO(#2351): This sets the committee and then checks that committee's signatures.
         if tip.is_first_block() && !self.state.chain.is_active() {
-            if let Some(incoming_bundle) = block.incoming_bundles.first() {
-                if let Some(posted_message) = incoming_bundle.bundle.messages.first() {
-                    let message_id = MessageId {
-                        chain_id: incoming_bundle.origin.sender,
-                        height: incoming_bundle.bundle.height,
-                        index: posted_message.index,
-                    };
-                    let local_time = self.state.storage.clock().current_time();
-                    self.state
-                        .chain
-                        .execute_init_message(
-                            message_id,
-                            &posted_message.message,
-                            incoming_bundle.bundle.timestamp,
-                            local_time,
-                        )
-                        .await?;
-                }
+            if let Some((incoming_bundle, posted_message, config)) = block.open_chain_message() {
+                let message_id = MessageId {
+                    chain_id: incoming_bundle.origin.sender,
+                    height: incoming_bundle.bundle.height,
+                    index: posted_message.index,
+                };
+                let local_time = self.state.storage.clock().current_time();
+                self.state
+                    .chain
+                    .execute_init_message(
+                        message_id,
+                        config,
+                        incoming_bundle.bundle.timestamp,
+                        local_time,
+                    )
+                    .await?;
             }
         }
         self.state.ensure_is_active()?;

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1297,7 +1297,7 @@ where
     // Create a new committee.
     let committee = Committee::new(validators, ResourceControlPolicy::only_fuel());
     admin.stage_new_committee(committee).await.unwrap();
-    assert_eq!(admin.next_block_height(), BlockHeight::from(4));
+    assert_eq!(admin.next_block_height(), BlockHeight::from(3));
     assert!(admin.pending_block().is_none());
     assert!(admin.key_pair().await.is_ok());
     assert_eq!(admin.epoch().await.unwrap(), Epoch::from(2));
@@ -1333,7 +1333,7 @@ where
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(1));
     user.synchronize_from_validators().await.unwrap();
 
-    // User is a unsubscribed, so the migration message is not even in the inbox yet.
+    // User is unsubscribed, so the migration message is not even in the inbox yet.
     user.process_inbox().await.unwrap();
     assert_eq!(user.epoch().await.unwrap(), Epoch::from(1));
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2337,6 +2337,12 @@ where
             *admin_chain.execution_state.system.admin_id.get(),
             Some(admin_id)
         );
+        // The new chain is subscribed to the admin chain.
+        assert!(admin_chain
+            .channels
+            .indices()
+            .await?
+            .contains(&admin_channel_full_name));
     }
 
     // Create a new committee and transfer money before accepting the subscription.

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2350,9 +2350,9 @@ where
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
                 messages: vec![
-                    vec![channel_admin_message(SystemMessage::SetCommittees {
+                    vec![channel_admin_message(SystemMessage::CreateCommittee {
                         epoch: Epoch::from(1),
-                        committees: committees2.clone(),
+                        committee: committee.clone(),
                     })],
                     vec![direct_credit_message(user_id, Amount::from_tokens(2))],
                 ],
@@ -2445,7 +2445,7 @@ where
             .expect("Missing inbox for admin channel in user chain");
         matches!(&channel_inbox.added_bundles.read_front(10).await?[..], [bundle]
             if matches!(bundle.messages[..], [PostedMessage {
-                message: Message::System(SystemMessage::SetCommittees { .. }), ..
+                message: Message::System(SystemMessage::CreateCommittee { .. }), ..
             }])
         );
         assert_eq!(channel_inbox.removed_bundles.count(), 0);
@@ -2506,9 +2506,9 @@ where
                             height: BlockHeight::from(1),
                             timestamp: Timestamp::from(0),
                             transaction_index: 0,
-                            messages: vec![Message::System(SystemMessage::SetCommittees {
+                            messages: vec![Message::System(SystemMessage::CreateCommittee {
                                 epoch: Epoch::from(1),
-                                committees: committees2.clone(),
+                                committee: committee.clone(),
                             })
                             .to_posted(0, MessageKind::Protected)],
                         },
@@ -2639,10 +2639,12 @@ where
         &worker,
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
-                messages: vec![vec![channel_admin_message(SystemMessage::SetCommittees {
-                    epoch: Epoch::from(1),
-                    committees: committees2.clone(),
-                })]],
+                messages: vec![vec![channel_admin_message(
+                    SystemMessage::CreateCommittee {
+                        epoch: Epoch::from(1),
+                        committee: committee.clone(),
+                    },
+                )]],
                 events: vec![Vec::new()],
                 state_hash: SystemExecutionState {
                     committees: committees2.clone(),
@@ -2760,10 +2762,6 @@ where
         ),
     );
     // Have the admin chain create a new epoch and retire the old one immediately.
-    let committees2 = BTreeMap::from_iter([
-        (Epoch::ZERO, committee.clone()),
-        (Epoch::from(1), committee.clone()),
-    ]);
     let committees3 = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
     let certificate1 = make_certificate(
         &committee,
@@ -2771,13 +2769,12 @@ where
         HashedCertificateValue::new_confirmed(
             BlockExecutionOutcome {
                 messages: vec![
-                    vec![channel_admin_message(SystemMessage::SetCommittees {
+                    vec![channel_admin_message(SystemMessage::CreateCommittee {
                         epoch: Epoch::from(1),
-                        committees: committees2.clone(),
+                        committee: committee.clone(),
                     })],
-                    vec![channel_admin_message(SystemMessage::SetCommittees {
-                        epoch: Epoch::from(1),
-                        committees: committees3.clone(),
+                    vec![channel_admin_message(SystemMessage::RemoveCommittee {
+                        epoch: Epoch::from(0),
                     })],
                 ],
                 events: vec![Vec::new(); 2],

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -45,6 +45,7 @@ use linera_base::{
 };
 use linera_views::{batch::Batch, views::ViewError};
 use serde::{Deserialize, Serialize};
+use system::OpenChainConfig;
 use thiserror::Error;
 
 #[cfg(with_testing)]
@@ -1000,6 +1001,14 @@ impl Message {
         }
     }
 
+    /// Returns whether this message must be added to the inbox.
+    pub fn goes_to_inbox(&self) -> bool {
+        !matches!(
+            self,
+            Message::System(SystemMessage::Subscribe { .. } | SystemMessage::Unsubscribe { .. })
+        )
+    }
+
     pub fn matches_subscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
         match self {
             Message::System(SystemMessage::Subscribe { id, subscription }) => {
@@ -1009,11 +1018,18 @@ impl Message {
         }
     }
 
-    pub fn unsubscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
+    pub fn matches_unsubscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
         match self {
             Message::System(SystemMessage::Unsubscribe { id, subscription }) => {
                 Some((id, subscription))
             }
+            _ => None,
+        }
+    }
+
+    pub fn matches_open_chain(&self) -> Option<&OpenChainConfig> {
+        match self {
+            Message::System(SystemMessage::OpenChain(config)) => Some(config),
             _ => None,
         }
     }

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -999,6 +999,24 @@ impl Message {
             Self::User { application_id, .. } => GenericApplicationId::User(*application_id),
         }
     }
+
+    pub fn subscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
+        match self {
+            Message::System(SystemMessage::Subscribe { id, subscription }) => {
+                Some((id, subscription))
+            }
+            _ => None,
+        }
+    }
+
+    pub fn unsubscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
+        match self {
+            Message::System(SystemMessage::Unsubscribe { id, subscription }) => {
+                Some((id, subscription))
+            }
+            _ => None,
+        }
+    }
 }
 
 impl From<SystemQuery> for Query {

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -1000,7 +1000,7 @@ impl Message {
         }
     }
 
-    pub fn subscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
+    pub fn matches_subscribe(&self) -> Option<(&ChainId, &ChannelSubscription)> {
         match self {
             Message::System(SystemMessage::Subscribe { id, subscription }) => {
                 Some((id, subscription))

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -814,20 +814,6 @@ where
                     SystemExecutionError::InvalidCommitteeRemoval
                 );
             }
-            Subscribe { id, subscription } => {
-                ensure!(
-                    subscription.chain_id == context.chain_id,
-                    SystemExecutionError::IncorrectChainId(subscription.chain_id)
-                );
-                outcome.subscribe.push((subscription.name.clone(), id));
-            }
-            Unsubscribe { id, subscription } => {
-                ensure!(
-                    subscription.chain_id == context.chain_id,
-                    SystemExecutionError::IncorrectChainId(subscription.chain_id)
-                );
-                outcome.unsubscribe.push((subscription.name.clone(), id));
-            }
             RegisterApplications { applications } => {
                 for application in applications {
                     self.registry
@@ -852,10 +838,10 @@ where
                 };
                 outcome.messages.push(message);
             }
-            OpenChain(_) => {
-                // This special message is executed immediately when cross-chain requests are received.
-            }
-            ApplicationCreated => (),
+            // These messages are executed immediately when cross-chain requests are received.
+            Subscribe { .. } | Unsubscribe { .. } | OpenChain(_) => {}
+            // This message is only a placeholder: Its ID is part of the application ID.
+            ApplicationCreated => {}
         }
         Ok(outcome)
     }

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -185,10 +185,10 @@ pub enum SystemOperation {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 pub enum AdminOperation {
     /// Registers a new committee. This will notify the subscribers of the admin chain so that they
-    /// can migrate to the new epoch by accepting the resulting `SetCommittees` as an incoming
+    /// can migrate to the new epoch by accepting the resulting `CreateCommittee` as an incoming
     /// message in a block.
     CreateCommittee { epoch: Epoch, committee: Committee },
-    /// Removes a committee. Once the resulting `SetCommittees` message is accepted by a chain,
+    /// Removes a committee. Once the resulting `RemoveCommittee` message is accepted by a chain,
     /// blocks from the retired epoch will not be accepted until they are followed (hence
     /// re-certified) by a block certified by a recent committee.
     RemoveCommittee { epoch: Epoch },
@@ -215,11 +215,10 @@ pub enum SystemMessage {
     },
     /// Creates (or activates) a new chain.
     OpenChain(OpenChainConfig),
-    /// Sets the current epoch and the recognized committees.
-    SetCommittees {
-        epoch: Epoch,
-        committees: BTreeMap<Epoch, Committee>,
-    },
+    /// Adds a new epoch and committee.
+    CreateCommittee { epoch: Epoch, committee: Committee },
+    /// Removes an old committee.
+    RemoveCommittee { epoch: Epoch },
     /// Subscribes to a channel.
     Subscribe {
         id: ChainId,
@@ -520,17 +519,14 @@ where
                             epoch == self.epoch.get().expect("chain is active").try_add_one()?,
                             SystemExecutionError::InvalidCommitteeCreation
                         );
-                        self.committees.get_mut().insert(epoch, committee);
+                        self.committees.get_mut().insert(epoch, committee.clone());
                         self.epoch.set(Some(epoch));
                         let message = RawOutgoingMessage {
                             destination: Destination::Subscribers(SystemChannel::Admin.name()),
                             authenticated: false,
                             grant: Amount::ZERO,
                             kind: MessageKind::Protected,
-                            message: SystemMessage::SetCommittees {
-                                epoch,
-                                committees: self.committees.get().clone(),
-                            },
+                            message: SystemMessage::CreateCommittee { epoch, committee },
                         };
                         outcome.messages.push(message);
                     }
@@ -544,10 +540,7 @@ where
                             authenticated: false,
                             grant: Amount::ZERO,
                             kind: MessageKind::Protected,
-                            message: SystemMessage::SetCommittees {
-                                epoch: self.epoch.get().expect("chain is active"),
-                                committees: self.committees.get().clone(),
-                            },
+                            message: SystemMessage::RemoveCommittee { epoch },
                         };
                         outcome.messages.push(message);
                     }
@@ -807,13 +800,19 @@ where
                     Recipient::Burn => (),
                 }
             }
-            SetCommittees { epoch, committees } => {
+            CreateCommittee { epoch, committee } => {
                 ensure!(
-                    epoch >= self.epoch.get().expect("chain is active"),
-                    SystemExecutionError::CannotRewindEpoch
+                    epoch == self.epoch.get().expect("chain is active").try_add_one()?,
+                    SystemExecutionError::InvalidCommitteeCreation
                 );
+                self.committees.get_mut().insert(epoch, committee.clone());
                 self.epoch.set(Some(epoch));
-                self.committees.set(committees);
+            }
+            RemoveCommittee { epoch } => {
+                ensure!(
+                    self.committees.get_mut().remove(&epoch).is_some(),
+                    SystemExecutionError::InvalidCommitteeRemoval
+                );
             }
             Subscribe { id, subscription } => {
                 ensure!(

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -866,39 +866,40 @@ SystemMessage:
         NEWTYPE:
           TYPENAME: OpenChainConfig
     3:
-      SetCommittees:
+      CreateCommittee:
         STRUCT:
           - epoch:
               TYPENAME: Epoch
-          - committees:
-              MAP:
-                KEY:
-                  TYPENAME: Epoch
-                VALUE:
-                  TYPENAME: Committee
+          - committee:
+              TYPENAME: Committee
     4:
+      RemoveCommittee:
+        STRUCT:
+          - epoch:
+              TYPENAME: Epoch
+    5:
       Subscribe:
         STRUCT:
           - id:
               TYPENAME: ChainId
           - subscription:
               TYPENAME: ChannelSubscription
-    5:
+    6:
       Unsubscribe:
         STRUCT:
           - id:
               TYPENAME: ChainId
           - subscription:
               TYPENAME: ChannelSubscription
-    6:
-      ApplicationCreated: UNIT
     7:
+      ApplicationCreated: UNIT
+    8:
       RegisterApplications:
         STRUCT:
           - applications:
               SEQ:
                 TYPENAME: UserApplicationDescription
-    8:
+    9:
       RequestApplication:
         NEWTYPE:
           TYPENAME: ApplicationId

--- a/linera-service-graphql-client/gql/service_requests.graphql
+++ b/linera-service-graphql-client/gql/service_requests.graphql
@@ -28,7 +28,9 @@ query ChainChannel($chainId: ChainId!, $channelFullName: ChannelFullName!) {
         key
         value {
           subscribers
-          blockHeight
+          blockHeights {
+            entries
+          }
         }
       }
     }
@@ -135,7 +137,9 @@ query Chain(
         key
         value {
           subscribers
-          blockHeight
+          blockHeights {
+            entries
+          }
         }
       }
     }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -277,7 +277,7 @@ type ChannelStateView {
 	"""
 	The block heights so far, to be sent to future subscribers.
 	"""
-	blockHeights: QueueView_BlockHeight_f5d50b5f!
+	blockHeights: LogView_BlockHeight_a5612a40!
 }
 
 """
@@ -490,6 +490,10 @@ type IncomingBundle {
 A scalar that can represent any JSON Object value.
 """
 scalar JSONObject
+
+type LogView_BlockHeight_a5612a40 {
+	entries(start: Int, end: Int): [BlockHeight!]!
+}
 
 type LogView_ChainAndHeight_de85b393 {
 	entries(start: Int, end: Int): [ChainAndHeight!]!

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -129,6 +129,20 @@ scalar BlockHeight
 
 
 """
+An origin and cursor of a unskippable bundle that is no longer in our inbox.
+"""
+type BundleInInbox {
+	"""
+	The origin from which we received the bundle.
+	"""
+	origin: Origin!
+	"""
+	The cursor of the bundle in the inbox.
+	"""
+	cursor: Cursor!
+}
+
+"""
 A WebAssembly module's bytecode
 """
 scalar Bytecode
@@ -205,11 +219,11 @@ type ChainStateExtendedView {
 	"""
 	A queue of unskippable bundles, with the timestamp when we added them to the inbox.
 	"""
-	unskippableEntries: QueueView_TimestampedInboxEntry_ce4d8b86!
+	unskippableBundles: QueueView_TimestampedBundleInInbox_c9bca311!
 	"""
-	Non-skippable bundles that have been removed but are still in the queue.
+	Unskippable bundles that have been removed but are still in the queue.
 	"""
-	removedUnskippable: [InboxEntry!]!
+	removedUnskippableBundles: [BundleInInbox!]!
 	"""
 	Mailboxes used to send messages, indexed by their target.
 	"""
@@ -418,20 +432,6 @@ type HashedCertificateValue {
 	value: CertificateValue!
 }
 
-
-"""
-An origin and cursor of a unskippable message that is no longer in our inbox.
-"""
-type InboxEntry {
-	"""
-	The origin from which we received the message.
-	"""
-	origin: Origin!
-	"""
-	The cursor of the message in the inbox.
-	"""
-	cursor: Cursor!
-}
 
 """
 The state of an inbox.
@@ -781,8 +781,8 @@ type QueueView_MessageBundle_f33fd73d {
 	entries(count: Int): [MessageBundle!]!
 }
 
-type QueueView_TimestampedInboxEntry_ce4d8b86 {
-	entries(count: Int): [TimestampedInboxEntry!]!
+type QueueView_TimestampedBundleInInbox_c9bca311 {
+	entries(count: Int): [TimestampedBundleInInbox!]!
 }
 
 """
@@ -926,15 +926,15 @@ A timestamp, in microseconds since the Unix epoch
 scalar Timestamp
 
 """
-An origin, cursor and timestamp of a unskippable message in our inbox.
+An origin, cursor and timestamp of a unskippable bundle in our inbox.
 """
-type TimestampedInboxEntry {
+type TimestampedBundleInInbox {
 	"""
-	The origin and cursor of the message.
+	The origin and cursor of the bundle.
 	"""
-	entry: InboxEntry!
+	entry: BundleInInbox!
 	"""
-	The timestamp when the message was added to the inbox.
+	The timestamp when the bundle was added to the inbox.
 	"""
 	seen: Timestamp!
 }

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -275,9 +275,9 @@ type ChannelStateView {
 	"""
 	subscribers: [ChainId!]!
 	"""
-	The latest block height, if any, to be sent to future subscribers.
+	The block heights so far, to be sent to future subscribers.
 	"""
-	blockHeight: BlockHeight
+	blockHeights: QueueView_BlockHeight_f5d50b5f!
 }
 
 """

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -205,7 +205,7 @@ type ChainStateExtendedView {
 	"""
 	A queue of unskippable bundles, with the timestamp when we added them to the inbox.
 	"""
-	unskippable: QueueView_TimestampedInboxEntry_ce4d8b86!
+	unskippableEntries: QueueView_TimestampedInboxEntry_ce4d8b86!
 	"""
 	Non-skippable bundles that have been removed but are still in the queue.
 	"""


### PR DESCRIPTION
## Motivation

Some channels, like the admin one, have a lot of subscribers. Handling all the `Subscribe` messages on-chain causes scalability issues.

In the long term, channels will be replaced with events anyway. (https://github.com/linera-io/linera-protocol/issues/365)

## Proposal

Handle them off-chain, and send all earlier messages to the subscriber.

User applications' subscriptions are still handled on-chain, and re-send only the latest message.

## Test Plan

The tests have been updated and should catch any regressions.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
