### PR TITLE
Faucet has a chain listener

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -523,6 +523,13 @@ Run a GraphQL service that exposes a faucet where users can claim tokens. This g
   Default value: `8080`
 * `--amount <AMOUNT>` — The number of tokens to send to each new chain
 * `--limit-rate-until <LIMIT_RATE_UNTIL>` — The end timestamp: The faucet will rate-limit the token supply so it runs out of money no earlier than this
+* `--listener-skip-process-inbox` — Do not create blocks automatically to receive incoming messages. Instead, wait for an explicit mutation `processInbox`
+* `--listener-delay-before-ms <DELAY_BEFORE_MS>` — Wait before processing any notification (useful for testing)
+
+  Default value: `0`
+* `--listener-delay-after-ms <DELAY_AFTER_MS>` — Wait after processing any notification (useful for rate limiting)
+
+  Default value: `0`
 
 
 

--- a/linera-client/src/chain_clients.rs
+++ b/linera-client/src/chain_clients.rs
@@ -71,15 +71,11 @@ where
         }
     }
 
-    pub async fn from_context(
-        context: &impl ClientContext<ValidatorNodeProvider = P, Storage = S>,
-    ) -> Self {
+    pub async fn from_clients(chains: impl IntoIterator<Item = ChainClient<P, S>>) -> Self {
         let chain_clients = Self(Default::default());
-        let chains = context.wallet().chain_ids();
-        for chain_id in chains {
+        for chain_client in chains.into_iter() {
             let mut map_guard = chain_clients.map_lock().await;
-            let client = context.make_chain_client(chain_id);
-            map_guard.insert(chain_id, client);
+            map_guard.insert(chain_client.chain_id(), chain_client);
         }
         chain_clients
     }

--- a/linera-client/src/chain_clients.rs
+++ b/linera-client/src/chain_clients.rs
@@ -73,7 +73,7 @@ where
 
     pub async fn from_clients(chains: impl IntoIterator<Item = ChainClient<P, S>>) -> Self {
         let chain_clients = Self(Default::default());
-        for chain_client in chains.into_iter() {
+        for chain_client in chains {
             let mut map_guard = chain_clients.map_lock().await;
             map_guard.insert(chain_client.chain_id(), chain_client);
         }

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -81,6 +81,14 @@ pub trait ClientContext {
         &mut self,
         client: &ChainClient<Self::ValidatorNodeProvider, Self::Storage>,
     ) -> Result<(), Error>;
+
+    fn clients(&self) -> Vec<ChainClient<Self::ValidatorNodeProvider, Self::Storage>> {
+        let mut clients = vec![];
+        for chain_id in &self.wallet().chain_ids() {
+            clients.push(self.make_chain_client(*chain_id));
+        }
+        clients
+    }
 }
 
 /// A `ChainListener` is a process that listens to notifications from validators and reacts

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::btree_map, sync::Arc, time::Duration};
+use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures::{
@@ -91,6 +91,7 @@ where
 {
     config: ChainListenerConfig,
     clients: ChainClients<P, S>,
+    listening: Arc<Mutex<HashSet<ChainId>>>,
 }
 
 impl<P, S> ChainListener<P, S>
@@ -101,7 +102,11 @@ where
 {
     /// Creates a new chain listener given client chains.
     pub fn new(config: ChainListenerConfig, clients: ChainClients<P, S>) -> Self {
-        Self { config, clients }
+        Self {
+            config,
+            clients,
+            listening: Default::default(),
+        }
     }
 
     /// Runs the chain listener.
@@ -117,6 +122,7 @@ where
                 context.clone(),
                 storage.clone(),
                 self.config.clone(),
+                self.listening.clone(),
             );
         }
     }
@@ -128,13 +134,15 @@ where
         context: Arc<Mutex<C>>,
         storage: S,
         config: ChainListenerConfig,
+        listening: Arc<Mutex<HashSet<ChainId>>>,
     ) where
         C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     {
         let _handle = linera_base::task::spawn(
             async move {
                 if let Err(err) =
-                    Self::run_client_stream(chain_id, clients, context, storage, config).await
+                    Self::run_client_stream(chain_id, clients, context, storage, config, listening)
+                        .await
                 {
                     error!("Stream for chain {} failed: {}", chain_id, err);
                 }
@@ -150,24 +158,23 @@ where
         context: Arc<Mutex<C>>,
         storage: S,
         config: ChainListenerConfig,
+        listening: Arc<Mutex<HashSet<ChainId>>>,
     ) -> Result<(), Error>
     where
         C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
     {
-        let client = {
-            let mut map_guard = clients.map_lock().await;
-            let context_guard = context.lock().await;
-            let btree_map::Entry::Vacant(entry) = map_guard.entry(chain_id) else {
-                // For every entry in the client map we are already listening to notifications, so
-                // there's nothing to do. This can happen if we download a child before the parent
-                // chain, and then process the OpenChain message in the parent.
-                return Ok(());
-            };
-            let client = context_guard.make_chain_client(chain_id);
-            entry.insert(client.clone());
-            client
-        };
+        let mut guard = listening.lock().await;
+        if guard.contains(&chain_id) {
+            // If we are already listening to notifications, there's nothing to do.
+            // This can happen if we download a child before the parent
+            // chain, and then process the OpenChain message in the parent.
+            return Ok(());
+        }
+        // If the client is not present, we can request it.
+        let client = clients.request_client(chain_id, context.clone()).await;
         let (listener, _listen_handle, mut local_stream) = client.listen().await?;
+        guard.insert(chain_id);
+        drop(guard);
         client.synchronize_from_validators().await?;
         drop(linera_base::task::spawn(listener.in_current_span()));
         let mut timeout = storage.clock().current_time();
@@ -268,6 +275,7 @@ where
                     context.clone(),
                     storage.clone(),
                     config.clone(),
+                    listening.clone(),
                 );
             }
         }

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -681,6 +681,10 @@ pub enum ClientCommand {
         /// no earlier than this.
         #[arg(long)]
         limit_rate_until: Option<DateTime<Utc>>,
+
+        /// Configuration for the faucet chain listener.
+        #[command(flatten)]
+        config: ChainListenerConfig,
     },
 
     /// Publish bytecode.

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -169,7 +169,6 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     context
         .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
         .await?;
-    // TODO vec![client0, client1]
     let chain_clients = ChainClients::from_clients(context.clients()).await;
     let context = Arc::new(Mutex::new(context));
     let listener = ChainListener::new(config, chain_clients);

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -31,7 +31,7 @@ use linera_views::memory::MemoryStore;
 use rand::SeedableRng as _;
 
 use crate::{
-    chain_listener::{self, ChainListener, ChainListenerConfig, ClientContext as _},
+    chain_listener::{self, ChainClients, ChainListener, ChainListenerConfig, ClientContext as _},
     config::{CommitteeConfig, GenesisConfig, ValidatorConfig},
     wallet::{UserChain, Wallet},
     Error,
@@ -166,11 +166,10 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     };
     let key_pair = KeyPair::generate_from(&mut rng);
     let public_key = key_pair.public();
-    context
-        .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
-        .await?;
+    context.update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time()).await?;
+    let chain_clients = ChainClients::from_context(&context).await;
     let context = Arc::new(Mutex::new(context));
-    let listener = ChainListener::new(config, Default::default());
+    let listener = ChainListener::new(config, chain_clients);
     listener.run(context, storage).await;
 
     // Transfer ownership of chain 0 to the chain listener and some other key. The listener will

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -169,7 +169,8 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     context
         .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
         .await?;
-    let chain_clients = ChainClients::from_context(&context).await;
+    // TODO vec![client0, client1]
+    let chain_clients = ChainClients::from_clients(context.clients()).await;
     let context = Arc::new(Mutex::new(context));
     let listener = ChainListener::new(config, chain_clients);
     listener.run(context, storage).await;

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -166,7 +166,9 @@ async fn test_chain_listener() -> anyhow::Result<()> {
     };
     let key_pair = KeyPair::generate_from(&mut rng);
     let public_key = key_pair.public();
-    context.update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time()).await?;
+    context
+        .update_wallet_for_new_chain(chain_id0, Some(key_pair), clock.current_time())
+        .await?;
     let chain_clients = ChainClients::from_context(&context).await;
     let context = Arc::new(Mutex::new(context));
     let listener = ChainListener::new(config, chain_clients);

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -13,8 +13,16 @@ use linera_base::{
     identifiers::{ChainId, MessageId},
     ownership::ChainOwnership,
 };
-use linera_client::{chain_listener::ClientContext, config::GenesisConfig};
-use linera_core::{client::ChainClient, data_types::ClientOutcome, node::ValidatorNodeProvider};
+use linera_client::{
+    chain_clients::ChainClients,
+    chain_listener::{ChainListener, ChainListenerConfig, ClientContext},
+    config::GenesisConfig,
+};
+use linera_core::{
+    client::ChainClient,
+    data_types::ClientOutcome,
+    node::{ValidatorNode, ValidatorNodeProvider},
+};
 use linera_execution::committee::ValidatorName;
 use linera_storage::{Clock as _, Storage};
 use serde::Deserialize;
@@ -192,6 +200,8 @@ where
     client: Arc<Mutex<ChainClient<P, S>>>,
     context: Arc<Mutex<C>>,
     genesis_config: Arc<GenesisConfig>,
+    config: ChainListenerConfig,
+    storage: S,
     port: NonZeroU16,
     amount: Amount,
     end_timestamp: Timestamp,
@@ -208,6 +218,8 @@ where
             client: self.client.clone(),
             context: self.context.clone(),
             genesis_config: self.genesis_config.clone(),
+            config: self.config.clone(),
+            storage: self.storage.clone(),
             port: self.port,
             amount: self.amount,
             end_timestamp: self.end_timestamp,
@@ -220,10 +232,12 @@ where
 impl<P, S, C> FaucetService<P, S, C>
 where
     P: ValidatorNodeProvider + Send + Sync + Clone + 'static,
+    <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
 {
     /// Creates a new instance of the faucet service.
+    #[allow(clippy::too_many_arguments)]
     pub async fn new(
         port: NonZeroU16,
         client: ChainClient<P, S>,
@@ -231,6 +245,8 @@ where
         amount: Amount,
         end_timestamp: Timestamp,
         genesis_config: Arc<GenesisConfig>,
+        config: ChainListenerConfig,
+        storage: S,
     ) -> anyhow::Result<Self> {
         let start_timestamp = client.storage_client().clock().current_time();
         client.process_inbox().await?;
@@ -239,6 +255,8 @@ where
             client: Arc::new(Mutex::new(client)),
             context: Arc::new(Mutex::new(context)),
             genesis_config,
+            config,
+            storage,
             port,
             amount,
             end_timestamp,
@@ -276,6 +294,10 @@ where
             .layer(CorsLayer::permissive());
 
         info!("GraphiQL IDE: http://localhost:{}", port);
+
+        ChainListener::new(self.config, ChainClients::default())
+            .run(self.context.clone(), self.storage.clone())
+            .await;
 
         axum::serve(
             tokio::net::TcpListener::bind(SocketAddr::from(([0, 0, 0, 0], port))).await?,

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -251,7 +251,7 @@ where
         config: ChainListenerConfig,
         storage: S,
     ) -> anyhow::Result<Self> {
-        let clients = ChainClients::<P, S>::from_context(&context).await;
+        let clients = ChainClients::<P, S>::from_clients(context.clients()).await;
         let context = Arc::new(Mutex::new(context));
         let client = clients.try_client_lock(&chain_id).await?;
         let start_timestamp = client.storage_client().clock().current_time();

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -800,6 +800,7 @@ impl Runnable for Job {
                 port,
                 amount,
                 limit_rate_until,
+                config,
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Starting faucet service using chain {}", chain_id);
@@ -819,6 +820,8 @@ impl Runnable for Job {
                     amount,
                     end_timestamp,
                     genesis_config,
+                    config,
+                    storage,
                 )
                 .await?;
                 faucet.run().await?;

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -791,7 +791,7 @@ impl Runnable for Job {
 
             Service { config, port } => {
                 let default_chain = context.wallet().default_chain();
-                let service = NodeService::new(config, port, default_chain, storage, context);
+                let service = NodeService::new(config, port, default_chain, storage, context).await;
                 service.run().await?;
             }
 
@@ -804,7 +804,6 @@ impl Runnable for Job {
             } => {
                 let chain_id = chain_id.unwrap_or_else(|| context.default_chain());
                 info!("Starting faucet service using chain {}", chain_id);
-                let chain_client = context.make_chain_client(chain_id);
                 let end_timestamp = limit_rate_until
                     .map(|et| {
                         let micros = u64::try_from(et.timestamp_micros())
@@ -815,7 +814,7 @@ impl Runnable for Job {
                 let genesis_config = Arc::new(context.wallet().genesis_config().clone());
                 let faucet = FaucetService::new(
                     port,
-                    chain_client,
+                    chain_id,
                     context,
                     amount,
                     end_timestamp,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -966,7 +966,7 @@ where
         context: C,
     ) -> Self {
         Self {
-            clients: ChainClients::from_context(&context).await,
+            clients: ChainClients::from_clients(context.clients()).await,
             config,
             port,
             default_chain,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -958,7 +958,7 @@ where
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
 {
     /// Creates a new instance of the node service given a client chain and a port.
-    pub fn new(
+    pub async fn new(
         config: ChainListenerConfig,
         port: NonZeroU16,
         default_chain: Option<ChainId>,
@@ -966,7 +966,7 @@ where
         context: C,
     ) -> Self {
         Self {
-            clients: ChainClients::default(),
+            clients: ChainClients::from_context(&context).await,
             config,
             port,
             default_chain,

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -176,7 +176,8 @@ async fn main() -> std::io::Result<()> {
         None,
         storage,
         context,
-    );
+    )
+    .await;
     let schema = service.schema().sdl();
     print!("{}", schema);
     Ok(())

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -154,6 +154,10 @@ impl<P: LocalValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientConte
     async fn update_wallet(&mut self, _: &ChainClient<P, S>) -> Result<(), Error> {
         Ok(())
     }
+
+    fn clients(&self) -> Vec<ChainClient<Self::ValidatorNodeProvider, Self::Storage>> {
+        vec![]
+    }
 }
 
 #[tokio::main]

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -74,7 +74,7 @@ async fn test_faucet_rate_limiting() {
         .unwrap();
     let chain_id = client.chain_id();
     let context = ClientContext::default();
-    let clients = ChainClients::from_context(&context).await;
+    let clients = ChainClients::from_clients(vec![client]).await;
     let context = Arc::new(Mutex::new(context));
     let root = MutationRoot {
         clients,

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -12,7 +12,7 @@ use linera_base::{
     data_types::{Amount, Timestamp},
     identifiers::{ChainDescription, ChainId},
 };
-use linera_client::{chain_listener, wallet::Wallet};
+use linera_client::{chain_clients::ChainClients, chain_listener, wallet::Wallet};
 use linera_core::{
     client::ChainClient,
     test_utils::{FaultType, MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
@@ -72,10 +72,13 @@ async fn test_faucet_rate_limiting() {
         .add_initial_chain(ChainDescription::Root(1), Amount::from_tokens(6))
         .await
         .unwrap();
-    let client = Arc::new(Mutex::new(client));
-    let context = Arc::new(Mutex::new(ClientContext::default()));
+    let chain_id = client.chain_id();
+    let context = ClientContext::default();
+    let clients = ChainClients::from_context(&context).await;
+    let context = Arc::new(Mutex::new(context));
     let root = MutationRoot {
-        client,
+        clients,
+        chain_id,
         context: context.clone(),
         amount: Amount::from_tokens(1),
         end_timestamp: Timestamp::from(6000),


### PR DESCRIPTION
## Motivation

We would like the faucet to listen for notifications from the admin change, especially for reconfigurations so that it can automatically update epoch.

## Proposal

Add a chain listener to the faucet service. This will work with #2303 so that the faucet _only_ listens for messages from the admin chain.
