### PR TITLE
Add a `get_test_config` to the `AdminKeyValueStore` and simplify `linera_storage`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4708,7 +4708,6 @@ dependencies = [
  "linera-chain",
  "linera-execution",
  "linera-storage",
- "linera-storage-service",
  "linera-views",
  "prometheus",
  "serde",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3497,7 +3497,6 @@ dependencies = [
  "linera-base",
  "linera-chain",
  "linera-execution",
- "linera-storage-service",
  "linera-views",
  "prometheus",
  "serde",

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -6,14 +6,18 @@ use std::{fmt, str::FromStr};
 use async_trait::async_trait;
 use linera_execution::WasmRuntime;
 use linera_storage::{DbStorage, Storage};
+#[cfg(feature = "storage-service")]
+use linera_storage_service::{client::ServiceStoreClient, common::ServiceStoreConfig};
 #[cfg(with_storage)]
 use linera_views::common::LocalAdminKeyValueStore as _;
-use linera_views::{common::CommonStoreConfig, memory::{MemoryStore, MemoryStoreConfig}, views::ViewError};
-use tracing::error;
 #[cfg(feature = "dynamodb")]
-use {
-    linera_views::dynamo_db::{get_config, DynamoDbStore, DynamoDbStoreConfig},
+use linera_views::dynamo_db::{get_config, DynamoDbStore, DynamoDbStoreConfig};
+use linera_views::{
+    common::CommonStoreConfig,
+    memory::{MemoryStore, MemoryStoreConfig},
+    views::ViewError,
 };
+use tracing::error;
 #[cfg(feature = "rocksdb")]
 use {
     linera_views::rocks_db::{PathWithGuard, RocksDbStore, RocksDbStoreConfig},
@@ -24,10 +28,6 @@ use {
     linera_views::scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
     std::num::NonZeroU16,
     tracing::debug,
-};
-#[cfg(feature = "storage-service")]
-use {
-    linera_storage_service::{client::ServiceStoreClient, common::ServiceStoreConfig},
 };
 
 use crate::{config::GenesisConfig, util};
@@ -567,28 +567,37 @@ where
         StoreConfig::Memory(config, namespace) => {
             let store_config = MemoryStoreConfig::new(config.common_config.max_stream_queries);
             let mut storage =
-                DbStorage::<MemoryStore, _>::new(store_config, &namespace, ROOT_KEY, wasm_runtime).await?;
+                DbStorage::<MemoryStore, _>::new(store_config, &namespace, ROOT_KEY, wasm_runtime)
+                    .await?;
             genesis_config.initialize_storage(&mut storage).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "storage-service")]
         StoreConfig::Service(config, namespace) => {
-            let storage = DbStorage::<ServiceStoreClient, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage =
+                DbStorage::<ServiceStoreClient, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
+                    .await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config, namespace) => {
-            let storage = DbStorage::<RocksDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage =
+                DbStorage::<RocksDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
+                    .await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "dynamodb")]
         StoreConfig::DynamoDb(config, namespace) => {
-            let storage = DbStorage::<DynamoDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage =
+                DbStorage::<DynamoDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
+                    .await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config, namespace) => {
-            let storage = DbStorage::<ScyllaDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage =
+                DbStorage::<ScyllaDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime)
+                    .await?;
             Ok(job.run(storage).await)
         }
     }
@@ -606,29 +615,49 @@ pub async fn full_initialize_storage(
         #[cfg(feature = "storage-service")]
         StoreConfig::Service(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage =
-                DbStorage::<ServiceStoreClient, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let mut storage = DbStorage::<ServiceStoreClient, _>::initialize(
+                config,
+                &namespace,
+                ROOT_KEY,
+                wasm_runtime,
+            )
+            .await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage =
-                DbStorage::<RocksDbStore, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let mut storage = DbStorage::<RocksDbStore, _>::initialize(
+                config,
+                &namespace,
+                ROOT_KEY,
+                wasm_runtime,
+            )
+            .await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "dynamodb")]
         StoreConfig::DynamoDb(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage =
-                DbStorage::<DynamoDbStore, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let mut storage = DbStorage::<DynamoDbStore, _>::initialize(
+                config,
+                &namespace,
+                ROOT_KEY,
+                wasm_runtime,
+            )
+            .await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config, namespace) => {
             let wasm_runtime = None;
-            let mut storage =
-                DbStorage::<ScyllaDbStore, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let mut storage = DbStorage::<ScyllaDbStore, _>::initialize(
+                config,
+                &namespace,
+                ROOT_KEY,
+                wasm_runtime,
+            )
+            .await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
     }

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -5,32 +5,28 @@ use std::{fmt, str::FromStr};
 
 use async_trait::async_trait;
 use linera_execution::WasmRuntime;
-use linera_storage::{MemoryStorage, Storage};
+use linera_storage::{DbStorage, Storage};
 #[cfg(with_storage)]
 use linera_views::common::LocalAdminKeyValueStore as _;
-use linera_views::{common::CommonStoreConfig, memory::MemoryStoreConfig, views::ViewError};
+use linera_views::{common::CommonStoreConfig, memory::{MemoryStore, MemoryStoreConfig}, views::ViewError};
 use tracing::error;
 #[cfg(feature = "dynamodb")]
 use {
-    linera_storage::DynamoDbStorage,
     linera_views::dynamo_db::{get_config, DynamoDbStore, DynamoDbStoreConfig},
 };
 #[cfg(feature = "rocksdb")]
 use {
-    linera_storage::RocksDbStorage,
     linera_views::rocks_db::{PathWithGuard, RocksDbStore, RocksDbStoreConfig},
     std::path::PathBuf,
 };
 #[cfg(feature = "scylladb")]
 use {
-    linera_storage::ScyllaDbStorage,
     linera_views::scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
     std::num::NonZeroU16,
     tracing::debug,
 };
 #[cfg(feature = "storage-service")]
 use {
-    linera_storage::ServiceStorage,
     linera_storage_service::{client::ServiceStoreClient, common::ServiceStoreConfig},
 };
 
@@ -571,28 +567,28 @@ where
         StoreConfig::Memory(config, namespace) => {
             let store_config = MemoryStoreConfig::new(config.common_config.max_stream_queries);
             let mut storage =
-                MemoryStorage::new(store_config, &namespace, ROOT_KEY, wasm_runtime).await?;
+                DbStorage::<MemoryStore, _>::new(store_config, &namespace, ROOT_KEY, wasm_runtime).await?;
             genesis_config.initialize_storage(&mut storage).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "storage-service")]
         StoreConfig::Service(config, namespace) => {
-            let storage = ServiceStorage::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage = DbStorage::<ServiceStoreClient, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config, namespace) => {
-            let storage = RocksDbStorage::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage = DbStorage::<RocksDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "dynamodb")]
         StoreConfig::DynamoDb(config, namespace) => {
-            let storage = DynamoDbStorage::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage = DbStorage::<DynamoDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config, namespace) => {
-            let storage = ScyllaDbStorage::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+            let storage = DbStorage::<ScyllaDbStore, _>::new(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(job.run(storage).await)
         }
     }
@@ -611,28 +607,28 @@ pub async fn full_initialize_storage(
         StoreConfig::Service(config, namespace) => {
             let wasm_runtime = None;
             let mut storage =
-                ServiceStorage::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+                DbStorage::<ServiceStoreClient, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "rocksdb")]
         StoreConfig::RocksDb(config, namespace) => {
             let wasm_runtime = None;
             let mut storage =
-                RocksDbStorage::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+                DbStorage::<RocksDbStore, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "dynamodb")]
         StoreConfig::DynamoDb(config, namespace) => {
             let wasm_runtime = None;
             let mut storage =
-                DynamoDbStorage::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+                DbStorage::<DynamoDbStore, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
         #[cfg(feature = "scylladb")]
         StoreConfig::ScyllaDb(config, namespace) => {
             let wasm_runtime = None;
             let mut storage =
-                ScyllaDbStorage::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
+                DbStorage::<ScyllaDbStore, _>::initialize(config, &namespace, ROOT_KEY, wasm_runtime).await?;
             Ok(genesis_config.initialize_storage(&mut storage).await?)
         }
     }

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -26,7 +26,8 @@ use linera_rpc::{
     config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
     simple::TransportProtocol,
 };
-use linera_storage::{MemoryStorage, TestClock};
+use linera_views::memory::MemoryStore;
+use linera_storage::{DbStorage, TestClock};
 use rand::SeedableRng as _;
 
 use crate::{
@@ -35,7 +36,7 @@ use crate::{
     wallet::{UserChain, Wallet},
 };
 
-type TestStorage = MemoryStorage<TestClock>;
+type TestStorage = DbStorage<MemoryStore, TestClock>;
 type TestProvider = NodeProvider<TestStorage>;
 
 struct ClientContext {

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -26,8 +26,8 @@ use linera_rpc::{
     config::{NetworkProtocol, ValidatorPublicNetworkPreConfig},
     simple::TransportProtocol,
 };
-use linera_views::memory::MemoryStore;
 use linera_storage::{DbStorage, TestClock};
+use linera_views::memory::MemoryStore;
 use rand::SeedableRng as _;
 
 use crate::{

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -55,7 +55,7 @@ use crate::{
 };
 
 type MemoryChainClient =
-    ChainClient<NodeProvider<DbStorage<MemoryStore,TestClock>>, DbStorage<MemoryStore,TestClock>>;
+    ChainClient<NodeProvider<DbStorage<MemoryStore, TestClock>>, DbStorage<MemoryStore, TestClock>>;
 
 /// A test to ensure that our chain client listener remains `Send`.  This is a bit of a
 /// hack, but requires that we not hold a `std::sync::Mutex` over `await` points, a

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -26,8 +26,8 @@ use linera_execution::{
     ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy, SystemExecutionError,
     SystemMessage, SystemQuery, SystemResponse,
 };
-use linera_storage::{MemoryStorage, Storage, TestClock};
-use linera_views::views::ViewError;
+use linera_storage::{DbStorage, Storage, TestClock};
+use linera_views::{memory::MemoryStore, views::ViewError};
 use test_case::test_case;
 
 #[cfg(feature = "dynamodb")]
@@ -55,7 +55,7 @@ use crate::{
 };
 
 type MemoryChainClient =
-    ChainClient<NodeProvider<MemoryStorage<TestClock>>, MemoryStorage<TestClock>>;
+    ChainClient<NodeProvider<DbStorage<MemoryStore,TestClock>>, DbStorage<MemoryStore,TestClock>>;
 
 /// A test to ensure that our chain client listener remains `Send`.  This is a bit of a
 /// hack, but requires that we not hold a `std::sync::Mutex` over `await` points, a

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -952,7 +952,7 @@ impl StorageBuilder for RocksDbStorageBuilder {
     type Storage = DbStorage<RocksDbStore, TestClock>;
 
     async fn build(&mut self) -> Result<Self::Storage, anyhow::Error> {
-        let store_config = RocksDbStore::get_test_config().await?;
+        let store_config = RocksDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
         let storage = DbStorage::new_for_testing(

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -23,26 +23,33 @@ use linera_execution::{
     committee::{Committee, ValidatorName},
     ResourceControlPolicy, WasmRuntime,
 };
-use linera_views::memory::MemoryStore;
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_version::VersionInfo;
-use linera_views::{memory::create_memory_store_test_config, views::ViewError};
-use tokio::sync::oneshot;
-use tokio_stream::wrappers::UnboundedReceiverStream;
 #[cfg(feature = "dynamodb")]
-use linera_views::dynamo_db::{create_dynamo_db_common_config, DynamoDbStore, DynamoDbStoreConfig, LocalStackTestContext};
-#[cfg(feature = "rocksdb")]
-use {
-    linera_views::common::{AdminKeyValueStore as _},
-    linera_views::rocks_db::RocksDbStore,
-    tokio::sync::{Semaphore, SemaphorePermit},
+use linera_views::dynamo_db::{
+    create_dynamo_db_common_config, DynamoDbStore, DynamoDbStoreConfig, LocalStackTestContext,
 };
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::{create_scylla_db_common_config, ScyllaDbStore, ScyllaDbStoreConfig};
+use linera_views::{
+    memory::{create_memory_store_test_config, MemoryStore},
+    views::ViewError,
+};
+use tokio::sync::oneshot;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 #[cfg(not(target_arch = "wasm32"))]
 use {
-    linera_storage_service::{client::{service_config_from_endpoint, ServiceStoreClient}, common::storage_service_test_endpoint},
+    linera_storage_service::{
+        client::{service_config_from_endpoint, ServiceStoreClient},
+        common::storage_service_test_endpoint,
+    },
     linera_views::test_utils::generate_test_namespace,
+};
+#[cfg(feature = "rocksdb")]
+use {
+    linera_views::common::AdminKeyValueStore as _,
+    linera_views::rocks_db::RocksDbStore,
+    tokio::sync::{Semaphore, SemaphorePermit},
 };
 
 use crate::{

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -37,7 +37,8 @@ use {
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStorage,
-    linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStoreConfig},
+    linera_views::common::{AdminKeyValueStore as _},
+    linera_views::rocks_db::RocksDbStore,
     tokio::sync::{Semaphore, SemaphorePermit},
 };
 #[cfg(feature = "scylladb")]
@@ -48,7 +49,7 @@ use {
 #[cfg(not(target_arch = "wasm32"))]
 use {
     linera_storage::ServiceStorage,
-    linera_storage_service::{client::service_config_from_endpoint, storage_service_test_endpoint},
+    linera_storage_service::{client::service_config_from_endpoint, common::storage_service_test_endpoint},
     linera_views::test_utils::generate_test_namespace,
 };
 
@@ -952,7 +953,7 @@ impl StorageBuilder for RocksDbStorageBuilder {
     type Storage = RocksDbStorage<TestClock>;
 
     async fn build(&mut self) -> Result<Self::Storage, anyhow::Error> {
-        let store_config = create_rocks_db_test_config();
+        let store_config = RocksDbStore::get_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
         let storage = RocksDbStorage::new_for_testing(

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -37,8 +37,7 @@ use {
 #[cfg(feature = "rocksdb")]
 use {
     linera_storage::RocksDbStorage,
-    linera_views::rocks_db::RocksDbStoreConfig,
-    linera_views::rocks_db::{create_rocks_db_common_config, create_rocks_db_test_path},
+    linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStoreConfig},
     tokio::sync::{Semaphore, SemaphorePermit},
 };
 #[cfg(feature = "scylladb")]
@@ -953,12 +952,7 @@ impl StorageBuilder for RocksDbStorageBuilder {
     type Storage = RocksDbStorage<TestClock>;
 
     async fn build(&mut self) -> Result<Self::Storage, anyhow::Error> {
-        let path_with_guard = create_rocks_db_test_path();
-        let common_config = create_rocks_db_common_config();
-        let store_config = RocksDbStoreConfig {
-            path_with_guard,
-            common_config,
-        };
+        let store_config = create_rocks_db_test_config();
         let namespace = generate_test_namespace();
         let root_key = &[];
         let storage = RocksDbStorage::new_for_testing(

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -32,7 +32,7 @@ use linera_execution::{
 use linera_storage::{DbStorage, Storage};
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::DynamoDbStore;
-#[cfg(feature = "scylladb")]
+#[cfg(feature = "rocksdb")]
 use linera_views::rocks_db::RocksDbStore;
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::ScyllaDbStore;

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -29,13 +29,15 @@ use linera_execution::{
     Message, MessageKind, Operation, OperationContext, ResourceController, TransactionTracker,
     UserApplicationDescription, UserApplicationId, WasmContractModule, WasmRuntime,
 };
+use linera_storage::DbStorage;
 #[cfg(feature = "dynamodb")]
-use linera_storage::DynamoDbStorage;
-#[cfg(feature = "rocksdb")]
-use linera_storage::RocksDbStorage;
+use linera_views::dynamo_db::DynamoDbStore;
 #[cfg(feature = "scylladb")]
-use linera_storage::ScyllaDbStorage;
-use linera_storage::{MemoryStorage, Storage};
+use linera_views::scylla_db::ScyllaDbStore;
+#[cfg(feature = "scylladb")]
+use linera_views::rocks_db::RocksDbStore;
+use linera_views::memory::MemoryStore;
+use linera_storage::Storage;
 use linera_views::views::{CryptoHashView, ViewError};
 use test_case::test_case;
 
@@ -47,7 +49,7 @@ use super::{init_worker_with_chains, make_certificate};
 async fn test_memory_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> anyhow::Result<()> {
-    let storage = MemoryStorage::make_test_storage(Some(wasm_runtime)).await;
+    let storage = DbStorage::<MemoryStore, _>::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
 
@@ -58,7 +60,7 @@ async fn test_memory_handle_certificates_to_create_application(
 async fn test_rocks_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> anyhow::Result<()> {
-    let storage = RocksDbStorage::make_test_storage(Some(wasm_runtime)).await;
+    let storage = DbStorage::<RocksDbStore, _>::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
 
@@ -69,7 +71,7 @@ async fn test_rocks_db_handle_certificates_to_create_application(
 async fn test_dynamo_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> anyhow::Result<()> {
-    let storage = DynamoDbStorage::make_test_storage(Some(wasm_runtime)).await;
+    let storage = DbStorage::<DynamoDbStore, _>::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
 
@@ -80,7 +82,7 @@ async fn test_dynamo_db_handle_certificates_to_create_application(
 async fn test_scylla_db_handle_certificates_to_create_application(
     wasm_runtime: WasmRuntime,
 ) -> anyhow::Result<()> {
-    let storage = ScyllaDbStorage::make_test_storage(Some(wasm_runtime)).await;
+    let storage = DbStorage::<ScyllaDbStore, _>::make_test_storage(Some(wasm_runtime)).await;
     run_test_handle_certificates_to_create_application(storage, wasm_runtime).await
 }
 

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -29,16 +29,17 @@ use linera_execution::{
     Message, MessageKind, Operation, OperationContext, ResourceController, TransactionTracker,
     UserApplicationDescription, UserApplicationId, WasmContractModule, WasmRuntime,
 };
-use linera_storage::DbStorage;
+use linera_storage::{DbStorage, Storage};
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::DynamoDbStore;
 #[cfg(feature = "scylladb")]
-use linera_views::scylla_db::ScyllaDbStore;
-#[cfg(feature = "scylladb")]
 use linera_views::rocks_db::RocksDbStore;
-use linera_views::memory::MemoryStore;
-use linera_storage::Storage;
-use linera_views::views::{CryptoHashView, ViewError};
+#[cfg(feature = "scylladb")]
+use linera_views::scylla_db::ScyllaDbStore;
+use linera_views::{
+    memory::MemoryStore,
+    views::{CryptoHashView, ViewError},
+};
 use test_case::test_case;
 
 use super::{init_worker_with_chains, make_certificate};

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -41,9 +41,9 @@ use linera_execution::{
     ChannelSubscription, ExecutionError, Message, MessageKind, Query, QueryContext, Response,
     SystemExecutionError, SystemQuery, SystemResponse, TestExecutionRuntimeContext,
 };
-use linera_storage::{MemoryStorage, Storage, TestClock};
+use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{
-    memory::{create_memory_store_test_config, MemoryContext},
+    memory::{create_memory_store_test_config, MemoryStore, MemoryContext},
     test_utils::generate_test_namespace,
     views::{CryptoHashView, RootView, ViewError},
 };
@@ -2954,7 +2954,7 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let namespace = generate_test_namespace();
     let root_key = &[];
     let store =
-        MemoryStorage::new_for_testing(store_config, &namespace, root_key, None, TestClock::new())
+        DbStorage::<MemoryStore,_>::new_for_testing(store_config, &namespace, root_key, None, TestClock::new())
             .await?;
     let (committee, worker) = init_worker(store, true);
     let committees = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -43,7 +43,7 @@ use linera_execution::{
 };
 use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{
-    memory::{create_memory_store_test_config, MemoryStore, MemoryContext},
+    memory::{create_memory_store_test_config, MemoryContext, MemoryStore},
     test_utils::generate_test_namespace,
     views::{CryptoHashView, RootView, ViewError},
 };
@@ -2953,9 +2953,14 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
     let store_config = create_memory_store_test_config();
     let namespace = generate_test_namespace();
     let root_key = &[];
-    let store =
-        DbStorage::<MemoryStore,_>::new_for_testing(store_config, &namespace, root_key, None, TestClock::new())
-            .await?;
+    let store = DbStorage::<MemoryStore, _>::new_for_testing(
+        store_config,
+        &namespace,
+        root_key,
+        None,
+        TestClock::new(),
+    )
+    .await?;
     let (committee, worker) = init_worker(store, true);
     let committees = BTreeMap::from_iter([(Epoch::from(1), committee.clone())]);
 

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -22,8 +22,8 @@ use linera_execution::{
     system::{OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
     WasmRuntime,
 };
-use linera_views::memory::MemoryStore;
 use linera_storage::{DbStorage, Storage, TestClock};
+use linera_views::memory::MemoryStore;
 use serde::Serialize;
 
 use super::ActiveChain;
@@ -42,7 +42,7 @@ use crate::ContractAbi;
 pub struct TestValidator {
     key_pair: KeyPair,
     committee: Committee,
-    worker: WorkerState<DbStorage<MemoryStore,TestClock>>,
+    worker: WorkerState<DbStorage<MemoryStore, TestClock>>,
     clock: TestClock,
     chains: Arc<DashMap<ChainId, ActiveChain>>,
 }
@@ -65,7 +65,7 @@ impl TestValidator {
         let key_pair = KeyPair::generate();
         let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
         let wasm_runtime = Some(WasmRuntime::default());
-        let storage = DbStorage::<MemoryStore,_>::make_test_storage(wasm_runtime)
+        let storage = DbStorage::<MemoryStore, _>::make_test_storage(wasm_runtime)
             .now_or_never()
             .expect("execution of DbStorage::new should not await anything");
         let clock = storage.clock.clone();
@@ -133,7 +133,7 @@ impl TestValidator {
     }
 
     /// Returns the locked [`WorkerState`] of this validator.
-    pub(crate) fn worker(&self) -> WorkerState<DbStorage<MemoryStore,TestClock>> {
+    pub(crate) fn worker(&self) -> WorkerState<DbStorage<MemoryStore, TestClock>> {
         self.worker.clone()
     }
 

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -22,7 +22,8 @@ use linera_execution::{
     system::{OpenChainConfig, SystemOperation, OPEN_CHAIN_MESSAGE_INDEX},
     WasmRuntime,
 };
-use linera_storage::{MemoryStorage, Storage, TestClock};
+use linera_views::memory::MemoryStore;
+use linera_storage::{DbStorage, Storage, TestClock};
 use serde::Serialize;
 
 use super::ActiveChain;
@@ -41,7 +42,7 @@ use crate::ContractAbi;
 pub struct TestValidator {
     key_pair: KeyPair,
     committee: Committee,
-    worker: WorkerState<MemoryStorage<TestClock>>,
+    worker: WorkerState<DbStorage<MemoryStore,TestClock>>,
     clock: TestClock,
     chains: Arc<DashMap<ChainId, ActiveChain>>,
 }
@@ -64,9 +65,9 @@ impl TestValidator {
         let key_pair = KeyPair::generate();
         let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
         let wasm_runtime = Some(WasmRuntime::default());
-        let storage = MemoryStorage::make_test_storage(wasm_runtime)
+        let storage = DbStorage::<MemoryStore,_>::make_test_storage(wasm_runtime)
             .now_or_never()
-            .expect("execution of MemoryStorage::new should not await anything");
+            .expect("execution of DbStorage::new should not await anything");
         let clock = storage.clock.clone();
         let worker = WorkerState::new(
             "Single validator node".to_string(),
@@ -132,7 +133,7 @@ impl TestValidator {
     }
 
     /// Returns the locked [`WorkerState`] of this validator.
-    pub(crate) fn worker(&self) -> WorkerState<MemoryStorage<TestClock>> {
+    pub(crate) fn worker(&self) -> WorkerState<DbStorage<MemoryStore,TestClock>> {
         self.worker.clone()
     }
 

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -22,7 +22,7 @@ use linera_base::{
 use linera_client::storage::{StorageConfig, StorageConfigNamespace};
 use linera_execution::ResourceControlPolicy;
 #[cfg(all(feature = "storage-service", with_testing))]
-use linera_storage_service::storage_service_test_endpoint;
+use linera_storage_service::common::storage_service_test_endpoint;
 #[cfg(all(feature = "scylladb", with_testing))]
 use linera_views::scylla_db::create_scylla_db_test_uri;
 use tempfile::{tempdir, TempDir};

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -24,10 +24,10 @@ use linera_core::{
 };
 use linera_execution::committee::{Committee, ValidatorName};
 use linera_service::node_service::NodeService;
-use linera_storage::{MemoryStorage, Storage};
+use linera_storage::{DbStorage, Storage};
 use linera_version::VersionInfo;
 use linera_views::{
-    memory::{MemoryStoreConfig, TEST_MEMORY_MAX_STREAM_QUERIES},
+    memory::{MemoryStore, MemoryStoreConfig, TEST_MEMORY_MAX_STREAM_QUERIES},
     views::ViewError,
 };
 
@@ -163,7 +163,7 @@ async fn main() -> std::io::Result<()> {
     let store_config = MemoryStoreConfig::new(TEST_MEMORY_MAX_STREAM_QUERIES);
     let namespace = "schema_export";
     let root_key = &[];
-    let storage = MemoryStorage::initialize(store_config, namespace, root_key, None)
+    let storage = DbStorage::<MemoryStore, _>::initialize(store_config, namespace, root_key, None)
         .await
         .expect("storage");
     let config = ChainListenerConfig::default();

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -17,7 +17,8 @@ use linera_core::{
     client::ChainClient,
     test_utils::{FaultType, MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
 };
-use linera_storage::{MemoryStorage, TestClock};
+use linera_views::memory::MemoryStore;
+use linera_storage::{DbStorage, TestClock};
 
 use super::MutationRoot;
 
@@ -26,7 +27,7 @@ struct ClientContext {
     update_calls: usize,
 }
 
-type TestStorage = MemoryStorage<TestClock>;
+type TestStorage = DbStorage<MemoryStore, TestClock>;
 type TestProvider = NodeProvider<TestStorage>;
 
 #[async_trait]
@@ -91,7 +92,7 @@ async fn test_faucet_rate_limiting() {
 
 #[test]
 fn test_multiply() {
-    let mul = MutationRoot::<(), MemoryStorage<TestClock>, ()>::multiply;
+    let mul = MutationRoot::<(), DbStorage<MemoryStore, TestClock>, ()>::multiply;
     assert_eq!(mul((1 << 127) + (1 << 63), 1 << 63), [1 << 62, 1 << 62, 0]);
     assert_eq!(mul(u128::MAX, u64::MAX), [u64::MAX - 1, u64::MAX, 1]);
 }

--- a/linera-service/src/unit_tests/faucet.rs
+++ b/linera-service/src/unit_tests/faucet.rs
@@ -17,8 +17,8 @@ use linera_core::{
     client::ChainClient,
     test_utils::{FaultType, MemoryStorageBuilder, NodeProvider, StorageBuilder as _, TestBuilder},
 };
-use linera_views::memory::MemoryStore;
 use linera_storage::{DbStorage, TestClock};
+use linera_views::memory::MemoryStore;
 
 use super::MutationRoot;
 

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -379,7 +379,7 @@ impl ServiceStoreClientInternal {
 impl AdminKeyValueStore for ServiceStoreClientInternal {
     type Config = ServiceStoreConfig;
 
-    async fn get_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
+    async fn new_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
         let endpoint = storage_service_test_endpoint()?;
         service_config_from_endpoint(&endpoint)
     }
@@ -529,7 +529,7 @@ pub async fn storage_service_check_validity(endpoint: &str) -> Result<(), Servic
 /// Creates a test store with an endpoint. The namespace is random.
 #[cfg(with_testing)]
 pub async fn create_service_test_store() -> Result<ServiceStoreClientInternal, ServiceStoreError> {
-    let config = ServiceStoreClientInternal::get_test_config().await?;
+    let config = ServiceStoreClientInternal::new_test_config().await?;
     let namespace = generate_test_namespace();
     let root_key = &[];
     ServiceStoreClientInternal::connect(&config, &namespace, root_key).await
@@ -605,8 +605,8 @@ impl WritableKeyValueStore for ServiceStoreClient {
 impl AdminKeyValueStore for ServiceStoreClient {
     type Config = ServiceStoreConfig;
 
-    async fn get_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
-        ServiceStoreClientInternal::get_test_config().await
+    async fn new_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
+        ServiceStoreClientInternal::new_test_config().await
     }
 
     async fn connect(

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -22,7 +22,10 @@ use tonic::transport::{Channel, Endpoint};
 #[cfg(with_metrics)]
 use crate::common::STORAGE_SERVICE_METRICS;
 use crate::{
-    common::{storage_service_test_endpoint, KeyTag, ServiceStoreConfig, ServiceStoreError, MAX_PAYLOAD_SIZE},
+    common::{
+        storage_service_test_endpoint, KeyTag, ServiceStoreConfig, ServiceStoreError,
+        MAX_PAYLOAD_SIZE,
+    },
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
         KeyValueAppend, ReplyContainsKey, ReplyContainsKeys, ReplyExistsNamespace,

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -22,7 +22,7 @@ use tonic::transport::{Channel, Endpoint};
 #[cfg(with_metrics)]
 use crate::common::STORAGE_SERVICE_METRICS;
 use crate::{
-    common::{KeyTag, ServiceStoreConfig, ServiceStoreError, MAX_PAYLOAD_SIZE},
+    common::{storage_service_test_endpoint, KeyTag, ServiceStoreConfig, ServiceStoreError, MAX_PAYLOAD_SIZE},
     key_value_store::{
         statement::Operation, store_processor_client::StoreProcessorClient, KeyValue,
         KeyValueAppend, ReplyContainsKey, ReplyContainsKeys, ReplyExistsNamespace,
@@ -376,6 +376,11 @@ impl ServiceStoreClientInternal {
 impl AdminKeyValueStore for ServiceStoreClientInternal {
     type Config = ServiceStoreConfig;
 
+    async fn get_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
+        let endpoint = storage_service_test_endpoint()?;
+        service_config_from_endpoint(&endpoint)
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,
@@ -520,10 +525,8 @@ pub async fn storage_service_check_validity(endpoint: &str) -> Result<(), Servic
 
 /// Creates a test store with an endpoint. The namespace is random.
 #[cfg(with_testing)]
-pub async fn create_service_test_store(
-    endpoint: &str,
-) -> Result<ServiceStoreClientInternal, ServiceStoreError> {
-    let config = service_config_from_endpoint(endpoint).unwrap();
+pub async fn create_service_test_store() -> Result<ServiceStoreClientInternal, ServiceStoreError> {
+    let config = ServiceStoreClientInternal::get_test_config().await?;
     let namespace = generate_test_namespace();
     let root_key = &[];
     ServiceStoreClientInternal::connect(&config, &namespace, root_key).await
@@ -598,6 +601,10 @@ impl WritableKeyValueStore for ServiceStoreClient {
 
 impl AdminKeyValueStore for ServiceStoreClient {
     type Config = ServiceStoreConfig;
+
+    async fn get_test_config() -> Result<ServiceStoreConfig, ServiceStoreError> {
+        ServiceStoreClientInternal::get_test_config().await
+    }
 
     async fn connect(
         config: &Self::Config,

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -65,6 +65,10 @@ pub enum ServiceStoreError {
     #[error(transparent)]
     TransportError(#[from] tonic::transport::Error),
 
+    /// Var error
+    #[error(transparent)]
+    VarError(#[from] std::env::VarError),
+
     /// An error occurred during BCS serialization
     #[error("An error occurred during BCS serialization")]
     Serialization(#[from] bcs::Error),
@@ -90,6 +94,10 @@ pub fn create_shared_store_common_config() -> CommonStoreConfig {
         max_stream_queries: TEST_SHARED_STORE_MAX_STREAM_QUERIES,
         cache_size: usize::MAX,
     }
+}
+
+pub fn storage_service_test_endpoint() -> Result<String, ServiceStoreError> {
+    Ok(std::env::var("LINERA_STORAGE_SERVICE")?)
 }
 
 #[cfg(with_metrics)]

--- a/linera-storage-service/src/lib.rs
+++ b/linera-storage-service/src/lib.rs
@@ -12,10 +12,6 @@ pub mod key_value_store {
     tonic::include_proto!("key_value_store.v1");
 }
 
-pub fn storage_service_test_endpoint() -> anyhow::Result<String> {
-    Ok(std::env::var("LINERA_STORAGE_SERVICE")?)
-}
-
 pub mod child;
 pub mod client;
 pub mod common;

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -5,8 +5,7 @@
 
 use anyhow::Result;
 use linera_storage_service::{
-    client::{create_service_test_store, service_config_from_endpoint, ServiceStoreClient},
-    storage_service_test_endpoint,
+    client::{create_service_test_store, ServiceStoreClient},
 };
 use linera_views::{
     batch::Batch,
@@ -42,8 +41,7 @@ async fn test_storage_service_writes_from_state() -> Result<()> {
 
 #[tokio::test]
 async fn test_storage_service_admin() -> Result<()> {
-    let config = service_config_from_endpoint()?;
-    admin_test::<ServiceStoreClient>(&config).await;
+    admin_test::<ServiceStoreClient>().await;
     Ok(())
 }
 

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -4,9 +4,7 @@
 #![cfg(feature = "storage-service")]
 
 use anyhow::Result;
-use linera_storage_service::{
-    client::{create_service_test_store, ServiceStoreClient},
-};
+use linera_storage_service::client::{create_service_test_store, ServiceStoreClient};
 use linera_views::{
     batch::Batch,
     test_utils,

--- a/linera-storage-service/tests/store_test.rs
+++ b/linera-storage-service/tests/store_test.rs
@@ -19,9 +19,8 @@ use linera_views::{
 
 #[tokio::test]
 async fn test_storage_service_reads() -> Result<()> {
-    let endpoint = storage_service_test_endpoint()?;
     for scenario in get_random_test_scenarios() {
-        let key_value_store = create_service_test_store(&endpoint).await?;
+        let key_value_store = create_service_test_store().await?;
         run_reads(key_value_store, scenario).await;
     }
     Ok(())
@@ -29,32 +28,28 @@ async fn test_storage_service_reads() -> Result<()> {
 
 #[tokio::test]
 async fn test_storage_service_writes_from_blank() -> Result<()> {
-    let endpoint = storage_service_test_endpoint()?;
-    let key_value_store = create_service_test_store(&endpoint).await?;
+    let key_value_store = create_service_test_store().await?;
     run_writes_from_blank(&key_value_store).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_storage_service_writes_from_state() -> Result<()> {
-    let endpoint = storage_service_test_endpoint()?;
-    let key_value_store = create_service_test_store(&endpoint).await?;
+    let key_value_store = create_service_test_store().await?;
     run_writes_from_state(&key_value_store).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_storage_service_admin() -> Result<()> {
-    let endpoint = storage_service_test_endpoint()?;
-    let config = service_config_from_endpoint(&endpoint)?;
+    let config = service_config_from_endpoint()?;
     admin_test::<ServiceStoreClient>(&config).await;
     Ok(())
 }
 
 #[tokio::test]
 async fn test_storage_service_big_raw_write() -> Result<()> {
-    let endpoint = storage_service_test_endpoint()?;
-    let key_value_store = create_service_test_store(&endpoint).await?;
+    let key_value_store = create_service_test_store().await?;
     let n = 5000000;
     let mut rng = test_utils::make_deterministic_rng();
     let vector = get_random_byte_vector(&mut rng, &[], n);

--- a/linera-storage/Cargo.toml
+++ b/linera-storage/Cargo.toml
@@ -50,9 +50,6 @@ prometheus.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-linera-storage-service.workspace = true
-
 [dev-dependencies]
 anyhow.workspace = true
 linera-storage = { path = ".", features = ["test"] }

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -824,7 +824,7 @@ where
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let config = Client::get_test_config().await.expect("config");
+        let config = Client::new_test_config().await.unwrap();
         let namespace = generate_test_namespace();
         let root_key = &[];
         DbStorage::<Client, TestClock>::new_for_testing(
@@ -835,7 +835,7 @@ where
             TestClock::new(),
         )
         .await
-        .expect("storage")
+        .unwrap()
     }
 
     pub async fn new_for_testing(

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -29,8 +29,8 @@ use linera_views::{
 use serde::{Deserialize, Serialize};
 #[cfg(with_testing)]
 use {
-    linera_views::test_utils::generate_test_namespace,
     futures::channel::oneshot::{self, Receiver},
+    linera_views::test_utils::generate_test_namespace,
     std::{cmp::Reverse, collections::BTreeMap},
 };
 #[cfg(with_metrics)]
@@ -855,4 +855,3 @@ where
         Ok(Self::create(storage, clock))
     }
 }
-

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -7,7 +7,8 @@ use {
     crate::db_storage::{DbStorageInner, TestClock},
     linera_execution::WasmRuntime,
     linera_views::{
-        dynamo_db::{create_dynamo_db_test_config, DynamoDbStoreConfig, DynamoDbStoreError},
+        dynamo_db::{DynamoDbStoreConfig, DynamoDbStoreError},
+        common::{AdminKeyValueStore as _},
         test_utils::generate_test_namespace,
     },
 };
@@ -19,11 +20,11 @@ pub type DynamoDbStorage<C> = DbStorage<DynamoDbStore, C>;
 #[cfg(with_testing)]
 impl DynamoDbStorage<TestClock> {
     pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let store_config = create_dynamo_db_test_config().await;
+        let config = DynamoDbStore::get_test_config().await.expect("config");
         let namespace = generate_test_namespace();
         let root_key = &[];
         DynamoDbStorage::new_for_testing(
-            store_config,
+            config,
             &namespace,
             root_key,
             wasm_runtime,

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Zefchain Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use linera_views::dynamo_db::DynamoDbStore;
-
-use crate::db_storage::DbStorage;
-
-pub type DynamoDbStorage<C> = DbStorage<DynamoDbStore, C>;

--- a/linera-storage/src/dynamo_db.rs
+++ b/linera-storage/src/dynamo_db.rs
@@ -2,52 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::dynamo_db::DynamoDbStore;
-#[cfg(with_testing)]
-use {
-    crate::db_storage::{DbStorageInner, TestClock},
-    linera_execution::WasmRuntime,
-    linera_views::{
-        dynamo_db::{DynamoDbStoreConfig, DynamoDbStoreError},
-        common::{AdminKeyValueStore as _},
-        test_utils::generate_test_namespace,
-    },
-};
 
 use crate::db_storage::DbStorage;
 
 pub type DynamoDbStorage<C> = DbStorage<DynamoDbStore, C>;
-
-#[cfg(with_testing)]
-impl DynamoDbStorage<TestClock> {
-    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let config = DynamoDbStore::get_test_config().await.expect("config");
-        let namespace = generate_test_namespace();
-        let root_key = &[];
-        DynamoDbStorage::new_for_testing(
-            config,
-            &namespace,
-            root_key,
-            wasm_runtime,
-            TestClock::new(),
-        )
-        .await
-        .expect("storage")
-    }
-
-    pub async fn new_for_testing(
-        store_config: DynamoDbStoreConfig,
-        namespace: &str,
-        root_key: &[u8],
-        wasm_runtime: Option<WasmRuntime>,
-        clock: TestClock,
-    ) -> Result<Self, DynamoDbStoreError> {
-        let storage = DbStorageInner::<DynamoDbStore>::new_for_testing(
-            store_config,
-            namespace,
-            root_key,
-            wasm_runtime,
-        )
-        .await?;
-        Ok(Self::create(storage, clock))
-    }
-}

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -6,15 +6,6 @@
 #![deny(clippy::large_futures)]
 
 mod db_storage;
-#[cfg(with_dynamodb)]
-mod dynamo_db;
-mod memory;
-#[cfg(with_rocksdb)]
-mod rocks_db;
-#[cfg(with_scylladb)]
-mod scylla_db;
-#[cfg(not(target_arch = "wasm32"))]
-mod service;
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -52,18 +43,7 @@ pub use crate::db_storage::{
     READ_CERTIFICATE_COUNTER, READ_HASHED_CERTIFICATE_VALUE_COUNTER, WRITE_CERTIFICATE_COUNTER,
     WRITE_HASHED_CERTIFICATE_VALUE_COUNTER,
 };
-#[cfg(with_dynamodb)]
-pub use crate::dynamo_db::DynamoDbStorage;
-#[cfg(with_rocksdb)]
-pub use crate::rocks_db::RocksDbStorage;
-#[cfg(with_scylladb)]
-pub use crate::scylla_db::ScyllaDbStorage;
-#[cfg(not(target_arch = "wasm32"))]
-pub use crate::service::ServiceStorage;
-pub use crate::{
-    db_storage::{Clock, DbStorage, WallClock},
-    memory::MemoryStorage,
-};
+pub use crate::db_storage::{Clock, DbStorage, WallClock};
 
 /// Communicate with a persistent storage using the "views" abstraction.
 #[async_trait]

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -38,12 +38,12 @@ use linera_views::{
 
 #[cfg(with_testing)]
 pub use crate::db_storage::TestClock;
+pub use crate::db_storage::{Clock, DbStorage, WallClock};
 #[cfg(with_metrics)]
 pub use crate::db_storage::{
     READ_CERTIFICATE_COUNTER, READ_HASHED_CERTIFICATE_VALUE_COUNTER, WRITE_CERTIFICATE_COUNTER,
     WRITE_HASHED_CERTIFICATE_VALUE_COUNTER,
 };
-pub use crate::db_storage::{Clock, DbStorage, WallClock};
 
 /// Communicate with a persistent storage using the "views" abstraction.
 #[async_trait]

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -2,51 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::memory::MemoryStore;
-#[cfg(with_testing)]
-use {
-    crate::db_storage::{DbStorageInner, TestClock},
-    linera_execution::WasmRuntime,
-    linera_views::{
-        memory::{create_memory_store_test_config, MemoryStoreConfig, MemoryStoreError},
-        test_utils::generate_test_namespace,
-    },
-};
 
 use crate::db_storage::DbStorage;
 
 pub type MemoryStorage<C> = DbStorage<MemoryStore, C>;
-
-#[cfg(with_testing)]
-impl MemoryStorage<TestClock> {
-    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let store_config = create_memory_store_test_config();
-        let namespace = generate_test_namespace();
-        let root_key = &[];
-        MemoryStorage::new_for_testing(
-            store_config,
-            &namespace,
-            root_key,
-            wasm_runtime,
-            TestClock::new(),
-        )
-        .await
-        .expect("storage")
-    }
-
-    pub async fn new_for_testing(
-        store_config: MemoryStoreConfig,
-        namespace: &str,
-        root_key: &[u8],
-        wasm_runtime: Option<WasmRuntime>,
-        clock: TestClock,
-    ) -> Result<Self, MemoryStoreError> {
-        let storage = DbStorageInner::<MemoryStore>::new_for_testing(
-            store_config,
-            namespace,
-            root_key,
-            wasm_runtime,
-        )
-        .await?;
-        Ok(Self::create(storage, clock))
-    }
-}

--- a/linera-storage/src/memory.rs
+++ b/linera-storage/src/memory.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Zefchain Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use linera_views::memory::MemoryStore;
-
-use crate::db_storage::DbStorage;
-
-pub type MemoryStorage<C> = DbStorage<MemoryStore, C>;

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Zefchain Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use linera_views::rocks_db::RocksDbStore;
-
-use crate::db_storage::DbStorage;
-
-pub type RocksDbStorage<C> = DbStorage<RocksDbStore, C>;

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -6,7 +6,8 @@ use linera_views::rocks_db::RocksDbStore;
 use {
     crate::db_storage::{DbStorageInner, TestClock},
     linera_execution::WasmRuntime,
-    linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStoreConfig, RocksDbStoreError},
+    linera_views::rocks_db::{RocksDbStoreConfig, RocksDbStoreError},
+    linera_views::common::{AdminKeyValueStore as _},
     linera_views::test_utils::generate_test_namespace,
 };
 
@@ -17,11 +18,11 @@ pub type RocksDbStorage<C> = DbStorage<RocksDbStore, C>;
 #[cfg(with_testing)]
 impl RocksDbStorage<TestClock> {
     pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let store_config = create_rocks_db_test_config().await;
+        let config = RocksDbStore::get_test_config().await.expect("config");
         let namespace = generate_test_namespace();
         let root_key = &[];
         RocksDbStorage::new_for_testing(
-            store_config,
+            config,
             &namespace,
             root_key,
             wasm_runtime,

--- a/linera-storage/src/rocks_db.rs
+++ b/linera-storage/src/rocks_db.rs
@@ -2,50 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::rocks_db::RocksDbStore;
-#[cfg(with_testing)]
-use {
-    crate::db_storage::{DbStorageInner, TestClock},
-    linera_execution::WasmRuntime,
-    linera_views::rocks_db::{RocksDbStoreConfig, RocksDbStoreError},
-    linera_views::common::{AdminKeyValueStore as _},
-    linera_views::test_utils::generate_test_namespace,
-};
 
 use crate::db_storage::DbStorage;
 
 pub type RocksDbStorage<C> = DbStorage<RocksDbStore, C>;
-
-#[cfg(with_testing)]
-impl RocksDbStorage<TestClock> {
-    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let config = RocksDbStore::get_test_config().await.expect("config");
-        let namespace = generate_test_namespace();
-        let root_key = &[];
-        RocksDbStorage::new_for_testing(
-            config,
-            &namespace,
-            root_key,
-            wasm_runtime,
-            TestClock::new(),
-        )
-        .await
-        .expect("storage")
-    }
-
-    pub async fn new_for_testing(
-        store_config: RocksDbStoreConfig,
-        namespace: &str,
-        root_key: &[u8],
-        wasm_runtime: Option<WasmRuntime>,
-        clock: TestClock,
-    ) -> Result<Self, RocksDbStoreError> {
-        let storage = DbStorageInner::<RocksDbStore>::new_for_testing(
-            store_config,
-            namespace,
-            root_key,
-            wasm_runtime,
-        )
-        .await?;
-        Ok(Self::create(storage, clock))
-    }
-}

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -6,9 +6,8 @@ use linera_views::scylla_db::ScyllaDbStore;
 use {
     crate::db_storage::{DbStorageInner, TestClock},
     linera_execution::WasmRuntime,
-    linera_views::scylla_db::{
-        create_scylla_db_test_config, ScyllaDbStoreConfig, ScyllaDbStoreError,
-    },
+    linera_views::scylla_db::{ScyllaDbStoreConfig, ScyllaDbStoreError},
+    linera_views::common::{AdminKeyValueStore as _},
     linera_views::test_utils::generate_test_namespace,
 };
 
@@ -19,7 +18,7 @@ pub type ScyllaDbStorage<C> = DbStorage<ScyllaDbStore, C>;
 #[cfg(with_testing)]
 impl ScyllaDbStorage<TestClock> {
     pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let store_config = create_scylla_db_test_config().await;
+        let store_config = ScyllaDbStore::get_test_config().await.expect("config");
         let namespace = generate_test_namespace();
         let root_key = &[];
         ScyllaDbStorage::new_for_testing(

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -2,50 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::scylla_db::ScyllaDbStore;
-#[cfg(with_testing)]
-use {
-    crate::db_storage::{DbStorageInner, TestClock},
-    linera_execution::WasmRuntime,
-    linera_views::scylla_db::{ScyllaDbStoreConfig, ScyllaDbStoreError},
-    linera_views::common::{AdminKeyValueStore as _},
-    linera_views::test_utils::generate_test_namespace,
-};
 
 use crate::db_storage::DbStorage;
 
 pub type ScyllaDbStorage<C> = DbStorage<ScyllaDbStore, C>;
-
-#[cfg(with_testing)]
-impl ScyllaDbStorage<TestClock> {
-    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let store_config = ScyllaDbStore::get_test_config().await.expect("config");
-        let namespace = generate_test_namespace();
-        let root_key = &[];
-        ScyllaDbStorage::new_for_testing(
-            store_config,
-            &namespace,
-            root_key,
-            wasm_runtime,
-            TestClock::new(),
-        )
-        .await
-        .expect("storage")
-    }
-
-    pub async fn new_for_testing(
-        store_config: ScyllaDbStoreConfig,
-        namespace: &str,
-        root_key: &[u8],
-        wasm_runtime: Option<WasmRuntime>,
-        clock: TestClock,
-    ) -> Result<Self, ScyllaDbStoreError> {
-        let storage = DbStorageInner::<ScyllaDbStore>::new_for_testing(
-            store_config,
-            namespace,
-            root_key,
-            wasm_runtime,
-        )
-        .await?;
-        Ok(Self::create(storage, clock))
-    }
-}

--- a/linera-storage/src/scylla_db.rs
+++ b/linera-storage/src/scylla_db.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Zefchain Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use linera_views::scylla_db::ScyllaDbStore;
-
-use crate::db_storage::DbStorage;
-
-pub type ScyllaDbStorage<C> = DbStorage<ScyllaDbStore, C>;

--- a/linera-storage/src/service.rs
+++ b/linera-storage/src/service.rs
@@ -2,53 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_storage_service::client::ServiceStoreClient;
-#[cfg(with_testing)]
-use {
-    crate::db_storage::{DbStorageInner, TestClock},
-    linera_execution::WasmRuntime,
-    linera_storage_service::{
-        client::service_config_from_endpoint,
-        common::{ServiceStoreConfig, ServiceStoreError},
-    },
-    linera_views::test_utils::generate_test_namespace,
-};
 
 use crate::db_storage::DbStorage;
 
 pub type ServiceStorage<C> = DbStorage<ServiceStoreClient, C>;
-
-#[cfg(with_testing)]
-impl ServiceStorage<TestClock> {
-    pub async fn make_test_storage(wasm_runtime: Option<WasmRuntime>) -> Self {
-        let endpoint = "127.0.0.1:8942";
-        let store_config = service_config_from_endpoint(endpoint).expect("store_config");
-        let namespace = generate_test_namespace();
-        let root_key = &[];
-        ServiceStorage::new_for_testing(
-            store_config,
-            &namespace,
-            root_key,
-            wasm_runtime,
-            TestClock::new(),
-        )
-        .await
-        .expect("storage")
-    }
-
-    pub async fn new_for_testing(
-        store_config: ServiceStoreConfig,
-        namespace: &str,
-        root_key: &[u8],
-        wasm_runtime: Option<WasmRuntime>,
-        clock: TestClock,
-    ) -> Result<Self, ServiceStoreError> {
-        let storage = DbStorageInner::<ServiceStoreClient>::new_for_testing(
-            store_config,
-            namespace,
-            root_key,
-            wasm_runtime,
-        )
-        .await?;
-        Ok(Self::create(storage, clock))
-    }
-}

--- a/linera-storage/src/service.rs
+++ b/linera-storage/src/service.rs
@@ -1,8 +1,0 @@
-// Copyright (c) Zefchain Labs, Inc.
-// SPDX-License-Identifier: Apache-2.0
-
-use linera_storage_service::client::ServiceStoreClient;
-
-use crate::db_storage::DbStorage;
-
-pub type ServiceStorage<C> = DbStorage<ServiceStoreClient, C>;

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -443,7 +443,7 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
     type Config: Send + Sync;
 
     /// Obtains a test config
-    async fn get_test_config() -> Result<Self::Config, Self::Error>;
+    async fn new_test_config() -> Result<Self::Config, Self::Error>;
 
     /// Connects to an existing namespace using the given configuration.
     async fn connect(

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -442,6 +442,9 @@ pub trait LocalAdminKeyValueStore: WithError + Sized {
     /// The configuration needed to interact with a new store.
     type Config: Send + Sync;
 
+    /// Obtains a test config
+    async fn get_test_config() -> Result<Self::Config, Self::Error>;
+
     /// Connects to an existing namespace using the given configuration.
     async fn connect(
         config: &Self::Config,

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -349,7 +349,7 @@ pub struct DynamoDbStoreConfig {
 impl AdminKeyValueStore for DynamoDbStoreInternal {
     type Config = DynamoDbStoreConfig;
 
-    async fn get_test_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreError> {
+    async fn new_test_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreError> {
         let common_config = create_dynamo_db_common_config();
         let use_localstack = true;
         let config = get_config(use_localstack).await?;
@@ -1040,8 +1040,8 @@ impl WritableKeyValueStore for DynamoDbStore {
 impl AdminKeyValueStore for DynamoDbStore {
     type Config = DynamoDbStoreConfig;
 
-    async fn get_test_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreError> {
-        DynamoDbStoreInternal::get_test_config().await
+    async fn new_test_config() -> Result<DynamoDbStoreConfig, DynamoDbStoreError> {
+        DynamoDbStoreInternal::new_test_config().await
     }
 
     async fn connect(
@@ -1324,7 +1324,7 @@ pub fn create_dynamo_db_common_config() -> CommonStoreConfig {
 /// Creates a basic client that can be used for tests.
 #[cfg(with_testing)]
 pub async fn create_dynamo_db_test_store() -> DynamoDbStore {
-    let config = DynamoDbStore::get_test_config().await.expect("config");
+    let config = DynamoDbStore::new_test_config().await.expect("config");
     let namespace = generate_test_namespace();
     let root_key = &[];
     DynamoDbStore::recreate_and_connect(&config, &namespace, root_key)

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -29,7 +29,6 @@ use linera_base::ensure;
 use thiserror::Error;
 #[cfg(with_testing)]
 use {
-    crate::lru_caching::TEST_CACHE_SIZE,
     crate::test_utils::generate_test_namespace,
     anyhow::Error,
     tokio::sync::{Mutex, MutexGuard},
@@ -46,7 +45,7 @@ use crate::{
         ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
-    lru_caching::LruCachingStore,
+    lru_caching::{LruCachingStore, TEST_CACHE_SIZE},
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
 };
 
@@ -171,11 +170,9 @@ const MAX_TRANSACT_WRITE_ITEM_TOTAL_SIZE: usize = 4000000;
 /// The DynamoDb database is potentially handling an infinite number of connections.
 /// However, for testing or some other purpose we really need to decrease the number of
 /// connections.
-#[cfg(with_testing)]
 const TEST_DYNAMO_DB_MAX_CONCURRENT_QUERIES: usize = 10;
 
 /// The number of entries in a stream of the tests can be controlled by this parameter for tests.
-#[cfg(with_testing)]
 const TEST_DYNAMO_DB_MAX_STREAM_QUERIES: usize = 10;
 
 /// Fundamental constants in DynamoDB: The maximum size of a TransactWriteItem is 100.

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -227,7 +227,7 @@ impl LocalWritableKeyValueStore for IndexedDbStore {
 impl LocalAdminKeyValueStore for IndexedDbStore {
     type Config = IndexedDbStoreConfig;
 
-    async fn get_test_config() -> Result<IndexedDbStoreConfig, IndexedDbStoreError> {
+    async fn new_test_config() -> Result<IndexedDbStoreConfig, IndexedDbStoreError> {
         Ok(IndexedDbStoreConfig::new(TEST_INDEX_DB_MAX_STREAM_QUERIES))
     }
 

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -37,7 +37,6 @@ impl IndexedDbStoreConfig {
 }
 
 /// The number of streams for the test
-#[cfg(with_testing)]
 pub const TEST_INDEX_DB_MAX_STREAM_QUERIES: usize = 10;
 
 const DATABASE_NAME: &str = "linera";
@@ -227,6 +226,10 @@ impl LocalWritableKeyValueStore for IndexedDbStore {
 
 impl LocalAdminKeyValueStore for IndexedDbStore {
     type Config = IndexedDbStoreConfig;
+
+    async fn get_test_config() -> Result<IndexedDbStoreConfig, IndexedDbStoreError> {
+        Ok(IndexedDbStoreConfig::new(TEST_INDEX_DB_MAX_STREAM_QUERIES))
+    }
 
     async fn connect(
         config: &Self::Config,

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -178,8 +178,8 @@ where
 {
     type Config = K::Config;
 
-    async fn get_test_config() -> Result<K::Config, Self::Error> {
-        K::get_test_config().await
+    async fn new_test_config() -> Result<K::Config, Self::Error> {
+        K::new_test_config().await
     }
 
     async fn connect(

--- a/linera-views/src/journaling.rs
+++ b/linera-views/src/journaling.rs
@@ -178,6 +178,10 @@ where
 {
     type Config = K::Config;
 
+    async fn get_test_config() -> Result<K::Config, Self::Error> {
+        K::get_test_config().await
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -305,7 +305,7 @@ impl MemoryStore {
 impl AdminKeyValueStore for MemoryStore {
     type Config = MemoryStoreConfig;
 
-    async fn get_test_config() -> Result<MemoryStoreConfig, MemoryStoreError> {
+    async fn new_test_config() -> Result<MemoryStoreConfig, MemoryStoreError> {
         let max_stream_queries = TEST_MEMORY_MAX_STREAM_QUERIES;
         let common_config = CommonStoreConfig {
             max_concurrent_queries: None,

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -305,6 +305,16 @@ impl MemoryStore {
 impl AdminKeyValueStore for MemoryStore {
     type Config = MemoryStoreConfig;
 
+    async fn get_test_config() -> Result<MemoryStoreConfig, MemoryStoreError> {
+        let max_stream_queries = TEST_MEMORY_MAX_STREAM_QUERIES;
+        let common_config = CommonStoreConfig {
+            max_concurrent_queries: None,
+            max_stream_queries,
+            cache_size: 1000,
+        };
+        Ok(MemoryStoreConfig { common_config })
+    }
+
     async fn connect(
         config: &Self::Config,
         namespace: &str,

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -18,17 +18,17 @@ use thiserror::Error;
 use crate::metering::{
     MeteredStore, LRU_CACHING_METRICS, ROCKS_DB_METRICS, VALUE_SPLITTING_METRICS,
 };
+#[cfg(with_testing)]
+use crate::test_utils::generate_test_namespace;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
         get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
         ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
-    lru_caching::{TEST_CACHE_SIZE, LruCachingStore},
+    lru_caching::{LruCachingStore, TEST_CACHE_SIZE},
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
 };
-#[cfg(with_testing)]
-use crate::test_utils::generate_test_namespace;
 
 /// The number of streams for the test
 const TEST_ROCKS_DB_MAX_STREAM_QUERIES: usize = 10;
@@ -588,7 +588,6 @@ impl WritableKeyValueStore for RocksDbStore {
 
 impl AdminKeyValueStore for RocksDbStore {
     type Config = RocksDbStoreConfig;
-
 
     async fn get_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
         RocksDbStoreInternal::get_test_config().await

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -342,7 +342,7 @@ fn root_key_as_string(root_key: &[u8]) -> String {
 impl AdminKeyValueStore for RocksDbStoreInternal {
     type Config = RocksDbStoreConfig;
 
-    async fn get_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
+    async fn new_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
         let path_with_guard = create_rocks_db_test_path();
         let common_config = create_rocks_db_common_config();
         Ok(RocksDbStoreConfig {
@@ -492,7 +492,7 @@ pub fn create_rocks_db_test_path() -> PathWithGuard {
 /// out of scope then the RocksDB client can become unstable.
 #[cfg(with_testing)]
 pub async fn create_rocks_db_test_store() -> RocksDbStore {
-    let config = RocksDbStore::get_test_config().await.expect("config");
+    let config = RocksDbStore::new_test_config().await.expect("config");
     let namespace = generate_test_namespace();
     let root_key = &[];
     RocksDbStore::recreate_and_connect(&config, &namespace, root_key)
@@ -589,8 +589,8 @@ impl WritableKeyValueStore for RocksDbStore {
 impl AdminKeyValueStore for RocksDbStore {
     type Config = RocksDbStoreConfig;
 
-    async fn get_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
-        RocksDbStoreInternal::get_test_config().await
+    async fn new_test_config() -> Result<RocksDbStoreConfig, RocksDbStoreError> {
+        RocksDbStoreInternal::new_test_config().await
     }
 
     async fn connect(

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -39,6 +39,8 @@ use thiserror::Error;
 
 #[cfg(with_metrics)]
 use crate::metering::{MeteredStore, LRU_CACHING_METRICS, SCYLLA_DB_METRICS};
+#[cfg(with_testing)]
+use crate::test_utils::generate_test_namespace;
 use crate::{
     batch::{Batch, UnorderedBatch},
     common::{
@@ -46,11 +48,9 @@ use crate::{
         ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
-    lru_caching::LruCachingStore,
+    lru_caching::{LruCachingStore, TEST_CACHE_SIZE},
     value_splitting::DatabaseConsistencyError,
 };
-#[cfg(with_testing)]
-use crate::{lru_caching::TEST_CACHE_SIZE, test_utils::generate_test_namespace};
 
 /// The client for ScyllaDb.
 /// * The session allows to pass queries
@@ -373,11 +373,9 @@ impl ScyllaDbClient {
 }
 
 /// We limit the number of connections that can be done for tests.
-#[cfg(with_testing)]
 const TEST_SCYLLA_DB_MAX_CONCURRENT_QUERIES: usize = 10;
 
 /// The number of connections in the stream is limited for tests.
-#[cfg(with_testing)]
 const TEST_SCYLLA_DB_MAX_STREAM_QUERIES: usize = 10;
 
 /// The maximal size of an operation on ScyllaDB seems to be 16M

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -572,7 +572,7 @@ fn get_big_root_key(root_key: &[u8]) -> Vec<u8> {
 impl AdminKeyValueStore for ScyllaDbStoreInternal {
     type Config = ScyllaDbStoreConfig;
 
-    async fn get_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
+    async fn new_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
         let uri = create_scylla_db_test_uri();
         let common_config = create_scylla_db_common_config();
         Ok(ScyllaDbStoreConfig { uri, common_config })
@@ -872,8 +872,8 @@ impl WritableKeyValueStore for ScyllaDbStore {
 impl AdminKeyValueStore for ScyllaDbStore {
     type Config = ScyllaDbStoreConfig;
 
-    async fn get_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
-        ScyllaDbStoreInternal::get_test_config().await
+    async fn new_test_config() -> Result<ScyllaDbStoreConfig, ScyllaDbStoreError> {
+        ScyllaDbStoreInternal::new_test_config().await
     }
 
     async fn connect(
@@ -952,7 +952,7 @@ pub fn create_scylla_db_test_uri() -> String {
 /// Creates a ScyllaDB test store.
 #[cfg(with_testing)]
 pub async fn create_scylla_db_test_store() -> ScyllaDbStore {
-    let config = ScyllaDbStore::get_test_config().await.expect("config");
+    let config = ScyllaDbStore::new_test_config().await.expect("config");
     let namespace = generate_test_namespace();
     let root_key = &[];
     ScyllaDbStore::recreate_and_connect(&config, &namespace, root_key)

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -697,7 +697,7 @@ pub async fn admin_test<S: LocalKeyValueStore>()
 where
     S::Error: Debug,
 {
-    let config = S::get_test_config().await.expect("config");
+    let config = S::new_test_config().await.expect("config");
     let prefix = generate_test_namespace();
     let namespaces = namespaces_with_prefix::<S>(&config, &prefix).await;
     assert_eq!(namespaces.len(), 0);

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -15,7 +15,7 @@ use crate::dynamo_db::{
 #[cfg(with_rocksdb)]
 use crate::rocks_db::{RocksDbContext, RocksDbStore};
 #[cfg(with_scylladb)]
-use crate::scylla_db::{create_scylla_db_test_config, ScyllaDbContext, ScyllaDbStore};
+use crate::scylla_db::{ScyllaDbContext, ScyllaDbStore};
 use crate::{
     batch::Batch,
     common::Context,
@@ -267,7 +267,7 @@ impl TestContextFactory for ScyllaDbContextFactory {
     type Context = ScyllaDbContext<()>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        let config = create_scylla_db_test_config().await;
+        let config = ScyllaDbStore::get_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
         let store = ScyllaDbStore::recreate_and_connect(&config, &namespace, root_key).await?;

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -216,7 +216,7 @@ impl TestContextFactory for RocksDbContextFactory {
     type Context = RocksDbContext<()>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        let config = RocksDbStore::get_test_config().await?;
+        let config = RocksDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
         let store = RocksDbStore::recreate_and_connect(&config, &namespace, root_key).await?;
@@ -266,7 +266,7 @@ impl TestContextFactory for ScyllaDbContextFactory {
     type Context = ScyllaDbContext<()>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        let config = ScyllaDbStore::get_test_config().await?;
+        let config = ScyllaDbStore::new_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
         let store = ScyllaDbStore::recreate_and_connect(&config, &namespace, root_key).await?;

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -219,8 +219,7 @@ impl TestContextFactory for RocksDbContextFactory {
         let config = RocksDbStore::get_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
-        let store = RocksDbStore::recreate_and_connect(&config, &namespace, root_key)
-            .await?;
+        let store = RocksDbStore::recreate_and_connect(&config, &namespace, root_key).await?;
         let context = RocksDbContext::new(store, ());
 
         Ok(context)

--- a/linera-views/src/unit_tests/views.rs
+++ b/linera-views/src/unit_tests/views.rs
@@ -13,7 +13,7 @@ use crate::dynamo_db::{
     LocalStackTestContext,
 };
 #[cfg(with_rocksdb)]
-use crate::rocks_db::{create_rocks_db_test_config, RocksDbContext, RocksDbStore};
+use crate::rocks_db::{RocksDbContext, RocksDbStore};
 #[cfg(with_scylladb)]
 use crate::scylla_db::{create_scylla_db_test_config, ScyllaDbContext, ScyllaDbStore};
 use crate::{
@@ -216,12 +216,11 @@ impl TestContextFactory for RocksDbContextFactory {
     type Context = RocksDbContext<()>;
 
     async fn new_context(&mut self) -> Result<Self::Context, anyhow::Error> {
-        let store_config = create_rocks_db_test_config().await;
+        let config = RocksDbStore::get_test_config().await?;
         let namespace = generate_test_namespace();
         let root_key = &[];
-        let store = RocksDbStore::recreate_and_connect(&store_config, &namespace, root_key)
-            .await
-            .expect("store");
+        let store = RocksDbStore::recreate_and_connect(&config, &namespace, root_key)
+            .await?;
         let context = RocksDbContext::new(store, ());
 
         Ok(context)

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "dynamodb")]
-use linera_views::dynamo_db::{create_dynamo_db_test_config, DynamoDbStore};
+use linera_views::dynamo_db::DynamoDbStore;
 #[cfg(feature = "rocksdb")]
 use linera_views::rocks_db::RocksDbStore;
 #[cfg(feature = "scylladb")]
@@ -29,7 +29,7 @@ async fn admin_test_rocks_db() {
 #[cfg(feature = "dynamodb")]
 #[tokio::test]
 async fn admin_test_dynamo_db() {
-    let config = create_dynamo_db_test_config().await;
+    let config = DynamoDbStore::get_test_config().await.expect("config");
     admin_test::<DynamoDbStore>(&config).await;
 }
 

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -7,10 +7,7 @@ use linera_views::dynamo_db::DynamoDbStore;
 use linera_views::rocks_db::RocksDbStore;
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::ScyllaDbStore;
-use linera_views::{
-    memory::MemoryStore,
-    test_utils::admin_test,
-};
+use linera_views::{memory::MemoryStore, test_utils::admin_test};
 
 #[tokio::test]
 async fn admin_test_memory() {

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -6,7 +6,7 @@ use linera_views::dynamo_db::DynamoDbStore;
 #[cfg(feature = "rocksdb")]
 use linera_views::rocks_db::RocksDbStore;
 #[cfg(feature = "scylladb")]
-use linera_views::scylla_db::{create_scylla_db_test_config, ScyllaDbStore};
+use linera_views::scylla_db::ScyllaDbStore;
 use linera_views::{
     memory::MemoryStore,
     common::{AdminKeyValueStore as _},
@@ -36,6 +36,6 @@ async fn admin_test_dynamo_db() {
 #[cfg(feature = "scylladb")]
 #[tokio::test]
 async fn admin_test_scylla_db() {
-    let config = create_scylla_db_test_config().await;
+    let config = ScyllaDbStore::get_test_config().await.expect("config");
     admin_test::<ScyllaDbStore>(&config).await;
 }

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -9,33 +9,28 @@ use linera_views::rocks_db::RocksDbStore;
 use linera_views::scylla_db::ScyllaDbStore;
 use linera_views::{
     memory::MemoryStore,
-    common::{AdminKeyValueStore as _},
     test_utils::admin_test,
 };
 
 #[tokio::test]
 async fn admin_test_memory() {
-    let config = MemoryStore::get_test_config().await.expect("config");
-    admin_test::<MemoryStore>(&config).await;
+    admin_test::<MemoryStore>().await;
 }
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn admin_test_rocks_db() {
-    let config = RocksDbStore::get_test_config().await.expect("config");
-    admin_test::<RocksDbStore>(&config).await;
+    admin_test::<RocksDbStore>().await;
 }
 
 #[cfg(feature = "dynamodb")]
 #[tokio::test]
 async fn admin_test_dynamo_db() {
-    let config = DynamoDbStore::get_test_config().await.expect("config");
-    admin_test::<DynamoDbStore>(&config).await;
+    admin_test::<DynamoDbStore>().await;
 }
 
 #[cfg(feature = "scylladb")]
 #[tokio::test]
 async fn admin_test_scylla_db() {
-    let config = ScyllaDbStore::get_test_config().await.expect("config");
-    admin_test::<ScyllaDbStore>(&config).await;
+    admin_test::<ScyllaDbStore>().await;
 }

--- a/linera-views/tests/admin_tests.rs
+++ b/linera-views/tests/admin_tests.rs
@@ -4,24 +4,25 @@
 #[cfg(feature = "dynamodb")]
 use linera_views::dynamo_db::{create_dynamo_db_test_config, DynamoDbStore};
 #[cfg(feature = "rocksdb")]
-use linera_views::rocks_db::{create_rocks_db_test_config, RocksDbStore};
+use linera_views::rocks_db::RocksDbStore;
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::{create_scylla_db_test_config, ScyllaDbStore};
 use linera_views::{
-    memory::{create_memory_store_test_config, MemoryStore},
+    memory::MemoryStore,
+    common::{AdminKeyValueStore as _},
     test_utils::admin_test,
 };
 
 #[tokio::test]
 async fn admin_test_memory() {
-    let config = create_memory_store_test_config();
+    let config = MemoryStore::get_test_config().await.expect("config");
     admin_test::<MemoryStore>(&config).await;
 }
 
 #[cfg(feature = "rocksdb")]
 #[tokio::test]
 async fn admin_test_rocks_db() {
-    let config = create_rocks_db_test_config().await;
+    let config = RocksDbStore::get_test_config().await.expect("config");
     admin_test::<RocksDbStore>(&config).await;
 }
 


### PR DESCRIPTION
## Motivation

The `linera_storage` contains a significant quantity of `store` specific code. This is due to the constraint of generating the test config.

## Proposal

The following was done:
* Introduce the `get_test_config` to the `AdminKeyValueStore`. Unfortunately, it was not possible to gate it with a `with_testing`.
* Introduce the corresponding entries to the stores and simplify the code.
* Move the code of the stores to the trait in `db_storage.rs` as it is now unified.
* Eliminate the files `memory.rs` and similar.
* Replace the `MemoryStorage` by `DbStorage<MemoryStore, _>` and appropriate.

This step simplifies the code, but there are surely other opportunities of unifying the source code.

## Test Plan

CI

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
