### PR TITLE
Enable `test` feature when testing `linera-sdk`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,6 +4567,7 @@ dependencies = [
  "linera-core",
  "linera-ethereum",
  "linera-execution",
+ "linera-sdk",
  "linera-sdk-derive",
  "linera-storage",
  "linera-views",

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -64,11 +64,12 @@ serde_json.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wasmtime.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+linera-sdk = { path = ".", features = ["test"] }
+tokio-test.workspace = true
+
 [build-dependencies]
 cfg_aliases.workspace = true
-
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio-test.workspace = true
 
 [[bin]]
 name = "wit-generator"


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
`cargo test -p linera-sdk --no-default-features` was running into a compile error. For some weird reason, the `with_testing` configuration alias was not being enabled when only `#[cfg(test)]` was active.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Enable the `test` feature when `#[cfg(test)]` is enabled, which makes it follow the same convention as used in other crates.

## Test Plan

<!-- How to test that the changes are correct. -->
Ran `cargo test -p linera-sdk --no-default-features` manually, and it now succeeds.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this just fixes compilation of an unreleased version.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
