### PR TITLE
Use `ruzstd` to decompress bytecodes in Wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4189,6 +4189,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand",
+ "ruzstd",
  "serde",
  "serde-name",
  "serde_bytes",
@@ -6583,6 +6584,16 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "ruzstd"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8b8f3d26bd9f945e5cbae77f7cdfbf37af9a66956f1115eb4516e45df519f4"
+dependencies = [
+ "byteorder",
+ "twox-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ quote = "1.0"
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
 rand_distr = { version = "0.4.3", default-features = false }
+ruzstd = "0.7.1"
 k8s-openapi = { version = "0.21.1", features = ["v1_28"] }
 pathdiff = "0.2.1"
 kube = "0.88.1"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3322,6 +3322,7 @@ dependencies = [
  "prometheus",
  "proptest",
  "rand",
+ "ruzstd",
  "serde",
  "serde-name",
  "serde_bytes",
@@ -5158,6 +5159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8b8f3d26bd9f945e5cbae77f7cdfbf37af9a66956f1115eb4516e45df519f4"
+dependencies = [
+ "byteorder",
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6256,6 +6267,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
 
 [[package]]
 name = "typenum"

--- a/linera-base/Cargo.toml
+++ b/linera-base/Cargo.toml
@@ -56,6 +56,9 @@ tracing-subscriber = { workspace = true, features = ["json", "fmt", "ansi"] }
 wasm-bindgen-futures = { workspace = true, optional = true }
 web-time = { workspace = true, optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ruzstd.workspace = true
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 chrono.workspace = true
 rand = { workspace = true, features = ["getrandom", "std", "std_rng"] }

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -839,9 +839,9 @@ impl fmt::Debug for Bytecode {
     }
 }
 
-/// A type for errors happening during compression.
+/// A type for errors happening during decompression.
 #[derive(Error, Debug)]
-pub enum CompressionError {
+pub enum DecompressionError {
     /// Compressed bytecode is invalid, and could not be decompressed.
     #[error("Bytecode could not be decompressed")]
     InvalidCompressedBytecode(#[source] io::Error),
@@ -874,11 +874,11 @@ impl From<Bytecode> for CompressedBytecode {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl TryFrom<&CompressedBytecode> for Bytecode {
-    type Error = CompressionError;
+    type Error = DecompressionError;
 
     fn try_from(compressed_bytecode: &CompressedBytecode) -> Result<Self, Self::Error> {
         let bytes = zstd::stream::decode_all(&*compressed_bytecode.compressed_bytes)
-            .map_err(CompressionError::InvalidCompressedBytecode)?;
+            .map_err(DecompressionError::InvalidCompressedBytecode)?;
 
         Ok(Bytecode { bytes })
     }
@@ -886,7 +886,7 @@ impl TryFrom<&CompressedBytecode> for Bytecode {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl TryFrom<CompressedBytecode> for Bytecode {
-    type Error = CompressionError;
+    type Error = DecompressionError;
 
     fn try_from(compressed_bytecode: CompressedBytecode) -> Result<Self, Self::Error> {
         Bytecode::try_from(&compressed_bytecode)

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -843,8 +843,14 @@ impl fmt::Debug for Bytecode {
 #[derive(Error, Debug)]
 pub enum DecompressionError {
     /// Compressed bytecode is invalid, and could not be decompressed.
+    #[cfg(not(target_arch = "wasm32"))]
     #[error("Bytecode could not be decompressed")]
     InvalidCompressedBytecode(#[source] io::Error),
+
+    /// Compressed bytecode is invalid, and could not be decompressed.
+    #[cfg(target_arch = "wasm32")]
+    #[error("Bytecode could not be decompressed")]
+    InvalidCompressedBytecode(#[from] ruzstd::frame_decoder::FrameDecoderError),
 }
 
 /// A compressed WebAssembly module's bytecode.
@@ -884,7 +890,29 @@ impl TryFrom<&CompressedBytecode> for Bytecode {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(target_arch = "wasm32")]
+impl TryFrom<&CompressedBytecode> for Bytecode {
+    type Error = DecompressionError;
+
+    fn try_from(compressed_bytecode: &CompressedBytecode) -> Result<Self, Self::Error> {
+        use ruzstd::{io::Read, streaming_decoder::StreamingDecoder};
+
+        let compressed_bytes = &*compressed_bytecode.compressed_bytes;
+        let mut bytes = Vec::new();
+        let mut decoder = StreamingDecoder::new(compressed_bytes)?;
+
+        // Decode multiple frames, if present
+        // (https://github.com/KillingSpark/zstd-rs/issues/57)
+        while !decoder.get_ref().is_empty() {
+            decoder
+                .read_to_end(&mut bytes)
+                .expect("Reading from a slice in memory should not result in IO errors");
+        }
+
+        Ok(Bytecode { bytes })
+    }
+}
+
 impl TryFrom<CompressedBytecode> for Bytecode {
     type Error = DecompressionError;
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -33,7 +33,7 @@ use linera_base::{
     abi::Abi,
     crypto::CryptoHash,
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, CompressionError,
+        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, DecompressionError,
         Resources, SendMessageRequest, Timestamp, UserApplicationDescription,
     },
     doc_scalar, hex_debug,
@@ -125,7 +125,7 @@ pub enum ExecutionError {
     #[error(transparent)]
     JoinError(#[from] linera_base::task::Error),
     #[error(transparent)]
-    CompressionError(#[from] CompressionError),
+    DecompressionError(#[from] DecompressionError),
     #[error("The given promise is invalid or was polled once already")]
     InvalidPromise,
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Bytecode compression was recently introduced (#2382). However, this means that the bytecode must be decompressed after it has been loaded from storage. Currently, decompression uses the `zstd` crate, which uses the Zstandard library installed on the system. Unfortunately, that library is not available in Wasm.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Use `ruzstd` to decompress the bytecode in Wasm. Compression is not supported by `ruzstd`, so bytecodes can't be published, but at least they can be decompressed so that they can executed.

## Test Plan

<!-- How to test that the changes are correct. -->
I commented out parts of the code to make it always decompress using `ruzstd`, and ran the end-to-end tests manually to confirm they pass (because they publish and use bytecodes).

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing is needed, because this only affects Wasm targets, for which we haven't released anything yet.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)

Closes #2413 
