### PR TITLE
Create get-application-creator-chain-id system-api call

### DIFF
--- a/examples/amm/src/contract.rs
+++ b/examples/amm/src/contract.rs
@@ -46,7 +46,7 @@ impl Contract for AmmContract {
     }
 
     async fn execute_operation(&mut self, operation: Self::Operation) -> Self::Response {
-        if self.runtime.chain_id() == self.runtime.application_id().creation.chain_id {
+        if self.runtime.chain_id() == self.runtime.application_creator_chain_id() {
             self.execute_order_local(operation).await;
         } else {
             self.execute_order_remote(operation).await;
@@ -56,7 +56,7 @@ impl Contract for AmmContract {
     async fn execute_message(&mut self, message: Self::Message) {
         assert_eq!(
             self.runtime.chain_id(),
-            self.runtime.application_id().creation.chain_id,
+            self.runtime.application_creator_chain_id(),
             "Action can only be executed on the chain that created the AMM"
         );
 
@@ -444,7 +444,7 @@ impl AmmContract {
     }
 
     fn get_amm_chain_id(&mut self) -> ChainId {
-        self.runtime.application_id().creation.chain_id
+        self.runtime.application_creator_chain_id()
     }
 
     fn get_amm_account(&mut self) -> Account {

--- a/examples/crowd-funding/src/contract.rs
+++ b/examples/crowd-funding/src/contract.rs
@@ -53,7 +53,7 @@ impl Contract for CrowdFundingContract {
     async fn execute_operation(&mut self, operation: Operation) -> Self::Response {
         match operation {
             Operation::Pledge { owner, amount } => {
-                if self.runtime.chain_id() == self.runtime.application_id().creation.chain_id {
+                if self.runtime.chain_id() == self.runtime.application_creator_chain_id() {
                     self.execute_pledge_with_account(owner, amount).await;
                 } else {
                     self.execute_pledge_with_transfer(owner, amount);
@@ -69,7 +69,7 @@ impl Contract for CrowdFundingContract {
             Message::PledgeWithAccount { owner, amount } => {
                 assert_eq!(
                     self.runtime.chain_id(),
-                    self.runtime.application_id().creation.chain_id,
+                    self.runtime.application_creator_chain_id(),
                     "Action can only be executed on the chain that created the crowd-funding \
                     campaign"
                 );
@@ -94,7 +94,7 @@ impl CrowdFundingContract {
     fn execute_pledge_with_transfer(&mut self, owner: AccountOwner, amount: Amount) {
         assert!(amount > Amount::ZERO, "Pledge is empty");
         // The campaign chain.
-        let chain_id = self.runtime.application_id().creation.chain_id;
+        let chain_id = self.runtime.application_creator_chain_id();
         // First, move the funds to the campaign chain (under the same owner).
         // TODO(#589): Simplify this when the messaging system guarantees atomic delivery
         // of all messages created in the same operation/message.

--- a/examples/hex-game/src/contract.rs
+++ b/examples/hex-game/src/contract.rs
@@ -193,7 +193,7 @@ impl HexContract {
     }
 
     fn main_chain_id(&mut self) -> ChainId {
-        self.runtime.application_id().creation.chain_id
+        self.runtime.application_creator_chain_id()
     }
 }
 

--- a/examples/matching-engine/src/contract.rs
+++ b/examples/matching-engine/src/contract.rs
@@ -78,7 +78,7 @@ impl Contract for MatchingEngineContract {
                 let owner = Self::get_owner(&order);
                 let chain_id = self.runtime.chain_id();
                 self.check_account_authentication(owner);
-                if chain_id == self.runtime.application_id().creation.chain_id {
+                if chain_id == self.runtime.application_creator_chain_id() {
                     self.execute_order_local(order, chain_id).await;
                 } else {
                     self.execute_order_remote(order);
@@ -109,7 +109,7 @@ impl Contract for MatchingEngineContract {
     async fn execute_message(&mut self, message: Message) {
         assert_eq!(
             self.runtime.chain_id(),
-            self.runtime.application_id().creation.chain_id,
+            self.runtime.application_creator_chain_id(),
             "Action can only be executed on the chain that created the matching engine"
         );
         match message {
@@ -276,7 +276,7 @@ impl MatchingEngineContract {
     /// * Creation of the message that will represent the order on the chain of the matching
     ///   engine
     fn execute_order_remote(&mut self, order: Order) {
-        let chain_id = self.runtime.application_id().creation.chain_id;
+        let chain_id = self.runtime.application_creator_chain_id();
         let message = Message::ExecuteOrder {
             order: order.clone(),
         };

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -342,6 +342,9 @@ pub trait BaseRuntime {
     /// The current application ID.
     fn application_id(&mut self) -> Result<UserApplicationId, ExecutionError>;
 
+    /// The current application creator's chain ID.
+    fn application_creator_chain_id(&mut self) -> Result<ChainId, ExecutionError>;
+
     /// The current application parameters.
     fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError>;
 

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -555,6 +555,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeHandle<UserInstance> {
         self.inner().application_id()
     }
 
+    fn application_creator_chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+        self.inner().application_creator_chain_id()
+    }
+
     fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {
         self.inner().application_parameters()
     }
@@ -710,6 +714,10 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
 
     fn application_id(&mut self) -> Result<UserApplicationId, ExecutionError> {
         Ok(self.current_application().id)
+    }
+
+    fn application_creator_chain_id(&mut self) -> Result<ChainId, ExecutionError> {
+        Ok(self.current_application().id.creation.chain_id)
     }
 
     fn application_parameters(&mut self) -> Result<Vec<u8>, ExecutionError> {

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -109,6 +109,15 @@ where
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 
+    /// Returns the chain ID of the current application creator.
+    fn get_application_creator_chain_id(caller: &mut Caller) -> Result<ChainId, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .application_creator_chain_id()
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
     /// Returns the application parameters provided when the application was created.
     fn application_parameters(caller: &mut Caller) -> Result<Vec<u8>, RuntimeError> {
         caller
@@ -431,6 +440,15 @@ where
             .user_data_mut()
             .runtime
             .application_id()
+            .map_err(|error| RuntimeError::Custom(error.into()))
+    }
+
+    /// Returns the chain ID of the current application creator.
+    fn get_application_creator_chain_id(caller: &mut Caller) -> Result<ChainId, RuntimeError> {
+        caller
+            .user_data_mut()
+            .runtime
+            .application_creator_chain_id()
             .map_err(|error| RuntimeError::Custom(error.into()))
     }
 

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -28,6 +28,7 @@ where
 {
     application_parameters: Option<Application::Parameters>,
     application_id: Option<ApplicationId<Application::Abi>>,
+    application_creator_chain_id: Option<ChainId>,
     chain_id: Option<ChainId>,
     authenticated_signer: Option<Option<Owner>>,
     block_height: Option<BlockHeight>,
@@ -46,6 +47,7 @@ where
         ContractRuntime {
             application_parameters: None,
             application_id: None,
+            application_creator_chain_id: None,
             chain_id: None,
             authenticated_signer: None,
             block_height: None,
@@ -77,6 +79,13 @@ where
         *self
             .application_id
             .get_or_insert_with(|| ApplicationId::from(wit::get_application_id()).with_abi())
+    }
+
+    /// Returns the chain ID of the current application creator.
+    pub fn application_creator_chain_id(&mut self) -> ChainId {
+        *self
+            .application_creator_chain_id
+            .get_or_insert_with(|| wit::get_application_creator_chain_id().into())
     }
 
     /// Returns the ID of the current chain.

--- a/linera-sdk/src/contract/test_runtime.rs
+++ b/linera-sdk/src/contract/test_runtime.rs
@@ -29,6 +29,7 @@ where
 {
     application_parameters: Option<Application::Parameters>,
     application_id: Option<ApplicationId<Application::Abi>>,
+    application_creator_chain_id: Option<ChainId>,
     chain_id: Option<ChainId>,
     authenticated_signer: Option<Option<Owner>>,
     block_height: Option<BlockHeight>,
@@ -74,6 +75,7 @@ where
         MockContractRuntime {
             application_parameters: None,
             application_id: None,
+            application_creator_chain_id: None,
             chain_id: None,
             authenticated_signer: None,
             block_height: None,
@@ -152,6 +154,26 @@ where
         self.application_id.expect(
             "Application ID has not been mocked, \
             please call `MockContractRuntime::set_application_id` first",
+        )
+    }
+
+    /// Configures the application creator chain ID to return during the test.
+    pub fn with_application_creator_chain_id(mut self, chain_id: ChainId) -> Self {
+        self.application_creator_chain_id = Some(chain_id);
+        self
+    }
+
+    /// Configures the application creator chain ID to return during the test.
+    pub fn set_application_creator_chain_id(&mut self, chain_id: ChainId) -> &mut Self {
+        self.application_creator_chain_id = Some(chain_id);
+        self
+    }
+
+    /// Returns the chain ID of the current application creator.
+    pub fn application_creator_chain_id(&mut self) -> ChainId {
+        self.application_creator_chain_id.expect(
+            "Application creator chain ID has not been mocked, \
+            please call `MockContractRuntime::set_application_creator_chain_id` first",
         )
     }
 

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -4,6 +4,7 @@ interface contract-system-api {
     get-chain-id: func() -> chain-id;
     get-block-height: func() -> block-height;
     get-application-id: func() -> application-id;
+    get-application-creator-chain-id: func() -> chain-id;
     application-parameters: func() -> list<u8>;
     authenticated-signer: func() -> option<owner>;
     read-system-timestamp: func() -> timestamp;

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -4,6 +4,7 @@ interface service-system-api {
     get-chain-id: func() -> chain-id;
     get-next-block-height: func() -> block-height;
     get-application-id: func() -> application-id;
+    get-application-creator-chain-id: func() -> chain-id;
     get-application-parameters: func() -> list<u8>;
     read-chain-balance: func() -> amount;
     read-owner-balance: func(owner: owner) -> amount;


### PR DESCRIPTION
## Motivation

Once we replace application descriptions with blobs, we won't have the creator's chain id in the `ApplicationId` anymore.

## Proposal

This PR creates another system API call in preparation for that.

## Test Plan

CI

