### PR TITLE
Recursively handle network actions triggered by subscriptions.

### DIFF
--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -114,7 +114,7 @@ where
     ProcessCrossChainUpdate {
         origin: Origin,
         bundles: Vec<(Epoch, MessageBundle)>,
-        callback: oneshot::Sender<Result<Option<BlockHeight>, WorkerError>>,
+        callback: oneshot::Sender<Result<Option<(BlockHeight, NetworkActions)>, WorkerError>>,
     },
 
     /// Handle cross-chain request to confirm that the recipient was updated.

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -375,7 +375,7 @@ where
         &mut self,
         origin: Origin,
         bundles: Vec<(Epoch, MessageBundle)>,
-    ) -> Result<Option<BlockHeight>, WorkerError> {
+    ) -> Result<Option<(BlockHeight, NetworkActions)>, WorkerError> {
         // Only process certificates with relevant heights and epochs.
         let next_height_to_receive = self
             .state
@@ -402,14 +402,17 @@ where
         // Process the received messages in certificates.
         let local_time = self.state.storage.clock().current_time();
         let mut previous_height = None;
+        let mut new_outbox_entries = false;
         for bundle in bundles {
             let add_to_received_log = previous_height != Some(bundle.height);
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
-            self.state
-                .chain
-                .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
-                .await?;
+            new_outbox_entries = new_outbox_entries
+                || self
+                    .state
+                    .chain
+                    .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
+                    .await?;
         }
         if !self.state.config.allow_inactive_chains && !self.state.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by
@@ -421,9 +424,15 @@ where
             );
             return Ok(None);
         }
+        let actions = if new_outbox_entries {
+            self.state.create_network_actions().await?
+        } else {
+            // Don't create network actions, so that old entries don't cause retry loops.
+            NetworkActions::default()
+        };
         // Save the chain.
         self.save().await?;
-        Ok(Some(last_updated_height))
+        Ok(Some((last_updated_height, actions)))
     }
 
     /// Handles the cross-chain request confirming that the recipient was updated.
@@ -598,8 +607,8 @@ impl<'a> CrossChainUpdateHelper<'a> {
         if skipped_len < bundles.len() && trusted_len < bundles.len() {
             let (sample_epoch, sample_bundle) = &bundles[trusted_len];
             warn!(
-                "Refusing messages to {recipient:?} from {origin:?} at height {} \
-                 because the epoch {:?} is not trusted any more",
+                "Refusing messages to {recipient:.8} from {origin:} at height {} \
+                 because the epoch {} is not trusted any more",
                 sample_bundle.height, sample_epoch,
             );
         }

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -419,7 +419,7 @@ where
             let request = self
                 .create_cross_chain_request(height_map.into_iter().collect(), recipient)
                 .await?;
-            actions.cross_chain_requests.extend(request);
+            actions.cross_chain_requests.push(request);
         }
         Ok(actions)
     }
@@ -430,7 +430,7 @@ where
         &self,
         height_map: Vec<(Medium, Vec<BlockHeight>)>,
         recipient: ChainId,
-    ) -> Result<Option<CrossChainRequest>, WorkerError> {
+    ) -> Result<CrossChainRequest, WorkerError> {
         // Load all the certificates we will need, regardless of the medium.
         let heights =
             BTreeSet::from_iter(height_map.iter().flat_map(|(_, heights)| heights).copied());
@@ -469,13 +469,11 @@ where
                 bundle_vecs.push((medium, bundles));
             }
         }
-        Ok(
-            (!bundle_vecs.is_empty()).then(|| CrossChainRequest::UpdateRecipient {
-                sender: self.chain.chain_id(),
-                recipient,
-                bundle_vecs,
-            }),
-        )
+        Ok(CrossChainRequest::UpdateRecipient {
+            sender: self.chain.chain_id(),
+            recipient,
+            bundle_vecs,
+        })
     }
 }
 

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -1343,6 +1343,9 @@ where
         .receive_certificate_and_update_validators(cert)
         .await
         .unwrap();
+    builder
+        .check_that_validators_have_empty_outboxes(ChainId::root(0))
+        .await;
     admin.process_inbox().await.unwrap();
 
     // Have the admin chain deprecate the previous epoch.

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -874,6 +874,15 @@ where
         }
         assert!(count >= target_count);
     }
+
+    /// Panics if any validator has a nonempty outbox for the given chain.
+    pub async fn check_that_validators_have_empty_outboxes(&self, chain_id: ChainId) {
+        for validator in &self.validator_clients {
+            let guard = validator.client.lock().await;
+            let chain = guard.state.chain_state_view(chain_id).await.unwrap();
+            assert_eq!(chain.outboxes.indices().await.unwrap(), []);
+        }
+    }
 }
 
 #[cfg(feature = "rocksdb")]

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -2261,16 +2261,12 @@ where
     };
     let admin_channel_origin = Origin::channel(admin_id, admin_channel_full_name.clone());
     // Have the admin chain create a user chain.
-    let user_id = ChainId::child(MessageId {
-        chain_id: admin_id,
-        height: BlockHeight::ZERO,
-        index: 0,
-    });
     let user_description = ChainDescription::Child(MessageId {
         chain_id: admin_id,
         height: BlockHeight::ZERO,
         index: 0,
     });
+    let user_id = ChainId::from(user_description);
     let certificate0 = make_certificate(
         &committee,
         &worker,


### PR DESCRIPTION
## Motivation

With https://github.com/linera-io/linera-protocol/pull/2407, cross-chain updates can now trigger more cross-chain updates, if the first one contains a `Subscribe` message. Since we don't create new network actions after handling a cross-chain update, the second update is only sent the next time a certificate or chain info request is submitted for that chain.

## Proposal

Handle them recursively, so all inboxes are updated as soon as possible.

## Test Plan

A test was updated to check that the outbox is empty. I verified that that check would fail without this fix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
