### PR TITLE
Fix Witty export of functions with 16 parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,18 +1587,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80c3a50b9c4c7e5b5f73c0ed746687774fc9e36ef652b110da8daebf0c6e0e6"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-entity 0.111.0",
+ "cranelift-entity 0.112.0",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38778758c2ca918b05acb2199134e0c561fb577c50574259b26190b6c2d95ded"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1627,18 +1625,17 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58258667ad10e468bfc13a8d620f50dfcd4bb35d668123e97defa2549b9ad397"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "bumpalo",
- "cranelift-bforest 0.111.0",
+ "cranelift-bforest 0.112.0",
  "cranelift-bitset",
- "cranelift-codegen-meta 0.111.0",
- "cranelift-codegen-shared 0.111.0",
+ "cranelift-codegen-meta 0.112.0",
+ "cranelift-codegen-shared 0.112.0",
  "cranelift-control",
- "cranelift-entity 0.111.0",
- "cranelift-isle 0.111.0",
+ "cranelift-entity 0.112.0",
+ "cranelift-isle 0.112.0",
  "gimli 0.29.0",
  "hashbrown 0.14.5",
  "log",
@@ -1659,11 +1656,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0b702e529dcb07ff92bd7d40e7d5317b5493595172c5eb0983343751ee06"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen-shared 0.111.0",
+ "cranelift-codegen-shared 0.112.0",
 ]
 
 [[package]]
@@ -1674,15 +1670,13 @@ checksum = "278e52e29c53fcf32431ef08406c295699a70306d05a0715c5b1bf50e33a9ab7"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7763578888ab53eca5ce7da141953f828e82c2bfadcffc106d10d1866094ffbb"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db15f08c05df570f11e8ab33cb1ec449a64b37c8a3498377b77650bef33d8b"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "arbitrary",
 ]
@@ -1709,9 +1703,8 @@ checksum = "9a59bcbca89c3f1b70b93ab3cbba5e5e0cbf3e63dadb23c7525cb142e21a9d4c"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5289cdb399381a27e7bbfa1b42185916007c3d49aeef70b1d01cb4caa8010130"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1732,11 +1725,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ba8ab24eb9470477e98ddfa3c799a649ac5a0d9a2042868c4c952133c234e8"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -1750,34 +1742,31 @@ checksum = "393bc73c451830ff8dbb3a07f61843d6cb41a084f9996319917c0b291ed785bb"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b72a3c5c166a70426dcb209bdd0bb71a787c1ea76023dc0974fbabca770e8f9"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a42424c956bbc31fc5c2706073df896156c5420ae8fa2a5d48dbc7b295d71b"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "libc",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49778df4289933d735b93c30a345513e030cf83101de0036e19b760f8aa09f68"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen 0.111.0",
- "cranelift-entity 0.111.0",
- "cranelift-frontend 0.111.0",
+ "cranelift-codegen 0.112.0",
+ "cranelift-entity 0.112.0",
+ "cranelift-frontend 0.112.0",
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-types",
 ]
 
@@ -8404,15 +8393,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb56df3e06b8e6b77e37d2969a50ba51281029a9aeb3855e76b7f49b6418847"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
@@ -8570,9 +8550,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fbde0881f24199b81cf49b6ff8f9c145ac8eb1b7fc439adb5c099734f7d90e"
+checksum = "bcdee6bea3619d311fb4b299721e89a986c3470f804b6d534340e412589028e3"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
@@ -8584,20 +8564,19 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e9a325d85053408209b3d2ce5eaddd0dd6864d1cff7a007147ba073157defc"
+checksum = "8f82916f3892e53620639217d6ec78fe15c678352a3fbf3f3745b6417d0bd70f"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5883d64dfc8423c56e3d8df27cffc44db25336aa468e8e0724fddf30a333d7"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -8631,8 +8610,8 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasm-encoder 0.215.0",
- "wasmparser 0.215.0",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -8651,18 +8630,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4dc7e2a379c0dd6be5b55857d14c4b277f43a9c429a9e14403eb61776ae3be"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5b179f263a318e08c93281ea77cbb95e2a0c8c11e99a6188b53ead77233722"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8680,9 +8657,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b07773d1c3dab5f014ec61316ee317aa424033e17e70a63abdf7c3a47e58fcf"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8690,49 +8666,47 @@ dependencies = [
  "syn 2.0.72",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.215.0",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38d735320f4e83478369ce649ad8fe87c6b893220902e798547a225fc0c5874"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e570d831d0785d93d7d8c722b1eb9a34e0d0c1534317666f65892818358a2da9"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "cranelift-control",
- "cranelift-entity 0.111.0",
- "cranelift-frontend 0.111.0",
+ "cranelift-entity 0.112.0",
+ "cranelift-frontend 0.112.0",
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.29.0",
  "log",
  "object",
+ "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fe80dfbd81687431a7d4f25929fae1ae96894786d5c96b14ae41164ee97377"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bitset",
- "cranelift-entity 0.111.0",
+ "cranelift-entity 0.112.0",
  "gimli 0.29.0",
  "indexmap 2.3.0",
  "log",
@@ -8743,8 +8717,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.215.0",
- "wasmparser 0.215.0",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -8752,9 +8726,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f39043d13c7b58db69dc9a0feb191a961e75a9ec2402aebf42de183c022bb8a"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cc",
@@ -8767,9 +8740,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec346412363eb26067cb6473281a45bd273cbbcafa3dc862793c946eff6ba7f"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "object",
  "once_cell",
@@ -8779,9 +8751,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15de8429db996f0d17a4163a35eccc3f874cbfb50f29c379951ea1bbb39452e"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8791,29 +8762,26 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f68d38fa6b30c5e1fc7d608263062997306f79e577ebd197ddcd6b0f55d87d1"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6634e7079d9c5cfc81af8610ed59b488cc5b7f9777a2f4c1667a2565c2e45249"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
- "cranelift-entity 0.111.0",
+ "cranelift-entity 0.112.0",
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3850e3511d6c7f11a72d571890b0ed5f6204681f7f050b9de2690e7f13123fed"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8822,16 +8790,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a25199625effa4c13dd790d64bd56884b014c69829431bfe43991c740bd5bc1"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "gimli 0.29.0",
  "object",
  "target-lexicon",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -8839,14 +8806,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb331ac7ed1d5ba49cddcdb6b11973752a857148858bb308777d2fc5584121f"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.3.0",
- "wit-parser 0.215.0",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
@@ -8973,17 +8939,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073efe897d9ead7fc609874f94580afc831114af5149b6a90ee0a3a39b497fe0"
+version = "0.23.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "gimli 0.29.0",
  "regalloc2 0.9.3",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -9412,9 +9377,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935a97eaffd57c3b413aa510f8f0b550a4a9fe7d59e79cd8b89a83dcb860321f"
+checksum = "a4d108165c1167a4ccc8a803dcf5c28e0a51d6739fd228cc7adce768632c764c"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -9425,7 +9390,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ wasm-instrument = "0.4.0"
 wasmer = { package = "linera-wasmer", version = "4.3.6-linera.3", default-features = false }
 wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "4.3.6-linera.3" }
 wasmparser = "0.101.1"
-wasmtime = "24.0.0"
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "58f82587462543e912b4edcbb247842711ba6415" }
 wasmtimer = "0.2.0"
 webassembly-test = "0.1.0"
 web-sys = "0.3.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ wasm-instrument = "0.4.0"
 wasmer = { package = "linera-wasmer", version = "4.3.6-linera.3", default-features = false }
 wasmer-compiler-singlepass = { package = "linera-wasmer-compiler-singlepass", version = "4.3.6-linera.3" }
 wasmparser = "0.101.1"
+# TODO(#2430): use the latest release of Wasmtime that includes the commit referenced below
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "58f82587462543e912b4edcbb247842711ba6415" }
 wasmtimer = "0.2.0"
 webassembly-test = "0.1.0"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1002,18 +1002,16 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80c3a50b9c4c7e5b5f73c0ed746687774fc9e36ef652b110da8daebf0c6e0e6"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-entity 0.111.0",
+ "cranelift-entity 0.112.0",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38778758c2ca918b05acb2199134e0c561fb577c50574259b26190b6c2d95ded"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1042,18 +1040,17 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58258667ad10e468bfc13a8d620f50dfcd4bb35d668123e97defa2549b9ad397"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "bumpalo",
- "cranelift-bforest 0.111.0",
+ "cranelift-bforest 0.112.0",
  "cranelift-bitset",
- "cranelift-codegen-meta 0.111.0",
- "cranelift-codegen-shared 0.111.0",
+ "cranelift-codegen-meta 0.112.0",
+ "cranelift-codegen-shared 0.112.0",
  "cranelift-control",
- "cranelift-entity 0.111.0",
- "cranelift-isle 0.111.0",
+ "cranelift-entity 0.112.0",
+ "cranelift-isle 0.112.0",
  "gimli 0.29.0",
  "hashbrown 0.14.3",
  "log",
@@ -1074,11 +1071,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043f0b702e529dcb07ff92bd7d40e7d5317b5493595172c5eb0983343751ee06"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen-shared 0.111.0",
+ "cranelift-codegen-shared 0.112.0",
 ]
 
 [[package]]
@@ -1089,15 +1085,13 @@ checksum = "278e52e29c53fcf32431ef08406c295699a70306d05a0715c5b1bf50e33a9ab7"
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7763578888ab53eca5ce7da141953f828e82c2bfadcffc106d10d1866094ffbb"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db15f08c05df570f11e8ab33cb1ec449a64b37c8a3498377b77650bef33d8b"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "arbitrary",
 ]
@@ -1124,9 +1118,8 @@ checksum = "9a59bcbca89c3f1b70b93ab3cbba5e5e0cbf3e63dadb23c7525cb142e21a9d4c"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5289cdb399381a27e7bbfa1b42185916007c3d49aeef70b1d01cb4caa8010130"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1147,11 +1140,10 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ba8ab24eb9470477e98ddfa3c799a649ac5a0d9a2042868c4c952133c234e8"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -1165,34 +1157,31 @@ checksum = "393bc73c451830ff8dbb3a07f61843d6cb41a084f9996319917c0b291ed785bb"
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b72a3c5c166a70426dcb209bdd0bb71a787c1ea76023dc0974fbabca770e8f9"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a42424c956bbc31fc5c2706073df896156c5420ae8fa2a5d48dbc7b295d71b"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "libc",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49778df4289933d735b93c30a345513e030cf83101de0036e19b760f8aa09f68"
+version = "0.112.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
- "cranelift-codegen 0.111.0",
- "cranelift-entity 0.111.0",
- "cranelift-frontend 0.111.0",
+ "cranelift-codegen 0.112.0",
+ "cranelift-entity 0.112.0",
+ "cranelift-frontend 0.112.0",
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-types",
 ]
 
@@ -6529,15 +6518,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.215.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb56df3e06b8e6b77e37d2969a50ba51281029a9aeb3855e76b7f49b6418847"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
@@ -6659,9 +6639,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fbde0881f24199b81cf49b6ff8f9c145ac8eb1b7fc439adb5c099734f7d90e"
+checksum = "bcdee6bea3619d311fb4b299721e89a986c3470f804b6d534340e412589028e3"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
@@ -6673,20 +6653,19 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e9a325d85053408209b3d2ce5eaddd0dd6864d1cff7a007147ba073157defc"
+checksum = "8f82916f3892e53620639217d6ec78fe15c678352a3fbf3f3745b6417d0bd70f"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5883d64dfc8423c56e3d8df27cffc44db25336aa468e8e0724fddf30a333d7"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -6720,8 +6699,8 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasm-encoder 0.215.0",
- "wasmparser 0.215.0",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -6740,18 +6719,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c4dc7e2a379c0dd6be5b55857d14c4b277f43a9c429a9e14403eb61776ae3be"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a5b179f263a318e08c93281ea77cbb95e2a0c8c11e99a6188b53ead77233722"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6769,9 +6746,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b07773d1c3dab5f014ec61316ee317aa424033e17e70a63abdf7c3a47e58fcf"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6779,49 +6755,47 @@ dependencies = [
  "syn 2.0.60",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.215.0",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e38d735320f4e83478369ce649ad8fe87c6b893220902e798547a225fc0c5874"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e570d831d0785d93d7d8c722b1eb9a34e0d0c1534317666f65892818358a2da9"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cfg-if",
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "cranelift-control",
- "cranelift-entity 0.111.0",
- "cranelift-frontend 0.111.0",
+ "cranelift-entity 0.112.0",
+ "cranelift-frontend 0.112.0",
  "cranelift-native",
  "cranelift-wasm",
  "gimli 0.29.0",
  "log",
  "object 0.36.3",
+ "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5fe80dfbd81687431a7d4f25929fae1ae96894786d5c96b14ae41164ee97377"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bitset",
- "cranelift-entity 0.111.0",
+ "cranelift-entity 0.112.0",
  "gimli 0.29.0",
  "indexmap 2.2.6",
  "log",
@@ -6832,8 +6806,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.215.0",
- "wasmparser 0.215.0",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -6841,9 +6815,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f39043d13c7b58db69dc9a0feb191a961e75a9ec2402aebf42de183c022bb8a"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cc",
@@ -6856,9 +6829,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec346412363eb26067cb6473281a45bd273cbbcafa3dc862793c946eff6ba7f"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "object 0.36.3",
  "once_cell",
@@ -6868,9 +6840,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15de8429db996f0d17a4163a35eccc3f874cbfb50f29c379951ea1bbb39452e"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -6880,29 +6851,26 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f68d38fa6b30c5e1fc7d608263062997306f79e577ebd197ddcd6b0f55d87d1"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6634e7079d9c5cfc81af8610ed59b488cc5b7f9777a2f4c1667a2565c2e45249"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
- "cranelift-entity 0.111.0",
+ "cranelift-entity 0.112.0",
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3850e3511d6c7f11a72d571890b0ed5f6204681f7f050b9de2690e7f13123fed"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6911,16 +6879,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a25199625effa4c13dd790d64bd56884b014c69829431bfe43991c740bd5bc1"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "gimli 0.29.0",
  "object 0.36.3",
  "target-lexicon",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -6928,14 +6895,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb331ac7ed1d5ba49cddcdb6b11973752a857148858bb308777d2fc5584121f"
+version = "25.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.2.6",
- "wit-parser 0.215.0",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
@@ -7038,17 +7004,16 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073efe897d9ead7fc609874f94580afc831114af5149b6a90ee0a3a39b497fe0"
+version = "0.23.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=58f82587462543e912b4edcbb247842711ba6415#58f82587462543e912b4edcbb247842711ba6415"
 dependencies = [
  "anyhow",
- "cranelift-codegen 0.111.0",
+ "cranelift-codegen 0.112.0",
  "gimli 0.29.0",
  "regalloc2 0.9.3",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -7387,9 +7352,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935a97eaffd57c3b413aa510f8f0b550a4a9fe7d59e79cd8b89a83dcb860321f"
+checksum = "a4d108165c1167a4ccc8a803dcf5c28e0a51d6739fd228cc7adce768632c764c"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -7400,7 +7365,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.215.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -320,7 +320,6 @@ where
         caller: &mut Caller,
         application_id: ApplicationId,
         query: Vec<u8>,
-        _dummy: u32,
     ) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()
@@ -493,7 +492,6 @@ where
         caller: &mut Caller,
         application: ApplicationId,
         argument: Vec<u8>,
-        _dummy: u32,
     ) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()
@@ -516,7 +514,6 @@ where
         caller: &mut Caller,
         application_id: ApplicationId,
         query: Vec<u8>,
-        _dummy: u32,
     ) -> Result<Vec<u8>, RuntimeError> {
         caller
             .user_data_mut()

--- a/linera-sdk/src/contract/runtime.rs
+++ b/linera-sdk/src/contract/runtime.rs
@@ -245,7 +245,7 @@ where
         query: A::Query,
     ) -> A::QueryResponse {
         let query = serde_json::to_vec(&query).expect("Failed to serialize service query");
-        let response = wit::query_service(application_id.forget_abi().into(), &query, 0);
+        let response = wit::query_service(application_id.forget_abi().into(), &query);
         serde_json::from_slice(&response).expect("Failed to deserialize service response")
     }
 

--- a/linera-sdk/src/service/runtime.rs
+++ b/linera-sdk/src/service/runtime.rs
@@ -124,7 +124,7 @@ where
             serde_json::to_vec(&query).expect("Failed to serialize query to another application");
 
         let response_bytes =
-            wit::try_query_application(application.forget_abi().into(), &query_bytes, 0);
+            wit::try_query_application(application.forget_abi().into(), &query_bytes);
 
         serde_json::from_slice(&response_bytes)
             .expect("Failed to deserialize query response from application")

--- a/linera-sdk/wit/contract-system-api.wit
+++ b/linera-sdk/wit/contract-system-api.wit
@@ -22,7 +22,7 @@ interface contract-system-api {
     close-chain: func() -> result<tuple<>, close-chain-error>;
     try-call-application: func(authenticated: bool, callee-id: application-id, argument: list<u8>) -> list<u8>;
     emit: func(name: stream-name, key: list<u8>, value: list<u8>);
-    query-service: func(application-id: application-id, query: list<u8>, dummy: u32) -> list<u8>;
+    query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     assert-before: func(timestamp: timestamp);
     read-data-blob: func(hash: crypto-hash) -> list<u8>;

--- a/linera-sdk/wit/service-system-api.wit
+++ b/linera-sdk/wit/service-system-api.wit
@@ -10,9 +10,9 @@ interface service-system-api {
     read-system-timestamp: func() -> timestamp;
     read-owner-balances: func() -> list<tuple<owner, amount>>;
     read-balance-owners: func() -> list<owner>;
-    try-query-application: func(application: application-id, argument: list<u8>, dummy: u32) -> list<u8>;
+    try-query-application: func(application: application-id, argument: list<u8>) -> list<u8>;
     fetch-url: func(url: string) -> list<u8>;
-    query-service: func(application-id: application-id, query: list<u8>, dummy: u32) -> list<u8>;
+    query-service: func(application-id: application-id, query: list<u8>) -> list<u8>;
     http-post: func(query: string, content-type: string, payload: list<u8>) -> list<u8>;
     read-data-blob: func(hash: crypto-hash) -> list<u8>;
     assert-data-blob-exists: func(hash: crypto-hash);

--- a/linera-witty/src/exported_function_interface/guest_interface.rs
+++ b/linera-witty/src/exported_function_interface/guest_interface.rs
@@ -146,7 +146,7 @@ macro_rules! indirect_results {
     };
 }
 
-repeat_macro!(indirect_results => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+repeat_macro!(indirect_results => A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
 
 /// Implements [`GuestInterface`] for the cases where the results are sent directly as the
 /// function's return value but the parameters are stored in memory instead.
@@ -191,18 +191,18 @@ indirect_parameters!(=> Z);
 
 /// Implements [`GuestInterface`] for the cases where the parameters and the results need to be
 /// stored in memory.
-impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, OtherParameters, Y, Z, OtherResults>
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, OtherParameters, Y, Z, OtherResults>
     GuestInterface
     for (
-        HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, ...OtherParameters],
+        HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...OtherParameters],
         HList![Y, Z, ...OtherResults],
     )
 where
-    HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, ...OtherParameters]: FlatLayout,
+    HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...OtherParameters]: FlatLayout,
     HList![Y, Z, ...OtherResults]: FlatLayout,
 {
     type FlatHostParameters =
-        HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, ...OtherParameters];
+        HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...OtherParameters];
     type FlatGuestParameters = HList![i32, i32];
     type ResultStorage = GuestPointer;
 

--- a/linera-witty/src/runtime/wasmer/export_function.rs
+++ b/linera-witty/src/runtime/wasmer/export_function.rs
@@ -83,4 +83,5 @@ repeat_macro!(export_function =>
     n: N,
     o: O,
     p: P,
+    q: Q,
 );

--- a/linera-witty/src/runtime/wasmer/function.rs
+++ b/linera-witty/src/runtime/wasmer/function.rs
@@ -78,5 +78,6 @@ repeat_macro!(impl_instance_with_function =>
     m: M,
     n: N,
     o: O,
-    p: P
+    p: P,
+    q: Q
 );

--- a/linera-witty/src/runtime/wasmer/parameters.rs
+++ b/linera-witty/src/runtime/wasmer/parameters.rs
@@ -103,5 +103,6 @@ repeat_macro!(parameters =>
     m: M,
     n: N,
     o: O,
-    p: P
+    p: P,
+    q: Q
 );

--- a/linera-witty/src/runtime/wasmtime/export_function.rs
+++ b/linera-witty/src/runtime/wasmtime/export_function.rs
@@ -65,4 +65,5 @@ repeat_macro!(export_function =>
     n: N,
     o: O,
     p: P,
+    q: Q,
 );

--- a/linera-witty/src/runtime/wasmtime/parameters.rs
+++ b/linera-witty/src/runtime/wasmtime/parameters.rs
@@ -67,10 +67,11 @@ repeat_macro!(parameters =>
     m: M,
     n: N,
     o: O,
-    p: P
+    p: P,
+    q: Q
 );
 
-impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Rest> WasmtimeParameters for HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...Rest]
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Rest> WasmtimeParameters for HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, ...Rest]
 where
     A: FlatType,
     B: FlatType,
@@ -89,6 +90,7 @@ where
     O: FlatType,
     P: FlatType,
     Q: FlatType,
+    R: FlatType,
     Rest: Layout,
 {
     type Parameters = (i32,);

--- a/linera-witty/src/runtime/wasmtime/parameters.rs
+++ b/linera-witty/src/runtime/wasmtime/parameters.rs
@@ -3,7 +3,7 @@
 
 //! Representation of Wasmtime function parameter types.
 
-use frunk::{hlist, hlist_pat, HCons, HList};
+use frunk::{hlist, hlist_pat, HList};
 use wasmtime::{WasmParams, WasmTy};
 
 use crate::{primitive_types::FlatType, Layout};
@@ -70,50 +70,7 @@ repeat_macro!(parameters =>
     p: P
 );
 
-impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Rest> WasmtimeParameters
-    for HCons<
-        A,
-        HCons<
-            B,
-            HCons<
-                C,
-                HCons<
-                    D,
-                    HCons<
-                        E,
-                        HCons<
-                            F,
-                            HCons<
-                                G,
-                                HCons<
-                                    H,
-                                    HCons<
-                                        I,
-                                        HCons<
-                                            J,
-                                            HCons<
-                                                K,
-                                                HCons<
-                                                    L,
-                                                    HCons<
-                                                        M,
-                                                        HCons<
-                                                            N,
-                                                            HCons<O, HCons<P, HCons<Q, Rest>>>,
-                                                        >,
-                                                    >,
-                                                >,
-                                            >,
-                                        >,
-                                    >,
-                                >,
-                            >,
-                        >,
-                    >,
-                >,
-            >,
-        >,
-    >
+impl<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Rest> WasmtimeParameters for HList![A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, ...Rest]
 where
     A: FlatType,
     B: FlatType,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When exporting functions with a specific signature type (with parameters that are flattened to exactly 16 flat types and with a return type that flattens to more than one flat type) to a Wasm instance, Witty's `#[wit_export]` macro would incorrectly lower all parameters and return types to the type.

This is different from what was specified in the [specification](https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening).

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Don't lower the parameters of functions if they can be flattened into 16 flat types, even if the return type is lowered into the heap.

## Test Plan

<!-- How to test that the changes are correct. -->
Ran tests manually to ensure that the `test_memory_run_application_with_dependency` passes without the dummy parameter that was introduced previously as a workaround before this fix.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
- Closes #2406 