### PR TITLE
Remove all ViewError bounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,6 +4597,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-test",
  "wasmtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4550,7 +4550,6 @@ dependencies = [
  "linera-rpc",
  "linera-storage",
  "linera-version",
- "linera-views",
  "prometheus",
  "proptest",
  "prost",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3500,6 +3500,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "wasmtime",
  "wit-bindgen",

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -34,7 +34,7 @@ use linera_views::{
     reentrant_collection_view::ReentrantCollectionView,
     register_view::RegisterView,
     set_view::SetView,
-    views::{ClonableView, CryptoHashView, RootView, View, ViewError},
+    views::{ClonableView, CryptoHashView, RootView, View},
 };
 use serde::{Deserialize, Serialize};
 
@@ -238,7 +238,6 @@ impl BundleInInbox {
 pub struct ChainStateView<C>
 where
     C: Clone + Context + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     /// Execution state, including system and user applications.
     pub execution_state: ExecutionStateView<C>,
@@ -355,7 +354,6 @@ impl ChainTipState {
 pub struct ChannelStateView<C>
 where
     C: Context + Send + Sync,
-    ViewError: From<C::Error>,
 {
     /// The current subscribers.
     pub subscribers: SetView<C, ChainId>,
@@ -366,7 +364,6 @@ where
 impl<C> ChainStateView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
     C::Extra: ExecutionRuntimeContext,
 {
     /// Returns the [`ChainId`] of the chain this [`ChainStateView`] represents.

--- a/linera-chain/src/inbox.rs
+++ b/linera-chain/src/inbox.rs
@@ -40,7 +40,6 @@ mod inbox_tests;
 pub struct InboxStateView<C>
 where
     C: Clone + Context + Send + Sync,
-    ViewError: From<C::Error>,
 {
     /// We have already added all the messages below this height and index.
     pub next_cursor_to_add: RegisterView<C, Cursor>,
@@ -152,7 +151,6 @@ impl From<(ChainId, Origin, InboxError)> for ChainError {
 impl<C> InboxStateView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     /// Converts the internal cursor for added bundles into an externally-visible block height.
     /// This makes sense because the rest of the system always adds bundles one block at a time.
@@ -280,7 +278,6 @@ where
 impl InboxStateView<MemoryContext<()>>
 where
     MemoryContext<()>: Context + Clone + Send + Sync + 'static,
-    ViewError: From<<MemoryContext<()> as linera_views::common::Context>::Error>,
 {
     pub async fn new() -> Self {
         let context = create_test_memory_context();

--- a/linera-chain/src/outbox.rs
+++ b/linera-chain/src/outbox.rs
@@ -26,7 +26,6 @@ mod outbox_tests;
 pub struct OutboxStateView<C>
 where
     C: Context + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     /// The minimum block height accepted in the future.
     pub next_height_to_schedule: RegisterView<C, BlockHeight>,
@@ -38,7 +37,6 @@ where
 impl<C> OutboxStateView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     /// Schedules a message at the given height if we haven't already.
     /// Returns true if a change was made.
@@ -76,7 +74,6 @@ where
 impl OutboxStateView<MemoryContext<()>>
 where
     MemoryContext<()>: Context + Clone + Send + Sync + 'static,
-    ViewError: From<<MemoryContext<()> as linera_views::common::Context>::Error>,
 {
     pub async fn new() -> Self {
         let context = create_test_memory_context();

--- a/linera-client/src/chain_clients.rs
+++ b/linera-client/src/chain_clients.rs
@@ -7,20 +7,17 @@ use futures::lock::{Mutex, MutexGuard};
 use linera_base::identifiers::ChainId;
 use linera_core::client::ChainClient;
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 
 use crate::error::{self, Error};
 
 pub type ClientMapInner<P, S> = BTreeMap<ChainId, ChainClient<P, S>>;
 pub struct ChainClients<P, S>(pub Arc<Mutex<ClientMapInner<P, S>>>)
 where
-    S: Storage,
-    ViewError: From<S::StoreError>;
+    S: Storage;
 
 impl<P, S> Clone for ChainClients<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     fn clone(&self) -> Self {
         ChainClients(self.0.clone())
@@ -30,7 +27,6 @@ where
 impl<P, S> Default for ChainClients<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     fn default() -> Self {
         Self(Arc::new(Mutex::new(BTreeMap::new())))
@@ -40,7 +36,6 @@ where
 impl<P, S> ChainClients<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     async fn client(&self, chain_id: &ChainId) -> Option<ChainClient<P, S>> {
         Some(self.0.lock().await.get(chain_id)?.clone())

--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -22,7 +22,6 @@ use linera_core::{
 };
 use linera_execution::{Message, SystemMessage};
 use linera_storage::{Clock as _, Storage};
-use linera_views::views::ViewError;
 use tracing::{debug, error, info, warn, Instrument as _};
 
 use crate::{chain_clients::ChainClients, wallet::Wallet, Error};
@@ -68,9 +67,7 @@ pub trait ClientContext {
     fn make_chain_client(
         &self,
         chain_id: ChainId,
-    ) -> ChainClient<Self::ValidatorNodeProvider, Self::Storage>
-    where
-        ViewError: From<<Self::Storage as Storage>::StoreError>;
+    ) -> ChainClient<Self::ValidatorNodeProvider, Self::Storage>;
 
     fn update_wallet_for_new_chain(
         &mut self,
@@ -82,8 +79,7 @@ pub trait ClientContext {
     async fn update_wallet(
         &mut self,
         client: &ChainClient<Self::ValidatorNodeProvider, Self::Storage>,
-    ) where
-        ViewError: From<<Self::Storage as Storage>::StoreError>;
+    );
 }
 
 /// A `ChainListener` is a process that listens to notifications from validators and reacts
@@ -91,7 +87,6 @@ pub trait ClientContext {
 pub struct ChainListener<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     config: ChainListenerConfig,
     clients: ChainClients<P, S>,
@@ -102,7 +97,6 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     /// Creates a new chain listener given client chains.
     pub fn new(config: ChainListenerConfig, clients: ChainClients<P, S>) -> Self {

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -24,7 +24,6 @@ use linera_core::{
 };
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use thiserror_context::Context;
 use tokio::task::JoinSet;
 use tracing::{debug, info};
@@ -76,7 +75,6 @@ use crate::{
 pub struct ClientContext<Storage, W>
 where
     Storage: linera_storage::Storage,
-    ViewError: From<Storage::StoreError>,
 {
     pub wallet: WalletState<W>,
     pub client: Arc<Client<NodeProvider, Storage>>,
@@ -92,7 +90,6 @@ where
 impl<S, W> chain_listener::ClientContext for ClientContext<S, W>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<<S as Storage>::StoreError>,
     W: Persist<Target = Wallet> + Send,
 {
     type ValidatorNodeProvider = NodeProvider;
@@ -124,7 +121,6 @@ where
 impl<S, W> ClientContext<S, W>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
     W: Persist<Target = Wallet>,
 {
     /// Returns the [`Wallet`] as a mutable reference.
@@ -368,7 +364,6 @@ where
 impl<S, W> ClientContext<S, W>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
     W: Persist<Target = Wallet>,
 {
     pub async fn publish_bytecode(
@@ -445,7 +440,6 @@ where
 impl<S, W> ClientContext<S, W>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
     W: Persist<Target = Wallet>,
 {
     pub async fn process_inboxes_and_force_validator_updates(&mut self) {

--- a/linera-client/src/config.rs
+++ b/linera-client/src/config.rs
@@ -15,7 +15,6 @@ use linera_execution::{
 };
 use linera_rpc::config::{ValidatorInternalNetworkConfig, ValidatorPublicNetworkConfig};
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
@@ -194,7 +193,6 @@ impl GenesisConfig {
     pub async fn initialize_storage<S>(&self, storage: &mut S) -> Result<(), Error>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let committee = self.create_committee();
         for (chain_number, (public_key, balance)) in (0..).zip(&self.chains) {

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -545,8 +545,7 @@ pub trait Runnable {
 
     async fn run<S>(self, storage: S) -> Self::Output
     where
-        S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>;
+        S: Storage + Clone + Send + Sync + 'static;
 }
 
 // The design is that the initialization of the accounts should be separate

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -15,7 +15,6 @@ use linera_base::{
 use linera_chain::data_types::Block;
 use linera_core::{client::ChainClient, node::LocalValidatorNodeProvider};
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
 
@@ -167,7 +166,6 @@ impl Wallet {
     where
         P: LocalValidatorNodeProvider + Sync + 'static,
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let key_pair = chain_client.key_pair().await.map(|k| k.copy()).ok();
         let state = chain_client.state();

--- a/linera-core/benches/client_benchmarks.rs
+++ b/linera-core/benches/client_benchmarks.rs
@@ -14,10 +14,10 @@ use linera_core::{
 };
 use linera_execution::system::{Recipient, UserData};
 use linera_storage::{
-    Storage, READ_CERTIFICATE_COUNTER, READ_HASHED_CERTIFICATE_VALUE_COUNTER,
-    WRITE_CERTIFICATE_COUNTER, WRITE_HASHED_CERTIFICATE_VALUE_COUNTER,
+    READ_CERTIFICATE_COUNTER, READ_HASHED_CERTIFICATE_VALUE_COUNTER, WRITE_CERTIFICATE_COUNTER,
+    WRITE_HASHED_CERTIFICATE_VALUE_COUNTER,
 };
-use linera_views::{views::ViewError, LOAD_VIEW_COUNTER, SAVE_VIEW_COUNTER};
+use linera_views::{LOAD_VIEW_COUNTER, SAVE_VIEW_COUNTER};
 use prometheus::core::Collector;
 use recorder::BenchRecorderMeasurement;
 use tokio::runtime;
@@ -33,7 +33,6 @@ mod recorder;
 pub fn setup_claim_bench<B>() -> (ChainClient<B>, ChainClient<B>)
 where
     B: StorageBuilder + Default,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage_builder = B::default();
     // Criterion doesn't allow setup functions to be async, but it runs them inside an async
@@ -59,7 +58,6 @@ where
 pub async fn run_claim_bench<B>((chain1, chain2): (ChainClient<B>, ChainClient<B>))
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let owner1 = chain1.identity().await.unwrap();
     let amt = Amount::ONE;

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -132,7 +132,6 @@ where
 pub struct ChainWorkerActor<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     worker: ChainWorkerState<StorageClient>,
     service_runtime_thread: linera_base::task::BlockingFuture<()>,
@@ -141,7 +140,6 @@ where
 impl<StorageClient> ChainWorkerActor<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     /// Spawns a new task to run the [`ChainWorkerActor`], returning an endpoint for sending
     /// requests to the worker.

--- a/linera-core/src/chain_worker/actor.rs
+++ b/linera-core/src/chain_worker/actor.rs
@@ -26,7 +26,6 @@ use linera_execution::{
     ServiceSyncRuntime,
 };
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{instrument, trace, warn};
 
@@ -41,7 +40,6 @@ use crate::{
 pub enum ChainWorkerRequest<Context>
 where
     Context: linera_views::common::Context + Clone + Send + Sync + 'static,
-    ViewError: From<Context::Error>,
 {
     /// Reads the certificate for a requested [`BlockHeight`].
     #[cfg(with_testing)]
@@ -327,7 +325,6 @@ where
 impl<Context> Debug for ChainWorkerRequest<Context>
 where
     Context: linera_views::common::Context + Clone + Send + Sync + 'static,
-    ViewError: From<Context::Error>,
 {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
         match self {

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -25,7 +25,7 @@ use linera_execution::{
 use linera_storage::{Clock as _, Storage};
 use linera_views::{
     common::Context,
-    views::{RootView, View, ViewError},
+    views::{RootView, View},
 };
 use tracing::{debug, warn};
 
@@ -40,7 +40,6 @@ use crate::{
 pub struct ChainWorkerStateWithAttemptedChanges<'state, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     state: &'state mut ChainWorkerState<StorageClient>,
     succeeded: bool,
@@ -49,7 +48,6 @@ where
 impl<'state, StorageClient> ChainWorkerStateWithAttemptedChanges<'state, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     /// Creates a new [`ChainWorkerStateWithAttemptedChanges`] instance to change the
     /// `state`.
@@ -518,7 +516,6 @@ where
 impl<StorageClient> Drop for ChainWorkerStateWithAttemptedChanges<'_, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     fn drop(&mut self) {
         if !self.succeeded {
@@ -539,7 +536,6 @@ impl<'a> CrossChainUpdateHelper<'a> {
     pub fn new<C>(config: &ChainWorkerConfig, chain: &'a ChainStateView<C>) -> Self
     where
         C: Context + Clone + Send + Sync + 'static,
-        ViewError: From<C::Error>,
     {
         CrossChainUpdateHelper {
             allow_messages_from_deprecated_epochs: config.allow_messages_from_deprecated_epochs,

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -50,7 +50,6 @@ use crate::{
 pub struct ChainWorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     config: ChainWorkerConfig,
     storage: StorageClient,
@@ -67,7 +66,6 @@ where
 impl<StorageClient> ChainWorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
     #[allow(clippy::too_many_arguments)]

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -19,7 +19,7 @@ use linera_chain::{
 };
 use linera_execution::{ChannelSubscription, Query, Response};
 use linera_storage::{Clock as _, Storage};
-use linera_views::views::{View, ViewError};
+use linera_views::views::View;
 #[cfg(with_testing)]
 use {
     linera_base::{crypto::CryptoHash, data_types::BlockHeight},
@@ -37,13 +37,11 @@ pub struct ChainWorkerStateWithTemporaryChanges<'state, StorageClient>(
     &'state mut ChainWorkerState<StorageClient>,
 )
 where
-    StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>;
+    StorageClient: Storage + Clone + Send + Sync + 'static;
 
 impl<'state, StorageClient> ChainWorkerStateWithTemporaryChanges<'state, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     /// Creates a new [`ChainWorkerStateWithAttemptedChanges`] instance to temporarily change the
     /// `state`.
@@ -345,7 +343,6 @@ where
 impl<StorageClient> Drop for ChainWorkerStateWithTemporaryChanges<'_, StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     fn drop(&mut self) {
         self.0.chain.rollback();

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -80,7 +80,6 @@ mod client_tests;
 pub struct Client<ValidatorNodeProvider, Storage>
 where
     Storage: linera_storage::Storage,
-    ViewError: From<Storage::StoreError>,
 {
     /// How to talk to the validators.
     validator_node_provider: ValidatorNodeProvider,
@@ -105,10 +104,7 @@ where
     chains: DashMap<ChainId, ChainState>,
 }
 
-impl<P, S: Storage + Clone> Client<P, S>
-where
-    ViewError: From<S::StoreError>,
-{
+impl<P, S: Storage + Clone> Client<P, S> {
     #[tracing::instrument(level = "trace", skip_all)]
     /// Creates a new `Client` with a new cache and notifiers.
     pub fn new(
@@ -173,10 +169,7 @@ where
         next_block_height: BlockHeight,
         pending_block: Option<Block>,
         pending_blobs: BTreeMap<BlobId, Blob>,
-    ) -> ChainClient<P, S>
-    where
-        ViewError: From<S::StoreError>,
-    {
+    ) -> ChainClient<P, S> {
         let known_key_pairs = known_key_pairs
             .into_iter()
             .map(|kp| (Owner::from(kp.public()), kp))
@@ -315,7 +308,6 @@ pub struct ChainClientOptions {
 pub struct ChainClient<ValidatorNodeProvider, Storage>
 where
     Storage: linera_storage::Storage,
-    ViewError: From<<Storage as linera_storage::Storage>::StoreError>,
 {
     /// The Linera [`Client`] that manages operations for this chain client.
     client: Arc<Client<ValidatorNodeProvider, Storage>>,
@@ -328,7 +320,6 @@ where
 impl<P, S> Clone for ChainClient<P, S>
 where
     S: linera_storage::Storage,
-    ViewError: From<<S as linera_storage::Storage>::StoreError>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -342,7 +333,6 @@ where
 impl<P, S> std::fmt::Debug for ChainClient<P, S>
 where
     S: linera_storage::Storage,
-    ViewError: From<<S as linera_storage::Storage>::StoreError>,
 {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         formatter
@@ -456,7 +446,6 @@ pub type ChainGuardMapped<'a, T> = Unsend<DashMapMappedRef<'a, ChainId, ChainSta
 impl<P, S> ChainClient<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     #[tracing::instrument(level = "trace", skip(self))]
     /// Gets a shared reference to the chain's state.
@@ -539,7 +528,6 @@ impl<P, S> ChainClient<P, S>
 where
     P: LocalValidatorNodeProvider + Sync,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[tracing::instrument(level = "trace")]
     /// Obtains a `ChainStateView` for a given `ChainId`.

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -19,7 +19,7 @@ use linera_execution::{
     ExecutionRuntimeContext,
 };
 use linera_storage::ChainRuntimeContext;
-use linera_views::{common::Context, views::ViewError};
+use linera_views::common::Context;
 use serde::{Deserialize, Serialize};
 
 use crate::client::ChainClientError;
@@ -220,7 +220,6 @@ impl<C, S> From<&ChainStateView<C>> for ChainInfo
 where
     C: Context<Extra = ChainRuntimeContext<S>> + Clone + Send + Sync + 'static,
     ChainRuntimeContext<S>: ExecutionRuntimeContext,
-    ViewError: From<C::Error>,
 {
     fn from(view: &ChainStateView<C>) -> Self {
         let system_state = &view.execution_state.system;

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -38,7 +38,6 @@ use crate::{
 pub struct LocalNode<S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     state: WorkerState<S>,
 }
@@ -48,7 +47,6 @@ where
 pub struct LocalNodeClient<S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     node: Arc<LocalNode<S>>,
 }
@@ -90,7 +88,6 @@ pub enum LocalNodeError {
 impl<S> LocalNodeClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[tracing::instrument(level = "trace", skip_all)]
     pub async fn handle_block_proposal(
@@ -147,7 +144,6 @@ where
 impl<S> LocalNodeClient<S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn new(state: WorkerState<S>) -> Self {
@@ -160,7 +156,6 @@ where
 impl<S> LocalNodeClient<S>
 where
     S: Storage + Clone,
-    ViewError: From<S::StoreError>,
 {
     #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn storage_client(&self) -> S {
@@ -171,7 +166,6 @@ where
 impl<S> LocalNodeClient<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[tracing::instrument(level = "trace", skip_all)]
     pub async fn stage_block_execution(

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -26,8 +26,8 @@ use linera_execution::{
     ExecutionError, Message, MessageKind, Operation, ResourceControlPolicy, SystemExecutionError,
     SystemMessage, SystemQuery, SystemResponse,
 };
-use linera_storage::{DbStorage, Storage, TestClock};
-use linera_views::{memory::MemoryStore, views::ViewError};
+use linera_storage::{DbStorage, TestClock};
+use linera_views::memory::MemoryStore;
 use test_case::test_case;
 
 #[cfg(feature = "dynamodb")]
@@ -87,7 +87,6 @@ async fn test_initiating_valid_transfer_with_notifications<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -144,7 +143,6 @@ where
 async fn test_claim_amount<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -277,7 +275,6 @@ where
 async fn test_rotate_key_pair<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -326,7 +323,6 @@ where
 async fn test_transfer_ownership<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -384,7 +380,6 @@ where
 async fn test_share_ownership<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let sender = builder
@@ -531,7 +526,6 @@ where
 async fn test_open_chain_then_close_it<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -578,7 +572,6 @@ where
 async fn test_transfer_then_open_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -688,7 +681,6 @@ where
 async fn test_open_chain_must_be_first<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -783,7 +775,6 @@ where
 async fn test_open_chain_then_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     // New chains use the admin chain to verify their creation certificate.
@@ -857,7 +848,6 @@ where
 async fn test_close_chain<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -961,7 +951,6 @@ where
 async fn test_initiating_valid_transfer_too_many_faults<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 2).await?;
     let sender = builder
@@ -1000,7 +989,6 @@ where
 async fn test_bidirectional_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let client1 = builder
@@ -1103,7 +1091,6 @@ where
 async fn test_receiving_unconfirmed_transfer<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -1157,7 +1144,6 @@ async fn test_receiving_unconfirmed_transfer_with_lagging_sender_balances<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let client1 = builder
@@ -1262,7 +1248,6 @@ where
 async fn test_change_voting_rights<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let admin = builder
@@ -1400,7 +1385,6 @@ where
 async fn test_insufficient_balance<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -1456,7 +1440,6 @@ where
 async fn test_finalize_locked_block_with_blobs<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let description1 = ChainDescription::Root(1);
@@ -1646,7 +1629,6 @@ where
 async fn test_handle_existing_proposal_with_blobs<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let description1 = ChainDescription::Root(1);
@@ -1785,7 +1767,6 @@ where
 async fn test_re_propose_locked_block_with_blobs<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
     let description1 = ChainDescription::Root(1);
@@ -2068,7 +2049,6 @@ where
 async fn test_request_leader_timeout<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let clock = storage_builder.clock().clone();
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
@@ -2194,7 +2174,6 @@ where
 async fn test_finalize_validated<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     // Configure a chain with two regular and no super owners.
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
@@ -2309,7 +2288,6 @@ where
 async fn test_propose_pending_block<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1).await?;
     let description = ChainDescription::Root(1);
@@ -2354,7 +2332,6 @@ where
 async fn test_re_propose_validated<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     // Configure a chain with two regular and no super owners.
     let mut builder = TestBuilder::new(storage_builder, 4, 0).await?;
@@ -2472,7 +2449,6 @@ where
 async fn test_message_policy<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -30,8 +30,6 @@ use linera_chain::data_types::{CertificateValue, EventRecord, MessageAction, Out
 use linera_execution::{
     Message, MessageKind, Operation, ResourceControlPolicy, SystemMessage, WasmRuntime,
 };
-use linera_storage::Storage;
-use linera_views::views::ViewError;
 use serde_json::json;
 use test_case::test_case;
 
@@ -91,7 +89,6 @@ async fn test_scylla_db_create_application(wasm_runtime: WasmRuntime) -> anyhow:
 async fn run_test_create_application<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -270,7 +267,6 @@ async fn test_scylla_db_run_application_with_dependency(
 async fn run_test_run_application_with_dependency<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -549,7 +545,6 @@ async fn test_scylla_db_cross_chain_message(wasm_runtime: WasmRuntime) -> anyhow
 async fn run_test_cross_chain_message<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?
@@ -756,7 +751,6 @@ async fn test_scylla_db_user_pub_sub_channels(wasm_runtime: WasmRuntime) -> anyh
 async fn run_test_user_pub_sub_channels<B>(storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let mut builder = TestBuilder::new(storage_builder, 4, 1)
         .await?

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -40,10 +40,7 @@ use linera_views::dynamo_db::DynamoDbStore;
 use linera_views::rocks_db::RocksDbStore;
 #[cfg(feature = "scylladb")]
 use linera_views::scylla_db::ScyllaDbStore;
-use linera_views::{
-    memory::MemoryStore,
-    views::{CryptoHashView, ViewError},
-};
+use linera_views::{memory::MemoryStore, views::CryptoHashView};
 use test_case::test_case;
 
 use super::{init_worker_with_chains, make_certificate};
@@ -97,7 +94,6 @@ async fn run_test_handle_certificates_to_create_application<S>(
 ) -> anyhow::Result<()>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     let admin_id = ChainDescription::Root(0);
     let publisher_key_pair = KeyPair::generate();

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -45,7 +45,7 @@ use linera_storage::{DbStorage, Storage, TestClock};
 use linera_views::{
     memory::{create_memory_store_test_config, MemoryContext, MemoryStore},
     test_utils::generate_test_namespace,
-    views::{CryptoHashView, RootView, ViewError},
+    views::{CryptoHashView, RootView},
 };
 use test_case::test_case;
 use test_log::test;
@@ -75,7 +75,6 @@ const TEST_GRACE_PERIOD_MICROS: u64 = 500_000;
 fn init_worker<S>(storage: S, is_client: bool) -> (Committee, WorkerState<S>)
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     let key_pair = KeyPair::generate();
     let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
@@ -91,7 +90,6 @@ async fn init_worker_with_chains<S, I>(storage: S, balances: I) -> (Committee, W
 where
     I: IntoIterator<Item = (ChainDescription, PublicKey, Amount)>,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     let (committee, worker) = init_worker(storage, /* is_client */ false);
     for (description, pubk, balance) in balances {
@@ -120,7 +118,6 @@ async fn init_worker_with_chain<S>(
 ) -> (Committee, WorkerState<S>)
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     init_worker_with_chains(storage, [(description, owner, balance)]).await
 }
@@ -132,7 +129,6 @@ fn make_certificate<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     make_certificate_with_round(committee, worker, value, Round::Fast)
 }
@@ -145,7 +141,6 @@ fn make_certificate_with_round<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     let vote = LiteVote::new(
         value.lite(),
@@ -173,7 +168,6 @@ async fn make_simple_transfer_certificate<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     make_transfer_certificate_for_epoch(
         chain_description,
@@ -208,7 +202,6 @@ async fn make_transfer_certificate<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     make_transfer_certificate_for_epoch(
         chain_description,
@@ -244,7 +237,6 @@ async fn make_transfer_certificate_for_epoch<S>(
 ) -> Certificate
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     let chain_id = chain_description.into();
     let system_state = SystemExecutionState {
@@ -401,7 +393,6 @@ fn update_recipient_direct(recipient: ChainId, certificate: &Certificate) -> Cro
 async fn test_handle_block_proposal_bad_signature<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, worker) = init_worker_with_chains(
@@ -447,7 +438,6 @@ where
 async fn test_handle_block_proposal_zero_amount<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, worker) = init_worker_with_chains(
@@ -498,7 +488,6 @@ where
 async fn test_handle_block_proposal_ticks<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -569,7 +558,6 @@ where
 async fn test_handle_block_proposal_unknown_sender<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, worker) = init_worker_with_chains(
@@ -612,7 +600,6 @@ where
 async fn test_handle_block_proposal_with_chaining<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -684,7 +671,6 @@ async fn test_handle_block_proposal_with_incoming_bundles<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
@@ -1047,7 +1033,6 @@ where
 async fn test_handle_block_proposal_exceed_balance<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, worker) = init_worker_with_chains(
@@ -1095,7 +1080,6 @@ where
 async fn test_handle_block_proposal<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, worker) = init_worker_with_chains(
@@ -1131,7 +1115,6 @@ where
 async fn test_handle_block_proposal_replay<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (_, worker) = init_worker_with_chains(
@@ -1173,7 +1156,6 @@ where
 async fn test_handle_certificate_unknown_sender<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1214,7 +1196,6 @@ where
 async fn test_handle_certificate_with_open_chain<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1293,7 +1274,6 @@ where
 async fn test_handle_certificate_wrong_owner<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1334,7 +1314,6 @@ where
 async fn test_handle_certificate_bad_block_height<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1383,7 +1362,6 @@ async fn test_handle_certificate_with_anticipated_incoming_bundle<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1485,7 +1463,6 @@ async fn test_handle_certificate_receiver_balance_overflow<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1554,7 +1531,6 @@ async fn test_handle_certificate_receiver_equal_sender<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let key_pair = KeyPair::generate();
@@ -1624,7 +1600,6 @@ where
 async fn test_handle_cross_chain_request<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1702,7 +1677,6 @@ async fn test_handle_cross_chain_request_no_recipient_chain<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = KeyPair::generate();
@@ -1740,7 +1714,6 @@ async fn test_handle_cross_chain_request_no_recipient_chain_on_client<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let sender_key_pair = KeyPair::generate();
@@ -1790,7 +1763,6 @@ async fn test_handle_certificate_to_active_recipient<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let recipient_key_pair = KeyPair::generate();
@@ -1944,7 +1916,6 @@ async fn test_handle_certificate_to_inactive_recipient<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -1991,7 +1962,6 @@ async fn test_handle_certificate_with_rejected_transfer<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let sender_key_pair = KeyPair::generate();
     let sender = Owner::from(sender_key_pair.public());
@@ -2236,7 +2206,6 @@ async fn run_test_chain_creation_with_committee_creation<B>(
 ) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair = KeyPair::generate();
     let (committee, worker) = init_worker_with_chains(
@@ -2593,7 +2562,6 @@ where
 async fn test_transfers_and_committee_creation<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
@@ -2725,7 +2693,6 @@ where
 async fn test_transfers_and_committee_removal<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let key_pair0 = KeyPair::generate();
     let key_pair1 = KeyPair::generate();
@@ -3128,7 +3095,6 @@ async fn test_cross_chain_helper() -> anyhow::Result<()> {
 async fn test_timeouts<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -3329,7 +3295,6 @@ where
 async fn test_round_types<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -3417,7 +3382,6 @@ where
 async fn test_fast_proposal_is_locked<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -3520,7 +3484,6 @@ where
 async fn test_fallback<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     let storage = storage_builder.build().await?;
     let clock = storage_builder.clock();
@@ -3588,7 +3551,6 @@ where
 async fn test_long_lived_service<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     const NUM_QUERIES: usize = 5;
 
@@ -3668,7 +3630,6 @@ where
 async fn test_new_block_causes_service_restart<B>(mut storage_builder: B) -> anyhow::Result<()>
 where
     B: StorageBuilder,
-    ViewError: From<<B::Storage as Storage>::StoreError>,
 {
     const NUM_QUERIES: usize = 2;
     const BLOCK_TIMESTAMP: u64 = 10;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -19,7 +19,6 @@ use linera_base::{
 use linera_chain::data_types::{BlockProposal, Certificate, LiteVote};
 use linera_execution::committee::{Committee, ValidatorName};
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use thiserror::Error;
 use tracing::{error, warn};
 
@@ -64,7 +63,6 @@ pub enum CommunicateAction {
 pub struct ValidatorUpdater<A, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     pub name: ValidatorName,
     pub node: A,
@@ -194,7 +192,6 @@ impl<A, S> ValidatorUpdater<A, S>
 where
     A: LocalValidatorNode + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     async fn send_optimized_certificate(
         &mut self,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -27,7 +27,6 @@ use linera_chain::{
 };
 use linera_execution::{committee::Epoch, Query, Response};
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -221,7 +220,6 @@ impl From<linera_chain::ChainError> for WorkerError {
 pub struct WorkerState<StorageClient>
 where
     StorageClient: Storage,
-    ViewError: From<StorageClient::StoreError>,
 {
     /// A name used for logging
     nickname: String,
@@ -254,7 +252,6 @@ pub(crate) type DeliveryNotifiers =
 impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage,
-    ViewError: From<StorageClient::StoreError>,
 {
     #[tracing::instrument(level = "trace", skip(nickname, key_pair, storage))]
     pub fn new(nickname: String, key_pair: Option<KeyPair>, storage: StorageClient) -> Self {
@@ -382,7 +379,6 @@ where
 impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<StorageClient::StoreError>,
 {
     // NOTE: This only works for non-sharded workers!
     #[tracing::instrument(level = "trace", skip(self, certificate, blobs))]
@@ -921,7 +917,6 @@ where
 impl<StorageClient> WorkerState<StorageClient>
 where
     StorageClient: Storage,
-    ViewError: From<StorageClient::StoreError>,
 {
     /// Gets a reference to the validator's [`PublicKey`].
     ///

--- a/linera-execution/src/applications.rs
+++ b/linera-execution/src/applications.rs
@@ -7,7 +7,7 @@ use linera_base::{data_types::UserApplicationDescription, identifiers::UserAppli
 use linera_views::{
     common::Context,
     map_view::HashedMapView,
-    views::{ClonableView, HashableView, ViewError},
+    views::{ClonableView, HashableView},
 };
 #[cfg(with_testing)]
 use {
@@ -37,7 +37,6 @@ pub struct ApplicationRegistry {
 impl<C> ApplicationRegistryView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     #[cfg(with_testing)]
     pub fn import(&mut self, registry: ApplicationRegistry) -> Result<(), SystemExecutionError> {
@@ -168,7 +167,6 @@ where
 impl ApplicationRegistryView<MemoryContext<()>>
 where
     MemoryContext<()>: Context + Clone + Send + Sync + 'static,
-    ViewError: From<<MemoryContext<()> as linera_views::common::Context>::Error>,
 {
     pub async fn new() -> Self {
         let context = create_test_memory_context();

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -15,7 +15,7 @@ use linera_views::{
     common::Context,
     key_value_store_view::KeyValueStoreView,
     reentrant_collection_view::HashedReentrantCollectionView,
-    views::{ClonableView, View, ViewError},
+    views::{ClonableView, View},
 };
 use linera_views_derive::CryptoHashView;
 #[cfg(with_testing)]
@@ -49,8 +49,6 @@ pub struct ExecutionStateView<C> {
 impl ExecutionStateView<MemoryContext<TestExecutionRuntimeContext>>
 where
     MemoryContext<TestExecutionRuntimeContext>: Context + Clone + Send + Sync + 'static,
-    ViewError:
-        From<<MemoryContext<TestExecutionRuntimeContext> as linera_views::common::Context>::Error>,
 {
     /// Simulates the instantiation of an application.
     pub async fn simulate_instantiation(
@@ -136,7 +134,6 @@ impl UserAction {
 impl<C> ExecutionStateView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
     C::Extra: ExecutionRuntimeContext,
 {
     #[allow(clippy::too_many_arguments)]

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -15,11 +15,7 @@ use linera_base::{
     identifiers::{Account, BlobId, MessageId, Owner},
     ownership::ChainOwnership,
 };
-use linera_views::{
-    batch::Batch,
-    common::Context,
-    views::{View, ViewError},
-};
+use linera_views::{batch::Batch, common::Context, views::View};
 use oneshot::Sender;
 #[cfg(with_metrics)]
 use prometheus::HistogramVec;
@@ -68,7 +64,6 @@ pub(crate) type ExecutionStateSender = mpsc::UnboundedSender<ExecutionRequest>;
 impl<C> ExecutionStateView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
     C::Extra: ExecutionRuntimeContext,
 {
     // TODO(#1416): Support concurrent I/O.

--- a/linera-execution/src/graphql.rs
+++ b/linera-execution/src/graphql.rs
@@ -9,7 +9,7 @@ use linera_base::{
     identifiers::{ChainDescription, ChainId, Owner},
     ownership::ChainOwnership,
 };
-use linera_views::{common::Context, map_view::MapView, views::ViewError};
+use linera_views::{common::Context, map_view::MapView};
 
 use crate::{
     committee::{Committee, Epoch, ValidatorName, ValidatorState},
@@ -49,10 +49,7 @@ impl Committee {
 }
 
 #[async_graphql::Object(cache_control(no_cache))]
-impl<C: Send + Sync + Context> ExecutionStateView<C>
-where
-    ViewError: From<C::Error>,
-{
+impl<C: Send + Sync + Context> ExecutionStateView<C> {
     #[graphql(derived(name = "system"))]
     async fn _system(&self) -> &SystemExecutionStateView<C> {
         &self.system
@@ -60,10 +57,7 @@ where
 }
 
 #[async_graphql::Object(cache_control(no_cache))]
-impl<C: Send + Sync + Context> SystemExecutionStateView<C>
-where
-    ViewError: From<C::Error>,
-{
+impl<C: Send + Sync + Context> SystemExecutionStateView<C> {
     #[graphql(derived(name = "description"))]
     async fn _description(&self) -> &Option<ChainDescription> {
         self.description.get()

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -322,7 +322,6 @@ impl ResourceController<Option<Owner>, ResourceTracker> {
     ) -> Result<ResourceController<Sources<'a>, &mut ResourceTracker>, ViewError>
     where
         C: Context + Clone + Send + Sync + 'static,
-        ViewError: From<C::Error>,
     {
         self.with_state_and_grant(view, None).await
     }
@@ -337,7 +336,6 @@ impl ResourceController<Option<Owner>, ResourceTracker> {
     ) -> Result<ResourceController<Sources<'a>, &mut ResourceTracker>, ViewError>
     where
         C: Context + Clone + Send + Sync + 'static,
-        ViewError: From<C::Error>,
     {
         let mut sources = Vec::new();
         // First, use the grant (e.g. for messages) and otherwise use the chain account

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -407,7 +407,6 @@ pub enum SystemExecutionError {
 impl<C> SystemExecutionStateView<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
     C::Extra: ExecutionRuntimeContext,
 {
     /// Invariant for the states of active chains.

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -63,7 +63,6 @@ pub async fn register_mock_applications<C>(
 where
     C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
-    ViewError: From<C::Error>,
 {
     let mock_applications: Vec<_> =
         create_dummy_user_application_registrations(&mut state.system.registry, count)
@@ -91,7 +90,6 @@ pub async fn create_dummy_user_application_registrations<C>(
 ) -> anyhow::Result<Vec<(UserApplicationId, UserApplicationDescription)>>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     let mut ids = Vec::with_capacity(count as usize);
 

--- a/linera-indexer/lib/src/indexer.rs
+++ b/linera-indexer/lib/src/indexer.rs
@@ -16,7 +16,7 @@ use linera_views::{
     register_view::RegisterView,
     set_view::SetView,
     value_splitting::DatabaseConsistencyError,
-    views::{RootView, View, ViewError},
+    views::{RootView, View},
 };
 use tokio::sync::Mutex;
 use tower_http::cors::CorsLayer;
@@ -65,7 +65,6 @@ where
         + Sync
         + std::error::Error
         + 'static,
-    ViewError: From<S::Error>,
 {
     /// Loads the indexer using a database backend with an `indexer` prefix.
     pub async fn load(store: S) -> Result<Self, IndexerError> {
@@ -217,7 +216,6 @@ pub struct HighestBlock {
 impl<C> State<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     /// Gets the plugins registered in the indexer
     pub async fn plugins(&self) -> Result<Vec<String>, IndexerError> {
@@ -245,7 +243,6 @@ where
 impl<C> State<C>
 where
     C: Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     pub fn schema(self) -> Schema<Self, EmptyMutation, EmptySubscription> {
         Schema::build(self, EmptyMutation, EmptySubscription).finish()

--- a/linera-indexer/lib/src/plugin.rs
+++ b/linera-indexer/lib/src/plugin.rs
@@ -10,7 +10,7 @@ use axum::Router;
 use linera_chain::data_types::HashedCertificateValue;
 use linera_views::{
     common::{ContextFromStore, KeyValueStore},
-    views::{View, ViewError},
+    views::View,
 };
 use tokio::sync::Mutex;
 
@@ -21,7 +21,6 @@ pub trait Plugin<S>: Send + Sync
 where
     S: KeyValueStore + Clone + Send + Sync + 'static,
     S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<S::Error>,
 {
     /// Gets the name of the plugin
     fn name(&self) -> String
@@ -74,7 +73,6 @@ pub async fn load<S, V: View<ContextFromStore<(), S>>>(
 where
     S: KeyValueStore + Clone + Send + Sync + 'static,
     S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<S::Error>,
 {
     let root_key = name.as_bytes().to_vec();
     let store = store

--- a/linera-indexer/lib/src/runner.rs
+++ b/linera-indexer/lib/src/runner.rs
@@ -4,9 +4,7 @@
 //! This module defines the trait for indexer runners.
 
 use linera_base::identifiers::ChainId;
-use linera_views::{
-    common::KeyValueStore, value_splitting::DatabaseConsistencyError, views::ViewError,
-};
+use linera_views::{common::KeyValueStore, value_splitting::DatabaseConsistencyError};
 use tokio::select;
 use tracing::{info, warn};
 
@@ -54,7 +52,6 @@ where
         + Sync
         + std::error::Error
         + 'static,
-    ViewError: From<S::Error>,
 {
     /// Loads a new runner
     pub async fn new(config: IndexerConfig<Config>, store: S) -> Result<Self, IndexerError>

--- a/linera-indexer/lib/src/service.rs
+++ b/linera-indexer/lib/src/service.rs
@@ -19,9 +19,7 @@ use linera_base::{crypto::CryptoHash, data_types::BlockHeight, identifiers::Chai
 use linera_chain::data_types::HashedCertificateValue;
 use linera_core::worker::Reason;
 use linera_service_graphql_client::{block, chains, notifications, Block, Chains, Notifications};
-use linera_views::{
-    common::KeyValueStore, value_splitting::DatabaseConsistencyError, views::ViewError,
-};
+use linera_views::{common::KeyValueStore, value_splitting::DatabaseConsistencyError};
 use tokio::runtime::Handle;
 use tracing::error;
 
@@ -138,7 +136,6 @@ impl Listener {
             + Sync
             + std::error::Error
             + 'static,
-        ViewError: From<S::Error>,
     {
         let mut request = self.service.websocket().into_client_request()?;
         request.headers_mut().insert(

--- a/linera-indexer/plugins/src/operations.rs
+++ b/linera-indexer/plugins/src/operations.rs
@@ -18,7 +18,7 @@ use linera_indexer::{
 use linera_views::{
     common::{Context, ContextFromStore, KeyValueStore},
     map_view::MapView,
-    views::{RootView, ViewError},
+    views::RootView,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -70,7 +70,6 @@ pub enum OperationKeyKind {
 impl<C> Operations<C>
 where
     C: Context + Send + Sync + 'static + Clone,
-    ViewError: From<C::Error>,
 {
     /// Registers an operation and update count and last entries for this chain ID
     async fn register_operation(
@@ -114,7 +113,6 @@ impl<S> Plugin<S> for OperationsPlugin<ContextFromStore<(), S>>
 where
     S: KeyValueStore + Clone + Send + Sync + 'static,
     S::Error: From<bcs::Error> + Send + Sync + std::error::Error + 'static,
-    ViewError: From<S::Error>,
 {
     fn name(&self) -> String {
         NAME.to_string()
@@ -164,7 +162,6 @@ where
 impl<C> OperationsPlugin<C>
 where
     C: Context + Send + Sync + 'static + Clone,
-    ViewError: From<C::Error>,
 {
     /// Gets the operation associated to its hash
     pub async fn operation(

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -27,7 +27,6 @@ metrics = [
     "linera-core/metrics",
     "linera-execution/metrics",
     "linera-storage/metrics",
-    "linera-views/metrics",
 ]
 
 server = ["tokio-util", "tonic-health", "tonic-reflection"]
@@ -38,7 +37,6 @@ web = [
     "linera-chain/web",
     "linera-core/web",
     "linera-execution/web",
-    "linera-views/web",
 ]
 
 [dependencies]
@@ -58,7 +56,6 @@ linera-core.workspace = true
 linera-execution.workspace = true
 linera-storage.workspace = true
 linera-version.workspace = true
-linera-views.workspace = true
 prometheus = { workspace = true, optional = true }
 prost.workspace = true
 rand.workspace = true

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -22,7 +22,6 @@ use linera_core::{
     JoinSetExt as _, TaskHandle,
 };
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use rand::Rng;
 use tokio::{sync::oneshot, task::JoinSet};
 use tokio_util::sync::CancellationToken;
@@ -106,7 +105,6 @@ static SERVER_REQUEST_LATENCY_PER_REQUEST_TYPE: LazyLock<HistogramVec> = LazyLoc
 pub struct GrpcServer<S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     state: WorkerState<S>,
     shard_id: ShardId,
@@ -180,7 +178,6 @@ where
 impl<S> GrpcServer<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn spawn(
@@ -438,7 +435,6 @@ where
 impl<S> ValidatorWorkerRpc for GrpcServer<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[instrument(target = "grpc_server", skip_all, err, fields(nickname = self.state.nickname(), chain_id = ?request.get_ref().chain_id()))]
     async fn handle_block_proposal(

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -11,7 +11,6 @@ use linera_core::{
     JoinSetExt as _,
 };
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use rand::Rng;
 use tokio::{sync::oneshot, task::JoinSet};
 use tokio_util::sync::CancellationToken;
@@ -27,7 +26,6 @@ use crate::{
 pub struct Server<S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     network: ValidatorInternalNetworkPreConfig<TransportProtocol>,
     host: String,
@@ -43,7 +41,6 @@ where
 impl<S> Server<S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -78,7 +75,6 @@ where
 impl<S> Server<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[allow(clippy::too_many_arguments)]
     async fn forward_cross_chain_queries(
@@ -183,7 +179,6 @@ where
 struct RunningServerState<S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     server: Server<S>,
     cross_chain_sender: mpsc::Sender<(RpcMessage, ShardId)>,
@@ -193,7 +188,6 @@ where
 impl<S> MessageHandler for RunningServerState<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[instrument(target = "simple_server", skip_all, fields(nickname = self.server.state.nickname(), chain_id = ?message.target_chain_id()))]
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
@@ -348,7 +342,6 @@ where
 impl<S> RunningServerState<S>
 where
     S: Storage + Send,
-    ViewError: From<S::StoreError>,
 {
     fn handle_network_actions(&mut self, actions: NetworkActions) {
         for request in actions.cross_chain_requests {

--- a/linera-sdk/Cargo.toml
+++ b/linera-sdk/Cargo.toml
@@ -46,6 +46,7 @@ linera-views.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 wit-bindgen.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/linera-sdk/src/views/system_api.rs
+++ b/linera-sdk/src/views/system_api.rs
@@ -9,9 +9,12 @@ use std::sync::Arc;
 use linera_base::ensure;
 use linera_views::{
     batch::Batch,
-    common::{ContextFromStore, ReadableKeyValueStore, WithError, WritableKeyValueStore},
-    views::ViewError,
+    common::{
+        ContextFromStore, KeyValueStoreError, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore,
+    },
 };
+use thiserror::Error;
 
 #[cfg(with_testing)]
 use super::mock_key_value_store::MockKeyValueStore;
@@ -80,7 +83,23 @@ impl KeyValueStore {
 }
 
 impl WithError for KeyValueStore {
-    type Error = ViewError;
+    type Error = StoreError;
+}
+
+/// The error type for [`ViewContainer`] operations.
+#[derive(Error, Debug)]
+pub enum StoreError {
+    /// Key too long
+    #[error("Key too long")]
+    KeyTooLong,
+
+    /// BCS serialization error.
+    #[error("BCS error: {0}")]
+    Bcs(#[from] bcs::Error),
+}
+
+impl KeyValueStoreError for StoreError {
+    const BACKEND: &'static str = "view_container";
 }
 
 impl ReadableKeyValueStore for KeyValueStore {
@@ -94,16 +113,16 @@ impl ReadableKeyValueStore for KeyValueStore {
         1
     }
 
-    async fn contains_key(&self, key: &[u8]) -> Result<bool, ViewError> {
-        ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
+    async fn contains_key(&self, key: &[u8]) -> Result<bool, StoreError> {
+        ensure!(key.len() <= Self::MAX_KEY_SIZE, StoreError::KeyTooLong);
         let promise = self.wit_api.contains_key_new(key);
         yield_once().await;
         Ok(self.wit_api.contains_key_wait(promise))
     }
 
-    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
+    async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, StoreError> {
         for key in &keys {
-            ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
+            ensure!(key.len() <= Self::MAX_KEY_SIZE, StoreError::KeyTooLong);
         }
         let promise = self.wit_api.contains_keys_new(&keys);
         yield_once().await;
@@ -113,26 +132,26 @@ impl ReadableKeyValueStore for KeyValueStore {
     async fn read_multi_values_bytes(
         &self,
         keys: Vec<Vec<u8>>,
-    ) -> Result<Vec<Option<Vec<u8>>>, ViewError> {
+    ) -> Result<Vec<Option<Vec<u8>>>, StoreError> {
         for key in &keys {
-            ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
+            ensure!(key.len() <= Self::MAX_KEY_SIZE, StoreError::KeyTooLong);
         }
         let promise = self.wit_api.read_multi_values_bytes_new(&keys);
         yield_once().await;
         Ok(self.wit_api.read_multi_values_bytes_wait(promise))
     }
 
-    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
-        ensure!(key.len() <= Self::MAX_KEY_SIZE, ViewError::KeyTooLong);
+    async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, StoreError> {
+        ensure!(key.len() <= Self::MAX_KEY_SIZE, StoreError::KeyTooLong);
         let promise = self.wit_api.read_value_bytes_new(key);
         yield_once().await;
         Ok(self.wit_api.read_value_bytes_wait(promise))
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, ViewError> {
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, StoreError> {
         ensure!(
             key_prefix.len() <= Self::MAX_KEY_SIZE,
-            ViewError::KeyTooLong
+            StoreError::KeyTooLong
         );
         let promise = self.wit_api.find_keys_new(key_prefix);
         yield_once().await;
@@ -142,10 +161,10 @@ impl ReadableKeyValueStore for KeyValueStore {
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
-    ) -> Result<Self::KeyValues, ViewError> {
+    ) -> Result<Self::KeyValues, StoreError> {
         ensure!(
             key_prefix.len() <= Self::MAX_KEY_SIZE,
-            ViewError::KeyTooLong
+            StoreError::KeyTooLong
         );
         let promise = self.wit_api.find_key_values_new(key_prefix);
         yield_once().await;
@@ -156,12 +175,12 @@ impl ReadableKeyValueStore for KeyValueStore {
 impl WritableKeyValueStore for KeyValueStore {
     const MAX_VALUE_SIZE: usize = usize::MAX;
 
-    async fn write_batch(&self, batch: Batch) -> Result<(), ViewError> {
+    async fn write_batch(&self, batch: Batch) -> Result<(), StoreError> {
         self.wit_api.write_batch(batch);
         Ok(())
     }
 
-    async fn clear_journal(&self) -> Result<(), ViewError> {
+    async fn clear_journal(&self) -> Result<(), StoreError> {
         Ok(())
     }
 }

--- a/linera-service/src/faucet.rs
+++ b/linera-service/src/faucet.rs
@@ -17,7 +17,6 @@ use linera_client::{chain_listener::ClientContext, config::GenesisConfig};
 use linera_core::{client::ChainClient, data_types::ClientOutcome, node::ValidatorNodeProvider};
 use linera_execution::committee::ValidatorName;
 use linera_storage::{Clock as _, Storage};
-use linera_views::views::ViewError;
 use serde::Deserialize;
 use tower_http::cors::CorsLayer;
 use tracing::info;
@@ -32,7 +31,6 @@ mod tests;
 pub struct QueryRoot<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     genesis_config: Arc<GenesisConfig>,
     client: Arc<Mutex<ChainClient<P, S>>>,
@@ -42,7 +40,6 @@ where
 pub struct MutationRoot<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     client: Arc<Mutex<ChainClient<P, S>>>,
     context: Arc<Mutex<C>>,
@@ -74,7 +71,6 @@ impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     /// Returns the version information on this faucet service.
     async fn version(&self) -> linera_version::VersionInfo {
@@ -108,7 +104,6 @@ where
     <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::StoreError>,
 {
     /// Creates a new chain with the given authentication key, and transfers tokens to it.
     async fn claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
@@ -122,7 +117,6 @@ where
     <P as ValidatorNodeProvider>::Node: Sync,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::StoreError>,
 {
     async fn do_claim(&self, public_key: PublicKey) -> Result<ClaimOutcome, Error> {
         let client = self.client.lock().await;
@@ -178,7 +172,6 @@ where
 impl<P, S, C> MutationRoot<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     /// Multiplies a `u128` with a `u64` and returns the result as a 192-bit number.
     fn multiply(a: u128, b: u64) -> [u64; 3] {
@@ -195,7 +188,6 @@ where
 pub struct FaucetService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     client: Arc<Mutex<ChainClient<P, S>>>,
     context: Arc<Mutex<C>>,
@@ -210,7 +202,6 @@ where
 impl<P, S: Clone, C> Clone for FaucetService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -231,7 +222,6 @@ where
     P: ValidatorNodeProvider + Send + Sync + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::StoreError>,
 {
     /// Creates a new instance of the faucet service.
     pub async fn new(

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -48,7 +48,6 @@ use linera_service::{
     util, wallet,
 };
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use serde_json::Value;
 use tokio::task::JoinSet;
 use tracing::{debug, info, warn, Instrument as _};
@@ -101,7 +100,6 @@ impl Runnable for Job {
     async fn run<S>(self, storage: S) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let Job(options) = self;
         let wallet = options.wallet()?;
@@ -1097,7 +1095,6 @@ impl Job {
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let state = WorkerState::new("Local node".to_string(), None, storage)
             .with_tracked_chains([message_id.chain_id, chain_id])
@@ -1173,7 +1170,6 @@ impl Job {
     ) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let mut chains = HashMap::new();
         for chain_id in chain_ids {

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -64,7 +64,6 @@ pub struct Chains {
 pub struct QueryRoot<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
     port: NonZeroU16,
@@ -75,7 +74,6 @@ where
 pub struct SubscriptionRoot<P, S>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
 }
@@ -84,7 +82,6 @@ where
 pub struct MutationRoot<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
     context: Arc<Mutex<C>>,
@@ -173,7 +170,6 @@ impl<P, S> SubscriptionRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     /// Subscribes to notifications from the specified chain.
     async fn notifications(
@@ -190,7 +186,6 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::StoreError>,
 {
     async fn execute_system_operation(
         &self,
@@ -245,7 +240,6 @@ where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::StoreError>,
 {
     /// Processes the inbox and returns the lists of certificate hashes that were created, if any.
     async fn process_inbox(&self, chain_id: ChainId) -> Result<Vec<CryptoHash>, Error> {
@@ -677,7 +671,6 @@ impl<P, S> QueryRoot<P, S>
 where
     P: ValidatorNodeProvider + Send + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     async fn chain(&self, chain_id: ChainId) -> Result<ChainStateExtendedView<S::Context>, Error> {
         let client = self.clients.try_client_lock(&chain_id).await?;
@@ -913,7 +906,6 @@ fn bytes_from_list(list: &[async_graphql::Value]) -> Option<Vec<u8>> {
 pub struct NodeService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     clients: ChainClients<P, S>,
     config: ChainListenerConfig,
@@ -926,7 +918,6 @@ where
 impl<P, S: Clone, C> Clone for NodeService<P, S, C>
 where
     S: Storage,
-    ViewError: From<S::StoreError>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -946,7 +937,6 @@ where
     <<P as ValidatorNodeProvider>::Node as ValidatorNode>::NotificationStream: Send,
     S: Storage + Clone + Send + Sync + 'static,
     C: ClientContext<ValidatorNodeProvider = P, Storage = S> + Send + 'static,
-    ViewError: From<S::StoreError>,
 {
     /// Creates a new instance of the node service given a client chain and a port.
     pub fn new(

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -44,7 +44,6 @@ use linera_execution::{
     Operation, Query, Response, SystemOperation,
 };
 use linera_storage::Storage;
-use linera_views::views::ViewError;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error as ThisError;
@@ -778,20 +777,17 @@ impl ChainStateViewExtension {
 struct ChainStateExtendedView<C>(ChainStateViewExtension, ReadOnlyChainStateView<C>)
 where
     C: linera_views::common::Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
     C::Extra: linera_execution::ExecutionRuntimeContext;
 
 /// A wrapper type that allows proxying GraphQL queries to a [`ChainStateView`] that's behind an
 /// [`OwnedRwLockReadGuard`].
 pub struct ReadOnlyChainStateView<C>(OwnedRwLockReadGuard<ChainStateView<C>>)
 where
-    C: linera_views::common::Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>;
+    C: linera_views::common::Context + Clone + Send + Sync + 'static;
 
 impl<C> ContainerType for ReadOnlyChainStateView<C>
 where
     C: linera_views::common::Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     async fn resolve_field(
         &self,
@@ -804,7 +800,6 @@ where
 impl<C> OutputType for ReadOnlyChainStateView<C>
 where
     C: linera_views::common::Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
 {
     fn type_name() -> Cow<'static, str> {
         ChainStateView::<C>::type_name()
@@ -826,7 +821,6 @@ where
 impl<C> ChainStateExtendedView<C>
 where
     C: linera_views::common::Context + Clone + Send + Sync + 'static,
-    ViewError: From<C::Error>,
     C::Extra: linera_execution::ExecutionRuntimeContext,
 {
     fn new(view: OwnedRwLockReadGuard<ChainStateView<C>>) -> Self {

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -25,7 +25,7 @@ use linera_rpc::{
 use linera_service::prometheus_server;
 use linera_service::{grpc_proxy::GrpcProxy, util};
 use linera_storage::Storage;
-use linera_views::{common::CommonStoreConfig, views::ViewError};
+use linera_views::common::CommonStoreConfig;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, instrument};
@@ -112,7 +112,6 @@ impl Runnable for ProxyContext {
     async fn run<S>(self, storage: S) -> Result<(), anyhow::Error>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let shutdown_notifier = CancellationToken::new();
         tokio::spawn(util::listen_for_shutdown_signals(shutdown_notifier.clone()));
@@ -192,7 +191,6 @@ where
 impl<S> MessageHandler for SimpleProxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[instrument(skip_all, fields(chain_id = ?message.target_chain_id()))]
     async fn handle_message(&mut self, message: RpcMessage) -> Option<RpcMessage> {
@@ -237,7 +235,6 @@ where
 impl<S> SimpleProxy<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
-    ViewError: From<S::StoreError>,
 {
     #[instrument(skip_all, fields(port = self.public_config.port, metrics_port = self.internal_config.metrics_port), err)]
     async fn run(self, shutdown_signal: CancellationToken) -> Result<()> {

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -26,10 +26,7 @@ use linera_execution::committee::{Committee, ValidatorName};
 use linera_service::node_service::NodeService;
 use linera_storage::{DbStorage, Storage};
 use linera_version::VersionInfo;
-use linera_views::{
-    memory::{MemoryStore, MemoryStoreConfig, TEST_MEMORY_MAX_STREAM_QUERIES},
-    views::ViewError,
-};
+use linera_views::memory::{MemoryStore, MemoryStoreConfig, TEST_MEMORY_MAX_STREAM_QUERIES};
 
 #[derive(Clone)]
 struct DummyValidatorNode;
@@ -140,20 +137,13 @@ impl<P: LocalValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientConte
         unimplemented!()
     }
 
-    fn make_chain_client(&self, _: ChainId) -> ChainClient<P, S>
-    where
-        ViewError: From<S::StoreError>,
-    {
+    fn make_chain_client(&self, _: ChainId) -> ChainClient<P, S> {
         unimplemented!()
     }
 
     fn update_wallet_for_new_chain(&mut self, _: ChainId, _: Option<KeyPair>, _: Timestamp) {}
 
-    async fn update_wallet(&mut self, _: &ChainClient<P, S>)
-    where
-        ViewError: From<S::StoreError>,
-    {
-    }
+    async fn update_wallet(&mut self, _: &ChainClient<P, S>) {}
 }
 
 #[tokio::main]

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -31,7 +31,7 @@ use linera_rpc::{
 use linera_service::prometheus_server;
 use linera_service::util;
 use linera_storage::Storage;
-use linera_views::{common::CommonStoreConfig, views::ViewError};
+use linera_views::common::CommonStoreConfig;
 use serde::Deserialize;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -54,7 +54,6 @@ impl ServerContext {
     ) -> (WorkerState<S>, ShardId, ShardConfig)
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let shard = self.server_config.internal_network.shard(shard_id);
         info!("Shard booted on {}", shard.host);
@@ -78,7 +77,6 @@ impl ServerContext {
     ) -> JoinSet<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let mut join_set = JoinSet::new();
         let handles = FuturesUnordered::new();
@@ -131,7 +129,6 @@ impl ServerContext {
     ) -> JoinSet<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let mut join_set = JoinSet::new();
         let handles = FuturesUnordered::new();
@@ -187,7 +184,6 @@ impl Runnable for ServerContext {
     async fn run<S>(self, storage: S) -> anyhow::Result<()>
     where
         S: Storage + Clone + Send + Sync + 'static,
-        ViewError: From<S::StoreError>,
     {
         let shutdown_notifier = CancellationToken::new();
         let listen_address = self.get_listen_address();

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -9,7 +9,7 @@ use linera_base::command::resolve_binary;
 #[cfg(with_metrics)]
 use linera_views::metering::KeyValueStoreMetrics;
 use linera_views::{
-    common::{CommonStoreConfig, MIN_VIEW_TAG},
+    common::{CommonStoreConfig, KeyValueStoreError, MIN_VIEW_TAG},
     value_splitting::DatabaseConsistencyError,
 };
 use thiserror::Error;
@@ -78,13 +78,8 @@ pub enum ServiceStoreError {
     DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
-impl From<ServiceStoreError> for linera_views::views::ViewError {
-    fn from(error: ServiceStoreError) -> Self {
-        Self::StoreError {
-            backend: "service".to_string(),
-            error: error.to_string(),
-        }
-    }
+impl KeyValueStoreError for ServiceStoreError {
+    const BACKEND: &'static str = "service";
 }
 
 #[cfg(with_testing)]

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -647,7 +647,6 @@ impl<Store, C> DbStorage<Store, C>
 where
     Store: KeyValueStore + Clone + Send + Sync + 'static,
     C: Clock,
-    ViewError: From<Store::Error>,
     Store::Error: From<bcs::Error> + Send + Sync + serde::ser::StdError,
 {
     fn add_hashed_cert_value_to_batch(
@@ -715,7 +714,6 @@ where
 impl<Store> DbStorage<Store, WallClock>
 where
     Store: KeyValueStore + Clone + Send + Sync + 'static,
-    ViewError: From<Store::Error>,
     Store::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
@@ -744,7 +742,6 @@ where
 impl<Store> DbStorage<Store, TestClock>
 where
     Store: KeyValueStore + Clone + Send + Sync + 'static,
-    ViewError: From<Store::Error>,
     Store::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {

--- a/linera-storage/src/db_storage.rs
+++ b/linera-storage/src/db_storage.rs
@@ -341,12 +341,10 @@ impl<Store, C> Storage for DbStorage<Store, C>
 where
     Store: KeyValueStore + Clone + Send + Sync + 'static,
     C: Clock + Clone + Send + Sync + 'static,
-    ViewError: From<Store::Error>,
     Store::Error:
         From<bcs::Error> + From<DatabaseConsistencyError> + Send + Sync + serde::ser::StdError,
 {
     type Context = ContextFromStore<ChainRuntimeContext<Self>, Store>;
-    type StoreError = Store::Error;
     type Clock = C;
 
     fn clock(&self) -> &C {
@@ -615,8 +613,8 @@ where
             READ_CERTIFICATE_COUNTER.with_label_values(&[]).inc();
         }
         let values = values?;
-        let cert_result = from_bytes_option::<LiteCertificate, _>(&values[0])?;
-        let value_result = from_bytes_option::<CertificateValue, _>(&values[1])?;
+        let cert_result = from_bytes_option::<LiteCertificate, Store::Error>(&values[0])?;
+        let value_result = from_bytes_option::<CertificateValue, Store::Error>(&values[1])?;
         let value = value_result.ok_or_else(|| ViewError::not_found("value for hash", hash))?;
         let cert = cert_result.ok_or_else(|| ViewError::not_found("certificate for hash", hash))?;
         Ok(cert

--- a/linera-views-derive/src/lib.rs
+++ b/linera-views-derive/src/lib.rs
@@ -65,7 +65,6 @@ fn context_and_constraints(
         constraints = parse_quote! {
             where
                 #context: linera_views::common::Context + Send + Sync + Clone + 'static,
-                linera_views::views::ViewError: From<#context::Error>,
         };
     }
 

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code-2.snap
@@ -5,7 +5,6 @@ expression: pretty(generate_clonable_view_code(input))
 impl<C, MyParam> linera_views::views::ClonableView<C> for TestView<C, MyParam>
 where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_clonable_view_code.snap
@@ -5,7 +5,6 @@ expression: pretty(generate_clonable_view_code(input))
 impl<C> linera_views::views::ClonableView<C> for TestView<C>
 where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     fn clone_unchecked(&mut self) -> Result<Self, linera_views::views::ViewError> {
         Ok(Self {

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code-2.snap
@@ -7,7 +7,6 @@ impl<C, MyParam> linera_views::views::CryptoHashView<C> for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__generate_crypto_hash_code.snap
@@ -6,7 +6,6 @@ expression: pretty(generate_crypto_hash_code(input))
 impl<C> linera_views::views::CryptoHashView<C> for TestView<C>
 where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     async fn crypto_hash(
         &self,

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C.snap
@@ -6,7 +6,6 @@ expression: pretty(generate_hash_view_code(input))
 impl<C> linera_views::views::HashableView<C> for TestView<C>
 where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_hash_view_code_C_with_where.snap
@@ -7,7 +7,6 @@ impl<C, MyParam> linera_views::views::HashableView<C> for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     type Hasher = linera_views::sha3::Sha3_256;
     async fn hash_mut(

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_save_delete_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_save_delete_view_code_metrics_C.snap
@@ -6,7 +6,6 @@ expression: pretty(generate_save_delete_view_code(input))
 impl<C> linera_views::views::RootView<C> for TestView<C>
 where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
         use linera_views::{common::Context, batch::Batch, views::View};

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_save_delete_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_save_delete_view_code_metrics_C_with_where.snap
@@ -7,7 +7,6 @@ impl<C, MyParam> linera_views::views::RootView<C> for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     async fn save(&mut self) -> Result<(), linera_views::views::ViewError> {
         use linera_views::{common::Context, batch::Batch, views::View};

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C.snap
@@ -6,7 +6,6 @@ expression: "pretty(generate_view_code(input, true))"
 impl<C> linera_views::views::View<C> for TestView<C>
 where
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
         + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;

--- a/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
+++ b/linera-views-derive/src/snapshots/linera_views_derive__tests__test_generate_view_code_metrics_C_with_where.snap
@@ -7,7 +7,6 @@ impl<C, MyParam> linera_views::views::View<C> for TestView<C, MyParam>
 where
     MyParam: Send + Sync + 'static,
     C: linera_views::common::Context + Send + Sync + Clone + 'static,
-    linera_views::views::ViewError: From<C::Error>,
 {
     const NUM_INIT_KEYS: usize = RegisterView::<C, usize>::NUM_INIT_KEYS
         + CollectionView::<C, usize, RegisterView<C, usize>>::NUM_INIT_KEYS;

--- a/linera-views/src/common.rs
+++ b/linera-views/src/common.rs
@@ -788,10 +788,7 @@ where
     ViewError: From<S::Error>,
 {
     /// Creates a context from store that also clears the journal before making it available.
-    pub async fn create(
-        store: S,
-        extra: E,
-    ) -> Result<Self, <ContextFromStore<E, S> as Context>::Error> {
+    pub async fn create(store: S, extra: E) -> Result<Self, S::Error> {
         store.clear_journal().await?;
         let base_key = Vec::new();
         Ok(ContextFromStore {

--- a/linera-views/src/dynamo_db.rs
+++ b/linera-views/src/dynamo_db.rs
@@ -42,7 +42,7 @@ use crate::{
     batch::{Batch, SimpleUnorderedBatch},
     common::{
         AdminKeyValueStore, CommonStoreConfig, ContextFromStore, KeyIterable, KeyValueIterable,
-        ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
     lru_caching::{LruCachingStore, TEST_CACHE_SIZE},
@@ -1298,13 +1298,8 @@ impl DynamoDbStoreError {
     }
 }
 
-impl From<DynamoDbStoreError> for crate::views::ViewError {
-    fn from(error: DynamoDbStoreError) -> Self {
-        Self::StoreError {
-            backend: "DynamoDB".to_string(),
-            error: error.to_string(),
-        }
-    }
+impl KeyValueStoreError for DynamoDbStoreError {
+    const BACKEND: &'static str = "dynamo_db";
 }
 
 /// A static lock to prevent multiple tests from using the same LocalStack instance at the same

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -10,11 +10,10 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::{
-        get_upper_bound_option, CommonStoreConfig, ContextFromStore, LocalAdminKeyValueStore,
-        LocalReadableKeyValueStore, LocalWritableKeyValueStore, WithError,
+        get_upper_bound_option, CommonStoreConfig, ContextFromStore, KeyValueStoreError,
+        LocalAdminKeyValueStore, LocalReadableKeyValueStore, LocalWritableKeyValueStore, WithError,
     },
     value_splitting::DatabaseConsistencyError,
-    views::ViewError,
 };
 
 /// The initial configuration of the system
@@ -395,11 +394,6 @@ impl From<wasm_bindgen::JsValue> for IndexedDbStoreError {
     }
 }
 
-impl From<IndexedDbStoreError> for ViewError {
-    fn from(error: IndexedDbStoreError) -> Self {
-        Self::StoreError {
-            backend: "indexed_db".to_string(),
-            error: error.to_string(),
-        }
-    }
+impl KeyValueStoreError for IndexedDbStoreError {
+    const BACKEND: &'static str = "indexed_db";
 }

--- a/linera-views/src/memory.rs
+++ b/linera-views/src/memory.rs
@@ -15,10 +15,9 @@ use crate::{
     batch::{Batch, DeletePrefixExpander, WriteOperation},
     common::{
         get_interval, AdminKeyValueStore, CommonStoreConfig, Context, ContextFromStore,
-        KeyIterable, ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        KeyIterable, KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     value_splitting::DatabaseConsistencyError,
-    views::ViewError,
 };
 
 /// The initial configuration of the system
@@ -456,13 +455,8 @@ pub enum MemoryStoreError {
     DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
-impl From<MemoryStoreError> for ViewError {
-    fn from(error: MemoryStoreError) -> Self {
-        Self::StoreError {
-            backend: "memory".to_string(),
-            error: error.to_string(),
-        }
-    }
+impl KeyValueStoreError for MemoryStoreError {
+    const BACKEND: &'static str = "memory";
 }
 
 impl DeletePrefixExpander for MemoryContext<()> {

--- a/linera-views/src/rocks_db.rs
+++ b/linera-views/src/rocks_db.rs
@@ -24,7 +24,7 @@ use crate::{
     batch::{Batch, WriteOperation},
     common::{
         get_upper_bound, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
-        ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     lru_caching::{LruCachingStore, TEST_CACHE_SIZE},
     value_splitting::{DatabaseConsistencyError, ValueSplittingStore},
@@ -690,11 +690,6 @@ pub enum RocksDbStoreError {
     DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 }
 
-impl From<RocksDbStoreError> for crate::views::ViewError {
-    fn from(error: RocksDbStoreError) -> Self {
-        Self::StoreError {
-            backend: "rocks_db".to_string(),
-            error: error.to_string(),
-        }
-    }
+impl KeyValueStoreError for RocksDbStoreError {
+    const BACKEND: &'static str = "rocks_db";
 }

--- a/linera-views/src/scylla_db.rs
+++ b/linera-views/src/scylla_db.rs
@@ -45,7 +45,7 @@ use crate::{
     batch::{Batch, UnorderedBatch},
     common::{
         get_upper_bound_option, AdminKeyValueStore, CommonStoreConfig, ContextFromStore,
-        ReadableKeyValueStore, WithError, WritableKeyValueStore,
+        KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore,
     },
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
     lru_caching::{LruCachingStore, TEST_CACHE_SIZE},
@@ -440,13 +440,8 @@ pub enum ScyllaDbStoreError {
     JournalConsistencyError(#[from] JournalConsistencyError),
 }
 
-impl From<ScyllaDbStoreError> for crate::views::ViewError {
-    fn from(error: ScyllaDbStoreError) -> Self {
-        Self::StoreError {
-            backend: "scylla_db".to_string(),
-            error: error.to_string(),
-        }
-    }
+impl KeyValueStoreError for ScyllaDbStoreError {
+    const BACKEND: &'static str = "scylla_db";
 }
 
 impl WithError for ScyllaDbStoreInternal {

--- a/linera-views/src/views.rs
+++ b/linera-views/src/views.rs
@@ -102,10 +102,6 @@ pub enum ViewError {
     #[error("The key must not be too long")]
     KeyTooLong,
 
-    /// Errors can happen within the Wasm guest and have to be transmitted within the Host/Guest where only elementary types can pass.
-    #[error("Following error occurs in wasm code: {0}")]
-    WasmHostGuestError(String),
-
     /// FIXME(#148): This belongs to a future `linera_storage::StoreError`.
     #[error("Entry does not exist in memory: {0}")]
     NotFound(String),


### PR DESCRIPTION
## Motivation

Simplify code

## Proposal

* Create trait KeyValueStoreError to make store errors always convertible to `ViewError`
* Remove Storage::StoreError
* Remove all ViewError bounds

## Test Plan

CI