### PR TITLE
CI: run Clippy on `web-default` features for Web-compatible crates

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -209,9 +209,13 @@ jobs:
         cargo clippy --all-targets --all-features --target x86_64-unknown-linux-gnu --locked
     - name: Run clippy
       run: |
-        cargo clippy --all-targets --all-features --locked
-        cargo clippy --no-default-features --features kubernetes --locked
-        cargo clippy --no-default-features --locked
+        cargo clippy --locked --all-targets --all-features
+        cargo clippy --locked --no-default-features --features kubernetes
+        cargo clippy --locked --no-default-features
+        cargo clippy --locked --target wasm32-unknown-unknown --no-default-features --features web-default \
+          -p linera-client \
+          -p linera-rpc \
+          -p linera-views
     - name: Run cargo doc
       run: |
         cargo doc --locked --all-features

--- a/linera-rpc/Cargo.toml
+++ b/linera-rpc/Cargo.toml
@@ -41,6 +41,8 @@ web = [
     "linera-views/web",
 ]
 
+web-default = ["web"]
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -23,6 +23,7 @@ metrics = ["dep:hex", "linera-base/metrics", "linera-views-derive/metrics"]
 test = ["tokio/macros", "rand"]
 web = ["linera-base/web"]
 indexeddb = ["indexed_db_futures", "wasm-bindgen"]
+web-default = ["web", "indexeddb"]
 
 dynamodb = ["aws-config", "aws-sdk-dynamodb", "aws-smithy-types"]
 scylladb = ["scylla"]

--- a/linera-views/src/indexed_db.rs
+++ b/linera-views/src/indexed_db.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, rc::Rc};
 
 use futures::future;
 use indexed_db_futures::{js_sys, prelude::*, web_sys};
@@ -45,7 +45,7 @@ const DATABASE_NAME: &str = "linera";
 /// API](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API#:~:text=IndexedDB%20is%20a%20low%2Dlevel,larger%20amounts%20of%20structured%20data.).
 pub struct IndexedDbStore {
     /// The database used for storing the data.
-    pub database: Arc<IdbDatabase>,
+    pub database: Rc<IdbDatabase>,
     /// The object store name used for storing the data.
     pub object_store_name: String,
     /// The maximum number of queries used for the stream.
@@ -250,7 +250,7 @@ impl LocalAdminKeyValueStore for IndexedDbStore {
             }));
             database = db_req.await?;
         }
-        let database = Arc::new(database);
+        let database = Rc::new(database);
         let root_key = root_key.to_vec();
         Ok(IndexedDbStore {
             database,
@@ -375,11 +375,11 @@ pub enum IndexedDbStoreError {
     DatabaseConsistencyError(#[from] DatabaseConsistencyError),
 
     /// A DOM exception occurred in the IndexedDB operations
-    #[error("DOM exception: {}", self.to_string())]
+    #[error("DOM exception: {0:?}")]
     Dom(web_sys::DomException),
 
     /// JavaScript threw an exception whilst handling IndexedDB operations
-    #[error("JavaScript exception: {}", self.to_string())]
+    #[error("JavaScript exception: {0:?}")]
     Js(wasm_bindgen::JsValue),
 }
 


### PR DESCRIPTION
## Motivation

Make sure we're Clippy-clean, at least for default features.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Add `web-default` features to all Web-capable targets that we can use when running Clippy for the Web.  Make Clippy's suggested changes.  Add commands to CI to run Clippy against these features under the `wasm32-unknown-unknown` target.

We can't use `--all-features`, despite our `build.rs` magic, because we can't have target-specific _and_ feature-specific dependencies.  So e.g. `aws-smithy` will always try to build as a dependency of `linera-views` with `--all-features` (or the `dynamodb` feature in general), even if marked as a non-`wasm32` dependency, and it will fail to build on `wasm32-unknown-unknown`.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

Adds a feature flag to `linera-rpc`, so should technically be a minor version bump.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- Fixes https://github.com/linera-io/linera-protocol/issues/2432
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
