### PR TITLE
Use different chain worker cache sizes depending on the context

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -6,6 +6,7 @@ use std::{
     collections::{hash_map, BTreeMap, HashMap, HashSet},
     convert::Infallible,
     iter,
+    num::NonZeroUsize,
     ops::{Deref, DerefMut},
     sync::{Arc, RwLock},
 };
@@ -120,10 +121,14 @@ where
         name: impl Into<String>,
     ) -> Self {
         let tracked_chains = Arc::new(RwLock::new(tracked_chains.into_iter().collect()));
-        let state =
-            WorkerState::new_for_client(name.into(), storage.clone(), tracked_chains.clone())
-                .with_allow_inactive_chains(true)
-                .with_allow_messages_from_deprecated_epochs(true);
+        let state = WorkerState::new_for_client(
+            name.into(),
+            storage.clone(),
+            tracked_chains.clone(),
+            NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
+        )
+        .with_allow_inactive_chains(true)
+        .with_allow_messages_from_deprecated_epochs(true);
         let local_node = LocalNodeClient::new(state);
 
         Self {

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
+    num::NonZeroUsize,
     sync::Arc,
 };
 
@@ -642,9 +643,14 @@ where
         for (i, key_pair) in key_pairs.into_iter().enumerate() {
             let name = ValidatorName(key_pair.public());
             let storage = storage_builder.build().await?;
-            let state = WorkerState::new(format!("Node {}", i), Some(key_pair), storage.clone())
-                .with_allow_inactive_chains(false)
-                .with_allow_messages_from_deprecated_epochs(false);
+            let state = WorkerState::new(
+                format!("Node {}", i),
+                Some(key_pair),
+                storage.clone(),
+                NonZeroUsize::new(100).expect("Chain worker limit should not be zero"),
+            )
+            .with_allow_inactive_chains(false)
+            .with_allow_messages_from_deprecated_epochs(false);
             let validator = LocalValidatorClient::new(name, state);
             if i < with_faulty_validators {
                 faulty_validators.insert(name);

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -10,6 +10,7 @@ mod wasm;
 use std::{
     collections::{BTreeMap, BTreeSet},
     iter,
+    num::NonZeroUsize,
     time::Duration,
 };
 
@@ -79,10 +80,15 @@ where
 {
     let key_pair = KeyPair::generate();
     let committee = Committee::make_simple(vec![ValidatorName(key_pair.public())]);
-    let worker = WorkerState::new("Single validator node".to_string(), Some(key_pair), storage)
-        .with_allow_inactive_chains(is_client)
-        .with_allow_messages_from_deprecated_epochs(is_client)
-        .with_grace_period(Duration::from_micros(TEST_GRACE_PERIOD_MICROS));
+    let worker = WorkerState::new(
+        "Single validator node".to_string(),
+        Some(key_pair),
+        storage,
+        NonZeroUsize::new(10).expect("Chain worker limit should not be zero"),
+    )
+    .with_allow_inactive_chains(is_client)
+    .with_allow_messages_from_deprecated_epochs(is_client)
+    .with_grace_period(Duration::from_micros(TEST_GRACE_PERIOD_MICROS));
     (committee, worker)
 }
 

--- a/linera-sdk/src/test/validator.rs
+++ b/linera-sdk/src/test/validator.rs
@@ -6,7 +6,7 @@
 //! The [`TestValidator`] is a minimal validator with a single shard. Micro-chains can be added to
 //! it, and blocks can be added to each microchain individually.
 
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use dashmap::DashMap;
 use futures::FutureExt as _;
@@ -76,6 +76,7 @@ impl TestValidator {
             "Single validator node".to_string(),
             Some(key_pair.copy()),
             storage,
+            NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
         );
 
         let validator = TestValidator {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -5,7 +5,7 @@
 #![recursion_limit = "256"]
 #![deny(clippy::large_futures)]
 
-use std::{collections::HashMap, env, path::PathBuf, sync::Arc, time::Instant};
+use std::{collections::HashMap, env, num::NonZeroUsize, path::PathBuf, sync::Arc, time::Instant};
 
 use anyhow::{anyhow, bail, ensure, Context};
 use async_trait::async_trait;
@@ -1099,10 +1099,15 @@ impl Job {
         S: Storage + Clone + Send + Sync + 'static,
         ViewError: From<S::StoreError>,
     {
-        let state = WorkerState::new("Local node".to_string(), None, storage)
-            .with_tracked_chains([message_id.chain_id, chain_id])
-            .with_allow_inactive_chains(true)
-            .with_allow_messages_from_deprecated_epochs(true);
+        let state = WorkerState::new(
+            "Local node".to_string(),
+            None,
+            storage,
+            NonZeroUsize::new(10).expect("Chain worker limit should not be zero"),
+        )
+        .with_tracked_chains([message_id.chain_id, chain_id])
+        .with_allow_inactive_chains(true)
+        .with_allow_messages_from_deprecated_epochs(true);
         let node_client = LocalNodeClient::new(state);
 
         // Take the latest committee we know of.

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -5,6 +5,7 @@
 #![deny(clippy::large_futures)]
 
 use std::{
+    num::NonZeroUsize,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -62,6 +63,7 @@ impl ServerContext {
             format!("Shard {} @ {}:{}", shard_id, local_ip_addr, shard.port),
             Some(self.server_config.key.copy()),
             storage,
+            NonZeroUsize::new(400).expect("Chain worker limit should not be zero"),
         )
         .with_allow_inactive_chains(false)
         .with_allow_messages_from_deprecated_epochs(false)


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
We ran into some hangs in a test, and the root cause was that we reached the limit of Tokio's blocking threads. That happened because after #2216, every `ChainWorkerActor` instance spawns a separate blocking thread to run the service runtime.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
As an initial fix, the limit of active chain workers should be reduced to below the maximum number of blocking threads (512). Because clients track much less chains than validators, the number can also be different depending on the context.

Add a `chain_worker_limit` parameter to the `WorkerState` constructor, and use different values depending on the context.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should catch regressions caused by this parameter tweak. Reducing the number of chain workers to below the limit of blocking threads made the test that initially discovered the issue pass.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.
- This PR is adding or removing Cargo features.
- Release is blocked and/or tracked by other issues (see links below)

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
