### PR TITLE
Fix race condition after evicting an active chain worker

### DIFF
--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -639,7 +639,7 @@ where
     ///
     /// The returned view holds a lock on the chain state, which prevents the worker from changing
     /// the state of that chain.
-    #[tracing::instrument(level = "trace", skip(self, chain_id))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub async fn chain_state_view(
         &self,
         chain_id: ChainId,
@@ -650,7 +650,7 @@ where
         .await
     }
 
-    #[tracing::instrument(level = "trace", skip(self, chain_id, request_builder))]
+    #[tracing::instrument(level = "trace", skip(self, request_builder))]
     /// Sends a request to the [`ChainWorker`] for a [`ChainId`] and waits for the `Response`.
     async fn query_chain_worker<Response>(
         &self,
@@ -673,7 +673,7 @@ where
 
     /// Retrieves an endpoint to a [`ChainWorkerActor`] from the cache, creating one and adding it
     /// to the cache if needed.
-    #[tracing::instrument(level = "trace", skip(self, chain_id))]
+    #[tracing::instrument(level = "trace", skip(self))]
     async fn get_chain_worker_endpoint(
         &self,
         chain_id: ChainId,

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -730,6 +730,10 @@ where
                 let chain_to_evict = *chain_to_evict;
 
                 chain_workers.pop(&chain_to_evict);
+                self.chain_worker_tasks
+                    .lock()
+                    .unwrap()
+                    .reap_finished_tasks();
             }
 
             let (sender, receiver) = mpsc::unbounded_channel();

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -710,6 +710,7 @@ where
     ///
     /// Returns [`None`] if the cache is full and no candidate for eviction was found.
     #[tracing::instrument(level = "trace", skip(self))]
+    #[allow(clippy::type_complexity)]
     fn try_get_chain_worker_endpoint(
         &self,
         chain_id: ChainId,


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
After #2444, chain worker evictions became more common in the token transfer benchmark. That uncovered a race condition, that happens in the following scenario:

1. One instance of `WorkerState` sends a request to a chain worker actor for chain "A"
2. Another instance of `WorkerState` sends a request to a new chain worker actor for chain "B", which ends up evicting the worker for chain "A" while it's still running
3. Another instance of `WorkerState` sends a request for chain "A", but that requires creating a new chain worker actor for chain "A"
4. Now there are two chain worker actors for chain "A" racing to change the chain state

While fixing this issue, a second issue was uncovered. There's a memory leak in `WorkerState`, because the finished tasks in `chain_worker_tasks` are never garbage collected, so it just grows indefinitely as new actors are created.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Only evict chain worker actors that aren't active. Activity is checked based on the count of active sender endpoints to a chain worker actor. This is safe because all requests to the chain worker wait for the request to be handled while keeping the sending endpoint alive.

Also reap finished tasks from `chain_worker_tasks` to prevent memory leaks.

## Test Plan

<!-- How to test that the changes are correct. -->
The token transfer benchmark now runs successfully.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
New patch version needed to include the bug fixes.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
