### PR TITLE
Update outdated comments and identifiers

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -98,7 +98,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `--recv-timeout-ms <RECV_TIMEOUT>` — Timeout for receiving responses (milliseconds)
 
   Default value: `4000`
-* `--max-pending-messages <MAX_PENDING_MESSAGES>`
+* `--max-pending-message-bundles <MAX_PENDING_MESSAGE_BUNDLES>` — The maximum number of incoming message bundles to include in a block proposal
 
   Default value: `10`
 * `--wasm-runtime <WASM_RUNTIME>` — The WebAssembly runtime to use

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -278,7 +278,7 @@ pub struct ChainTipState {
     pub block_hash: Option<CryptoHash>,
     /// Sequence number tracking blocks.
     pub next_block_height: BlockHeight,
-    /// Number of incoming messages.
+    /// Number of incoming message bundles.
     pub num_incoming_bundles: u32,
     /// Number of operations.
     pub num_operations: u32,
@@ -623,7 +623,7 @@ where
         Ok(true)
     }
 
-    /// Removes the incoming messages in the block from the inboxes.
+    /// Removes the incoming message bundles in the block from the inboxes.
     pub async fn remove_bundles_from_inboxes(&mut self, block: &Block) -> Result<(), ChainError> {
         let chain_id = self.chain_id();
         let mut bundles_by_origin: BTreeMap<_, Vec<&MessageBundle>> = Default::default();
@@ -691,7 +691,7 @@ where
     /// * Modifies the state of outboxes and channels, if needed.
     /// * As usual, in case of errors, `self` may not be consistent any more and should be thrown
     ///   away.
-    /// * Returns the list of messages caused by the block being executed.
+    /// * Returns the outcome of the execution.
     pub async fn execute_block(
         &mut self,
         block: &Block,

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -140,7 +140,7 @@ where
         let client = Client::new(
             node_provider,
             storage,
-            options.max_pending_messages,
+            options.max_pending_message_bundles,
             delivery,
             wallet.chain_ids(),
             "Client node",

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -86,8 +86,9 @@ pub struct ClientOptions {
     #[arg(long = "recv-timeout-ms", default_value = "4000", value_parser = util::parse_millis)]
     pub recv_timeout: Duration,
 
+    /// The maximum number of incoming message bundles to include in a block proposal.
     #[arg(long, default_value = "10")]
-    pub max_pending_messages: usize,
+    pub max_pending_message_bundles: usize,
 
     /// The WebAssembly runtime to use.
     #[arg(long)]

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -283,7 +283,7 @@ where
                 }
             );
         }
-        if query.request_pending_messages {
+        if query.request_pending_message_bundles {
             let mut messages = Vec::new();
             let pairs = chain.inboxes.try_load_all_entries().await?;
             let action = if *chain.execution_state.system.closed.get() {
@@ -315,7 +315,7 @@ where
                 }
             }
 
-            info.requested_pending_messages = messages;
+            info.requested_pending_message_bundles = messages;
         }
         if let Some(range) = query.request_sent_certificate_hashes_in_range {
             let start: usize = range.start.try_into()?;

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -55,7 +55,7 @@ pub struct ChainInfoQuery {
     /// Query the current committees.
     pub request_committees: bool,
     /// Query the received messages that are waiting be picked in the next block.
-    pub request_pending_messages: bool,
+    pub request_pending_message_bundles: bool,
     /// Query a range of certificate hashes sent from the chain.
     pub request_sent_certificate_hashes_in_range: Option<BlockHeightRange>,
     /// Query new certificate sender chain IDs and block heights received from the chain.
@@ -75,7 +75,7 @@ impl ChainInfoQuery {
             test_next_block_height: None,
             request_committees: false,
             request_owner_balance: None,
-            request_pending_messages: false,
+            request_pending_message_bundles: false,
             request_sent_certificate_hashes_in_range: None,
             request_received_log_excluding_first_nth: None,
             request_manager_values: false,
@@ -99,8 +99,8 @@ impl ChainInfoQuery {
         self
     }
 
-    pub fn with_pending_messages(mut self) -> Self {
-        self.request_pending_messages = true;
+    pub fn with_pending_message_bundles(mut self) -> Self {
+        self.request_pending_message_bundles = true;
         self
     }
 
@@ -156,7 +156,7 @@ pub struct ChainInfo {
     /// The current committees.
     pub requested_committees: Option<BTreeMap<Epoch, Committee>>,
     /// The received messages that are waiting be picked in the next block (if requested).
-    pub requested_pending_messages: Vec<IncomingBundle>,
+    pub requested_pending_message_bundles: Vec<IncomingBundle>,
     /// The response to `request_sent_certificate_hashes_in_range`
     pub requested_sent_certificate_hashes: Vec<CryptoHash>,
     /// The current number of received certificates (useful for `request_received_log_excluding_first_nth`)
@@ -236,7 +236,7 @@ where
             state_hash: *view.execution_state_hash.get(),
             requested_committees: None,
             requested_owner_balance: None,
-            requested_pending_messages: Vec::new(),
+            requested_pending_message_bundles: Vec::new(),
             requested_sent_certificate_hashes: Vec::new(),
             count_received_log: view.received_log.count(),
             requested_received_log: Vec::new(),

--- a/linera-rpc/proto/rpc.proto
+++ b/linera-rpc/proto/rpc.proto
@@ -140,7 +140,7 @@ message ChainInfoQuery {
   bool request_committees = 3;
 
   // Query the received messages that are waiting be picked in the next block.
-  bool request_pending_messages = 4;
+  bool request_pending_message_bundles = 4;
 
   // Query a range of certificates hashes sent from the chain.
   optional bytes request_sent_certificate_hashes_in_range = 5;

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -377,7 +377,7 @@ impl TryFrom<api::ChainInfoQuery> for ChainInfoQuery {
                 .request_owner_balance
                 .map(TryInto::try_into)
                 .transpose()?,
-            request_pending_messages: chain_info_query.request_pending_messages,
+            request_pending_message_bundles: chain_info_query.request_pending_message_bundles,
             chain_id: try_proto_convert(chain_info_query.chain_id)?,
             request_sent_certificate_hashes_in_range,
             request_received_log_excluding_first_nth: chain_info_query
@@ -403,7 +403,7 @@ impl TryFrom<ChainInfoQuery> for api::ChainInfoQuery {
             chain_id: Some(chain_info_query.chain_id.into()),
             request_committees: chain_info_query.request_committees,
             request_owner_balance: chain_info_query.request_owner_balance.map(Into::into),
-            request_pending_messages: chain_info_query.request_pending_messages,
+            request_pending_message_bundles: chain_info_query.request_pending_message_bundles,
             test_next_block_height: chain_info_query.test_next_block_height.map(Into::into),
             request_sent_certificate_hashes_in_range,
             request_received_log_excluding_first_nth: chain_info_query
@@ -698,7 +698,7 @@ pub mod tests {
             state_hash: None,
             requested_committees: None,
             requested_owner_balance: None,
-            requested_pending_messages: vec![],
+            requested_pending_message_bundles: vec![],
             requested_sent_certificate_hashes: vec![],
             count_received_log: 0,
             requested_received_log: vec![],
@@ -729,7 +729,7 @@ pub mod tests {
             test_next_block_height: Some(BlockHeight::from(10)),
             request_committees: false,
             request_owner_balance: None,
-            request_pending_messages: false,
+            request_pending_message_bundles: false,
             request_sent_certificate_hashes_in_range: Some(
                 linera_core::data_types::BlockHeightRange {
                     start: BlockHeight::from(3),

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -216,7 +216,7 @@ ChainInfo:
               TYPENAME: Epoch
             VALUE:
               TYPENAME: Committee
-    - requested_pending_messages:
+    - requested_pending_message_bundles:
         SEQ:
           TYPENAME: IncomingBundle
     - requested_sent_certificate_hashes:
@@ -237,7 +237,7 @@ ChainInfoQuery:
         OPTION:
           TYPENAME: Owner
     - request_committees: BOOL
-    - request_pending_messages: BOOL
+    - request_pending_message_bundles: BOOL
     - request_sent_certificate_hashes_in_range:
         OPTION:
           TYPENAME: BlockHeightRange

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -135,10 +135,10 @@ impl ActiveChain {
         let (information, _) = self
             .validator
             .worker()
-            .handle_chain_info_query(ChainInfoQuery::new(chain_id).with_pending_messages())
+            .handle_chain_info_query(ChainInfoQuery::new(chain_id).with_pending_message_bundles())
             .await
             .expect("Failed to query chain's pending messages");
-        let messages = information.info.requested_pending_messages;
+        let messages = information.info.requested_pending_message_bundles;
 
         self.add_block(|block| {
             block.with_incoming_bundles(messages);

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -252,7 +252,7 @@ type ChainTipState {
 	"""
 	nextBlockHeight: BlockHeight!
 	"""
-	Number of incoming messages.
+	Number of incoming message bundles.
 	"""
 	numIncomingBundles: Int!
 	"""

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -57,7 +57,7 @@ pub struct ClientWrapper {
     testing_prng_seed: Option<u64>,
     storage: String,
     wallet: String,
-    max_pending_messages: usize,
+    max_pending_message_bundles: usize,
     network: Network,
     pub path_provider: PathProvider,
 }
@@ -79,7 +79,7 @@ impl ClientWrapper {
             testing_prng_seed,
             storage,
             wallet,
-            max_pending_messages: 10_000,
+            max_pending_message_bundles: 10_000,
             network,
             path_provider,
         }
@@ -152,8 +152,8 @@ impl ClientWrapper {
             .args(["--wallet", &self.wallet])
             .args(["--storage", &self.storage])
             .args([
-                "--max-pending-messages",
-                &self.max_pending_messages.to_string(),
+                "--max-pending-message-bundles",
+                &self.max_pending_message_bundles.to_string(),
             ])
             .args(["--send-timeout-ms", "500000"])
             .args(["--recv-timeout-ms", "500000"])

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -303,7 +303,8 @@ impl Runnable for Job {
                 let account = account.unwrap_or_else(|| context.default_account());
                 let chain_client = context.make_chain_client(account.chain_id);
                 info!(
-                    "Evaluating the local balance of {} by staging execution of known incoming messages", account
+                    "Evaluating the local balance of {account} by staging execution of known \
+                    incoming messages"
                 );
                 let time_start = Instant::now();
                 let balance = match account.owner {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -438,7 +438,6 @@ impl Runnable for Job {
                 info!("Starting operations to change validator set");
                 let time_start = Instant::now();
 
-                // Make sure genesis chains are subscribed to the admin chain.
                 let context = Arc::new(Mutex::new(context));
                 let mut context = context.lock().await;
                 if let SetValidator {


### PR DESCRIPTION
## Motivation

A few comments and identifiers in the code are outdated, most of them related to https://github.com/linera-io/linera-protocol/pull/2343.

## Proposal

Update them: Use "message bundles" instead of "messages" where appropriate, and remove an outdated comment about admin subscriptions.

## Test Plan

No logic was changed.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
