### PR TITLE
Implement the `BucketQueueView`

### DIFF
--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -84,3 +84,7 @@ harness = false
 [[bench]]
 name = "stores"
 harness = false
+
+[[bench]]
+name = "queue_view"
+harness = false

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -73,7 +73,6 @@ where
     for _ in 0..iterations {
         let operations = generate_test_case(N_OPERATIONS, &mut rng);
         let mut view = QueueStateView::load(context.clone()).await.unwrap();
-        //
         let measurement = Instant::now();
         for operation in operations {
             match operation {

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -150,11 +150,9 @@ pub async fn performance_bucket_queue_view<S: KeyValueStore + Clone + Sync + 'st
 where
     S::Error: Debug + Send + Sync + 'static,
 {
-    let context = ViewContext {
-        store,
-        base_key: Vec::new(),
-        extra: (),
-    };
+    let context = ViewContext::<(), S>::create_root_context(store, ())
+        .await
+        .unwrap();
     let mut total_time = Duration::ZERO;
     let mut rng = make_deterministic_rng();
     for _ in 0..iterations {

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -1,0 +1,225 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::{Duration, Instant};
+use std::fmt::Debug;
+
+use linera_views::test_utils::{DeterministicRng, make_deterministic_rng};
+use linera_views::views::{CryptoHashRootView, RootView};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use linera_views::{
+    common::KeyValueStore,
+    backends::memory::create_test_memory_store,
+    context::ViewContext,
+    bucket_queue_view::BucketQueueView,
+    queue_view::QueueView,
+    views::View,
+};
+use rand::Rng;
+#[cfg(with_dynamodb)]
+use linera_views::dynamo_db::create_dynamo_db_test_store;
+#[cfg(with_rocksdb)]
+use linera_views::rocks_db::create_rocks_db_test_store;
+#[cfg(with_scylladb)]
+use linera_views::scylla_db::create_scylla_db_test_store;
+use tokio::runtime::Runtime;
+
+/// The number of operations
+const N_OPERATIONS: usize = 1000;
+
+enum Operations {
+    Save,
+    DeleteFront,
+    PushBack(u8),
+}
+
+fn generate_test_case(n_operation: usize, rng: &mut DeterministicRng) -> Vec<Operations> {
+    let mut operations = Vec:: new();
+    let mut total_length = 0;
+    for _ in 0..n_operation {
+        let choice = rng.gen_range(0..10);
+        if choice == 0 {
+            operations.push(Operations::Save);
+        } else if choice < 3 && total_length > 0 {
+            operations.push(Operations::DeleteFront);
+            total_length -= 1;
+        } else {
+            let val = rng.gen::<u8>();
+            operations.push(Operations::PushBack(val));
+            total_length += 1;
+        }
+    }
+    operations
+}
+
+#[derive(CryptoHashRootView)]
+pub struct QueueStateView<C> {
+    pub queue: QueueView<C, u8>,
+}
+
+pub async fn performance_queue_view<S: KeyValueStore + Clone + Sync + 'static>(store: S, iterations: u64) -> Duration
+where
+    S::Error: Debug + Send + Sync + 'static,
+{
+    let context = ViewContext { store, base_key: Vec::new(), extra: () };
+    let mut total_time = Duration::ZERO;
+    let mut rng = make_deterministic_rng();
+    for _ in 0..iterations {
+        let operations = generate_test_case(N_OPERATIONS, &mut rng);
+        let mut view = QueueStateView::load(context.clone()).await.unwrap();
+        //
+        let measurement = Instant::now();
+        for operation in operations {
+            match operation {
+                Operations::Save => {
+                    view.save().await.unwrap();
+                },
+                Operations::DeleteFront => {
+                    view.queue.delete_front();
+                },
+                Operations::PushBack(val) => {
+                    view.queue.push_back(val);
+                },
+            }
+            black_box(view.queue.front().await.unwrap());
+        }
+        view.clear();
+        view.save().await.unwrap();
+        total_time += measurement.elapsed();
+    }
+
+    total_time
+}
+
+fn bench_queue_view(criterion: &mut Criterion) {
+    criterion.bench_function("memory_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_test_memory_store();
+                performance_queue_view(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_rocks_db_test_store().await;
+                performance_queue_view(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_queue_view(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_queue_view(store, iterations).await
+            })
+    });
+}
+
+#[derive(CryptoHashRootView)]
+pub struct BucketQueueStateView<C> {
+    pub queue: BucketQueueView<C, u8, 100>,
+}
+
+pub async fn performance_bucket_queue_view<S: KeyValueStore + Clone + Sync + 'static>(store: S, iterations: u64) -> Duration
+where
+    S::Error: Debug + Send + Sync + 'static,
+{
+    let context = ViewContext { store, base_key: Vec::new(), extra: () };
+    let mut total_time = Duration::ZERO;
+    let mut rng = make_deterministic_rng();
+    for _ in 0..iterations {
+        let operations = generate_test_case(N_OPERATIONS, &mut rng);
+        let mut view = BucketQueueStateView::load(context.clone()).await.unwrap();
+        //
+        let measurement = Instant::now();
+        for operation in operations {
+            match operation {
+                Operations::Save => {
+                    view.save().await.unwrap();
+                },
+                Operations::DeleteFront => {
+                    view.queue.delete_front().await.unwrap();
+                },
+                Operations::PushBack(val) => {
+                    view.queue.push_back(val);
+                },
+            }
+            black_box(view.queue.front());
+        }
+        view.clear();
+        view.save().await.unwrap();
+        total_time += measurement.elapsed();
+    }
+
+    total_time
+}
+
+fn bench_bucket_queue_view(criterion: &mut Criterion) {
+    criterion.bench_function("memory_bucket_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_test_memory_store();
+                performance_bucket_queue_view(store, iterations).await
+            })
+    });
+
+    #[cfg(with_rocksdb)]
+    criterion.bench_function("rocksdb_bucket_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_rocks_db_test_store().await;
+                performance_bucket_queue_view(store, iterations).await
+            })
+    });
+
+    #[cfg(with_dynamodb)]
+    criterion.bench_function("dynamodb_bucket_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_dynamo_db_test_store().await;
+                performance_bucket_queue_view(store, iterations).await
+            })
+    });
+
+    #[cfg(with_scylladb)]
+    criterion.bench_function("scylladb_bucket_queue_view", |bencher| {
+        bencher
+            .to_async(Runtime::new().expect("Failed to create Tokio runtime"))
+            .iter_custom(|iterations| async move {
+                let store = create_scylla_db_test_store().await;
+                performance_bucket_queue_view(store, iterations).await
+            })
+    });
+}
+
+
+
+
+
+criterion_group!(
+    benches,
+    bench_queue_view,
+    bench_bucket_queue_view
+);
+criterion_main!(benches);

--- a/linera-views/benches/queue_view.rs
+++ b/linera-views/benches/queue_view.rs
@@ -65,11 +65,9 @@ pub async fn performance_queue_view<S: KeyValueStore + Clone + Sync + 'static>(
 where
     S::Error: Debug + Send + Sync + 'static,
 {
-    let context = ViewContext {
-        store,
-        base_key: Vec::new(),
-        extra: (),
-    };
+    let context = ViewContext::<(), S>::create_root_context(store, ())
+        .await
+        .unwrap();
     let mut total_time = Duration::ZERO;
     let mut rng = make_deterministic_rng();
     for _ in 0..iterations {

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -167,11 +167,11 @@ pub trait Context: Clone {
 #[derive(Debug, Default, Clone)]
 pub struct ViewContext<E, S> {
     /// The DB client that is shared between views.
-    pub store: S,
+    store: S,
     /// The base key for the context.
-    pub base_key: Vec<u8>,
+    base_key: Vec<u8>,
     /// User-defined data attached to the view.
-    pub extra: E,
+    extra: E,
 }
 
 impl<E, S> ViewContext<E, S>

--- a/linera-views/src/context.rs
+++ b/linera-views/src/context.rs
@@ -167,11 +167,11 @@ pub trait Context: Clone {
 #[derive(Debug, Default, Clone)]
 pub struct ViewContext<E, S> {
     /// The DB client that is shared between views.
-    store: S,
+    pub store: S,
     /// The base key for the context.
-    base_key: Vec<u8>,
+    pub base_key: Vec<u8>,
     /// User-defined data attached to the view.
-    extra: E,
+    pub extra: E,
 }
 
 impl<E, S> ViewContext<E, S>

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -97,7 +97,7 @@ pub use backends::rocks_db;
 pub use backends::scylla_db;
 pub use backends::{journaling, lru_caching, memory, value_splitting};
 pub use views::{
-    collection_view, hashable_wrapper, key_value_store_view, log_view, map_view, queue_view,
+    bucket_queue_view, collection_view, hashable_wrapper, key_value_store_view, log_view, map_view, queue_view,
     reentrant_collection_view, register_view, set_view,
 };
 /// Re-exports used by the derive macros of this library.

--- a/linera-views/src/lib.rs
+++ b/linera-views/src/lib.rs
@@ -97,8 +97,8 @@ pub use backends::rocks_db;
 pub use backends::scylla_db;
 pub use backends::{journaling, lru_caching, memory, value_splitting};
 pub use views::{
-    bucket_queue_view, collection_view, hashable_wrapper, key_value_store_view, log_view, map_view, queue_view,
-    reentrant_collection_view, register_view, set_view,
+    bucket_queue_view, collection_view, hashable_wrapper, key_value_store_view, log_view, map_view,
+    queue_view, reentrant_collection_view, register_view, set_view,
 };
 /// Re-exports used by the derive macros of this library.
 #[doc(hidden)]

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -38,7 +38,7 @@ static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(||
     .expect("Histogram can be created")
 });
 
-/// Key tags to create the sub-keys of a BucketQueueView on top of the base key.
+/// Key tags to create the sub-keys of a [`BucketQueueView`] on top of the base key.
 #[repr(u8)]
 enum KeyTag {
     /// Prefix for the front of the view

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -263,7 +263,7 @@ where
     C: Context + Send + Sync,
     ViewError: From<C::Error>,
 {
-    /// Get the key corresponding to the index
+    /// Gets the key corresponding to the index
     fn get_index_key(&self, index: usize) -> Result<Vec<u8>, ViewError> {
         Ok(if index == 0 {
             self.context.base_tag(KeyTag::Front as u8)

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -69,7 +69,7 @@ struct Cursor {
 
 impl Cursor {
     pub fn new(stored_indices: &StoredIndices) -> Self {
-        if stored_indices.indices.len() == 0 {
+        if stored_indices.indices.is_empty() {
             Cursor { position: None }
         } else {
             Cursor { position: Some((0, stored_indices.position)) }
@@ -153,7 +153,7 @@ where
         if self.delete_storage_first {
             return true;
         }
-        if self.stored_indices.indices.len() > 0 {
+        if !self.stored_indices.indices.is_empty() {
             let Some((i_block, position)) = self.cursor.position else {
                 return true;
             };
@@ -439,7 +439,7 @@ where
         let mut count_remain = count;
         if let Some(pair) = position {
             let mut keys = Vec::new();
-            let (i_block, mut position) = pair.clone();
+            let (i_block, mut position) = pair;
             for block in i_block..self.data.len() {
                 let size = self.stored_indices.indices[block].0 - position;
                 if self.data[block].is_none() {
@@ -454,7 +454,7 @@ where
                 position = 0;
             }
             let values = self.context.read_multi_values_bytes(keys).await?;
-            let (i_block, mut position) = pair.clone();
+            position = pair.1;
             let mut pos = 0;
             count_remain = count;
             for block in i_block..self.data.len() {

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -177,27 +177,25 @@ where
             batch.delete_key_prefix(key_prefix);
             self.stored_indices = StoredIndices::default();
             self.data.clear();
-        } else {
-            if let Some((i_block, position)) = self.cursor.position {
-                for block in 0..i_block {
-                    let index = self.stored_indices.indices[block].1;
-                    let key = self.get_index_key(index)?;
-                    batch.delete_key(key);
-                }
-                self.stored_indices.indices.drain(0..i_block);
-                self.data.drain(0..i_block);
-                self.cursor = Cursor { position: Some((0, position)) };
-                // We need to ensure that the first index is in the front.
-                let first_index = self.stored_indices.indices[0].1;
-                if first_index != 0 {
-                    let size = self.stored_indices.indices[0].0;
-                    self.stored_indices.indices[0] = (size, 0);
-                    let key = self.get_index_key(first_index)?;
-                    batch.delete_key(key);
-                    let key = self.get_index_key(0)?;
-                    let data0 = self.data.first().unwrap().as_ref().unwrap();
-                    batch.put_key_value(key, &data0)?;
-                }
+        } else if let Some((i_block, position)) = self.cursor.position {
+            for block in 0..i_block {
+                let index = self.stored_indices.indices[block].1;
+                let key = self.get_index_key(index)?;
+                batch.delete_key(key);
+            }
+            self.stored_indices.indices.drain(0..i_block);
+            self.data.drain(0..i_block);
+            self.cursor = Cursor { position: Some((0, position)) };
+            // We need to ensure that the first index is in the front.
+            let first_index = self.stored_indices.indices[0].1;
+            if first_index != 0 {
+                let size = self.stored_indices.indices[0].0;
+                self.stored_indices.indices[0] = (size, 0);
+                let key = self.get_index_key(first_index)?;
+                batch.delete_key(key);
+                let key = self.get_index_key(0)?;
+                let data0 = self.data.first().unwrap().as_ref().unwrap();
+                batch.put_key_value(key, &data0)?;
             }
         }
         if !self.new_back_values.is_empty() {

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -43,7 +43,7 @@ static BUCKET_QUEUE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(||
 enum KeyTag {
     /// Prefix for the front of the view
     Front = MIN_VIEW_TAG,
-    /// Prefix for the storing of the stored-indices information
+    /// Prefix for [`StoredIndices`]
     Store,
     /// Prefix for the indices of the log.
     Index,

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -294,7 +294,7 @@ where
         })
     }
 
-    /// Get the number of entries in the container that are stored
+    /// Gets the number of entries in the container that are stored
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::context::create_test_memory_context;
@@ -543,7 +543,7 @@ where
         Ok(elements)
     }
 
-    /// Returns the last element of a bucket queue view
+    /// Returns the first elements of a bucket queue view
     /// ```rust
     /// # tokio_test::block_on(async {
     /// # use linera_views::context::create_test_memory_context;
@@ -572,7 +572,7 @@ where
     /// queue.push_back(34);
     /// queue.push_back(37);
     /// queue.push_back(47);
-    /// assert_eq!(queue.read_front(2).await.unwrap(), vec![34, 37]);
+    /// assert_eq!(queue.read_back(2).await.unwrap(), vec![37, 47]);
     /// # })
     /// ```
     pub async fn read_back(&self, count: usize) -> Result<Vec<T>, ViewError> {

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -574,11 +574,12 @@ where
     async fn load_all(&mut self) -> Result<(), ViewError> {
         if !self.delete_storage_first {
             let elements = self.elements().await?;
-            self.data.clear();
-            self.stored_indices = StoredIndices::default();
+            println!("load_all, |elements|={}", elements.len());
+            self.new_back_values.clear();
             for elt in elements {
                 self.new_back_values.push_back(elt);
             }
+            self.cursor = Cursor { position: None };
             self.delete_storage_first = true;
         }
         Ok(())

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -57,7 +57,7 @@ struct StoredIndices {
 
 impl StoredIndices {
     fn is_empty(&self) -> bool {
-        self.indices.len() == 0
+        self.indices.is_empty()
     }
 }
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -272,8 +272,19 @@ where
         })
     }
 
-    /// Get the stored_count
-    fn stored_count(&self) -> usize {
+    /// Get the number of entries in the container that are stored
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::bucket_queue_view::BucketQueueView;
+    /// # use crate::linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
+    /// queue.push_back(34);
+    /// assert_eq!(queue.stored_count(), 0);
+    /// # })
+    /// ```
+    pub fn stored_count(&self) -> usize {
         if self.delete_storage_first {
             0
         } else {
@@ -290,6 +301,17 @@ where
     }
 
     /// The total number of entries of the container
+    /// ```rust
+    /// # tokio_test::block_on(async {
+    /// # use linera_views::context::create_test_memory_context;
+    /// # use linera_views::bucket_queue_view::BucketQueueView;
+    /// # use crate::linera_views::views::View;
+    /// # let context = create_test_memory_context();
+    /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
+    /// queue.push_back(34);
+    /// assert_eq!(queue.count(), 1);
+    /// # })
+    /// ```
     pub fn count(&self) -> usize {
         self.stored_count() + self.new_back_values.len()
     }

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -383,19 +383,19 @@ where
     /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// queue.push_back(42);
-    /// assert_eq!(queue.front(), Some(34));
+    /// assert_eq!(queue.front().cloned(), Some(34));
     /// # })
     /// ```
-    pub fn front(&self) -> Option<T> {
+    pub fn front(&self) -> Option<&T> {
         match self.cursor.position {
             Some((i_block, position)) => {
                 let block = &self.stored_data[i_block].1;
                 let Bucket::Loaded { data } = block else {
                     unreachable!();
                 };
-                Some(data[position].clone())
+                Some(&data[position])
             }
-            None => self.new_back_values.front().cloned(),
+            None => self.new_back_values.front(),
         }
     }
 

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -578,7 +578,7 @@ where
     /// # use linera_views::bucket_queue_view::BucketQueueView;
     /// # use linera_views::views::View;
     /// # let context = create_test_memory_context();
-    /// let mut queue = QueueView::<_, u8, 5>::load(context).await.unwrap();
+    /// let mut queue = BucketQueueView::<_, u8, 5>::load(context).await.unwrap();
     /// queue.push_back(34);
     /// let mut iter = queue.iter_mut().await.unwrap();
     /// let value = iter.next().unwrap();

--- a/linera-views/src/views/bucket_queue_view.rs
+++ b/linera-views/src/views/bucket_queue_view.rs
@@ -129,6 +129,9 @@ fn stored_indices<T>(stored_data: &VecDeque<(usize, Bucket<T>)>, position: usize
 
 
 /// A view that supports a FIFO queue for values of type `T`.
+/// The size `N` has to be chosen by taking into account the size of the type `T`
+/// and the basic size of a block. For example a total size of 100bytes to 10KB
+/// seems adequate.
 pub struct BucketQueueView<C, T, const N: usize> {
     context: C,
     /// The buckets of stored data. If missing, then it has not been loaded. The first index is always loaded.
@@ -584,14 +587,7 @@ where
                         &bcs::from_bytes::<Vec<T>>(value)?
                     }
                 };
-                let end = if count_remain <= size {
-                    position + count_remain
-                } else {
-                    position + size
-                };
-                for element in &vec[position..end] {
-                    elements.push(element.clone());
-                }
+                elements.extend(vec[position..].iter().take(count_remain).cloned());
                 if size >= count_remain {
                     return Ok(elements);
                 }

--- a/linera-views/src/views/mod.rs
+++ b/linera-views/src/views/mod.rs
@@ -23,6 +23,9 @@ pub mod register_view;
 /// The `LogView` implements a log list that can be pushed.
 pub mod log_view;
 
+/// The `BucketQueueView` implements a queue that can push on the back and delete on the front and group data in buckets.
+pub mod bucket_queue_view;
+
 /// The `QueueView` implements a queue that can push on the back and delete on the front.
 pub mod queue_view;
 

--- a/linera-views/src/views/queue_view.rs
+++ b/linera-views/src/views/queue_view.rs
@@ -463,8 +463,7 @@ where
     async fn hash(&self) -> Result<<Self::Hasher as Hasher>::Output, ViewError> {
         #[cfg(with_metrics)]
         let _hash_latency = QUEUE_VIEW_HASH_RUNTIME.measure_latency();
-        let count = self.count();
-        let elements = self.read_front(count).await?;
+        let elements = self.elements().await?;
         let mut hasher = sha3::Sha3_256::default();
         hasher.update_with_bcs_bytes(&elements)?;
         Ok(hasher.finalize())

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -420,7 +420,6 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
         let save = rng.gen::<bool>();
         let elements = view.queue.elements().await?;
         assert_eq!(elements, vector);
-        //
         let count_oper = rng.gen_range(0..25);
         let mut new_vector = vector.clone();
         for _ in 0..count_oper {

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -474,6 +474,13 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
             let back2 = new_vector.last().cloned();
             assert_eq!(back1, back2);
             println!("new_vector={:?}", new_vector);
+            for _ in 0..3 {
+                let count = rng.gen_range(0..new_vector.len()+1);
+                println!("count={}", count);
+                let vec1 = view.queue.read_front(count).await?;
+                let vec2 = new_vector[0..count].to_vec();
+                assert_eq!(vec1, vec2);
+            }
         }
         println!("------------------- save={} -----------------", save);
         if save {

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -426,7 +426,7 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
         let count_oper = rng.gen_range(0..25);
         let mut new_vector = vector.clone();
         for i_oper in 0..count_oper {
-            let choice = rng.gen_range(0..5);
+            let choice = rng.gen_range(0..6);
             let count = view.queue.count();
             println!("------------- ITER={} i_oper={}/{} choice={} count={}", i, i_oper, count_oper, choice, count);
             if choice == 0 {
@@ -450,13 +450,28 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
                     new_vector.remove(0);
                 }
             }
-            if choice == 2 {
+            if choice == 2 && count > 0 {
+                // changing some random entries
+                let pos = rng.gen_range(0..count);
+                let val = rng.gen::<u8>();
+                let mut iter = view.queue.iter_mut().await?;
+                (for _ in 0..pos {
+                    iter.next();
+                });
+                if let Some(value) = iter.next() {
+                    *value = val;
+                }
+                if let Some(value) = new_vector.get_mut(pos) {
+                    *value = val;
+                }
+            }
+            if choice == 3 {
                 // Doing the clearing
                 println!("choice 2, clear");
                 view.clear();
                 new_vector.clear();
             }
-            if choice == 3 {
+            if choice == 4 {
                 // Doing the rollback
                 println!("choice 3, rollback");
                 view.rollback();

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -5,12 +5,12 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Result;
 use linera_views::{
+    bucket_queue_view::HashedBucketQueueView,
     collection_view::HashedCollectionView,
     context::{create_test_memory_context, Context},
     key_value_store_view::{KeyValueStoreView, SizeData},
     map_view::HashedByteMapView,
     queue_view::HashedQueueView,
-    bucket_queue_view::HashedBucketQueueView,
     reentrant_collection_view::HashedReentrantCollectionView,
     register_view::RegisterView,
     test_utils,
@@ -486,7 +486,7 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
             let back2 = new_vector.last().cloned();
             assert_eq!(back1, back2);
             for _ in 0..3 {
-                let count = rng.gen_range(0..new_vector.len()+1);
+                let count = rng.gen_range(0..new_vector.len() + 1);
                 let vec1 = view.queue.read_front(count).await?;
                 let vec2 = new_vector[..count].to_vec();
                 assert_eq!(vec1, vec2);

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -577,6 +577,9 @@ async fn queue_view_mutability_check() -> Result<()> {
                 assert!(!view.has_pending_changes().await);
                 new_vector.clone_from(&vector);
             }
+            let front1 = view.queue.front().await?;
+            let front2 = new_vector.first().cloned();
+            assert_eq!(front1, front2);
             let new_elements = view.queue.elements().await?;
             let new_hash = view.crypto_hash().await?;
             if elements == new_elements {

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -478,7 +478,11 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
                 let count = rng.gen_range(0..new_vector.len()+1);
                 println!("count={}", count);
                 let vec1 = view.queue.read_front(count).await?;
-                let vec2 = new_vector[0..count].to_vec();
+                let vec2 = new_vector[..count].to_vec();
+                assert_eq!(vec1, vec2);
+                let vec1 = view.queue.read_back(count).await?;
+                let start = new_vector.len() - count;
+                let vec2 = new_vector[start..].to_vec();
                 assert_eq!(vec1, vec2);
             }
         }

--- a/linera-views/tests/random_container_tests.rs
+++ b/linera-views/tests/random_container_tests.rs
@@ -480,7 +480,7 @@ async fn bucket_queue_view_mutability_check() -> Result<()> {
             }
             assert_eq!(new_elements, new_vector);
             let front1 = view.queue.front();
-            let front2 = new_vector.first().cloned();
+            let front2 = new_vector.first();
             assert_eq!(front1, front2);
             let back1 = view.queue.back().await?;
             let back2 = new_vector.last().cloned();


### PR DESCRIPTION
## Motivation

The `QueueView` is used for the protocol and this leads to painful-to-read loops where we read the front, then deleting and so on until we get what we want. This leads to many storage calls which are not storage friendly.

## Proposal

The following change was proposed:
* It was identified that only the `front`, `delete_front`, and `push_back` are used in the protocol. So, this is what needs to be optimized.
* The arrangement of keys is made so that when the view is loaded the front is loaded as well. 
* So, the `BucketQueueView` has `fn front` being a regular function. But of course, it has a cost in that the `delete_front` needs to be async and can return an error.
* All the other functions of `QueueView` are implemented in `BucketQueueView`.

The protocol has not been changed so far but could be later on. Whether we keep `QueueView` in the future is an open question.

## Test Plan

The unit test have been added to the documentation of the code. The random tests are added. Also benchmarks are added.
The benchmarks proved the reliability of the idea. Two realistic scenarios are created and run against `QueueView` and `BucketQueueView`. The result is that `QueueView<_,u8>` takes 836 microseconds and `BucketQueueView<_,u8,100>` takes 177 microseconds.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
