### PR TITLE
`linera-client`: relax unnecessary `Send` bound on `P`

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -448,10 +448,7 @@ pub type ChainGuard<'a, T> = Unsend<DashMapRef<'a, ChainId, T>>;
 pub type ChainGuardMut<'a, T> = Unsend<DashMapRefMut<'a, ChainId, T>>;
 pub type ChainGuardMapped<'a, T> = Unsend<DashMapMappedRef<'a, ChainId, ChainState, T>>;
 
-impl<P, S> ChainClient<P, S>
-where
-    S: Storage,
-{
+impl<P: 'static, S: Storage> ChainClient<P, S> {
     #[tracing::instrument(level = "trace", skip(self))]
     /// Gets a shared reference to the chain's state.
     pub fn state(&self) -> ChainGuard<ChainState> {
@@ -531,7 +528,7 @@ enum ReceiveCertificateMode {
 
 impl<P, S> ChainClient<P, S>
 where
-    P: LocalValidatorNodeProvider + Sync,
+    P: LocalValidatorNodeProvider + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
 {
     #[tracing::instrument(level = "trace")]
@@ -2951,10 +2948,7 @@ where
     /// and synchronizes the local state accordingly.
     pub async fn listen(
         &self,
-    ) -> Result<(impl Future<Output = ()>, AbortOnDrop, NotificationStream), ChainClientError>
-    where
-        P: Send + 'static,
-    {
+    ) -> Result<(impl Future<Output = ()>, AbortOnDrop, NotificationStream), ChainClientError> {
         use future::FutureExt as _;
 
         async fn await_while_polling<F: FusedFuture>(
@@ -3027,10 +3021,7 @@ where
     async fn update_streams(
         &self,
         senders: &mut HashMap<ValidatorName, AbortHandle>,
-    ) -> Result<impl Future<Output = ()>, ChainClientError>
-    where
-        P: Send + 'static,
-    {
+    ) -> Result<impl Future<Output = ()>, ChainClientError> {
         let (chain_id, nodes, local_node) = {
             let committee = self.local_committee().await?;
             let nodes: HashMap<_, _> = self


### PR DESCRIPTION
## Motivation

Needed to call `ChainClient` functions on the Web, where `P` may be non-`Send`.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Remove the `Send` bound on `P`, which isn't used anyway.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->

None.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
