### PR TITLE
`linera_core::join_set_ext`: replace `spawn_local` with `wasm_bindgen_futures::spawn_local`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4367,6 +4367,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "trait-variant",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -16,13 +16,12 @@ use linera_chain::data_types::Certificate;
 use linera_core::{
     client::{ChainClient, Client, MessagePolicy},
     data_types::ClientOutcome,
+    join_set_ext::{JoinSet, JoinSetExt as _},
     node::CrossChainMessageDelivery,
-    JoinSetExt as _,
 };
 use linera_rpc::node_provider::{NodeOptions, NodeProvider};
 use linera_storage::Storage;
 use thiserror_context::Context;
-use tokio::task::JoinSet;
 use tracing::{debug, info};
 #[cfg(feature = "benchmark")]
 use {
@@ -83,7 +82,7 @@ where
     pub notification_retry_delay: Duration,
     pub notification_retries: u32,
     pub options: ClientOptions,
-    pub chain_listeners: JoinSet<()>,
+    pub chain_listeners: JoinSet,
 }
 
 #[cfg_attr(not(web), async_trait)]
@@ -172,7 +171,7 @@ where
             notification_retry_delay: options.notification_retry_delay,
             notification_retries: options.notification_retries,
             options,
-            chain_listeners: JoinSet::new(),
+            chain_listeners: JoinSet::default(),
         }
     }
 

--- a/linera-core/Cargo.toml
+++ b/linera-core/Cargo.toml
@@ -45,6 +45,7 @@ web = [
     "linera-execution/web",
     "linera-storage/web",
     "linera-views/web",
+    "wasm-bindgen-futures",
 ]
 
 [dependencies]
@@ -75,6 +76,7 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tracing.workspace = true
 trait-variant.workspace = true
+wasm-bindgen-futures = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 linera-storage-service.workspace = true

--- a/linera-core/src/join_set_ext.rs
+++ b/linera-core/src/join_set_ext.rs
@@ -137,7 +137,7 @@ pub use implementation::*;
 
 /// A handle to a task spawned with [`JoinSetExt`].
 ///
-/// Dropping a handle aborts its respective task.
+/// Dropping a handle detaches its respective task.
 pub struct TaskHandle<Output> {
     output_receiver: oneshot::Receiver<Output>,
     abort_handle: AbortHandle,

--- a/linera-core/src/join_set_ext.rs
+++ b/linera-core/src/join_set_ext.rs
@@ -5,8 +5,126 @@
 //! runtime.
 //!
 //! In most cases the [`Future`] task to be spawned should implement [`Send`], but that's
-//! not possible when compiling for `wasm32-unknown-unknown`. In that case, the task is
-//! spawned in a [`LocalSet`][`tokio::tast::LocalSet`].
+//! not possible when compiling for the Web. In that case, the task is spawned on the
+//! browser event loop.
+
+use futures::channel::oneshot;
+
+#[cfg(web)]
+mod implementation {
+    pub use futures::future::AbortHandle;
+    use futures::{future, stream, StreamExt as _};
+
+    use super::*;
+
+    #[derive(Default)]
+    pub struct JoinSet(Vec<oneshot::Receiver<()>>);
+
+    /// An extension trait for the [`JoinSet`] type.
+    pub trait JoinSetExt: Sized {
+        /// Spawns a `future` task on this [`JoinSet`] using [`JoinSet::spawn_local`].
+        ///
+        /// Returns a [`oneshot::Receiver`] to receive the `future`'s output, and an
+        /// [`AbortHandle`] to cancel execution of the task.
+        fn spawn_task<F: Future + 'static>(&mut self, future: F) -> TaskHandle<F::Output>;
+
+        /// Awaits all tasks spawned in this [`JoinSet`].
+        fn await_all_tasks(&mut self) -> impl Future<Output = ()>;
+
+        /// Reaps tasks that have finished.
+        fn reap_finished_tasks(&mut self);
+    }
+
+    impl JoinSetExt for JoinSet {
+        fn spawn_task<F: Future + 'static>(&mut self, future: F) -> TaskHandle<F::Output> {
+            let (abort_handle, abort_registration) = AbortHandle::new_pair();
+            let (send_done, recv_done) = oneshot::channel();
+            let (send_output, recv_output) = oneshot::channel();
+            let future = async move {
+                let _ = send_output.send(future.await);
+                let _ = send_done.send(());
+            };
+            self.0.push(recv_done);
+            wasm_bindgen_futures::spawn_local(
+                future::Abortable::new(future, abort_registration).map(drop),
+            );
+
+            TaskHandle {
+                output_receiver: recv_output,
+                abort_handle,
+            }
+        }
+
+        async fn await_all_tasks(&mut self) {
+            stream::iter(&mut self.0)
+                .then(|x| x)
+                .map(drop)
+                .collect()
+                .await
+        }
+
+        fn reap_finished_tasks(&mut self) {
+            for mut done in self.0.drain(..) {
+                while done.try_recv() == Ok(None) {}
+            }
+        }
+    }
+}
+
+#[cfg(not(web))]
+mod implementation {
+    pub use tokio::task::AbortHandle;
+
+    use super::*;
+
+    pub type JoinSet = tokio::task::JoinSet<()>;
+
+    /// An extension trait for the [`JoinSet`] type.
+    #[trait_variant::make(Send)]
+    pub trait JoinSetExt: Sized {
+        /// Spawns a `future` task on this [`JoinSet`] using [`JoinSet::spawn`].
+        ///
+        /// Returns a [`oneshot::Receiver`] to receive the `future`'s output, and an
+        /// [`AbortHandle`] to cancel execution of the task.
+        fn spawn_task<F: Future<Output: Send> + Send + 'static>(
+            &mut self,
+            future: F,
+        ) -> TaskHandle<F::Output>;
+
+        /// Awaits all tasks spawned in this [`JoinSet`].
+        async fn await_all_tasks(&mut self);
+
+        /// Reaps tasks that have finished.
+        fn reap_finished_tasks(&mut self);
+    }
+
+    impl JoinSetExt for JoinSet {
+        fn spawn_task<F>(&mut self, future: F) -> TaskHandle<F::Output>
+        where
+            F: Future + Send + 'static,
+            F::Output: Send,
+        {
+            let (output_sender, output_receiver) = oneshot::channel();
+
+            let abort_handle = self.spawn(async move {
+                let _ = output_sender.send(future.await);
+            });
+
+            TaskHandle {
+                output_receiver,
+                abort_handle,
+            }
+        }
+
+        async fn await_all_tasks(&mut self) {
+            while self.join_next().await.is_some() {}
+        }
+
+        fn reap_finished_tasks(&mut self) {
+            while self.try_join_next().is_some() {}
+        }
+    }
+}
 
 use std::{
     future::Future,
@@ -15,102 +133,7 @@ use std::{
 };
 
 use futures::FutureExt as _;
-use tokio::{
-    sync::oneshot,
-    task::{AbortHandle, JoinSet},
-};
-
-/// An extension trait for the [`JoinSet`] type.
-#[cfg(not(web))]
-pub trait JoinSetExt: Sized {
-    /// Spawns a `future` task on this [`JoinSet`] using [`JoinSet::spawn`].
-    ///
-    /// Returns a [`oneshot::Receiver`] to receive the `future`'s output, and an
-    /// [`AbortHandle`] to cancel execution of the task.
-    fn spawn_task<F>(&mut self, future: F) -> TaskHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send;
-
-    /// Awaits all tasks spawned in this [`JoinSet`].
-    fn await_all_tasks(&mut self) -> impl Future<Output = ()> + Send;
-
-    /// Reaps tasks that have finished.
-    fn reap_finished_tasks(&mut self);
-}
-
-/// An extension trait for the [`JoinSet`] type.
-#[cfg(web)]
-pub trait JoinSetExt: Sized {
-    /// Spawns a `future` task on this [`JoinSet`] using [`JoinSet::spawn_local`].
-    ///
-    /// Returns a [`oneshot::Receiver`] to receive the `future`'s output, and an
-    /// [`AbortHandle`] to cancel execution of the task.
-    fn spawn_task<F>(&mut self, future: F) -> TaskHandle<F::Output>
-    where
-        F: Future + 'static;
-
-    /// Awaits all tasks spawned in this [`JoinSet`].
-    fn await_all_tasks(&mut self) -> impl Future<Output = ()>;
-
-    /// Reaps tasks that have finished.
-    fn reap_finished_tasks(&mut self);
-}
-
-#[cfg(not(web))]
-impl JoinSetExt for JoinSet<()> {
-    fn spawn_task<F>(&mut self, future: F) -> TaskHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send,
-    {
-        let (output_sender, output_receiver) = oneshot::channel();
-
-        let abort_handle = self.spawn(async move {
-            let _ = output_sender.send(future.await);
-        });
-
-        TaskHandle {
-            output_receiver,
-            abort_handle,
-        }
-    }
-
-    async fn await_all_tasks(&mut self) {
-        while self.join_next().await.is_some() {}
-    }
-
-    fn reap_finished_tasks(&mut self) {
-        while self.try_join_next().is_some() {}
-    }
-}
-
-#[cfg(web)]
-impl JoinSetExt for JoinSet<()> {
-    fn spawn_task<F>(&mut self, future: F) -> TaskHandle<F::Output>
-    where
-        F: Future + 'static,
-    {
-        let (output_sender, output_receiver) = oneshot::channel();
-
-        let abort_handle = self.spawn_local(async move {
-            let _ = output_sender.send(future.await);
-        });
-
-        TaskHandle {
-            output_receiver,
-            abort_handle,
-        }
-    }
-
-    async fn await_all_tasks(&mut self) {
-        while self.join_next().await.is_some() {}
-    }
-
-    fn reap_finished_tasks(&mut self) {
-        while self.try_join_next().is_some() {}
-    }
-}
+pub use implementation::*;
 
 /// A handle to a task spawned with [`JoinSetExt`].
 ///
@@ -121,7 +144,7 @@ pub struct TaskHandle<Output> {
 }
 
 impl<Output> Future for TaskHandle<Output> {
-    type Output = Result<Output, oneshot::error::RecvError>;
+    type Output = Result<Output, oneshot::Canceled>;
 
     fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
         self.as_mut().output_receiver.poll_unpin(context)
@@ -136,9 +159,6 @@ impl<Output> TaskHandle<Output> {
 
     /// Returns [`true`] if the task is still running.
     pub fn is_running(&mut self) -> bool {
-        matches!(
-            self.output_receiver.try_recv(),
-            Err(oneshot::error::TryRecvError::Empty)
-        )
+        self.output_receiver.try_recv().is_err()
     }
 }

--- a/linera-core/src/lib.rs
+++ b/linera-core/src/lib.rs
@@ -9,7 +9,7 @@
 pub mod chain_worker;
 pub mod client;
 pub mod data_types;
-mod join_set_ext;
+pub mod join_set_ext;
 pub mod local_node;
 pub mod node;
 pub mod notifier;

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -33,7 +33,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
     sync::{mpsc, oneshot, OwnedRwLockReadGuard},
-    task::JoinSet,
 };
 use tracing::{error, instrument, trace, warn, Instrument as _};
 #[cfg(with_metrics)]
@@ -46,7 +45,7 @@ use {
 use crate::{
     chain_worker::{ChainWorkerActor, ChainWorkerConfig, ChainWorkerRequest},
     data_types::{ChainInfoQuery, ChainInfoResponse, CrossChainRequest},
-    join_set_ext::JoinSetExt,
+    join_set_ext::{JoinSet, JoinSetExt},
     value_cache::ValueCache,
 };
 
@@ -244,7 +243,7 @@ where
     /// delivered.
     delivery_notifiers: Arc<Mutex<DeliveryNotifiers>>,
     /// The set of spawned [`ChainWorkerActor`] tasks.
-    chain_worker_tasks: Arc<Mutex<JoinSet<()>>>,
+    chain_worker_tasks: Arc<Mutex<JoinSet>>,
     /// The cache of running [`ChainWorkerActor`]s.
     chain_workers: Arc<Mutex<LruCache<ChainId, ChainActorEndpoint<StorageClient>>>>,
 }

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -31,9 +31,7 @@ use linera_storage::Storage;
 use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::{
-    sync::{mpsc, oneshot, OwnedRwLockReadGuard},
-};
+use tokio::sync::{mpsc, oneshot, OwnedRwLockReadGuard};
 use tracing::{error, instrument, trace, warn, Instrument as _};
 #[cfg(with_metrics)]
 use {

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -29,8 +29,8 @@ pub enum GrpcError {
     #[error("failed to communicate cross-chain queries: {0}")]
     CrossChain(#[from] tonic::Status),
 
-    #[error("failed to execute task to completion: {0}")]
-    Join(#[from] tokio::sync::oneshot::error::RecvError),
+    #[error("failed to execute task to completion")]
+    Join(#[from] futures::channel::oneshot::Canceled),
 
     #[error("failed to parse socket address: {0}")]
     SocketAddr(#[from] std::net::AddrParseError),


### PR DESCRIPTION
## Motivation

Tokio's `spawn_local` needs to be called from the context of a `LocalSet`, which is annoying to set up when our entry point is in JavaScript, and besides would block the browser worker, which is undesirable.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Instead, use the browser's event loop.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI for the native case; `linera-web` will test this in the browser case.

<!-- How to test that the changes are correct. -->

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
None.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
