### PR TITLE
Make service runtime short-lived by default

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -116,6 +116,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 
   Default value: `10`
 * `--wait-for-outgoing-messages` — Whether to wait until a quorum of validators has confirmed that all sent cross-chain messages have been delivered
+* `--long-lived-services` — (EXPERIMENTAL) Whether application services can persist in some cases between queries
 * `--tokio-threads <TOKIO_THREADS>` — The number of Tokio worker threads to use
 * `--blanket-message-policy <BLANKET_MESSAGE_POLICY>` — The policy for handling incoming messages
 

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -59,8 +59,11 @@ Then, a node service for the current wallet has to be started:
 
 ```bash
 PORT=8080
-linera service --port $PORT &
-```
+linera --long-lived-services service --port $PORT &
+ ```
+
+The experimental option `--long-lived-services` is used for performance, to avoid
+reloading the model between queries.
 
 Next, navigate to `llm/web-frontend` and install the requisite `npm`
 dependencies:
@@ -75,6 +78,5 @@ Finally, navigate to `localhost:3000` to interact with the Linera ChatBot.
 ```bash
 echo "http://localhost:3000/$CHAIN?app=$APP_ID&port=$PORT"
 ```
- 
 
 <!-- cargo-rdme end -->

--- a/examples/llm/README.md
+++ b/examples/llm/README.md
@@ -9,11 +9,6 @@ The model used by Linera Stories is a 40M parameter TinyLlama by A. Karpathy. Fi
 
 CAVEAT:
 
-* We currently use a local HTTP service to provide model data to the wallet
-  implementation (aka "node service"). In the future, model data will be stored on-chain
-  ([#1981](https://github.com/linera-io/linera-protocol/issues/1981)) or in an external
-  decentralized storage.
-
 * Running larger LLMs with acceptable performance will likely require hardware acceleration ([#1931](https://github.com/linera-io/linera-protocol/issues/1931)).
 
 * The service currently is restarted when the wallet receives a new block for the chain where the

--- a/examples/llm/src/lib.rs
+++ b/examples/llm/src/lib.rs
@@ -11,11 +11,6 @@ The model used by Linera Stories is a 40M parameter TinyLlama by A. Karpathy. Fi
 
 CAVEAT:
 
-* We currently use a local HTTP service to provide model data to the wallet
-  implementation (aka "node service"). In the future, model data will be stored on-chain
-  ([#1981](https://github.com/linera-io/linera-protocol/issues/1981)) or in an external
-  decentralized storage.
-
 * Running larger LLMs with acceptable performance will likely require hardware acceleration ([#1931](https://github.com/linera-io/linera-protocol/issues/1931)).
 
 * The service currently is restarted when the wallet receives a new block for the chain where the

--- a/examples/llm/src/lib.rs
+++ b/examples/llm/src/lib.rs
@@ -61,8 +61,11 @@ Then, a node service for the current wallet has to be started:
 
 ```bash
 PORT=8080
-linera service --port $PORT &
-```
+linera --long-lived-services service --port $PORT &
+ ```
+
+The experimental option `--long-lived-services` is used for performance, to avoid
+reloading the model between queries.
 
 Next, navigate to `llm/web-frontend` and install the requisite `npm`
 dependencies:
@@ -77,7 +80,7 @@ Finally, navigate to `localhost:3000` to interact with the Linera ChatBot.
 ```bash
 echo "http://localhost:3000/$CHAIN?app=$APP_ID&port=$PORT"
 ```
- */
+*/
 
 use async_graphql::{Request, Response};
 use linera_sdk::base::{ContractAbi, ServiceAbi};

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -22,10 +22,10 @@ use linera_base::{
     },
 };
 use linera_execution::{
-    system::OpenChainConfig, ExecutionError, ExecutionOutcome, ExecutionRequest,
-    ExecutionRuntimeContext, ExecutionStateView, Message, MessageContext, Operation,
-    OperationContext, Query, QueryContext, RawExecutionOutcome, RawOutgoingMessage,
-    ResourceController, ResourceTracker, Response, ServiceRuntimeRequest, TransactionTracker,
+    system::OpenChainConfig, ExecutionError, ExecutionOutcome, ExecutionRuntimeContext,
+    ExecutionStateView, Message, MessageContext, Operation, OperationContext, Query, QueryContext,
+    RawExecutionOutcome, RawOutgoingMessage, ResourceController, ResourceTracker, Response,
+    ServiceRuntimeEndpoint, TransactionTracker,
 };
 use linera_views::{
     context::Context,
@@ -375,10 +375,7 @@ where
         &mut self,
         local_time: Timestamp,
         query: Query,
-        incoming_execution_requests: Option<
-            &mut futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-        >,
-        runtime_request_sender: Option<&mut std::sync::mpsc::Sender<ServiceRuntimeRequest>>,
+        service_runtime_endpoint: Option<&mut ServiceRuntimeEndpoint>,
     ) -> Result<Response, ChainError> {
         let context = QueryContext {
             chain_id: self.chain_id(),
@@ -387,12 +384,7 @@ where
         };
         let response = self
             .execution_state
-            .query_application(
-                context,
-                query,
-                incoming_execution_requests,
-                runtime_request_sender,
-            )
+            .query_application(context, query, service_runtime_endpoint)
             .await
             .map_err(|error| ChainError::ExecutionError(error, ChainExecutionContext::Query))?;
         Ok(response)

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -375,10 +375,10 @@ where
         &mut self,
         local_time: Timestamp,
         query: Query,
-        incoming_execution_requests: &mut futures::channel::mpsc::UnboundedReceiver<
-            ExecutionRequest,
+        incoming_execution_requests: Option<
+            &mut futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
         >,
-        runtime_request_sender: &mut std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+        runtime_request_sender: Option<&mut std::sync::mpsc::Sender<ServiceRuntimeRequest>>,
     ) -> Result<Response, ChainError> {
         let context = QueryContext {
             chain_id: self.chain_id(),

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -162,6 +162,7 @@ where
             storage,
             options.max_pending_message_bundles,
             delivery,
+            options.long_lived_services,
             wallet.chain_ids(),
             "Client node",
         );

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -129,6 +129,10 @@ pub struct ClientOptions {
     #[arg(long)]
     pub wait_for_outgoing_messages: bool,
 
+    /// Whether to application services can persist in some cases between queries.
+    #[arg(long)]
+    pub long_lived_services: bool,
+
     /// The number of Tokio worker threads to use.
     #[arg(long, env = "LINERA_CLIENT_TOKIO_THREADS")]
     pub tokio_threads: Option<usize>,

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -129,7 +129,7 @@ pub struct ClientOptions {
     #[arg(long)]
     pub wait_for_outgoing_messages: bool,
 
-    /// Whether to application services can persist in some cases between queries.
+    /// (EXPERIMENTAL) Whether application services can persist in some cases between queries.
     #[arg(long)]
     pub long_lived_services: bool,
 

--- a/linera-client/src/unit_tests/chain_listener.rs
+++ b/linera-client/src/unit_tests/chain_listener.rs
@@ -159,6 +159,7 @@ async fn test_chain_listener() -> anyhow::Result<()> {
             storage.clone(),
             10,
             delivery,
+            false,
             [chain_id0],
             "Client node",
         )),

--- a/linera-core/src/chain_worker/config.rs
+++ b/linera-core/src/chain_worker/config.rs
@@ -17,6 +17,8 @@ pub struct ChainWorkerConfig {
     pub allow_inactive_chains: bool,
     /// Whether new messages from deprecated epochs are allowed.
     pub allow_messages_from_deprecated_epochs: bool,
+    /// Whether the user application services should be long-lived.
+    pub long_lived_services: bool,
     /// Blocks with a timestamp this far in the future will still be accepted, but the validator
     /// will wait until that timestamp before voting.
     pub grace_period: Duration,

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -55,8 +55,8 @@ where
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
     shared_chain_view: Option<Arc<RwLock<ChainStateView<StorageClient::Context>>>>,
-    execution_state_receiver: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-    runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+    execution_state_receiver: Option<futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>>,
+    runtime_request_sender: Option<std::sync::mpsc::Sender<ServiceRuntimeRequest>>,
     recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
     recent_blobs: Arc<ValueCache<BlobId, Blob>>,
     tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
@@ -76,8 +76,10 @@ where
         blob_cache: Arc<ValueCache<BlobId, Blob>>,
         tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
         chain_id: ChainId,
-        execution_state_receiver: futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-        runtime_request_sender: std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+        execution_state_receiver: Option<
+            futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
+        >,
+        runtime_request_sender: Option<std::sync::mpsc::Sender<ServiceRuntimeRequest>>,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -26,8 +26,7 @@ use linera_chain::{
     ChainError, ChainStateView,
 };
 use linera_execution::{
-    committee::Epoch, ExecutionRequest, Message, Query, QueryContext, Response,
-    ServiceRuntimeRequest, SystemMessage,
+    committee::Epoch, Message, Query, QueryContext, Response, ServiceRuntimeEndpoint, SystemMessage,
 };
 use linera_storage::{Clock as _, Storage};
 use linera_views::views::{ClonableView, ViewError};
@@ -55,8 +54,7 @@ where
     storage: StorageClient,
     chain: ChainStateView<StorageClient::Context>,
     shared_chain_view: Option<Arc<RwLock<ChainStateView<StorageClient::Context>>>>,
-    execution_state_receiver: Option<futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>>,
-    runtime_request_sender: Option<std::sync::mpsc::Sender<ServiceRuntimeRequest>>,
+    service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
     recent_hashed_certificate_values: Arc<ValueCache<CryptoHash, HashedCertificateValue>>,
     recent_blobs: Arc<ValueCache<BlobId, Blob>>,
     tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
@@ -76,10 +74,7 @@ where
         blob_cache: Arc<ValueCache<BlobId, Blob>>,
         tracked_chains: Option<Arc<sync::RwLock<HashSet<ChainId>>>>,
         chain_id: ChainId,
-        execution_state_receiver: Option<
-            futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
-        >,
-        runtime_request_sender: Option<std::sync::mpsc::Sender<ServiceRuntimeRequest>>,
+        service_runtime_endpoint: Option<ServiceRuntimeEndpoint>,
     ) -> Result<Self, WorkerError> {
         let chain = storage.load_chain(chain_id).await?;
 
@@ -88,8 +83,7 @@ where
             storage,
             chain,
             shared_chain_view: None,
-            execution_state_receiver,
-            runtime_request_sender,
+            service_runtime_endpoint,
             recent_hashed_certificate_values: certificate_value_cache,
             recent_blobs: blob_cache,
             tracked_chains,

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -105,8 +105,8 @@ where
             .query_application(
                 local_time,
                 query,
-                &mut self.0.execution_state_receiver,
-                &mut self.0.runtime_request_sender,
+                self.0.execution_state_receiver.as_mut(),
+                self.0.runtime_request_sender.as_mut(),
             )
             .await?;
         Ok(response)

--- a/linera-core/src/chain_worker/state/temporary_changes.rs
+++ b/linera-core/src/chain_worker/state/temporary_changes.rs
@@ -102,12 +102,7 @@ where
         let response = self
             .0
             .chain
-            .query_application(
-                local_time,
-                query,
-                self.0.execution_state_receiver.as_mut(),
-                self.0.runtime_request_sender.as_mut(),
-            )
+            .query_application(local_time, query, self.0.service_runtime_endpoint.as_mut())
             .await?;
         Ok(response)
     }

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -113,6 +113,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
         storage: S,
         max_pending_message_bundles: usize,
         cross_chain_message_delivery: CrossChainMessageDelivery,
+        long_lived_services: bool,
         tracked_chains: impl IntoIterator<Item = ChainId>,
         name: impl Into<String>,
     ) -> Self {
@@ -123,6 +124,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
             tracked_chains.clone(),
             NonZeroUsize::new(20).expect("Chain worker limit should not be zero"),
         )
+        .with_long_lived_services(long_lived_services)
         .with_allow_inactive_chains(true)
         .with_allow_messages_from_deprecated_epochs(true);
         let local_node = LocalNodeClient::new(state);

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -786,6 +786,7 @@ where
             storage,
             10,
             CrossChainMessageDelivery::NonBlocking,
+            false,
             [chain_id],
             format!("Client node for {:.8}", chain_id),
         ));

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -313,6 +313,13 @@ where
         self
     }
 
+    #[tracing::instrument(level = "trace", skip(self, value))]
+    pub fn with_long_lived_services(mut self, value: bool) -> Self {
+        self.chain_worker_config.long_lived_services = value;
+        self
+    }
+
+    #[tracing::instrument(level = "trace", skip(self, tracked_chains))]
     /// Configures the subset of chains that this worker is tracking.
     pub fn with_tracked_chains(
         mut self,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -32,8 +32,8 @@ use crate::{
     resources::ResourceController, system::SystemExecutionStateView, ContractSyncRuntime,
     ExecutionError, ExecutionOutcome, ExecutionRuntimeConfig, ExecutionRuntimeContext, Message,
     MessageContext, MessageKind, Operation, OperationContext, Query, QueryContext,
-    RawExecutionOutcome, RawOutgoingMessage, Response, SystemMessage, TransactionTracker,
-    UserApplicationDescription, UserApplicationId,
+    RawExecutionOutcome, RawOutgoingMessage, Response, ServiceSyncRuntime, SystemMessage,
+    TransactionTracker, UserApplicationDescription, UserApplicationId,
 };
 
 /// A view accessing the execution state of a chain.
@@ -443,10 +443,10 @@ where
         &mut self,
         context: QueryContext,
         query: Query,
-        incoming_execution_requests: &mut futures::channel::mpsc::UnboundedReceiver<
-            ExecutionRequest,
+        incoming_execution_requests: Option<
+            &mut futures::channel::mpsc::UnboundedReceiver<ExecutionRequest>,
         >,
-        runtime_request_sender: &mut std::sync::mpsc::Sender<ServiceRuntimeRequest>,
+        runtime_request_sender: Option<&mut std::sync::mpsc::Sender<ServiceRuntimeRequest>>,
     ) -> Result<Response, ExecutionError> {
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match query {
@@ -459,21 +459,49 @@ where
                 bytes,
             } => {
                 let ExecutionRuntimeConfig {} = self.context().extra().execution_runtime_config();
-                let response = self
-                    .query_user_application(
-                        application_id,
-                        context,
-                        bytes,
-                        incoming_execution_requests,
-                        runtime_request_sender,
-                    )
-                    .await?;
+                let response = match (incoming_execution_requests, runtime_request_sender) {
+                    (Some(requests), Some(sender)) => {
+                        self.query_user_application_with_long_lived_service(
+                            application_id,
+                            context,
+                            bytes,
+                            requests,
+                            sender,
+                        )
+                        .await?
+                    }
+                    (None, None) => {
+                        self.query_user_application(application_id, context, bytes)
+                            .await?
+                    }
+                    _ => unreachable!("invalid parameters"),
+                };
                 Ok(Response::User(response))
             }
         }
     }
 
     async fn query_user_application(
+        &mut self,
+        application_id: UserApplicationId,
+        context: QueryContext,
+        query: Vec<u8>,
+    ) -> Result<Vec<u8>, ExecutionError> {
+        let (execution_state_sender, mut execution_state_receiver) =
+            futures::channel::mpsc::unbounded();
+        let execution_outcomes_future = linera_base::task::spawn_blocking(move || {
+            let mut runtime = ServiceSyncRuntime::new(execution_state_sender, context);
+            runtime.run_query(application_id, query)
+        });
+        while let Some(request) = execution_state_receiver.next().await {
+            self.handle_request(request).await?;
+        }
+
+        let response = execution_outcomes_future.await??;
+        Ok(response)
+    }
+
+    async fn query_user_application_with_long_lived_service(
         &mut self,
         application_id: UserApplicationId,
         context: QueryContext,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::wasm::{
 };
 pub use crate::{
     applications::ApplicationRegistryView,
-    execution::ExecutionStateView,
+    execution::{ExecutionStateView, ServiceRuntimeEndpoint},
     execution_state_actor::ExecutionRequest,
     policy::ResourceControlPolicy,
     resources::{ResourceController, ResourceTracker},

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -197,6 +197,14 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         ]
     );
 
+    {
+        let state_key = state_key.clone();
+        caller_application.expect_call(ExpectedCall::handle_query(|runtime, _context, _query| {
+            let state = runtime.read_value_bytes(state_key)?.unwrap_or_default();
+            Ok(state)
+        }));
+    }
+
     caller_application.expect_call(ExpectedCall::handle_query(|runtime, _context, _query| {
         let state = runtime.read_value_bytes(state_key)?.unwrap_or_default();
         Ok(state)
@@ -229,7 +237,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![]
             },
-            None,
+            Some(&mut service_runtime_endpoint),
         )
         .await
         .unwrap(),

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -207,8 +207,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
-    let (mut execution_request_receiver, mut runtime_request_sender) =
-        context.spawn_service_runtime_actor();
+    let mut service_runtime_endpoint = context.spawn_service_runtime_actor();
     assert_eq!(
         view.query_application(
             context,
@@ -216,8 +215,7 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![]
             },
-            Some(&mut execution_request_receiver),
-            Some(&mut runtime_request_sender),
+            Some(&mut service_runtime_endpoint),
         )
         .await
         .unwrap(),
@@ -231,7 +229,6 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![]
             },
-            None,
             None,
         )
         .await

--- a/linera-execution/tests/test_execution.rs
+++ b/linera-execution/tests/test_execution.rs
@@ -216,8 +216,23 @@ async fn test_simple_user_operation() -> anyhow::Result<()> {
                 application_id: caller_id,
                 bytes: vec![]
             },
-            &mut execution_request_receiver,
-            &mut runtime_request_sender,
+            Some(&mut execution_request_receiver),
+            Some(&mut runtime_request_sender),
+        )
+        .await
+        .unwrap(),
+        Response::User(dummy_operation.clone())
+    );
+
+    assert_eq!(
+        view.query_application(
+            context,
+            Query::User {
+                application_id: caller_id,
+                bytes: vec![]
+            },
+            None,
+            None,
         )
         .await
         .unwrap(),

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -117,7 +117,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         local_time: Timestamp::from(0),
     };
     let response = view
-        .query_application(context, Query::System(SystemQuery), None, None)
+        .query_application(context, Query::System(SystemQuery), None)
         .await
         .unwrap();
     assert_eq!(

--- a/linera-execution/tests/test_system_execution.rs
+++ b/linera-execution/tests/test_system_execution.rs
@@ -117,12 +117,7 @@ async fn test_simple_system_query() -> anyhow::Result<()> {
         local_time: Timestamp::from(0),
     };
     let response = view
-        .query_application(
-            context,
-            Query::System(SystemQuery),
-            &mut futures::channel::mpsc::unbounded().1,
-            &mut std::sync::mpsc::channel().0,
-        )
+        .query_application(context, Query::System(SystemQuery), None, None)
         .await
         .unwrap();
     assert_eq!(

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -125,8 +125,7 @@ async fn test_fuel_for_counter_wasm_application(
         next_block_height: BlockHeight(0),
         local_time: Timestamp::from(0),
     };
-    let (mut execution_request_receiver, mut runtime_request_sender) =
-        context.spawn_service_runtime_actor();
+    let mut service_runtime_endpoint = context.spawn_service_runtime_actor();
     let expected_value = async_graphql::Response::new(
         async_graphql::Value::from_json(json!({"value" : increments.into_iter().sum::<u64>()}))
             .unwrap(),
@@ -136,8 +135,7 @@ async fn test_fuel_for_counter_wasm_application(
         .query_application(
             context,
             Query::user(app_id, &request).unwrap(),
-            Some(&mut execution_request_receiver),
-            Some(&mut runtime_request_sender),
+            Some(&mut service_runtime_endpoint),
         )
         .await?
     else {

--- a/linera-execution/tests/wasm.rs
+++ b/linera-execution/tests/wasm.rs
@@ -136,8 +136,8 @@ async fn test_fuel_for_counter_wasm_application(
         .query_application(
             context,
             Query::user(app_id, &request).unwrap(),
-            &mut execution_request_receiver,
-            &mut runtime_request_sender,
+            Some(&mut execution_request_receiver),
+            Some(&mut runtime_request_sender),
         )
         .await?
     else {


### PR DESCRIPTION
## Motivation

The long-lived services are somehow experimental and are mostly used for the LLM demo.
Stability issues were solved but we should probably not activate long-lived services by default anyway.

## Proposal

* Add a configuration option
* Use short-lived service instances by default

## Test Plan

* [x] CI
* [x] Test LLM demo manually

## Release Plan

* Not breaking for validators
* May affect users but they can pass an option on the CLI