### PR TITLE
Add a block size limit

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -399,6 +399,7 @@ View or update the resource control policy
 * `--operation-byte <OPERATION_BYTE>` — Set the additional price for each byte in the argument of a user operation
 * `--message <MESSAGE>` — Set the base price of sending a message from a block..
 * `--message-byte <MESSAGE_BYTE>` — Set the additional price for each byte in the argument of a user message
+* `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
 
@@ -458,6 +459,7 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--message-byte-price <MESSAGE_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user message
 
   Default value: `0`
+* `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
 * `--testing-prng-seed <TESTING_PRNG_SEED>` — Force this wallet to generate keys using a PRNG and a given seed. USE FOR TESTING ONLY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,6 +4248,7 @@ dependencies = [
  "assert_matches",
  "async-graphql",
  "async-trait",
+ "bcs",
  "cfg_aliases",
  "futures",
  "hex",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3400,7 +3400,6 @@ version = "0.12.0"
 dependencies = [
  "async-graphql",
  "async-trait",
- "bcs",
  "cfg_aliases",
  "futures",
  "hex",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3400,6 +3400,7 @@ version = "0.12.0"
 dependencies = [
  "async-graphql",
  "async-trait",
+ "bcs",
  "cfg_aliases",
  "futures",
  "hex",

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -19,6 +19,7 @@ web = ["linera-base/web", "linera-views/web", "linera-execution/web"]
 [dependencies]
 async-graphql.workspace = true
 async-trait.workspace = true
+bcs.workspace = true
 futures.workspace = true
 hex.workspace = true
 linera-base.workspace = true

--- a/linera-chain/Cargo.toml
+++ b/linera-chain/Cargo.toml
@@ -19,7 +19,6 @@ web = ["linera-base/web", "linera-views/web", "linera-execution/web"]
 [dependencies]
 async-graphql.workspace = true
 async-trait.workspace = true
-bcs.workspace = true
 futures.workspace = true
 hex.workspace = true
 linera-base.workspace = true
@@ -35,6 +34,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 assert_matches.workspace = true
+bcs.workspace = true
 linera-chain = { path = ".", features = ["test"] }
 
 [build-dependencies]

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -203,6 +203,9 @@ static STATE_HASH_COMPUTATION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(||
     .expect("Histogram can be created")
 });
 
+/// The BCS-serialized size of an empty `ExecutedBlock`.
+const EMPTY_EXECUTED_BLOCK_SIZE: usize = 91;
+
 /// An origin, cursor and timestamp of a unskippable bundle in our inbox.
 #[derive(Debug, Clone, Serialize, Deserialize, async_graphql::SimpleObject)]
 pub struct TimestampedBundleInInbox {
@@ -732,6 +735,9 @@ where
             tracker: ResourceTracker::default(),
             account: block.authenticated_signer,
         };
+        resource_controller
+            .track_executed_block_size(EMPTY_EXECUTED_BLOCK_SIZE)
+            .map_err(|err| ChainError::ExecutionError(err, ChainExecutionContext::Block))?;
 
         if self.is_closed() {
             ensure!(
@@ -789,6 +795,9 @@ where
             let mut txn_tracker = TransactionTracker::new(next_message_index, maybe_responses);
             match transaction {
                 Transaction::ReceiveMessages(incoming_bundle) => {
+                    resource_controller
+                        .track_executed_block_size_of(&incoming_bundle)
+                        .map_err(with_context)?;
                     for (message_id, posted_message) in incoming_bundle.messages_and_ids() {
                         self.execute_message_in_block(
                             message_id,
@@ -804,6 +813,9 @@ where
                     }
                 }
                 Transaction::ExecuteOperation(operation) => {
+                    resource_controller
+                        .track_executed_block_size_of(&operation)
+                        .map_err(with_context)?;
                     #[cfg(with_metrics)]
                     let _operation_latency = OPERATION_EXECUTION_LATENCY.measure_latency();
                     let context = OperationContext {
@@ -857,6 +869,9 @@ where
                         .map_err(with_context)?;
                 }
             }
+            resource_controller
+                .track_executed_block_size_of(&(&txn_oracle_responses, &txn_messages, &txn_events))
+                .map_err(with_context)?;
             oracle_responses.push(txn_oracle_responses);
             messages.push(txn_messages);
             events.push(txn_events);
@@ -910,12 +925,31 @@ where
             messages.len(),
             block.incoming_bundles.len() + block.operations.len()
         );
-        Ok(BlockExecutionOutcome {
+        let outcome = BlockExecutionOutcome {
             messages,
             state_hash,
             oracle_responses,
             events,
-        })
+        };
+        // Check the size again: Adding the parts could have missed changes in the ULEB128-encoded
+        // vector lengths. If that's the case, we blame the last transaction.
+        let executed_block_size = bcs::serialized_size(&(block, &outcome))
+            .map_err(|err| ChainError::ExecutionError(err.into(), ChainExecutionContext::Block))?;
+        ensure!(
+            u64::try_from(executed_block_size).unwrap_or(u64::MAX)
+                <= resource_controller.policy.maximum_executed_block_size,
+            ChainError::ExecutionError(
+                ExecutionError::ExecutedBlockTooLarge,
+                match block.transactions().last() {
+                    Some((txn_index, Transaction::ExecuteOperation(_))) =>
+                        ChainExecutionContext::Operation(txn_index),
+                    Some((txn_index, Transaction::ReceiveMessages(_))) =>
+                        ChainExecutionContext::IncomingBundle(txn_index),
+                    None => ChainExecutionContext::Block,
+                }
+            )
+        );
+        Ok(outcome)
     }
 
     /// Executes a message as part of an incoming bundle in a block.
@@ -1239,4 +1273,14 @@ where
         }
         Ok(())
     }
+}
+
+#[test]
+fn empty_executed_block_size() {
+    let executed_block = crate::data_types::ExecutedBlock {
+        block: crate::test::make_first_block(ChainId::root(0)),
+        outcome: crate::data_types::BlockExecutionOutcome::default(),
+    };
+    let size = bcs::serialized_size(&executed_block).unwrap();
+    assert_eq!(size, EMPTY_EXECUTED_BLOCK_SIZE);
 }

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -511,6 +511,10 @@ pub enum ClientCommand {
         #[arg(long)]
         message_byte: Option<Amount>,
 
+        /// Set the maximum size of an executed block.
+        #[arg(long)]
+        maximum_executed_block_size: Option<u64>,
+
         /// Set the maximum read data per block.
         #[arg(long)]
         maximum_bytes_read_per_block: Option<u64>,
@@ -616,6 +620,10 @@ pub enum ClientCommand {
         /// Set the additional price for each byte in the argument of a user message.
         #[arg(long, default_value = "0")]
         message_byte_price: Amount,
+
+        /// Set the maximum size of an executed block.
+        #[arg(long)]
+        maximum_executed_block_size: Option<u64>,
 
         /// Set the maximum read data per block.
         #[arg(long)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -148,6 +148,8 @@ pub enum ExecutionError {
     ExcessiveRead,
     #[error("Excessive number of bytes written to storage")]
     ExcessiveWrite,
+    #[error("Serialized size of the executed block exceeds limit")]
+    ExecutedBlockTooLarge,
     #[error("Runtime failed to respond to application")]
     MissingRuntimeResponse,
     #[error("Bytecode ID {0:?} is invalid")]
@@ -164,6 +166,8 @@ pub enum ExecutionError {
     UnexpectedOracleResponse,
     #[error("Invalid JSON: {}", .0)]
     Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Bcs(#[from] bcs::Error),
     #[error("Recorded response for oracle query has the wrong type")]
     OracleResponseMismatch,
     #[error("Assertion failed: local time {local_time} is not earlier than {timestamp}")]

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -36,6 +36,9 @@ pub struct ResourceControlPolicy {
 
     // TODO(#1538): Cap the number of transactions per block and the total size of their
     // arguments.
+    /// The maximum size of an executed block. This includes the block proposal itself as well as
+    /// the execution outcome.
+    pub maximum_executed_block_size: u64,
     /// The maximum data to read per block
     pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
@@ -56,6 +59,7 @@ impl Default for ResourceControlPolicy {
             operation_byte: Amount::default(),
             message: Amount::default(),
             message_byte: Amount::default(),
+            maximum_executed_block_size: u64::MAX,
             maximum_bytes_read_per_block: u64::MAX,
             maximum_bytes_written_per_block: u64::MAX,
         }
@@ -173,6 +177,7 @@ impl ResourceControlPolicy {
             operation_byte: Amount::from_nanos(10),
             operation: Amount::from_micros(10),
             message: Amount::from_micros(10),
+            maximum_executed_block_size: 1_000_000,
             maximum_bytes_read_per_block: 100_000_000,
             maximum_bytes_written_per_block: 10_000_000,
         }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -269,6 +269,9 @@ where
         old_len: usize,
         delta: usize,
     ) -> Result<(), ExecutionError> {
+        if delta == 0 {
+            return Ok(());
+        }
         let new_len = old_len + delta;
         // ULEB128 uses one byte per 7 bits of the number. It always uses at least one byte.
         let old_size = ((usize::BITS - old_len.leading_zeros()) / 7).max(1);

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -8,9 +8,11 @@ use std::sync::Arc;
 use custom_debug_derive::Debug;
 use linera_base::{
     data_types::{Amount, ArithmeticError},
+    ensure,
     identifiers::Owner,
 };
 use linera_views::{context::Context, views::ViewError};
+use serde::Serialize;
 
 use crate::{
     system::SystemExecutionError, ExecutionError, ExecutionStateView, Message, Operation,
@@ -32,6 +34,8 @@ pub struct ResourceController<Account = Amount, Tracker = ResourceTracker> {
 pub struct ResourceTracker {
     /// The number of blocks created.
     pub blocks: u32,
+    /// The total size of the executed block so far.
+    pub executed_block_size: u64,
     /// The fuel used so far.
     pub fuel: u64,
     /// The number of read operations.
@@ -249,6 +253,33 @@ where
             .bytes_stored
             .checked_add(delta)
             .ok_or(ArithmeticError::Overflow)?;
+        Ok(())
+    }
+}
+
+impl<Account, Tracker> ResourceController<Account, Tracker>
+where
+    Tracker: AsMut<ResourceTracker>,
+{
+    /// Tracks the serialized size of an executed block, or parts of it.
+    pub fn track_executed_block_size_of(
+        &mut self,
+        data: &impl Serialize,
+    ) -> Result<(), ExecutionError> {
+        self.track_executed_block_size(bcs::serialized_size(data)?)
+    }
+
+    /// Tracks the serialized size of an executed block, or parts of it.
+    pub fn track_executed_block_size(&mut self, size: usize) -> Result<(), ExecutionError> {
+        let tracker = self.tracker.as_mut();
+        tracker.executed_block_size = u64::try_from(size)
+            .ok()
+            .and_then(|size| tracker.executed_block_size.checked_add(size))
+            .ok_or(ExecutionError::ExecutedBlockTooLarge)?;
+        ensure!(
+            tracker.executed_block_size <= self.policy.maximum_executed_block_size,
+            ExecutionError::ExecutedBlockTooLarge
+        );
         Ok(())
     }
 }

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -261,6 +261,24 @@ impl<Account, Tracker> ResourceController<Account, Tracker>
 where
     Tracker: AsMut<ResourceTracker>,
 {
+    /// Tracks the extension of a sequence in an executed block.
+    ///
+    /// The sequence length is ULEB128-encoded, so extending a sequence can add an additional byte.
+    pub fn track_executed_block_size_sequence_extension(
+        &mut self,
+        old_len: usize,
+        delta: usize,
+    ) -> Result<(), ExecutionError> {
+        let new_len = old_len + delta;
+        // ULEB128 uses one byte per 7 bits of the number. It always uses at least one byte.
+        let old_size = ((usize::BITS - old_len.leading_zeros()) / 7).max(1);
+        let new_size = ((usize::BITS - new_len.leading_zeros()) / 7).max(1);
+        if new_size > old_size {
+            self.track_executed_block_size((new_size - old_size) as usize)?;
+        }
+        Ok(())
+    }
+
     /// Tracks the serialized size of an executed block, or parts of it.
     pub fn track_executed_block_size_of(
         &mut self,

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -146,8 +146,9 @@ async fn test_fee_consumption(
         operation_byte: Amount::from_tokens(23),
         message: Amount::from_tokens(29),
         message_byte: Amount::from_tokens(31),
-        maximum_bytes_read_per_block: 37,
-        maximum_bytes_written_per_block: 41,
+        maximum_executed_block_size: 37,
+        maximum_bytes_read_per_block: 41,
+        maximum_bytes_written_per_block: 43,
     };
 
     let consumed_fees = spends

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -727,6 +727,7 @@ ResourceControlPolicy:
         TYPENAME: Amount
     - message_byte:
         TYPENAME: Amount
+    - maximum_executed_block_size: U64
     - maximum_bytes_read_per_block: U64
     - maximum_bytes_written_per_block: U64
 Round:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -857,6 +857,11 @@ input ResourceControlPolicy {
 	"""
 	messageByte: Amount!
 	"""
+	The maximum size of an executed block. This includes the block proposal itself as well as
+	the execution outcome.
+	"""
+	maximumExecutedBlockSize: Int!
+	"""
 	The maximum data to read per block
 	"""
 	maximumBytesReadPerBlock: Int!

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -180,6 +180,7 @@ impl ClientWrapper {
             operation_byte,
             message,
             message_byte,
+            maximum_executed_block_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
         } = policy;
@@ -203,6 +204,10 @@ impl ClientWrapper {
             .args(["--operation-price", &operation.to_string()])
             .args(["--operation-byte-price", &operation_byte.to_string()])
             .args(["--message-price", &message.to_string()])
+            .args([
+                "--maximum-executed-block-size",
+                &maximum_executed_block_size.to_string(),
+            ])
             .args([
                 "--maximum-bytes-read-per-block",
                 &maximum_bytes_read_per_block.to_string(),

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -599,6 +599,7 @@ impl Runnable for Job {
                             {:.2} per byte in the argument of an operation\n\
                             {:.2} per outgoing messages\n\
                             {:.2} per byte in the argument of an outgoing messages\n\
+                            {:.2} maximum size of an executed block\n\
                             {:.2} maximum number bytes read per block\n\
                             {:.2} maximum number bytes written per block",
                                         policy.block,
@@ -612,6 +613,7 @@ impl Runnable for Job {
                                         policy.operation_byte,
                                         policy.message,
                                         policy.message_byte,
+                                        policy.maximum_executed_block_size,
                                         policy.maximum_bytes_read_per_block,
                                         policy.maximum_bytes_written_per_block
                                     );
@@ -626,6 +628,7 @@ impl Runnable for Job {
                                         && operation_byte.is_none()
                                         && message.is_none()
                                         && message_byte.is_none()
+                                        && maximum_executed_block_size.is_none()
                                         && maximum_bytes_read_per_block.is_none()
                                         && maximum_bytes_written_per_block.is_none()
                                     {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -531,6 +531,7 @@ impl Runnable for Job {
                                     operation_byte,
                                     message,
                                     message_byte,
+                                    maximum_executed_block_size,
                                     maximum_bytes_read_per_block,
                                     maximum_bytes_written_per_block,
                                 } => {
@@ -566,6 +567,12 @@ impl Runnable for Job {
                                     }
                                     if let Some(message_byte) = message_byte {
                                         policy.message_byte = message_byte;
+                                    }
+                                    if let Some(maximum_executed_block_size) =
+                                        maximum_executed_block_size
+                                    {
+                                        policy.maximum_executed_block_size =
+                                            maximum_executed_block_size;
                                     }
                                     if let Some(maximum_bytes_read_per_block) =
                                         maximum_bytes_read_per_block
@@ -1294,6 +1301,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
             operation_byte_price,
             message_price,
             message_byte_price,
+            maximum_executed_block_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
             testing_prng_seed,
@@ -1301,14 +1309,10 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
         } => {
             let committee_config: CommitteeConfig = util::read_json(committee_config_path)
                 .expect("Unable to read committee config file");
-            let maximum_bytes_read_per_block = match *maximum_bytes_read_per_block {
-                Some(value) => value,
-                None => u64::MAX,
-            };
-            let maximum_bytes_written_per_block = match *maximum_bytes_written_per_block {
-                Some(value) => value,
-                None => u64::MAX,
-            };
+            let maximum_bytes_read_per_block = maximum_bytes_read_per_block.unwrap_or(u64::MAX);
+            let maximum_bytes_written_per_block =
+                maximum_bytes_written_per_block.unwrap_or(u64::MAX);
+            let maximum_executed_block_size = maximum_executed_block_size.unwrap_or(u64::MAX);
             let policy = ResourceControlPolicy {
                 block: *block_price,
                 fuel_unit: *fuel_unit_price,
@@ -1321,6 +1325,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                 operation: *operation_price,
                 message_byte: *message_byte_price,
                 message: *message_price,
+                maximum_executed_block_size,
                 maximum_bytes_read_per_block,
                 maximum_bytes_written_per_block,
             };


### PR DESCRIPTION
## Motivation

We can't allow blocks to be arbitrarily large; e.g. they need to fit in a single gRPC message. See https://github.com/linera-io/linera-protocol/issues/1538 for more details.

## Proposal

Add a block size limit to the policy and enforce it.

## Test Plan

A unit test was added to `linera-chain`.

## Release Plan

- Need to bump the major/minor version number in the next release of the crates.
- Need to update the developer manual.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2455.
- Part of https://github.com/linera-io/linera-protocol/issues/1538.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
