### PR TITLE
Enable the remote-net in the CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,26 +74,26 @@ jobs:
     - name: Run Ethereum tests
       run: |
         cargo test -p linera-ethereum --features ethereum
-        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,storage-service,unstable-oracles
+        cargo test test_wasm_end_to_end_ethereum_tracker --features ethereum,remote-net,unstable-oracles
+    - name: Run the set of validators
+      run: |
+        cargo run --bin linera -- --storage service:tcp:127.0.0.1:1235:TEST net up --policy-config devnet --path /tmp/WORK &
     - name: Compile Wasm test modules for Witty integration tests
       run: |
         cargo build -p linera-witty-test-modules --target wasm32-unknown-unknown
     - name: Check that the WIT files are up-to-date
       run: |
         cargo run --bin wit-generator -- -c
+    - name: Run the faucet
+      run: |
+        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
     - name: Run all tests using the default features
       run: |
         cargo test --features unstable-oracles --locked
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime
-    - name: Run the set of validators
-      run: |
-        cargo run --bin linera -- --storage service:tcp:127.0.0.1:1235:TEST net up --policy-config devnet --path /tmp/WORK --validators 4 --shards 4 &
-    - name: Run the faucet
-      run: |
-        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
-    - Name: Run the end-to-end tests for the smart contracts
+    - Name: Run the end-to-end tests for the linera-net smart contracts tests
       run: |
         cargo test -p linera-service --features remote-net
     - name: Run the benchmark test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,7 +60,9 @@ jobs:
     - name: Set environment variables
       run: |
         echo "LINERA_STORAGE_SERVICE=127.0.0.1:1235" >> "$GITHUB_ENV"
-
+        echo "LINERA_WALLET=/tmp/WORK/wallet_0.json" >> "$GITHUB_ENV"
+        echo "LINERA_STORAGE=rocksdb:/tmp/WORK/client_0.db" >> "$GITHUB_ENV"
+        echo "LINERA_FAUCET_URL=http://localhost:8079" >> "$GITHUB_ENV"
     - name: Build example applications
       run: |
         cd examples
@@ -85,6 +87,15 @@ jobs:
     - name: Run some extra execution tests with wasmtime
       run: |
         cargo test --locked -p linera-execution --features wasmtime
+    - name: Run the set of validators
+      run: |
+        cargo run --bin linera -- --storage service:tcp:127.0.0.1:1235:TEST net up --policy-config devnet --path /tmp/WORK --validators 4 --shards 4 &
+    - name: Run the faucet
+      run: |
+        cargo run --release --bin linera -- faucet --amount 1000 --port 8079 &
+    - Name: Run the end-to-end tests for the smart contracts
+      run: |
+        cargo test -p linera-service --features remote-net
     - name: Run the benchmark test
       run: |
         cargo build --locked -p linera-service --bin linera-benchmark --features benchmark

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -872,6 +872,11 @@ pub enum NetCommand {
         #[cfg(feature = "kubernetes")]
         #[arg(long, num_args=0..=1)]
         binaries: Option<Option<PathBuf>>,
+
+        /// Run with a specific path where the wallet and storage are put.
+        /// If none, then a temporary directory is created.
+        #[arg(long)]
+        path: Option<String>,
     },
 
     /// Print a bash helper script to make `linera net up` easier to use. The script is

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -214,9 +214,18 @@ impl PathProvider {
         Ok(PathProvider::TemporaryDirectory { tmp_dir })
     }
 
-    pub fn new(path: &Path) -> Self {
-        let path_buf = path.to_path_buf();
-        PathProvider::ExternalPath { path_buf }
+    pub fn new(path: &Option<String>) -> anyhow::Result<Self> {
+        match path {
+            None => {
+                let tmp_dir = Arc::new(tempfile::tempdir()?);
+                Ok(PathProvider::TemporaryDirectory { tmp_dir })
+            },
+            Some(path) => {
+                let path = Path::new(path);
+                let path_buf = path.to_path_buf();
+                Ok(PathProvider::ExternalPath { path_buf })
+            },
+        }
     }
 }
 

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -215,17 +215,17 @@ impl PathProvider {
     }
 
     pub fn new(path: &Option<String>) -> anyhow::Result<Self> {
-        match path {
+        Ok(match path {
             None => {
                 let tmp_dir = Arc::new(tempfile::tempdir()?);
-                Ok(PathProvider::TemporaryDirectory { tmp_dir })
-            },
+                PathProvider::TemporaryDirectory { tmp_dir }
+            }
             Some(path) => {
                 let path = Path::new(path);
                 let path_buf = path.to_path_buf();
-                Ok(PathProvider::ExternalPath { path_buf })
-            },
-        }
+                PathProvider::ExternalPath { path_buf }
+            }
+        })
     }
 }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1475,6 +1475,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                 testing_prng_seed,
                 table_name,
                 policy_config,
+                path,
                 ..
             } => {
                 net_up_utils::handle_net_up_service(
@@ -1486,6 +1487,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                     *testing_prng_seed,
                     table_name,
                     policy_config.into_policy(),
+                    path,
                 )
                 .boxed()
                 .await

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1451,6 +1451,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                 policy_config,
                 kubernetes: true,
                 binaries,
+                path: _,
             } => {
                 net_up_utils::handle_net_up_kubernetes(
                     *extra_wallets,

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -71,6 +71,7 @@ pub async fn handle_net_up_service(
     testing_prng_seed: Option<u64>,
     table_name: &str,
     policy: ResourceControlPolicy,
+    path: &Option<String>,
 ) -> anyhow::Result<()> {
     if num_initial_validators < 1 {
         panic!("The local test network must have at least one validator.");
@@ -82,9 +83,6 @@ pub async fn handle_net_up_service(
     let shutdown_notifier = CancellationToken::new();
     tokio::spawn(listen_for_shutdown_signals(shutdown_notifier.clone()));
 
-    let tmp_dir = tempfile::tempdir()?;
-    let path = tmp_dir.path();
-
     let service_endpoint = get_free_endpoint().await.unwrap();
     let binary = get_service_storage_binary().await?.display().to_string();
     let service = StorageService::new(&service_endpoint, binary);
@@ -94,7 +92,7 @@ pub async fn handle_net_up_service(
         endpoint: service_endpoint,
     };
     let storage_config_builder = StorageConfigBuilder::ExistingConfig { storage_config };
-    let path_provider = PathProvider::new(path);
+    let path_provider = PathProvider::new(path)?;
     let config = LocalNetConfig {
         network: Network::Grpc,
         database: Database::Service,

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -10,8 +10,6 @@
     feature = "remote-net"
 ))]
 
-mod common;
-
 use std::{env, time::Duration};
 
 use anyhow::Result;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -16,7 +16,6 @@ use std::{env, time::Duration};
 
 use anyhow::Result;
 use async_graphql::InputType;
-use common::INTEGRATION_TEST_GUARD;
 use futures::{channel::mpsc, SinkExt, StreamExt};
 use linera_base::{
     command::resolve_binary,
@@ -349,7 +348,6 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
         client::EthereumQueries,
         test_utils::{get_anvil, SimpleTokenContractFunction},
     };
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Setting up the Ethereum smart contract
@@ -443,7 +441,6 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
@@ -497,7 +494,6 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
 async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
 
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
@@ -547,7 +543,6 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::time::Instant;
     use social::SocialAbi;
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -660,7 +655,6 @@ async fn test_wasm_end_to_end_fungible(
 
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
 
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -824,7 +818,6 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 
     use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
 
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -940,7 +933,6 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Result<()> {
     use non_fungible::{NftOutput, NonFungibleTokenAbi};
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -1223,7 +1215,6 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
     use linera_base::data_types::Timestamp;
 
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -1357,7 +1348,6 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
 
     use matching_engine::{MatchingEngineAbi, OrderNature, Parameters, Price};
 
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client_admin) = config.instantiate().await?;
@@ -1639,7 +1629,6 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
 
     use amm::{AmmAbi, Parameters};
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client_amm) = config.instantiate().await?;
@@ -2381,7 +2370,6 @@ async fn test_resolve_binary() -> Result<()> {
 #[test_log::test(tokio::test)]
 async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
@@ -2502,7 +2490,6 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Result<()> {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create net and two clients.
@@ -2548,7 +2535,6 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) -> Result<()> {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2618,7 +2604,6 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::crypto::PublicKey;
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and client.
@@ -2659,7 +2644,6 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConfig) -> Result<()> {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2705,7 +2689,6 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2841,7 +2824,6 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Res
     use linera_base::command::CommandExt;
     use tokio::process::Command;
 
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2883,7 +2865,6 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Res
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> Result<()> {
-    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     use tokio::task::JoinHandle;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2765,12 +2765,13 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 }
 
 /// Tests creating a new wallet using a Faucet that has already created a lot of microchains.
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -10,6 +10,22 @@
     feature = "remote-net"
 ))]
 
+#[cfg(any(
+    feature = "dynamodb",
+    feature = "scylladb",
+    feature = "storage-service",
+    feature = "kubernetes",
+))]
+mod common;
+
+#[cfg(any(
+    feature = "dynamodb",
+    feature = "scylladb",
+    feature = "storage-service",
+    feature = "kubernetes",
+))]
+use common::INTEGRATION_TEST_GUARD;
+
 use std::{env, time::Duration};
 
 use anyhow::Result;
@@ -33,10 +49,17 @@ use linera_service::cli_wrappers::remote_net::RemoteNetTestingConfig;
 use linera_service::cli_wrappers::{
     docker::BuildArg, local_kubernetes_net::SharedLocalKubernetesNetTestingConfig,
 };
+#[cfg(any(
+    feature = "dynamodb",
+    feature = "scylladb",
+    feature = "storage-service",
+    feature = "kubernetes",
+))]
+use linera_service::cli_wrappers::Network;
 use linera_service::{
     cli_wrappers::{
         local_net::{get_node_port, ProcessInbox},
-        ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet, LineraNetConfig, Network,
+        ApplicationWrapper, ClientWrapper, FaucetOption, LineraNet, LineraNetConfig,
     },
     test_name,
 };
@@ -346,6 +369,13 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
         client::EthereumQueries,
         test_utils::{get_anvil, SimpleTokenContractFunction},
     };
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Setting up the Ethereum smart contract
@@ -439,6 +469,13 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
@@ -491,7 +528,13 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
-
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
@@ -541,6 +584,13 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::time::Instant;
     use social::SocialAbi;
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -652,7 +702,13 @@ async fn test_wasm_end_to_end_fungible(
     use std::collections::BTreeMap;
 
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
-
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -815,7 +871,13 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     use std::collections::BTreeMap;
 
     use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
-
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -931,6 +993,13 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Result<()> {
     use non_fungible::{NftOutput, NonFungibleTokenAbi};
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -1212,7 +1281,13 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     use crowd_funding::{CrowdFundingAbi, InstantiationArgument};
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
     use linera_base::data_types::Timestamp;
-
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client1) = config.instantiate().await?;
@@ -1345,7 +1420,13 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     use std::collections::BTreeMap;
 
     use matching_engine::{MatchingEngineAbi, OrderNature, Parameters, Price};
-
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client_admin) = config.instantiate().await?;
@@ -1627,6 +1708,13 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
 
     use amm::{AmmAbi, Parameters};
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client_amm) = config.instantiate().await?;
@@ -2368,6 +2456,13 @@ async fn test_resolve_binary() -> Result<()> {
 #[test_log::test(tokio::test)]
 async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     let (mut net, client) = config.instantiate().await?;
@@ -2488,6 +2583,13 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create net and two clients.
@@ -2533,6 +2635,13 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2602,6 +2711,13 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::crypto::PublicKey;
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and client.
@@ -2642,6 +2758,13 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2687,6 +2810,13 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2821,7 +2951,13 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::command::CommandExt;
     use tokio::process::Command;
-
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     // Create runner and two clients.
@@ -2863,6 +2999,13 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Res
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> Result<()> {
+    #[cfg(any(
+        feature = "dynamodb",
+        feature = "scylladb",
+        feature = "storage-service",
+        feature = "kubernetes",
+    ))]
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
     use tokio::task::JoinHandle;

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -5,31 +5,19 @@
 #![cfg(any(
     feature = "dynamodb",
     feature = "scylladb",
-    feature = "storage-service",
     feature = "kubernetes",
     feature = "remote-net"
 ))]
 
-#[cfg(any(
-    feature = "dynamodb",
-    feature = "scylladb",
-    feature = "storage-service",
-    feature = "kubernetes",
-))]
+#[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
 mod common;
-
-#[cfg(any(
-    feature = "dynamodb",
-    feature = "scylladb",
-    feature = "storage-service",
-    feature = "kubernetes",
-))]
-use common::INTEGRATION_TEST_GUARD;
 
 use std::{env, time::Duration};
 
 use anyhow::Result;
 use async_graphql::InputType;
+#[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
+use common::INTEGRATION_TEST_GUARD;
 use futures::{channel::mpsc, SinkExt, StreamExt};
 use linera_base::{
     command::resolve_binary,
@@ -37,25 +25,16 @@ use linera_base::{
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
 };
 use linera_sdk::DataBlobHash;
-#[cfg(any(
-    feature = "dynamodb",
-    feature = "scylladb",
-    feature = "storage-service",
-))]
+#[cfg(any(feature = "dynamodb", feature = "scylladb",))]
 use linera_service::cli_wrappers::local_net::{Database, LocalNetConfig};
 #[cfg(feature = "remote-net")]
 use linera_service::cli_wrappers::remote_net::RemoteNetTestingConfig;
+#[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
+use linera_service::cli_wrappers::Network;
 #[cfg(feature = "kubernetes")]
 use linera_service::cli_wrappers::{
     docker::BuildArg, local_kubernetes_net::SharedLocalKubernetesNetTestingConfig,
 };
-#[cfg(any(
-    feature = "dynamodb",
-    feature = "scylladb",
-    feature = "storage-service",
-    feature = "kubernetes",
-))]
-use linera_service::cli_wrappers::Network;
 use linera_service::{
     cli_wrappers::{
         local_net::{get_node_port, ProcessInbox},
@@ -302,8 +281,10 @@ impl MatchingEngineApp {
     }
 }
 
+#[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes"))]
 struct AmmApp(ApplicationWrapper<amm::AmmAbi>);
 
+#[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes"))]
 impl AmmApp {
     async fn swap(
         &self,
@@ -357,7 +338,6 @@ impl AmmApp {
 }
 
 #[cfg(feature = "ethereum")]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -369,12 +349,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
         client::EthereumQueries,
         test_utils::{get_anvil, SimpleTokenContractFunction},
     };
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -461,7 +436,6 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -469,12 +443,7 @@ async fn test_wasm_end_to_end_ethereum_tracker(config: impl LineraNetConfig) -> 
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -520,7 +489,6 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -528,12 +496,7 @@ async fn test_wasm_end_to_end_counter(config: impl LineraNetConfig) -> Result<()
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfig) -> Result<()> {
     use counter::CounterAbi;
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -575,7 +538,6 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -584,12 +546,7 @@ async fn test_wasm_end_to_end_counter_publish_create(config: impl LineraNetConfi
 async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::time::Instant;
     use social::SocialAbi;
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -682,11 +639,6 @@ async fn test_wasm_end_to_end_social_user_pub_sub(config: impl LineraNetConfig) 
     Ok(())
 }
 
-// TODO(#2051): Enable the test `test_wasm_end_to_end_fungible::scylladb_grpc` that is frequently failing.
-// The failure is `Error: Could not find application URI: .... after 15 tries`.
-//#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "fungible" ; "scylladb_grpc"))]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "storage_service_grpc"))]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "native-fungible" ; "native_scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "fungible" ; "aws_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "native-fungible" ; "native_aws_grpc"))]
@@ -702,12 +654,7 @@ async fn test_wasm_end_to_end_fungible(
     use std::collections::BTreeMap;
 
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -853,8 +800,6 @@ async fn test_wasm_end_to_end_fungible(
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "fungible" ; "storage_service_grpc"))]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc), "native-fungible" ; "native_storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "fungible" ; "scylladb_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc), "native-fungible" ; "native_scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc), "fungible" ; "aws_grpc"))]
@@ -871,12 +816,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     use std::collections::BTreeMap;
 
     use fungible::{Account, FungibleTokenAbi, InitialState, Parameters};
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -985,7 +925,6 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -993,12 +932,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Result<()> {
     use non_fungible::{NftOutput, NonFungibleTokenAbi};
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -1269,7 +1203,6 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -1281,12 +1214,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     use crowd_funding::{CrowdFundingAbi, InstantiationArgument};
     use fungible::{FungibleTokenAbi, InitialState, Parameters};
     use linera_base::data_types::Timestamp;
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -1410,7 +1338,6 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -1420,12 +1347,7 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     use std::collections::BTreeMap;
 
     use matching_engine::{MatchingEngineAbi, OrderNature, Parameters, Price};
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -1698,22 +1620,15 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
-#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
 
     use amm::{AmmAbi, Parameters};
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2448,7 +2363,6 @@ async fn test_resolve_binary() -> Result<()> {
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2456,12 +2370,7 @@ async fn test_resolve_binary() -> Result<()> {
 #[test_log::test(tokio::test)]
 async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()> {
     use std::collections::BTreeMap;
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2576,19 +2485,13 @@ async fn test_open_chain_node_service(config: impl LineraNetConfig) -> Result<()
     panic!("Failed to receive new block");
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Result<()> {
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2628,19 +2531,13 @@ async fn test_end_to_end_multiple_wallets(config: impl LineraNetConfig) -> Resul
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) -> Result<()> {
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2703,7 +2600,6 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2711,12 +2607,7 @@ async fn test_end_to_end_open_multi_owner_chain(config: impl LineraNetConfig) ->
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::crypto::PublicKey;
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2751,19 +2642,13 @@ async fn test_end_to_end_change_ownership(config: impl LineraNetConfig) -> Resul
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConfig) -> Result<()> {
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2803,19 +2688,13 @@ async fn test_end_to_end_assign_greatgrandchild_chain(config: impl LineraNetConf
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2942,7 +2821,6 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 }
 
 #[cfg(feature = "benchmark")]
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
@@ -2951,12 +2829,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
 async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Result<()> {
     use linera_base::command::CommandExt;
     use tokio::process::Command;
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
@@ -2992,19 +2865,13 @@ async fn test_end_to_end_fungible_benchmark(config: impl LineraNetConfig) -> Res
     Ok(())
 }
 
-#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
 #[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
 #[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
 async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> Result<()> {
-    #[cfg(any(
-        feature = "dynamodb",
-        feature = "scylladb",
-        feature = "storage-service",
-        feature = "kubernetes",
-    ))]
+    #[cfg(any(feature = "dynamodb", feature = "scylladb", feature = "kubernetes",))]
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -603,7 +603,7 @@ async fn main() {
     };
     let endpoint = endpoint.parse().unwrap();
     info!(
-        "Starting of storage_service_service on endpoint={}",
+        "Starting of linera_storage_service on endpoint={}",
         endpoint
     );
     Server::builder()


### PR DESCRIPTION
## Motivation

We would like to run the tests of `linera_net_test.rs` in a single set of validators.

## Proposal

The following changes are made:
* The `path: Option<String>` is added to the `Up` section which is of general interest.
* The `PathProvider` is changed accordingly.
* A specific `LINERA_STORAGE`/ `LINERA_WALLET` is used instead of temporary directory.
* The relevant options are added to the `rust.yml` CI files.
* The `INTEGRATION_TEST_GUARD` is selectively enabled in `linera_net.rs`. It is for kubernetes, ScyllaDb and DynamoDb but not for remote-net.
* For the `test_wasm_end_to_end_amm` it is disabled as it currently creates error.

## Test Plan

The CI is the point. We should gain 15 minutes of CI runtime.

## Release Plan

The addition of the option "--path" to the "net up" ought to have some importance.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
