### PR TITLE
Upgrade to 1.81.0; fix a few allow attributes

### DIFF
--- a/examples/crowd-funding/src/lib.rs
+++ b/examples/crowd-funding/src/lib.rs
@@ -324,7 +324,6 @@ impl std::fmt::Display for InstantiationArgument {
 
 /// Operations that can be executed by the application.
 #[derive(Debug, Deserialize, Serialize, GraphQLMutationRoot)]
-#[allow(clippy::large_enum_variant)]
 pub enum Operation {
     /// Pledge some tokens to the campaign (from an account on the current chain to the campaign chain).
     Pledge { owner: AccountOwner, amount: Amount },
@@ -336,7 +335,6 @@ pub enum Operation {
 
 /// Messages that can be exchanged across chains from the same application instance.
 #[derive(Debug, Deserialize, Serialize)]
-#[allow(clippy::large_enum_variant)]
 pub enum Message {
     /// Pledge some tokens to the campaign (from an account on the receiver chain).
     PledgeWithAccount { owner: AccountOwner, amount: Amount },

--- a/linera-base/src/crypto.rs
+++ b/linera-base/src/crypto.rs
@@ -706,7 +706,6 @@ impl BcsSignable for TestString {}
 
 #[cfg(with_getrandom)]
 #[test]
-#[allow(clippy::disallowed_names)]
 fn test_signatures() {
     #[derive(Debug, Serialize, Deserialize)]
     struct Foo(String);

--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -782,7 +782,6 @@ impl FromStr for OracleResponse {
 }
 
 /// Description of the necessary information to run a user application.
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Hash, Serialize)]
 pub struct UserApplicationDescription {
     /// The unique ID of the bytecode to use for the application.

--- a/linera-chain/src/chain.rs
+++ b/linera-chain/src/chain.rs
@@ -952,7 +952,7 @@ where
     }
 
     /// Executes a message as part of an incoming bundle in a block.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn execute_message_in_block(
         &mut self,
         message_id: MessageId,

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -57,7 +57,6 @@ util::impl_from_dynamic!(Error:Backend, linera_views::dynamo_db::DynamoDbStoreEr
 util::impl_from_dynamic!(Error:Backend, linera_views::scylla_db::ScyllaDbStoreError);
 
 /// The configuration of the key value store in use.
-#[allow(clippy::large_enum_variant)]
 pub enum StoreConfig {
     /// The storage service key-value store
     #[cfg(feature = "storage-service")]

--- a/linera-core/src/chain_worker/state/mod.rs
+++ b/linera-core/src/chain_worker/state/mod.rs
@@ -66,7 +66,6 @@ where
     StorageClient: Storage + Clone + Send + Sync + 'static,
 {
     /// Creates a new [`ChainWorkerState`] using the provided `storage` client.
-    #[allow(clippy::too_many_arguments)]
     pub async fn load(
         config: ChainWorkerConfig,
         storage: StorageClient,

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -165,7 +165,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
 
     #[tracing::instrument(level = "trace", skip_all, fields(chain_id, next_block_height))]
     /// Creates a new `ChainClient`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn create_chain_client(
         self: &Arc<Self>,
         chain_id: ChainId,

--- a/linera-core/src/data_types.rs
+++ b/linera-core/src/data_types.rs
@@ -313,7 +313,7 @@ impl<T> ClientOutcome<T> {
         }
     }
 
-    #[allow(clippy::result_large_err)]
+    #[expect(clippy::result_large_err)]
     pub fn try_map<F, S>(self, f: F) -> Result<ClientOutcome<S>, ChainClientError>
     where
         F: FnOnce(T) -> Result<S, ChainClientError>,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -94,7 +94,7 @@ pub trait LocalValidatorNode {
 }
 
 /// Turn an address into a validator node.
-#[allow(clippy::result_large_err)]
+#[expect(clippy::result_large_err)]
 pub trait LocalValidatorNodeProvider {
     type Node: LocalValidatorNode + Clone + 'static;
 

--- a/linera-core/src/unit_tests/worker_tests.rs
+++ b/linera-core/src/unit_tests/worker_tests.rs
@@ -168,7 +168,7 @@ where
         .unwrap()
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn make_simple_transfer_certificate<S>(
     chain_description: ChainDescription,
     key_pair: &KeyPair,
@@ -200,7 +200,7 @@ where
     .await
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn make_transfer_certificate<S>(
     chain_description: ChainDescription,
     key_pair: &KeyPair,
@@ -234,7 +234,7 @@ where
     .await
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 async fn make_transfer_certificate_for_epoch<S>(
     chain_description: ChainDescription,
     key_pair: &KeyPair,

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -35,7 +35,6 @@ const GRACE_PERIOD: f64 = 0.2;
 const MAX_TIMEOUT: Duration = Duration::from_secs(60 * 60 * 24); // 1 day.
 
 /// Used for `communicate_chain_action`
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum CommunicateAction {
     SubmitBlock {

--- a/linera-core/src/worker.rs
+++ b/linera-core/src/worker.rs
@@ -118,7 +118,6 @@ doc_scalar!(
 );
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[allow(clippy::large_enum_variant)]
 /// Reason for the notification.
 pub enum Reason {
     NewBlock {
@@ -720,7 +719,7 @@ where
     ///
     /// Returns [`None`] if the cache is full and no candidate for eviction was found.
     #[tracing::instrument(level = "trace", skip(self))]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn try_get_chain_worker_endpoint(
         &self,
         chain_id: ChainId,

--- a/linera-ethereum/src/test_utils/mod.rs
+++ b/linera-ethereum/src/test_utils/mod.rs
@@ -36,7 +36,7 @@ sol!(
     "./contracts/EventNumerics.json"
 );
 
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct AnvilTest {
     pub anvil_instance: AnvilInstance,
     pub endpoint: String,

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -144,7 +144,7 @@ where
     C: Context + Clone + Send + Sync + 'static,
     C::Extra: ExecutionRuntimeContext,
 {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn run_user_action(
         &mut self,
         application_id: UserApplicationId,
@@ -171,7 +171,7 @@ where
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn run_user_action_with_runtime(
         &mut self,
         application_id: UserApplicationId,

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -457,7 +457,7 @@ pub trait BaseRuntime {
 
     /// Reads the data from the key/values having a specific prefix.
     #[cfg(feature = "test")]
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn find_key_values_by_prefix(
         &mut self,
         key_prefix: Vec<u8>,
@@ -473,7 +473,7 @@ pub trait BaseRuntime {
     ) -> Result<Self::FindKeyValuesByPrefix, ExecutionError>;
 
     /// Resolves the promise to access key/values having a specific prefix
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn find_key_values_by_prefix_wait(
         &mut self,
         promise: &Self::FindKeyValuesByPrefix,
@@ -744,7 +744,7 @@ pub struct ChannelSubscription {
 /// Externally visible results of an execution, tagged by their application.
 #[derive(Debug)]
 #[cfg_attr(with_testing, derive(Eq, PartialEq))]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum ExecutionOutcome {
     System(RawExecutionOutcome<SystemMessage, Amount>),
     User(UserApplicationId, RawExecutionOutcome<Vec<u8>, Amount>),

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -274,7 +274,7 @@ impl<UserInstance> Drop for SyncRuntime<UserInstance> {
 }
 
 impl<UserInstance> SyncRuntimeInternal<UserInstance> {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         chain_id: ChainId,
         height: BlockHeight,
@@ -1030,7 +1030,7 @@ impl<UserInstance> Clone for SyncRuntimeHandle<UserInstance> {
 
 impl ContractSyncRuntime {
     /// Main entry point to start executing a user action.
-    #[allow(clippy::type_complexity, clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn run_action(
         execution_state_sender: ExecutionStateSender,
         application_id: UserApplicationId,

--- a/linera-execution/src/wasm/system_api.rs
+++ b/linera-execution/src/wasm/system_api.rs
@@ -735,7 +735,7 @@ where
     }
 
     /// Waits for the promise to search for entries whose keys that start with the `key_prefix`.
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn find_key_values_wait(
         caller: &mut Caller,
         promise_id: u32,

--- a/linera-rpc/src/grpc/mod.rs
+++ b/linera-rpc/src/grpc/mod.rs
@@ -15,8 +15,6 @@ pub use node_provider::*;
 #[cfg(with_server)]
 pub use server::*;
 
-#[allow(clippy::derive_partial_eq_without_eq)]
-// https://github.com/hyperium/tonic/issues/1056
 pub mod api {
     tonic::include_proto!("rpc.v1");
 }

--- a/linera-rpc/src/grpc/server.rs
+++ b/linera-rpc/src/grpc/server.rs
@@ -179,7 +179,7 @@ impl<S> GrpcServer<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub fn spawn(
         host: String,
         port: u16,
@@ -338,7 +338,7 @@ where
     }
 
     #[instrument(skip_all, fields(nickname, %this_shard))]
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn forward_cross_chain_queries(
         nickname: String,
         network: ValidatorInternalNetworkConfig,

--- a/linera-rpc/src/simple/server.rs
+++ b/linera-rpc/src/simple/server.rs
@@ -41,7 +41,6 @@ impl<S> Server<S>
 where
     S: Storage,
 {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         network: ValidatorInternalNetworkPreConfig<TransportProtocol>,
         host: String,
@@ -75,7 +74,7 @@ impl<S> Server<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn forward_cross_chain_queries(
         nickname: String,
         network: ValidatorInternalNetworkPreConfig<TransportProtocol>,

--- a/linera-sdk/src/util.rs
+++ b/linera-sdk/src/util.rs
@@ -86,7 +86,7 @@ mod tests {
     /// Checks the internal state before and after the first and second polls, and ensures that
     /// only the first poll returns [`Poll::Pending`].
     #[test]
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn yield_once_returns_pending_only_on_first_call() {
         let mut future = yield_once();
 

--- a/linera-service-graphql-client/src/service.rs
+++ b/linera-service-graphql-client/src/service.rs
@@ -41,7 +41,7 @@ mod types {
     }
 
     #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-    #[allow(clippy::enum_variant_names)]
+    #[expect(clippy::enum_variant_names)]
     pub enum Reason {
         NewBlock {
             height: BlockHeight,

--- a/linera-service/src/cli_wrappers/local_net.rs
+++ b/linera-service/src/cli_wrappers/local_net.rs
@@ -415,7 +415,7 @@ impl LineraNet for LocalNet {
 }
 
 impl LocalNet {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         database: Database,
         network: Network,

--- a/linera-service/src/linera/net_up_utils.rs
+++ b/linera-service/src/linera/net_up_utils.rs
@@ -24,7 +24,7 @@ use {
     std::path::PathBuf,
 };
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 #[cfg(feature = "kubernetes")]
 pub async fn handle_net_up_kubernetes(
     extra_wallets: Option<usize>,
@@ -61,7 +61,7 @@ pub async fn handle_net_up_kubernetes(
     wait_for_shutdown(shutdown_notifier, &mut net).await
 }
 
-#[allow(clippy::too_many_arguments)]
+#[expect(clippy::too_many_arguments)]
 pub async fn handle_net_up_service(
     extra_wallets: Option<usize>,
     num_other_initial_chains: u32,

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -304,7 +304,7 @@ where
     /// Claims `amount` units of value from the given owner's account in the remote
     /// `target` chain. Depending on its configuration, the `target` chain may refuse to
     /// process the message.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn claim(
         &self,
         chain_id: ChainId,
@@ -362,7 +362,7 @@ where
 
     /// Creates (or activates) a new chain by installing the given authentication keys.
     /// This will automatically subscribe to the future committees created by `admin_id`.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn open_multi_owner_chain(
         &self,
         chain_id: ChainId,
@@ -459,7 +459,7 @@ where
     }
 
     /// Changes the authentication key of the chain.
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     async fn change_multiple_owners(
         &self,
         chain_id: ChainId,
@@ -956,7 +956,7 @@ where
         }
     }
 
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     pub fn schema(&self) -> Schema<QueryRoot<P, S>, MutationRoot<P, S, C>, SubscriptionRoot<P, S>> {
         Schema::build(
             QueryRoot {

--- a/linera-service/src/util.rs
+++ b/linera-service/src/util.rs
@@ -111,7 +111,7 @@ impl QuotedBashAndGraphQlScript {
         &self.path
     }
 
-    #[allow(clippy::while_let_on_iterator)]
+    #[expect(clippy::while_let_on_iterator)]
     fn read_bash_and_gql_quotes(
         reader: impl std::io::BufRead,
         pause_after_gql_mutations: Option<Duration>,

--- a/linera-storage-service/src/lib.rs
+++ b/linera-storage-service/src/lib.rs
@@ -6,8 +6,6 @@
 
 #![deny(clippy::large_futures)]
 
-#[allow(clippy::derive_partial_eq_without_eq)]
-// https://github.com/hyperium/tonic/issues/1056
 pub mod key_value_store {
     tonic::include_proto!("key_value_store.v1");
 }

--- a/linera-storage-service/src/server.rs
+++ b/linera-storage-service/src/server.rs
@@ -34,8 +34,6 @@ use crate::key_value_store::{
     RequestSpecificChunk, RequestWriteBatchExtended,
 };
 
-#[allow(clippy::derive_partial_eq_without_eq)]
-// https://github.com/hyperium/tonic/issues/1056
 pub mod key_value_store {
     tonic::include_proto!("key_value_store.v1");
 }

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -701,7 +701,7 @@ struct QueryResponses {
 
 // Inspired by https://depth-first.com/articles/2020/06/22/returning-rust-iterators/
 #[doc(hidden)]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct DynamoDbKeyBlockIterator<'a> {
     prefix_len: usize,
     pos: usize,
@@ -761,7 +761,7 @@ pub struct DynamoDbKeyValues {
 }
 
 #[doc(hidden)]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct DynamoDbKeyValueIterator<'a> {
     prefix_len: usize,
     pos: usize,
@@ -793,7 +793,7 @@ impl<'a> Iterator for DynamoDbKeyValueIterator<'a> {
 }
 
 #[doc(hidden)]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct DynamoDbKeyValueIteratorOwned {
     prefix_len: usize,
     pos: usize,
@@ -966,7 +966,7 @@ impl DirectWritableKeyValueStore for DynamoDbStoreInternal {
 
 /// A shared DB client for DynamoDb implementing LruCaching
 #[derive(Clone)]
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct DynamoDbStore {
     #[cfg(with_metrics)]
     store: MeteredStore<

--- a/linera-views/src/backends/value_splitting.rs
+++ b/linera-views/src/backends/value_splitting.rs
@@ -420,7 +420,7 @@ mod tests {
     // The key splitting means that when a key is overwritten
     // some previous segments may still be present.
     #[tokio::test]
-    #[allow(clippy::assertions_on_constants)]
+    #[expect(clippy::assertions_on_constants)]
     async fn test_value_splitting1_testing_leftovers() {
         let store = LimitedTestMemoryStore::new();
         const MAX_LEN: usize = LimitedTestMemoryStore::MAX_VALUE_SIZE;

--- a/linera-views/src/views/collection_view.rs
+++ b/linera-views/src/views/collection_view.rs
@@ -1413,7 +1413,6 @@ mod graphql {
             T::create_type_info(registry)
         }
 
-        #[allow(clippy::trivially_copy_pass_by_ref)]
         async fn resolve(
             &self,
             ctx: &async_graphql::ContextSelectionSet<'_>,

--- a/linera-views/src/views/reentrant_collection_view.rs
+++ b/linera-views/src/views/reentrant_collection_view.rs
@@ -75,7 +75,6 @@ impl<T> std::ops::DerefMut for WriteGuardedView<T> {
 /// A view that supports accessing a collection of views of the same kind, indexed by `Vec<u8>`,
 /// possibly several subviews at a time.
 #[derive(Debug)]
-#[allow(clippy::type_complexity)]
 pub struct ReentrantByteCollectionView<C, W> {
     /// The view [`Context`].
     context: C,

--- a/linera-views/src/views/register_view.rs
+++ b/linera-views/src/views/register_view.rs
@@ -253,7 +253,6 @@ mod graphql {
             T::create_type_info(registry)
         }
 
-        #[allow(clippy::trivially_copy_pass_by_ref)]
         async fn resolve(
             &self,
             ctx: &async_graphql::ContextSelectionSet<'_>,

--- a/linera-views/tests/views_tests.rs
+++ b/linera-views/tests/views_tests.rs
@@ -42,7 +42,6 @@ use linera_views::{
 };
 use rand::{Rng, RngCore};
 
-#[allow(clippy::type_complexity)]
 #[derive(CryptoHashRootView)]
 pub struct StateView<C> {
     pub x1: HashedRegisterView<C, u64>,

--- a/linera-witty/src/runtime/memory.rs
+++ b/linera-witty/src/runtime/memory.rs
@@ -72,7 +72,7 @@ pub trait RuntimeMemory<Instance> {
 }
 
 /// A handle to interface with a guest Wasm module instance's memory.
-#[allow(clippy::type_complexity)]
+#[expect(clippy::type_complexity)]
 pub struct Memory<'runtime, Instance>
 where
     Instance: CabiReallocAlias + CabiFreeAlias,

--- a/linera-witty/src/runtime/wasmer/parameters.rs
+++ b/linera-witty/src/runtime/wasmer/parameters.rs
@@ -43,7 +43,6 @@ where
     type ImportParameters = Parameter;
     type ExportParameters = (Parameter,);
 
-    #[allow(clippy::unused_unit)]
     fn into_wasmer(self) -> Self::ImportParameters {
         let hlist_pat![parameter] = self;
 

--- a/linera-witty/test-modules/src/export/setters.rs
+++ b/linera-witty/test-modules/src/export/setters.rs
@@ -14,7 +14,7 @@ use self::exports::witty_macros::test_modules::setters::Setters;
 struct Implementation;
 
 impl Setters for Implementation {
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn set_bool(value: bool) {
         assert_eq!(value, false);
     }

--- a/linera-witty/test-modules/src/import/getters.rs
+++ b/linera-witty/test-modules/src/import/getters.rs
@@ -17,7 +17,7 @@ use self::{
 struct Implementation;
 
 impl Entrypoint for Implementation {
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn entrypoint() {
         assert_eq!(get_true(), true);
         assert_eq!(get_false(), false);

--- a/linera-witty/test-modules/src/import/operations.rs
+++ b/linera-witty/test-modules/src/import/operations.rs
@@ -17,7 +17,7 @@ use self::{
 struct Implementation;
 
 impl Entrypoint for Implementation {
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn entrypoint() {
         assert_eq!(and_bool(true, true), true);
         assert_eq!(and_bool(true, false), false);

--- a/linera-witty/test-modules/src/reentrancy/getters.rs
+++ b/linera-witty/test-modules/src/reentrancy/getters.rs
@@ -17,7 +17,7 @@ use self::{
 struct Implementation;
 
 impl Entrypoint for Implementation {
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn entrypoint() {
         assert_eq!(get_true(), true);
         assert_eq!(get_false(), false);

--- a/linera-witty/test-modules/src/reentrancy/operations.rs
+++ b/linera-witty/test-modules/src/reentrancy/operations.rs
@@ -18,7 +18,7 @@ use self::{
 struct Implementation;
 
 impl Entrypoint for Implementation {
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn entrypoint() {
         assert_eq!(and_bool(true, true), true);
         assert_eq!(and_bool(true, false), false);

--- a/linera-witty/test-modules/src/reentrancy/setters.rs
+++ b/linera-witty/test-modules/src/reentrancy/setters.rs
@@ -32,7 +32,7 @@ impl Entrypoint for Implementation {
 }
 
 impl Setters for Implementation {
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn set_bool(value: bool) {
         assert_eq!(value, false);
     }

--- a/linera-witty/tests/common/test_instance.rs
+++ b/linera-witty/tests/common/test_instance.rs
@@ -470,7 +470,6 @@ where
             assert_eq!(value, expected_value);
         }
 
-        #[allow(clippy::bool_assert_comparison)]
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/entrypoint#entrypoint",
@@ -515,7 +514,6 @@ where
                 .unwrap_or_else(|error| panic!("Failed to call setter function {name:?}: {error}"));
         }
 
-        #[allow(clippy::bool_assert_comparison)]
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/entrypoint#entrypoint",
@@ -558,7 +556,6 @@ where
             assert_eq!(result, expected_result);
         }
 
-        #[allow(clippy::bool_assert_comparison)]
         self.mock_exported_function(
             instance,
             "witty-macros:test-modules/entrypoint#entrypoint",

--- a/linera-witty/tests/wit_export.rs
+++ b/linera-witty/tests/wit_export.rs
@@ -140,7 +140,7 @@ pub struct Setters;
 
 #[wit_export(package = "witty-macros:test-modules")]
 impl Setters {
-    #[allow(clippy::bool_assert_comparison)]
+    #[expect(clippy::bool_assert_comparison)]
     fn set_bool(value: bool) {
         assert_eq!(value, false);
     }

--- a/toolchains/build/rust-toolchain.toml
+++ b/toolchains/build/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 components = [ "clippy", "rustfmt", "rust-src" ]
 targets = [ "wasm32-unknown-unknown" ]
 profile = "minimal"


### PR DESCRIPTION
## Motivation

Rust 1.81.0 introduces [`#[expect(lint)]`](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#expectlint), which does the same as `allow`, but complains when it's no longer needed.

## Proposal

Upgrade to Rust 1.81.0, and use `expect` to remove several outdated `allow` attributes.

## Test Plan

CI should catch issues.

I also tried to avoid removing `allow`s from macros, where they may only apply in some but not all cases. Please double-check that I didn't miss anything!

## Links
- [Rust 1.81.0 announcement](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
