### PR TITLE
Make BlobContent into enum

### DIFF
--- a/examples/non-fungible/README.md
+++ b/examples/non-fungible/README.md
@@ -93,11 +93,13 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
     mutation {
         publishDataBlob(
           chainId: "$CHAIN_1",
-          blobContent: {
-            bytes: [1, 2, 3, 4]
-          }
+          bytes: [1, 2, 3, 4]
         )
     }
+```
+
+```bash
+BLOB_HASH=$(echo "$QUERY_RESULT" | jq -r '.publishDataBlob')
 ```
 
 - Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
@@ -108,7 +110,7 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
         mint(
             minter: "User:$OWNER_1",
             name: "nft1",
-            blobHash: "34a20da0fdd7e24ddbff60cb7f952b053b3f0e196e622d47c3a368f690f01326",
+            blobHash: "$BLOB_HASH",
         )
     }
 ```

--- a/examples/non-fungible/src/lib.rs
+++ b/examples/non-fungible/src/lib.rs
@@ -97,11 +97,13 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
     mutation {
         publishDataBlob(
           chainId: "$CHAIN_1",
-          blobContent: {
-            bytes: [1, 2, 3, 4]
-          }
+          bytes: [1, 2, 3, 4]
         )
     }
+```
+
+```bash
+BLOB_HASH=$(echo "$QUERY_RESULT" | jq -r '.publishDataBlob')
 ```
 
 - Navigate to `http://localhost:8080/chains/$CHAIN_1/applications/$APP_ID`.
@@ -112,7 +114,7 @@ Type each of these in the GraphiQL interface and substitute the env variables wi
         mint(
             minter: "User:$OWNER_1",
             name: "nft1",
-            blobHash: "34a20da0fdd7e24ddbff60cb7f952b053b3f0e196e622d47c3a368f690f01326",
+            blobHash: "$BLOB_HASH",
         )
     }
 ```

--- a/examples/non-fungible/web-frontend/src/App.js
+++ b/examples/non-fungible/web-frontend/src/App.js
@@ -43,8 +43,8 @@ const MINT_NFT = gql`
 `;
 
 const PUBLISH_DATA_BLOB = gql`
-  mutation PublishDataBlob($chainId: ChainId!, $blobContent: BlobContent!) {
-    publishDataBlob(chainId: $chainId, blobContent: $blobContent)
+  mutation PublishDataBlob($chainId: ChainId!, $bytes: [Int!]!) {
+    publishDataBlob(chainId: $chainId, bytes: $bytes)
   }
 `;
 
@@ -186,9 +186,7 @@ function App({ chainId, owner }) {
     publishDataBlob({
       variables: {
         chainId: chainId,
-        blobContent: {
-          bytes: Array.from(byteArrayFile),
-        },
+        bytes: Array.from(byteArrayFile),
       },
     }).then((r) => {
       if ('errors' in r) {
@@ -197,7 +195,7 @@ function App({ chainId, owner }) {
         );
       } else {
         console.log('Data Blob published: ' + JSON.stringify(r, null, 2));
-        const blobHash = r['data']['publishDataBlob']['hash'];
+        const blobHash = r['data']['publishDataBlob'];
         mintNft({
           variables: {
             minter: `User:${owner}`,
@@ -380,21 +378,21 @@ function App({ chainId, owner }) {
             dataSource={
               ownedNftsData
                 ? Object.entries(ownedNftsData.ownedNfts).map(
-                    ([token_id, nft]) => {
-                      const decoder = new TextDecoder();
-                      const deserializedImage = decoder.decode(
-                        new Uint8Array(nft.payload)
-                      );
+                  ([token_id, nft]) => {
+                    const decoder = new TextDecoder();
+                    const deserializedImage = decoder.decode(
+                      new Uint8Array(nft.payload)
+                    );
 
-                      return {
-                        key: token_id,
-                        token_id: token_id,
-                        name: nft.name,
-                        minter: nft.minter,
-                        payload: deserializedImage,
-                      };
-                    }
-                  )
+                    return {
+                      key: token_id,
+                      token_id: token_id,
+                      name: nft.name,
+                      minter: nft.minter,
+                      payload: deserializedImage,
+                    };
+                  }
+                )
                 : []
             }
           />

--- a/linera-chain/src/data_types.rs
+++ b/linera-chain/src/data_types.rs
@@ -10,8 +10,8 @@ use linera_base::{
     data_types::{Amount, Blob, BlockHeight, OracleResponse, Round, Timestamp},
     doc_scalar, ensure,
     identifiers::{
-        Account, BlobId, ChainId, ChannelName, Destination, GenericApplicationId, MessageId, Owner,
-        StreamId,
+        Account, BlobId, BlobType, ChainId, ChannelName, Destination, GenericApplicationId,
+        MessageId, Owner, StreamId,
     },
 };
 use linera_execution::{
@@ -66,12 +66,12 @@ impl Block {
         let mut blob_ids = HashSet::new();
         for operation in &self.operations {
             if let Operation::System(SystemOperation::PublishDataBlob { blob_hash }) = operation {
-                blob_ids.insert(BlobId::new_data_from_hash(*blob_hash));
+                blob_ids.insert(BlobId::new(*blob_hash, BlobType::Data));
             }
             if let Operation::System(SystemOperation::PublishBytecode { bytecode_id }) = operation {
                 blob_ids.extend([
-                    BlobId::new_contract_bytecode_from_hash(bytecode_id.contract_blob_hash),
-                    BlobId::new_service_bytecode_from_hash(bytecode_id.service_blob_hash),
+                    BlobId::new(bytecode_id.contract_blob_hash, BlobType::ContractBytecode),
+                    BlobId::new(bytecode_id.service_blob_hash, BlobType::ServiceBytecode),
                 ]);
             }
         }

--- a/linera-core/src/client/mod.rs
+++ b/linera-core/src/client/mod.rs
@@ -28,8 +28,7 @@ use linera_base::{
     abi::Abi,
     crypto::{CryptoHash, KeyPair, PublicKey},
     data_types::{
-        Amount, ApplicationPermissions, ArithmeticError, Blob, BlobContent, BlockHeight, Round,
-        Timestamp,
+        Amount, ApplicationPermissions, ArithmeticError, Blob, BlockHeight, Round, Timestamp,
     },
     ensure,
     identifiers::{
@@ -2493,14 +2492,12 @@ where
     }
 
     /// Publishes some data blobs.
-    #[tracing::instrument(level = "trace", skip(blob_contents))]
+    #[tracing::instrument(level = "trace", skip(bytes))]
     pub async fn publish_data_blobs(
         &self,
-        blob_contents: Vec<BlobContent>,
+        bytes: Vec<Vec<u8>>,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
-        let blobs = blob_contents
-            .into_iter()
-            .map(|blob_content| blob_content.with_data_blob_id());
+        let blobs = bytes.into_iter().map(Blob::new_data);
         let publish_blob_operations = blobs
             .clone()
             .map(|blob| {
@@ -2514,12 +2511,12 @@ where
     }
 
     /// Publishes some data blob.
-    #[tracing::instrument(level = "trace", skip(blob_content))]
+    #[tracing::instrument(level = "trace", skip(bytes))]
     pub async fn publish_data_blob(
         &self,
-        blob_content: BlobContent,
+        bytes: Vec<u8>,
     ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
-        self.publish_data_blobs(vec![blob_content]).await
+        self.publish_data_blobs(vec![bytes]).await
     }
 
     /// Adds pending blobs

--- a/linera-core/src/unit_tests/client_tests.rs
+++ b/linera-core/src/unit_tests/client_tests.rs
@@ -10,7 +10,7 @@ use futures::StreamExt;
 use linera_base::{
     crypto::*,
     data_types::*,
-    identifiers::{Account, ChainDescription, ChainId, MessageId, Owner},
+    identifiers::{Account, BlobId, BlobType, ChainDescription, ChainId, MessageId, Owner},
     ownership::{ChainOwnership, TimeoutConfig},
 };
 use linera_chain::{
@@ -1495,8 +1495,11 @@ where
         )
         .await?;
 
-    let blob0 = Blob::test_data_blob("blob0");
-    let blob0_id = blob0.id();
+    let blob0_bytes = b"blob0".to_vec();
+    let blob0_id = BlobId::new(
+        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
+        BlobType::Data,
+    );
 
     // Try to read a blob without publishing it first, should fail
     let result = client1_a
@@ -1512,7 +1515,7 @@ where
 
     // Publish blob on chain 1
     let publish_certificate = client1_a
-        .publish_data_blob(blob0.into_inner())
+        .publish_data_blob(blob0_bytes)
         .await
         .unwrap()
         .unwrap();
@@ -1546,7 +1549,7 @@ where
         .await;
 
     client2_a.synchronize_from_validators().await.unwrap();
-    let blob1 = Blob::test_data_blob("blob1");
+    let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
     client2_a.add_pending_blobs([blob1]).await;
@@ -1668,12 +1671,15 @@ where
     // Take one validator down
     builder.set_fault_type([3], FaultType::Offline).await;
 
-    let blob0 = Blob::test_data_blob("blob0");
-    let blob0_id = blob0.id();
+    let blob0_bytes = b"blob0".to_vec();
+    let blob0_id = BlobId::new(
+        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
+        BlobType::Data,
+    );
 
     // Publish blob on chain 1
     let publish_certificate = client1
-        .publish_data_blob(blob0.into_inner())
+        .publish_data_blob(blob0_bytes)
         .await
         .unwrap()
         .unwrap();
@@ -1688,7 +1694,7 @@ where
         .await;
 
     client2_a.synchronize_from_validators().await.unwrap();
-    let blob1 = Blob::test_data_blob("blob1");
+    let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
     client2_a.add_pending_blobs([blob1]).await;
@@ -1820,13 +1826,16 @@ where
     // Take one validator down
     builder.set_fault_type([3], FaultType::Offline).await;
 
-    let blob0 = Blob::test_data_blob("blob0");
-    let blob0_id = blob0.id();
+    let blob0_bytes = b"blob0".to_vec();
+    let blob0_id = BlobId::new(
+        CryptoHash::new(&BlobBytes(blob0_bytes.clone())),
+        BlobType::Data,
+    );
 
     client1.synchronize_from_validators().await.unwrap();
     // Publish blob0 on chain 1
     let publish_certificate0 = client1
-        .publish_data_blob(blob0.into_inner())
+        .publish_data_blob(blob0_bytes)
         .await
         .unwrap()
         .unwrap();
@@ -1836,13 +1845,16 @@ where
         .unwrap()
         .requires_blob(&blob0_id));
 
-    let blob2 = Blob::test_data_blob("blob2");
-    let blob2_id = blob2.id();
+    let blob2_bytes = b"blob2".to_vec();
+    let blob2_id = BlobId::new(
+        CryptoHash::new(&BlobBytes(blob2_bytes.clone())),
+        BlobType::Data,
+    );
 
     client2.synchronize_from_validators().await.unwrap();
     // Publish blob2 on chain 2
     let publish_certificate2 = client2
-        .publish_data_blob(blob2.into_inner())
+        .publish_data_blob(blob2_bytes)
         .await
         .unwrap()
         .unwrap();
@@ -1860,7 +1872,7 @@ where
         .await;
 
     client3_a.synchronize_from_validators().await.unwrap();
-    let blob1 = Blob::test_data_blob("blob1");
+    let blob1 = Blob::new_data(b"blob1".to_vec());
     let blob1_hash = blob1.id().hash;
 
     client3_a.add_pending_blobs([blob1]).await;
@@ -1935,7 +1947,7 @@ where
         .await;
 
     client3_b.synchronize_from_validators().await.unwrap();
-    let blob3 = Blob::test_data_blob("blob3");
+    let blob3 = Blob::new_data(b"blob3".to_vec());
     let blob3_hash = blob3.id().hash;
 
     client3_b.add_pending_blobs([blob3]).await;
@@ -2231,9 +2243,7 @@ where
         .manager;
     assert!(manager.requested_proposed.is_some());
     assert_eq!(manager.current_round, Round::MultiLeader(0));
-    let result = client1
-        .publish_data_blob(BlobContent::test_blob_content("blob1"))
-        .await;
+    let result = client1.publish_data_blob(b"blob1".to_vec()).await;
     assert!(result.is_err());
     assert!(client1.pending_block().is_some());
     assert!(!client1.pending_blobs().is_empty());
@@ -2526,10 +2536,13 @@ where
     builder.set_fault_type([3], FaultType::Offline).await;
 
     // Publish a blob on chain 1.
-    let blob = Blob::test_data_blob("blob");
-    let blob_id = blob.id();
+    let blob_bytes = b"blob".to_vec();
+    let blob_id = BlobId::new(
+        CryptoHash::new(&BlobBytes(blob_bytes.clone())),
+        BlobType::Data,
+    );
     client1
-        .publish_data_blob(blob.into_inner())
+        .publish_data_blob(blob_bytes)
         .await
         .unwrap()
         .unwrap();

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -434,7 +434,7 @@ where
             .read_blob(blob_id)
             .await
             .map_err(Into::into);
-        sender.send(blob.map(|blob| blob.into_inner()))
+        sender.send(blob.map(|blob| blob.into_inner_content()))
     }
 
     async fn do_download_certificate_value(

--- a/linera-core/src/unit_tests/value_cache_tests.rs
+++ b/linera-core/src/unit_tests/value_cache_tests.rs
@@ -526,9 +526,9 @@ fn create_dummy_certificate_value(height: impl Into<BlockHeight>) -> HashedCerti
     .into()
 }
 
-/// Creates a new dummy [`Blob`] to use in the tests.
+/// Creates a new dummy data [`Blob`] to use in the tests.
 fn create_dummy_blob(id: usize) -> Blob {
-    Blob::test_data_blob(&format!("test{}", id))
+    Blob::new_data(format!("test{}", id).as_bytes().to_vec())
 }
 
 /// Creates a dummy [`HashedCertificateValue::ValidatedBlock`] to use in the tests.

--- a/linera-core/src/unit_tests/wasm_client_tests.rs
+++ b/linera-core/src/unit_tests/wasm_client_tests.rs
@@ -19,7 +19,7 @@ use assert_matches::assert_matches;
 use async_graphql::Request;
 use counter::CounterAbi;
 use linera_base::{
-    data_types::{Amount, Blob, Bytecode, OracleResponse, UserApplicationDescription},
+    data_types::{Amount, Bytecode, OracleResponse, UserApplicationDescription},
     identifiers::{
         AccountOwner, ApplicationId, ChainDescription, ChainId, Destination, Owner, StreamId,
         StreamName,
@@ -102,53 +102,6 @@ where
 
     let (contract_path, service_path) =
         linera_execution::wasm_test::get_example_bytecode_paths("counter")?;
-
-    let contract_blob = Blob::load_data_blob_from_file(contract_path.clone()).await?;
-    let expected_contract_blob_id = contract_blob.id();
-    let certificate = publisher
-        .publish_data_blob(contract_blob.content().clone())
-        .await
-        .unwrap()
-        .unwrap();
-    assert!(certificate
-        .value()
-        .executed_block()
-        .unwrap()
-        .outcome
-        .oracle_responses
-        .iter()
-        .any(|responses| responses.contains(&OracleResponse::Blob(expected_contract_blob_id))));
-
-    let service_blob = Blob::load_data_blob_from_file(service_path.clone()).await?;
-    let expected_service_blob_id = service_blob.id();
-    let certificate = publisher
-        .publish_data_blob(service_blob.content().clone())
-        .await
-        .unwrap()
-        .unwrap();
-    assert!(certificate
-        .value()
-        .executed_block()
-        .unwrap()
-        .outcome
-        .oracle_responses
-        .iter()
-        .any(|responses| responses.contains(&OracleResponse::Blob(expected_service_blob_id))));
-
-    // If I try to upload the contract blob again, I should get the same blob ID
-    let certificate = publisher
-        .publish_data_blob(contract_blob.into_inner())
-        .await
-        .unwrap()
-        .unwrap();
-    assert!(certificate
-        .value()
-        .executed_block()
-        .unwrap()
-        .outcome
-        .oracle_responses
-        .iter()
-        .any(|responses| responses.contains(&OracleResponse::Blob(expected_contract_blob_id))));
 
     let (bytecode_id, _cert) = publisher
         .publish_bytecode(

--- a/linera-execution/src/runtime.rs
+++ b/linera-execution/src/runtime.rs
@@ -17,7 +17,8 @@ use linera_base::{
     },
     ensure,
     identifiers::{
-        Account, ApplicationId, BlobId, ChainId, ChannelName, MessageId, Owner, StreamName,
+        Account, ApplicationId, BlobId, BlobType, ChainId, ChannelName, MessageId, Owner,
+        StreamName,
     },
     ownership::ChainOwnership,
 };
@@ -1001,18 +1002,18 @@ impl<UserInstance> BaseRuntime for SyncRuntimeInternal<UserInstance> {
     }
 
     fn read_data_blob(&mut self, hash: &CryptoHash) -> Result<Vec<u8>, ExecutionError> {
-        let blob_id = BlobId::new_data_from_hash(*hash);
+        let blob_id = BlobId::new(*hash, BlobType::Data);
         self.transaction_tracker
             .replay_oracle_response(OracleResponse::Blob(blob_id))?;
         let blob_content = self
             .execution_state_sender
             .send_request(|callback| ExecutionRequest::ReadBlobContent { blob_id, callback })?
             .recv_response()?;
-        Ok(blob_content.bytes)
+        Ok(blob_content.inner_bytes())
     }
 
     fn assert_data_blob_exists(&mut self, hash: &CryptoHash) -> Result<(), ExecutionError> {
-        let blob_id = BlobId::new_data_from_hash(*hash);
+        let blob_id = BlobId::new(*hash, BlobType::Data);
         self.transaction_tracker
             .replay_oracle_response(OracleResponse::Blob(blob_id))?;
         self.execution_state_sender

--- a/linera-execution/src/test_utils/mod.rs
+++ b/linera-execution/src/test_utils/mod.rs
@@ -13,7 +13,7 @@ use std::{sync::Arc, thread, vec};
 use linera_base::{
     crypto::{BcsSignable, CryptoHash},
     data_types::BlockHeight,
-    identifiers::{BlobId, BlobType, BytecodeId, ChainId, MessageId},
+    identifiers::{BlobId, BytecodeId, ChainId, MessageId},
 };
 use linera_views::{
     context::Context,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -283,7 +283,7 @@ impl ValidatorNode for GrpcClient {
             .download_blob_content(api::BlobId::try_from(blob_id)?)
             .await?
             .into_inner()
-            .into())
+            .try_into()?)
     }
 
     #[instrument(target = "grpc_client", skip_all, err, fields(address = self.address))]

--- a/linera-rpc/src/grpc/conversions.rs
+++ b/linera-rpc/src/grpc/conversions.rs
@@ -559,15 +559,21 @@ impl TryFrom<api::CryptoHash> for CryptoHash {
     }
 }
 
-impl From<BlobContent> for api::BlobContent {
-    fn from(blob: BlobContent) -> Self {
-        Self { bytes: blob.bytes }
+impl TryFrom<BlobContent> for api::BlobContent {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from(blob: BlobContent) -> Result<Self, Self::Error> {
+        Ok(Self {
+            bytes: bincode::serialize(&blob)?,
+        })
     }
 }
 
-impl From<api::BlobContent> for BlobContent {
-    fn from(blob: api::BlobContent) -> Self {
-        Self { bytes: blob.bytes }
+impl TryFrom<api::BlobContent> for BlobContent {
+    type Error = GrpcProtoConversionError;
+
+    fn try_from(blob: api::BlobContent) -> Result<Self, Self::Error> {
+        Ok(bincode::deserialize(blob.bytes.as_slice())?)
     }
 }
 

--- a/linera-rpc/tests/format.rs
+++ b/linera-rpc/tests/format.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::{
-    data_types::{OracleResponse, Round},
+    data_types::{BlobContent, OracleResponse, Round},
     identifiers::{BlobType, ChainDescription, Destination, GenericApplicationId},
     ownership::ChainOwnership,
 };
@@ -51,6 +51,7 @@ fn get_registry() -> Result<Registry> {
     tracer.trace_type::<NodeError>(&samples)?;
     tracer.trace_type::<RpcMessage>(&samples)?;
     tracer.trace_type::<BlobType>(&samples)?;
+    tracer.trace_type::<BlobContent>(&samples)?;
     tracer.registry()
 }
 

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -43,15 +43,19 @@ ApplicationPermissions:
     - close_chain:
         SEQ:
           TYPENAME: ApplicationId
-Blob:
-  STRUCT:
-    - blob_type:
-        TYPENAME: BlobType
-    - blob_content:
-        TYPENAME: BlobContent
 BlobContent:
-  STRUCT:
-    - bytes: BYTES
+  ENUM:
+    0:
+      Data:
+        NEWTYPE: BYTES
+    1:
+      ContractBytecode:
+        NEWTYPE:
+          TYPENAME: CompressedBytecode
+    2:
+      ServiceBytecode:
+        NEWTYPE:
+          TYPENAME: CompressedBytecode
 BlobId:
   STRUCT:
     - hash:
@@ -122,7 +126,7 @@ BlockProposal:
         TYPENAME: Signature
     - blobs:
         SEQ:
-          TYPENAME: Blob
+          TYPENAME: BlobContent
     - validated_block_certificate:
         OPTION:
           TYPENAME: LiteCertificate
@@ -291,7 +295,7 @@ ChainManagerInfo:
           KEY:
             TYPENAME: BlobId
           VALUE:
-            TYPENAME: Blob
+            TYPENAME: BlobContent
 ChainOwnership:
   STRUCT:
     - super_owners:
@@ -335,6 +339,9 @@ Committee:
             TYPENAME: ValidatorState
     - policy:
         TYPENAME: ResourceControlPolicy
+CompressedBytecode:
+  STRUCT:
+    - compressed_bytes: BYTES
 CrateVersion:
   STRUCT:
     - major: U32
@@ -415,7 +422,7 @@ HandleCertificateRequest:
     - wait_for_outgoing_messages: BOOL
     - blobs:
         SEQ:
-          TYPENAME: Blob
+          TYPENAME: BlobContent
 HandleLiteCertRequest:
   STRUCT:
     - certificate:

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -41,11 +41,6 @@ input ApplicationPermissions {
 }
 
 """
-A blob of binary data.
-"""
-scalar BlobContent
-
-"""
 A block containing operations to apply on a given chain, as well as the
 acknowledgment of a number of incoming messages from other chains.
 * Incoming messages must be selected in the order they were
@@ -688,7 +683,7 @@ type MutationRoot {
 	"""
 	Publishes a new data blob.
 	"""
-	publishDataBlob(chainId: ChainId!, blobContent: BlobContent!): CryptoHash!
+	publishDataBlob(chainId: ChainId!, bytes: [Int!]!): CryptoHash!
 	"""
 	Creates a new application.
 	"""

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -19,7 +19,7 @@ use linera_base::{
     abi::ContractAbi,
     command::{resolve_binary, CommandExt},
     crypto::{CryptoHash, PublicKey},
-    data_types::{Amount, BlobContent, Bytecode},
+    data_types::{Amount, Bytecode},
     identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
 use linera_client::{config::GenesisConfig, wallet::Wallet};
@@ -957,12 +957,12 @@ impl NodeService {
     pub async fn publish_data_blob(
         &self,
         chain_id: &ChainId,
-        blob_content: &BlobContent,
+        bytes: Vec<u8>,
     ) -> Result<CryptoHash> {
         let query = format!(
-            "mutation {{ publishDataBlob(chainId: {}, blobContent: {}) }}",
+            "mutation {{ publishDataBlob(chainId: {}, bytes: {}) }}",
             chain_id.to_value(),
-            blob_content.to_value(),
+            bytes.to_value(),
         );
         let data = self.query_node(query).await?;
         serde_json::from_value(data["publishDataBlob"].clone())

--- a/linera-service/src/grpc_proxy.rs
+++ b/linera-service/src/grpc_proxy.rs
@@ -426,7 +426,7 @@ where
             .read_blob(blob_id)
             .await
             .map_err(|err| Status::from_error(Box::new(err)))?;
-        Ok(Response::new(blob.into_inner().into()))
+        Ok(Response::new(blob.into_inner_content().try_into()?))
     }
 
     #[instrument(skip_all, err(Display))]

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -20,7 +20,7 @@ use futures::{
 use linera_base::{
     crypto::{CryptoError, CryptoHash, PublicKey},
     data_types::{
-        Amount, ApplicationPermissions, BlobContent, Bytecode, TimeDelta, Timestamp,
+        Amount, ApplicationPermissions, BlobBytes, Bytecode, TimeDelta, Timestamp,
         UserApplicationDescription,
     },
     identifiers::{ApplicationId, BytecodeId, ChainId, Owner, UserApplicationId},
@@ -613,14 +613,14 @@ where
     async fn publish_data_blob(
         &self,
         chain_id: ChainId,
-        blob_content: BlobContent,
+        bytes: Vec<u8>,
     ) -> Result<CryptoHash, Error> {
-        let hash = CryptoHash::new(&blob_content);
+        let hash = CryptoHash::new(&BlobBytes(bytes.clone()));
         self.apply_client_command(&chain_id, move |client| {
-            let blob_content = blob_content.clone();
+            let bytes = bytes.clone();
             async move {
                 let result = client
-                    .publish_data_blob(blob_content)
+                    .publish_data_blob(bytes)
                     .await
                     .map_err(Error::from)
                     .map(|outcome| outcome.map(|_| hash));

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -295,7 +295,11 @@ where
                 self.genesis_config.hash().into(),
             ))),
             DownloadBlobContent(blob_id) => Ok(Some(
-                self.storage.read_blob(*blob_id).await?.into_inner().into(),
+                self.storage
+                    .read_blob(*blob_id)
+                    .await?
+                    .into_inner_content()
+                    .into(),
             )),
             DownloadCertificateValue(hash) => Ok(Some(
                 self.storage

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -27,7 +27,8 @@ use futures::{
 };
 use linera_base::{
     command::resolve_binary,
-    data_types::{Amount, Blob},
+    crypto::CryptoHash,
+    data_types::{Amount, BlobBytes},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
 };
 use linera_chain::data_types::{Medium, Origin};
@@ -1007,14 +1008,14 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let nft1_name = "nft1".to_string();
     let nft1_minter = account_owner1;
 
-    let nft1_blob = Blob::test_data_blob("nft1_data");
-    let nft1_blob_id = nft1_blob.id();
+    let nft1_blob_bytes = b"nft1_data".to_vec();
+    let nft1_blob_hash = CryptoHash::new(&BlobBytes(nft1_blob_bytes.clone()));
     let blob_hash = node_service1
-        .publish_data_blob(&chain1, nft1_blob.content())
+        .publish_data_blob(&chain1, nft1_blob_bytes.clone())
         .await?;
-    assert_eq!(nft1_blob_id.hash, blob_hash);
+    assert_eq!(nft1_blob_hash, blob_hash);
 
-    let nft1_blob_hash = DataBlobHash(nft1_blob_id.hash);
+    let nft1_blob_hash = DataBlobHash(nft1_blob_hash);
 
     let nft1_id = NonFungibleApp::create_token_id(
         &chain1,
@@ -1033,7 +1034,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
         owner: account_owner1,
         name: nft1_name,
         minter: nft1_minter,
-        payload: nft1_blob.content().bytes.clone(),
+        payload: nft1_blob_bytes,
     };
 
     assert_eq!(app1.get_nft(&nft1_id).await?, expected_nft1);
@@ -1137,14 +1138,14 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
 
     let nft2_name = "nft2".to_string();
     let nft2_minter = account_owner2;
-    let nft2_blob = Blob::test_data_blob("nft2_data");
-    let nft2_blob_id = nft2_blob.id();
+    let nft2_blob_bytes = b"nft2_data".to_vec();
+    let nft2_blob_hash = CryptoHash::new(&BlobBytes(nft2_blob_bytes.clone()));
     let blob_hash = node_service2
-        .publish_data_blob(&chain2, nft2_blob.content())
+        .publish_data_blob(&chain2, nft2_blob_bytes.clone())
         .await?;
-    assert_eq!(nft2_blob_id.hash, blob_hash);
+    assert_eq!(nft2_blob_hash, blob_hash);
 
-    let nft2_blob_hash = DataBlobHash(nft2_blob_id.hash);
+    let nft2_blob_hash = DataBlobHash(nft2_blob_hash);
 
     let nft2_id = NonFungibleApp::create_token_id(
         &chain2,
@@ -1164,7 +1165,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
         owner: account_owner2,
         name: nft2_name,
         minter: nft2_minter,
-        payload: nft2_blob.content().bytes.clone(),
+        payload: nft2_blob_bytes,
     };
 
     // Confirm it's there


### PR DESCRIPTION
## Motivation

Right now we have `BlobContent` always as a blob of bytes, but it can have many forms. This causes us to have to serialize/deserialize into those forms back and forth in the code more than we have to.

## Proposal

Encode the blob type into the `BlobContent`. Now `BlobId` and `BlobContent` will have the type encoded in them. They're supposed to be a 1:1 mapping to each other. This will avoid unecessary serialization/deserialization

## Test Plan

CI

