### PR TITLE
Minor `linera-service` tracing output improvements

### DIFF
--- a/linera-service/Cargo.toml
+++ b/linera-service/Cargo.toml
@@ -161,7 +161,7 @@ path = "src/server.rs"
 
 [[bin]]
 name = "linera-proxy"
-path = "src/proxy.rs"
+path = "src/proxy/main.rs"
 
 [[bin]]
 name = "linera-schema-export"

--- a/linera-service/src/lib.rs
+++ b/linera-service/src/lib.rs
@@ -8,7 +8,6 @@
 
 pub mod cli_wrappers;
 pub mod faucet;
-pub mod grpc_proxy;
 pub mod node_service;
 pub mod project;
 #[cfg(with_metrics)]

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1231,7 +1231,7 @@ fn main() -> anyhow::Result<()> {
         builder
     };
 
-    let span = tracing::info_span!("run");
+    let span = tracing::info_span!("linera::main");
     if let Some(wallet_id) = options.with_wallet {
         span.record("wallet_id", wallet_id);
     }

--- a/linera-service/src/proxy/grpc.rs
+++ b/linera-service/src/proxy/grpc.rs
@@ -231,7 +231,16 @@ where
 
     /// Runs the proxy. If either the public server or private server dies for whatever
     /// reason we'll kill the proxy.
-    #[instrument(name = "GrpcProxy::run", skip_all, fields(public_address = %self.public_address(), internal_address = %self.internal_address(), metrics_address = %self.metrics_address()), err)]
+    #[instrument(
+        name = "GrpcProxy::run",
+        skip_all,
+        fields(
+            public_address = %self.public_address(),
+            internal_address = %self.internal_address(),
+            metrics_address = %self.metrics_address(),
+        ),
+        err,
+    )]
     pub async fn run(self, shutdown_signal: CancellationToken) -> Result<()> {
         info!("Starting gRPC server");
         let mut join_set = JoinSet::new();


### PR DESCRIPTION
## Motivation

A lot of our spans in `linera-service` had the name `run`, which made it sometimes difficult to distinguish their output on the console.

<!-- Short text indicating what this PR aims to accomplish. -->

## Proposal

Demarcate the proxy a little more (moving `proxy.rs` and `grpc_proxy.rs` into their own subdirectory) and give them more unique spans.

<!-- What are the proposed changes and why are they appropriate? -->

## Test Plan

CI.

<!-- How to test that the changes are correct. -->

## Release Plan

None required.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
