### PR TITLE
Compress and decompress bytecodes in blocking thread

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -824,6 +824,15 @@ impl Bytecode {
         let bytes = fs::read(path)?;
         Ok(Bytecode { bytes })
     }
+
+    /// Compresses the [`Bytecode`] into a [`CompressedBytecode`].
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn compress(&self) -> CompressedBytecode {
+        let compressed_bytes = zstd::stream::encode_all(&*self.bytes, 19)
+            .expect("Compressing bytes in memory should not fail");
+
+        CompressedBytecode { compressed_bytes }
+    }
 }
 
 impl AsRef<[u8]> for Bytecode {
@@ -858,23 +867,6 @@ pub struct CompressedBytecode {
     /// Compressed bytes of the bytecode.
     #[serde(with = "serde_bytes")]
     pub compressed_bytes: Vec<u8>,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl From<&Bytecode> for CompressedBytecode {
-    fn from(bytecode: &Bytecode) -> Self {
-        let compressed_bytes = zstd::stream::encode_all(&*bytecode.bytes, 19)
-            .expect("Compressing bytes in memory should not fail");
-
-        CompressedBytecode { compressed_bytes }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl From<Bytecode> for CompressedBytecode {
-    fn from(bytecode: Bytecode) -> Self {
-        CompressedBytecode::from(&bytecode)
-    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2540,7 +2540,7 @@ where
         service: Bytecode,
     ) -> Result<ClientOutcome<(BytecodeId, Certificate)>, ChainClientError> {
         let (compressed_contract, compressed_service) =
-            tokio::task::spawn_blocking(move || (contract.into(), service.into()))
+            tokio::task::spawn_blocking(move || (contract.compress(), service.compress()))
                 .await
                 .expect("Compression should not panic");
         let contract_blob = Blob::new_contract_bytecode(compressed_contract);

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -2531,7 +2531,6 @@ where
             .await
     }
 
-    // TODO(#2413): Use ruztd instead of zstd for bytecode compression
     #[cfg(not(target_arch = "wasm32"))]
     #[tracing::instrument(level = "trace", skip(contract, service))]
     /// Publishes some bytecode.

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -115,8 +115,8 @@ where
     let contract_bytecode = Bytecode::load_from_file(contract_path).await?;
     let service_bytecode = Bytecode::load_from_file(service_path).await?;
 
-    let contract_blob = Blob::new_contract_bytecode(contract_bytecode.clone().into());
-    let service_blob = Blob::new_service_bytecode(service_bytecode.into());
+    let contract_blob = Blob::new_contract_bytecode(contract_bytecode.clone().compress());
+    let service_blob = Blob::new_service_bytecode(service_bytecode.compress());
 
     let contract_blob_id = contract_blob.id();
     let service_blob_id = service_blob.id();

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -267,7 +267,7 @@ impl ActiveChain {
             .await
             .expect("Failed to load service bytecode from file");
 
-        tokio::task::spawn_blocking(move || (contract.into(), service.into()))
+        tokio::task::spawn_blocking(move || (contract.compress(), service.compress()))
             .await
             .expect("Failed to compress bytecodes")
     }

--- a/linera-sdk/src/test/chain.rs
+++ b/linera-sdk/src/test/chain.rs
@@ -267,7 +267,9 @@ impl ActiveChain {
             .await
             .expect("Failed to load service bytecode from file");
 
-        (contract.into(), service.into())
+        tokio::task::spawn_blocking(move || (contract.into(), service.into()))
+            .await
+            .expect("Failed to compress bytecodes")
     }
 
     /// Searches for the directory where the built WebAssembly binaries should be.

--- a/linera-storage/src/lib.rs
+++ b/linera-storage/src/lib.rs
@@ -295,7 +295,8 @@ pub trait Storage: Sized {
             .into_inner_contract_bytecode()
             .expect("Contract Bytecode Blob is of the wrong Blob type!");
         let contract_bytecode =
-            tokio::task::spawn_blocking(move || compressed_contract_bytecode.try_into()).await??;
+            tokio::task::spawn_blocking(move || compressed_contract_bytecode.decompress())
+                .await??;
         Ok(Arc::new(
             WasmContractModule::new(contract_bytecode, wasm_runtime).await?,
         ))
@@ -332,7 +333,7 @@ pub trait Storage: Sized {
             .into_inner_service_bytecode()
             .expect("Service Bytecode Blob is of the wrong Blob type!");
         let service_bytecode =
-            tokio::task::spawn_blocking(move || compressed_service_bytecode.try_into()).await??;
+            tokio::task::spawn_blocking(move || compressed_service_bytecode.decompress()).await??;
         Ok(Arc::new(
             WasmServiceModule::new(service_bytecode, wasm_runtime).await?,
         ))


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When bytecode compression was introduced (#2382), compression and decompression ran in asynchronous tasks. Since these operations are CPU bound, they are best executed in separate non-blocking threads. This allows handling more IO bound operations.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Spawn Tokio's blocking threads to compress and decompress bytecodes.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should catch any regressions from this is an internal refactor.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this is an internal refactor.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
