### PR TITLE
Make synchronize_received_certificates_from_validator a method.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1079,21 +1079,25 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(
-        level = "trace",
-        skip(tracker, committees, max_epoch, node, node_client)
-    )]
+    #[tracing::instrument(level = "trace", skip(node))]
     /// Downloads and processes all confirmed block certificates that sent any message to this
     /// chain, including their ancestors.
     async fn synchronize_received_certificates_from_validator(
+        &self,
         chain_id: ChainId,
         name: ValidatorName,
-        tracker: u64,
-        committees: BTreeMap<Epoch, Committee>,
-        max_epoch: Epoch,
         node: impl LocalValidatorNode,
-        node_client: LocalNodeClient<S>,
     ) -> Result<(ValidatorName, u64, Vec<Certificate>), NodeError> {
+        let tracker = self
+            .state()
+            .received_certificate_trackers
+            .get(&name)
+            .copied()
+            .unwrap_or(0);
+        let (committees, max_epoch) = self
+            .known_committees()
+            .await
+            .map_err(|_| NodeError::InvalidChainInfoResponse)?;
         // Retrieve newly received certificates from this validator.
         let query = ChainInfoQuery::new(chain_id).with_received_log_excluding_first_nth(tracker);
         let response = node.handle_chain_info_query(query).await?;
@@ -1104,7 +1108,9 @@ where
         for entry in response.info.requested_received_log {
             let query = ChainInfoQuery::new(entry.chain_id)
                 .with_sent_certificate_hashes_in_range(BlockHeightRange::single(entry.height));
-            let local_response = node_client
+            let local_response = self
+                .client
+                .local_node
                 .handle_chain_info_query(query.clone())
                 .await
                 .map_err(|error| NodeError::LocalNodeQuery {
@@ -1223,32 +1229,19 @@ where
         // Synchronize the state of the admin chain from the network.
         self.synchronize_chain_state(&nodes, self.admin_id())
             .await?;
-        let node_client = self.client.local_node.clone();
-        // Now we should have a complete view of all committees in the system.
-        let (committees, max_epoch) = self.known_committees().await?;
+        let client = self.clone();
         // Proceed to downloading received certificates.
         let result = communicate_with_quorum(
             &nodes,
             &local_committee,
             |_| (),
             |name, node| {
-                let tracker = self
-                    .state()
-                    .received_certificate_trackers
-                    .get(&name)
-                    .copied()
-                    .unwrap_or(0);
-                let committees = committees.clone();
-                let node_client = node_client.clone();
-                Box::pin(Self::synchronize_received_certificates_from_validator(
-                    chain_id,
-                    name,
-                    tracker,
-                    committees,
-                    max_epoch,
-                    node,
-                    node_client,
-                ))
+                let client = client.clone();
+                Box::pin(async move {
+                    client
+                        .synchronize_received_certificates_from_validator(chain_id, name, node)
+                        .await
+                })
             },
         )
         .await;
@@ -2879,7 +2872,7 @@ where
                     return;
                 }
                 if let Err(error) = self
-                    .find_received_certificates_from_validator(name, node, local_node.clone())
+                    .find_received_certificates_from_validator(name, node)
                     .await
                 {
                     error!("Fail to process notification: {error}");
@@ -3064,7 +3057,7 @@ where
         Ok(validator_tasks.collect())
     }
 
-    #[tracing::instrument(level = "trace", skip(node, node_client))]
+    #[tracing::instrument(level = "trace", skip(node))]
     /// Attempts to download new received certificates from a particular validator.
     ///
     /// This is similar to `find_received_certificates` but for only one validator.
@@ -3073,27 +3066,12 @@ where
         &self,
         name: ValidatorName,
         node: <P as LocalValidatorNodeProvider>::Node,
-        node_client: LocalNodeClient<S>,
     ) -> Result<(), ChainClientError> {
         let chain_id = self.chain_id;
-        let (committees, max_epoch) = self.known_committees().await?;
-        let current_tracker = self
-            .state()
-            .received_certificate_trackers
-            .get(&name)
-            .copied()
-            .unwrap_or(0);
         // Proceed to downloading received certificates.
-        let (name, tracker, certificates) = Self::synchronize_received_certificates_from_validator(
-            chain_id,
-            name,
-            current_tracker,
-            committees,
-            max_epoch,
-            node,
-            node_client,
-        )
-        .await?;
+        let (name, tracker, certificates) = self
+            .synchronize_received_certificates_from_validator(chain_id, name, node)
+            .await?;
         // Process received certificates. If the client state has changed during the
         // network calls, we should still be fine.
         self.receive_certificates_from_validator(name, tracker, certificates)


### PR DESCRIPTION
## Motivation

In an upcoming optimization (synchronizing the admin chain less often) I will need to use `ChainClient` methods from within `synchronize_received_certificates_from_validator`. (We will sync the admin chain in that function when necessary, and then call `known_committees`.)

## Proposal

Make `synchronize_received_certificates_from_validator` a method. This also reduces the number of its parameters.

## Test Plan

Just a refactoring. Existing tests should catch any regression.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
