### PR TITLE
Sync admin chain only when needed; fix bytecode blobs.

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -9,7 +9,8 @@ use assert_matches::assert_matches;
 use linera_base::{
     crypto::{CryptoHash, PublicKey},
     data_types::{
-        Amount, ApplicationPermissions, BlockHeight, Timestamp, UserApplicationDescription,
+        Amount, ApplicationPermissions, Blob, BlockHeight, Bytecode, Timestamp,
+        UserApplicationDescription,
     },
     identifiers::{ApplicationId, BytecodeId, ChainId, MessageId},
     ownership::ChainOwnership,
@@ -59,11 +60,14 @@ where
 }
 
 fn make_app_description() -> UserApplicationDescription {
+    let contract = Bytecode::new(b"contract".into());
+    let service = Bytecode::new(b"service".into());
+    let contract_blob = Blob::new_contract_bytecode(contract.into());
+    let service_blob = Blob::new_service_bytecode(service.into());
+
+    let bytecode_id = BytecodeId::new(contract_blob.id().hash, service_blob.id().hash);
     UserApplicationDescription {
-        bytecode_id: BytecodeId::new(
-            CryptoHash::test_hash("contract"),
-            CryptoHash::test_hash("service"),
-        ),
+        bytecode_id,
         creation: make_admin_message_id(BlockHeight(2)),
         required_application_ids: vec![],
         parameters: vec![],
@@ -186,6 +190,10 @@ async fn test_application_permissions() {
     extra
         .user_contracts()
         .insert(application_id, application.clone());
+    let contract_blob = Blob::new_contract_bytecode(Bytecode::new(b"contract".into()).into());
+    extra.add_blob(contract_blob);
+    let service_blob = Blob::new_service_bytecode(Bytecode::new(b"service".into()).into());
+    extra.add_blob(service_blob);
 
     // Initialize the chain, with a chain application.
     let config = OpenChainConfig {

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1094,7 +1094,7 @@ where
             .get(&name)
             .copied()
             .unwrap_or(0);
-        let (committees, max_epoch) = self
+        let (mut committees, mut max_epoch) = self
             .known_committees()
             .await
             .map_err(|_| NodeError::InvalidChainInfoResponse)?;
@@ -1138,6 +1138,18 @@ where
             };
             let block = &executed_block.block;
             // Check that certificates are valid w.r.t one of our trusted committees.
+            if block.epoch > max_epoch {
+                // Synchronize the state of the admin chain from the network.
+                self.try_synchronize_chain_state_from(&name, &node, self.admin_id())
+                    .await
+                    .map_err(|_| NodeError::InvalidChainInfoResponse)?;
+                let (new_committees, new_max_epoch) = self
+                    .known_committees()
+                    .await
+                    .map_err(|_| NodeError::InvalidChainInfoResponse)?;
+                committees = new_committees;
+                max_epoch = new_max_epoch;
+            }
             if block.epoch > max_epoch {
                 // We don't accept a certificate from a committee in the future.
                 warn!(
@@ -1226,9 +1238,6 @@ where
             .validator_node_provider
             .make_nodes(&local_committee)?
             .collect();
-        // Synchronize the state of the admin chain from the network.
-        self.synchronize_chain_state(&nodes, self.admin_id())
-            .await?;
         let client = self.clone();
         // Proceed to downloading received certificates.
         let result = communicate_with_quorum(

--- a/linera-core/src/unit_tests/wasm_worker_tests.rs
+++ b/linera-core/src/unit_tests/wasm_worker_tests.rs
@@ -229,7 +229,10 @@ where
             }]],
             events: vec![Vec::new()],
             state_hash: creator_state.crypto_hash().await?,
-            oracle_responses: vec![Vec::new()],
+            oracle_responses: vec![vec![
+                OracleResponse::Blob(contract_blob_id),
+                OracleResponse::Blob(service_blob_id),
+            ]],
         }
         .with(create_block),
     );

--- a/linera-execution/src/execution.rs
+++ b/linera-execution/src/execution.rs
@@ -353,7 +353,10 @@ where
         assert_eq!(context.chain_id, self.context().extra().chain_id());
         match message {
             Message::System(message) => {
-                let outcome = self.system.execute_message(context, message).await?;
+                let outcome = self
+                    .system
+                    .execute_message(context, message, txn_tracker)
+                    .await?;
                 txn_tracker.add_system_outcome(outcome)?;
             }
             Message::User {

--- a/linera-execution/src/execution_state_actor.rs
+++ b/linera-execution/src/execution_state_actor.rs
@@ -307,7 +307,11 @@ where
             }
 
             ReadBlobContent { blob_id, callback } => {
-                let blob = self.system.read_blob_content(blob_id).await?;
+                let blob = self
+                    .system
+                    .read_blob_content(blob_id)
+                    .await
+                    .map_err(|_| SystemExecutionError::BlobNotFoundOnRead(blob_id))?;
                 callback.respond(blob);
             }
 

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -885,6 +885,10 @@ impl TestExecutionRuntimeContext {
             blobs: Arc::default(),
         }
     }
+
+    pub fn add_blob(&self, blob: Blob) {
+        self.blobs.insert(blob.id(), blob);
+    }
 }
 
 #[cfg(with_testing)]


### PR DESCRIPTION
## Motivation

Currently the client synchronizes the admin chain in addition to the user's chain (or whatever chain is currently being used) in every call to `find_received_certificates`, to make sure we have all committees, even the ones that have been created by the admin chain but not handled yet by the other chain. That is wasteful.

Work on this uncovered another issue: Bytecode blobs are not recorded as oracle responses, but then are expected to be present when we try to load the bytecode.

## Proposal

Synchronize the admin chain only when we encounter an incoming message from a future epoch.

Record the service and contract bytecode blobs as oracle responses whenever we register an application.

## Test Plan

No new features were added, and the admin chain change was just an optimization, where existing tests should catch any regressions.

It did, however cause the existing tests to reveal the other problem. With the bytecode blob fix, they pass again.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
