### PR TITLE
Fix compression of bytecodes in tests

### DIFF
--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -62,8 +62,8 @@ where
 fn make_app_description() -> UserApplicationDescription {
     let contract = Bytecode::new(b"contract".into());
     let service = Bytecode::new(b"service".into());
-    let contract_blob = Blob::new_contract_bytecode(contract.into());
-    let service_blob = Blob::new_service_bytecode(service.into());
+    let contract_blob = Blob::new_contract_bytecode(contract.compress());
+    let service_blob = Blob::new_service_bytecode(service.compress());
 
     let bytecode_id = BytecodeId::new(contract_blob.id().hash, service_blob.id().hash);
     UserApplicationDescription {
@@ -190,9 +190,9 @@ async fn test_application_permissions() {
     extra
         .user_contracts()
         .insert(application_id, application.clone());
-    let contract_blob = Blob::new_contract_bytecode(Bytecode::new(b"contract".into()).into());
+    let contract_blob = Blob::new_contract_bytecode(Bytecode::new(b"contract".into()).compress());
     extra.add_blob(contract_blob);
-    let service_blob = Blob::new_service_bytecode(Bytecode::new(b"service".into()).into());
+    let service_blob = Blob::new_service_bytecode(Bytecode::new(b"service".into()).compress());
     extra.add_blob(service_blob);
 
     // Initialize the chain, with a chain application.

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -1070,8 +1070,8 @@ mod tests {
         let (mut view, context) = new_view_and_context().await;
         let contract = Bytecode::new(b"contract".into());
         let service = Bytecode::new(b"service".into());
-        let contract_blob = Blob::new_contract_bytecode(contract.into());
-        let service_blob = Blob::new_service_bytecode(service.into());
+        let contract_blob = Blob::new_contract_bytecode(contract.compress());
+        let service_blob = Blob::new_service_bytecode(service.compress());
         let bytecode_id = BytecodeId::new(contract_blob.id().hash, service_blob.id().hash);
 
         let operation = SystemOperation::CreateApplication {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
There was a "PR race condition" when merging to `main`, where #2471 changed the API to compress/decompress bytecodes but #2473 updated some tests and added bytecodes compressed with the previous API. Merging both of them caused `main` to break.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Fix the tests to use the new `compress()` method instead of the removed `From` implementation.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should reveal if this fixes the tests that were broken.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, as this only affects tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
