### PR TITLE
Add metrics for compression and decompression latency

### DIFF
--- a/linera-base/src/data_types.rs
+++ b/linera-base/src/data_types.rs
@@ -6,6 +6,8 @@
 
 #[cfg(with_testing)]
 use std::ops;
+#[cfg(with_metrics)]
+use std::sync::LazyLock;
 use std::{
     fmt::{self, Display},
     fs, io, iter,
@@ -19,9 +21,13 @@ use async_graphql::InputObject;
 use base64::engine::{general_purpose::STANDARD_NO_PAD, Engine as _};
 use custom_debug_derive::Debug;
 use linera_witty::{WitLoad, WitStore, WitType};
+#[cfg(with_metrics)]
+use prometheus::HistogramVec;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
+#[cfg(with_metrics)]
+use crate::prometheus_util::{self, MeasureLatency};
 use crate::{
     crypto::BcsHashable,
     doc_scalar, hex_debug,
@@ -873,6 +879,8 @@ impl CompressedBytecode {
     /// Decompresses a [`CompressedBytecode`] into a [`Bytecode`].
     #[cfg(not(target_arch = "wasm32"))]
     pub fn decompress(&self) -> Result<Bytecode, DecompressionError> {
+        #[cfg(with_metrics)]
+        let _decompression_latency = BYTECODE_DECOMPRESSION_LATENCY.measure_latency();
         let bytes = zstd::stream::decode_all(&*self.compressed_bytes)
             .map_err(DecompressionError::InvalidCompressedBytecode)?;
 
@@ -883,6 +891,9 @@ impl CompressedBytecode {
     #[cfg(target_arch = "wasm32")]
     pub fn decompress(&self) -> Result<Bytecode, DecompressionError> {
         use ruzstd::{io::Read, streaming_decoder::StreamingDecoder};
+
+        #[cfg(with_metrics)]
+        let _decompression_latency = BYTECODE_DECOMPRESSION_LATENCY.measure_latency();
 
         let compressed_bytes = &*self.compressed_bytes;
         let mut bytes = Vec::new();
@@ -1190,6 +1201,21 @@ doc_scalar!(
     UserApplicationDescription,
     "Description of the necessary information to run a user application"
 );
+
+/// The time it takes to decompress a bytecode.
+#[cfg(with_metrics)]
+static BYTECODE_DECOMPRESSION_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "bytecode_decompression_latency",
+        "Bytecode decompression latency",
+        &[],
+        Some(vec![
+            0.000_1, 0.000_25, 0.000_5, 0.001, 0.002_5, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+            1.0, 2.5, 5.0, 10.0,
+        ]),
+    )
+    .expect("Histogram creation should not fail")
+});
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
Introducing bytecode compression (#2382) results in a CPU overhead. It is `expected` to be fairly low, but it should be measured to be sure.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Add latency metrics for compressing and decompressing bytecodes.

## Test Plan

<!-- How to test that the changes are correct. -->
CI should catch any regressions caused by introducing the metrics.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Nothing needed, because this just adds two latency metrics.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
