### PR TITLE
In the node service, don't unnecessarily call prepare_chain.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -16,7 +16,7 @@ use linera_base::{
 };
 use linera_chain::data_types::OutgoingMessage;
 use linera_core::{
-    client::ChainClient,
+    client::{ChainClient, ChainClientError},
     node::{LocalValidatorNodeProvider, ValidatorNode, ValidatorNodeProvider},
     worker::Reason,
 };
@@ -183,7 +183,8 @@ where
                         continue;
                     }
                     debug!("Processing inbox");
-                    match client.process_inbox_if_owned().await {
+                    match client.process_inbox_without_prepare().await {
+                        Err(ChainClientError::CannotFindKeyForChain(_)) => continue,
                         Err(error) => {
                             warn!(%error, "Failed to process inbox.");
                             timeout = Timestamp::from(u64::MAX);


### PR DESCRIPTION
## Motivation

The node service listens to notifications from the validators about new blocks and incoming messages, so calling `prepare_chain` should never be necessary. In particular, if we are processing the inbox _because_ of a notification about a new message, we already have that message in the inbox.

## Proposal

Don't call `prepare_chain`.

## Test Plan

We use both `ProcessInbox` policies in the tests, so any regressions should be caught.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
