### PR TITLE
In the node service, don't unnecessarily call prepare_chain. (Devnet backport.)

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -16,7 +16,7 @@ use linera_base::{
 };
 use linera_chain::data_types::OutgoingMessage;
 use linera_core::{
-    client::ChainClient,
+    client::{ChainClient, ChainClientError},
     node::{LocalValidatorNodeProvider, ValidatorNode, ValidatorNodeProvider},
     worker::Reason,
 };
@@ -182,7 +182,8 @@ where
                         continue;
                     }
                     debug!("Processing inbox");
-                    match client.process_inbox_if_owned().await {
+                    match client.process_inbox_without_prepare().await {
+                        Err(ChainClientError::CannotFindKeyForChain(_)) => continue,
                         Err(error) => {
                             warn!(%error, "Failed to process inbox.");
                             timeout = Timestamp::from(u64::MAX);


### PR DESCRIPTION
This is a backport of https://github.com/linera-io/linera-protocol/pull/2479 to devnet.

## Motivation

The node service listens to notifications from the validators about new blocks, so calling `prepare_chain` should never be necessary.

## Proposal

Don't call `prepare_chain`.

## Test Plan

We use both `ProcessInbox` policies in the tests, so any regressions should be caught.

## Links

- PR for the main branch: https://github.com/linera-io/linera-protocol/pull/2479
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
