### PR TITLE
Revert admin chain sync optimization.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -1094,7 +1094,7 @@ where
             .get(&name)
             .copied()
             .unwrap_or(0);
-        let (mut committees, mut max_epoch) = self
+        let (committees, max_epoch) = self
             .known_committees()
             .await
             .map_err(|_| NodeError::InvalidChainInfoResponse)?;
@@ -1138,18 +1138,6 @@ where
             };
             let block = &executed_block.block;
             // Check that certificates are valid w.r.t one of our trusted committees.
-            if block.epoch > max_epoch {
-                // Synchronize the state of the admin chain from the network.
-                self.try_synchronize_chain_state_from(&name, &node, self.admin_id())
-                    .await
-                    .map_err(|_| NodeError::InvalidChainInfoResponse)?;
-                let (new_committees, new_max_epoch) = self
-                    .known_committees()
-                    .await
-                    .map_err(|_| NodeError::InvalidChainInfoResponse)?;
-                committees = new_committees;
-                max_epoch = new_max_epoch;
-            }
             if block.epoch > max_epoch {
                 // We don't accept a certificate from a committee in the future.
                 warn!(
@@ -1238,6 +1226,9 @@ where
             .validator_node_provider
             .make_nodes(&local_committee)?
             .collect();
+        // Synchronize the state of the admin chain from the network.
+        self.synchronize_chain_state(&nodes, self.admin_id())
+            .await?;
         let client = self.clone();
         // Proceed to downloading received certificates.
         let result = communicate_with_quorum(


### PR DESCRIPTION
## Motivation

Several end-to-end tests are unstable on main. It's not clear to me yet why, but if the tests repeatedly pass on this PR, the optimization in https://github.com/linera-io/linera-protocol/pull/2473 is to blame.

## Proposal

Revert the optimization.

## Test Plan

See if CI passes _multiple times_ to make sure this is actually related.


## Links

- Original PR: https://github.com/linera-io/linera-protocol/pull/2473
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
