### PR TITLE
Log to separate files

### DIFF
--- a/linera-base/src/lib.rs
+++ b/linera-base/src/lib.rs
@@ -24,6 +24,7 @@ pub mod prometheus_util;
 #[cfg(not(chain))]
 pub mod task;
 pub mod time;
+#[cfg_attr(web, path = "tracing_web.rs")]
 pub mod tracing;
 #[cfg(test)]
 mod unit_tests;

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -3,34 +3,10 @@
 
 //! This module provides unified handling for tracing subscribers within Linera binaries.
 
-/// Initializes tracing for the browser, sending messages to the developer console and
-/// span events to the [Performance
-/// API](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
-#[cfg(web)]
-pub fn init() {
-    use tracing_subscriber::{
-        prelude::__tracing_subscriber_SubscriberExt as _, util::SubscriberInitExt as _,
-    };
-
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .without_time()
-                .with_writer(tracing_web::MakeWebConsoleWriter::new()),
-        )
-        .with(
-            tracing_web::performance_layer()
-                .with_details_from_fields(tracing_subscriber::fmt::format::Pretty::default()),
-        )
-        .init();
-}
-
 /// Initializes tracing in a standard way.
 /// The environment variables `RUST_LOG`, `RUST_LOG_SPAN_EVENTS`, and `RUST_LOG_FORMAT`
 /// can be used to control the verbosity, the span event verbosity, and the output format,
 /// respectively.
-#[cfg(not(web))]
 pub fn init() {
     use is_terminal::IsTerminal as _;
     use tracing_subscriber::fmt::format::FmtSpan;

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -4,36 +4,69 @@
 //! This module provides unified handling for tracing subscribers within Linera binaries.
 
 use is_terminal::IsTerminal as _;
-use tracing_subscriber::fmt::format::FmtSpan;
+use tracing::Subscriber;
+use tracing_subscriber::{
+    fmt::{
+        self,
+        format::{FmtSpan, Format, Full},
+        time::FormatTime,
+        FormatFields, MakeWriter,
+    },
+    layer::{Layer, SubscriberExt as _},
+    registry::LookupSpan,
+    util::SubscriberInitExt,
+};
 
 /// Initializes tracing in a standard way.
 /// The environment variables `RUST_LOG`, `RUST_LOG_SPAN_EVENTS`, and `RUST_LOG_FORMAT`
 /// can be used to control the verbosity, the span event verbosity, and the output format,
 /// respectively.
 pub fn init() {
+    let env_filter = tracing_subscriber::EnvFilter::builder()
+        .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        .from_env_lossy();
+
     let span_events = std::env::var("RUST_LOG_SPAN_EVENTS")
         .ok()
         .map(|s| fmt_span_from_str(&s))
         .unwrap_or(FmtSpan::NONE);
 
-    let mut subscriber = tracing_subscriber::fmt()
-        .with_span_events(span_events)
-        .with_writer(std::io::stderr)
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-                .from_env_lossy(),
-        );
+    let format = std::env::var("RUST_LOG_FORMAT").ok();
 
-    if std::env::var("NO_COLOR").is_ok_and(|x| !x.is_empty()) || !std::io::stderr().is_terminal() {
-        subscriber = subscriber.with_ansi(false);
-    }
+    let color_output =
+        !std::env::var("NO_COLOR").is_ok_and(|x| !x.is_empty()) && std::io::stderr().is_terminal();
 
-    let format = std::env::var("RUST_LOG_FORMAT").unwrap_or("plain".to_string());
-    match format.as_str() {
-        "json" => subscriber.json().init(),
-        "pretty" => subscriber.pretty().init(),
-        "plain" => subscriber.init(),
+    let stderr_layer = prepare_formatted_layer(
+        format.as_deref(),
+        fmt::layer()
+            .with_span_events(span_events)
+            .with_writer(std::io::stderr)
+            .with_ansi(color_output),
+    );
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(stderr_layer)
+        .init();
+}
+
+/// Applies a requested `formatting` to the log output of the provided `layer`.
+///
+/// Returns a boxed [`Layer`] with the formatting applied to the original `layer`.
+fn prepare_formatted_layer<S, N, W, T>(
+    formatting: Option<&str>,
+    layer: fmt::Layer<S, N, Format<Full, T>, W>,
+) -> Box<dyn Layer<S> + Send + Sync>
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+    N: for<'writer> FormatFields<'writer> + Send + Sync + 'static,
+    W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
+    T: FormatTime + Send + Sync + 'static,
+{
+    match formatting.unwrap_or("plain") {
+        "json" => layer.json().boxed(),
+        "pretty" => layer.pretty().boxed(),
+        "plain" => layer.boxed(),
         format => {
             panic!("Invalid RUST_LOG_FORMAT: `{format}`.  Valid values are `json` or `pretty`.")
         }

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -3,30 +3,14 @@
 
 //! This module provides unified handling for tracing subscribers within Linera binaries.
 
+use is_terminal::IsTerminal as _;
+use tracing_subscriber::fmt::format::FmtSpan;
+
 /// Initializes tracing in a standard way.
 /// The environment variables `RUST_LOG`, `RUST_LOG_SPAN_EVENTS`, and `RUST_LOG_FORMAT`
 /// can be used to control the verbosity, the span event verbosity, and the output format,
 /// respectively.
 pub fn init() {
-    use is_terminal::IsTerminal as _;
-    use tracing_subscriber::fmt::format::FmtSpan;
-
-    fn fmt_span_from_str(events: &str) -> FmtSpan {
-        let mut fmt_span = FmtSpan::NONE;
-        for event in events.split(',') {
-            fmt_span |= match event {
-                "new" => FmtSpan::NEW,
-                "enter" => FmtSpan::ENTER,
-                "exit" => FmtSpan::EXIT,
-                "close" => FmtSpan::CLOSE,
-                "active" => FmtSpan::ACTIVE,
-                "full" => FmtSpan::FULL,
-                _ => FmtSpan::NONE,
-            };
-        }
-        fmt_span
-    }
-
     let span_events = std::env::var("RUST_LOG_SPAN_EVENTS")
         .ok()
         .map(|s| fmt_span_from_str(&s))
@@ -54,4 +38,20 @@ pub fn init() {
             panic!("Invalid RUST_LOG_FORMAT: `{format}`.  Valid values are `json` or `pretty`.")
         }
     }
+}
+
+fn fmt_span_from_str(events: &str) -> FmtSpan {
+    let mut fmt_span = FmtSpan::NONE;
+    for event in events.split(',') {
+        fmt_span |= match event {
+            "new" => FmtSpan::NEW,
+            "enter" => FmtSpan::ENTER,
+            "exit" => FmtSpan::EXIT,
+            "close" => FmtSpan::CLOSE,
+            "active" => FmtSpan::ACTIVE,
+            "full" => FmtSpan::FULL,
+            _ => FmtSpan::NONE,
+        };
+    }
+    fmt_span
 }

--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -18,10 +18,15 @@ use tracing_subscriber::{
 };
 
 /// Initializes tracing in a standard way.
+///
 /// The environment variables `RUST_LOG`, `RUST_LOG_SPAN_EVENTS`, and `RUST_LOG_FORMAT`
 /// can be used to control the verbosity, the span event verbosity, and the output format,
 /// respectively.
-pub fn init() {
+///
+/// The `LINERA_LOG_DIR` environment variable can be used to configure a directory to
+/// store log files. If it is set, a file named `log_name` with the `log` extension is
+/// created in the directory.
+pub fn init(log_name: &str) {
     let env_filter = tracing_subscriber::EnvFilter::builder()
         .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
         .from_env_lossy();

--- a/linera-base/src/tracing_web.rs
+++ b/linera-base/src/tracing_web.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Zefchain Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides unified handling for tracing subscribers within Linera binaries.
+
+use tracing_subscriber::{
+    prelude::__tracing_subscriber_SubscriberExt as _, util::SubscriberInitExt as _,
+};
+
+/// Initializes tracing for the browser, sending messages to the developer console and
+/// span events to the [Performance
+/// API](https://developer.mozilla.org/en-US/docs/Web/API/Performance).
+pub fn init() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .without_time()
+                .with_writer(tracing_web::MakeWebConsoleWriter::new()),
+        )
+        .with(
+            tracing_web::performance_layer()
+                .with_details_from_fields(tracing_subscriber::fmt::format::Pretty::default()),
+        )
+        .init();
+}

--- a/linera-service/src/benchmark.rs
+++ b/linera-service/src/benchmark.rs
@@ -54,7 +54,7 @@ enum Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    linera_base::tracing::init();
+    linera_base::tracing::init("benchmark");
 
     let args = Args::parse();
     match args {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -5,7 +5,10 @@
 #![recursion_limit = "256"]
 #![deny(clippy::large_futures)]
 
-use std::{collections::HashMap, env, num::NonZeroUsize, path::PathBuf, sync::Arc, time::Instant};
+use std::{
+    borrow::Cow, collections::HashMap, env, num::NonZeroUsize, path::PathBuf, sync::Arc,
+    time::Instant,
+};
 
 use anyhow::{anyhow, bail, ensure, Context};
 use async_trait::async_trait;
@@ -1277,6 +1280,46 @@ fn main() -> anyhow::Result<()> {
         .build()
         .expect("Failed to create Tokio runtime")
         .block_on(run(&options).instrument(span))
+}
+
+/// Returns the log file name to use based on the [`ClientCommand`] that will run.
+fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
+    match command {
+        ClientCommand::HelpMarkdown
+        | ClientCommand::Transfer { .. }
+        | ClientCommand::OpenChain { .. }
+        | ClientCommand::OpenMultiOwnerChain { .. }
+        | ClientCommand::ChangeOwnership { .. }
+        | ClientCommand::ChangeApplicationPermissions { .. }
+        | ClientCommand::CloseChain { .. }
+        | ClientCommand::LocalBalance { .. }
+        | ClientCommand::QueryBalance { .. }
+        | ClientCommand::SyncBalance { .. }
+        | ClientCommand::Sync { .. }
+        | ClientCommand::ProcessInbox { .. }
+        | ClientCommand::QueryValidator { .. }
+        | ClientCommand::QueryValidators { .. }
+        | ClientCommand::SetValidator { .. }
+        | ClientCommand::RemoveValidator { .. }
+        | ClientCommand::ResourceControlPolicy { .. }
+        | ClientCommand::CreateGenesisConfig { .. }
+        | ClientCommand::PublishBytecode { .. }
+        | ClientCommand::PublishDataBlob { .. }
+        | ClientCommand::CreateApplication { .. }
+        | ClientCommand::PublishAndCreate { .. }
+        | ClientCommand::RequestApplication { .. }
+        | ClientCommand::Keygen { .. }
+        | ClientCommand::Assign { .. }
+        | ClientCommand::Wallet { .. }
+        | ClientCommand::RetryPendingBlock { .. } => "client".into(),
+        #[cfg(feature = "benchmark")]
+        ClientCommand::Benchmark { .. } => "benchmark".into(),
+        ClientCommand::Net { .. } => "net".into(),
+        ClientCommand::Project { .. } => "project".into(),
+        ClientCommand::Watch { .. } => "watch".into(),
+        ClientCommand::Service { port, .. } => format!("service-{port}").into(),
+        ClientCommand::Faucet { .. } => "faucet".into(),
+    }
 }
 
 async fn run(options: &ClientOptions) -> anyhow::Result<()> {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1254,9 +1254,9 @@ impl Job {
 }
 
 fn main() -> anyhow::Result<()> {
-    linera_base::tracing::init();
-
     let options = ClientOptions::init()?;
+
+    linera_base::tracing::init(&log_file_name_for(&options.command));
 
     let mut runtime = if options.tokio_threads == Some(1) {
         tokio::runtime::Builder::new_current_thread()

--- a/linera-service/src/proxy.rs
+++ b/linera-service/src/proxy.rs
@@ -331,9 +331,12 @@ where
 }
 
 fn main() -> Result<()> {
-    linera_base::tracing::init();
-
     let options = <ProxyOptions as clap::Parser>::parse();
+    let server_config: ValidatorServerConfig =
+        util::read_json(&options.config_path).expect("Fail to read server config");
+    let name = &server_config.validator.name;
+
+    linera_base::tracing::init(&format!("validator-{name}-proxy"));
 
     let mut runtime = if options.tokio_threads == Some(1) {
         tokio::runtime::Builder::new_current_thread()

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -5,6 +5,7 @@
 #![deny(clippy::large_futures)]
 
 use std::{
+    borrow::Cow,
     num::NonZeroUsize,
     path::{Path, PathBuf},
     time::Duration,
@@ -418,6 +419,29 @@ fn main() {
         .build()
         .expect("Failed to create Tokio runtime")
         .block_on(run(options))
+}
+
+/// Returns the log file name to use based on the [`ServerCommand`] that will run.
+fn log_file_name_for(command: &ServerCommand) -> Cow<'static, str> {
+    match command {
+        ServerCommand::Run {
+            shard,
+            server_config_path,
+            ..
+        } => {
+            let server_config: ValidatorServerConfig =
+                util::read_json(server_config_path).expect("Fail to read server config");
+            let name = &server_config.validator.name;
+
+            if let Some(shard) = shard {
+                format!("validator-{name}-shard-{shard}")
+            } else {
+                format!("validator-{name}")
+            }
+            .into()
+        }
+        ServerCommand::Generate { .. } | ServerCommand::Initialize { .. } => "server".into(),
+    }
 }
 
 async fn run(options: ServerOptions) {

--- a/linera-service/src/server.rs
+++ b/linera-service/src/server.rs
@@ -398,9 +398,9 @@ enum ServerCommand {
 }
 
 fn main() {
-    linera_base::tracing::init();
-
     let options = <ServerOptions as clap::Parser>::parse();
+
+    linera_base::tracing::init(&log_file_name_for(&options.command));
 
     let mut runtime = if options.tokio_threads == Some(1) {
         tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
When debugging issues, it is hard to navigate through the log because it contains messages from multiple sources (validators, proxies, clients, etc.).

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Allow logging each source to different log file, all stored in a single directory specified by a `LINERA_LOG_DIR` environment variable. If the variable isn't set, no log files are written.

## Test Plan

<!-- How to test that the changes are correct. -->
Tested manually by running some end-to-end tests with the environment variable set.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
Release a new minor version update, because this is a new feature that's backwards compatible with previous versions.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
