### PR TITLE
Workaround ANSI escape codes in log files

### DIFF
--- a/linera-base/src/tracing.rs
+++ b/linera-base/src/tracing.rs
@@ -68,8 +68,8 @@ pub fn init(log_name: &str) {
 
     tracing_subscriber::registry()
         .with(env_filter)
-        .with(stderr_layer)
         .with(maybe_log_file_layer)
+        .with(stderr_layer)
         .init();
 }
 


### PR DESCRIPTION
## Motivation

<!-- Short text indicating what this PR aims to accomplish. -->
After allowing logging to files (#2484), the log files seem to include some ANSI escape codes, which seem to enable some record names to appear in italic. This makes the log files harder to view in an editor.

This could be a bug in `tracing-subscriber`. I can investigate more later when I have some more time.

## Proposal

<!-- What are the proposed changes and why are they appropriate? -->
Making the layer without ANSI escape sequences come first seems to workaround the issue.

### Regression

The consequence seems to be that italics also becomes disabled in the terminal output, but IMHO that's a minor issue.

## Test Plan

<!-- How to test that the changes are correct. -->
Manually tested to see if italics was removed.

## Release Plan

<!--
How to safely release the changes.

Please only include the relevant items (if any) and create issues to track future release work.
-->
New patch version, as this fixes a tiny bug.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
