### PR TITLE
Stabilize `SystemOperation::ReadBlob`

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -27,6 +27,7 @@ This document contains the help content for the `linera` command-line program.
 * [`linera faucet`↴](#linera-faucet)
 * [`linera publish-bytecode`↴](#linera-publish-bytecode)
 * [`linera publish-data-blob`↴](#linera-publish-data-blob)
+* [`linera read-data-blob`↴](#linera-read-data-blob)
 * [`linera create-application`↴](#linera-create-application)
 * [`linera publish-and-create`↴](#linera-publish-and-create)
 * [`linera request-application`↴](#linera-request-application)
@@ -77,6 +78,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `faucet` — Run a GraphQL service that exposes a faucet where users can claim tokens. This gives away the chain's tokens, and is mainly intended for testing
 * `publish-bytecode` — Publish bytecode
 * `publish-data-blob` — Publish a data blob of binary data
+* `read-data-blob` — Verify that a data blob is readable
 * `create-application` — Create an application
 * `publish-and-create` — Create an application, and publish the required bytecode
 * `request-application` — Request an application from another chain, so it can be used on this one
@@ -548,6 +550,19 @@ Publish a data blob of binary data
 
 * `<BLOB_PATH>` — Path to data blob file to be published
 * `<PUBLISHER>` — An optional chain ID to publish the blob. The default chain of the wallet is used otherwise
+
+
+
+## `linera read-data-blob`
+
+Verify that a data blob is readable
+
+**Usage:** `linera read-data-blob <HASH> [READER]`
+
+###### **Arguments:**
+
+* `<HASH>` — The hash of the content
+* `<READER>` — An optional chain ID to verify the blob. The default chain of the wallet is used otherwise
 
 
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
-    crypto::KeyPair,
+    crypto::{CryptoHash, KeyPair},
     data_types::{BlockHeight, Timestamp},
     identifiers::{Account, ChainId},
     ownership::ChainOwnership,
@@ -463,6 +463,28 @@ where
 
         info!("{}", "Data blob published successfully!");
         Ok(BlobId::new_data(&blob_content))
+    }
+
+    // TODO(#2490): Consider removing or renaming this.
+    pub async fn read_data_blob(
+        &mut self,
+        chain_client: &ChainClient<NodeProvider, S>,
+        hash: CryptoHash,
+    ) -> Result<(), Error> {
+        info!("Verifying data blob");
+        self.apply_client_command(chain_client, |chain_client| {
+            let chain_client = chain_client.clone();
+            async move {
+                chain_client
+                    .read_data_blob(hash)
+                    .await
+                    .context("Failed to verify data blob")
+            }
+        })
+        .await?;
+
+        info!("{}", "Data blob verified successfully!");
+        Ok(())
     }
 }
 

--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -6,7 +6,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use async_trait::async_trait;
 use futures::Future;
 use linera_base::{
-    crypto::{CryptoHash, KeyPair},
+    crypto::KeyPair,
     data_types::{BlockHeight, Timestamp},
     identifiers::{Account, ChainId},
     ownership::ChainOwnership,
@@ -52,6 +52,7 @@ use {
 #[cfg(feature = "fs")]
 use {
     linera_base::{
+        crypto::CryptoHash,
         data_types::{BlobContent, Bytecode},
         identifiers::{BlobId, BytecodeId},
     },

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, env, fmt, iter, num::NonZeroU16, path::PathBuf, 
 
 use chrono::{DateTime, Utc};
 use linera_base::{
-    crypto::PublicKey,
+    crypto::{CryptoHash, PublicKey},
     data_types::{Amount, ApplicationPermissions, TimeDelta},
     identifiers::{
         Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner, UserApplicationId,
@@ -703,6 +703,16 @@ pub enum ClientCommand {
         /// An optional chain ID to publish the blob. The default chain of the wallet
         /// is used otherwise.
         publisher: Option<ChainId>,
+    },
+
+    // TODO(#2490): Consider removing or renaming this.
+    /// Verify that a data blob is readable.
+    ReadDataBlob {
+        /// The hash of the content.
+        hash: CryptoHash,
+        /// An optional chain ID to verify the blob. The default chain of the wallet
+        /// is used otherwise.
+        reader: Option<ChainId>,
     },
 
     /// Create an application.

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -30,7 +30,8 @@ use linera_base::{
     },
     ensure,
     identifiers::{
-        Account, ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner, UserApplicationId,
+        Account, ApplicationId, BlobId, BlobType, BytecodeId, ChainId, MessageId, Owner,
+        UserApplicationId,
     },
     ownership::{ChainOwnership, TimeoutConfig},
 };
@@ -1281,6 +1282,21 @@ where
             user_data,
         }))
         .await
+    }
+
+    #[tracing::instrument(level = "trace", skip(hash))]
+    /// Verify if a data blob is readable from storage.
+    // TODO(#2490): Consider removing or renaming this.
+    pub async fn read_data_blob(
+        &self,
+        hash: CryptoHash,
+    ) -> Result<ClientOutcome<Certificate>, ChainClientError> {
+        let blob_id = BlobId {
+            hash,
+            blob_type: BlobType::Data,
+        };
+        self.execute_operation(Operation::System(SystemOperation::ReadBlob { blob_id }))
+            .await
     }
 
     #[tracing::instrument(level = "trace", skip(user_data))]

--- a/linera-execution/src/system.rs
+++ b/linera-execution/src/system.rs
@@ -159,8 +159,8 @@ pub enum SystemOperation {
     PublishBytecode { bytecode_id: BytecodeId },
     /// Publishes a new data blob.
     PublishDataBlob { blob_hash: CryptoHash },
-    /// Reads a blob. This is test-only, so we can test without a Wasm application.
-    #[cfg(with_testing)]
+    /// Reads a blob and discards the result.
+    // TODO(#2490): Consider removing this.
     ReadBlob { blob_id: BlobId },
     /// Creates a new application.
     CreateApplication {
@@ -658,7 +658,6 @@ where
                     BlobId::new_data_from_hash(blob_hash),
                 ))?;
             }
-            #[cfg(with_testing)]
             ReadBlob { blob_id } => {
                 txn_tracker.replay_oracle_response(OracleResponse::Blob(blob_id))?;
                 self.read_blob_content(blob_id).await?;

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -582,6 +582,10 @@ type MutationRoot {
 	"""
 	claim(chainId: ChainId!, owner: Owner!, targetId: ChainId!, recipient: Recipient!, amount: Amount!, userData: UserData): CryptoHash!
 	"""
+	Test if a data blob is readable from a transaction in the current chain.
+	"""
+	readDataBlob(chainId: ChainId!, hash: CryptoHash!): CryptoHash!
+	"""
 	Creates (or activates) a new chain by installing the given authentication key.
 	This will automatically subscribe to the future committees created by `admin_id`.
 	"""

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -728,7 +728,7 @@ impl ClientWrapper {
         }
         let stdout = command.spawn_and_wait_for_stdout().await?;
         let stdout = stdout.trim();
-        BlobId::from_str(&stdout)
+        BlobId::from_str(stdout)
     }
 
     /// Runs `linera read-data-blob`.

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -715,6 +715,33 @@ impl ClientWrapper {
         }
     }
 
+    /// Runs `linera publish-data-blob`.
+    pub async fn publish_data_blob(
+        &self,
+        path: &Path,
+        chain_id: Option<ChainId>,
+    ) -> Result<BlobId> {
+        let mut command = self.command().await?;
+        command.arg("publish-data-blob").arg(path);
+        if let Some(chain_id) = chain_id {
+            command.arg(chain_id.to_string());
+        }
+        let stdout = command.spawn_and_wait_for_stdout().await?;
+        let stdout = stdout.trim();
+        BlobId::from_str(&stdout)
+    }
+
+    /// Runs `linera read-data-blob`.
+    pub async fn read_data_blob(&self, hash: CryptoHash, chain_id: Option<ChainId>) -> Result<()> {
+        let mut command = self.command().await?;
+        command.arg("read-data-blob").arg(hash.to_string());
+        if let Some(chain_id) = chain_id {
+            command.arg(chain_id.to_string());
+        }
+        command.spawn_and_wait_for_stdout().await?;
+        Ok(())
+    }
+
     pub fn load_wallet(&self) -> Result<Wallet> {
         util::read_json(self.wallet_path())
     }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -1314,6 +1314,7 @@ fn log_file_name_for(command: &ClientCommand) -> Cow<'static, str> {
         | ClientCommand::CreateGenesisConfig { .. }
         | ClientCommand::PublishBytecode { .. }
         | ClientCommand::PublishDataBlob { .. }
+        | ClientCommand::ReadDataBlob { .. }
         | ClientCommand::CreateApplication { .. }
         | ClientCommand::PublishAndCreate { .. }
         | ClientCommand::RequestApplication { .. }

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -849,9 +849,20 @@ impl Runnable for Job {
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing data blob on chain {}", publisher);
                 let chain_client = context.make_chain_client(publisher);
+                // TODO(#2491): PublishDataBlob should return a CryptoHash.
                 let blob_id = context.publish_data_blob(&chain_client, blob_path).await?;
                 println!("{}", blob_id);
                 info!("{}", "Data blob published successfully!".green().bold());
+                info!("Time elapsed: {} ms", start_time.elapsed().as_millis());
+            }
+
+            // TODO(#2490): Consider removing or renaming this.
+            ReadDataBlob { hash, reader } => {
+                let start_time = Instant::now();
+                let reader = reader.unwrap_or_else(|| context.default_chain());
+                info!("Verifying data blob on chain {}", reader);
+                let chain_client = context.make_chain_client(reader);
+                context.read_data_blob(&chain_client, hash).await?;
                 info!("Time elapsed: {} ms", start_time.elapsed().as_millis());
             }
 

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -837,7 +837,6 @@ impl Runnable for Job {
                     .publish_bytecode(&chain_client, contract, service)
                     .await?;
                 println!("{}", bytecode_id);
-                info!("{}", "Bytecode published successfully!".green().bold());
                 info!("Time elapsed: {} ms", start_time.elapsed().as_millis());
             }
 
@@ -852,7 +851,6 @@ impl Runnable for Job {
                 // TODO(#2491): PublishDataBlob should return a CryptoHash.
                 let blob_id = context.publish_data_blob(&chain_client, blob_path).await?;
                 println!("{}", blob_id);
-                info!("{}", "Data blob published successfully!".green().bold());
                 info!("Time elapsed: {} ms", start_time.elapsed().as_millis());
             }
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -334,6 +334,25 @@ where
         .await
     }
 
+    /// Test if a data blob is readable from a transaction in the current chain.
+    #[allow(clippy::too_many_arguments)]
+    // TODO(#2490): Consider removing or renaming this.
+    async fn read_data_blob(
+        &self,
+        chain_id: ChainId,
+        hash: CryptoHash,
+    ) -> Result<CryptoHash, Error> {
+        self.apply_client_command(&chain_id, move |client| async move {
+            let result = client
+                .read_data_blob(hash)
+                .await
+                .map_err(Error::from)
+                .map(|outcome| outcome.map(|certificate| certificate.hash()));
+            (result, client)
+        })
+        .await
+    }
+
     /// Creates (or activates) a new chain by installing the given authentication key.
     /// This will automatically subscribe to the future committees created by `admin_id`.
     async fn open_chain(


### PR DESCRIPTION
## Motivation

The variant `SystemOperation::ReadBlob` is marked as `#[cfg(with_testing)]`, causing format divergence depending on the compilation mode.

## Proposal

Make `ReadBlob` a real thing, with a CLI and a node-service mutation etc as least until we decide otherwise.

I created #2490 to suggest removing`read_data_blob` or renaming it into `verify_data_blob` on the main branch.

## Test Plan

CI

Cherry-pick on the devnet branch, then run:
```
export LINERA_FAUCET_URL=https://faucet.devnet-2024-09-04.linera.net
cargo test -p linera-service --features remote-net data_blob
```

## Release Plan

Need to be cherry-picked on the devnet branch.