### PR TITLE
Improvements to the LRU cache

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -121,9 +121,7 @@ A Byzantine-fault tolerant sidechain with low-latency finality and high throughp
 * `--max-stream-queries <MAX_STREAM_QUERIES>` — The maximal number of simultaneous stream queries to the database
 
   Default value: `10`
-* `--cache-size <CACHE_SIZE>` — The maximal number of entries in the storage cache
-
-  Default value: `1000`
+* `--storage-cache-policy <STORAGE_CACHE_POLICY>` — The storage cache policy
 * `--retry-delay-ms <RETRY_DELAY>` — Delay increment for retrying to connect to a validator
 
   Default value: `1000`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,6 +5014,7 @@ dependencies = [
  "rocksdb",
  "scylla",
  "serde",
+ "serde_json",
  "sha3",
  "static_assertions",
  "tempfile",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3611,6 +3611,7 @@ dependencies = [
  "prometheus",
  "rand",
  "serde",
+ "serde_json",
  "sha3",
  "static_assertions",
  "tempfile",

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -22,7 +22,7 @@ use linera_core::{client::BlanketMessagePolicy, DEFAULT_GRACE_PERIOD};
 use linera_execution::{
     committee::ValidatorName, ResourceControlPolicy, WasmRuntime, WithWasmDefault as _,
 };
-use linera_views::store::CommonStoreConfig;
+use linera_views::{lru_caching::read_storage_cache_policy, store::CommonStoreConfig};
 
 #[cfg(feature = "fs")]
 use crate::config::GenesisConfig;
@@ -114,9 +114,9 @@ pub struct ClientOptions {
     #[arg(long, default_value = "10")]
     pub max_stream_queries: usize,
 
-    /// The maximal number of entries in the storage cache.
-    #[arg(long, default_value = "1000")]
-    pub cache_size: usize,
+    /// The storage cache policy
+    #[arg(long)]
+    pub storage_cache_policy: Option<String>,
 
     /// Subcommand.
     #[command(subcommand)]
@@ -182,10 +182,11 @@ impl ClientOptions {
     }
 
     fn common_config(&self) -> CommonStoreConfig {
+        let storage_cache_policy = read_storage_cache_policy(self.storage_cache_policy.clone());
         CommonStoreConfig {
             max_concurrent_queries: self.max_concurrent_queries,
             max_stream_queries: self.max_stream_queries,
-            cache_size: self.cache_size,
+            storage_cache_policy,
         }
     }
 

--- a/linera-client/src/storage.rs
+++ b/linera-client/src/storage.rs
@@ -344,7 +344,7 @@ impl StorageConfigNamespace {
                 };
                 let config = ServiceStoreConfig {
                     inner_config,
-                    cache_size: common_config.cache_size,
+                    storage_cache_policy: common_config.storage_cache_policy,
                 };
                 Ok(StoreConfig::Service(config, namespace))
             }

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -39,13 +39,13 @@ pub type RocksDbRunner = Runner<RocksDbStore, RocksDbConfig>;
 impl RocksDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
         let config = IndexerConfig::<RocksDbConfig>::parse();
+        let storage_cache_policy =
+            read_storage_cache_policy(config.client.storage_cache_policy.clone());
         let common_config = CommonStoreConfig {
             max_concurrent_queries: config.client.max_concurrent_queries,
             max_stream_queries: config.client.max_stream_queries,
-            cache_size: config.client.cache_size,
+            storage_cache_policy,
         };
-        let storage_cache_policy =
-            read_storage_cache_policy(config.client.storage_cache_policy.clone());
         let path_buf = config.client.storage.as_path().to_path_buf();
         let path_with_guard = PathWithGuard::new(path_buf);
         // The tests are run in single threaded mode, therefore we need

--- a/linera-indexer/lib/src/rocks_db.rs
+++ b/linera-indexer/lib/src/rocks_db.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use clap::Parser as _;
 use linera_views::{
+    lru_caching::read_storage_cache_policy,
     rocks_db::{PathWithGuard, RocksDbSpawnMode, RocksDbStore, RocksDbStoreConfig},
     store::{AdminKeyValueStore, CommonStoreConfig},
 };
@@ -28,9 +29,9 @@ pub struct RocksDbConfig {
     /// The maximal number of simultaneous stream queries to the database
     #[arg(long, default_value = "10")]
     pub max_stream_queries: usize,
-    /// The maximal number of entries in the storage cache.
-    #[arg(long, default_value = "1000")]
-    cache_size: usize,
+    /// The file of the storage cache policy
+    #[arg(long)]
+    storage_cache_policy: Option<String>,
 }
 
 pub type RocksDbRunner = Runner<RocksDbStore, RocksDbConfig>;
@@ -43,6 +44,8 @@ impl RocksDbRunner {
             max_stream_queries: config.client.max_stream_queries,
             cache_size: config.client.cache_size,
         };
+        let storage_cache_policy =
+            read_storage_cache_policy(config.client.storage_cache_policy.clone());
         let path_buf = config.client.storage.as_path().to_path_buf();
         let path_with_guard = PathWithGuard::new(path_buf);
         // The tests are run in single threaded mode, therefore we need

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -36,13 +36,13 @@ pub type ScyllaDbRunner = Runner<ScyllaDbStore, ScyllaDbConfig>;
 impl ScyllaDbRunner {
     pub async fn load() -> Result<Self, IndexerError> {
         let config = <IndexerConfig<ScyllaDbConfig> as clap::Parser>::parse();
+        let storage_cache_policy =
+            read_storage_cache_policy(config.client.storage_cache_policy.clone());
         let common_config = CommonStoreConfig {
             max_concurrent_queries: config.client.max_concurrent_queries,
             max_stream_queries: config.client.max_stream_queries,
-            cache_size: config.client.cache_size,
+            storage_cache_policy,
         };
-        let storage_cache_policy =
-            read_storage_cache_policy(config.client.storage_cache_policy.clone());
         let namespace = config.client.table.clone();
         let root_key = &[];
         let store_config = ScyllaDbStoreConfig::new(config.client.uri.clone(), common_config);

--- a/linera-indexer/lib/src/scylla_db.rs
+++ b/linera-indexer/lib/src/scylla_db.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_views::{
+    lru_caching::read_storage_cache_policy,
     scylla_db::{ScyllaDbStore, ScyllaDbStoreConfig},
     store::{AdminKeyValueStore, CommonStoreConfig},
 };
@@ -25,9 +26,9 @@ pub struct ScyllaDbConfig {
     /// The maximal number of simultaneous stream queries to the database
     #[arg(long, default_value = "10")]
     pub max_stream_queries: usize,
-    /// The maximal number of entries in the storage cache.
-    #[arg(long, default_value = "1000")]
-    cache_size: usize,
+    /// The storage cache policy
+    #[arg(long)]
+    storage_cache_policy: Option<String>,
 }
 
 pub type ScyllaDbRunner = Runner<ScyllaDbStore, ScyllaDbConfig>;
@@ -40,6 +41,8 @@ impl ScyllaDbRunner {
             max_stream_queries: config.client.max_stream_queries,
             cache_size: config.client.cache_size,
         };
+        let storage_cache_policy =
+            read_storage_cache_policy(config.client.storage_cache_policy.clone());
         let namespace = config.client.table.clone();
         let root_key = &[];
         let store_config = ScyllaDbStoreConfig::new(config.client.uri.clone(), common_config);

--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -11,7 +11,7 @@ use linera_views::metering::MeteredStore;
 use linera_views::store::TestKeyValueStore;
 use linera_views::{
     batch::{Batch, WriteOperation},
-    lru_caching::LruCachingStore,
+    lru_caching::CachingStore,
     store::{
         AdminKeyValueStore, CommonStoreInternalConfig, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
@@ -524,9 +524,8 @@ pub async fn storage_service_check_validity(endpoint: &str) -> Result<(), Servic
 
 /// The service store client with metrics
 #[cfg(with_metrics)]
-pub type ServiceStoreClient =
-    MeteredStore<LruCachingStore<MeteredStore<ServiceStoreClientInternal>>>;
+pub type ServiceStoreClient = MeteredStore<CachingStore<MeteredStore<ServiceStoreClientInternal>>>;
 
 /// The service store client without metrics
 #[cfg(not(with_metrics))]
-pub type ServiceStoreClient = LruCachingStore<ServiceStoreClientInternal>;
+pub type ServiceStoreClient = CachingStore<ServiceStoreClientInternal>;

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 
 use linera_base::command::resolve_binary;
 use linera_views::{
-    lru_caching::LruCachingConfig,
+    lru_caching::CachingConfig,
     store::{CommonStoreInternalConfig, KeyValueStoreError},
     views::MIN_VIEW_TAG,
 };
@@ -78,7 +78,7 @@ pub struct ServiceStoreInternalConfig {
 }
 
 /// The config type
-pub type ServiceStoreConfig = LruCachingConfig<ServiceStoreInternalConfig>;
+pub type ServiceStoreConfig = CachingConfig<ServiceStoreInternalConfig>;
 
 impl ServiceStoreInternalConfig {
     pub fn http_address(&self) -> String {

--- a/linera-views/Cargo.toml
+++ b/linera-views/Cargo.toml
@@ -50,6 +50,7 @@ rand = { workspace = true, features = ["small_rng"] }
 rocksdb = { workspace = true, optional = true }
 scylla = { workspace = true, optional = true }
 serde.workspace = true
+serde_json.workspace = true
 sha3.workspace = true
 static_assertions.workspace = true
 tempfile.workspace = true

--- a/linera-views/DESIGN.md
+++ b/linera-views/DESIGN.md
@@ -17,7 +17,7 @@ We provide an implementation of the trait `KeyValueStore` for the following key-
 The trait `KeyValueStore` was designed so that more storage solutions can be easily added in the future.
 
 The `KeyValueStore` trait is also implemented for several internal constructions of clients:
-* The `LruCachingStore<K>` client implements the Least Recently Used (LRU)
+* The `CachingStore<K>` client implements the Least Recently Used (LRU)
 caching of reads into the client.
 * The `ViewContainer<C>` client implements a key-value store client from a context.
 * The `ValueSplittingStore<K>` implements a client for which the

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -38,7 +38,7 @@ use crate::{
     batch::SimpleUnorderedBatch,
     common::get_uleb128_size,
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
-    lru_caching::{LruCachingConfig, LruCachingStore},
+    lru_caching::{CachingConfig, CachingStore},
     store::{
         AdminKeyValueStore, CommonStoreInternalConfig, KeyIterable, KeyValueIterable,
         KeyValueStoreError, ReadableKeyValueStore, WithError,
@@ -1130,26 +1130,26 @@ impl TestKeyValueStore for JournalingKeyValueStore<DynamoDbStoreInternal> {
     }
 }
 
-/// A shared DB client for DynamoDb implementing LruCaching and metrics
+/// A shared DB client for DynamoDb implementing Caching and metrics
 #[cfg(with_metrics)]
 pub type DynamoDbStore = MeteredStore<
-    LruCachingStore<
+    CachingStore<
         MeteredStore<
             ValueSplittingStore<MeteredStore<JournalingKeyValueStore<DynamoDbStoreInternal>>>,
         >,
     >,
 >;
 
-/// A shared DB client for DynamoDb implementing LruCaching
+/// A shared DB client for DynamoDb implementing Caching
 #[cfg(not(with_metrics))]
 pub type DynamoDbStore =
-    LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<DynamoDbStoreInternal>>>;
+    CachingStore<ValueSplittingStore<JournalingKeyValueStore<DynamoDbStoreInternal>>>;
 
 /// The combined error type for the `DynamoDbStore`.
 pub type DynamoDbStoreError = ValueSplittingError<DynamoDbStoreInternalError>;
 
 /// The config type for DynamoDbStore
-pub type DynamoDbStoreConfig = LruCachingConfig<DynamoDbStoreInternalConfig>;
+pub type DynamoDbStoreConfig = CachingConfig<DynamoDbStoreInternalConfig>;
 
 /// Getting a configuration for the system
 pub async fn get_config(use_localstack: bool) -> Result<Config, DynamoDbStoreError> {

--- a/linera-views/src/backends/dynamo_db.rs
+++ b/linera-views/src/backends/dynamo_db.rs
@@ -1168,7 +1168,7 @@ impl DynamoDbStoreConfig {
         };
         DynamoDbStoreConfig {
             inner_config,
-            cache_size: common_config.cache_size,
+            storage_cache_policy: common_config.storage_cache_policy,
         }
     }
 }

--- a/linera-views/src/backends/indexed_db.rs
+++ b/linera-views/src/backends/indexed_db.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 use crate::{
     batch::{Batch, WriteOperation},
     common::get_upper_bound_option,
+    lru_caching::DEFAULT_STORAGE_CACHE_POLICY,
     store::{
         CommonStoreConfig, KeyValueStoreError, LocalAdminKeyValueStore, LocalReadableKeyValueStore,
         LocalWritableKeyValueStore, WithError,
@@ -31,7 +32,7 @@ impl IndexedDbStoreConfig {
         let common_config = CommonStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries,
-            cache_size: 1000,
+            storage_cache_policy: DEFAULT_STORAGE_CACHE_POLICY,
         };
         Self { common_config }
     }

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -12,8 +12,6 @@ use std::{
 };
 
 use linked_hash_map::LinkedHashMap;
-#[cfg(with_metrics)]
-use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCounterVec};
 
 use crate::{
     batch::{Batch, WriteOperation},
@@ -26,6 +24,7 @@ use crate::{
 #[cfg(with_testing)]
 use crate::{memory::MemoryStore, store::TestKeyValueStore};
 
+#[cfg(with_metrics)]
 mod metrics {
     use std::sync::LazyLock;
 

--- a/linera-views/src/backends/lru_caching.rs
+++ b/linera-views/src/backends/lru_caching.rs
@@ -1,15 +1,13 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Add LRU (least recently used) caching to a given store.
+//! Add caching to a given store.
+//! The current policy is based on the LRU (Least Recently Used).
 
-/// The standard cache size used for tests.
-pub const TEST_CACHE_SIZE: usize = 1000;
-
-#[cfg(with_metrics)]
-use std::sync::LazyLock;
 use std::{
-    collections::{btree_map, hash_map::RandomState, BTreeMap},
+    collections::{btree_map, hash_map::RandomState, BTreeMap, BTreeSet},
+    fs::File,
+    io::BufReader,
     sync::{Arc, Mutex},
 };
 
@@ -20,22 +18,278 @@ use {linera_base::prometheus_util::register_int_counter_vec, prometheus::IntCoun
 use crate::{
     batch::{Batch, WriteOperation},
     common::get_interval,
-    store::{AdminKeyValueStore, ReadableKeyValueStore, WithError, WritableKeyValueStore},
+    store::{
+        AdminKeyValueStore, KeyIterable, KeyValueIterable, ReadableKeyValueStore, WithError,
+        WritableKeyValueStore,
+    },
 };
 #[cfg(with_testing)]
 use crate::{memory::MemoryStore, store::TestKeyValueStore};
 
-#[cfg(with_metrics)]
-/// The total number of cache faults
-static NUM_CACHE_FAULT: LazyLock<IntCounterVec> =
-    LazyLock::new(|| register_int_counter_vec("num_cache_fault", "Number of cache faults", &[]));
+mod metrics {
+    use std::sync::LazyLock;
 
-#[cfg(with_metrics)]
-/// The total number of cache successes
-static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> =
-    LazyLock::new(|| register_int_counter_vec("num_cache_success", "Number of cache success", &[]));
+    use linera_base::prometheus_util;
+    use prometheus::{HistogramVec, IntCounterVec};
 
-/// The `LruPrefixCache` stores the data for simple `read_values` queries
+    /// The total number of value cache faults
+    pub static NUM_CACHE_VALUE_FAULT: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        prometheus_util::register_int_counter_vec(
+            "num_cache_value_fault",
+            "Number of value cache faults",
+            &[],
+        )
+    });
+
+    /// The total number of cache successes
+    pub static NUM_CACHE_VALUE_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        prometheus_util::register_int_counter_vec(
+            "num_cache_value_success",
+            "Number of value cache success",
+            &[],
+        )
+    });
+
+    /// The total number of find cache faults
+    pub static NUM_CACHE_FIND_FAULT: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        prometheus_util::register_int_counter_vec(
+            "num_cache_find_fault",
+            "Number of find cache faults",
+            &[],
+        )
+    });
+
+    /// The total number of find cache successes
+    pub static NUM_CACHE_FIND_SUCCESS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+        prometheus_util::register_int_counter_vec(
+            "num_cache_find_success",
+            "Number of find cache success",
+            &[],
+        )
+    });
+
+    /// Size of the inserted value entry
+    pub static VALUE_CACHE_ENTRY_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
+        prometheus_util::register_histogram_vec(
+            "value_cache_entry_size",
+            "Value cache entry size",
+            &[],
+            Some(vec![
+                10.0, 30.0, 100.0, 300.0, 1000.0, 3000.0, 10000.0, 30000.0, 100000.0, 300000.0,
+                1000000.0,
+            ]),
+        )
+    });
+
+    /// Size of the inserted find entry
+    pub static FIND_CACHE_ENTRY_SIZE: LazyLock<HistogramVec> = LazyLock::new(|| {
+        prometheus_util::register_histogram_vec(
+            "find_cache_entry_size",
+            "Find cache entry size",
+            &[],
+            Some(vec![
+                10.0, 30.0, 100.0, 300.0, 1000.0, 3000.0, 10000.0, 30000.0, 100000.0, 300000.0,
+                1000000.0,
+            ]),
+        )
+    });
+}
+
+/// The parametrization of the cache
+#[derive(Clone, Debug, serde::Deserialize)]
+pub struct StorageCachePolicy {
+    /// The maximum size of the cache, in bytes (keys size + value sizes)
+    pub max_cache_size: usize,
+    /// The maximum size of an entry size, in bytes
+    pub max_entry_size: usize,
+    /// The maximum number of entries in the cache.
+    pub max_cache_entries: usize,
+}
+
+/// The maximum number of entries in the cache.
+/// If the number of entries in the cache is too large then the underlying maps
+/// become the limiting factor
+pub const DEFAULT_STORAGE_CACHE_POLICY: StorageCachePolicy = StorageCachePolicy {
+    max_cache_size: 10000000,
+    max_entry_size: 1000000,
+    max_cache_entries: 1000,
+};
+
+/// Read the `StorageCachePolicy` from the existing file and if None, then the default
+/// storage policy is returned
+pub fn read_storage_cache_policy(storage_cache_policy: Option<String>) -> StorageCachePolicy {
+    match storage_cache_policy {
+        None => DEFAULT_STORAGE_CACHE_POLICY,
+        Some(storage_cache_policy) => {
+            let file = File::open(storage_cache_policy)
+                .expect("File {storage_cache_policy} does not exist");
+            let reader = BufReader::new(file);
+            serde_json::from_reader(reader).expect("The parsing of the StorageCachePolicy failed")
+        }
+    }
+}
+
+#[derive(Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+enum CacheEntry {
+    Find,
+    Value,
+}
+
+enum ValueCacheEntry {
+    DoesNotExist,
+    Exists,
+    Value(Vec<u8>),
+}
+
+impl ValueCacheEntry {
+    fn from_contains_key(test: bool) -> ValueCacheEntry {
+        match test {
+            false => ValueCacheEntry::DoesNotExist,
+            true => ValueCacheEntry::Exists,
+        }
+    }
+
+    fn from_read_value(result: &Option<Vec<u8>>) -> ValueCacheEntry {
+        match result {
+            None => ValueCacheEntry::DoesNotExist,
+            Some(vec) => ValueCacheEntry::Value(vec.to_vec()),
+        }
+    }
+
+    fn get_contains_key(&self) -> bool {
+        match self {
+            ValueCacheEntry::DoesNotExist => false,
+            ValueCacheEntry::Exists => true,
+            ValueCacheEntry::Value(_) => true,
+        }
+    }
+
+    fn get_read_value(&self) -> Option<Option<Vec<u8>>> {
+        match self {
+            ValueCacheEntry::DoesNotExist => Some(None),
+            ValueCacheEntry::Exists => None,
+            ValueCacheEntry::Value(vec) => Some(Some(vec.clone())),
+        }
+    }
+
+    fn size(&self) -> usize {
+        match self {
+            ValueCacheEntry::DoesNotExist => 0,
+            ValueCacheEntry::Exists => 0,
+            ValueCacheEntry::Value(vec) => vec.len(),
+        }
+    }
+}
+
+enum FindCacheEntry {
+    Keys(BTreeSet<Vec<u8>>),
+    KeyValues(BTreeMap<Vec<u8>, Vec<u8>>),
+}
+
+impl FindCacheEntry {
+    fn get_find_keys(&self, key_prefix: &[u8]) -> Vec<Vec<u8>> {
+        let key_prefix = key_prefix.to_vec();
+        let delta = key_prefix.len();
+        match self {
+            FindCacheEntry::Keys(map) => map
+                .range(get_interval(key_prefix))
+                .map(|key| key[delta..].to_vec())
+                .collect::<Vec<_>>(),
+            FindCacheEntry::KeyValues(map) => map
+                .range(get_interval(key_prefix))
+                .map(|(key, _)| key[delta..].to_vec())
+                .collect::<Vec<_>>(),
+        }
+    }
+
+    fn get_find_key_values(&self, key_prefix: &[u8]) -> Option<Vec<(Vec<u8>, Vec<u8>)>> {
+        match self {
+            FindCacheEntry::Keys(_) => None,
+            FindCacheEntry::KeyValues(map) => {
+                let key_prefix = key_prefix.to_vec();
+                let delta = key_prefix.len();
+                Some(
+                    map.range(get_interval(key_prefix))
+                        .map(|(key, value)| (key[delta..].to_vec(), value.to_vec()))
+                        .collect::<Vec<_>>(),
+                )
+            }
+        }
+    }
+
+    fn get_contains_key(&self, key: &[u8]) -> bool {
+        match self {
+            FindCacheEntry::Keys(map) => map.contains(key),
+            FindCacheEntry::KeyValues(map) => map.contains_key(key),
+        }
+    }
+
+    fn get_read_value(&self, key: &[u8]) -> Option<Option<Vec<u8>>> {
+        match self {
+            FindCacheEntry::Keys(_map) => None,
+            FindCacheEntry::KeyValues(map) => Some(map.get(key).cloned()),
+        }
+    }
+
+    fn update_cache_entry(&mut self, key: &[u8], new_value: Option<Vec<u8>>) {
+        match self {
+            FindCacheEntry::Keys(map) => {
+                match new_value {
+                    None => map.remove(key),
+                    Some(_) => map.insert(key.to_vec()),
+                };
+            }
+            FindCacheEntry::KeyValues(map) => {
+                match new_value {
+                    None => map.remove(key),
+                    Some(new_value) => map.insert(key.to_vec(), new_value),
+                };
+            }
+        }
+    }
+
+    fn delete_prefix(&mut self, key_prefix: &[u8]) {
+        match self {
+            FindCacheEntry::Keys(map) => {
+                let keys = map
+                    .range(get_interval(key_prefix.to_vec()))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                for key in keys {
+                    map.remove(&key);
+                }
+            }
+            FindCacheEntry::KeyValues(map) => {
+                let keys = map
+                    .range(get_interval(key_prefix.to_vec()))
+                    .map(|(key, _)| key.clone())
+                    .collect::<Vec<_>>();
+                for key in keys {
+                    map.remove(&key);
+                }
+            }
+        }
+    }
+
+    fn size(&self) -> usize {
+        let mut total_size = 0;
+        match self {
+            FindCacheEntry::Keys(map) => {
+                for key in map {
+                    total_size += key.len();
+                }
+            }
+            FindCacheEntry::KeyValues(map) => {
+                for (key, value) in map {
+                    total_size += key.len() + value.len();
+                }
+            }
+        }
+        total_size
+    }
+}
+
+/// The `StoragePrefixCache` stores the data for simple `read_values` queries
 /// It is inspired by the crate `lru-cache`.
 ///
 /// We cannot apply this crate directly because the batch operation
@@ -44,118 +298,406 @@ static NUM_CACHE_SUCCESS: LazyLock<IntCounterVec> =
 /// keep track of this.
 
 /// The data structures
-struct LruPrefixCache {
-    map: BTreeMap<Vec<u8>, Option<Vec<u8>>>,
-    queue: LinkedHashMap<Vec<u8>, (), RandomState>,
-    max_cache_size: usize,
+#[allow(clippy::type_complexity)]
+struct StoragePrefixCache {
+    map_find: BTreeMap<Vec<u8>, FindCacheEntry>,
+    map_value: BTreeMap<Vec<u8>, ValueCacheEntry>,
+    queue: LinkedHashMap<(Vec<u8>, CacheEntry), usize, RandomState>,
+    storage_cache_policy: StorageCachePolicy,
+    total_size: usize,
 }
 
-impl<'a> LruPrefixCache {
+impl StoragePrefixCache {
     /// Creates a LruPrefixCache.
-    pub fn new(max_cache_size: usize) -> Self {
+    pub fn new(storage_cache_policy: StorageCachePolicy) -> Self {
         Self {
-            map: BTreeMap::new(),
+            map_find: BTreeMap::new(),
+            map_value: BTreeMap::new(),
             queue: LinkedHashMap::new(),
-            max_cache_size,
+            storage_cache_policy,
+            total_size: 0,
         }
     }
 
-    /// Inserts an entry into the cache.
-    pub fn insert(&mut self, key: Vec<u8>, value: Option<Vec<u8>>) {
-        match self.map.entry(key.clone()) {
-            btree_map::Entry::Occupied(mut entry) => {
-                entry.insert(value);
-                // Put it on first position for LRU
-                self.queue.remove(&key);
-                self.queue.insert(key, ());
-            }
-            btree_map::Entry::Vacant(entry) => {
-                entry.insert(value);
-                self.queue.insert(key, ());
-                if self.queue.len() > self.max_cache_size {
-                    let Some(value) = self.queue.pop_front() else {
-                        unreachable!()
-                    };
-                    self.map.remove(&value.0);
+    fn get_lower_bound(&self, key: &[u8]) -> Option<(&Vec<u8>, &FindCacheEntry)> {
+        match self.map_find.range(..=key.to_vec()).next_back() {
+            None => None,
+            Some((key_store, value)) => {
+                if key.starts_with(key_store) {
+                    Some((key_store, value))
+                } else {
+                    None
                 }
             }
         }
     }
 
-    /// Marks cached keys that match the prefix as deleted. Importantly, this does not create new entries in the cache.
-    pub fn delete_prefix(&mut self, key_prefix: &[u8]) {
-        for (_, value) in self.map.range_mut(get_interval(key_prefix.to_vec())) {
-            *value = None;
+    fn get_lower_bound_update(&mut self, key: &[u8]) -> Option<(&Vec<u8>, &mut FindCacheEntry)> {
+        match self.map_find.range_mut(..=key.to_vec()).next_back() {
+            None => None,
+            Some((key_store, value)) => {
+                if key.starts_with(key_store) {
+                    Some((key_store, value))
+                } else {
+                    None
+                }
+            }
         }
     }
 
-    /// Gets the entry from the key.
-    pub fn query(&'a self, key: &'a [u8]) -> Option<&'a Option<Vec<u8>>> {
-        self.map.get(key)
+    /// Inserts a new entry, clearing entries of the queue if needed
+    fn insert_queue(&mut self, full_key: (Vec<u8>, CacheEntry), cache_size: usize) {
+        self.queue.insert(full_key, cache_size);
+        self.total_size += cache_size;
+        while self.total_size > self.storage_cache_policy.max_cache_size
+            || self.queue.len() > self.storage_cache_policy.max_cache_entries
+        {
+            let Some(value) = self.queue.pop_front() else {
+                break;
+            };
+            match value.0 {
+                (v, CacheEntry::Find) => {
+                    self.map_find.remove(&v);
+                }
+                (v, CacheEntry::Value) => {
+                    self.map_value.remove(&v);
+                }
+            }
+            self.total_size -= value.1;
+        }
+    }
+
+    /// Removes an entry from the queue
+    fn remove_from_queue(&mut self, full_key: &(Vec<u8>, CacheEntry)) {
+        let existing_cache_size = self.queue.remove(full_key).unwrap();
+        self.total_size -= existing_cache_size;
+    }
+
+    /// Sets a size to zero in the queue
+    fn zero_set_entry_in_queue(&mut self, full_key: &(Vec<u8>, CacheEntry)) {
+        let len = full_key.0.len();
+        let cache_size = self.queue.get_mut(full_key).unwrap();
+        self.total_size -= *cache_size;
+        *cache_size = len;
+        self.total_size += *cache_size;
+    }
+
+    /// Inserts a value entry into the cache.
+    pub fn insert_value(&mut self, key: Vec<u8>, cache_entry: ValueCacheEntry) {
+        let cache_size = cache_entry.size() + key.len();
+        #[cfg(with_metrics)]
+        metrics::VALUE_CACHE_ENTRY_SIZE
+            .with_label_values(&[])
+            .observe(cache_size as f64);
+        if cache_size > self.storage_cache_policy.max_entry_size {
+            return;
+        }
+        let full_key = (key.clone(), CacheEntry::Value);
+        match self.map_value.entry(key) {
+            btree_map::Entry::Occupied(mut entry) => {
+                entry.insert(cache_entry);
+                self.remove_from_queue(&full_key);
+            }
+            btree_map::Entry::Vacant(entry) => {
+                entry.insert(cache_entry);
+            }
+        }
+        self.insert_queue(full_key, cache_size);
+    }
+
+    /// Invalidates corresponding find entries
+    pub fn correct_find_entry(&mut self, key: &[u8], new_value: Option<Vec<u8>>) {
+        let lower_bound = self.get_lower_bound_update(key);
+        if let Some((lower_bound, cache_entry)) = lower_bound {
+            let key_red = &key[lower_bound.len()..];
+            cache_entry.update_cache_entry(key_red, new_value);
+        }
+    }
+
+    /// Inserts a read_value entry into the cache.
+    pub fn insert_read_value(&mut self, key: Vec<u8>, value: &Option<Vec<u8>>) {
+        let cache_entry = ValueCacheEntry::from_read_value(value);
+        self.insert_value(key, cache_entry)
+    }
+
+    /// Inserts a read_value entry into the cache.
+    pub fn insert_contains_key(&mut self, key: Vec<u8>, result: bool) {
+        let cache_entry = ValueCacheEntry::from_contains_key(result);
+        self.insert_value(key, cache_entry)
+    }
+
+    /// Inserts a find entry into the cache.
+    pub fn insert_find(&mut self, key_prefix: Vec<u8>, cache_entry: FindCacheEntry) {
+        let cache_size = cache_entry.size() + key_prefix.len();
+        #[cfg(with_metrics)]
+        metrics::FIND_CACHE_ENTRY_SIZE
+            .with_label_values(&[])
+            .observe(cache_size as f64);
+        if cache_size > self.storage_cache_policy.max_cache_size {
+            // Inserting that entry would lead to complete clearing of the cache
+            // which is counter productive
+            return;
+        }
+        let keys = self
+            .map_find
+            .range(get_interval(key_prefix.clone()))
+            .map(|(x, _)| x.clone())
+            .collect::<Vec<_>>();
+        for key in keys {
+            self.map_find.remove(&key);
+            let full_key = (key, CacheEntry::Find);
+            self.remove_from_queue(&full_key);
+        }
+        if let FindCacheEntry::KeyValues(_) = cache_entry {
+            let keys = self
+                .map_value
+                .range(get_interval(key_prefix.clone()))
+                .map(|(x, _)| x.clone())
+                .collect::<Vec<_>>();
+            for key in keys {
+                self.map_value.remove(&key);
+                let full_key = (key, CacheEntry::Value);
+                self.remove_from_queue(&full_key);
+            }
+        }
+        let full_prefix = (key_prefix.clone(), CacheEntry::Find);
+        match self.map_find.entry(key_prefix.clone()) {
+            btree_map::Entry::Occupied(mut entry) => {
+                entry.insert(cache_entry);
+                self.remove_from_queue(&full_prefix);
+            }
+            btree_map::Entry::Vacant(entry) => {
+                entry.insert(cache_entry);
+            }
+        }
+        self.insert_queue(full_prefix, cache_size);
+    }
+
+    /// Inserts a find entry into the cache.
+    pub fn insert_find_keys(&mut self, key_prefix: Vec<u8>, value: &[Vec<u8>]) {
+        let map = value.iter().cloned().collect::<BTreeSet<_>>();
+        let cache_entry = FindCacheEntry::Keys(map);
+        self.insert_find(key_prefix, cache_entry);
+    }
+
+    /// Inserts a find_key_values entry into the cache.
+    pub fn insert_find_key_values(&mut self, key_prefix: Vec<u8>, value: &[(Vec<u8>, Vec<u8>)]) {
+        let map = value.iter().cloned().collect::<BTreeMap<_, _>>();
+        let cache_entry = FindCacheEntry::KeyValues(map);
+        self.insert_find(key_prefix, cache_entry);
+    }
+
+    /// Marks cached keys that match the prefix as deleted. Importantly, this does not create new entries in the cache.
+    pub fn delete_prefix(&mut self, key_prefix: &[u8]) {
+        let mut cache_entries = Vec::new();
+        for (key, value) in self.map_value.range_mut(get_interval(key_prefix.to_vec())) {
+            *value = ValueCacheEntry::DoesNotExist;
+            cache_entries.push((key.clone(), CacheEntry::Value));
+        }
+        for (key, value) in self.map_find.range_mut(get_interval(key_prefix.to_vec())) {
+            *value = FindCacheEntry::KeyValues(BTreeMap::new());
+            cache_entries.push((key.clone(), CacheEntry::Find));
+        }
+        for cache_entry in cache_entries {
+            self.zero_set_entry_in_queue(&cache_entry);
+        }
+        let lower_bound = self.get_lower_bound_update(key_prefix);
+        let result = if let Some((lower_bound, cache_entry)) = lower_bound {
+            let key_prefix_red = &key_prefix[lower_bound.len()..];
+            cache_entry.delete_prefix(key_prefix_red);
+            let new_cache_size = cache_entry.size() + key_prefix.len();
+            Some((new_cache_size, lower_bound.clone()))
+        } else {
+            None
+        };
+        if let Some((new_cache_size, lower_bound)) = result {
+            let full_prefix = (lower_bound.clone(), CacheEntry::Find);
+            let existing_cache_size = self.queue.get_mut(&full_prefix).unwrap();
+            self.total_size -= *existing_cache_size;
+            *existing_cache_size = new_cache_size;
+            self.total_size += new_cache_size;
+        }
+    }
+
+    /// Gets the read_value entry from the key.
+    pub fn query_read_value(&mut self, key: &[u8]) -> Option<Option<Vec<u8>>> {
+        let result = match self.map_value.get(key) {
+            None => None,
+            Some(entry) => entry.get_read_value(),
+        };
+        if let Some(result) = result {
+            let full_key = (key.to_vec(), CacheEntry::Value);
+            let cache_size = self.queue.remove(&full_key).unwrap();
+            self.queue.insert(full_key, cache_size);
+            return Some(result);
+        }
+        let lower_bound = self.get_lower_bound(key);
+        let (lower_bound, result) = if let Some((lower_bound, cache_entry)) = lower_bound {
+            let key_red = &key[lower_bound.len()..];
+            (Some(lower_bound), cache_entry.get_read_value(key_red))
+        } else {
+            (None, None)
+        };
+        if result.is_some() {
+            if let Some(lower_bound) = lower_bound {
+                let full_key = (lower_bound.clone(), CacheEntry::Find);
+                let cache_size = self.queue.remove(&full_key).unwrap();
+                self.queue.insert(full_key, cache_size);
+            }
+        }
+        result
+    }
+
+    /// Gets the contains_key entry from the key.
+    pub fn query_contains_key(&mut self, key: &[u8]) -> Option<bool> {
+        let result = self
+            .map_value
+            .get(key)
+            .map(|entry| entry.get_contains_key());
+        if let Some(result) = result {
+            let full_key = (key.to_vec(), CacheEntry::Value);
+            let cache_size = self.queue.remove(&full_key).unwrap();
+            self.queue.insert(full_key, cache_size);
+            return Some(result);
+        }
+        let lower_bound = self.get_lower_bound(key);
+        let (lower_bound, result) = if let Some((lower_bound, cache_entry)) = lower_bound {
+            let key_red = &key[lower_bound.len()..];
+            (
+                Some(lower_bound),
+                Some(cache_entry.get_contains_key(key_red)),
+            )
+        } else {
+            (None, None)
+        };
+        if result.is_some() {
+            if let Some(lower_bound) = lower_bound {
+                let full_key = (lower_bound.clone(), CacheEntry::Find);
+                let cache_size = self.queue.remove(&full_key).unwrap();
+                self.queue.insert(full_key, cache_size);
+            }
+        }
+        result
+    }
+
+    /// Gets the find_keys entry from the key prefix
+    pub fn query_find_keys(&mut self, key_prefix: &[u8]) -> Option<Vec<Vec<u8>>> {
+        let (lower_bound, result) = match self.get_lower_bound(key_prefix) {
+            None => (None, None),
+            Some((lower_bound, cache_entry)) => {
+                let key_prefix_red = &key_prefix[lower_bound.len()..];
+                (
+                    Some(lower_bound),
+                    Some(cache_entry.get_find_keys(key_prefix_red)),
+                )
+            }
+        };
+        if let Some(lower_bound) = lower_bound {
+            let full_key = (lower_bound.clone(), CacheEntry::Find);
+            let cache_size = self.queue.remove(&full_key).unwrap();
+            self.queue.insert(full_key, cache_size);
+        }
+        result
+    }
+
+    /// Gets the find key values entry from the key prefix
+    pub fn query_find_key_values(&mut self, key_prefix: &[u8]) -> Option<Vec<(Vec<u8>, Vec<u8>)>> {
+        let (lower_bound, result) = match self.get_lower_bound(key_prefix) {
+            None => (None, None),
+            Some((lower_bound, cache_entry)) => {
+                let key_prefix_red = &key_prefix[lower_bound.len()..];
+                (
+                    Some(lower_bound),
+                    cache_entry.get_find_key_values(key_prefix_red),
+                )
+            }
+        };
+        if result.is_some() {
+            if let Some(lower_bound) = lower_bound {
+                let full_key = (lower_bound.clone(), CacheEntry::Find);
+                let cache_size = self.queue.remove(&full_key).unwrap();
+                self.queue.insert(full_key, cache_size);
+            }
+        }
+        result
     }
 }
 
-/// We take a store, a maximum size and build a LRU-based system.
+/// We take a store, a maximum size and build a cache based system.
 #[derive(Clone)]
-pub struct LruCachingStore<K> {
+pub struct CachingStore<K> {
     /// The inner store that is called by the LRU cache one
     store: K,
-    lru_read_values: Option<Arc<Mutex<LruPrefixCache>>>,
+    cache: Option<Arc<Mutex<StoragePrefixCache>>>,
 }
 
-impl<K> WithError for LruCachingStore<K>
+impl<K> WithError for CachingStore<K>
 where
     K: WithError,
 {
     type Error = K::Error;
 }
 
-impl<K> ReadableKeyValueStore for LruCachingStore<K>
+impl<K> ReadableKeyValueStore for CachingStore<K>
 where
     K: ReadableKeyValueStore + Send + Sync,
 {
-    // The LRU cache does not change the underlying store's size limits.
+    // The cache does not change the underlying store's size limits.
     const MAX_KEY_SIZE: usize = K::MAX_KEY_SIZE;
-    type Keys = K::Keys;
-    type KeyValues = K::KeyValues;
+    type Keys = Vec<Vec<u8>>;
+    type KeyValues = Vec<(Vec<u8>, Vec<u8>)>;
 
     fn max_stream_queries(&self) -> usize {
         self.store.max_stream_queries()
     }
 
     async fn read_value_bytes(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
-        let Some(lru_read_values) = &self.lru_read_values else {
+        let Some(cache) = &self.cache else {
             return self.store.read_value_bytes(key).await;
         };
-        // First inquiring in the read_value_bytes LRU
+        // First inquiring in the read_value_bytes cache
         {
-            let lru_read_values_container = lru_read_values.lock().unwrap();
-            if let Some(value) = lru_read_values_container.query(key) {
+            let mut cache = cache.lock().unwrap();
+            if let Some(value) = cache.query_read_value(key) {
                 #[cfg(with_metrics)]
-                NUM_CACHE_SUCCESS.with_label_values(&[]).inc();
-                return Ok(value.clone());
+                metrics::NUM_CACHE_VALUE_SUCCESS
+                    .with_label_values(&[])
+                    .inc();
+                return Ok(value);
             }
         }
         #[cfg(with_metrics)]
-        NUM_CACHE_FAULT.with_label_values(&[]).inc();
+        metrics::NUM_CACHE_VALUE_FAULT.with_label_values(&[]).inc();
         let value = self.store.read_value_bytes(key).await?;
-        let mut lru_read_values = lru_read_values.lock().unwrap();
-        lru_read_values.insert(key.to_vec(), value.clone());
+        let mut cache = cache.lock().unwrap();
+        cache.insert_read_value(key.to_vec(), &value);
         Ok(value)
     }
 
     async fn contains_key(&self, key: &[u8]) -> Result<bool, Self::Error> {
-        if let Some(values) = &self.lru_read_values {
-            let values = values.lock().unwrap();
-            if let Some(value) = values.query(key) {
-                return Ok(value.is_some());
+        let Some(cache) = &self.cache else {
+            return self.store.contains_key(key).await;
+        };
+        {
+            let mut cache = cache.lock().unwrap();
+            if let Some(result) = cache.query_contains_key(key) {
+                #[cfg(with_metrics)]
+                metrics::NUM_CACHE_VALUE_SUCCESS
+                    .with_label_values(&[])
+                    .inc();
+                return Ok(result);
             }
         }
-        self.store.contains_key(key).await
+        #[cfg(with_metrics)]
+        metrics::NUM_CACHE_VALUE_FAULT.with_label_values(&[]).inc();
+        let result = self.store.contains_key(key).await?;
+        let mut cache = cache.lock().unwrap();
+        cache.insert_contains_key(key.to_vec(), result);
+        Ok(result)
     }
 
     async fn contains_keys(&self, keys: Vec<Vec<u8>>) -> Result<Vec<bool>, Self::Error> {
-        let Some(values) = &self.lru_read_values else {
+        let Some(cache) = &self.cache else {
             return self.store.contains_keys(keys).await;
         };
         let size = keys.len();
@@ -163,20 +705,28 @@ where
         let mut indices = Vec::new();
         let mut key_requests = Vec::new();
         {
-            let values = values.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
             for i in 0..size {
-                if let Some(value) = values.query(&keys[i]) {
-                    results[i] = value.is_some();
+                if let Some(result) = cache.query_contains_key(&keys[i]) {
+                    #[cfg(with_metrics)]
+                    metrics::NUM_CACHE_VALUE_SUCCESS
+                        .with_label_values(&[])
+                        .inc();
+                    results[i] = result;
                 } else {
+                    #[cfg(with_metrics)]
+                    metrics::NUM_CACHE_VALUE_FAULT.with_label_values(&[]).inc();
                     indices.push(i);
                     key_requests.push(keys[i].clone());
                 }
             }
         }
         if !key_requests.is_empty() {
-            let key_results = self.store.contains_keys(key_requests).await?;
-            for (index, result) in indices.into_iter().zip(key_results) {
+            let key_results = self.store.contains_keys(key_requests.clone()).await?;
+            let mut cache = cache.lock().unwrap();
+            for ((index, result), key) in indices.into_iter().zip(key_results).zip(key_requests) {
                 results[index] = result;
+                cache.insert_contains_key(key, result);
             }
         }
         Ok(results)
@@ -186,7 +736,7 @@ where
         &self,
         keys: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
-        let Some(lru_read_values) = &self.lru_read_values else {
+        let Some(cache) = &self.cache else {
             return self.store.read_multi_values_bytes(keys).await;
         };
 
@@ -194,15 +744,17 @@ where
         let mut cache_miss_indices = Vec::new();
         let mut miss_keys = Vec::new();
         {
-            let lru_read_values_container = lru_read_values.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
             for (i, key) in keys.into_iter().enumerate() {
-                if let Some(value) = lru_read_values_container.query(&key) {
+                if let Some(value) = cache.query_read_value(&key) {
                     #[cfg(with_metrics)]
-                    NUM_CACHE_SUCCESS.with_label_values(&[]).inc();
-                    result.push(value.clone());
+                    metrics::NUM_CACHE_VALUE_SUCCESS
+                        .with_label_values(&[])
+                        .inc();
+                    result.push(value);
                 } else {
                     #[cfg(with_metrics)]
-                    NUM_CACHE_FAULT.with_label_values(&[]).inc();
+                    metrics::NUM_CACHE_VALUE_FAULT.with_label_values(&[]).inc();
                     result.push(None);
                     cache_miss_indices.push(i);
                     miss_keys.push(key);
@@ -214,54 +766,89 @@ where
                 .store
                 .read_multi_values_bytes(miss_keys.clone())
                 .await?;
-            let mut lru_read_values = lru_read_values.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
             for (i, (key, value)) in cache_miss_indices
                 .into_iter()
                 .zip(miss_keys.into_iter().zip(values))
             {
-                lru_read_values.insert(key, value.clone());
+                cache.insert_read_value(key, &value);
                 result[i] = value;
             }
         }
         Ok(result)
     }
 
-    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Self::Keys, Self::Error> {
-        self.store.find_keys_by_prefix(key_prefix).await
+    async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, Self::Error> {
+        let Some(cache) = &self.cache else {
+            return self.uncached_find_keys_by_prefix(key_prefix).await;
+        };
+        {
+            let mut cache = cache.lock().unwrap();
+            if let Some(value) = cache.query_find_keys(key_prefix) {
+                #[cfg(with_metrics)]
+                metrics::NUM_CACHE_FIND_SUCCESS.with_label_values(&[]).inc();
+                return Ok(value);
+            }
+        }
+        #[cfg(with_metrics)]
+        metrics::NUM_CACHE_FIND_FAULT.with_label_values(&[]).inc();
+        let keys = self.uncached_find_keys_by_prefix(key_prefix).await?;
+        let mut cache = cache.lock().unwrap();
+        cache.insert_find_keys(key_prefix.to_vec(), &keys);
+        Ok(keys)
     }
 
     async fn find_key_values_by_prefix(
         &self,
         key_prefix: &[u8],
     ) -> Result<Self::KeyValues, Self::Error> {
-        self.store.find_key_values_by_prefix(key_prefix).await
+        let Some(cache) = &self.cache else {
+            return self.uncached_find_key_values_by_prefix(key_prefix).await;
+        };
+        {
+            let mut cache = cache.lock().unwrap();
+            if let Some(value) = cache.query_find_key_values(key_prefix) {
+                #[cfg(with_metrics)]
+                metrics::NUM_CACHE_FIND_SUCCESS.with_label_values(&[]).inc();
+                return Ok(value);
+            }
+        }
+        #[cfg(with_metrics)]
+        metrics::NUM_CACHE_FIND_FAULT.with_label_values(&[]).inc();
+        let key_values = self.uncached_find_key_values_by_prefix(key_prefix).await?;
+        let mut cache = cache.lock().unwrap();
+        cache.insert_find_key_values(key_prefix.to_vec(), &key_values);
+        Ok(key_values)
     }
 }
 
-impl<K> WritableKeyValueStore for LruCachingStore<K>
+impl<K> WritableKeyValueStore for CachingStore<K>
 where
     K: WritableKeyValueStore + Send + Sync,
 {
-    // The LRU cache does not change the underlying store's size limits.
+    // The cache does not change the underlying store's size limits.
     const MAX_VALUE_SIZE: usize = K::MAX_VALUE_SIZE;
 
     async fn write_batch(&self, batch: Batch) -> Result<(), Self::Error> {
-        let Some(lru_read_values) = &self.lru_read_values else {
+        let Some(cache) = &self.cache else {
             return self.store.write_batch(batch).await;
         };
-
         {
-            let mut lru_read_values = lru_read_values.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
             for operation in &batch.operations {
                 match operation {
                     WriteOperation::Put { key, value } => {
-                        lru_read_values.insert(key.to_vec(), Some(value.to_vec()));
+                        cache.correct_find_entry(key, Some(value.to_vec()));
+                        let cache_entry = ValueCacheEntry::Value(value.to_vec());
+                        cache.insert_value(key.to_vec(), cache_entry);
                     }
                     WriteOperation::Delete { key } => {
-                        lru_read_values.insert(key.to_vec(), None);
+                        cache.correct_find_entry(key, None);
+                        let cache_entry = ValueCacheEntry::DoesNotExist;
+                        cache.insert_value(key.to_vec(), cache_entry);
                     }
                     WriteOperation::DeletePrefix { key_prefix } => {
-                        lru_read_values.delete_prefix(key_prefix);
+                        cache.delete_prefix(key_prefix);
                     }
                 }
             }
@@ -274,22 +861,22 @@ where
     }
 }
 
-/// The configuration type for the `LruCachingStore`.
-pub struct LruCachingConfig<C> {
-    /// The inner configuration of the `LruCachingStore`.
+/// The configuration type for the `CachingStore`.
+pub struct CachingConfig<C> {
+    /// The inner configuration of the `CachingStore`.
     pub inner_config: C,
     /// The cache size being used
-    pub cache_size: usize,
+    pub storage_cache_policy: StorageCachePolicy,
 }
 
-impl<K> AdminKeyValueStore for LruCachingStore<K>
+impl<K> AdminKeyValueStore for CachingStore<K>
 where
     K: AdminKeyValueStore + Send + Sync,
 {
-    type Config = LruCachingConfig<K::Config>;
+    type Config = CachingConfig<K::Config>;
 
     fn get_name() -> String {
-        format!("lru caching {}", K::get_name())
+        format!("caching {}", K::get_name())
     }
 
     async fn connect(
@@ -298,14 +885,14 @@ where
         root_key: &[u8],
     ) -> Result<Self, Self::Error> {
         let store = K::connect(&config.inner_config, namespace, root_key).await?;
-        let cache_size = config.cache_size;
-        Ok(LruCachingStore::new(store, cache_size))
+        let storage_cache_policy = config.storage_cache_policy.clone();
+        Ok(CachingStore::new(store, storage_cache_policy))
     }
 
     fn clone_with_root_key(&self, root_key: &[u8]) -> Result<Self, Self::Error> {
         let store = self.store.clone_with_root_key(root_key)?;
-        let cache_size = self.cache_size();
-        Ok(LruCachingStore::new(store, cache_size))
+        let storage_cache_policy = self.storage_cache_policy();
+        Ok(CachingStore::new(store, storage_cache_policy))
     }
 
     async fn list_all(config: &Self::Config) -> Result<Vec<String>, Self::Error> {
@@ -330,50 +917,85 @@ where
 }
 
 #[cfg(with_testing)]
-impl<K> TestKeyValueStore for LruCachingStore<K>
+impl<K> TestKeyValueStore for CachingStore<K>
 where
     K: TestKeyValueStore + Send + Sync,
 {
-    async fn new_test_config() -> Result<LruCachingConfig<K::Config>, K::Error> {
+    async fn new_test_config() -> Result<CachingConfig<K::Config>, K::Error> {
         let inner_config = K::new_test_config().await?;
-        let cache_size = TEST_CACHE_SIZE;
-        Ok(LruCachingConfig {
+        let storage_cache_policy = DEFAULT_STORAGE_CACHE_POLICY;
+        Ok(CachingConfig {
             inner_config,
-            cache_size,
+            storage_cache_policy,
         })
     }
 }
 
-fn new_lru_prefix_cache(cache_size: usize) -> Option<Arc<Mutex<LruPrefixCache>>> {
-    if cache_size == 0 {
+fn new_storage_prefix_cache(
+    storage_cache_policy: StorageCachePolicy,
+) -> Option<Arc<Mutex<StoragePrefixCache>>> {
+    if storage_cache_policy.max_cache_size == 0 {
         None
     } else {
-        Some(Arc::new(Mutex::new(LruPrefixCache::new(cache_size))))
+        let cache = StoragePrefixCache::new(storage_cache_policy);
+        Some(Arc::new(Mutex::new(cache)))
     }
 }
 
-impl<K> LruCachingStore<K> {
-    /// Creates a new key-value store that provides LRU caching at top of the given store.
-    pub fn new(store: K, cache_size: usize) -> Self {
-        let lru_read_values = new_lru_prefix_cache(cache_size);
-        Self {
-            store,
-            lru_read_values,
-        }
+impl<K> CachingStore<K> {
+    /// Creates a new key-value store that provides caching at top of the given store.
+    pub fn new(store: K, storage_cache_policy: StorageCachePolicy) -> Self {
+        let cache = new_storage_prefix_cache(storage_cache_policy);
+        Self { store, cache }
     }
 
-    /// Gets the `cache_size`
-    pub fn cache_size(&self) -> usize {
-        match &self.lru_read_values {
-            None => 0,
-            Some(lru_read_values) => {
-                let lru_read_values = lru_read_values.lock().unwrap();
-                lru_read_values.max_cache_size
+    /// Gets the `storage_cache_policy` or if absent one that matches to an empty cache.
+    pub fn storage_cache_policy(&self) -> StorageCachePolicy {
+        match &self.cache {
+            None => StorageCachePolicy {
+                max_cache_size: 0,
+                max_entry_size: 0,
+                max_cache_entries: 0,
+            },
+            Some(cache) => {
+                let cache = cache.lock().unwrap();
+                cache.storage_cache_policy.clone()
             }
         }
     }
 }
 
+impl<K> CachingStore<K>
+where
+    K: ReadableKeyValueStore + WithError,
+{
+    async fn uncached_find_keys_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Vec<Vec<u8>>, K::Error> {
+        let keys = self.store.find_keys_by_prefix(key_prefix).await?;
+        let mut keys_vec = Vec::new();
+        for key in keys.iterator() {
+            keys_vec.push(key?.to_vec());
+        }
+        Ok(keys_vec)
+    }
+
+    async fn uncached_find_key_values_by_prefix(
+        &self,
+        key_prefix: &[u8],
+    ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, K::Error> {
+        let key_values = self.store.find_key_values_by_prefix(key_prefix).await?;
+        let mut key_values_vec = Vec::new();
+        for key_value in key_values.iterator() {
+            let key_value = key_value?;
+            let key_value = (key_value.0.to_vec(), key_value.1.to_vec());
+            key_values_vec.push(key_value);
+        }
+        Ok(key_values_vec)
+    }
+}
+
 /// A memory store with caching.
 #[cfg(with_testing)]
-pub type LruCachingMemoryStore = LruCachingStore<MemoryStore>;
+pub type CachingMemoryStore = CachingStore<MemoryStore>;

--- a/linera-views/src/backends/rocks_db.rs
+++ b/linera-views/src/backends/rocks_db.rs
@@ -620,7 +620,7 @@ impl RocksDbStoreConfig {
         };
         RocksDbStoreConfig {
             inner_config,
-            cache_size: common_config.cache_size,
+            storage_cache_policy: common_config.storage_cache_policy,
         }
     }
 }

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -872,8 +872,13 @@ impl TestKeyValueStore for JournalingKeyValueStore<ScyllaDbStoreInternal> {
 
 /// The `ScyllaDbStore` composed type with metrics
 #[cfg(with_metrics)]
-pub type ScyllaDbStore =
-    MeteredStore<CachingStore<MeteredStore<ValueSplittingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>>>>;
+pub type ScyllaDbStore = MeteredStore<
+    CachingStore<
+        MeteredStore<
+            ValueSplittingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>,
+        >,
+    >,
+>;
 
 /// The `ScyllaDbStore` composed type
 #[cfg(not(with_metrics))]
@@ -892,7 +897,7 @@ impl ScyllaDbStoreConfig {
         };
         ScyllaDbStoreConfig {
             inner_config,
-            cache_size: common_config.cache_size,
+            storage_cache_policy: common_config.storage_cache_policy,
         }
     }
 }

--- a/linera-views/src/backends/scylla_db.rs
+++ b/linera-views/src/backends/scylla_db.rs
@@ -34,7 +34,7 @@ use crate::{
     batch::UnorderedBatch,
     common::{get_uleb128_size, get_upper_bound_option},
     journaling::{DirectWritableKeyValueStore, JournalConsistencyError, JournalingKeyValueStore},
-    lru_caching::{LruCachingConfig, LruCachingStore},
+    lru_caching::{CachingConfig, CachingStore},
     store::{
         AdminKeyValueStore, CommonStoreInternalConfig, KeyValueStoreError, ReadableKeyValueStore,
         WithError,
@@ -872,21 +872,16 @@ impl TestKeyValueStore for JournalingKeyValueStore<ScyllaDbStoreInternal> {
 
 /// The `ScyllaDbStore` composed type with metrics
 #[cfg(with_metrics)]
-pub type ScyllaDbStore = MeteredStore<
-    LruCachingStore<
-        MeteredStore<
-            ValueSplittingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>,
-        >,
-    >,
->;
+pub type ScyllaDbStore =
+    MeteredStore<CachingStore<MeteredStore<ValueSplittingStore<MeteredStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>>>>;
 
 /// The `ScyllaDbStore` composed type
 #[cfg(not(with_metrics))]
 pub type ScyllaDbStore =
-    LruCachingStore<ValueSplittingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>;
+    CachingStore<ValueSplittingStore<JournalingKeyValueStore<ScyllaDbStoreInternal>>>;
 
 /// The `ScyllaDbStoreConfig` input type
-pub type ScyllaDbStoreConfig = LruCachingConfig<ScyllaDbStoreInternalConfig>;
+pub type ScyllaDbStoreConfig = CachingConfig<ScyllaDbStoreInternalConfig>;
 
 impl ScyllaDbStoreConfig {
     /// Creates a `ScyllaDbStoreConfig` from the inputs.

--- a/linera-views/src/store.rs
+++ b/linera-views/src/store.rs
@@ -9,7 +9,12 @@ use serde::de::DeserializeOwned;
 
 #[cfg(with_testing)]
 use crate::random::generate_test_namespace;
-use crate::{batch::Batch, common::from_bytes_option, views::ViewError};
+use crate::{
+    batch::Batch,
+    common::from_bytes_option,
+    lru_caching::{StorageCachePolicy, DEFAULT_STORAGE_CACHE_POLICY},
+    views::ViewError,
+};
 
 /// The common initialization parameters for the `KeyValueStore`
 #[derive(Debug, Clone)]
@@ -27,8 +32,8 @@ pub struct CommonStoreConfig {
     pub max_concurrent_queries: Option<usize>,
     /// The number of streams used for the async streams.
     pub max_stream_queries: usize,
-    /// The cache size being used.
-    pub cache_size: usize,
+    /// The cache policy being used.
+    pub storage_cache_policy: StorageCachePolicy,
 }
 
 impl CommonStoreConfig {
@@ -46,7 +51,7 @@ impl Default for CommonStoreConfig {
         CommonStoreConfig {
             max_concurrent_queries: None,
             max_stream_queries: 10,
-            cache_size: 1000,
+            storage_cache_policy: DEFAULT_STORAGE_CACHE_POLICY,
         }
     }
 }

--- a/linera-views/src/test_utils/mod.rs
+++ b/linera-views/src/test_utils/mod.rs
@@ -590,6 +590,38 @@ pub async fn run_lru_related_test2<S: LocalRestrictedKeyValueStore>(store: &S) {
     }
 }
 
+/// Reading many keys at a time could trigger an error. This needs to be tested.
+pub async fn big_read_multi_values<C: LocalKeyValueStore>(
+    config: C::Config,
+    value_size: usize,
+    n_entries: usize,
+) {
+    let mut rng = make_deterministic_rng();
+    let namespace = generate_test_namespace();
+    let root_key = &[];
+    //
+    let store = C::recreate_and_connect(&config, &namespace, root_key)
+        .await
+        .unwrap();
+    let key_prefix = vec![42, 54];
+    let mut batch = Batch::new();
+    let mut keys = Vec::new();
+    let mut values = Vec::new();
+    for i in 0..n_entries {
+        let mut key = key_prefix.clone();
+        bcs::serialize_into(&mut key, &i).unwrap();
+        let value = get_random_byte_vector(&mut rng, &[], value_size);
+        batch.put_key_value_bytes(key.clone(), value.clone());
+        keys.push(key);
+        values.push(Some(value));
+    }
+    store.write_batch(batch).await.unwrap();
+    // We reconnect so that the read is not using the cache.
+    let store = C::connect(&config, &namespace, root_key).await.unwrap();
+    let values_read = store.read_multi_values_bytes(keys).await.unwrap();
+    assert_eq!(values, values_read);
+}
+
 /// That test is especially challenging for ScyllaDB.
 /// In its default settings, Scylla has a limitation to 10000 tombstones.
 /// A tombstone is an indication that the data has been deleted. That

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -9,8 +9,9 @@ use linera_views::{
     random::make_deterministic_rng,
     store::TestKeyValueStore as _,
     test_utils::{
-        get_random_test_scenarios, run_big_write_read, run_lru_related_test1,
-        run_lru_related_test2, run_reads, run_writes_from_blank, run_writes_from_state,
+        big_read_multi_values, get_random_test_scenarios, run_big_write_read,
+        run_lru_related_test1, run_lru_related_test2, run_reads, run_writes_from_blank,
+        run_writes_from_state,
     },
     value_splitting::create_value_splitting_memory_store,
 };

--- a/linera-views/tests/store_tests.rs
+++ b/linera-views/tests/store_tests.rs
@@ -9,8 +9,8 @@ use linera_views::{
     random::make_deterministic_rng,
     store::TestKeyValueStore as _,
     test_utils::{
-        big_read_multi_values, get_random_test_scenarios, run_big_write_read, run_reads,
-        run_writes_from_blank, run_writes_from_state,
+        get_random_test_scenarios, run_big_write_read, run_lru_related_test1,
+        run_lru_related_test2, run_reads, run_writes_from_blank, run_writes_from_state,
     },
     value_splitting::create_value_splitting_memory_store,
 };
@@ -92,6 +92,36 @@ async fn test_reads_scylla_db() {
             .unwrap();
         run_reads(store, scenario).await;
     }
+}
+
+#[tokio::test]
+async fn test_lru1_memory() {
+    let store = MemoryStore::new_test_store().await.unwrap();
+    run_lru_related_test1(&store).await;
+}
+
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_lru1_scylla_db() {
+    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
+        .await
+        .unwrap();
+    run_lru_related_test1(&store).await;
+}
+
+#[tokio::test]
+async fn test_lru2_memory() {
+    let store = MemoryStore::new_test_store().await.unwrap();
+    run_lru_related_test2(&store).await;
+}
+
+#[cfg(with_scylladb)]
+#[tokio::test]
+async fn test_lru2_scylla_db() {
+    let store = linera_views::scylla_db::ScyllaDbStore::new_test_store()
+        .await
+        .unwrap();
+    run_lru_related_test2(&store).await;
 }
 
 #[cfg(with_indexeddb)]


### PR DESCRIPTION
## Motivation

The LRU is currently caching only the `read_value` operations. This leaves some optimizations away.

## Proposal

The following was done:
* The `map` was renamed as `map_value`.
* A map for find is introduced keeping track of the `find_keys_by_prefix` and `find_key_values_by_prefix`.
* For the `find_keys_by_prefix` we keep the map as suffix closed and we use the existing entries to get some value. So, if we already computed for prefix `[0]` then we can deduce the result for `[0,2]`.
* Similarly for `find_key_values_by_prefix`.
* Write batch tries to update as much as possible the cache.
* The `max_cache_size` which before was a maximum on the number of entries becomes a maximum on the number of bytes in the cache (and is expanded from 1000 to 10000000).
* The maximum number of entries in the cache is set to 1000.

Measurement setup:
* Done with the `test_wasm_end_to_end_amm` on `remote-net`.
* Storage used is `ScyllaDb` which has LRU caching.
* Code compiled in `--release` which takes about 1H to compile.
* Done 10 times with the 1st entry discarded.
* Scripting available at https://github.com/MathieuDutSik/linera_parsing_tools 

Averaged results:
* **Cache hit**. Old code 82.9%, new code: 84.8% for values (_contains_key_ and _read_value_), 91% for finds (_find_keys_by_prefix_ and _find_key_values_by_prefix_).
* **read_value_bytes**. 0.0276ms (Old code) vs 0.019 ms (New code).
* **contains_key**: 0.25 ms (Old code) vs 0.076 ms (New code)
* **find_keys_by_prefix**: 1.17 ms (Old code) vs 0.087 ms (New code)
* **find_key_values_by_prefix**: 1.08 ms (Old code) vs 0.13 ms (New code)
* **write_batch**: 2.22 ms (Old code) vs 2.52 ms (New code)
* **total runtime**: 16.63 second (Old code) vs 15.83 seconds (New code)

## Test Plan

The CI.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
