### PR TITLE
Reset timeout in chain listener if we don't own the chain.

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -177,25 +177,24 @@ where
                 Either::Left((Some(notification), _)) => notification,
                 Either::Left((None, _)) => break,
                 Either::Right(((), _)) => {
+                    timeout = Timestamp::from(u64::MAX);
                     if config.skip_process_inbox {
                         debug!("Not processing inbox due to listener configuration");
-                        timeout = Timestamp::from(u64::MAX);
                         continue;
                     }
                     debug!("Processing inbox");
                     match client.process_inbox_without_prepare().await {
-                        Err(ChainClientError::CannotFindKeyForChain(_)) => continue,
-                        Err(error) => {
-                            warn!(%error, "Failed to process inbox.");
-                            timeout = Timestamp::from(u64::MAX);
-                        }
+                        Err(ChainClientError::CannotFindKeyForChain(_)) => {}
+                        Err(error) => warn!(%error, "Failed to process inbox."),
                         Ok((certs, None)) => {
-                            info!("Done processing inbox ({} blocks created)", certs.len());
-                            timeout = Timestamp::from(u64::MAX);
+                            info!("Done processing inbox. {} blocks created.", certs.len());
                         }
                         Ok((certs, Some(new_timeout))) => {
-                            info!("Done processing inbox ({} blocks created)", certs.len());
-                            info!("I will try processing the inbox later based on the given round timeout: {:?}", new_timeout);
+                            info!(
+                                "{} blocks created. I will try processing the inbox later based \
+                                 on the given round timeout: {new_timeout:?}",
+                                certs.len(),
+                            );
                             timeout = new_timeout.timestamp;
                         }
                     }


### PR DESCRIPTION
## Motivation

In the chain listener we automatically process the inbox when we are notified about an incoming message. If we don't own the chain in question, we skip this.

However, we currently don't reset the timeout, so this would retry processing the inbox repeatedly.

## Proposal

Reset the timeout in _all_ cases. Also fix a few log statements.

## Test Plan

This was found running `test_wasm_end_to_end_social_user_pub_sub::storage_service_grpc` locally: It doesn't make the test fail, but it creates a lot of log messages.

## Release Plan

- We should release a patch version of the client to fix this.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
