### PR TITLE
publish-data-blob should return the hash, not blob ID.

### DIFF
--- a/linera-client/src/client_context.rs
+++ b/linera-client/src/client_context.rs
@@ -54,7 +54,7 @@ use {
     linera_base::{
         crypto::CryptoHash,
         data_types::{BlobContent, Bytecode},
-        identifiers::{BlobId, BytecodeId},
+        identifiers::BytecodeId,
     },
     std::path::PathBuf,
 };
@@ -440,7 +440,7 @@ where
         &mut self,
         chain_client: &ChainClient<NodeProvider, S>,
         blob_path: PathBuf,
-    ) -> Result<BlobId, Error> {
+    ) -> Result<CryptoHash, Error> {
         info!("Loading data blob file");
         let blob_content = BlobContent::load_from_file(&blob_path)
             .await
@@ -463,7 +463,7 @@ where
         .await?;
 
         info!("{}", "Data blob published successfully!");
-        Ok(BlobId::new_data(&blob_content))
+        Ok(CryptoHash::new(&blob_content))
     }
 
     // TODO(#2490): Consider removing or renaming this.

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -46,11 +46,6 @@ A blob of binary data.
 scalar BlobContent
 
 """
-A content-addressed blob ID i.e. the hash of the `BlobContent`
-"""
-scalar BlobId
-
-"""
 A block containing operations to apply on a given chain, as well as the
 acknowledgment of a number of incoming messages from other chains.
 * Incoming messages must be selected in the order they were
@@ -672,7 +667,7 @@ type MutationRoot {
 	"""
 	Publishes a new data blob.
 	"""
-	publishDataBlob(chainId: ChainId!, blobContent: BlobContent!): BlobId!
+	publishDataBlob(chainId: ChainId!, blobContent: BlobContent!): CryptoHash!
 	"""
 	Creates a new application.
 	"""

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -20,7 +20,7 @@ use linera_base::{
     command::{resolve_binary, CommandExt},
     crypto::{CryptoHash, PublicKey},
     data_types::{Amount, BlobContent, Bytecode},
-    identifiers::{Account, ApplicationId, BlobId, BytecodeId, ChainId, MessageId, Owner},
+    identifiers::{Account, ApplicationId, BytecodeId, ChainId, MessageId, Owner},
 };
 use linera_client::{config::GenesisConfig, wallet::Wallet};
 use linera_core::worker::Notification;
@@ -720,7 +720,7 @@ impl ClientWrapper {
         &self,
         path: &Path,
         chain_id: Option<ChainId>,
-    ) -> Result<BlobId> {
+    ) -> Result<CryptoHash> {
         let mut command = self.command().await?;
         command.arg("publish-data-blob").arg(path);
         if let Some(chain_id) = chain_id {
@@ -728,7 +728,7 @@ impl ClientWrapper {
         }
         let stdout = command.spawn_and_wait_for_stdout().await?;
         let stdout = stdout.trim();
-        BlobId::from_str(stdout)
+        Ok(CryptoHash::from_str(stdout)?)
     }
 
     /// Runs `linera read-data-blob`.
@@ -953,7 +953,7 @@ impl NodeService {
         &self,
         chain_id: &ChainId,
         blob_content: &BlobContent,
-    ) -> Result<BlobId> {
+    ) -> Result<CryptoHash> {
         let query = format!(
             "mutation {{ publishDataBlob(chainId: {}, blobContent: {}) }}",
             chain_id.to_value(),

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -848,9 +848,8 @@ impl Runnable for Job {
                 let publisher = publisher.unwrap_or_else(|| context.default_chain());
                 info!("Publishing data blob on chain {}", publisher);
                 let chain_client = context.make_chain_client(publisher);
-                // TODO(#2491): PublishDataBlob should return a CryptoHash.
-                let blob_id = context.publish_data_blob(&chain_client, blob_path).await?;
-                println!("{}", blob_id);
+                let hash = context.publish_data_blob(&chain_client, blob_path).await?;
+                println!("{}", hash);
                 info!("Time elapsed: {} ms", start_time.elapsed().as_millis());
             }
 

--- a/linera-service/src/node_service.rs
+++ b/linera-service/src/node_service.rs
@@ -23,7 +23,7 @@ use linera_base::{
         Amount, ApplicationPermissions, BlobContent, Bytecode, TimeDelta, Timestamp,
         UserApplicationDescription,
     },
-    identifiers::{ApplicationId, BlobId, BytecodeId, ChainId, Owner, UserApplicationId},
+    identifiers::{ApplicationId, BytecodeId, ChainId, Owner, UserApplicationId},
     ownership::{ChainOwnership, TimeoutConfig},
     BcsHexParseError,
 };
@@ -614,8 +614,8 @@ where
         &self,
         chain_id: ChainId,
         blob_content: BlobContent,
-    ) -> Result<BlobId, Error> {
-        let blob_id = BlobId::new_data(&blob_content);
+    ) -> Result<CryptoHash, Error> {
+        let hash = CryptoHash::new(&blob_content);
         self.apply_client_command(&chain_id, move |client| {
             let blob_content = blob_content.clone();
             async move {
@@ -623,7 +623,7 @@ where
                     .publish_data_blob(blob_content)
                     .await
                     .map_err(Error::from)
-                    .map(|outcome| outcome.map(|_| blob_id));
+                    .map(|outcome| outcome.map(|_| hash));
                 (result, client)
             }
         })

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -984,10 +984,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
 
     let nft1_blob = Blob::test_data_blob("nft1_data");
     let nft1_blob_id = nft1_blob.id();
-    let blob_id = node_service1
+    let blob_hash = node_service1
         .publish_data_blob(&chain1, nft1_blob.content())
         .await?;
-    assert_eq!(nft1_blob_id, blob_id);
+    assert_eq!(nft1_blob_id.hash, blob_hash);
 
     let nft1_blob_hash = DataBlobHash(nft1_blob_id.hash);
 
@@ -1114,10 +1114,10 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     let nft2_minter = account_owner2;
     let nft2_blob = Blob::test_data_blob("nft2_data");
     let nft2_blob_id = nft2_blob.id();
-    let blob_id = node_service2
+    let blob_hash = node_service2
         .publish_data_blob(&chain2, nft2_blob.content())
         .await?;
-    assert_eq!(nft2_blob_id, blob_id);
+    assert_eq!(nft2_blob_id.hash, blob_hash);
 
     let nft2_blob_hash = DataBlobHash(nft2_blob_id.hash);
 
@@ -2727,9 +2727,9 @@ async fn test_end_to_end_publish_data_blob_in_cli(config: impl LineraNetConfig) 
     let mut f = std::fs::File::create_new(&path)?;
     std::io::Write::write_all(&mut f, b"Hello, world!")?;
 
-    let blob_id = client1.publish_data_blob(&path, None).await?;
-    client2.read_data_blob(blob_id.hash, None).await?;
-    client1.read_data_blob(blob_id.hash, None).await?;
+    let blob_hash = client1.publish_data_blob(&path, None).await?;
+    client2.read_data_blob(blob_hash, None).await?;
+    client1.read_data_blob(blob_hash, None).await?;
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

Data blobs are identified by the hash of their content. Blob IDs are an internal concept.

Currently the `publish-data-blob` command and the `publishDataBlob` node service mutation return blob IDs.

## Proposal

Make them return the hashes instead.

## Test Plan

The tests have been updated.

## Links

- Closes https://github.com/linera-io/linera-protocol/issues/2491.
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
