### PR TITLE
fix rust-toolchain for examples

### DIFF
--- a/examples/llm/rust-toolchain.toml
+++ b/examples/llm/rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-channel = "1.81.0"
-components = [ "clippy", "rustfmt", "rust-src" ]
-targets = [ "wasm32-unknown-unknown" ]
-profile = "minimal"

--- a/examples/rust-toolchain.toml
+++ b/examples/rust-toolchain.toml
@@ -1,0 +1,1 @@
+../rust-toolchain.toml


### PR DESCRIPTION
## Motivation

I was running `linera project publish` from `examples` and run into a compiler error due to version mismatch

## Proposal

Create a toolchain file in `example/`.

## Test Plan

CI + tested manually
