### PR TITLE
Add a fuel limit for blocks.

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -401,6 +401,7 @@ View or update the resource control policy
 * `--operation-byte <OPERATION_BYTE>` — Set the additional price for each byte in the argument of a user operation
 * `--message <MESSAGE>` — Set the base price of sending a message from a block..
 * `--message-byte <MESSAGE_BYTE>` — Set the additional price for each byte in the argument of a user message
+* `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block
@@ -461,6 +462,7 @@ Create genesis configuration for a Linera deployment. Create initial user chains
 * `--message-byte-price <MESSAGE_BYTE_PRICE>` — Set the additional price for each byte in the argument of a user message
 
   Default value: `0`
+* `--maximum-fuel-per-block <MAXIMUM_FUEL_PER_BLOCK>` — Set the maximum amount of fuel per block
 * `--maximum-executed-block-size <MAXIMUM_EXECUTED_BLOCK_SIZE>` — Set the maximum size of an executed block
 * `--maximum-bytes-read-per-block <MAXIMUM_BYTES_READ_PER_BLOCK>` — Set the maximum read data per block
 * `--maximum-bytes-written-per-block <MAXIMUM_BYTES_WRITTEN_PER_BLOCK>` — Set the maximum write data per block

--- a/examples/amm/README.md
+++ b/examples/amm/README.md
@@ -104,7 +104,7 @@ To properly setup the tokens in the proper chains, we need to do some transfer o
 
 - Transfer 50 FUN1 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_1` in `$CHAIN_1`, so they're in the proper chain.
   Run `echo "http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID"` to print the URL
-  of the GrahpiQL interface for the FUN1 app. Navigate to that URL and enter:
+  of the GraphiQL interface for the FUN1 app. Navigate to that URL and enter:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID
     mutation {

--- a/examples/amm/src/lib.rs
+++ b/examples/amm/src/lib.rs
@@ -108,7 +108,7 @@ To properly setup the tokens in the proper chains, we need to do some transfer o
 
 - Transfer 50 FUN1 from `$OWNER_AMM` in `$CHAIN_AMM` to `$OWNER_1` in `$CHAIN_1`, so they're in the proper chain.
   Run `echo "http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID"` to print the URL
-  of the GrahpiQL interface for the FUN1 app. Navigate to that URL and enter:
+  of the GraphiQL interface for the FUN1 app. Navigate to that URL and enter:
 
 ```gql,uri=http://localhost:8080/chains/$CHAIN_AMM/applications/$FUN1_APP_ID
     mutation {

--- a/linera-chain/src/unit_tests/chain_tests.rs
+++ b/linera-chain/src/unit_tests/chain_tests.rs
@@ -106,7 +106,7 @@ async fn test_block_size_limit() {
     let mut chain = ChainStateView::new(chain_id).await;
 
     // The size of the executed valid block below.
-    let maximum_executed_block_size = 667;
+    let maximum_executed_block_size = 675;
 
     // Initialize the chain.
     let mut config = make_open_chain_config();

--- a/linera-client/src/client_options.rs
+++ b/linera-client/src/client_options.rs
@@ -511,6 +511,10 @@ pub enum ClientCommand {
         #[arg(long)]
         message_byte: Option<Amount>,
 
+        /// Set the maximum amount of fuel per block.
+        #[arg(long)]
+        maximum_fuel_per_block: Option<u64>,
+
         /// Set the maximum size of an executed block.
         #[arg(long)]
         maximum_executed_block_size: Option<u64>,
@@ -620,6 +624,10 @@ pub enum ClientCommand {
         /// Set the additional price for each byte in the argument of a user message.
         #[arg(long, default_value = "0")]
         message_byte_price: Amount,
+
+        /// Set the maximum amount of fuel per block.
+        #[arg(long)]
+        maximum_fuel_per_block: Option<u64>,
 
         /// Set the maximum size of an executed block.
         #[arg(long)]

--- a/linera-execution/src/lib.rs
+++ b/linera-execution/src/lib.rs
@@ -148,6 +148,8 @@ pub enum ExecutionError {
     ExcessiveRead,
     #[error("Excessive number of bytes written to storage")]
     ExcessiveWrite,
+    #[error("Block execution required too much fuel")]
+    MaximumFuelExceeded,
     #[error("Serialized size of the executed block exceeds limit")]
     ExecutedBlockTooLarge,
     #[error("Runtime failed to respond to application")]

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -3,6 +3,8 @@
 
 //! This module contains types related to fees and pricing.
 
+use std::fmt;
+
 use async_graphql::InputObject;
 use linera_base::data_types::{Amount, ArithmeticError, Resources};
 use serde::{Deserialize, Serialize};
@@ -45,6 +47,47 @@ pub struct ResourceControlPolicy {
     pub maximum_bytes_read_per_block: u64,
     /// The maximum data to write per block
     pub maximum_bytes_written_per_block: u64,
+}
+
+impl fmt::Display for ResourceControlPolicy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ResourceControlPolicy {
+            block,
+            fuel_unit,
+            read_operation,
+            write_operation,
+            byte_read,
+            byte_written,
+            byte_stored,
+            operation,
+            operation_byte,
+            message,
+            message_byte,
+            maximum_fuel_per_block,
+            maximum_executed_block_size,
+            maximum_bytes_read_per_block,
+            maximum_bytes_written_per_block,
+        } = self;
+        write!(
+            f,
+            "Resource control policy:\n\
+            {block:.2} base cost per block\n\
+            {fuel_unit:.2} cost per fuel unit\n\
+            {read_operation:.2} cost per read operation\n\
+            {write_operation:.2} cost per write operation\n\
+            {byte_read:.2} cost per byte read\n\
+            {byte_written:.2} cost per byte written\n\
+            {byte_stored:.2} cost per byte stored\n\
+            {operation:.2} per operation\n\
+            {operation_byte:.2} per byte in the argument of an operation\n\
+            {message:.2} per outgoing messages\n\
+            {message_byte:.2} per byte in the argument of an outgoing messages\n\
+            {maximum_fuel_per_block} maximum fuel per block\n\
+            {maximum_executed_block_size} maximum size of an executed block\n\
+            {maximum_bytes_read_per_block} maximum number bytes read per block\n\
+            {maximum_bytes_written_per_block} maximum number bytes written per block",
+        )
+    }
 }
 
 impl Default for ResourceControlPolicy {

--- a/linera-execution/src/policy.rs
+++ b/linera-execution/src/policy.rs
@@ -36,6 +36,8 @@ pub struct ResourceControlPolicy {
 
     // TODO(#1538): Cap the number of transactions per block and the total size of their
     // arguments.
+    /// The maximum amount of fuel a block can consume.
+    pub maximum_fuel_per_block: u64,
     /// The maximum size of an executed block. This includes the block proposal itself as well as
     /// the execution outcome.
     pub maximum_executed_block_size: u64,
@@ -59,6 +61,7 @@ impl Default for ResourceControlPolicy {
             operation_byte: Amount::default(),
             message: Amount::default(),
             message_byte: Amount::default(),
+            maximum_fuel_per_block: u64::MAX,
             maximum_executed_block_size: u64::MAX,
             maximum_bytes_read_per_block: u64::MAX,
             maximum_bytes_written_per_block: u64::MAX,
@@ -177,6 +180,7 @@ impl ResourceControlPolicy {
             operation_byte: Amount::from_nanos(10),
             operation: Amount::from_micros(10),
             message: Amount::from_micros(10),
+            maximum_fuel_per_block: 100_000_000,
             maximum_executed_block_size: 1_000_000,
             maximum_bytes_read_per_block: 100_000_000,
             maximum_bytes_written_per_block: 10_000_000,

--- a/linera-execution/src/resources.rs
+++ b/linera-execution/src/resources.rs
@@ -73,7 +73,7 @@ pub trait BalanceHolder {
 impl<Account, Tracker> ResourceController<Account, Tracker>
 where
     Account: BalanceHolder,
-    Tracker: AsMut<ResourceTracker>,
+    Tracker: AsRef<ResourceTracker> + AsMut<ResourceTracker>,
 {
     /// Obtains the balance of the account. The only possible error is an arithmetic
     /// overflow, which should not happen in practice due to final token supply.
@@ -111,6 +111,11 @@ where
     pub(crate) fn remaining_fuel(&self) -> u64 {
         self.policy
             .remaining_fuel(self.balance().unwrap_or(Amount::MAX))
+            .min(
+                self.policy
+                    .maximum_fuel_per_block
+                    .saturating_sub(self.tracker.as_ref().fuel),
+            )
     }
 
     /// Tracks the allocation of a grant.
@@ -184,10 +189,14 @@ where
     pub(crate) fn track_fuel(&mut self, fuel: u64) -> Result<(), ExecutionError> {
         self.tracker.as_mut().fuel = self
             .tracker
-            .as_mut()
+            .as_ref()
             .fuel
             .checked_add(fuel)
             .ok_or(ArithmeticError::Overflow)?;
+        ensure!(
+            self.tracker.as_ref().fuel <= self.policy.maximum_fuel_per_block,
+            ExecutionError::MaximumFuelExceeded
+        );
         self.update_balance(self.policy.fuel_price(fuel)?)
     }
 
@@ -324,6 +333,12 @@ impl BalanceHolder for Amount {
 // See https://doc.rust-lang.org/std/convert/trait.AsMut.html#reflexivity for general context.
 impl AsMut<ResourceTracker> for ResourceTracker {
     fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl AsRef<ResourceTracker> for ResourceTracker {
+    fn as_ref(&self) -> &Self {
         self
     }
 }

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -146,9 +146,10 @@ async fn test_fee_consumption(
         operation_byte: Amount::from_tokens(23),
         message: Amount::from_tokens(29),
         message_byte: Amount::from_tokens(31),
-        maximum_executed_block_size: 37,
-        maximum_bytes_read_per_block: 41,
-        maximum_bytes_written_per_block: 43,
+        maximum_fuel_per_block: 37,
+        maximum_executed_block_size: 41,
+        maximum_bytes_read_per_block: 43,
+        maximum_bytes_written_per_block: 47,
     };
 
     let consumed_fees = spends

--- a/linera-execution/tests/fee_consumption.rs
+++ b/linera-execution/tests/fee_consumption.rs
@@ -146,10 +146,10 @@ async fn test_fee_consumption(
         operation_byte: Amount::from_tokens(23),
         message: Amount::from_tokens(29),
         message_byte: Amount::from_tokens(31),
-        maximum_fuel_per_block: 37,
-        maximum_executed_block_size: 41,
-        maximum_bytes_read_per_block: 43,
-        maximum_bytes_written_per_block: 47,
+        maximum_fuel_per_block: 4_868_145_137,
+        maximum_executed_block_size: 37,
+        maximum_bytes_read_per_block: 41,
+        maximum_bytes_written_per_block: 43,
     };
 
     let consumed_fees = spends

--- a/linera-rpc/tests/snapshots/format__format.yaml.snap
+++ b/linera-rpc/tests/snapshots/format__format.yaml.snap
@@ -727,6 +727,7 @@ ResourceControlPolicy:
         TYPENAME: Amount
     - message_byte:
         TYPENAME: Amount
+    - maximum_fuel_per_block: U64
     - maximum_executed_block_size: U64
     - maximum_bytes_read_per_block: U64
     - maximum_bytes_written_per_block: U64

--- a/linera-service-graphql-client/gql/service_schema.graphql
+++ b/linera-service-graphql-client/gql/service_schema.graphql
@@ -856,6 +856,10 @@ input ResourceControlPolicy {
 	"""
 	messageByte: Amount!
 	"""
+	The maximum amount of fuel a block can consume.
+	"""
+	maximumFuelPerBlock: Int!
+	"""
 	The maximum size of an executed block. This includes the block proposal itself as well as
 	the execution outcome.
 	"""

--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -180,6 +180,7 @@ impl ClientWrapper {
             operation_byte,
             message,
             message_byte,
+            maximum_fuel_per_block,
             maximum_executed_block_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
@@ -204,6 +205,10 @@ impl ClientWrapper {
             .args(["--operation-price", &operation.to_string()])
             .args(["--operation-byte-price", &operation_byte.to_string()])
             .args(["--message-price", &message.to_string()])
+            .args([
+                "--maximum-fuel-per-block",
+                &maximum_fuel_per_block.to_string(),
+            ])
             .args([
                 "--maximum-executed-block-size",
                 &maximum_executed_block_size.to_string(),

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -534,6 +534,7 @@ impl Runnable for Job {
                                     operation_byte,
                                     message,
                                     message_byte,
+                                    maximum_fuel_per_block,
                                     maximum_executed_block_size,
                                     maximum_bytes_read_per_block,
                                     maximum_bytes_written_per_block,
@@ -571,6 +572,9 @@ impl Runnable for Job {
                                     if let Some(message_byte) = message_byte {
                                         policy.message_byte = message_byte;
                                     }
+                                    if let Some(maximum_fuel_per_block) = maximum_fuel_per_block {
+                                        policy.maximum_fuel_per_block = maximum_fuel_per_block;
+                                    }
                                     if let Some(maximum_executed_block_size) =
                                         maximum_executed_block_size
                                     {
@@ -591,20 +595,21 @@ impl Runnable for Job {
                                     }
                                     info!(
                                         "ResourceControlPolicy:\n\
-                            {:.2} base cost per block\n\
-                            {:.2} cost per fuel unit\n\
-                            {:.2} cost per read operation\n\
-                            {:.2} cost per write operation\n\
-                            {:.2} cost per byte read\n\
-                            {:.2} cost per byte written\n\
-                            {:.2} cost per byte stored\n\
-                            {:.2} per operation\n\
-                            {:.2} per byte in the argument of an operation\n\
-                            {:.2} per outgoing messages\n\
-                            {:.2} per byte in the argument of an outgoing messages\n\
-                            {:.2} maximum size of an executed block\n\
-                            {:.2} maximum number bytes read per block\n\
-                            {:.2} maximum number bytes written per block",
+                                        {:.2} base cost per block\n\
+                                        {:.2} cost per fuel unit\n\
+                                        {:.2} cost per read operation\n\
+                                        {:.2} cost per write operation\n\
+                                        {:.2} cost per byte read\n\
+                                        {:.2} cost per byte written\n\
+                                        {:.2} cost per byte stored\n\
+                                        {:.2} per operation\n\
+                                        {:.2} per byte in the argument of an operation\n\
+                                        {:.2} per outgoing messages\n\
+                                        {:.2} per byte in the argument of an outgoing messages\n\
+                                        {} maximum fuel per block\n\
+                                        {} maximum size of an executed block\n\
+                                        {} maximum number bytes read per block\n\
+                                        {} maximum number bytes written per block",
                                         policy.block,
                                         policy.fuel_unit,
                                         policy.read_operation,
@@ -616,6 +621,7 @@ impl Runnable for Job {
                                         policy.operation_byte,
                                         policy.message,
                                         policy.message_byte,
+                                        policy.maximum_fuel_per_block,
                                         policy.maximum_executed_block_size,
                                         policy.maximum_bytes_read_per_block,
                                         policy.maximum_bytes_written_per_block
@@ -631,6 +637,7 @@ impl Runnable for Job {
                                         && operation_byte.is_none()
                                         && message.is_none()
                                         && message_byte.is_none()
+                                        && maximum_fuel_per_block.is_none()
                                         && maximum_executed_block_size.is_none()
                                         && maximum_bytes_read_per_block.is_none()
                                         && maximum_bytes_written_per_block.is_none()
@@ -1356,6 +1363,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
             operation_byte_price,
             message_price,
             message_byte_price,
+            maximum_fuel_per_block,
             maximum_executed_block_size,
             maximum_bytes_read_per_block,
             maximum_bytes_written_per_block,
@@ -1364,6 +1372,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
         } => {
             let committee_config: CommitteeConfig = util::read_json(committee_config_path)
                 .expect("Unable to read committee config file");
+            let maximum_fuel_per_block = maximum_fuel_per_block.unwrap_or(u64::MAX);
             let maximum_bytes_read_per_block = maximum_bytes_read_per_block.unwrap_or(u64::MAX);
             let maximum_bytes_written_per_block =
                 maximum_bytes_written_per_block.unwrap_or(u64::MAX);
@@ -1380,6 +1389,7 @@ async fn run(options: &ClientOptions) -> anyhow::Result<()> {
                 operation: *operation_price,
                 message_byte: *message_byte_price,
                 message: *message_price,
+                maximum_fuel_per_block,
                 maximum_executed_block_size,
                 maximum_bytes_read_per_block,
                 maximum_bytes_written_per_block,

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -593,55 +593,8 @@ impl Runnable for Job {
                                         policy.maximum_bytes_written_per_block =
                                             maximum_bytes_written_per_block;
                                     }
-                                    info!(
-                                        "ResourceControlPolicy:\n\
-                                        {:.2} base cost per block\n\
-                                        {:.2} cost per fuel unit\n\
-                                        {:.2} cost per read operation\n\
-                                        {:.2} cost per write operation\n\
-                                        {:.2} cost per byte read\n\
-                                        {:.2} cost per byte written\n\
-                                        {:.2} cost per byte stored\n\
-                                        {:.2} per operation\n\
-                                        {:.2} per byte in the argument of an operation\n\
-                                        {:.2} per outgoing messages\n\
-                                        {:.2} per byte in the argument of an outgoing messages\n\
-                                        {} maximum fuel per block\n\
-                                        {} maximum size of an executed block\n\
-                                        {} maximum number bytes read per block\n\
-                                        {} maximum number bytes written per block",
-                                        policy.block,
-                                        policy.fuel_unit,
-                                        policy.read_operation,
-                                        policy.write_operation,
-                                        policy.byte_read,
-                                        policy.byte_written,
-                                        policy.byte_stored,
-                                        policy.operation,
-                                        policy.operation_byte,
-                                        policy.message,
-                                        policy.message_byte,
-                                        policy.maximum_fuel_per_block,
-                                        policy.maximum_executed_block_size,
-                                        policy.maximum_bytes_read_per_block,
-                                        policy.maximum_bytes_written_per_block
-                                    );
-                                    if block.is_none()
-                                        && fuel_unit.is_none()
-                                        && read_operation.is_none()
-                                        && write_operation.is_none()
-                                        && byte_read.is_none()
-                                        && byte_written.is_none()
-                                        && byte_stored.is_none()
-                                        && operation.is_none()
-                                        && operation_byte.is_none()
-                                        && message.is_none()
-                                        && message_byte.is_none()
-                                        && maximum_fuel_per_block.is_none()
-                                        && maximum_executed_block_size.is_none()
-                                        && maximum_bytes_read_per_block.is_none()
-                                        && maximum_bytes_written_per_block.is_none()
-                                    {
+                                    info!("{policy}");
+                                    if committee.policy() == &policy {
                                         return Ok(ClientOutcome::Committed(None));
                                     }
                                 }


### PR DESCRIPTION
## Motivation

Block execution time needs to be limited.

## Proposal

Add a per-block fuel limit to the resource control policy. This doesn't address the problem completely yet: We also need to limit some oracle and host function calls.

## Test Plan

I added a client test.

## Links

- Part of https://github.com/linera-io/linera-protocol/issues/2457
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
