### PR TITLE
Add an end-to-end test that doubles as a latency benchmark.

### DIFF
--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -3046,8 +3046,11 @@ async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Res
             .transfer(Amount::from_attos(1), chain1, chain2)
             .await
             .unwrap();
+        let timeout = Instant::now() + Duration::from_secs(1);
         loop {
-            let sleep = Box::pin(linera_base::time::timer::sleep(Duration::from_secs(5)));
+            let sleep = Box::pin(linera_base::time::timer::sleep(
+                timeout.duration_since(Instant::now()),
+            ));
             match future::select(notifications2.next(), sleep).await {
                 Either::Right(((), _)) | Either::Left((None, _)) => {
                     panic!("Failed to receive notification about transfer #{i}.")

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -12,18 +12,26 @@
 
 mod common;
 
-use std::{env, time::Duration};
+use std::{
+    env,
+    time::{Duration, Instant},
+};
 
 use anyhow::Result;
 use async_graphql::InputType;
 use common::INTEGRATION_TEST_GUARD;
-use futures::{channel::mpsc, SinkExt, StreamExt};
+use futures::{
+    channel::mpsc,
+    future::{self, Either},
+    SinkExt, StreamExt,
+};
 use linera_base::{
     command::resolve_binary,
     data_types::{Amount, Blob},
     identifiers::{Account, AccountOwner, ApplicationId, ChainId},
 };
-use linera_sdk::DataBlobHash;
+use linera_core::worker::{Notification, Reason};
+use linera_sdk::{base::BlockHeight, DataBlobHash};
 #[cfg(any(
     feature = "dynamodb",
     feature = "scylladb",
@@ -2974,6 +2982,80 @@ async fn test_end_to_end_listen_for_new_rounds(config: impl LineraNetConfig) -> 
     let (result1, result2) = futures::join!(handle1, handle2);
     assert!(result1?.is_err());
     assert!(result2?.is_err());
+
+    net.ensure_is_running().await?;
+    net.terminate().await?;
+
+    Ok(())
+}
+
+/// Tests token transfers between two chains and measures the latency.
+///
+/// To use this as a benchmark, make sure to run it with `--nocapture`, e.g.:
+///
+/// ```bash
+/// RUST_LOG=info cargo test -p linera-service \
+///     --features storage-service
+///     test_end_to_end_repeated_transfers::storage_service_grpc \
+///     -- --nocapture
+/// ```
+///
+/// It will print the average end-to-end transfer latency, including creating the sending block,
+/// the receiving block, and the resulting `NewBlock` notification.
+#[cfg_attr(feature = "storage-service", test_case(LocalNetConfig::new_test(Database::Service, Network::Grpc) ; "storage_service_grpc"))]
+#[cfg_attr(feature = "scylladb", test_case(LocalNetConfig::new_test(Database::ScyllaDb, Network::Grpc) ; "scylladb_grpc"))]
+#[cfg_attr(feature = "dynamodb", test_case(LocalNetConfig::new_test(Database::DynamoDb, Network::Grpc) ; "aws_grpc"))]
+#[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
+#[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
+#[test_log::test(tokio::test)]
+async fn test_end_to_end_repeated_transfers(config: impl LineraNetConfig) -> Result<()> {
+    let _guard = INTEGRATION_TEST_GUARD.lock().await;
+    tracing::info!("Starting test {}", test_name!());
+
+    const TRANSFER_COUNT: usize = 100;
+
+    let (mut net, client1) = config.instantiate().await?;
+    let chain1 = client1.load_wallet()?.default_chain().unwrap();
+    let client2 = net.make_client().await;
+    client2.wallet_init(&[], FaucetOption::None).await?;
+    let chain2 = client1.open_and_assign(&client2, Amount::ONE).await?;
+    let node_service2 = client2
+        .run_node_service(None, ProcessInbox::Automatic)
+        .await?;
+    let mut notifications2 = Box::pin(node_service2.notifications(chain2).await.unwrap());
+
+    let start_time = Instant::now();
+    for i in 0..TRANSFER_COUNT {
+        client1
+            .transfer(Amount::from_attos(1), chain1, chain2)
+            .await
+            .unwrap();
+        loop {
+            let sleep = Box::pin(linera_base::time::timer::sleep(Duration::from_secs(5)));
+            match future::select(notifications2.next(), sleep).await {
+                Either::Right(((), _)) | Either::Left((None, _)) => {
+                    panic!("Failed to receive notification about transfer #{i}.")
+                }
+                Either::Left((Some(Err(error)), _)) => {
+                    panic!("Error waiting for notification about transfer #{i}: {error}")
+                }
+                Either::Left((
+                    Some(Ok(Notification {
+                        reason: Reason::NewBlock { height, .. },
+                        chain_id,
+                    })),
+                    _,
+                )) if height == BlockHeight(i as u64 + 1) && chain_id == chain2 => {
+                    break;
+                }
+                Either::Left((Some(Ok(_)), _)) => {}
+            }
+        }
+    }
+    tracing::info!(
+        "Average end-to-end transfer latency: {} ms",
+        (start_time.elapsed() / (TRANSFER_COUNT as u32)).as_millis()
+    );
 
     net.ensure_is_running().await?;
     net.terminate().await?;


### PR DESCRIPTION
## Motivation

We want to get better performance measurements, so we can optimize end-to-end latency.

## Proposal

Add an end-to-end test that makes a number of transfers in a loop.

In each iteration it waits until the receiver gets a `NewBlock` notification, so the loop only continues after:
* the sender's block has been confirmed,
* the receiver's node service got a notification and ran `process_inbox_without_prepare`,
* the receiver's block got confirmed.

The number of iterations is configurable using the `LINERA_TEST_ITERATIONS` environment variable. This also applies to the `test_end_to_end_faucet_with_long_chains` test.

## Test Plan

This runs with 100 iterations in CI.

Locally, one can use

```bash
LINERA_TEST_ITERATIONS=250 RUST_LOG=info cargo test -p linera-service \
    --features storage-service
    test_end_to_end_repeated_transfers::storage_service_grpc \
    -- --nocapture
```

This will print the latency in a log message towards the end:

```
INFO linera_net_tests: 250 transfers completed. Average end-to-end latency: 517 ms
```

With the `remote-net` flag it can also run against a (compatible) devnet or testnet.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
