### PR TITLE
Resend proposal if both messages and blobs are missing.

### DIFF
--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -975,7 +975,13 @@ where
         proposal: BlockProposal,
         value: HashedCertificateValue,
     ) -> Result<Certificate, ChainClientError> {
-        let submit_action = CommunicateAction::SubmitBlock { proposal };
+        let blob_ids = value
+            .inner()
+            .executed_block()
+            .expect("The result of executing a proposal is always an executed block")
+            .outcome
+            .required_blob_ids();
+        let submit_action = CommunicateAction::SubmitBlock { proposal, blob_ids };
         let certificate = self
             .communicate_chain_action(committee, submit_action, value)
             .await?;

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -264,13 +264,6 @@ where
                 self.send_chain_information_for_senders(chain_id).await?;
                 self.node.handle_block_proposal(proposal.clone()).await?
             }
-            Err(ref e @ NodeError::BlobsNotFound(ref blob_ids)) => {
-                if !blob_ids.is_empty() {
-                    return Err(e.clone());
-                }
-
-                self.node.handle_block_proposal(proposal.clone()).await?
-            }
             Err(NodeError::BlobNotFoundOnRead(blob_id)) => {
                 // For `BlobNotFoundOnRead`, we assume that the local node should already be
                 // updated with the needed blobs, so sending the chain information about the

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -260,7 +260,7 @@ where
         let chain_id = proposal.content.block.chain_id;
         let mut sent_cross_chain_updates = false;
         for blob in &proposal.blobs {
-            blob_ids.remove(&blob.id());
+            blob_ids.remove(&blob.id()); // Keep only blobs we may need to resend.
         }
         loop {
             match self.node.handle_block_proposal(proposal.clone()).await {
@@ -295,7 +295,6 @@ where
                         let last_used_by_hash =
                             local_storage.read_blob_state(blob_id).await?.last_used_by;
                         let certificate = local_storage.read_certificate(last_used_by_hash).await?;
-
                         let block_chain_id = certificate.value().chain_id();
                         let block_height = certificate.value().height();
                         self.send_chain_information(
@@ -306,10 +305,8 @@ where
                         .await?;
                     }
                 }
-                Err(e) => {
-                    // Fail immediately on other errors.
-                    return Err(e);
-                }
+                // Fail immediately on other errors.
+                Err(e) => return Err(e),
             }
         }
     }


### PR DESCRIPTION
## Motivation

When the client sends a block proposal to a validator, and the block reads blobs or receives messages it doesn't know, the sends back a corresponding error message and the client sends the missing data.

Currently, if _both_ messages _and_ blobs are missing, it only sends one of the missing pieces and then fails.

## Proposal

In that case, retry twice, to make sure the validator has all the data.

Also, to reduce round-trips, if the validator complains about _one_ missing blob, we send _all_ missing blobs. This is similar to what we do for messages.

## Test Plan

A regression test was added. This fails without the fix.

## Release Plan

Since this is a client-side fix, it could easily be backported, if needed.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
