### PR TITLE
Remove LocalValidatorNode(Provider) and LocalNotificationStream

### DIFF
--- a/linera-client/src/chain_listener.rs
+++ b/linera-client/src/chain_listener.rs
@@ -17,7 +17,7 @@ use linera_base::{
 use linera_chain::data_types::OutgoingMessage;
 use linera_core::{
     client::{ChainClient, ChainClientError},
-    node::{LocalValidatorNodeProvider, ValidatorNode, ValidatorNodeProvider},
+    node::{ValidatorNode, ValidatorNodeProvider},
     worker::Reason,
 };
 use linera_execution::{Message, SystemMessage};
@@ -60,7 +60,7 @@ pub struct ChainListenerConfig {
 #[cfg_attr(not(web), async_trait)]
 #[cfg_attr(web, async_trait(?Send))]
 pub trait ClientContext {
-    type ValidatorNodeProvider: LocalValidatorNodeProvider;
+    type ValidatorNodeProvider: ValidatorNodeProvider;
     type Storage: Storage;
 
     fn wallet(&self) -> &Wallet;

--- a/linera-client/src/wallet.rs
+++ b/linera-client/src/wallet.rs
@@ -13,7 +13,7 @@ use linera_base::{
     identifiers::{BlobId, ChainDescription, ChainId},
 };
 use linera_chain::data_types::Block;
-use linera_core::{client::ChainClient, node::LocalValidatorNodeProvider};
+use linera_core::{client::ChainClient, node::ValidatorNodeProvider};
 use linera_storage::Storage;
 use rand::Rng as _;
 use serde::{Deserialize, Serialize};
@@ -164,7 +164,7 @@ impl Wallet {
 
     pub async fn update_from_state<P, S>(&mut self, chain_client: &ChainClient<P, S>)
     where
-        P: LocalValidatorNodeProvider + Sync + 'static,
+        P: ValidatorNodeProvider + Sync + 'static,
         S: Storage + Clone + Send + Sync + 'static,
     {
         let key_pair = chain_client.key_pair().await.map(|k| k.copy()).ok();

--- a/linera-core/src/client.rs
+++ b/linera-core/src/client.rs
@@ -68,8 +68,8 @@ use crate::{
     },
     local_node::{LocalNodeClient, LocalNodeError, NamedNode},
     node::{
-        CrossChainMessageDelivery, LocalValidatorNode, LocalValidatorNodeProvider, NodeError,
-        NotificationStream,
+        CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
+        ValidatorNodeProvider,
     },
     notifier::Notifier,
     updater::{communicate_with_quorum, CommunicateAction, CommunicationError, ValidatorUpdater},
@@ -288,7 +288,7 @@ impl<P, S: Storage + Clone> Client<P, S> {
 
 impl<P, S> Client<P, S>
 where
-    P: LocalValidatorNodeProvider + Sync + 'static,
+    P: ValidatorNodeProvider + Sync + 'static,
     S: Storage + Sync + Send + Clone + 'static,
 {
     async fn download_certificates(
@@ -657,7 +657,7 @@ enum ReceiveCertificateMode {
 
 impl<P, S> ChainClient<P, S>
 where
-    P: LocalValidatorNodeProvider + Sync + 'static,
+    P: ValidatorNodeProvider + Sync + 'static,
     S: Storage + Clone + Send + Sync + 'static,
 {
     #[tracing::instrument(level = "trace")]

--- a/linera-core/src/local_node.rs
+++ b/linera-core/src/local_node.rs
@@ -31,7 +31,7 @@ use tracing::warn;
 
 use crate::{
     data_types::{BlockHeightRange, ChainInfo, ChainInfoQuery, ChainInfoResponse},
-    node::{CrossChainMessageDelivery, LocalValidatorNode, NodeError},
+    node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
     value_cache::ValueCache,
     worker::{Notification, WorkerError, WorkerState},
 };
@@ -256,7 +256,7 @@ where
     #[tracing::instrument(level = "trace", skip_all)]
     pub async fn try_process_certificates(
         &self,
-        named_node: &NamedNode<impl LocalValidatorNode>,
+        named_node: &NamedNode<impl ValidatorNode>,
         chain_id: ChainId,
         certificates: Vec<Certificate>,
         notifications: &mut impl Extend<Notification>,
@@ -364,7 +364,7 @@ where
     /// Downloads and processes all certificates up to (excluding) the specified height.
     pub async fn download_certificates(
         &self,
-        validators: &[NamedNode<impl LocalValidatorNode>],
+        validators: &[NamedNode<impl ValidatorNode>],
         chain_id: ChainId,
         target_next_block_height: BlockHeight,
         notifications: &mut impl Extend<Notification>,
@@ -424,7 +424,7 @@ where
     /// given validator.
     async fn try_download_certificates_from(
         &self,
-        named_node: &NamedNode<impl LocalValidatorNode>,
+        named_node: &NamedNode<impl ValidatorNode>,
         chain_id: ChainId,
         mut start: BlockHeight,
         stop: BlockHeight,
@@ -457,7 +457,7 @@ where
     #[tracing::instrument(level = "trace", skip_all)]
     async fn try_query_certificates_from(
         &self,
-        named_node: &NamedNode<impl LocalValidatorNode>,
+        named_node: &NamedNode<impl ValidatorNode>,
         chain_id: ChainId,
         start: BlockHeight,
         limit: u64,
@@ -483,7 +483,7 @@ where
 
     #[tracing::instrument(level = "trace", skip(validators))]
     async fn download_blob(
-        validators: &[NamedNode<impl LocalValidatorNode>],
+        validators: &[NamedNode<impl ValidatorNode>],
         blob_id: BlobId,
     ) -> Option<Blob> {
         // Sequentially try each validator in random order.
@@ -500,7 +500,7 @@ where
     #[tracing::instrument(level = "trace", skip(nodes))]
     pub async fn download_blobs(
         blob_ids: &[BlobId],
-        nodes: &[NamedNode<impl LocalValidatorNode>],
+        nodes: &[NamedNode<impl ValidatorNode>],
     ) -> Vec<Blob> {
         future::join_all(
             blob_ids
@@ -549,7 +549,7 @@ impl<N> fmt::Debug for NamedNode<N> {
 }
 
 #[allow(clippy::result_large_err)]
-impl<N: LocalValidatorNode> NamedNode<N> {
+impl<N: ValidatorNode> NamedNode<N> {
     pub async fn handle_chain_info_query(
         &self,
         query: ChainInfoQuery,

--- a/linera-core/src/node.rs
+++ b/linera-core/src/node.rs
@@ -2,7 +2,11 @@
 // Copyright (c) Zefchain Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::stream::{BoxStream, LocalBoxStream, Stream};
+#[cfg(not(web))]
+use futures::stream::BoxStream;
+#[cfg(web)]
+use futures::stream::LocalBoxStream as BoxStream;
+use futures::stream::Stream;
 use linera_base::{
     crypto::{CryptoError, CryptoHash},
     data_types::{ArithmeticError, Blob, BlobContent, BlockHeight},
@@ -28,8 +32,6 @@ use crate::{
 
 /// A pinned [`Stream`] of Notifications.
 pub type NotificationStream = BoxStream<'static, Notification>;
-/// A pinned [`Stream`] of Notifications, without the `Send` constraint.
-pub type LocalNotificationStream = LocalBoxStream<'static, Notification>;
 
 /// Whether to wait for the delivery of outgoing cross-chain messages.
 #[derive(Debug, Default, Clone, Copy)]

--- a/linera-core/src/unit_tests/test_utils.rs
+++ b/linera-core/src/unit_tests/test_utils.rs
@@ -54,8 +54,8 @@ use crate::{
     client::{ChainClient, Client},
     data_types::*,
     node::{
-        CrossChainMessageDelivery, LocalValidatorNodeProvider, NodeError, NotificationStream,
-        ValidatorNode,
+        CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
+        ValidatorNodeProvider,
     },
     notifier::Notifier,
     worker::{NetworkActions, Notification, WorkerState},
@@ -492,7 +492,7 @@ pub struct NodeProvider<S>(BTreeMap<ValidatorName, Arc<Mutex<LocalValidator<S>>>
 where
     S: Storage;
 
-impl<S> LocalValidatorNodeProvider for NodeProvider<S>
+impl<S> ValidatorNodeProvider for NodeProvider<S>
 where
     S: Storage + Clone + Send + Sync + 'static,
 {

--- a/linera-core/src/updater.rs
+++ b/linera-core/src/updater.rs
@@ -26,7 +26,7 @@ use tracing::{error, warn};
 use crate::{
     data_types::{ChainInfo, ChainInfoQuery},
     local_node::{LocalNodeClient, NamedNode},
-    node::{CrossChainMessageDelivery, LocalValidatorNode, NodeError},
+    node::{CrossChainMessageDelivery, NodeError, ValidatorNode},
 };
 
 /// The amount of time we wait for additional validators to contribute to the result, as a fraction
@@ -101,7 +101,7 @@ pub async fn communicate_with_quorum<'a, A, V, K, F, R, G>(
     execute: F,
 ) -> Result<(K, Vec<V>), CommunicationError<NodeError>>
 where
-    A: LocalValidatorNode + Clone + 'static,
+    A: ValidatorNode + Clone + 'static,
     F: Clone + Fn(NamedNode<A>) -> R,
     R: Future<Output = Result<V, NodeError>> + 'a,
     G: Fn(&V) -> K,
@@ -192,7 +192,7 @@ where
 
 impl<A, S> ValidatorUpdater<A, S>
 where
-    A: LocalValidatorNode + Clone + 'static,
+    A: ValidatorNode + Clone + 'static,
     S: Storage + Clone + Send + Sync + 'static,
 {
     async fn send_optimized_certificate(

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -9,13 +9,9 @@ use linera_base::{
 use linera_chain::data_types::{
     BlockProposal, Certificate, HashedCertificateValue, LiteCertificate,
 };
-#[cfg(web)]
-use linera_core::node::{LocalValidatorNode as ValidatorNode, NotificationStream};
-#[cfg(not(web))]
-use linera_core::node::{NotificationStream, ValidatorNode};
 use linera_core::{
     data_types::{ChainInfoQuery, ChainInfoResponse},
-    node::{CrossChainMessageDelivery, NodeError},
+    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
 };
 
 use crate::grpc::GrpcClient;

--- a/linera-rpc/src/client.rs
+++ b/linera-rpc/src/client.rs
@@ -10,9 +10,7 @@ use linera_chain::data_types::{
     BlockProposal, Certificate, HashedCertificateValue, LiteCertificate,
 };
 #[cfg(web)]
-use linera_core::node::{
-    LocalNotificationStream as NotificationStream, LocalValidatorNode as ValidatorNode,
-};
+use linera_core::node::{LocalValidatorNode as ValidatorNode, NotificationStream};
 #[cfg(not(web))]
 use linera_core::node::{NotificationStream, ValidatorNode};
 use linera_core::{

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -12,9 +12,7 @@ use linera_base::{
 };
 use linera_chain::data_types::{self, Certificate, CertificateValue, HashedCertificateValue};
 #[cfg(web)]
-use linera_core::node::{
-    LocalNotificationStream as NotificationStream, LocalValidatorNode as ValidatorNode,
-};
+use linera_core::node::{LocalValidatorNode as ValidatorNode, NotificationStream};
 use linera_core::{
     node::{CrossChainMessageDelivery, NodeError},
     worker::Notification,

--- a/linera-rpc/src/grpc/client.rs
+++ b/linera-rpc/src/grpc/client.rs
@@ -11,10 +11,8 @@ use linera_base::{
     time::Duration,
 };
 use linera_chain::data_types::{self, Certificate, CertificateValue, HashedCertificateValue};
-#[cfg(web)]
-use linera_core::node::{LocalValidatorNode as ValidatorNode, NotificationStream};
 use linera_core::{
-    node::{CrossChainMessageDelivery, NodeError},
+    node::{CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode},
     worker::Notification,
 };
 use linera_version::VersionInfo;
@@ -24,7 +22,6 @@ use tracing::{debug, info, instrument, warn};
 use {
     super::GrpcProtoConversionError,
     crate::{mass_client, RpcMessage},
-    linera_core::node::{NotificationStream, ValidatorNode},
 };
 
 use super::{

--- a/linera-rpc/src/grpc/node_provider.rs
+++ b/linera-rpc/src/grpc/node_provider.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr as _;
 
-use linera_core::node::{LocalValidatorNodeProvider, NodeError};
+use linera_core::node::{NodeError, ValidatorNodeProvider};
 
 use super::GrpcClient;
 use crate::{config::ValidatorPublicNetworkConfig, node_provider::NodeOptions};
@@ -17,7 +17,7 @@ impl GrpcNodeProvider {
     }
 }
 
-impl LocalValidatorNodeProvider for GrpcNodeProvider {
+impl ValidatorNodeProvider for GrpcNodeProvider {
     type Node = GrpcClient;
 
     fn make_node(&self, address: &str) -> anyhow::Result<Self::Node, NodeError> {

--- a/linera-rpc/src/node_provider.rs
+++ b/linera-rpc/src/node_provider.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use linera_base::time::Duration;
-use linera_core::node::{LocalValidatorNodeProvider, NodeError};
+use linera_core::node::{NodeError, ValidatorNodeProvider};
 
 #[cfg(with_simple_network)]
 use crate::simple::SimpleNodeProvider;
@@ -27,7 +27,7 @@ impl NodeProvider {
     }
 }
 
-impl LocalValidatorNodeProvider for NodeProvider {
+impl ValidatorNodeProvider for NodeProvider {
     type Node = Client;
 
     fn make_node(&self, address: &str) -> anyhow::Result<Self::Node, NodeError> {

--- a/linera-rpc/src/simple/node_provider.rs
+++ b/linera-rpc/src/simple/node_provider.rs
@@ -3,7 +3,7 @@
 
 use std::str::FromStr as _;
 
-use linera_core::node::{LocalValidatorNodeProvider, NodeError};
+use linera_core::node::{NodeError, ValidatorNodeProvider};
 
 use super::SimpleClient;
 use crate::{config::ValidatorPublicNetworkPreConfig, node_provider::NodeOptions};
@@ -18,7 +18,7 @@ impl SimpleNodeProvider {
     }
 }
 
-impl LocalValidatorNodeProvider for SimpleNodeProvider {
+impl ValidatorNodeProvider for SimpleNodeProvider {
     type Node = SimpleClient;
 
     fn make_node(&self, address: &str) -> Result<Self::Node, NodeError> {

--- a/linera-rpc/tests/transport.rs
+++ b/linera-rpc/tests/transport.rs
@@ -10,7 +10,7 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 // this test currently must be run manually, as it requires a Linera proxy to be running on 127.0.0.1:9000.
 async fn client() {
     use linera_base::time::Duration;
-    use linera_core::node::LocalValidatorNode as _;
+    use linera_core::node::ValidatorNode as _;
     use linera_rpc::config::*;
 
     let network_config = ValidatorPublicNetworkPreConfig {

--- a/linera-service/src/linera/main.rs
+++ b/linera-service/src/linera/main.rs
@@ -34,7 +34,7 @@ use linera_client::{
 use linera_core::{
     data_types::{ChainInfoQuery, ClientOutcome},
     local_node::{LocalNodeClient, NamedNode},
-    node::LocalValidatorNodeProvider,
+    node::ValidatorNodeProvider,
     worker::{Reason, WorkerState},
     JoinSetExt as _,
 };

--- a/linera-service/src/schema_export.rs
+++ b/linera-service/src/schema_export.rs
@@ -19,8 +19,8 @@ use linera_core::{
     client::ChainClient,
     data_types::{ChainInfoQuery, ChainInfoResponse},
     node::{
-        CrossChainMessageDelivery, LocalValidatorNodeProvider, NodeError, NotificationStream,
-        ValidatorNode,
+        CrossChainMessageDelivery, NodeError, NotificationStream, ValidatorNode,
+        ValidatorNodeProvider,
     },
 };
 use linera_execution::committee::{Committee, ValidatorName};
@@ -100,7 +100,7 @@ impl ValidatorNode for DummyValidatorNode {
 
 struct DummyValidatorNodeProvider;
 
-impl LocalValidatorNodeProvider for DummyValidatorNodeProvider {
+impl ValidatorNodeProvider for DummyValidatorNodeProvider {
     type Node = DummyValidatorNode;
 
     fn make_node(&self, _address: &str) -> Result<Self::Node, NodeError> {
@@ -128,7 +128,7 @@ struct DummyContext<P, S> {
 }
 
 #[async_trait]
-impl<P: LocalValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientContext
+impl<P: ValidatorNodeProvider + Send, S: Storage + Send + Sync> ClientContext
     for DummyContext<P, S>
 {
     type ValidatorNodeProvider = P;


### PR DESCRIPTION
## Motivation

* The word `Local` is used for local (vs remote) nodes.
* Simplify the code by exposing only the definition that is relevant for a particular configuration.

## Proposal

Use `cfg(web)` to remove `LocalValidatorNode(Provider)` and `LocalNotificationStream`

## Test Plan

CI
