### PR TITLE
change debug level in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,6 +28,7 @@ env:
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
+  RUST_LOG_FORMAT: plain
 
 permissions:
   contents: read

--- a/.github/workflows/dynamodb.yml
+++ b/.github/workflows/dynamodb.yml
@@ -26,6 +26,7 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
+  RUST_LOG_FORMAT: plain
 
 permissions:
   contents: read

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ env:
   RUSTDOCFLAGS: -A rustdoc::redundant_explicit_links -D warnings
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
-  RUST_LOG: linera=debug
+  RUST_LOG: linera=warn
   RUST_LOG_FORMAT: plain
 
 permissions:

--- a/.github/workflows/scylladb.yml
+++ b/.github/workflows/scylladb.yml
@@ -27,6 +27,7 @@ env:
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
   RUST_LOG: warn
+  RUST_LOG_FORMAT: plain
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation

Logs are too large to be displayed in the UI of github (can only be downloaded)

## Proposal

Reduce log verbosity in CI

## Test Plan

CI

## Release Plan

- [ ] These changes should be backported to the latest `devnet` branch.
- [ ] These changes should be backported to the latest `testnet` branch.
