### PR TITLE
Add the LRU caching to the `storage-service`

### DIFF
--- a/linera-storage-service/src/client.rs
+++ b/linera-storage-service/src/client.rs
@@ -15,13 +15,13 @@ use linera_views::{
         AdminKeyValueStore, CommonStoreConfig, ReadableKeyValueStore, WithError,
         WritableKeyValueStore,
     },
-    lru_caching::{LruCachingStore},
+    lru_caching::LruCachingStore,
 };
 use serde::de::DeserializeOwned;
 use tonic::transport::{Channel, Endpoint};
 
 #[cfg(with_metrics)]
-use crate::common::{STORAGE_SERVICE_METRICS, LRU_STORAGE_SERVICE_METRICS};
+use crate::common::{LRU_STORAGE_SERVICE_METRICS, STORAGE_SERVICE_METRICS};
 use crate::{
     common::{
         storage_service_test_endpoint, KeyTag, ServiceStoreConfig, ServiceStoreError,

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -99,6 +99,10 @@ pub fn storage_service_test_endpoint() -> Result<String, ServiceStoreError> {
 pub(crate) static STORAGE_SERVICE_METRICS: LazyLock<KeyValueStoreMetrics> =
     LazyLock::new(|| KeyValueStoreMetrics::new("storage service".to_string()));
 
+#[cfg(with_metrics)]
+pub(crate) static LRU_STORAGE_SERVICE_METRICS: LazyLock<KeyValueStoreMetrics> =
+    LazyLock::new(|| KeyValueStoreMetrics::new("lru caching".to_string()));
+
 #[derive(Debug, Clone)]
 pub struct ServiceStoreConfig {
     /// The endpoint used by the shared store

--- a/linera-storage-service/src/common.rs
+++ b/linera-storage-service/src/common.rs
@@ -101,7 +101,7 @@ pub(crate) static STORAGE_SERVICE_METRICS: LazyLock<KeyValueStoreMetrics> =
 
 #[cfg(with_metrics)]
 pub(crate) static LRU_STORAGE_SERVICE_METRICS: LazyLock<KeyValueStoreMetrics> =
-    LazyLock::new(|| KeyValueStoreMetrics::new("lru caching".to_string()));
+    LazyLock::new(|| KeyValueStoreMetrics::new("storage service lru caching".to_string()));
 
 #[derive(Debug, Clone)]
 pub struct ServiceStoreConfig {


### PR DESCRIPTION
## Motivation

We want to achieve the best performance and the `storage-service` does not use the LRU caching.

## Proposal

The following was done:
* The LRU was implemented in a similar way to `ScyllaDb` / `DynamoDb` which lead to a streamlinging of the code
* Perhaps controversially, the variable `LRU_STORAGE_SERVICE_METRICS` is introduced in the `linera-storage-service/src/common.rs`. This is because the variable is set in `metering.rs` but feature gated by `RocksDb`, `ScyllaDb` and `DynamoDb`. Since the feature `storage-service` is not available in `linera-views`. This is why we have the duplication.

## Test Plan

CI for the correctness of the tests.

Performance analysis.

Model setup:
* Use the `test_wasm_end_to_end_amm` on release and debug mode.
* Use the scripting program `run_and_obtain_metrics` from https://github.com/MathieuDutSik/linera_parsing_tools
* Input file is `run_release_service_amm.json` but the essential is 10 runs with the 1st discarded.
* Run local on Maxbook Pro 16, 2.3GHz with very little other process run.

Results in release mode:
* **read_value_byte**: Old: 0.21 ms vs New 0.005 ms
* **lru_caching_read_multi_value_bytes**: Old: 0.23 ms vs 0.20 ms
* **contains_key**: Old 0.33 ms vs 0.06 ms
* **total runtime**: Old 17.2 s vs 18.08 s (so 5% improvement)

Results in debug mode (relevant to the CI):
* **total runtime**: Old 77.85s vs 71.5s (so 8% improvement)

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
