### PR TITLE
Move long faucet chain test to different CI workflow

### DIFF
--- a/.github/workflows/long_faucet_chain_test.yml
+++ b/.github/workflows/long_faucet_chain_test.yml
@@ -1,0 +1,37 @@
+name: Long Faucet chain test
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_NET_RETRY: 10
+  LINERA_STORAGE_SERVICE: 127.0.0.1:1235
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest-16-cores
+    timeout-minutes: 180
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+    - name: Clear up some space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+    - name: Install Protoc
+      uses: arduino/setup-protoc@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Build
+      run: |
+        cargo build --release -p linera-service
+    - name: Run end-to-end tests
+      run: |
+        cargo run --release -p linera-storage-service -- memory --endpoint $LINERA_STORAGE_SERVICE &
+        cargo test -p linera-service --features storage-service -- --ignored test_end_to_end_faucet_with_long_chains --nocapture

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2845,6 +2845,7 @@ async fn test_end_to_end_faucet(config: impl LineraNetConfig) -> Result<()> {
 #[cfg_attr(feature = "kubernetes", test_case(SharedLocalKubernetesNetTestingConfig::new(Network::Grpc, BuildArg::Build) ; "kubernetes_grpc"))]
 #[cfg_attr(feature = "remote-net", test_case(RemoteNetTestingConfig::new(None) ; "remote_net_grpc"))]
 #[test_log::test(tokio::test)]
+#[ignore = "This test takes a long time to run"]
 async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -> Result<()> {
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -2850,7 +2850,7 @@ async fn test_end_to_end_faucet_with_long_chains(config: impl LineraNetConfig) -
     let _guard = INTEGRATION_TEST_GUARD.lock().await;
     tracing::info!("Starting test {}", test_name!());
 
-    let chain_count = test_iterations().unwrap_or(1_000);
+    let chain_count = test_iterations().unwrap_or(10_000);
 
     let (mut net, faucet_client) = config.instantiate().await?;
 


### PR DESCRIPTION
## Motivation

<!--
Briefly describe the goal(s) of this PR.
-->
One of the CI tests takes to long to finish, and also doesn't stress as much as it should.

## Proposal

<!--
Summarize the proposed changes and how they address the goal(s) stated above.
-->
Move the test to a separate GitHub Actions workflow, that only runs _after_ a PR has been merged. That way it still detects any problems, but doesn't block the usual development workflow.

## Test Plan

<!--
Explain how you made sure that the changes are correct and that they perform as intended.

Please describe testing protocols (CI, manual tests, benchmarks, etc) in a way that others
can reproduce the results.
-->
Manually ran the test command, but still need to check how GitHub will handle it.

## Release Plan

<!--
If this PR targets the `main` branch, indicate if your recommend the changes to be picked
in release branches.

Note that this generally only concerns hot fixes.
-->
Nothing needed because this only affects tests.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
