### PR TITLE
Latency metrics for the `KeyValueStoreView`.

### DIFF
--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -712,6 +712,8 @@ where
     /// # })
     /// ```
     pub async fn get(&self, index: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
+        #[cfg(with_metrics)]
+        let _latency = KEY_VALUE_STORE_VIEW_GET_RUNTIME.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let value = match update {
@@ -741,6 +743,8 @@ where
     /// # })
     /// ```
     pub async fn contains_key(&self, index: &[u8]) -> Result<bool, ViewError> {
+        #[cfg(with_metrics)]
+        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEY_RUNTIME.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let test = match update {
@@ -771,6 +775,8 @@ where
     /// # })
     /// ```
     pub async fn contains_keys(&self, indices: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
+        #[cfg(with_metrics)]
+        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_RUNTIME.measure_latency();
         let mut results = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
@@ -817,6 +823,8 @@ where
         &self,
         indices: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, ViewError> {
+        #[cfg(with_metrics)]
+        let _latency = KEY_VALUE_STORE_VIEW_MULTI_GET_RUNTIME.measure_latency();
         let mut result = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -40,6 +40,104 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
     .expect("Histogram can be created")
 });
 
+#[cfg(with_metrics)]
+/// The runtime of get
+static KEY_VALUE_STORE_VIEW_GET_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "key_value_store_view_get_runtime",
+        "KeyValueStoreView get runtime",
+        &[],
+        Some(vec![
+            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+        ]),
+    )
+    .expect("Histogram can be created")
+});
+
+#[cfg(with_metrics)]
+/// The runtime of multi get
+static KEY_VALUE_STORE_VIEW_MULTI_GET_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "key_value_store_view_multi_get_runtime",
+        "KeyValueStoreView multi get runtime",
+        &[],
+        Some(vec![
+            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+        ]),
+    )
+    .expect("Histogram can be created")
+});
+
+#[cfg(with_metrics)]
+/// The runtime of contains key
+static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "key_value_store_view_contains_key_runtime",
+        "KeyValueStoreView contains key runtime",
+        &[],
+        Some(vec![
+            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+        ]),
+    )
+    .expect("Histogram can be created")
+});
+
+#[cfg(with_metrics)]
+/// The runtime of contains keys
+static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "key_value_store_view_contains_keys_runtime",
+        "KeyValueStoreView contains keys runtime",
+        &[],
+        Some(vec![
+            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+        ]),
+    )
+    .expect("Histogram can be created")
+});
+
+#[cfg(with_metrics)]
+/// The runtime of find keys by prefix
+static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "key_value_store_view_find_keys_by_prefix_runtime",
+        "KeyValueStoreView find keys by prefix runtime",
+        &[],
+        Some(vec![
+            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+        ]),
+    )
+    .expect("Histogram can be created")
+});
+
+#[cfg(with_metrics)]
+/// The runtime of find key values by prefix
+static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "key_value_store_view_find_key_values_by_prefix_runtime",
+        "KeyValueStoreView find key values by prefix runtime",
+        &[],
+        Some(vec![
+            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+        ]),
+    )
+    .expect("Histogram can be created")
+});
+
+#[cfg(with_metrics)]
+/// The runtime of write batch
+static KEY_VALUE_STORE_VIEW_WRITE_BATCH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+    prometheus_util::register_histogram_vec(
+        "key_value_store_view_write_batch_runtime",
+        "KeyValueStoreView write batch runtime",
+        &[],
+        Some(vec![
+            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+        ]),
+    )
+    .expect("Histogram can be created")
+});
+
 #[cfg(with_testing)]
 use {
     crate::common::{KeyValueStoreError, ReadableKeyValueStore, WithError, WritableKeyValueStore},
@@ -765,6 +863,8 @@ where
     /// # })
     /// ```
     pub async fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
+        #[cfg(with_metrics)]
+        let _latency = KEY_VALUE_STORE_VIEW_WRITE_BATCH_RUNTIME.measure_latency();
         *self.hash.get_mut().unwrap() = None;
         let max_key_size = self.max_key_size();
         for operation in batch.operations {
@@ -901,6 +1001,8 @@ where
     /// # })
     /// ```
     pub async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, ViewError> {
+        #[cfg(with_metrics)]
+        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_RUNTIME.measure_latency();
         ensure!(
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong
@@ -975,6 +1077,8 @@ where
         &self,
         key_prefix: &[u8],
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
+        #[cfg(with_metrics)]
+        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_RUNTIME.measure_latency();
         ensure!(
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -27,11 +27,11 @@ use crate::{
 };
 
 #[cfg(with_metrics)]
-/// The runtime of hash computation
-static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+/// The latency of hash computation
+static KEY_VALUE_STORE_VIEW_HASH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
-        "key_value_store_view_hash_runtime",
-        "KeyValueStoreView hash runtime",
+        "key_value_store_view_hash_latency",
+        "KeyValueStoreView hash latency",
         &[],
         Some(vec![
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -41,11 +41,11 @@ static KEY_VALUE_STORE_VIEW_HASH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new
 });
 
 #[cfg(with_metrics)]
-/// The runtime of get
-static KEY_VALUE_STORE_VIEW_GET_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+/// The latency of get operation
+static KEY_VALUE_STORE_VIEW_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
-        "key_value_store_view_get_runtime",
-        "KeyValueStoreView get runtime",
+        "key_value_store_view_get_latency",
+        "KeyValueStoreView get latency",
         &[],
         Some(vec![
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -55,11 +55,11 @@ static KEY_VALUE_STORE_VIEW_GET_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(
 });
 
 #[cfg(with_metrics)]
-/// The runtime of multi get
-static KEY_VALUE_STORE_VIEW_MULTI_GET_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+/// The latency of multi get
+static KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
-        "key_value_store_view_multi_get_runtime",
-        "KeyValueStoreView multi get runtime",
+        "key_value_store_view_multi_get_latency",
+        "KeyValueStoreView multi get latency",
         &[],
         Some(vec![
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -69,11 +69,11 @@ static KEY_VALUE_STORE_VIEW_MULTI_GET_RUNTIME: LazyLock<HistogramVec> = LazyLock
 });
 
 #[cfg(with_metrics)]
-/// The runtime of contains key
-static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+/// The latency of contains key
+static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
-        "key_value_store_view_contains_key_runtime",
-        "KeyValueStoreView contains key runtime",
+        "key_value_store_view_contains_key_latency",
+        "KeyValueStoreView contains key latency",
         &[],
         Some(vec![
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -83,11 +83,11 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEY_RUNTIME: LazyLock<HistogramVec> = LazyL
 });
 
 #[cfg(with_metrics)]
-/// The runtime of contains keys
-static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+/// The latency of contains keys
+static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
-        "key_value_store_view_contains_keys_runtime",
-        "KeyValueStoreView contains keys runtime",
+        "key_value_store_view_contains_keys_latency",
+        "KeyValueStoreView contains keys latency",
         &[],
         Some(vec![
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -97,12 +97,12 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_RUNTIME: LazyLock<HistogramVec> = Lazy
 });
 
 #[cfg(with_metrics)]
-/// The runtime of find keys by prefix
-static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> =
+/// The latency of find keys by prefix operation
+static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
     LazyLock::new(|| {
         prometheus_util::register_histogram_vec(
-            "key_value_store_view_find_keys_by_prefix_runtime",
-            "KeyValueStoreView find keys by prefix runtime",
+            "key_value_store_view_find_keys_by_prefix_latency",
+            "KeyValueStoreView find keys by prefix latency",
             &[],
             Some(vec![
                 0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -112,12 +112,12 @@ static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> 
     });
 
 #[cfg(with_metrics)]
-/// The runtime of find key values by prefix
-static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> =
+/// The latency of find key values by prefix operation
+static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY: LazyLock<HistogramVec> =
     LazyLock::new(|| {
         prometheus_util::register_histogram_vec(
-            "key_value_store_view_find_key_values_by_prefix_runtime",
-            "KeyValueStoreView find key values by prefix runtime",
+            "key_value_store_view_find_key_values_by_prefix_latency",
+            "KeyValueStoreView find key values by prefix latency",
             &[],
             Some(vec![
                 0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -127,11 +127,11 @@ static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_RUNTIME: LazyLock<Histogra
     });
 
 #[cfg(with_metrics)]
-/// The runtime of write batch
-static KEY_VALUE_STORE_VIEW_WRITE_BATCH_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
+/// The latency of write batch operation
+static KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY: LazyLock<HistogramVec> = LazyLock::new(|| {
     prometheus_util::register_histogram_vec(
-        "key_value_store_view_write_batch_runtime",
-        "KeyValueStoreView write batch runtime",
+        "key_value_store_view_write_batch_latency",
+        "KeyValueStoreView write batch latency",
         &[],
         Some(vec![
             0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
@@ -715,7 +715,7 @@ where
     /// ```
     pub async fn get(&self, index: &[u8]) -> Result<Option<Vec<u8>>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_GET_RUNTIME.measure_latency();
+        let _latency = KEY_VALUE_STORE_VIEW_GET_LATENCY.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let value = match update {
@@ -746,7 +746,7 @@ where
     /// ```
     pub async fn contains_key(&self, index: &[u8]) -> Result<bool, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEY_RUNTIME.measure_latency();
+        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEY_LATENCY.measure_latency();
         ensure!(index.len() <= self.max_key_size(), ViewError::KeyTooLong);
         if let Some(update) = self.updates.get(index) {
             let test = match update {
@@ -778,7 +778,7 @@ where
     /// ```
     pub async fn contains_keys(&self, indices: Vec<Vec<u8>>) -> Result<Vec<bool>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_RUNTIME.measure_latency();
+        let _latency = KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_LATENCY.measure_latency();
         let mut results = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
@@ -826,7 +826,7 @@ where
         indices: Vec<Vec<u8>>,
     ) -> Result<Vec<Option<Vec<u8>>>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_MULTI_GET_RUNTIME.measure_latency();
+        let _latency = KEY_VALUE_STORE_VIEW_MULTI_GET_LATENCY.measure_latency();
         let mut result = Vec::with_capacity(indices.len());
         let mut missed_indices = Vec::new();
         let mut vector_query = Vec::new();
@@ -874,7 +874,7 @@ where
     /// ```
     pub async fn write_batch(&mut self, batch: Batch) -> Result<(), ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_WRITE_BATCH_RUNTIME.measure_latency();
+        let _latency = KEY_VALUE_STORE_VIEW_WRITE_BATCH_LATENCY.measure_latency();
         *self.hash.get_mut().unwrap() = None;
         let max_key_size = self.max_key_size();
         for operation in batch.operations {
@@ -1012,7 +1012,7 @@ where
     /// ```
     pub async fn find_keys_by_prefix(&self, key_prefix: &[u8]) -> Result<Vec<Vec<u8>>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_RUNTIME.measure_latency();
+        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_LATENCY.measure_latency();
         ensure!(
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong
@@ -1088,7 +1088,7 @@ where
         key_prefix: &[u8],
     ) -> Result<Vec<(Vec<u8>, Vec<u8>)>, ViewError> {
         #[cfg(with_metrics)]
-        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_RUNTIME.measure_latency();
+        let _latency = KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_LATENCY.measure_latency();
         ensure!(
             key_prefix.len() <= self.max_key_size(),
             ViewError::KeyTooLong
@@ -1147,7 +1147,7 @@ where
 
     async fn compute_hash(&self) -> Result<<sha3::Sha3_256 as Hasher>::Output, ViewError> {
         #[cfg(with_metrics)]
-        let _hash_latency = KEY_VALUE_STORE_VIEW_HASH_RUNTIME.measure_latency();
+        let _hash_latency = KEY_VALUE_STORE_VIEW_HASH_LATENCY.measure_latency();
         let mut hasher = sha3::Sha3_256::default();
         let mut count = 0;
         self.for_each_index_value(|index, value| -> Result<(), ViewError> {

--- a/linera-views/src/views/key_value_store_view.rs
+++ b/linera-views/src/views/key_value_store_view.rs
@@ -98,31 +98,33 @@ static KEY_VALUE_STORE_VIEW_CONTAINS_KEYS_RUNTIME: LazyLock<HistogramVec> = Lazy
 
 #[cfg(with_metrics)]
 /// The runtime of find keys by prefix
-static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
-        "key_value_store_view_find_keys_by_prefix_runtime",
-        "KeyValueStoreView find keys by prefix runtime",
-        &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
-    )
-    .expect("Histogram can be created")
-});
+static KEY_VALUE_STORE_VIEW_FIND_KEYS_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        prometheus_util::register_histogram_vec(
+            "key_value_store_view_find_keys_by_prefix_runtime",
+            "KeyValueStoreView find keys by prefix runtime",
+            &[],
+            Some(vec![
+                0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+            ]),
+        )
+        .expect("Histogram can be created")
+    });
 
 #[cfg(with_metrics)]
 /// The runtime of find key values by prefix
-static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> = LazyLock::new(|| {
-    prometheus_util::register_histogram_vec(
-        "key_value_store_view_find_key_values_by_prefix_runtime",
-        "KeyValueStoreView find key values by prefix runtime",
-        &[],
-        Some(vec![
-            0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
-        ]),
-    )
-    .expect("Histogram can be created")
-});
+static KEY_VALUE_STORE_VIEW_FIND_KEY_VALUES_BY_PREFIX_RUNTIME: LazyLock<HistogramVec> =
+    LazyLock::new(|| {
+        prometheus_util::register_histogram_vec(
+            "key_value_store_view_find_key_values_by_prefix_runtime",
+            "KeyValueStoreView find key values by prefix runtime",
+            &[],
+            Some(vec![
+                0.001, 0.003, 0.01, 0.03, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1.0, 2.0, 5.0,
+            ]),
+        )
+        .expect("Histogram can be created")
+    });
 
 #[cfg(with_metrics)]
 /// The runtime of write batch


### PR DESCRIPTION
## Motivation

The `KeyValueStoreView` is not exactly a `KeyValueStore` so we cannot put the `metering.rs` metrics.

## Proposal

The following was done:
* The functions used by the `execution_state_actor.rs` are `get`, `multi_get`, `contains_key(s)` and `find_key*_by_prefix`.
* The metrics were added for each.

This should help identify the latencies for the `KeyValueStoreView` that are relevant to the smart contracts.

## Test Plan

The CI. But so far there is nom impact on the tests so far.

## Release Plan

Not relevant.

## Links

<!--
Optional section for related PRs, related issues, and other references.

If needed, please create issues to track future improvements and link them here.
-->
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
