### PR TITLE
Assert that the inboxes are not empty.

### DIFF
--- a/linera-service/src/cli_wrappers/wallet.rs
+++ b/linera-service/src/cli_wrappers/wallet.rs
@@ -911,10 +911,10 @@ impl NodeService {
         self.child.ensure_is_running()
     }
 
-    pub async fn process_inbox(&self, chain_id: &ChainId) -> Result<()> {
+    pub async fn process_inbox(&self, chain_id: &ChainId) -> Result<Vec<CryptoHash>> {
         let query = format!("mutation {{ processInbox(chainId: \"{chain_id}\") }}");
-        self.query_node(query).await?;
-        Ok(())
+        let mut data = self.query_node(query).await?;
+        Ok(serde_json::from_value(data["processInbox"].take())?)
     }
 
     pub async fn make_application<A: ContractAbi>(

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -743,7 +743,7 @@ async fn test_wasm_end_to_end_fungible(
     );
 
     // Needed synchronization though removing it does not get error in 100% of cases.
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     let expected_balances = [
         (account_owner1, Amount::from_tokens(5)),
@@ -773,7 +773,7 @@ async fn test_wasm_end_to_end_fungible(
     app1.assert_entries(expected_balances).await;
     app1.assert_keys([account_owner1, account_owner2]).await;
 
-    node_service2.process_inbox(&chain2).await?;
+    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
 
     // Fungible didn't exist on chain2 initially but now it does and we can talk to it.
     let app2 = FungibleApp(
@@ -806,8 +806,8 @@ async fn test_wasm_end_to_end_fungible(
     .await;
 
     // Make sure that the cross-chain communication happens fast enough.
-    node_service1.process_inbox(&chain1).await?;
-    node_service2.process_inbox(&chain2).await?;
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
 
     // Checking the final value
     let expected_balances = [
@@ -913,7 +913,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     );
 
     // Needed synchronization though removing it does not get error in 100% of cases.
-    node_service.process_inbox(&chain1).await?;
+    assert_eq!(node_service.process_inbox(&chain1).await?.len(), 1);
 
     let expected_balances = [
         (account_owner1, Amount::from_tokens(5)),
@@ -934,7 +934,7 @@ async fn test_wasm_end_to_end_same_wallet_fungible(
     )
     .await;
 
-    node_service.process_inbox(&chain2).await?;
+    assert_eq!(node_service.process_inbox(&chain2).await?.len(), 1);
 
     // Checking the final values on chain1 and chain2.
     let expected_balances = [
@@ -1053,7 +1053,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     )
     .await;
 
-    node_service2.process_inbox(&chain2).await?;
+    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
 
     // Checking the NFT is removed from chain1
     assert!(app1.get_nft(&nft1_id).await.is_err());
@@ -1091,8 +1091,8 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // Make sure that the cross-chain communication happens fast enough.
-    node_service2.process_inbox(&chain2).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     // Checking the NFT is removed from chain2
     assert!(app2.get_nft(&nft1_id).await.is_err());
@@ -1118,7 +1118,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // The transfer is received by chain2 and needs to be processed.
-    node_service2.process_inbox(&chain2).await?;
+    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
 
     // Checking the NFT is removed from chain1
     assert!(app1.get_nft(&nft1_id).await.is_err());
@@ -1186,7 +1186,7 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // The transfer from chain2 has to be received from chain1.
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     // Checking the NFT is removed from chain2
     assert!(app2.get_nft(&nft2_id).await.is_err());
@@ -1216,8 +1216,8 @@ async fn test_wasm_end_to_end_non_fungible(config: impl LineraNetConfig) -> Resu
     .await;
 
     // Make sure that the cross-chain communication happens fast enough.
-    node_service1.process_inbox(&chain1).await?;
-    node_service2.process_inbox(&chain2).await?;
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
 
     // Checking the final state
 
@@ -1343,8 +1343,8 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
 
     // Chain2 requests the application from chain1, so chain1 has
     // to receive the request and then chain2 receive the answer.
-    node_service1.process_inbox(&chain1).await?;
-    node_service2.process_inbox(&chain2).await?;
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
+    assert_eq!(node_service2.process_inbox(&chain2).await?.len(), 1);
 
     let app_crowd2 = node_service2
         .make_application(&chain2, &application_id_crowd)
@@ -1359,7 +1359,7 @@ async fn test_wasm_end_to_end_crowd_funding(config: impl LineraNetConfig) -> Res
     app_crowd2.mutate(mutation).await?;
 
     // Make sure that the pledge is processed fast enough by client1.
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     // Ending the campaign.
     app_crowd1.mutate("collect").await?;
@@ -1474,10 +1474,13 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // In an operation node_service_a.request_application(&chain_a, app_b)
     // chain_b needs to process the request first and then chain_a
     // the answer.
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_b.process_inbox(&chain_b).await?;
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_admin.process_inbox(&chain_admin).await?;
+    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
+    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    assert_eq!(
+        node_service_admin.process_inbox(&chain_admin).await?.len(),
+        1
+    );
 
     let app_fungible0_a = FungibleApp(node_service_a.make_application(&chain_a, &token0).await?);
     let app_fungible1_a = FungibleApp(node_service_a.make_application(&chain_a, &token1).await?);
@@ -1556,9 +1559,12 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
 
     // First chain_admin needs to process the two requests and
     // then chain_a / chain_b the answers.
-    node_service_admin.process_inbox(&chain_admin).await?;
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_b.process_inbox(&chain_b).await?;
+    assert_eq!(
+        node_service_admin.process_inbox(&chain_admin).await?.len(),
+        1
+    );
+    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
 
     let app_matching_a = MatchingEngineApp(
         node_service_a
@@ -1597,9 +1603,12 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // The orders are sent on chain_a / chain_b. First they are
     // rerouted to the admin chain for processing. This leads
     // to order being sent to chain_a / chain_b.
-    node_service_admin.process_inbox(&chain_admin).await?;
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_b.process_inbox(&chain_b).await?;
+    assert_eq!(
+        node_service_admin.process_inbox(&chain_admin).await?.len(),
+        1
+    );
+    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
 
     // Now reading the order_ids
     let order_ids_a = app_matching_admin.get_account_info(&owner_a).await;
@@ -1627,9 +1636,12 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     }
 
     // Same logic as for the insertion of orders.
-    node_service_admin.process_inbox(&chain_admin).await?;
-    node_service_a.process_inbox(&chain_a).await?;
-    node_service_b.process_inbox(&chain_b).await?;
+    assert_eq!(
+        node_service_admin.process_inbox(&chain_admin).await?.len(),
+        1
+    );
+    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
+    assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
 
     // Check balances
     app_fungible0_a
@@ -1802,8 +1814,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         )
         .await;
 
-    node_service0.process_inbox(&chain0).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service0.process_inbox(&chain0).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     let app_fungible0_0 = FungibleApp(node_service0.make_application(&chain0, &token0).await?);
     let app_fungible1_0 = FungibleApp(node_service0.make_application(&chain0, &token1).await?);
@@ -1892,9 +1904,9 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
 
     // The chain_amm must first requests those two requests
     // and then chain0 / chain1 must handle the answers.
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service0.process_inbox(&chain0).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service0.process_inbox(&chain0).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     let app_amm0 = AmmApp(
         node_service0
@@ -1918,8 +1930,7 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .add_liquidity(owner0, Amount::from_tokens(100), Amount::from_tokens(100))
         .await?;
 
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service0.process_inbox(&chain0).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
 
     // Ownership of the used owner_amm_chain's tokens should be with the AMM now
     app_fungible0_amm
@@ -1978,8 +1989,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .add_liquidity(owner1, Amount::from_tokens(120), Amount::from_tokens(100))
         .await?;
 
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     app_fungible0_amm
         .assert_balances([
@@ -2038,8 +2049,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .expect_err("Swapping from the AMM chain should fail");
 
     app_amm1.swap(owner1, 0, Amount::from_tokens(50)).await?;
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     app_fungible0_amm
         .assert_balances([
@@ -2107,8 +2118,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     app_amm1
         .remove_liquidity(owner1, 0, Amount::from_tokens(500))
         .await?;
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 0);
 
     // Balances will be unaltered
     app_fungible0_amm
@@ -2163,8 +2174,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .await;
 
     app_amm1.swap(owner1, 1, Amount::from_tokens(40)).await?;
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     app_fungible0_amm
         .assert_balances([
@@ -2220,8 +2231,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
     app_amm1
         .remove_liquidity(owner1, 0, Amount::from_tokens(100))
         .await?;
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service1.process_inbox(&chain1).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service1.process_inbox(&chain1).await?.len(), 1);
 
     app_fungible0_amm
         .assert_balances([
@@ -2275,8 +2286,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .await;
 
     app_amm0.swap(owner0, 1, Amount::from_tokens(25)).await?;
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service0.process_inbox(&chain0).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service0.process_inbox(&chain0).await?.len(), 1);
 
     app_fungible0_amm
         .assert_balances([
@@ -2330,8 +2341,8 @@ async fn test_wasm_end_to_end_amm(config: impl LineraNetConfig) -> Result<()> {
         .await;
 
     app_amm0.remove_all_added_liquidity(owner0).await?;
-    node_service_amm.process_inbox(&chain_amm).await?;
-    node_service0.process_inbox(&chain0).await?;
+    assert_eq!(node_service_amm.process_inbox(&chain_amm).await?.len(), 1);
+    assert_eq!(node_service0.process_inbox(&chain0).await?.len(), 1);
 
     app_fungible0_amm
         .assert_balances([


### PR DESCRIPTION
## Motivation

In some end-to-end tests we run the node service with the `Skip` policy, so it doesn't automatically process its inbox. That means the outcomes of the explicit calls to `process_inbox` should be deterministic.

## Proposal

Check that these calls do return one new certificate hash.

## Test Plan

This should make the tests fail earlier if there is a problem.

## Links

- (Related to debugging https://github.com/linera-io/linera-protocol/pull/2538.)
- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
