### PR TITLE
Receive bundles even if new_outbox_entries.

### DIFF
--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -405,12 +405,14 @@ where
             let add_to_received_log = previous_height != Some(bundle.height);
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
-            new_outbox_entries = self
+            if self
                 .state
                 .chain
                 .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
                 .await?
-                || new_outbox_entries;
+            {
+                new_outbox_entries = true;
+            }
         }
         if !self.state.config.allow_inactive_chains && !self.state.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by

--- a/linera-core/src/chain_worker/state/attempted_changes.rs
+++ b/linera-core/src/chain_worker/state/attempted_changes.rs
@@ -405,12 +405,12 @@ where
             let add_to_received_log = previous_height != Some(bundle.height);
             previous_height = Some(bundle.height);
             // Update the staged chain state with the received block.
-            new_outbox_entries = new_outbox_entries
-                || self
-                    .state
-                    .chain
-                    .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
-                    .await?;
+            new_outbox_entries = self
+                .state
+                .chain
+                .receive_message_bundle(&origin, bundle, local_time, add_to_received_log)
+                .await?
+                || new_outbox_entries;
         }
         if !self.state.config.allow_inactive_chains && !self.state.chain.is_active() {
             // Refuse to create a chain state if the chain is still inactive by

--- a/linera-service/tests/linera_net_tests.rs
+++ b/linera-service/tests/linera_net_tests.rs
@@ -1475,13 +1475,10 @@ async fn test_wasm_end_to_end_matching_engine(config: impl LineraNetConfig) -> R
     // In an operation node_service_a.request_application(&chain_a, app_b)
     // chain_b needs to process the request first and then chain_a
     // the answer.
-    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
-    assert_eq!(node_service_b.process_inbox(&chain_b).await?.len(), 1);
-    assert_eq!(node_service_a.process_inbox(&chain_a).await?.len(), 1);
-    assert_eq!(
-        node_service_admin.process_inbox(&chain_admin).await?.len(),
-        1
-    );
+    node_service_a.process_inbox(&chain_a).await?;
+    node_service_b.process_inbox(&chain_b).await?;
+    node_service_a.process_inbox(&chain_a).await?;
+    node_service_admin.process_inbox(&chain_admin).await?;
 
     let app_fungible0_a = FungibleApp(node_service_a.make_application(&chain_a, &token0).await?);
     let app_fungible1_a = FungibleApp(node_service_a.make_application(&chain_a, &token1).await?);


### PR DESCRIPTION
## Motivation

There is a bug in `process_cross_chain_update`: `new_outbox_entries` is meant to be `true` if any `receive_message_bundle` returned true, so I used `||` without taking into account that that short-circuits, so the `receive_message_bundle` call isn't actually made if `new_outbox_entries` is already `true`.

## Proposal

Switch the order of the arguments.

## Test Plan

Since this is a simple fix, we could merge that as soon as possible. Coming up with a scenario that exposes this and writing a regression test will take some time (https://github.com/linera-io/linera-protocol/issues/2544). The failure will probably look similar to the one in https://github.com/linera-io/linera-protocol/pull/2538, but this fix didn't address that.

## Release Plan

- These changes should be backported to the latest `devnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.
- These changes should be backported to the latest `testnet` branch, then
    - be released in a new SDK,
    - be released in a validator hotfix.

## Links

- [reviewer checklist](https://github.com/linera-io/linera-protocol/blob/main/CONTRIBUTING.md#reviewer-checklist)
